### PR TITLE
Persist ANSI preference, clamp armor HP, and cap inbound per tick

### DIFF
--- a/src/main/kotlin/dev/ambon/MudServer.kt
+++ b/src/main/kotlin/dev/ambon/MudServer.kt
@@ -85,6 +85,7 @@ class MudServer(
                     clock = clock,
                     tickMillis = tickMillis,
                     scheduler = scheduler,
+                    maxInboundEventsPerTick = config.server.maxInboundEventsPerTick,
                     loginConfig = config.login,
                     engineConfig = config.engine,
                     progression = progression,

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -20,6 +20,7 @@ data class AppConfig(
         require(server.inboundChannelCapacity > 0) { "ambonMUD.server.inboundChannelCapacity must be > 0" }
         require(server.outboundChannelCapacity > 0) { "ambonMUD.server.outboundChannelCapacity must be > 0" }
         require(server.sessionOutboundQueueCapacity > 0) { "ambonMUD.server.sessionOutboundQueueCapacity must be > 0" }
+        require(server.maxInboundEventsPerTick > 0) { "ambonMUD.server.maxInboundEventsPerTick must be > 0" }
         require(server.tickMillis > 0L) { "ambonMUD.server.tickMillis must be > 0" }
 
         require(world.resources.isNotEmpty()) { "ambonMUD.world.resources must not be empty" }
@@ -85,6 +86,7 @@ data class ServerConfig(
     val inboundChannelCapacity: Int = 10_000,
     val outboundChannelCapacity: Int = 10_000,
     val sessionOutboundQueueCapacity: Int = 200,
+    val maxInboundEventsPerTick: Int = 1_000,
     val tickMillis: Long = 100L,
 )
 

--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -201,8 +201,14 @@ class CombatSystem(
         if (currentDefense == previousDefense) return
 
         val delta = currentDefense - previousDefense
-        player.maxHp += delta
-        player.hp = (player.hp + delta).coerceAtMost(player.maxHp)
+        val newMaxHp = (player.maxHp + delta).coerceAtLeast(0)
+        player.maxHp = newMaxHp
+        player.hp =
+            if (delta > 0) {
+                (player.hp + delta).coerceAtMost(newMaxHp)
+            } else {
+                player.hp.coerceAtMost(newMaxHp)
+            }
         if (player.hp < 0) player.hp = 0
 
         defenseByPlayer[sessionId] = currentDefense

--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -15,6 +15,7 @@ data class PlayerState(
     var constitution: Int = 0,
     var level: Int = 1,
     var xpTotal: Long = 0L,
+    var ansiEnabled: Boolean = false,
 ) {
     companion object {
         const val BASE_MAX_HP = 10

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandRouter.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandRouter.kt
@@ -96,12 +96,14 @@ class CommandRouter(
 
             Command.AnsiOn -> {
                 outbound.send(OutboundEvent.SetAnsi(sessionId, true))
+                players.setAnsiEnabled(sessionId, true)
                 outbound.send(OutboundEvent.SendInfo(sessionId, "ANSI enabled"))
                 outbound.send(OutboundEvent.SendPrompt(sessionId))
             }
 
             Command.AnsiOff -> {
                 outbound.send(OutboundEvent.SetAnsi(sessionId, false))
+                players.setAnsiEnabled(sessionId, false)
                 outbound.send(OutboundEvent.SendInfo(sessionId, "ANSI disabled"))
                 outbound.send(OutboundEvent.SendPrompt(sessionId))
             }

--- a/src/main/kotlin/dev/ambon/engine/events/InboundEvent.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/InboundEvent.kt
@@ -5,6 +5,7 @@ import dev.ambon.domain.ids.SessionId
 sealed interface InboundEvent {
     data class Connected(
         val sessionId: SessionId,
+        val defaultAnsiEnabled: Boolean = false,
     ) : InboundEvent
 
     data class Disconnected(

--- a/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
@@ -17,5 +17,5 @@ data class PlayerRecord(
     val createdAtEpochMs: Long,
     val lastSeenEpochMs: Long,
     val passwordHash: String = "",
-    val ansiEnabled: Boolean = true,
+    val ansiEnabled: Boolean = false,
 )

--- a/src/main/kotlin/dev/ambon/persistence/PlayerRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayerRepository.kt
@@ -10,6 +10,7 @@ interface PlayerRepository {
         startRoomId: dev.ambon.domain.ids.RoomId,
         nowEpochMs: Long,
         passwordHash: String,
+        ansiEnabled: Boolean,
     ): PlayerRecord
 
     suspend fun save(record: PlayerRecord)

--- a/src/main/kotlin/dev/ambon/persistence/YamlPlayerRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/YamlPlayerRepository.kt
@@ -85,6 +85,7 @@ class YamlPlayerRepository(
         startRoomId: RoomId,
         nowEpochMs: Long,
         passwordHash: String,
+        ansiEnabled: Boolean,
     ): PlayerRecord =
         withContext(Dispatchers.IO) {
             val nm = name.trim()
@@ -106,7 +107,7 @@ class YamlPlayerRepository(
                     createdAtEpochMs = nowEpochMs,
                     lastSeenEpochMs = nowEpochMs,
                     passwordHash = passwordHash,
-                    ansiEnabled = false,
+                    ansiEnabled = ansiEnabled,
                 )
 
             save(record)

--- a/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
+++ b/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
@@ -113,7 +113,10 @@ private suspend fun DefaultWebSocketServerSession.bridgeWebSocketSession(
         }
     }
 
-    val connectedOk = runCatching { inbound.send(InboundEvent.Connected(sessionId)) }.isSuccess
+    val connectedOk =
+        runCatching {
+            inbound.send(InboundEvent.Connected(sessionId, defaultAnsiEnabled = true))
+        }.isSuccess
     if (!connectedOk) {
         noteDisconnectReason("inbound closed")
         disconnect()

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,6 +5,7 @@ ambonMUD:
     inboundChannelCapacity: 10000
     outboundChannelCapacity: 10000
     sessionOutboundQueueCapacity: 200
+    maxInboundEventsPerTick: 1000
     tickMillis: 100
 
   world:

--- a/src/test/kotlin/dev/ambon/engine/GameEngineLoginFlowTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GameEngineLoginFlowTest.kt
@@ -93,7 +93,7 @@ class GameEngineLoginFlowTest {
 
             val world = WorldFactory.demoWorld()
             val repo = InMemoryPlayerRepository()
-            repo.create("Alice", world.startRoom, 0L, BCrypt.hashpw("secret", BCrypt.gensalt()))
+            repo.create("Alice", world.startRoom, 0L, BCrypt.hashpw("secret", BCrypt.gensalt()), ansiEnabled = false)
             val players = PlayerRegistry(world.startRoom, repo, ItemRegistry())
 
             val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)
@@ -165,7 +165,7 @@ class GameEngineLoginFlowTest {
 
             val world = WorldFactory.demoWorld()
             val repo = InMemoryPlayerRepository()
-            repo.create("Alice", world.startRoom, 0L, BCrypt.hashpw("secret", BCrypt.gensalt()))
+            repo.create("Alice", world.startRoom, 0L, BCrypt.hashpw("secret", BCrypt.gensalt()), ansiEnabled = false)
             val players = PlayerRegistry(world.startRoom, repo, ItemRegistry())
 
             val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)
@@ -257,7 +257,7 @@ class GameEngineLoginFlowTest {
 
             val world = WorldFactory.demoWorld()
             val repo = InMemoryPlayerRepository()
-            repo.create("Alice", world.startRoom, 0L, BCrypt.hashpw("secret", BCrypt.gensalt()))
+            repo.create("Alice", world.startRoom, 0L, BCrypt.hashpw("secret", BCrypt.gensalt()), ansiEnabled = false)
             val players = PlayerRegistry(world.startRoom, repo, ItemRegistry())
 
             val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)

--- a/src/test/kotlin/dev/ambon/persistence/InMemoryPlayerRepository.kt
+++ b/src/test/kotlin/dev/ambon/persistence/InMemoryPlayerRepository.kt
@@ -16,6 +16,7 @@ class InMemoryPlayerRepository : PlayerRepository {
         startRoomId: RoomId,
         nowEpochMs: Long,
         passwordHash: String,
+        ansiEnabled: Boolean,
     ): PlayerRecord {
         val id = PlayerId(nextId.getAndIncrement())
         val record =
@@ -26,6 +27,7 @@ class InMemoryPlayerRepository : PlayerRepository {
                 createdAtEpochMs = nowEpochMs,
                 lastSeenEpochMs = nowEpochMs,
                 passwordHash = passwordHash,
+                ansiEnabled = ansiEnabled,
             )
         players[id] = record
         return record

--- a/src/test/kotlin/dev/ambon/persistence/YamlPlayerRepositoryTest.kt
+++ b/src/test/kotlin/dev/ambon/persistence/YamlPlayerRepositoryTest.kt
@@ -30,7 +30,7 @@ class YamlPlayerRepositoryTest {
             val now = 1234L
             val hash = BCrypt.hashpw("password", BCrypt.gensalt())
 
-            val r = repo.create("Alice", RoomId("test:a"), now, hash)
+            val r = repo.create("Alice", RoomId("test:a"), now, hash, ansiEnabled = false)
 
             val byId = repo.findById(r.id)
             assertNotNull(byId)
@@ -49,7 +49,7 @@ class YamlPlayerRepositoryTest {
             val now = 1000L
             val hash = BCrypt.hashpw("password", BCrypt.gensalt())
 
-            val r = repo.create("Bob", RoomId("test:a"), now, hash)
+            val r = repo.create("Bob", RoomId("test:a"), now, hash, ansiEnabled = false)
             val updated =
                 r.copy(
                     roomId = RoomId("test:b"),
@@ -76,11 +76,11 @@ class YamlPlayerRepositoryTest {
             val now = 1L
             val hash = BCrypt.hashpw("password", BCrypt.gensalt())
 
-            repo.create("Carol", RoomId("test:a"), now, hash)
+            repo.create("Carol", RoomId("test:a"), now, hash, ansiEnabled = false)
 
             val ex =
                 try {
-                    repo.create("carol", RoomId("test:a"), now, hash)
+                    repo.create("carol", RoomId("test:a"), now, hash, ansiEnabled = false)
                     fail("Expected PlayerPersistenceException")
                 } catch (e: PlayerPersistenceException) {
                     e
@@ -97,7 +97,14 @@ class YamlPlayerRepositoryTest {
             val clock = Clock.fixed(Instant.ofEpochMilli(1000), ZoneOffset.UTC)
 
             // create a record that lives in room b
-            val existing = repo.create("Alice", RoomId("test:b"), 1000, BCrypt.hashpw("password", BCrypt.gensalt()))
+            val existing =
+                repo.create(
+                    "Alice",
+                    RoomId("test:b"),
+                    1000,
+                    BCrypt.hashpw("password", BCrypt.gensalt()),
+                    ansiEnabled = false,
+                )
 
             val players = PlayerRegistry(start, repo, ItemRegistry(), clock)
             val sid = SessionId(1)

--- a/src/test/kotlin/dev/ambon/transport/KtorWebSocketTransportTest.kt
+++ b/src/test/kotlin/dev/ambon/transport/KtorWebSocketTransportTest.kt
@@ -45,7 +45,7 @@ class KtorWebSocketTransportTest {
 
                 wsClient.webSocket("/ws") {
                     assertEquals(
-                        InboundEvent.Connected(sid),
+                        InboundEvent.Connected(sid, defaultAnsiEnabled = true),
                         withTimeout(3_000) { inbound.receive() },
                     )
 


### PR DESCRIPTION
## Summary
- Persist and restore ANSI preference on login.
- Clamp HP to new max on armor removal without reducing current HP.
- Add configurable per-tick inbound event cap.