### PR TITLE
Implement login takeover (steal session)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -98,6 +98,19 @@ class CombatSystem(
         return null
     }
 
+    fun remapSession(
+        oldSid: SessionId,
+        newSid: SessionId,
+    ) {
+        val fight = fightsByPlayer.remove(oldSid)
+        if (fight != null) {
+            val newFight = fight.copy(sessionId = newSid)
+            fightsByPlayer[newSid] = newFight
+            fightsByMob[fight.mobId] = newFight
+        }
+        defenseByPlayer.remove(oldSid)?.let { defenseByPlayer[newSid] = it }
+    }
+
     fun onPlayerDisconnected(sessionId: SessionId) {
         val fight = fightsByPlayer[sessionId]
         if (fight != null) {

--- a/src/main/kotlin/dev/ambon/engine/RegenSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/RegenSystem.kt
@@ -17,6 +17,13 @@ class RegenSystem(
 ) {
     private val lastRegenAtMs = mutableMapOf<SessionId, Long>()
 
+    fun remapSession(
+        oldSid: SessionId,
+        newSid: SessionId,
+    ) {
+        lastRegenAtMs.remove(oldSid)?.let { lastRegenAtMs[newSid] = it }
+    }
+
     fun onPlayerDisconnected(sessionId: SessionId) {
         lastRegenAtMs.remove(sessionId)
     }

--- a/src/main/kotlin/dev/ambon/engine/items/ItemRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/items/ItemRegistry.kt
@@ -154,6 +154,14 @@ class ItemRegistry {
         equippedItems.getOrPut(sessionId) { mutableMapOf() }
     }
 
+    fun remapPlayer(
+        oldSid: SessionId,
+        newSid: SessionId,
+    ) {
+        inventoryItems.remove(oldSid)?.let { inventoryItems[newSid] = it }
+        equippedItems.remove(oldSid)?.let { equippedItems[newSid] = it }
+    }
+
     fun removePlayer(sessionId: SessionId) {
         inventoryItems.remove(sessionId)
         equippedItems.remove(sessionId)

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterTest.kt
@@ -357,7 +357,7 @@ class CommandRouterTest {
             val res2 = players.login(b, "alice", "password")
 
             assertEquals(LoginResult.Ok, res1)
-            assertEquals(LoginResult.Taken, res2)
+            assertTrue(res2 is LoginResult.Takeover, "Expected Takeover for duplicate name with correct password. got=$res2")
         }
 
     @Test

--- a/src/test/kotlin/dev/ambon/engine/commands/NamesTellGossipTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/NamesTellGossipTest.kt
@@ -53,7 +53,7 @@ class NamesTellGossipTest {
             login(players, a, "Alice")
 
             val res = players.login(b, "alice", "password")
-            assertTrue(res == LoginResult.Taken, "Expected taken for duplicate login. got=$res")
+            assertTrue(res is LoginResult.Takeover, "Expected Takeover for duplicate login with correct password. got=$res")
         }
 
     @Test


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                       
                                                            
  - A second login for an already-online character now succeeds when the correct password is supplied, kicking the first session instead of rejecting the attempt
  - The kicked session receives: "Your account has logged in from another location."
  - The room sees: "[Name] briefly flickers." (no duplicate "enters." broadcast)
  - All in-game state (room, HP, equipment, inventory, active combat, regen timer) is inherited by the new session

  ## Changes

  - **`PlayerRegistry`** — moved the online-name guard to after BCrypt verification; added `LoginResult.Takeover` and `takeoverSession()` which remaps all per-session registries
  - **`GameEngine`** — removed name-stage online guard; handles `Takeover` result by remapping combat/regen, closing old session, broadcasting flicker, and suppressing the "enters." broadcast
  - **`CombatSystem`** — added `remapSession()` to transfer active fight and defense state
  - **`RegenSystem`** — added `remapSession()` to transfer regen timer
  - **`ItemRegistry`** — added `remapPlayer()` to transfer inventory and equipped items

  ## Test plan

  - [ ] Happy-path takeover: second login with correct password kicks first session, observer sees flicker, new session sees room look without "enters."
  - [ ] Wrong password on live name: original session is untouched
  - [ ] Combat inherited: flee succeeds on the new session after takeover
  - [ ] Full suite: `./gradlew ktlintCheck test`
  
  
  Closes #39 
