### PR TITLE
Add substring fallback for item lookup (get/wear/drop)

### DIFF
--- a/docs/world-zone-yaml-spec.md
+++ b/docs/world-zone-yaml-spec.md
@@ -80,7 +80,10 @@ armor: <integer, optional, default 0, must be >= 0>
 constitution: <integer, optional, default 0, must be >= 0>
 room: <room-id string, optional>
 mob: <mob-id string, optional>
+matchByKey: <boolean, optional, default false>
 ```
+
+`matchByKey` — optional boolean (default `false`). When `true`, players must type the exact keyword; substring-based fallback on `displayName` and `description` is disabled. Use for intentionally hidden or keyword-gated items.
 
 Location rules for items:
 

--- a/src/main/kotlin/dev/ambon/domain/items/Item.kt
+++ b/src/main/kotlin/dev/ambon/domain/items/Item.kt
@@ -8,4 +8,5 @@ data class Item(
     val damage: Int = 0,
     val armor: Int = 0,
     val constitution: Int = 0,
+    val matchByKey: Boolean = false,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/data/ItemFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/ItemFile.kt
@@ -10,4 +10,5 @@ data class ItemFile(
     val constitution: Int = 0,
     val room: String? = null,
     val mob: String? = null,
+    val matchByKey: Boolean = false,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -164,6 +164,7 @@ object WorldLoader {
                                         damage = damage,
                                         armor = armor,
                                         constitution = constitution,
+                                        matchByKey = itemFile.matchByKey,
                                     ),
                             ),
                         roomId = roomId,

--- a/src/test/kotlin/dev/ambon/engine/items/ItemRegistryTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/items/ItemRegistryTest.kt
@@ -2,11 +2,15 @@ package dev.ambon.engine.items
 
 import dev.ambon.domain.ids.ItemId
 import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.items.Item
 import dev.ambon.domain.items.ItemInstance
+import dev.ambon.domain.items.ItemSlot
 import dev.ambon.domain.world.ItemSpawn
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -42,6 +46,137 @@ class ItemRegistryTest {
         assertTrue(itemIds.contains("swamp:totem"))
         assertTrue(itemIds.contains("demo:coin"))
         assertFalse(itemIds.contains("demo:lantern"))
+    }
+
+    // --- Substring fallback tests ---
+
+    @Test
+    fun `takeFromRoom finds item by displayName substring`() {
+        val registry = ItemRegistry()
+        val roomId = RoomId("demo:room1")
+        val sid = SessionId(1L)
+        registry.ensurePlayer(sid)
+        registry.setRoomItems(roomId, listOf(instance("demo:lantern", "lantern", "a brass lantern")))
+
+        val result = registry.takeFromRoom(sid, roomId, "lant")
+
+        assertNotNull(result)
+        assertEquals("demo:lantern", result!!.id.value)
+    }
+
+    @Test
+    fun `takeFromRoom exact match takes priority over substring`() {
+        val registry = ItemRegistry()
+        val roomId = RoomId("demo:room1")
+        val sid = SessionId(1L)
+        registry.ensurePlayer(sid)
+        registry.setRoomItems(
+            roomId,
+            listOf(
+                instance("demo:lan", "lan", "a lantern"),
+                instance("demo:lantern", "lantern", "a brass lantern"),
+            ),
+        )
+
+        val result = registry.takeFromRoom(sid, roomId, "lan")
+
+        assertNotNull(result)
+        assertEquals("demo:lan", result!!.id.value)
+    }
+
+    @Test
+    fun `takeFromRoom rejects short input less than 3 chars`() {
+        val registry = ItemRegistry()
+        val roomId = RoomId("demo:room1")
+        val sid = SessionId(1L)
+        registry.ensurePlayer(sid)
+        registry.setRoomItems(roomId, listOf(instance("demo:lantern", "lantern", "a brass lantern")))
+
+        val result = registry.takeFromRoom(sid, roomId, "la")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `takeFromRoom respects matchByKey flag`() {
+        val registry = ItemRegistry()
+        val roomId = RoomId("demo:room1")
+        val sid = SessionId(1L)
+        registry.ensurePlayer(sid)
+        registry.setRoomItems(
+            roomId,
+            listOf(
+                ItemInstance(
+                    id = ItemId("demo:lantern"),
+                    item = Item(keyword = "lantern", displayName = "a brass lantern", matchByKey = true),
+                ),
+            ),
+        )
+
+        val result = registry.takeFromRoom(sid, roomId, "lant")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `dropToRoom finds item in inventory by displayName substring`() {
+        val registry = ItemRegistry()
+        val roomId = RoomId("demo:room1")
+        val sid = SessionId(1L)
+        registry.ensurePlayer(sid)
+        // Seed inventory directly via takeFromRoom round-trip
+        val sourceRoom = RoomId("demo:source")
+        registry.setRoomItems(sourceRoom, listOf(instance("demo:lantern", "lantern", "a brass lantern")))
+        registry.takeFromRoom(sid, sourceRoom, "lantern")
+
+        val result = registry.dropToRoom(sid, roomId, "lant")
+
+        assertNotNull(result)
+        assertEquals("demo:lantern", result!!.id.value)
+    }
+
+    @Test
+    fun `equipFromInventory finds item by displayName substring`() {
+        val registry = ItemRegistry()
+        val sid = SessionId(1L)
+        registry.ensurePlayer(sid)
+        val sourceRoom = RoomId("demo:source")
+        registry.setRoomItems(
+            sourceRoom,
+            listOf(
+                ItemInstance(
+                    id = ItemId("demo:helm"),
+                    item = Item(keyword = "helm", displayName = "a dented helm", slot = ItemSlot.HEAD),
+                ),
+            ),
+        )
+        registry.takeFromRoom(sid, sourceRoom, "helm")
+
+        val result = registry.equipFromInventory(sid, "dent")
+
+        assertTrue(result is ItemRegistry.EquipResult.Equipped)
+    }
+
+    @Test
+    fun `equipFromInventory respects matchByKey flag`() {
+        val registry = ItemRegistry()
+        val sid = SessionId(1L)
+        registry.ensurePlayer(sid)
+        val sourceRoom = RoomId("demo:source")
+        registry.setRoomItems(
+            sourceRoom,
+            listOf(
+                ItemInstance(
+                    id = ItemId("demo:helm"),
+                    item = Item(keyword = "helm", displayName = "a dented helm", slot = ItemSlot.HEAD, matchByKey = true),
+                ),
+            ),
+        )
+        registry.takeFromRoom(sid, sourceRoom, "helm")
+
+        val result = registry.equipFromInventory(sid, "dent")
+
+        assertTrue(result is ItemRegistry.EquipResult.NotFound)
     }
 
     private fun instance(


### PR DESCRIPTION
## Summary

- Players can now type partial names (e.g. \`get lant\`) to pick up items — the engine falls back to a substring search on \`displayName\` and \`description\` when no exact keyword match is found.
- Exact keyword match still takes priority; inputs shorter than 3 characters are rejected outright.
- New \`matchByKey: true\` YAML field lets world builders opt individual items out of substring matching (e.g. keyword-gated or hidden items).

## Changes

- \`Item.kt\` / \`ItemFile.kt\` — added \`matchByKey: Boolean = false\` field
- \`WorldLoader.kt\` — passes \`matchByKey\` through to \`Item\` constructor
- \`ItemRegistry.kt\` — added \`matchesSubstring\` helper; updated \`takeFromRoom\`, \`dropToRoom\`, and \`equipFromInventory\` (refactored into \`equipFromInventoryWithMatcher\`) with two-pass exact-then-substring logic
- \`ItemRegistryTest.kt\` — 7 new unit tests covering substring match, exact-takes-priority, short-input rejection, and \`matchByKey\` opt-out for all three operations
- \`docs/world-zone-yaml-spec.md\` — documented the new \`matchByKey\` field

## Test plan

- [ ] \`./gradlew ktlintCheck test\` passes (all existing + 7 new tests green)
- [ ] \`get lant\` picks up a lantern (substring match)
- [ ] \`get la\` → "You don't see 'la' here." (too short)
- [ ] \`get lantern\` still works (exact match)
- [ ] Item with \`matchByKey: true\` — \`get lant\` fails, \`get lantern\` succeeds

Closes #37 