### PR TITLE
Add admin/staff commands (goto, transfer, spawn, smite, kick, shutdown)

### DIFF
--- a/src/main/kotlin/dev/ambon/Main.kt
+++ b/src/main/kotlin/dev/ambon/Main.kt
@@ -33,8 +33,9 @@ fun main() =
         log.info { "AmbonMUD listening on telnet port ${config.server.telnetPort} (telnet localhost ${config.server.telnetPort})" }
         log.info { "AmbonMUD web client at $webClientUrl" }
         maybeAutoLaunchBrowser(webClientUrl, config.demo.autoLaunchBrowser)
-        // keep alive
-        kotlinx.coroutines.delay(Long.MAX_VALUE)
+        server.awaitShutdown()
+        log.info { "Shutdown signal received. Stopping server..." }
+        server.stop()
     }
 
 private fun maybeAutoLaunchBrowser(

--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -121,6 +121,11 @@ class CombatSystem(
         defenseByPlayer.remove(sessionId)
     }
 
+    fun endCombatFor(sessionId: SessionId) {
+        val fight = fightsByPlayer[sessionId] ?: return
+        endFight(fight)
+    }
+
     suspend fun onMobRemovedExternally(mobId: MobId) {
         val fight = fightsByMob[mobId] ?: return
         endFight(fight)

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -40,6 +40,7 @@ class GameEngine(
     private val engineConfig: EngineConfig = EngineConfig(),
     private val progression: PlayerProgression = PlayerProgression(),
     private val metrics: GameMetrics = GameMetrics.noop(),
+    private val onShutdown: suspend () -> Unit = {},
 ) {
     private val zoneResetDueAtMillis =
         world.zoneLifespansMinutes
@@ -83,7 +84,19 @@ class GameEngine(
             metrics = metrics,
         )
 
-    private val router = CommandRouter(world, players, mobs, items, combatSystem, outbound, progression = progression, metrics = metrics)
+    private val router =
+        CommandRouter(
+            world = world,
+            players = players,
+            mobs = mobs,
+            items = items,
+            combat = combatSystem,
+            outbound = outbound,
+            progression = progression,
+            metrics = metrics,
+            onShutdown = onShutdown,
+            onMobSmited = mobSystem::onMobRemoved,
+        )
     private val pendingLogins = mutableMapOf<SessionId, LoginState>()
     private val failedLoginAttempts = mutableMapOf<SessionId, Int>()
     private val sessionAnsiDefaults = mutableMapOf<SessionId, Boolean>()

--- a/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
@@ -145,6 +145,7 @@ class PlayerRegistry(
                 level = level,
                 xpTotal = xpTotal,
                 ansiEnabled = boundRecord.ansiEnabled,
+                isStaff = boundRecord.isStaff,
             )
         players[sessionId] = ps
         roomMembers.getOrPut(ps.roomId) { mutableSetOf() }.add(sessionId)

--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -16,6 +16,7 @@ data class PlayerState(
     var level: Int = 1,
     var xpTotal: Long = 0L,
     var ansiEnabled: Boolean = false,
+    var isStaff: Boolean = false,
 ) {
     companion object {
         const val BASE_MAX_HP = 10

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -80,6 +80,29 @@ sealed interface Command {
 
     data object Score : Command
 
+    data class Goto(
+        val arg: String,
+    ) : Command
+
+    data class Transfer(
+        val playerName: String,
+        val arg: String,
+    ) : Command
+
+    data class Spawn(
+        val templateArg: String,
+    ) : Command
+
+    data object Shutdown : Command
+
+    data class Smite(
+        val target: String,
+    ) : Command
+
+    data class Kick(
+        val playerName: String,
+    ) : Command
+
     data class Unknown(
         val raw: String,
     ) : Command
@@ -181,6 +204,36 @@ object CommandParser {
             if (target.isEmpty()) Command.Invalid(line, "kill <mob>") else Command.Kill(target)
         }?.let { return it }
 
+        // goto
+        matchPrefix(line, listOf("goto")) { rest ->
+            if (rest.isEmpty()) Command.Invalid(line, "goto <zone:room | room | zone:>") else Command.Goto(rest)
+        }?.let { return it }
+
+        // transfer
+        matchPrefix(line, listOf("transfer")) { rest ->
+            val parts = rest.split(Regex("\\s+"), limit = 2)
+            if (parts.size < 2 || parts[1].isBlank()) {
+                Command.Invalid(line, "transfer <player> <room>")
+            } else {
+                Command.Transfer(parts[0], parts[1].trim())
+            }
+        }?.let { return it }
+
+        // spawn
+        matchPrefix(line, listOf("spawn")) { rest ->
+            if (rest.isEmpty()) Command.Invalid(line, "spawn <mob-template>") else Command.Spawn(rest)
+        }?.let { return it }
+
+        // smite
+        matchPrefix(line, listOf("smite")) { rest ->
+            if (rest.isEmpty()) Command.Invalid(line, "smite <player|mob>") else Command.Smite(rest)
+        }?.let { return it }
+
+        // kick
+        matchPrefix(line, listOf("kick")) { rest ->
+            if (rest.isEmpty()) Command.Invalid(line, "kick <player>") else Command.Kick(rest)
+        }?.let { return it }
+
         return when (lower) {
             "help", "?" -> Command.Help
             "look", "l" -> Command.Look
@@ -199,6 +252,7 @@ object CommandParser {
             "exits", "ex" -> Command.Exits
             "flee" -> Command.Flee
             "score", "sc" -> Command.Score
+            "shutdown" -> Command.Shutdown
             else -> Command.Unknown(line)
         }
     }

--- a/src/main/kotlin/dev/ambon/engine/items/ItemRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/items/ItemRegistry.kt
@@ -128,6 +128,10 @@ class ItemRegistry {
 
     fun itemsInMob(mobId: MobId): List<ItemInstance> = mobItems[mobId]?.toList() ?: emptyList()
 
+    fun removeMobItems(mobId: MobId) {
+        mobItems.remove(mobId)
+    }
+
     /**
      * Move all items carried by a mob into a room. Returns moved items.
      */

--- a/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
@@ -18,4 +18,5 @@ data class PlayerRecord(
     val lastSeenEpochMs: Long,
     val passwordHash: String = "",
     val ansiEnabled: Boolean = false,
+    val isStaff: Boolean = false,
 )

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
@@ -119,4 +119,86 @@ class CommandParserTest {
         val c = CommandParser.parse("look sideways")
         assertTrue(c is Command.Invalid)
     }
+
+    @Test
+    fun `parses goto with full zone and room`() {
+        assertEquals(Command.Goto("demo_ruins:caravan_gate"), CommandParser.parse("goto demo_ruins:caravan_gate"))
+    }
+
+    @Test
+    fun `parses goto with local room only`() {
+        assertEquals(Command.Goto("caravan_gate"), CommandParser.parse("goto caravan_gate"))
+    }
+
+    @Test
+    fun `parses goto with zone colon empty room`() {
+        assertEquals(Command.Goto("demo_ruins:"), CommandParser.parse("goto demo_ruins:"))
+    }
+
+    @Test
+    fun `goto with no arg returns Invalid`() {
+        assertTrue(CommandParser.parse("goto") is Command.Invalid)
+        assertTrue(CommandParser.parse("goto   ") is Command.Invalid)
+    }
+
+    @Test
+    fun `parses transfer with player and room`() {
+        assertEquals(Command.Transfer("Alice", "demo_ruins:caravan_gate"), CommandParser.parse("transfer Alice demo_ruins:caravan_gate"))
+    }
+
+    @Test
+    fun `transfer with missing room returns Invalid`() {
+        assertTrue(CommandParser.parse("transfer Alice") is Command.Invalid)
+        assertTrue(CommandParser.parse("transfer Alice   ") is Command.Invalid)
+    }
+
+    @Test
+    fun `transfer with no args returns Invalid`() {
+        assertTrue(CommandParser.parse("transfer") is Command.Invalid)
+    }
+
+    @Test
+    fun `parses spawn with local name`() {
+        assertEquals(Command.Spawn("gate_scout"), CommandParser.parse("spawn gate_scout"))
+    }
+
+    @Test
+    fun `parses spawn with fully qualified name`() {
+        assertEquals(Command.Spawn("demo_ruins:gate_scout"), CommandParser.parse("spawn demo_ruins:gate_scout"))
+    }
+
+    @Test
+    fun `spawn with no arg returns Invalid`() {
+        assertTrue(CommandParser.parse("spawn") is Command.Invalid)
+        assertTrue(CommandParser.parse("spawn   ") is Command.Invalid)
+    }
+
+    @Test
+    fun `parses shutdown`() {
+        assertEquals(Command.Shutdown, CommandParser.parse("shutdown"))
+        assertEquals(Command.Shutdown, CommandParser.parse("  shutdown  "))
+    }
+
+    @Test
+    fun `parses smite with target`() {
+        assertEquals(Command.Smite("Alice"), CommandParser.parse("smite Alice"))
+        assertEquals(Command.Smite("gate_scout"), CommandParser.parse("smite gate_scout"))
+    }
+
+    @Test
+    fun `smite with no target returns Invalid`() {
+        assertTrue(CommandParser.parse("smite") is Command.Invalid)
+        assertTrue(CommandParser.parse("smite   ") is Command.Invalid)
+    }
+
+    @Test
+    fun `parses kick with player name`() {
+        assertEquals(Command.Kick("Bob"), CommandParser.parse("kick Bob"))
+    }
+
+    @Test
+    fun `kick with no player returns Invalid`() {
+        assertTrue(CommandParser.parse("kick") is Command.Invalid)
+        assertTrue(CommandParser.parse("kick   ") is Command.Invalid)
+    }
 }

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterAdminTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterAdminTest.kt
@@ -1,0 +1,558 @@
+package dev.ambon.engine.commands
+
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.mob.MobState
+import dev.ambon.domain.world.WorldFactory
+import dev.ambon.engine.CombatSystem
+import dev.ambon.engine.LoginResult
+import dev.ambon.engine.MobRegistry
+import dev.ambon.engine.PlayerRegistry
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.persistence.InMemoryPlayerRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CommandRouterAdminTest {
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    private fun drain(ch: Channel<OutboundEvent>): List<OutboundEvent> {
+        val out = mutableListOf<OutboundEvent>()
+        while (true) {
+            val ev = ch.tryReceive().getOrNull() ?: break
+            out += ev
+        }
+        return out
+    }
+
+    private suspend fun login(
+        players: PlayerRegistry,
+        sessionId: SessionId,
+        name: String,
+    ) {
+        val res = players.login(sessionId, name, "password")
+        require(res == LoginResult.Ok) { "Login failed: $res" }
+    }
+
+    private suspend fun loginStaff(
+        players: PlayerRegistry,
+        sessionId: SessionId,
+        name: String,
+    ) {
+        login(players, sessionId, name)
+        players.get(sessionId)!!.isStaff = true
+    }
+
+    private fun makeRouter(
+        players: PlayerRegistry,
+        mobs: MobRegistry,
+        items: ItemRegistry,
+        outbound: Channel<OutboundEvent>,
+        onShutdown: suspend () -> Unit = {},
+        onMobSmited: (MobId) -> Unit = {},
+    ): CommandRouter {
+        val world = WorldFactory.demoWorld()
+        val combat = CombatSystem(players, mobs, items, outbound)
+        return CommandRouter(
+            world = world,
+            players = players,
+            mobs = mobs,
+            items = items,
+            combat = combat,
+            outbound = outbound,
+            onShutdown = onShutdown,
+            onMobSmited = onMobSmited,
+        )
+    }
+
+    // ── staff guard ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `non-staff player receives error on goto`() =
+        runTest {
+            val world = WorldFactory.demoWorld()
+            val items = ItemRegistry()
+            val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
+            val mobs = MobRegistry()
+            val outbound = Channel<OutboundEvent>(Channel.UNLIMITED)
+            val router = makeRouter(players, mobs, items, outbound)
+
+            val sid = SessionId(1)
+            login(players, sid, "Alice")
+            drain(outbound)
+
+            router.handle(sid, Command.Goto("demo_ruins:caravan_gate"))
+            val outs = drain(outbound)
+
+            assertTrue(
+                outs.any { it is OutboundEvent.SendError && it.sessionId == sid && it.text.contains("not staff") },
+                "Expected 'not staff' error. got=$outs",
+            )
+            assertTrue(outs.any { it is OutboundEvent.SendPrompt }, "Missing prompt. got=$outs")
+        }
+
+    // ── goto ───────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `goto moves staff player to exact room`() =
+        runTest {
+            val world = WorldFactory.demoWorld()
+            val items = ItemRegistry()
+            val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
+            val mobs = MobRegistry()
+            val outbound = Channel<OutboundEvent>(Channel.UNLIMITED)
+            val router = makeRouter(players, mobs, items, outbound)
+
+            val sid = SessionId(1)
+            loginStaff(players, sid, "Alice")
+            drain(outbound)
+
+            val target = "demo_ruins:caravan_gate"
+            router.handle(sid, Command.Goto(target))
+            drain(outbound)
+
+            assertEquals(target, players.get(sid)!!.roomId.value)
+        }
+
+    @Test
+    fun `goto with local room resolves in current zone`() =
+        runTest {
+            val world = WorldFactory.demoWorld()
+            val items = ItemRegistry()
+            val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
+            val mobs = MobRegistry()
+            val outbound = Channel<OutboundEvent>(Channel.UNLIMITED)
+            val router = makeRouter(players, mobs, items, outbound)
+
+            val sid = SessionId(1)
+            loginStaff(players, sid, "Alice")
+            drain(outbound)
+
+            // First teleport to demo_ruins zone
+            router.handle(sid, Command.Goto("demo_ruins:caravan_gate"))
+            drain(outbound)
+
+            // Now goto a local room name only — should resolve in demo_ruins
+            router.handle(sid, Command.Goto("campfire_ring"))
+            drain(outbound)
+
+            assertEquals("demo_ruins:campfire_ring", players.get(sid)!!.roomId.value)
+        }
+
+    @Test
+    fun `goto zone-colon resolves to a room in that zone`() =
+        runTest {
+            val world = WorldFactory.demoWorld()
+            val items = ItemRegistry()
+            val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
+            val mobs = MobRegistry()
+            val outbound = Channel<OutboundEvent>(Channel.UNLIMITED)
+            val router = makeRouter(players, mobs, items, outbound)
+
+            val sid = SessionId(1)
+            loginStaff(players, sid, "Alice")
+            drain(outbound)
+
+            router.handle(sid, Command.Goto("demo_ruins:"))
+            drain(outbound)
+
+            val roomId = players.get(sid)!!.roomId
+            assertEquals("demo_ruins", roomId.zone, "Should have landed in demo_ruins zone. got=$roomId")
+        }
+
+    @Test
+    fun `goto unknown room emits error and prompt`() =
+        runTest {
+            val world = WorldFactory.demoWorld()
+            val items = ItemRegistry()
+            val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
+            val mobs = MobRegistry()
+            val outbound = Channel<OutboundEvent>(Channel.UNLIMITED)
+            val router = makeRouter(players, mobs, items, outbound)
+
+            val sid = SessionId(1)
+            loginStaff(players, sid, "Alice")
+            drain(outbound)
+
+            router.handle(sid, Command.Goto("nonexistent:fakery"))
+            val outs = drain(outbound)
+
+            assertTrue(
+                outs.any { it is OutboundEvent.SendError && it.sessionId == sid },
+                "Expected SendError. got=$outs",
+            )
+            assertTrue(outs.any { it is OutboundEvent.SendPrompt }, "Missing prompt. got=$outs")
+        }
+
+    // ── transfer ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `transfer moves target player and sends them a look`() =
+        runTest {
+            val world = WorldFactory.demoWorld()
+            val items = ItemRegistry()
+            val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
+            val mobs = MobRegistry()
+            val outbound = Channel<OutboundEvent>(Channel.UNLIMITED)
+            val router = makeRouter(players, mobs, items, outbound)
+
+            val staffSid = SessionId(1)
+            val bobSid = SessionId(2)
+            loginStaff(players, staffSid, "Admin")
+            login(players, bobSid, "Bob")
+            drain(outbound)
+
+            router.handle(staffSid, Command.Transfer("Bob", "demo_ruins:caravan_gate"))
+            val outs = drain(outbound)
+
+            assertEquals("demo_ruins:caravan_gate", players.get(bobSid)!!.roomId.value, "Bob should be in new room")
+            assertTrue(
+                outs.any { it is OutboundEvent.SendText && it.sessionId == bobSid && it.text.contains("divine hand") },
+                "Bob should receive divine transport message. got=$outs",
+            )
+            assertTrue(
+                outs.any { it is OutboundEvent.SendInfo && it.sessionId == staffSid && it.text.contains("Bob") },
+                "Staff should see confirmation. got=$outs",
+            )
+        }
+
+    @Test
+    fun `transfer unknown player emits error`() =
+        runTest {
+            val world = WorldFactory.demoWorld()
+            val items = ItemRegistry()
+            val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
+            val mobs = MobRegistry()
+            val outbound = Channel<OutboundEvent>(Channel.UNLIMITED)
+            val router = makeRouter(players, mobs, items, outbound)
+
+            val staffSid = SessionId(1)
+            loginStaff(players, staffSid, "Admin")
+            drain(outbound)
+
+            router.handle(staffSid, Command.Transfer("Ghost", "demo_ruins:caravan_gate"))
+            val outs = drain(outbound)
+
+            assertTrue(
+                outs.any { it is OutboundEvent.SendError && it.sessionId == staffSid },
+                "Expected SendError. got=$outs",
+            )
+        }
+
+    // ── spawn ──────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `spawn creates mob in staff room`() =
+        runTest {
+            val world = WorldFactory.demoWorld()
+            val items = ItemRegistry()
+            val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
+            val mobs = MobRegistry()
+            val outbound = Channel<OutboundEvent>(Channel.UNLIMITED)
+            val router = makeRouter(players, mobs, items, outbound)
+
+            val staffSid = SessionId(1)
+            loginStaff(players, staffSid, "Admin")
+            val staffRoom = players.get(staffSid)!!.roomId
+            drain(outbound)
+
+            router.handle(staffSid, Command.Spawn("gate_scout"))
+            val outs = drain(outbound)
+
+            val spawned = mobs.mobsInRoom(staffRoom)
+            assertTrue(spawned.isNotEmpty(), "Expected a mob to be spawned in staff room")
+            assertTrue(
+                outs.any { it is OutboundEvent.SendInfo && it.sessionId == staffSid },
+                "Expected spawn confirmation. got=$outs",
+            )
+        }
+
+    @Test
+    fun `spawn with fully qualified name works`() =
+        runTest {
+            val world = WorldFactory.demoWorld()
+            val items = ItemRegistry()
+            val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
+            val mobs = MobRegistry()
+            val outbound = Channel<OutboundEvent>(Channel.UNLIMITED)
+            val router = makeRouter(players, mobs, items, outbound)
+
+            val staffSid = SessionId(1)
+            loginStaff(players, staffSid, "Admin")
+            val staffRoom = players.get(staffSid)!!.roomId
+            drain(outbound)
+
+            router.handle(staffSid, Command.Spawn("demo_ruins:gate_scout"))
+            drain(outbound)
+
+            assertTrue(mobs.mobsInRoom(staffRoom).isNotEmpty(), "Expected a mob to be spawned in staff room")
+        }
+
+    @Test
+    fun `spawn unknown template emits error`() =
+        runTest {
+            val world = WorldFactory.demoWorld()
+            val items = ItemRegistry()
+            val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
+            val mobs = MobRegistry()
+            val outbound = Channel<OutboundEvent>(Channel.UNLIMITED)
+            val router = makeRouter(players, mobs, items, outbound)
+
+            val staffSid = SessionId(1)
+            loginStaff(players, staffSid, "Admin")
+            drain(outbound)
+
+            router.handle(staffSid, Command.Spawn("nonexistent_mob"))
+            val outs = drain(outbound)
+
+            assertTrue(
+                outs.any { it is OutboundEvent.SendError && it.sessionId == staffSid },
+                "Expected SendError for unknown template. got=$outs",
+            )
+        }
+
+    // ── shutdown ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `shutdown broadcasts to all players and calls onShutdown callback`() =
+        runTest {
+            val world = WorldFactory.demoWorld()
+            val items = ItemRegistry()
+            val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
+            val mobs = MobRegistry()
+            val outbound = Channel<OutboundEvent>(Channel.UNLIMITED)
+            var shutdownCalled = false
+            val router = makeRouter(players, mobs, items, outbound, onShutdown = { shutdownCalled = true })
+
+            val staffSid = SessionId(1)
+            val bobSid = SessionId(2)
+            loginStaff(players, staffSid, "Admin")
+            login(players, bobSid, "Bob")
+            drain(outbound)
+
+            router.handle(staffSid, Command.Shutdown)
+            val outs = drain(outbound)
+
+            assertTrue(shutdownCalled, "onShutdown callback should have been invoked")
+            assertTrue(
+                outs.any { it is OutboundEvent.SendText && it.sessionId == staffSid && it.text.contains("shutdown") },
+                "Staff should receive shutdown broadcast. got=$outs",
+            )
+            assertTrue(
+                outs.any { it is OutboundEvent.SendText && it.sessionId == bobSid && it.text.contains("shutdown") },
+                "Bob should receive shutdown broadcast. got=$outs",
+            )
+        }
+
+    @Test
+    fun `non-staff cannot trigger shutdown`() =
+        runTest {
+            val world = WorldFactory.demoWorld()
+            val items = ItemRegistry()
+            val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
+            val mobs = MobRegistry()
+            val outbound = Channel<OutboundEvent>(Channel.UNLIMITED)
+            var shutdownCalled = false
+            val router = makeRouter(players, mobs, items, outbound, onShutdown = { shutdownCalled = true })
+
+            val sid = SessionId(1)
+            login(players, sid, "Alice")
+            drain(outbound)
+
+            router.handle(sid, Command.Shutdown)
+            assertFalse(shutdownCalled, "onShutdown should not be called for non-staff")
+        }
+
+    // ── smite ──────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `smite player sets hp to 1 and moves to start room`() =
+        runTest {
+            val world = WorldFactory.demoWorld()
+            val items = ItemRegistry()
+            val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
+            val mobs = MobRegistry()
+            val outbound = Channel<OutboundEvent>(Channel.UNLIMITED)
+            val router = makeRouter(players, mobs, items, outbound)
+
+            val staffSid = SessionId(1)
+            val bobSid = SessionId(2)
+            loginStaff(players, staffSid, "Admin")
+            login(players, bobSid, "Bob")
+            drain(outbound)
+
+            // Move Bob to a different room first
+            players.moveTo(bobSid, world.rooms.keys.first { it != world.startRoom })
+
+            router.handle(staffSid, Command.Smite("Bob"))
+            drain(outbound)
+
+            val bob = players.get(bobSid)!!
+            assertEquals(1, bob.hp, "Bob's HP should be 1 after smite")
+            assertEquals(world.startRoom, bob.roomId, "Bob should be at start room after smite")
+        }
+
+    @Test
+    fun `smite player sends divine message to target`() =
+        runTest {
+            val world = WorldFactory.demoWorld()
+            val items = ItemRegistry()
+            val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
+            val mobs = MobRegistry()
+            val outbound = Channel<OutboundEvent>(Channel.UNLIMITED)
+            val router = makeRouter(players, mobs, items, outbound)
+
+            val staffSid = SessionId(1)
+            val bobSid = SessionId(2)
+            loginStaff(players, staffSid, "Admin")
+            login(players, bobSid, "Bob")
+            drain(outbound)
+
+            router.handle(staffSid, Command.Smite("Bob"))
+            val outs = drain(outbound)
+
+            assertTrue(
+                outs.any { it is OutboundEvent.SendText && it.sessionId == bobSid && it.text.contains("divine") },
+                "Bob should receive divine smite message. got=$outs",
+            )
+        }
+
+    @Test
+    fun `smite mob removes it from registry`() =
+        runTest {
+            val world = WorldFactory.demoWorld()
+            val items = ItemRegistry()
+            val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
+            val mobs = MobRegistry()
+            val outbound = Channel<OutboundEvent>(Channel.UNLIMITED)
+            var smitedMobId: MobId? = null
+            val router = makeRouter(players, mobs, items, outbound, onMobSmited = { smitedMobId = it })
+
+            val staffSid = SessionId(1)
+            loginStaff(players, staffSid, "Admin")
+            val staffRoom = players.get(staffSid)!!.roomId
+            drain(outbound)
+
+            // Place a mob in the same room as staff
+            val mobId = MobId("demo_ruins:test_scout")
+            mobs.upsert(MobState(id = mobId, name = "a wary caravan scout", roomId = staffRoom))
+
+            router.handle(staffSid, Command.Smite("scout"))
+            drain(outbound)
+
+            assertNull(mobs.get(mobId), "Mob should be removed from registry after smite")
+            assertEquals(mobId, smitedMobId, "onMobSmited callback should have been called with mob ID")
+        }
+
+    @Test
+    fun `smite mob not found emits error`() =
+        runTest {
+            val world = WorldFactory.demoWorld()
+            val items = ItemRegistry()
+            val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
+            val mobs = MobRegistry()
+            val outbound = Channel<OutboundEvent>(Channel.UNLIMITED)
+            val router = makeRouter(players, mobs, items, outbound)
+
+            val staffSid = SessionId(1)
+            loginStaff(players, staffSid, "Admin")
+            drain(outbound)
+
+            router.handle(staffSid, Command.Smite("ghost_mob"))
+            val outs = drain(outbound)
+
+            assertTrue(
+                outs.any { it is OutboundEvent.SendError && it.sessionId == staffSid },
+                "Expected SendError when target not found. got=$outs",
+            )
+        }
+
+    // ── kick ───────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `kick sends Close event to target session`() =
+        runTest {
+            val world = WorldFactory.demoWorld()
+            val items = ItemRegistry()
+            val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
+            val mobs = MobRegistry()
+            val outbound = Channel<OutboundEvent>(Channel.UNLIMITED)
+            val router = makeRouter(players, mobs, items, outbound)
+
+            val staffSid = SessionId(1)
+            val bobSid = SessionId(2)
+            loginStaff(players, staffSid, "Admin")
+            login(players, bobSid, "Bob")
+            drain(outbound)
+
+            router.handle(staffSid, Command.Kick("Bob"))
+            val outs = drain(outbound)
+
+            assertTrue(
+                outs.any { it is OutboundEvent.Close && it.sessionId == bobSid },
+                "Expected Close event for Bob's session. got=$outs",
+            )
+            assertTrue(
+                outs.any { it is OutboundEvent.SendInfo && it.sessionId == staffSid && it.text.contains("Bob") },
+                "Staff should see kick confirmation. got=$outs",
+            )
+        }
+
+    @Test
+    fun `kick self emits error`() =
+        runTest {
+            val world = WorldFactory.demoWorld()
+            val items = ItemRegistry()
+            val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
+            val mobs = MobRegistry()
+            val outbound = Channel<OutboundEvent>(Channel.UNLIMITED)
+            val router = makeRouter(players, mobs, items, outbound)
+
+            val staffSid = SessionId(1)
+            loginStaff(players, staffSid, "Admin")
+            drain(outbound)
+
+            router.handle(staffSid, Command.Kick("Admin"))
+            val outs = drain(outbound)
+
+            assertTrue(
+                outs.any { it is OutboundEvent.SendError && it.sessionId == staffSid },
+                "Expected error when trying to kick self. got=$outs",
+            )
+            assertFalse(
+                outs.any { it is OutboundEvent.Close && it.sessionId == staffSid },
+                "Staff should not be kicked. got=$outs",
+            )
+        }
+
+    @Test
+    fun `kick unknown player emits error`() =
+        runTest {
+            val world = WorldFactory.demoWorld()
+            val items = ItemRegistry()
+            val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
+            val mobs = MobRegistry()
+            val outbound = Channel<OutboundEvent>(Channel.UNLIMITED)
+            val router = makeRouter(players, mobs, items, outbound)
+
+            val staffSid = SessionId(1)
+            loginStaff(players, staffSid, "Admin")
+            drain(outbound)
+
+            router.handle(staffSid, Command.Kick("Ghost"))
+            val outs = drain(outbound)
+
+            assertTrue(
+                outs.any { it is OutboundEvent.SendError && it.sessionId == staffSid },
+                "Expected SendError for unknown player. got=$outs",
+            )
+        }
+}


### PR DESCRIPTION
## Summary

- Adds a boolean `isStaff` flag to `PlayerRecord` (defaulting to `false`; granted by adding `isStaff: true` to a player's YAML file in `data/players/`)
- Implements six staff-gated in-game commands: `goto`, `transfer`, `spawn`, `smite`, `kick`, and `shutdown`
- Wires graceful in-game shutdown via `CompletableDeferred` from `CommandRouter` → `GameEngine` → `MudServer`; `Main.kt` now awaits the signal instead of `delay(Long.MAX_VALUE)`

### Command details

| Command | Effect |
|---|---|
| `goto <zone:room \| room \| zone:>` | Teleport to any room. Bare `room` resolves in current zone; `zone:` lands at zone start. |
| `transfer <player> <room>` | Move another online player to any room. |
| `spawn <template>` | Instantiate a mob from world templates in the current room (`name` or `zone:name`). |
| `smite <player\|mob>` | Players: HP→1, teleported to start room. Mobs: clean removal, no loot drop. |
| `kick <player>` | Disconnect a session. |
| `shutdown` | Broadcast farewell to all, then gracefully stop the server. |

## Test plan

- [ ] Run `./gradlew ktlintCheck test` — all 13 new parser tests and 17 new router tests pass
- [ ] Manual smoke test: log in as a staff-flagged player and exercise each command
- [ ] Verify non-staff player receives "You are not staff." on any admin command
- [ ] Verify existing player YAML files deserialize correctly (new `isStaff` field defaults to `false`)