### PR TITLE
Add per-mob stats and difficulty tiers

### DIFF
--- a/docs/world-zone-yaml-spec.md
+++ b/docs/world-zone-yaml-spec.md
@@ -61,9 +61,40 @@ Each key is a mob ID (local or fully qualified).
 Each value:
 
 ```yaml
-name: <string, required>
-room: <room-id string, required>
+name:       <string, required>
+room:       <room-id string, required>
+tier:       <string, optional — one of weak|standard|elite|boss (case-insensitive); default standard>
+level:      <integer >= 1, optional; default 1>
+hp:         <integer >= 1, optional — overrides tier-computed hp>
+minDamage:  <integer >= 1, optional — overrides tier-computed minDamage>
+maxDamage:  <integer >= minDamage, optional — overrides tier-computed maxDamage>
+armor:      <integer >= 0, optional — overrides tier baseArmor (flat damage reduction, no level scaling)>
+xpReward:   <long >= 0, optional — overrides tier-computed xpReward>
 ```
+
+**Tier formula** (for tier `T` and level `L`, where `L` defaults to 1):
+
+```
+hp         = T.baseHp + (L-1) * T.hpPerLevel
+minDamage  = T.baseMinDamage + (L-1) * T.damagePerLevel
+maxDamage  = T.baseMaxDamage + (L-1) * T.damagePerLevel
+armor      = T.baseArmor                          (flat, no level scaling)
+xpReward   = T.baseXpReward + (L-1) * T.xpRewardPerLevel
+```
+
+Any explicit per-mob field overrides the computed value from the tier formula.
+
+Tier default values are operator-configurable via `application.yaml` under `ambonMUD.engine.mob.tiers`.
+The built-in defaults are:
+
+| Tier     | baseHp | hpPerLevel | baseMinDmg | baseMaxDmg | dmgPerLevel | baseArmor | baseXp | xpPerLevel |
+|----------|--------|------------|------------|------------|-------------|-----------|--------|------------|
+| weak     | 5      | 2          | 1          | 2          | 0           | 0         | 15     | 5          |
+| standard | 10     | 3          | 1          | 4          | 1           | 0         | 30     | 10         |
+| elite    | 20     | 5          | 2          | 6          | 1           | 1         | 75     | 20         |
+| boss     | 50     | 10         | 3          | 8          | 2           | 3         | 200    | 50         |
+
+**Mob armor** applies as flat damage reduction: `effectiveDamage = max(1, playerRoll - mob.armor)`.
 
 ### `items` map
 
@@ -189,6 +220,11 @@ mobs:
   rat:
     name: "a cave rat"
     room: hall
+  sentinel:
+    name: "a stone sentinel"
+    room: entry
+    tier: elite
+    level: 3
 
 items:
   helm:

--- a/src/main/kotlin/dev/ambon/MudServer.kt
+++ b/src/main/kotlin/dev/ambon/MudServer.kt
@@ -78,7 +78,7 @@ class MudServer(
     private val mobs = MobRegistry()
     private val progression = PlayerProgression(config.progression)
 
-    private val world = WorldFactory.demoWorld(config.world.resources)
+    private val world = WorldFactory.demoWorld(config.world.resources, config.engine.mob.tiers)
     private val tickMillis: Long = config.server.tickMillis
     private val scheduler: Scheduler = Scheduler(clock)
 

--- a/src/main/kotlin/dev/ambon/domain/mob/MobState.kt
+++ b/src/main/kotlin/dev/ambon/domain/mob/MobState.kt
@@ -9,4 +9,8 @@ data class MobState(
     var roomId: RoomId,
     var hp: Int = 10,
     var maxHp: Int = 10,
+    val minDamage: Int = 1,
+    val maxDamage: Int = 4,
+    val armor: Int = 0,
+    val xpReward: Long = 30L,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
@@ -7,4 +7,9 @@ data class MobSpawn(
     val id: MobId,
     val name: String,
     val roomId: RoomId,
+    val maxHp: Int = 10,
+    val minDamage: Int = 1,
+    val maxDamage: Int = 4,
+    val armor: Int = 0,
+    val xpReward: Long = 30L,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/WorldFactory.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/WorldFactory.kt
@@ -1,9 +1,13 @@
 package dev.ambon.domain.world
 
+import dev.ambon.config.MobTiersConfig
 import dev.ambon.domain.world.load.WorldLoader
 
 object WorldFactory {
     private val defaultWorldResources = listOf("world/ambon_hub.yaml", "world/noecker_resume.yaml", "world/demo_ruins.yaml")
 
-    fun demoWorld(resources: List<String> = defaultWorldResources): World = WorldLoader.loadFromResources(resources)
+    fun demoWorld(
+        resources: List<String> = defaultWorldResources,
+        tiers: MobTiersConfig = MobTiersConfig(),
+    ): World = WorldLoader.loadFromResources(resources, tiers)
 }

--- a/src/main/kotlin/dev/ambon/domain/world/data/MobFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/MobFile.kt
@@ -3,4 +3,11 @@ package dev.ambon.domain.world.data
 data class MobFile(
     val name: String,
     val room: String,
+    val tier: String? = null,
+    val level: Int? = null,
+    val hp: Int? = null,
+    val minDamage: Int? = null,
+    val maxDamage: Int? = null,
+    val armor: Int? = null,
+    val xpReward: Long? = null,
 )

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -125,7 +125,16 @@ class GameEngine(
     }
 
     init {
-        world.mobSpawns.forEach { mobs.upsert(MobState(it.id, it.name, it.roomId)) }
+        world.mobSpawns.forEach { spawn ->
+            mobs.upsert(
+                MobState(
+                    id = spawn.id, name = spawn.name, roomId = spawn.roomId,
+                    hp = spawn.maxHp, maxHp = spawn.maxHp,
+                    minDamage = spawn.minDamage, maxDamage = spawn.maxDamage,
+                    armor = spawn.armor, xpReward = spawn.xpReward,
+                ),
+            )
+        }
         items.loadSpawns(world.itemSpawns)
         mobSystem.setCombatChecker(combatSystem::isMobInCombat)
     }
@@ -235,7 +244,14 @@ class GameEngine(
         }
 
         for (spawn in zoneMobSpawns) {
-            mobs.upsert(MobState(spawn.id, spawn.name, spawn.roomId))
+            mobs.upsert(
+                MobState(
+                    id = spawn.id, name = spawn.name, roomId = spawn.roomId,
+                    hp = spawn.maxHp, maxHp = spawn.maxHp,
+                    minDamage = spawn.minDamage, maxDamage = spawn.maxDamage,
+                    armor = spawn.armor, xpReward = spawn.xpReward,
+                ),
+            )
             mobSystem.onMobSpawned(spawn.id)
         }
 

--- a/src/main/kotlin/dev/ambon/engine/PlayerProgression.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerProgression.kt
@@ -83,12 +83,7 @@ class PlayerProgression(
 
     fun defaultKillXpReward(): Long = scaledXp(config.xp.defaultKillXp)
 
-    fun killXpReward(
-        @Suppress("UNUSED_PARAMETER") mob: MobState,
-    ): Long {
-        // Placeholder for future per-mob tuning.
-        return defaultKillXpReward()
-    }
+    fun killXpReward(mob: MobState): Long = scaledXp(mob.xpReward)
 
     fun grantXp(
         player: PlayerState,

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandRouter.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandRouter.kt
@@ -469,7 +469,14 @@ class CommandRouter(
                 val zone = template.id.value.substringBefore(':', template.id.value)
                 val local = template.id.value.substringAfter(':', template.id.value)
                 val newMobId = MobId("$zone:${local}_adm_$seq")
-                mobs.upsert(MobState(id = newMobId, name = template.name, roomId = me.roomId))
+                mobs.upsert(
+                    MobState(
+                        id = newMobId, name = template.name, roomId = me.roomId,
+                        hp = template.maxHp, maxHp = template.maxHp,
+                        minDamage = template.minDamage, maxDamage = template.maxDamage,
+                        armor = template.armor, xpReward = template.xpReward,
+                    ),
+                )
                 outbound.send(OutboundEvent.SendInfo(sessionId, "${template.name} appears."))
                 outbound.send(OutboundEvent.SendPrompt(sessionId))
             }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -26,6 +26,43 @@ ambonMUD:
       maxMovesPerTick: 10
       minWanderDelayMillis: 5000
       maxWanderDelayMillis: 12000
+      tiers:
+        weak:
+          baseHp: 5
+          hpPerLevel: 2
+          baseMinDamage: 1
+          baseMaxDamage: 2
+          damagePerLevel: 0
+          baseArmor: 0
+          baseXpReward: 15
+          xpRewardPerLevel: 5
+        standard:
+          baseHp: 10
+          hpPerLevel: 3
+          baseMinDamage: 1
+          baseMaxDamage: 4
+          damagePerLevel: 1
+          baseArmor: 0
+          baseXpReward: 30
+          xpRewardPerLevel: 10
+        elite:
+          baseHp: 20
+          hpPerLevel: 5
+          baseMinDamage: 2
+          baseMaxDamage: 6
+          damagePerLevel: 1
+          baseArmor: 1
+          baseXpReward: 75
+          xpRewardPerLevel: 20
+        boss:
+          baseHp: 50
+          hpPerLevel: 10
+          baseMinDamage: 3
+          baseMaxDamage: 8
+          damagePerLevel: 2
+          baseArmor: 3
+          baseXpReward: 200
+          xpRewardPerLevel: 50
     combat:
       maxCombatsPerTick: 20
       tickMillis: 1000

--- a/src/test/kotlin/dev/ambon/config/AppConfigLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/config/AppConfigLoaderTest.kt
@@ -34,4 +34,14 @@ class AppConfigLoaderTest {
         val invalid = AppConfig(progression = ProgressionConfig(maxLevel = 0))
         assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
     }
+
+    @Test
+    fun `validated rejects tier with baseHp 0`() {
+        val badTier = MobTierConfig(baseHp = 0)
+        val invalid =
+            AppConfig(
+                engine = EngineConfig(mob = MobEngineConfig(tiers = MobTiersConfig(standard = badTier))),
+            )
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
 }

--- a/src/test/resources/world/bad_mob_bad_level.yaml
+++ b/src/test/resources/world/bad_mob_bad_level.yaml
@@ -1,0 +1,11 @@
+zone: bad_mob_bad_level
+startRoom: room
+mobs:
+  rat:
+    name: "a rat"
+    room: room
+    level: 0
+rooms:
+  room:
+    title: "Room"
+    description: "A plain room."

--- a/src/test/resources/world/bad_mob_damage_range.yaml
+++ b/src/test/resources/world/bad_mob_damage_range.yaml
@@ -1,0 +1,12 @@
+zone: bad_mob_damage_range
+startRoom: room
+mobs:
+  rat:
+    name: "a rat"
+    room: room
+    minDamage: 5
+    maxDamage: 2
+rooms:
+  room:
+    title: "Room"
+    description: "A plain room."

--- a/src/test/resources/world/bad_mob_unknown_tier.yaml
+++ b/src/test/resources/world/bad_mob_unknown_tier.yaml
@@ -1,0 +1,11 @@
+zone: bad_mob_unknown_tier
+startRoom: room
+mobs:
+  monster:
+    name: "a legendary monster"
+    room: room
+    tier: legendary
+rooms:
+  room:
+    title: "Room"
+    description: "A plain room."

--- a/src/test/resources/world/ok_mob_stats.yaml
+++ b/src/test/resources/world/ok_mob_stats.yaml
@@ -1,0 +1,29 @@
+zone: ok_mob_stats
+startRoom: hall
+mobs:
+  rat:
+    name: "a small rat"
+    room: hall
+  bandit:
+    name: "a bandit"
+    room: hall
+    tier: standard
+    level: 3
+  override_mob:
+    name: "a custom mob"
+    room: hall
+    tier: standard
+    level: 1
+    hp: 99
+    minDamage: 5
+    maxDamage: 10
+    armor: 2
+    xpReward: 999
+  boss_mob:
+    name: "the dungeon boss"
+    room: hall
+    tier: boss
+rooms:
+  hall:
+    title: "Hall"
+    description: "A stone hall."


### PR DESCRIPTION
## Summary

- Adds `weak`, `standard`, `elite`, and `boss` tier definitions to `AppConfig` with level-scaled HP, damage, armor, and XP reward defaults; configurable in `application.yaml` under `ambonMUD.engine.mob.tiers`
- `MobFile` gains optional fields (`tier`, `level`, `hp`, `minDamage`, `maxDamage`, `armor`, `xpReward`); `WorldLoader` resolves them at load time via the tier formula, with explicit fields overriding computed values
- `CombatSystem` now uses each mob's own damage range for mob attacks, and applies mob armor as flat player-damage reduction (`max(1, roll - armor)`)
- `PlayerProgression.killXpReward` reads `mob.xpReward` directly instead of the fixed `defaultKillXp`
- `docs/world-zone-yaml-spec.md` updated with new mob fields, tier formula, and armor semantics

## Test plan

- [ ] `./gradlew ktlintCheck test` passes (verified locally)
- [ ] `WorldLoaderTest`: 7 new tests covering standard defaults, tier formula at level 3, explicit stat overrides, boss defaults, unknown tier error, bad level error, bad damage range error
- [ ] `CombatSystemTest`: fixed XP test (added `xpReward = 50L`); 3 new tests for armor min-1, armor flat reduction, and mob using its own damage range
- [ ] `AppConfigLoaderTest`: new test rejecting a tier with `baseHp = 0`
- [ ] Manual smoke test: connect via telnet, `kill rat` — observe varied damage output; after assigning tiers to world mobs, verify elite mobs survive longer than weak ones