### PR TITLE
feat(world): add mob loot tables and replace items.mob placement

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/mob/MobState.kt
+++ b/src/main/kotlin/dev/ambon/domain/mob/MobState.kt
@@ -2,6 +2,7 @@ package dev.ambon.domain.mob
 
 import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.world.MobDrop
 
 data class MobState(
     val id: MobId,
@@ -13,4 +14,5 @@ data class MobState(
     val maxDamage: Int = 4,
     val armor: Int = 0,
     val xpReward: Long = 30L,
+    val drops: List<MobDrop> = emptyList(),
 )

--- a/src/main/kotlin/dev/ambon/domain/world/ItemSpawn.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/ItemSpawn.kt
@@ -1,11 +1,9 @@
 package dev.ambon.domain.world
 
-import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.items.ItemInstance
 
 data class ItemSpawn(
     val instance: ItemInstance,
     val roomId: RoomId? = null,
-    val mobId: MobId? = null,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/MobDrop.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/MobDrop.kt
@@ -1,0 +1,8 @@
+package dev.ambon.domain.world
+
+import dev.ambon.domain.ids.ItemId
+
+data class MobDrop(
+    val itemId: ItemId,
+    val chance: Double,
+)

--- a/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
@@ -12,4 +12,5 @@ data class MobSpawn(
     val maxDamage: Int = 4,
     val armor: Int = 0,
     val xpReward: Long = 30L,
+    val drops: List<MobDrop> = emptyList(),
 )

--- a/src/main/kotlin/dev/ambon/domain/world/data/MobDropFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/MobDropFile.kt
@@ -1,0 +1,6 @@
+package dev.ambon.domain.world.data
+
+data class MobDropFile(
+    val itemId: String,
+    val chance: Double,
+)

--- a/src/main/kotlin/dev/ambon/domain/world/data/MobFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/MobFile.kt
@@ -10,4 +10,5 @@ data class MobFile(
     val maxDamage: Int? = null,
     val armor: Int? = null,
     val xpReward: Long? = null,
+    val drops: List<MobDropFile> = emptyList(),
 )

--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -259,8 +259,18 @@ class CombatSystem(
         mobs.remove(mob.id)
         onMobRemoved(mob.id)
         items.dropMobItemsToRoom(mob.id, mob.roomId)
+        rollDrops(mob)
         broadcastToRoom(mob.roomId, "${mob.name} dies.")
         grantKillXp(killerSessionId, mob)
+    }
+
+    private fun rollDrops(mob: MobState) {
+        for (drop in mob.drops) {
+            if (drop.chance <= 0.0) continue
+            val shouldDrop = drop.chance >= 1.0 || rng.nextDouble() < drop.chance
+            if (!shouldDrop) continue
+            items.placeMobDrop(drop.itemId, mob.roomId)
+        }
     }
 
     private suspend fun grantKillXp(

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -132,6 +132,7 @@ class GameEngine(
                     hp = spawn.maxHp, maxHp = spawn.maxHp,
                     minDamage = spawn.minDamage, maxDamage = spawn.maxDamage,
                     armor = spawn.armor, xpReward = spawn.xpReward,
+                    drops = spawn.drops,
                 ),
             )
         }
@@ -250,6 +251,7 @@ class GameEngine(
                     hp = spawn.maxHp, maxHp = spawn.maxHp,
                     minDamage = spawn.minDamage, maxDamage = spawn.maxDamage,
                     armor = spawn.armor, xpReward = spawn.xpReward,
+                    drops = spawn.drops,
                 ),
             )
             mobSystem.onMobSpawned(spawn.id)

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandRouter.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandRouter.kt
@@ -475,6 +475,7 @@ class CommandRouter(
                         hp = template.maxHp, maxHp = template.maxHp,
                         minDamage = template.minDamage, maxDamage = template.maxDamage,
                         armor = template.armor, xpReward = template.xpReward,
+                        drops = template.drops,
                     ),
                 )
                 outbound.send(OutboundEvent.SendInfo(sessionId, "${template.name} appears."))

--- a/src/main/resources/world/demo_ruins.yaml
+++ b/src/main/resources/world/demo_ruins.yaml
@@ -6,21 +6,36 @@ mobs:
   gate_scout:
     name: "a wary caravan scout"
     room: caravan_gate
+    drops:
+      - itemId: travel_cloak
+        chance: 1.0
   camp_cook:
     name: "a soot-faced camp cook"
     room: campfire_ring
+    drops:
+      - itemId: cook_knife
+        chance: 1.0
   shrine_acolyte:
     name: "a whispering shrine acolyte"
     room: shrine_antechamber
+    drops:
+      - itemId: acolyte_mask
+        chance: 1.0
   beetle_swarm:
     name: "a swarm of glassy beetles"
     room: beetle_grotto
+    drops:
+      - itemId: beetle_shell
+        chance: 1.0
   stone_sentinel:
     name: "a cracked stone sentinel"
     room: cracked_sanctum
   bridge_bandit:
     name: "a bridge bandit"
     room: rope_bridge
+    drops:
+      - itemId: bandit_dagger
+        chance: 1.0
   drowned_warder:
     name: "a drowned warder"
     room: flooded_steps
@@ -30,9 +45,15 @@ mobs:
   archive_scribe:
     name: "a dust-choked archive scribe"
     room: archive_stacks
+    drops:
+      - itemId: archive_key
+        chance: 1.0
   sunken_treasurer:
     name: "a sunken treasurer"
     room: submerged_vault
+    drops:
+      - itemId: pearl_ring
+        chance: 1.0
 
 items:
   brass_lantern:
@@ -47,7 +68,6 @@ items:
     description: "A sturdy cloak patched at the hem. It still repels drizzle."
     slot: body
     constitution: 1
-    mob: gate_scout
 
   iron_pot:
     displayName: "a dented iron pot"
@@ -61,7 +81,6 @@ items:
     description: "Sharp enough to make you careful."
     slot: hand
     damage: 1
-    mob: camp_cook
 
   river_charm:
     displayName: "a braided river charm"
@@ -76,7 +95,6 @@ items:
     description: "A small blade with a chipped tip and a confident grip."
     slot: hand
     damage: 2
-    mob: bridge_bandit
 
   shrine_censer:
     displayName: "a bronze censer"
@@ -90,13 +108,11 @@ items:
     description: "A pale mask with tiny bead eyes. It makes your breath sound far away."
     slot: head
     armor: 1
-    mob: shrine_acolyte
 
   beetle_shell:
     displayName: "a beetle shell shard"
     keyword: "shell"
     description: "A shard of iridescent shell that catches light like broken glass."
-    mob: beetle_swarm
 
   sentinel_tablet:
     displayName: "a cracked stone tablet"
@@ -116,7 +132,6 @@ items:
     displayName: "a thin iron key"
     keyword: "key"
     description: "A narrow key with an odd, asymmetrical tooth pattern."
-    mob: archive_scribe
 
   scribe_quill:
     displayName: "a brittle quill"
@@ -130,7 +145,6 @@ items:
     description: "A band set with a cloudy pearl. It gleams faintly when wet."
     slot: hand
     constitution: 2
-    mob: sunken_treasurer
 
   vault_mace:
     displayName: "a silt-caked ceremonial mace"

--- a/src/test/kotlin/dev/ambon/engine/items/ItemRegistryTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/items/ItemRegistryTest.kt
@@ -48,6 +48,34 @@ class ItemRegistryTest {
         assertFalse(itemIds.contains("demo:lantern"))
     }
 
+    @Test
+    fun `placeMobDrop instantiates template item into room`() {
+        val registry = ItemRegistry()
+        val roomId = RoomId("demo:trailhead")
+        val itemId = ItemId("demo:coin")
+        registry.loadSpawns(
+            listOf(
+                ItemSpawn(
+                    instance = instance("demo:coin", "coin", "a silver coin"),
+                ),
+            ),
+        )
+
+        val dropped = registry.placeMobDrop(itemId, roomId)
+
+        assertNotNull(dropped)
+        val roomItems = registry.itemsInRoom(roomId)
+        assertEquals(1, roomItems.size)
+        assertEquals("demo:coin", roomItems.single().id.value)
+    }
+
+    @Test
+    fun `placeMobDrop returns null when item template is missing`() {
+        val registry = ItemRegistry()
+        val dropped = registry.placeMobDrop(ItemId("demo:missing"), RoomId("demo:room"))
+        assertNull(dropped)
+    }
+
     // --- Substring fallback tests ---
 
     @Test

--- a/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
@@ -1,6 +1,5 @@
 package dev.ambon.domain.world.load
 
-import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.items.ItemSlot
 import dev.ambon.domain.world.Direction
@@ -45,6 +44,9 @@ class WorldLoaderTest {
         assertEquals(4, mob.maxDamage)
         assertEquals(0, mob.armor)
         assertEquals(30L, mob.xpReward)
+        assertEquals(1, mob.drops.size)
+        assertEquals("ok_small:tooth", mob.drops.single().itemId.value)
+        assertEquals(1.0, mob.drops.single().chance)
     }
 
     @Test
@@ -65,17 +67,14 @@ class WorldLoaderTest {
         assertEquals("coin", coin.instance.item.keyword)
         assertEquals("a silver coin", coin.instance.item.displayName)
         assertEquals(RoomId("ok_small:a"), coin.roomId)
-        assertTrue(coin.mobId == null)
 
         val tooth = items.getValue("ok_small:tooth")
         assertEquals("tooth", tooth.instance.item.keyword)
-        assertEquals(MobId("ok_small:rat"), tooth.mobId)
         assertTrue(tooth.roomId == null)
 
         val sigil = items.getValue("ok_small:sigil")
         assertEquals("sigil", sigil.instance.item.keyword)
         assertTrue(sigil.roomId == null)
-        assertTrue(sigil.mobId == null)
     }
 
     @Test
@@ -162,13 +161,13 @@ class WorldLoaderTest {
     }
 
     @Test
-    fun `fails when an item starts in a missing mob`() {
+    fun `fails when an item uses deprecated mob placement`() {
         val ex =
             assertThrows(WorldLoadException::class.java) {
                 WorldLoader.loadFromResource("world/bad_item_missing_mob.yaml")
             }
-        assertTrue(ex.message!!.contains("starts in missing mob", ignoreCase = true), "Got: ${ex.message}")
-        assertTrue(ex.message!!.contains("items.", ignoreCase = true), "Got: ${ex.message}")
+        assertTrue(ex.message!!.contains("deprecated", ignoreCase = true), "Got: ${ex.message}")
+        assertTrue(ex.message!!.contains("drops", ignoreCase = true), "Got: ${ex.message}")
     }
 
     @Test
@@ -287,6 +286,24 @@ class WorldLoaderTest {
                 WorldLoader.loadFromResource("world/bad_mob_damage_range.yaml")
             }
         assertTrue(ex.message!!.contains("maxDamage", ignoreCase = true), "Got: ${ex.message}")
+    }
+
+    @Test
+    fun `fails when mob drop chance is out of range`() {
+        val ex =
+            assertThrows(WorldLoadException::class.java) {
+                WorldLoader.loadFromResource("world/bad_mob_drop_chance.yaml")
+            }
+        assertTrue(ex.message!!.contains("chance", ignoreCase = true), "Got: ${ex.message}")
+    }
+
+    @Test
+    fun `fails when mob drop references missing item`() {
+        val ex =
+            assertThrows(WorldLoadException::class.java) {
+                WorldLoader.loadFromResource("world/bad_mob_drop_missing_item.yaml")
+            }
+        assertTrue(ex.message!!.contains("missing item", ignoreCase = true), "Got: ${ex.message}")
     }
 
     class MultiZoneWorldLoaderTest {

--- a/src/test/resources/world/bad_mob_drop_chance.yaml
+++ b/src/test/resources/world/bad_mob_drop_chance.yaml
@@ -1,0 +1,16 @@
+zone: bad_mob_drop_chance
+startRoom: hall
+mobs:
+  rat:
+    name: "a small rat"
+    room: hall
+    drops:
+      - itemId: tooth
+        chance: 1.2
+items:
+  tooth:
+    displayName: "a rat tooth"
+rooms:
+  hall:
+    title: "Hall"
+    description: "A stone hall."

--- a/src/test/resources/world/bad_mob_drop_missing_item.yaml
+++ b/src/test/resources/world/bad_mob_drop_missing_item.yaml
@@ -1,0 +1,16 @@
+zone: bad_mob_drop_missing_item
+startRoom: hall
+mobs:
+  rat:
+    name: "a small rat"
+    room: hall
+    drops:
+      - itemId: missing_tooth
+        chance: 0.5
+items:
+  tooth:
+    displayName: "a rat tooth"
+rooms:
+  hall:
+    title: "Hall"
+    description: "A stone hall."

--- a/src/test/resources/world/ok_small.yaml
+++ b/src/test/resources/world/ok_small.yaml
@@ -5,13 +5,15 @@ mobs:
   rat:
     name: "a small rat"
     room: b
+    drops:
+      - itemId: tooth
+        chance: 1.0
 items:
   coin:
     displayName: "a silver coin"
     room: a
   tooth:
     displayName: "a rat tooth"
-    mob: rat
   sigil:
     displayName: "a chalk sigil"
 rooms:


### PR DESCRIPTION
## Summary

This PR adds loot tables for mobs and removes the old static `items.<id>.mob` placement pattern.

Mobs can now define probabilistic drops directly in zone YAML:

```yaml
mobs:
  bandit:
    name: "a bridge bandit"
    room: rope_bridge
    drops:
      - itemId: bandit_dagger
        chance: 0.3
Why
Static mob-carried items made loot deterministic and limited kill rewards to XP + guaranteed items.
This introduces standard MUD-style kill excitement through per-drop roll chances.
Changes
•
Added drop schema/model support:
◦
MobDropFile (YAML data model)
◦
MobDrop (runtime model)
◦
drops added to MobFile, MobSpawn, and MobState
•
World loader updates:
◦
parses/normalizes mobs.*.drops.*.itemId
◦
validates chance is in [0.0, 1.0]
◦
validates dropped item references resolve to existing items
◦
rejects deprecated items.*.mob usage with migration guidance
•
Runtime/item updates:
◦
removed ItemSpawn.mobId
◦
added ItemRegistry.placeMobDrop(itemId, roomId) from item templates
•
Combat updates:
◦
added drop rolling on mob death (rollDrops)
◦
successful drops are placed in the death room
•
Engine wiring:
◦
mob drops are preserved on initial spawn, zone reset respawn, and admin spawn
•
Content migration:
◦
updated demo_ruins.yaml and ok_small.yaml to mobs.*.drops with chance: 1.0 for previous guaranteed drops
•
Docs:
◦
updated docs/world-zone-yaml-spec.md
Breaking / Migration Notes
•
items.<id>.mob is no longer supported.
•
Existing content must move mob loot to mobs.<id>.drops.
•
Equivalent migration for guaranteed loot is chance: 1.0.
Testing
Executed:
•
.\gradlew.bat ktlintCheck test
Added/updated tests for:
•
loader validation for bad drop chance
•
loader validation for missing drop item reference
•
deprecated items.*.mob rejection
•
combat guaranteed/zero-chance drop behavior
•
registry placeMobDrop behavior