### PR TITLE
Combat feedback improvements: roll/mitigation summaries with config toggles (#71)

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -54,6 +54,9 @@ data class AppConfig(
         require(engine.combat.maxDamage >= engine.combat.minDamage) {
             "ambonMUD.engine.combat.maxDamage must be >= minDamage"
         }
+        require(!engine.combat.feedback.roomBroadcastEnabled || engine.combat.feedback.enabled) {
+            "ambonMUD.engine.combat.feedback.roomBroadcastEnabled requires feedback.enabled=true"
+        }
 
         require(engine.regen.maxPlayersPerTick > 0) { "ambonMUD.engine.regen.maxPlayersPerTick must be > 0" }
         require(engine.regen.baseIntervalMillis > 0L) { "ambonMUD.engine.regen.baseIntervalMillis must be > 0" }
@@ -221,6 +224,12 @@ data class CombatEngineConfig(
     val tickMillis: Long = 1_000L,
     val minDamage: Int = 1,
     val maxDamage: Int = 4,
+    val feedback: CombatFeedbackConfig = CombatFeedbackConfig(),
+)
+
+data class CombatFeedbackConfig(
+    val enabled: Boolean = false,
+    val roomBroadcastEnabled: Boolean = false,
 )
 
 data class RegenEngineConfig(

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -68,6 +68,8 @@ class GameEngine(
             tickMillis = engineConfig.combat.tickMillis,
             minDamage = engineConfig.combat.minDamage,
             maxDamage = engineConfig.combat.maxDamage,
+            detailedFeedbackEnabled = engineConfig.combat.feedback.enabled,
+            detailedFeedbackRoomBroadcastEnabled = engineConfig.combat.feedback.roomBroadcastEnabled,
             onMobRemoved = mobSystem::onMobRemoved,
             progression = progression,
             metrics = metrics,

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -68,6 +68,9 @@ ambonMUD:
       tickMillis: 1000
       minDamage: 1
       maxDamage: 4
+      feedback:
+        enabled: true
+        roomBroadcastEnabled: false
     regen:
       maxPlayersPerTick: 50
       baseIntervalMillis: 5000

--- a/src/test/kotlin/dev/ambon/config/AppConfigLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/config/AppConfigLoaderTest.kt
@@ -44,4 +44,19 @@ class AppConfigLoaderTest {
             )
         assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
     }
+
+    @Test
+    fun `validated rejects combat room feedback when feedback is disabled`() {
+        val invalid =
+            AppConfig(
+                engine =
+                    EngineConfig(
+                        combat =
+                            CombatEngineConfig(
+                                feedback = CombatFeedbackConfig(enabled = false, roomBroadcastEnabled = true),
+                            ),
+                    ),
+            )
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
 }


### PR DESCRIPTION
## Summary
Implements #71 by adding compact combat feedback that shows:
- damage roll summary
- armor mitigation summary
- min-damage clamp note when applicable

This is now toggleable via config and applies to both player and mob hit messages.

## Changes
- Added combat feedback config:
    - `ambonMUD.engine.combat.feedback.enabled`
    - `ambonMUD.engine.combat.feedback.roomBroadcastEnabled`
- Added config validation to prevent `roomBroadcastEnabled=true` when `enabled=false`.
- Wired feedback config from `AppConfig` -> `GameEngine` -> `CombatSystem`.
- Updated combat hit messages to include compact detail when enabled.
- Added optional room observer broadcast of detailed combat lines (off by default).
- Added/updated tests in:
    - `CombatSystemTest`
    - `AppConfigLoaderTest`

## Default behavior
In `application.yaml`:
- `feedback.enabled: true`
- `feedback.roomBroadcastEnabled: false`

So detailed feedback is visible to the fighting player by default, while room bystanders do not see it.

## Verification
- Ran `.\gradlew.bat ktlintCheck test`
- Result: PASS

## Notes
- Combat mechanics were not changed; only feedback output and config wiring were added.
- Includes regression coverage for the new toggles and message formatting