### PR TITLE
docs: update all documentation for Phases 1–3 scalability refactor

### DIFF
--- a/docs/scalability-plan-brainstorm.md
+++ b/docs/scalability-plan-brainstorm.md
@@ -30,7 +30,7 @@ Clients (telnet/WS)                     Clients (telnet/WS)
 
 ---
 
-## Phase 1: Abstract the Event Transport Layer
+## Phase 1: Abstract the Event Transport Layer ✅ IMPLEMENTED
 
 **Goal:** Extract `EventBus` interfaces to replace direct `Channel` usage, creating the seam for future gRPC swap. Also abstract session ID allocation.
 
@@ -71,7 +71,7 @@ Clients (telnet/WS)                     Clients (telnet/WS)
 
 ---
 
-## Phase 2: Async Persistence Worker
+## Phase 2: Async Persistence Worker ✅ IMPLEMENTED
 
 **Goal:** Move player saves off the engine tick into a background worker. Write-behind with dirty-flag coalescing.
 
@@ -118,9 +118,16 @@ Reads (`findByName`, `findById`) must stay synchronous for login flow. Only writ
 
 ---
 
-## Phase 3: Redis Integration
+## Phase 3: Redis Integration ✅ IMPLEMENTED
 
 **Goal:** Add Redis as cache + pub/sub bus. YAML stays durable. Redis is opt-in (`enabled: false` default).
+
+> **Implementation notes (actual vs plan):**
+> - `RedisCachingPlayerRepository` wraps the coalescing repo (not YAML directly as originally sketched)
+> - Key scheme uses `player:id:<id>` instead of a hash (`player:<playerId>`) — JSON string, not Redis hash
+> - Bus is split into `RedisInboundBus` / `RedisOutboundBus` (separate from a monolithic `RedisPubSubBus`)
+> - `RedisSessionRegistry` was deferred to Phase 4 (not yet needed in single-engine mode)
+> - `instanceId` is UUID auto-generated if not set in config
 
 ### New files
 
@@ -164,7 +171,7 @@ implementation("io.lettuce:lettuce-core:6.3.2.RELEASE")
 
 ---
 
-## Phase 4: gRPC Gateway Split
+## Phase 4: gRPC Gateway Split 🔲 PLANNED
 
 **Goal:** Split into Gateway (transports + routing) and Engine (game logic + persistence) processes, communicating via gRPC bidirectional streaming.
 


### PR DESCRIPTION
## Summary

- **README**: rewrote Current State, expanded Commands (score + all admin), added persistence stack section, replaced Out-of-Scope with a Scalability Roadmap table, documented Redis config
- **CLAUDE.md**: added `bus/`, `redis/`, `session/`, `metrics/` to Key Locations; updated architecture diagram to show bus layer; expanded Change Playbooks with admin, persistence chain, and Redis guidance
- **AGENTS.md**: added new packages to Project Map; added event bus boundary contract; expanded persistence/admin/Redis change playbooks
- **docs/onboarding.md**: added four new sections (Event Bus System, Redis Integration, Metrics & Observability, Staff/Admin System); updated project layout, `MobState`/`PlayerRecord` fields, config table, and test coverage map; renumbered all sections
- **DesignDecisions.md**: updated decision #7 (persistence phasing), added decisions #10–12 (bus abstraction, write-behind worker, Redis opt-in)
- **docs/scalability-plan-brainstorm.md**: marked Phases 1–3 as ✅ implemented with Phase 3 implementation notes; marked Phase 4 as 🔲 planned

## Test plan

- [ ] Review each doc for accuracy against the current codebase
- [ ] Verify all cross-references between docs are consistent
- [ ] Confirm no outdated "out of scope" or missing feature callouts remain