### PR TITLE
feat(metrics): expose Prometheus scrape endpoint in ENGINE mode

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -108,6 +108,9 @@ data class AppConfig(
         require(observability.metricsEndpoint.startsWith("/")) {
             "ambonMUD.observability.metricsEndpoint must start with '/'"
         }
+        require(observability.metricsHttpPort in 1..65535) {
+            "ambonMUD.observability.metricsHttpPort must be between 1 and 65535"
+        }
 
         if (redis.enabled) {
             require(redis.uri.isNotBlank()) { "ambonMUD.redis.uri must be non-blank when redis.enabled=true" }
@@ -308,6 +311,7 @@ data class DemoConfig(
 data class ObservabilityConfig(
     val metricsEnabled: Boolean = true,
     val metricsEndpoint: String = "/metrics",
+    val metricsHttpPort: Int = 9090,
     val staticTags: Map<String, String> = emptyMap(),
 )
 

--- a/src/main/kotlin/dev/ambon/metrics/MetricsHttpServer.kt
+++ b/src/main/kotlin/dev/ambon/metrics/MetricsHttpServer.kt
@@ -1,0 +1,50 @@
+package dev.ambon.metrics
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.http.ContentType
+import io.ktor.server.application.Application
+import io.ktor.server.application.call
+import io.ktor.server.engine.ApplicationEngine
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+
+private val log = KotlinLogging.logger {}
+
+class MetricsHttpServer(
+    private val port: Int,
+    private val registry: PrometheusMeterRegistry,
+    private val endpoint: String = "/metrics",
+) {
+    private var engine: ApplicationEngine? = null
+
+    fun start() {
+        engine =
+            embeddedServer(Netty, port = port) {
+                metricsModule(registry, endpoint)
+            }.start(wait = false)
+        log.info { "Metrics HTTP server started on port $port (endpoint=$endpoint)" }
+    }
+
+    fun stop() {
+        engine?.stop(gracePeriodMillis = 0, timeoutMillis = 1_000)
+        engine = null
+    }
+}
+
+internal fun Application.metricsModule(
+    registry: PrometheusMeterRegistry,
+    endpoint: String = "/metrics",
+) {
+    routing {
+        get(endpoint) {
+            call.respondText(
+                contentType = ContentType.parse("text/plain; version=0.0.4; charset=utf-8"),
+                text = registry.scrape(),
+            )
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -124,6 +124,7 @@ ambonMUD:
   observability:
     metricsEnabled: true
     metricsEndpoint: "/metrics"
+    metricsHttpPort: 9090
     staticTags: {}
 
   logging:

--- a/src/test/kotlin/dev/ambon/metrics/MetricsHttpServerTest.kt
+++ b/src/test/kotlin/dev/ambon/metrics/MetricsHttpServerTest.kt
@@ -1,0 +1,52 @@
+package dev.ambon.metrics
+
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import io.micrometer.prometheusmetrics.PrometheusConfig
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class MetricsHttpServerTest {
+    @Test
+    fun `GET metrics returns 200 with prometheus text format`(): Unit =
+        runBlocking {
+            val registry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+            registry.counter("test_counter").increment()
+
+            testApplication {
+                application {
+                    metricsModule(registry, "/metrics")
+                }
+
+                val response = client.get("/metrics")
+                assertEquals(HttpStatusCode.OK, response.status)
+                val body = response.bodyAsText()
+                assertTrue(body.contains("# HELP"), "Expected Prometheus HELP comments in body")
+            }
+        }
+
+    @Test
+    fun `GET metrics returns text-plain content type`(): Unit =
+        runBlocking {
+            val registry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+            registry.counter("test_counter").increment()
+
+            testApplication {
+                application {
+                    metricsModule(registry, "/metrics")
+                }
+
+                val response = client.get("/metrics")
+                assertEquals(HttpStatusCode.OK, response.status)
+                assertTrue(
+                    response.headers["Content-Type"]?.contains("text/plain") == true,
+                    "Expected text/plain content type",
+                )
+            }
+        }
+}


### PR DESCRIPTION
## Summary

- Adds `MetricsHttpServer` — a lightweight Ktor/Netty HTTP server that serves the Prometheus scrape endpoint in ENGINE mode, where no WebSocket transport (and thus no existing Ktor server) is present
- Wires it into `EngineServer`: started after gRPC when `metricsEnabled=true`, stopped gracefully on shutdown
- Adds `metricsHttpPort: Int = 9090` to `ObservabilityConfig` with port-range validation, and updates `application.yaml`
- Extracts a testable `Application.metricsModule()` extension function (same response logic as `KtorWebSocketTransport`)

## Test plan

- [x] `MetricsHttpServerTest` — GET `/metrics` returns 200 with `# HELP` content and `text/plain` Content-Type (via `testApplication` + `metricsModule`)
- [x] `./gradlew ktlintCheck test` — all passing