### PR TITLE
feat(session): harden Snowflake IDs — overflow WAIT, clock rollback floor, Redis gateway lease (#87)

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -125,6 +125,9 @@ data class AppConfig(
             require(grpc.client.engineHost.isNotBlank()) { "ambonMUD.grpc.client.engineHost must be non-blank in gateway mode" }
             require(grpc.client.enginePort in 1..65535) { "ambonMUD.grpc.client.enginePort must be between 1 and 65535" }
             require(gateway.id in 0..0xFFFF) { "ambonMUD.gateway.id must be between 0 and 65535" }
+            require(gateway.snowflake.idLeaseTtlSeconds > 0L) {
+                "ambonMUD.gateway.snowflake.idLeaseTtlSeconds must be > 0"
+            }
         }
 
         return this
@@ -334,10 +337,17 @@ data class GrpcConfig(
     val client: GrpcClientConfig = GrpcClientConfig(),
 )
 
+/** Snowflake session-ID hardening settings (used by GATEWAY mode). */
+data class SnowflakeConfig(
+    /** TTL in seconds for the Redis gateway-ID exclusive lease. */
+    val idLeaseTtlSeconds: Long = 300L,
+)
+
 /** Gateway-specific settings. */
 data class GatewayConfig(
     /** 16-bit gateway ID for [SnowflakeSessionIdFactory] bit-field (0–65535). */
     val id: Int = 0,
+    val snowflake: SnowflakeConfig = SnowflakeConfig(),
 )
 
 data class RedisBusConfig(

--- a/src/main/kotlin/dev/ambon/metrics/GameMetrics.kt
+++ b/src/main/kotlin/dev/ambon/metrics/GameMetrics.kt
@@ -103,6 +103,11 @@ class GameMetrics(
     private val playerSavesCounter = Counter.builder("player_saves_total").register(registry)
     private val playerSaveFailuresCounter = Counter.builder("player_save_failures_total").register(registry)
 
+    private val sessionIdSequenceOverflowCounter =
+        Counter.builder("session_id_sequence_overflow_total").register(registry)
+    private val sessionIdClockRollbackCounter =
+        Counter.builder("session_id_clock_rollback_total").register(registry)
+
     fun onTelnetConnected() {
         telnetConnectedCounter.increment()
         sessionsOnlineCount.incrementAndGet()
@@ -186,6 +191,10 @@ class GameMetrics(
     fun onPlayerSave() = playerSavesCounter.increment()
 
     fun onPlayerSaveFailure() = playerSaveFailuresCounter.increment()
+
+    fun onSessionIdSequenceOverflow() = sessionIdSequenceOverflowCounter.increment()
+
+    fun onSessionIdClockRollback() = sessionIdClockRollbackCounter.increment()
 
     fun bindPlayerRegistry(supplier: () -> Int) {
         Gauge.builder("players_online") { supplier().toDouble() }.register(registry)

--- a/src/main/kotlin/dev/ambon/session/GatewayIdLeaseManager.kt
+++ b/src/main/kotlin/dev/ambon/session/GatewayIdLeaseManager.kt
@@ -1,0 +1,38 @@
+package dev.ambon.session
+
+/**
+ * Manages an exclusive Redis lease for a gateway ID to detect duplicate gateway deployments.
+ *
+ * Uses a SET NX EX key to claim ownership.  All Redis interactions are injected as functional
+ * parameters so the class is testable without Mockito or a live Redis instance.
+ *
+ * @param gatewayId     The numeric gateway ID being leased (used as part of the Redis key).
+ * @param instanceId    Unique identifier for this gateway instance (stored as the lease value).
+ * @param leaseTtlSeconds TTL for the Redis key so stale leases expire automatically.
+ * @param setNxEx       `SET key value NX EX ttl` — returns `true` if the key was set (acquired).
+ * @param getValue      `GET key` — returns the current value, or `null` if the key does not exist.
+ * @param deleteKey     `DEL key` — unconditionally deletes the key.
+ */
+class GatewayIdLeaseManager(
+    gatewayId: Int,
+    private val instanceId: String,
+    private val leaseTtlSeconds: Long,
+    private val setNxEx: (key: String, value: String, ttl: Long) -> Boolean,
+    private val getValue: (key: String) -> String?,
+    private val deleteKey: (key: String) -> Unit,
+) {
+    private val leaseKey = "gateway:lock:$gatewayId"
+
+    /** Attempts to acquire the lease.  Returns `true` if this instance now holds it. */
+    fun tryAcquire(): Boolean = setNxEx(leaseKey, instanceId, leaseTtlSeconds)
+
+    /** Releases the lease only if this instance still owns it. */
+    fun release() {
+        if (getValue(leaseKey) == instanceId) {
+            deleteKey(leaseKey)
+        }
+    }
+
+    /** Returns the current leaseholder's instance ID, or `null` if the key is not set. */
+    fun currentOwner(): String? = getValue(leaseKey)
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,6 +10,8 @@ ambonMUD:
 
   gateway:
     id: 0
+    snowflake:
+      idLeaseTtlSeconds: 300
 
   server:
     telnetPort: 4000

--- a/src/test/kotlin/dev/ambon/session/GatewayIdLeaseManagerTest.kt
+++ b/src/test/kotlin/dev/ambon/session/GatewayIdLeaseManagerTest.kt
@@ -1,0 +1,77 @@
+package dev.ambon.session
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class GatewayIdLeaseManagerTest {
+    /** In-memory Redis stand-in: simple mutable map with SET NX EX semantics. */
+    private fun buildStore(): MutableMap<String, String> = mutableMapOf()
+
+    private fun leaseManager(
+        store: MutableMap<String, String>,
+        instanceId: String,
+        gatewayId: Int = 1,
+        ttl: Long = 300L,
+    ) = GatewayIdLeaseManager(
+        gatewayId = gatewayId,
+        instanceId = instanceId,
+        leaseTtlSeconds = ttl,
+        setNxEx = { key, value, _ ->
+            if (store.containsKey(key)) {
+                false
+            } else {
+                store[key] = value
+                true
+            }
+        },
+        getValue = { key -> store[key] },
+        deleteKey = { key -> store.remove(key) },
+    )
+
+    @Test
+    fun `acquire succeeds when key is unset`() {
+        val store = buildStore()
+        val mgr = leaseManager(store, instanceId = "instance-A")
+
+        assertTrue(mgr.tryAcquire(), "tryAcquire() must return true when key is free")
+        assertEquals("instance-A", mgr.currentOwner(), "currentOwner() must return this instance's ID")
+    }
+
+    @Test
+    fun `acquire fails when key is already held by another instance`() {
+        val store = buildStore()
+        val mgrA = leaseManager(store, instanceId = "instance-A")
+        val mgrB = leaseManager(store, instanceId = "instance-B")
+
+        mgrA.tryAcquire()
+
+        assertFalse(mgrB.tryAcquire(), "tryAcquire() must return false when key is already held")
+        assertEquals("instance-A", mgrB.currentOwner(), "currentOwner() must return the other instance's ID")
+    }
+
+    @Test
+    fun `release deletes key when this instance owns it`() {
+        val store = buildStore()
+        val mgr = leaseManager(store, instanceId = "instance-A")
+
+        mgr.tryAcquire()
+        mgr.release()
+
+        assertNull(mgr.currentOwner(), "After release the key must not exist")
+    }
+
+    @Test
+    fun `release does not delete key when owned by a different instance`() {
+        val store = buildStore()
+        val mgrA = leaseManager(store, instanceId = "instance-A")
+        val mgrB = leaseManager(store, instanceId = "instance-B")
+
+        mgrA.tryAcquire() // A holds the lease
+        mgrB.release() // B tries to release — must be a no-op
+
+        assertEquals("instance-A", mgrA.currentOwner(), "Key must still exist and be owned by A")
+    }
+}

--- a/src/test/kotlin/dev/ambon/session/SnowflakeSessionIdFactoryTest.kt
+++ b/src/test/kotlin/dev/ambon/session/SnowflakeSessionIdFactoryTest.kt
@@ -5,6 +5,10 @@ import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 
 class SnowflakeSessionIdFactoryTest {
     @Test
@@ -76,5 +80,107 @@ class SnowflakeSessionIdFactoryTest {
         val factory: SessionIdFactory = SnowflakeSessionIdFactory(gatewayId = 5)
         val id = factory.allocate()
         assertTrue(id.value != 0L)
+    }
+
+    // -------------------------------------------------------------------------
+    // New hardening tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `clock rollback applies monotonic floor`() {
+        val clock = AtomicLong(100L)
+        val factory = SnowflakeSessionIdFactory(gatewayId = 1, clockSeconds = { clock.get() })
+
+        val idBefore = factory.allocate().value
+        val tsBefore = (idBefore ushr 16) and 0xFFFFFFFFL
+
+        // Roll the clock back by 5 seconds
+        clock.set(95L)
+        val idAfter = factory.allocate().value
+        val tsAfter = (idAfter ushr 16) and 0xFFFFFFFFL
+
+        assertEquals(tsBefore, tsAfter, "Timestamp bits must not decrease on clock rollback")
+        assertNotEquals(idBefore, idAfter, "IDs must still be unique after clock rollback")
+    }
+
+    @Test
+    fun `clock rollback fires callback exactly once per rollback event`() {
+        val clock = AtomicLong(100L)
+        val rollbackCount = AtomicInteger(0)
+        val factory =
+            SnowflakeSessionIdFactory(
+                gatewayId = 1,
+                clockSeconds = { clock.get() },
+                onClockRollback = { rollbackCount.incrementAndGet() },
+            )
+
+        factory.allocate() // second=100, seq=0
+        clock.set(99L) // rollback
+        factory.allocate() // should fire callback once
+        clock.set(98L) // another rollback
+        factory.allocate() // should fire callback again
+
+        assertEquals(2, rollbackCount.get(), "Callback must fire once per rollback-detected allocate()")
+    }
+
+    @Test
+    fun `sequence overflow waits then resumes with new timestamp`() {
+        val clock = AtomicLong(0L)
+        val factory = SnowflakeSessionIdFactory(gatewayId = 1, clockSeconds = { clock.get() })
+
+        // Fill the sequence for second 0 (seq 0..65535 = 65536 allocations)
+        repeat(65536) { factory.allocate() }
+
+        // 65537th call will overflow. Advance the clock from a background thread after a short delay.
+        val future =
+            CompletableFuture.supplyAsync {
+                factory.allocate()
+            }
+        Thread.sleep(15) // give the factory time to enter the wait loop
+        clock.set(1L) // advance the clock to unblock the wait
+
+        val id = future.get(2, TimeUnit.SECONDS)
+        val ts = (id.value ushr 16) and 0xFFFFFFFFL
+        val seq = id.value and 0xFFFFL
+
+        assertEquals(1L, ts, "ID after overflow must carry the new timestamp second")
+        assertEquals(0L, seq, "Sequence must reset to 0 after clock advances")
+    }
+
+    @Test
+    fun `sequence overflow fires callback`() {
+        val clock = AtomicLong(0L)
+        val overflowCount = AtomicInteger(0)
+        val factory =
+            SnowflakeSessionIdFactory(
+                gatewayId = 1,
+                clockSeconds = { clock.get() },
+                onSequenceOverflow = { overflowCount.incrementAndGet() },
+            )
+
+        // Fill the sequence
+        repeat(65536) { factory.allocate() }
+
+        // Trigger overflow in a background thread
+        val future = CompletableFuture.supplyAsync { factory.allocate() }
+        Thread.sleep(15)
+        clock.set(1L)
+        future.get(2, TimeUnit.SECONDS)
+
+        assertEquals(1, overflowCount.get(), "Overflow callback must fire exactly once")
+    }
+
+    @Test
+    fun `sustained high allocation produces no collisions across clock boundaries`() {
+        val clock = AtomicLong(1_000L)
+        val factory = SnowflakeSessionIdFactory(gatewayId = 7, clockSeconds = { clock.get() })
+
+        val ids = mutableSetOf<Long>()
+        repeat(200_000) { i ->
+            // Advance clock every 65536 allocations to keep sequence from exhausting
+            if (i > 0 && i % 65536 == 0) clock.incrementAndGet()
+            val id = factory.allocate().value
+            assertTrue(ids.add(id), "Duplicate ID detected at allocation $i: $id")
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **Sequence overflow (WAIT policy):** `SnowflakeSessionIdFactory` now blocks via `Object.wait(1)` in a loop when all 65 536 sequence slots in a second are exhausted, instead of silently wrapping and producing duplicate IDs. Resumes as soon as the clock second advances.
- **Clock rollback (MONOTONIC_FLOOR policy):** backward clock movement no longer re-enters old timestamp buckets; `lastSecond` is kept as a monotonic floor and the sequence continues incrementing.
- **Duplicate gateway-ID detection:** new `GatewayIdLeaseManager` acquires a Redis `SET NX EX` lease at gateway startup; a second gateway with the same ID fails fast with `IllegalStateException`. Gracefully degrades to a WARN log when Redis is unavailable.
- **Metrics:** `session_id_sequence_overflow_total` and `session_id_clock_rollback_total` Prometheus counters added to `GameMetrics`.
- **Config:** `ambonMUD.gateway.snowflake.idLeaseTtlSeconds` (default `300`) controls the Redis lease TTL; validated when `mode=GATEWAY`.

## Test plan

- [x] `SnowflakeSessionIdFactoryTest` — 5 new cases: rollback floor, rollback callback, overflow wait/resume with new timestamp, overflow callback, 200 K no-collision across clock boundaries
- [x] `GatewayIdLeaseManagerTest` — 4 cases using an in-memory map (no Mockito, no live Redis): acquire free key, acquire contested key, release owned key, release unowned key
- [x] `./gradlew ktlintCheck test` passes clean