### PR TITLE
chore: bump Ktor 3, ktlint 14, JUnit 6, Gradle 9

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     kotlin("jvm") version "2.3.10"
     application
-    id("org.jlleitschuh.gradle.ktlint") version "12.1.1"
+    id("org.jlleitschuh.gradle.ktlint") version "14.0.1"
     id("com.google.protobuf") version "0.9.6"
 }
 
@@ -12,7 +12,7 @@ repositories {
     mavenCentral()
 }
 
-val ktorVersion = "2.3.12"
+val ktorVersion = "3.4.0"
 val hopliteVersion = "2.9.0"
 val micrometerVersion = "1.16.3"
 val grpcVersion = "1.79.0"
@@ -62,7 +62,8 @@ dependencies {
     testImplementation("io.grpc:grpc-testing:$grpcVersion")
     testImplementation("io.grpc:grpc-inprocess:$grpcVersion")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
-    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testImplementation("org.junit.jupiter:junit-jupiter:6.0.3")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("io.ktor:ktor-server-test-host-jvm:$ktorVersion")
     testImplementation("io.ktor:ktor-client-cio-jvm:$ktorVersion")
     testImplementation("io.ktor:ktor-client-websockets-jvm:$ktorVersion")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Jan 23 16:56:41 EST 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/dev/ambon/MudServer.kt
+++ b/src/main/kotlin/dev/ambon/MudServer.kt
@@ -134,7 +134,8 @@ class MudServer(
     private val playerRepo = coalescingRepo ?: l2Repo
 
     private val instanceId: String =
-        config.redis.bus.instanceId.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
+        config.redis.bus.instanceId
+            .takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
 
     private val inbound: InboundBus =
         if (config.redis.enabled && config.redis.bus.enabled && redisManager != null) {
@@ -171,7 +172,11 @@ class MudServer(
     private val progression = PlayerProgression(config.progression)
     private val shardingEnabled = config.sharding.enabled
     private val engineId = config.sharding.engineId
-    private val configuredShardedZones = config.sharding.zones.map(String::trim).filter { it.isNotEmpty() }.toSet()
+    private val configuredShardedZones =
+        config.sharding.zones
+            .map(String::trim)
+            .filter { it.isNotEmpty() }
+            .toSet()
     private val zoneFilter =
         if (shardingEnabled && configuredShardedZones.isNotEmpty()) {
             configuredShardedZones
@@ -235,7 +240,10 @@ class MudServer(
                                 assignment.engineId to
                                     Pair(
                                         EngineAddress(assignment.engineId, assignment.host, assignment.port),
-                                        assignment.zones.map(String::trim).filter { it.isNotEmpty() }.toSet(),
+                                        assignment.zones
+                                            .map(String::trim)
+                                            .filter { it.isNotEmpty() }
+                                            .toSet(),
                                     )
                             }
                         }
@@ -351,7 +359,9 @@ class MudServer(
                     interEngineBus = interEngineBus,
                     engineId = engineId,
                     peerEngineCount = {
-                        zoneRegistry?.allAssignments()?.values
+                        zoneRegistry
+                            ?.allAssignments()
+                            ?.values
                             ?.map { it.engineId }
                             ?.filter { it != engineId }
                             ?.toSet()
@@ -425,7 +435,13 @@ class MudServer(
     private fun bindWorldStateGauges() {
         gameMetrics.bindPlayerRegistry { players.allPlayers().size }
         gameMetrics.bindMobRegistry { mobs.all().size }
-        gameMetrics.bindRoomsOccupied { players.allPlayers().map { it.roomId }.toSet().size }
+        gameMetrics.bindRoomsOccupied {
+            players
+                .allPlayers()
+                .map { it.roomId }
+                .toSet()
+                .size
+        }
     }
 
     suspend fun awaitShutdown() = shutdownSignal.await()

--- a/src/main/kotlin/dev/ambon/bus/LocalInboundBus.kt
+++ b/src/main/kotlin/dev/ambon/bus/LocalInboundBus.kt
@@ -4,7 +4,9 @@ import dev.ambon.engine.events.InboundEvent
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ChannelResult
 
-class LocalInboundBus(capacity: Int = Channel.UNLIMITED) : InboundBus {
+class LocalInboundBus(
+    capacity: Int = Channel.UNLIMITED,
+) : InboundBus {
     private val channel = Channel<InboundEvent>(capacity)
 
     override suspend fun send(event: InboundEvent) = channel.send(event)

--- a/src/main/kotlin/dev/ambon/bus/LocalOutboundBus.kt
+++ b/src/main/kotlin/dev/ambon/bus/LocalOutboundBus.kt
@@ -5,7 +5,9 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ChannelResult
 import kotlinx.coroutines.channels.ReceiveChannel
 
-class LocalOutboundBus(capacity: Int = Channel.UNLIMITED) : OutboundBus {
+class LocalOutboundBus(
+    capacity: Int = Channel.UNLIMITED,
+) : OutboundBus {
     private val channel = Channel<OutboundEvent>(capacity)
 
     override suspend fun send(event: OutboundEvent) = channel.send(event)

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -156,10 +156,15 @@ class GameEngine(
         world.mobSpawns.forEach { spawn ->
             mobs.upsert(
                 MobState(
-                    id = spawn.id, name = spawn.name, roomId = spawn.roomId,
-                    hp = spawn.maxHp, maxHp = spawn.maxHp,
-                    minDamage = spawn.minDamage, maxDamage = spawn.maxDamage,
-                    armor = spawn.armor, xpReward = spawn.xpReward,
+                    id = spawn.id,
+                    name = spawn.name,
+                    roomId = spawn.roomId,
+                    hp = spawn.maxHp,
+                    maxHp = spawn.maxHp,
+                    minDamage = spawn.minDamage,
+                    maxDamage = spawn.maxDamage,
+                    armor = spawn.armor,
+                    xpReward = spawn.xpReward,
                     drops = spawn.drops,
                 ),
             )
@@ -292,10 +297,15 @@ class GameEngine(
         for (spawn in zoneMobSpawns) {
             mobs.upsert(
                 MobState(
-                    id = spawn.id, name = spawn.name, roomId = spawn.roomId,
-                    hp = spawn.maxHp, maxHp = spawn.maxHp,
-                    minDamage = spawn.minDamage, maxDamage = spawn.maxDamage,
-                    armor = spawn.armor, xpReward = spawn.xpReward,
+                    id = spawn.id,
+                    name = spawn.name,
+                    roomId = spawn.roomId,
+                    hp = spawn.maxHp,
+                    maxHp = spawn.maxHp,
+                    minDamage = spawn.minDamage,
+                    maxDamage = spawn.maxDamage,
+                    armor = spawn.armor,
+                    xpReward = spawn.xpReward,
                     drops = spawn.drops,
                 ),
             )
@@ -545,13 +555,12 @@ class GameEngine(
     private fun resolveRoomId(
         arg: String,
         currentZone: String,
-    ): RoomId? {
-        return if (':' in arg) {
+    ): RoomId? =
+        if (':' in arg) {
             runCatching { RoomId(arg) }.getOrNull()
         } else {
             runCatching { RoomId("$currentZone:$arg") }.getOrNull()
         }
-    }
 
     private suspend fun handle(ev: InboundEvent) {
         when (ev) {

--- a/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
@@ -19,7 +19,9 @@ sealed interface LoginResult {
 
     data object WrongPassword : LoginResult
 
-    data class Takeover(val oldSessionId: SessionId) : LoginResult
+    data class Takeover(
+        val oldSessionId: SessionId,
+    ) : LoginResult
 }
 
 sealed interface CreateResult {

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandRouter.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandRouter.kt
@@ -537,10 +537,15 @@ class CommandRouter(
                 val newMobId = MobId("$zone:${local}_adm_$seq")
                 mobs.upsert(
                     MobState(
-                        id = newMobId, name = template.name, roomId = me.roomId,
-                        hp = template.maxHp, maxHp = template.maxHp,
-                        minDamage = template.minDamage, maxDamage = template.maxDamage,
-                        armor = template.armor, xpReward = template.xpReward,
+                        id = newMobId,
+                        name = template.name,
+                        roomId = me.roomId,
+                        hp = template.maxHp,
+                        maxHp = template.maxHp,
+                        minDamage = template.minDamage,
+                        maxDamage = template.maxDamage,
+                        armor = template.armor,
+                        xpReward = template.xpReward,
                         drops = template.drops,
                     ),
                 )
@@ -662,8 +667,8 @@ class CommandRouter(
     private fun resolveGotoArg(
         arg: String,
         currentZone: String,
-    ): RoomId? {
-        return if (':' in arg) {
+    ): RoomId? =
+        if (':' in arg) {
             val zone = arg.substringBefore(':').trim()
             val local = arg.substringAfter(':').trim()
             val effectiveZone = zone.ifEmpty { currentZone }
@@ -680,7 +685,6 @@ class CommandRouter(
         } else {
             runCatching { RoomId("$currentZone:$arg") }.getOrNull()
         }
-    }
 
     private fun findMobTemplate(arg: String): MobSpawn? {
         val trimmed = arg.trim()
@@ -688,7 +692,11 @@ class CommandRouter(
             world.mobSpawns.firstOrNull { it.id.value.equals(trimmed, ignoreCase = true) }
         } else {
             val lowerLocal = trimmed.lowercase()
-            world.mobSpawns.firstOrNull { it.id.value.substringAfter(':', it.id.value).lowercase() == lowerLocal }
+            world.mobSpawns.firstOrNull {
+                it.id.value
+                    .substringAfter(':', it.id.value)
+                    .lowercase() == lowerLocal
+            }
         }
     }
 

--- a/src/main/kotlin/dev/ambon/gateway/GatewayServer.kt
+++ b/src/main/kotlin/dev/ambon/gateway/GatewayServer.kt
@@ -80,7 +80,8 @@ class GatewayServer(
         if (prometheusRegistry != null) GameMetrics(prometheusRegistry) else GameMetrics.noop()
 
     private val instanceId: String =
-        config.redis.bus.instanceId.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
+        config.redis.bus.instanceId
+            .takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
 
     private val redisManager: RedisConnectionManager? =
         if (config.redis.enabled) RedisConnectionManager(config.redis) else null

--- a/src/main/kotlin/dev/ambon/gateway/SessionRouter.kt
+++ b/src/main/kotlin/dev/ambon/gateway/SessionRouter.kt
@@ -175,9 +175,8 @@ class SessionRouter(
         return result
     }
 
-    override fun tryReceive(): ChannelResult<InboundEvent> {
+    override fun tryReceive(): ChannelResult<InboundEvent> =
         throw UnsupportedOperationException("SessionRouter does not support tryReceive — engines read from their own channels")
-    }
 
     override fun close() {
         for ((_, channel) in engineChannels) {

--- a/src/main/kotlin/dev/ambon/grpc/EngineGrpcServer.kt
+++ b/src/main/kotlin/dev/ambon/grpc/EngineGrpcServer.kt
@@ -35,7 +35,8 @@ class EngineGrpcServer(
     private val dispatcher = GrpcOutboundDispatcher(outbound = outbound, serviceImpl = serviceImpl, scope = scope, metrics = metrics)
 
     private val server: Server =
-        ServerBuilder.forPort(port)
+        ServerBuilder
+            .forPort(port)
             .addService(serviceImpl)
             .build()
 

--- a/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
+++ b/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
@@ -144,7 +144,11 @@ class EngineServer(
     private val progression = PlayerProgression(config.progression)
     private val shardingEnabled = config.sharding.enabled
     private val engineId = config.sharding.engineId
-    private val configuredShardedZones = config.sharding.zones.map(String::trim).filter { it.isNotEmpty() }.toSet()
+    private val configuredShardedZones =
+        config.sharding.zones
+            .map(String::trim)
+            .filter { it.isNotEmpty() }
+            .toSet()
     private val zoneFilter =
         if (shardingEnabled && configuredShardedZones.isNotEmpty()) {
             configuredShardedZones
@@ -207,7 +211,10 @@ class EngineServer(
                                 assignment.engineId to
                                     Pair(
                                         EngineAddress(assignment.engineId, assignment.host, assignment.port),
-                                        assignment.zones.map(String::trim).filter { it.isNotEmpty() }.toSet(),
+                                        assignment.zones
+                                            .map(String::trim)
+                                            .filter { it.isNotEmpty() }
+                                            .toSet(),
                                     )
                             }
                         }
@@ -317,7 +324,9 @@ class EngineServer(
                     interEngineBus = interEngineBus,
                     engineId = engineId,
                     peerEngineCount = {
-                        zoneRegistry?.allAssignments()?.values
+                        zoneRegistry
+                            ?.allAssignments()
+                            ?.values
                             ?.map { it.engineId }
                             ?.filter { it != engineId }
                             ?.toSet()

--- a/src/main/kotlin/dev/ambon/grpc/ProtoMapper.kt
+++ b/src/main/kotlin/dev/ambon/grpc/ProtoMapper.kt
@@ -23,32 +23,35 @@ import dev.ambon.grpc.proto.ShowLoginScreenProto
 fun InboundEvent.toProto(): InboundEventProto =
     when (this) {
         is InboundEvent.Connected ->
-            InboundEventProto.newBuilder()
+            InboundEventProto
+                .newBuilder()
                 .setSessionId(sessionId.value)
                 .setConnected(
-                    ConnectedProto.newBuilder()
+                    ConnectedProto
+                        .newBuilder()
                         .setDefaultAnsiEnabled(defaultAnsiEnabled)
                         .build(),
-                )
-                .build()
+                ).build()
         is InboundEvent.Disconnected ->
-            InboundEventProto.newBuilder()
+            InboundEventProto
+                .newBuilder()
                 .setSessionId(sessionId.value)
                 .setDisconnected(
-                    DisconnectedProto.newBuilder()
+                    DisconnectedProto
+                        .newBuilder()
                         .setReason(reason)
                         .build(),
-                )
-                .build()
+                ).build()
         is InboundEvent.LineReceived ->
-            InboundEventProto.newBuilder()
+            InboundEventProto
+                .newBuilder()
                 .setSessionId(sessionId.value)
                 .setLineReceived(
-                    LineReceivedProto.newBuilder()
+                    LineReceivedProto
+                        .newBuilder()
                         .setLine(line)
                         .build(),
-                )
-                .build()
+                ).build()
     }
 
 /** Converts [InboundEventProto] → domain [InboundEvent], or null if the oneof is not set. */
@@ -78,61 +81,71 @@ fun InboundEventProto.toDomain(): InboundEvent? {
 fun OutboundEvent.toProto(): OutboundEventProto =
     when (this) {
         is OutboundEvent.SendText ->
-            OutboundEventProto.newBuilder()
+            OutboundEventProto
+                .newBuilder()
                 .setSessionId(sessionId.value)
                 .setSendText(SendTextProto.newBuilder().setText(text).build())
                 .build()
         is OutboundEvent.SendInfo ->
-            OutboundEventProto.newBuilder()
+            OutboundEventProto
+                .newBuilder()
                 .setSessionId(sessionId.value)
                 .setSendInfo(SendInfoProto.newBuilder().setText(text).build())
                 .build()
         is OutboundEvent.SendError ->
-            OutboundEventProto.newBuilder()
+            OutboundEventProto
+                .newBuilder()
                 .setSessionId(sessionId.value)
                 .setSendError(SendErrorProto.newBuilder().setText(text).build())
                 .build()
         is OutboundEvent.SendPrompt ->
-            OutboundEventProto.newBuilder()
+            OutboundEventProto
+                .newBuilder()
                 .setSessionId(sessionId.value)
                 .setSendPrompt(SendPromptProto.getDefaultInstance())
                 .build()
         is OutboundEvent.ShowLoginScreen ->
-            OutboundEventProto.newBuilder()
+            OutboundEventProto
+                .newBuilder()
                 .setSessionId(sessionId.value)
                 .setShowLoginScreen(ShowLoginScreenProto.getDefaultInstance())
                 .build()
         is OutboundEvent.SetAnsi ->
-            OutboundEventProto.newBuilder()
+            OutboundEventProto
+                .newBuilder()
                 .setSessionId(sessionId.value)
                 .setSetAnsi(SetAnsiProto.newBuilder().setEnabled(enabled).build())
                 .build()
         is OutboundEvent.Close ->
-            OutboundEventProto.newBuilder()
+            OutboundEventProto
+                .newBuilder()
                 .setSessionId(sessionId.value)
                 .setClose(CloseProto.newBuilder().setReason(reason).build())
                 .build()
         is OutboundEvent.ClearScreen ->
-            OutboundEventProto.newBuilder()
+            OutboundEventProto
+                .newBuilder()
                 .setSessionId(sessionId.value)
                 .setClearScreen(ClearScreenProto.getDefaultInstance())
                 .build()
         is OutboundEvent.ShowAnsiDemo ->
-            OutboundEventProto.newBuilder()
+            OutboundEventProto
+                .newBuilder()
                 .setSessionId(sessionId.value)
                 .setShowAnsiDemo(ShowAnsiDemoProto.getDefaultInstance())
                 .build()
         is OutboundEvent.SessionRedirect ->
-            OutboundEventProto.newBuilder()
+            OutboundEventProto
+                .newBuilder()
                 .setSessionId(sessionId.value)
                 .setSessionRedirect(
-                    SessionRedirectProto.newBuilder()
+                    SessionRedirectProto
+                        .newBuilder()
                         .setNewEngineId(newEngineId)
                         .setNewEngineHost(newEngineHost)
                         .setNewEnginePort(newEnginePort)
                         .build(),
-                )
-                .build()
+                ).build()
     }
 
 /** Converts [OutboundEventProto] → domain [OutboundEvent], or null if the oneof is not set. */

--- a/src/main/kotlin/dev/ambon/metrics/GameMetrics.kt
+++ b/src/main/kotlin/dev/ambon/metrics/GameMetrics.kt
@@ -60,7 +60,8 @@ class GameMetrics(
         Counter.builder("grpc_outbound_control_plane_fallback_total").register(registry)
 
     val engineTickTimer: Timer =
-        Timer.builder("engine_tick_duration_seconds")
+        Timer
+            .builder("engine_tick_duration_seconds")
             .publishPercentileHistogram()
             .register(registry)
     private val engineTicksCounter = Counter.builder("engine_ticks_total").register(registry)
@@ -69,16 +70,19 @@ class GameMetrics(
         Counter.builder("engine_inbound_events_processed_total").register(registry)
 
     val mobSystemTickTimer: Timer =
-        Timer.builder("mob_system_tick_duration_seconds")
+        Timer
+            .builder("mob_system_tick_duration_seconds")
             .publishPercentileHistogram()
             .register(registry)
     val combatSystemTickTimer: Timer =
-        Timer.builder("combat_system_tick_duration_seconds")
+        Timer
+            .builder("combat_system_tick_duration_seconds")
             .publishPercentileHistogram()
             .register(registry)
     val regenTickTimer: Timer = Timer.builder("regen_tick_duration_seconds").register(registry)
     val schedulerRunDueTimer: Timer =
-        Timer.builder("scheduler_run_due_duration_seconds")
+        Timer
+            .builder("scheduler_run_due_duration_seconds")
             .publishPercentileHistogram()
             .register(registry)
 

--- a/src/main/kotlin/dev/ambon/metrics/MetricsHttpServer.kt
+++ b/src/main/kotlin/dev/ambon/metrics/MetricsHttpServer.kt
@@ -4,9 +4,10 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.http.ContentType
 import io.ktor.server.application.Application
 import io.ktor.server.application.call
-import io.ktor.server.engine.ApplicationEngine
+import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
+import io.ktor.server.netty.NettyApplicationEngine
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
@@ -19,7 +20,7 @@ class MetricsHttpServer(
     private val registry: PrometheusMeterRegistry,
     private val endpoint: String = "/metrics",
 ) {
-    private var engine: ApplicationEngine? = null
+    private var engine: EmbeddedServer<NettyApplicationEngine, NettyApplicationEngine.Configuration>? = null
 
     fun start() {
         engine =

--- a/src/main/kotlin/dev/ambon/persistence/DatabaseManager.kt
+++ b/src/main/kotlin/dev/ambon/persistence/DatabaseManager.kt
@@ -6,7 +6,9 @@ import dev.ambon.config.DatabaseConfig
 import org.flywaydb.core.Flyway
 import org.jetbrains.exposed.sql.Database
 
-class DatabaseManager(private val config: DatabaseConfig) {
+class DatabaseManager(
+    private val config: DatabaseConfig,
+) {
     private val hikariDataSource: HikariDataSource
 
     val database: Database
@@ -25,7 +27,8 @@ class DatabaseManager(private val config: DatabaseConfig) {
     }
 
     fun migrate() {
-        Flyway.configure()
+        Flyway
+            .configure()
             .dataSource(hikariDataSource)
             .load()
             .migrate()

--- a/src/main/kotlin/dev/ambon/persistence/PostgresPlayerRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PostgresPlayerRepository.kt
@@ -19,7 +19,8 @@ class PostgresPlayerRepository(
         val sample = Timer.start()
         try {
             return newSuspendedTransaction(Dispatchers.IO, database) {
-                PlayersTable.selectAll()
+                PlayersTable
+                    .selectAll()
                     .where { PlayersTable.nameLower eq name.trim().lowercase() }
                     .firstOrNull()
                     ?.toPlayerRecord()
@@ -33,7 +34,8 @@ class PostgresPlayerRepository(
         val sample = Timer.start()
         try {
             return newSuspendedTransaction(Dispatchers.IO, database) {
-                PlayersTable.selectAll()
+                PlayersTable
+                    .selectAll()
                     .where { PlayersTable.id eq id.value }
                     .firstOrNull()
                     ?.toPlayerRecord()

--- a/src/main/kotlin/dev/ambon/redis/RedisConnectionManager.kt
+++ b/src/main/kotlin/dev/ambon/redis/RedisConnectionManager.kt
@@ -13,7 +13,8 @@ private val log = KotlinLogging.logger {}
 
 class RedisConnectionManager(
     private val config: RedisConfig,
-) : AutoCloseable, StringCache {
+) : AutoCloseable,
+    StringCache {
     var commands: RedisCommands<String, String>? = null
         private set
 

--- a/src/main/kotlin/dev/ambon/session/AtomicSessionIdFactory.kt
+++ b/src/main/kotlin/dev/ambon/session/AtomicSessionIdFactory.kt
@@ -3,7 +3,9 @@ package dev.ambon.session
 import dev.ambon.domain.ids.SessionId
 import java.util.concurrent.atomic.AtomicLong
 
-class AtomicSessionIdFactory(startId: Long = 1L) : SessionIdFactory {
+class AtomicSessionIdFactory(
+    startId: Long = 1L,
+) : SessionIdFactory {
     private val seq = AtomicLong(startId)
 
     override fun allocate(): SessionId = SessionId(seq.getAndIncrement())

--- a/src/main/kotlin/dev/ambon/sharding/HandoffManager.kt
+++ b/src/main/kotlin/dev/ambon/sharding/HandoffManager.kt
@@ -18,7 +18,9 @@ import java.time.Clock
 private val log = KotlinLogging.logger {}
 
 sealed interface HandoffResult {
-    data class Initiated(val targetEngine: EngineAddress) : HandoffResult
+    data class Initiated(
+        val targetEngine: EngineAddress,
+    ) : HandoffResult
 
     data object PlayerNotFound : HandoffResult
 
@@ -28,9 +30,13 @@ sealed interface HandoffResult {
 }
 
 sealed interface HandoffAckResult {
-    data class Completed(val targetEngine: EngineAddress) : HandoffAckResult
+    data class Completed(
+        val targetEngine: EngineAddress,
+    ) : HandoffAckResult
 
-    data class Failed(val errorMessage: String?) : HandoffAckResult
+    data class Failed(
+        val errorMessage: String?,
+    ) : HandoffAckResult
 
     data object NotPending : HandoffAckResult
 }

--- a/src/main/kotlin/dev/ambon/sharding/RedisZoneRegistry.kt
+++ b/src/main/kotlin/dev/ambon/sharding/RedisZoneRegistry.kt
@@ -49,7 +49,12 @@ class RedisZoneRegistry(
         // In practice, the engine knows its own zones; callers should
         // call claimZones again to renew. This is a convenience for
         // the heartbeat loop.
-        val cursor = commands.scan(io.lettuce.core.ScanArgs.Builder.matches("$keyPrefix*").limit(100))
+        val cursor =
+            commands.scan(
+                io.lettuce.core.ScanArgs.Builder
+                    .matches("$keyPrefix*")
+                    .limit(100),
+            )
         for (key in cursor.keys) {
             val json = commands.get(key) ?: continue
             val addr =
@@ -67,7 +72,12 @@ class RedisZoneRegistry(
     override fun allAssignments(): Map<String, EngineAddress> {
         val commands = redis.commands ?: return emptyMap()
         val result = mutableMapOf<String, EngineAddress>()
-        val cursor = commands.scan(io.lettuce.core.ScanArgs.Builder.matches("$keyPrefix*").limit(1000))
+        val cursor =
+            commands.scan(
+                io.lettuce.core.ScanArgs.Builder
+                    .matches("$keyPrefix*")
+                    .limit(1000),
+            )
         for (key in cursor.keys) {
             val zone = key.removePrefix(keyPrefix)
             val json = commands.get(key) ?: continue

--- a/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
+++ b/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
@@ -9,10 +9,11 @@ import io.ktor.http.ContentType
 import io.ktor.server.application.Application
 import io.ktor.server.application.call
 import io.ktor.server.application.install
-import io.ktor.server.engine.ApplicationEngine
+import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.http.content.staticResources
 import io.ktor.server.netty.Netty
+import io.ktor.server.netty.NettyApplicationEngine
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
@@ -48,7 +49,7 @@ class KtorWebSocketTransport(
     private val metricsEndpoint: String = "/metrics",
     private val metrics: GameMetrics = GameMetrics.noop(),
 ) : Transport {
-    private var engine: ApplicationEngine? = null
+    private var engine: EmbeddedServer<NettyApplicationEngine, NettyApplicationEngine.Configuration>? = null
 
     override suspend fun start() {
         engine =

--- a/src/test/kotlin/dev/ambon/bus/GrpcOutboundBusTest.kt
+++ b/src/test/kotlin/dev/ambon/bus/GrpcOutboundBusTest.kt
@@ -78,7 +78,9 @@ class GrpcOutboundBusTest {
     @Test
     fun `unknown proto variant is silently dropped`() =
         runBlocking {
-            val emptyProto = dev.ambon.grpc.proto.OutboundEventProto.getDefaultInstance()
+            val emptyProto =
+                dev.ambon.grpc.proto.OutboundEventProto
+                    .getDefaultInstance()
             val grpcFlow = flow { emit(emptyProto) }
 
             bus = GrpcOutboundBus(delegate = delegate, grpcReceiveFlow = grpcFlow, scope = scope)

--- a/src/test/kotlin/dev/ambon/engine/GameEngineLoginFlowTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GameEngineLoginFlowTest.kt
@@ -486,7 +486,8 @@ class GameEngineLoginFlowTest {
 
             // New session does NOT receive an "enters." broadcast
             assertFalse(
-                outs.filterIsInstance<OutboundEvent.SendText>()
+                outs
+                    .filterIsInstance<OutboundEvent.SendText>()
                     .any { it.sessionId == sid2 && it.text.contains("enters.") },
                 "Expected no 'enters.' broadcast for takeover. got=$outs",
             )
@@ -641,7 +642,8 @@ class GameEngineLoginFlowTest {
                 "Expected flee to succeed (combat inherited). got=$outs",
             )
             assertTrue(
-                outs.filterIsInstance<OutboundEvent.SendText>()
+                outs
+                    .filterIsInstance<OutboundEvent.SendText>()
                     .any { it.sessionId == sid2 && it.text.startsWith("You flee from") },
                 "Expected 'You flee from...' message on new session. got=$outs",
             )

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterScoreTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterScoreTest.kt
@@ -126,8 +126,17 @@ class CommandRouterScoreTest {
     ) {
         val instance = ItemInstance(itemId, item)
         items.ensurePlayer(sessionId)
-        items.addRoomItem(dev.ambon.domain.ids.RoomId("test:room"), instance)
-        items.takeFromRoom(sessionId, dev.ambon.domain.ids.RoomId("test:room"), item.keyword)
+        items.addRoomItem(
+            dev.ambon.domain.ids
+                .RoomId("test:room"),
+            instance,
+        )
+        items.takeFromRoom(
+            sessionId,
+            dev.ambon.domain.ids
+                .RoomId("test:room"),
+            item.keyword,
+        )
         items.equipFromInventory(sessionId, item.keyword)
     }
 }

--- a/src/test/kotlin/dev/ambon/grpc/EngineGrpcServerTest.kt
+++ b/src/test/kotlin/dev/ambon/grpc/EngineGrpcServerTest.kt
@@ -46,12 +46,13 @@ class EngineGrpcServerTest {
             val gatewayJob =
                 scope.launch {
                     runCatching {
-                        stub.eventStream(
-                            flow {
-                                emit(InboundEvent.Connected(sessionId = SessionId(1L)).toProto())
-                                delay(10_000L)
-                            },
-                        ).collect {}
+                        stub
+                            .eventStream(
+                                flow {
+                                    emit(InboundEvent.Connected(sessionId = SessionId(1L)).toProto())
+                                    delay(10_000L)
+                                },
+                            ).collect {}
                     }
                 }
 

--- a/src/test/kotlin/dev/ambon/grpc/EngineServiceImplTest.kt
+++ b/src/test/kotlin/dev/ambon/grpc/EngineServiceImplTest.kt
@@ -45,14 +45,16 @@ class EngineServiceImplTest {
         serviceImpl = EngineServiceImpl(inbound = inbound, outbound = outbound, scope = scope)
 
         grpcServer =
-            InProcessServerBuilder.forName(serverName)
+            InProcessServerBuilder
+                .forName(serverName)
                 .directExecutor()
                 .addService(serviceImpl)
                 .build()
                 .start()
 
         channel =
-            InProcessChannelBuilder.forName(serverName)
+            InProcessChannelBuilder
+                .forName(serverName)
                 .directExecutor()
                 .build()
     }
@@ -64,7 +66,9 @@ class EngineServiceImplTest {
         scope.cancel()
     }
 
-    private fun stub() = dev.ambon.grpc.proto.EngineServiceGrpcKt.EngineServiceCoroutineStub(channel)
+    private fun stub() =
+        dev.ambon.grpc.proto.EngineServiceGrpcKt
+            .EngineServiceCoroutineStub(channel)
 
     @Test
     fun `Connected event is forwarded to InboundBus`() =
@@ -74,11 +78,12 @@ class EngineServiceImplTest {
             // Flow completes immediately after emitting — stream closes cleanly.
             val job =
                 launch {
-                    stub().eventStream(
-                        flow {
-                            emit(InboundEvent.Connected(sessionId = sid, defaultAnsiEnabled = false).toProto())
-                        },
-                    ).toList()
+                    stub()
+                        .eventStream(
+                            flow {
+                                emit(InboundEvent.Connected(sessionId = sid, defaultAnsiEnabled = false).toProto())
+                            },
+                        ).toList()
                 }
             job.join()
 
@@ -96,11 +101,12 @@ class EngineServiceImplTest {
 
             val job =
                 launch {
-                    stub().eventStream(
-                        flow {
-                            emit(InboundEvent.Connected(sessionId = sid, defaultAnsiEnabled = true).toProto())
-                        },
-                    ).toList()
+                    stub()
+                        .eventStream(
+                            flow {
+                                emit(InboundEvent.Connected(sessionId = sid, defaultAnsiEnabled = true).toProto())
+                            },
+                        ).toList()
                 }
             job.join()
 
@@ -117,12 +123,13 @@ class EngineServiceImplTest {
             // Stream opens and immediately closes — after join, session should be gone.
             val job =
                 launch {
-                    stub().eventStream(
-                        flow {
-                            emit(InboundEvent.Connected(sessionId = sid).toProto())
-                            emit(InboundEvent.Disconnected(sessionId = sid, reason = "quit").toProto())
-                        },
-                    ).toList()
+                    stub()
+                        .eventStream(
+                            flow {
+                                emit(InboundEvent.Connected(sessionId = sid).toProto())
+                                emit(InboundEvent.Disconnected(sessionId = sid, reason = "quit").toProto())
+                            },
+                        ).toList()
                 }
             job.join()
 
@@ -136,12 +143,13 @@ class EngineServiceImplTest {
 
             val job =
                 launch {
-                    stub().eventStream(
-                        flow {
-                            emit(InboundEvent.Connected(sessionId = sid).toProto())
-                            emit(InboundEvent.LineReceived(sessionId = sid, line = "look").toProto())
-                        },
-                    ).toList()
+                    stub()
+                        .eventStream(
+                            flow {
+                                emit(InboundEvent.Connected(sessionId = sid).toProto())
+                                emit(InboundEvent.LineReceived(sessionId = sid, line = "look").toProto())
+                            },
+                        ).toList()
                 }
             job.join()
 

--- a/src/test/kotlin/dev/ambon/grpc/GatewayEngineIntegrationTest.kt
+++ b/src/test/kotlin/dev/ambon/grpc/GatewayEngineIntegrationTest.kt
@@ -91,7 +91,8 @@ class GatewayEngineIntegrationTest {
             )
 
         grpcServer =
-            InProcessServerBuilder.forName(serverName)
+            InProcessServerBuilder
+                .forName(serverName)
                 .directExecutor()
                 .addService(serviceImpl)
                 .build()
@@ -141,10 +142,13 @@ class GatewayEngineIntegrationTest {
     fun `connect login say quit flows through gRPC`() =
         runBlocking {
             val grpcChannel =
-                InProcessChannelBuilder.forName(serverName)
+                InProcessChannelBuilder
+                    .forName(serverName)
                     .directExecutor()
                     .build()
-            val stub = dev.ambon.grpc.proto.EngineServiceGrpcKt.EngineServiceCoroutineStub(grpcChannel)
+            val stub =
+                dev.ambon.grpc.proto.EngineServiceGrpcKt
+                    .EngineServiceCoroutineStub(grpcChannel)
             val sid = SessionId(1L)
 
             val received = Channel<OutboundEventProto>(Channel.UNLIMITED)
@@ -152,24 +156,25 @@ class GatewayEngineIntegrationTest {
             // Gateway stream: emit inbound events then keep stream open for responses.
             val gatewayJob =
                 launch {
-                    stub.eventStream(
-                        flow {
-                            emit(InboundEvent.Connected(sessionId = sid, defaultAnsiEnabled = false).toProto())
-                            delay(50)
-                            emit(InboundEvent.LineReceived(sessionId = sid, line = "Alice").toProto())
-                            delay(50)
-                            emit(InboundEvent.LineReceived(sessionId = sid, line = "yes").toProto())
-                            delay(50)
-                            emit(InboundEvent.LineReceived(sessionId = sid, line = "password").toProto())
-                            delay(100)
-                            emit(InboundEvent.LineReceived(sessionId = sid, line = "say Hello world!").toProto())
-                            delay(50)
-                            emit(InboundEvent.LineReceived(sessionId = sid, line = "quit").toProto())
-                            delay(500)
-                        },
-                    ).collect { proto ->
-                        received.trySend(proto)
-                    }
+                    stub
+                        .eventStream(
+                            flow {
+                                emit(InboundEvent.Connected(sessionId = sid, defaultAnsiEnabled = false).toProto())
+                                delay(50)
+                                emit(InboundEvent.LineReceived(sessionId = sid, line = "Alice").toProto())
+                                delay(50)
+                                emit(InboundEvent.LineReceived(sessionId = sid, line = "yes").toProto())
+                                delay(50)
+                                emit(InboundEvent.LineReceived(sessionId = sid, line = "password").toProto())
+                                delay(100)
+                                emit(InboundEvent.LineReceived(sessionId = sid, line = "say Hello world!").toProto())
+                                delay(50)
+                                emit(InboundEvent.LineReceived(sessionId = sid, line = "quit").toProto())
+                                delay(500)
+                            },
+                        ).collect { proto ->
+                            received.trySend(proto)
+                        }
                 }
 
             // Wait for the full flow to complete (or timeout after 5 seconds).
@@ -289,11 +294,13 @@ class GatewayEngineIntegrationTest {
             val busScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
             try {
                 val grpcChannel =
-                    InProcessChannelBuilder.forName(serverName)
+                    InProcessChannelBuilder
+                        .forName(serverName)
                         .directExecutor()
                         .build()
                 val stub =
-                    dev.ambon.grpc.proto.EngineServiceGrpcKt.EngineServiceCoroutineStub(grpcChannel)
+                    dev.ambon.grpc.proto.EngineServiceGrpcKt
+                        .EngineServiceCoroutineStub(grpcChannel)
                 val sid = SessionId(2L)
                 val failureLatch = Channel<Throwable>(1)
                 val delegate = LocalOutboundBus(capacity = 1_000)
@@ -337,7 +344,8 @@ class GatewayEngineIntegrationTest {
 
                 // Restart the gRPC server with the same in-process name.
                 newGrpcServer =
-                    InProcessServerBuilder.forName(serverName)
+                    InProcessServerBuilder
+                        .forName(serverName)
                         .directExecutor()
                         .addService(serviceImpl)
                         .build()

--- a/src/test/kotlin/dev/ambon/grpc/ProtoMapperTest.kt
+++ b/src/test/kotlin/dev/ambon/grpc/ProtoMapperTest.kt
@@ -38,7 +38,9 @@ class ProtoMapperTest {
 
     @Test
     fun `Empty InboundEventProto toDomain returns null`() {
-        val proto = dev.ambon.grpc.proto.InboundEventProto.getDefaultInstance()
+        val proto =
+            dev.ambon.grpc.proto.InboundEventProto
+                .getDefaultInstance()
         assertNull(proto.toDomain())
     }
 
@@ -118,7 +120,9 @@ class ProtoMapperTest {
 
     @Test
     fun `Empty OutboundEventProto toDomain returns null`() {
-        val proto = dev.ambon.grpc.proto.OutboundEventProto.getDefaultInstance()
+        val proto =
+            dev.ambon.grpc.proto.OutboundEventProto
+                .getDefaultInstance()
         assertNull(proto.toDomain())
     }
 

--- a/src/test/kotlin/dev/ambon/transport/MetricsEndpointTest.kt
+++ b/src/test/kotlin/dev/ambon/transport/MetricsEndpointTest.kt
@@ -29,7 +29,10 @@ class MetricsEndpointTest {
                     ambonMUDWebModule(
                         inbound = inbound,
                         outboundRouter = outboundRouter,
-                        sessionIdFactory = { dev.ambon.domain.ids.SessionId(1) },
+                        sessionIdFactory = {
+                            dev.ambon.domain.ids
+                                .SessionId(1)
+                        },
                         prometheusRegistry = prometheusRegistry,
                         metricsEndpoint = "/metrics",
                     )
@@ -61,7 +64,10 @@ class MetricsEndpointTest {
                     ambonMUDWebModule(
                         inbound = inbound,
                         outboundRouter = outboundRouter,
-                        sessionIdFactory = { dev.ambon.domain.ids.SessionId(1) },
+                        sessionIdFactory = {
+                            dev.ambon.domain.ids
+                                .SessionId(1)
+                        },
                         prometheusRegistry = null,
                     )
                 }

--- a/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
@@ -45,7 +45,12 @@ class WorldLoaderTest {
         assertEquals(0, mob.armor)
         assertEquals(30L, mob.xpReward)
         assertEquals(1, mob.drops.size)
-        assertEquals("ok_small:tooth", mob.drops.single().itemId.value)
+        assertEquals(
+            "ok_small:tooth",
+            mob.drops
+                .single()
+                .itemId.value,
+        )
         assertEquals(1.0, mob.drops.single().chance)
     }
 


### PR DESCRIPTION
Resolves the four failed Dependabot PRs (#91, #97, #98, #99) in a single coordinated upgrade.

## Changes

### Ktor 2.3.12 → 3.4.0 (fixes #91)
In Ktor 3, `embeddedServer()` returns `EmbeddedServer<E, C>` instead of `ApplicationEngine`. Updated the `engine` field type and imports in:
- `MetricsHttpServer.kt`
- `KtorWebSocketTransport.kt`

### ktlint 12.1.1 → 14.0.1 (fixes #97)
Bumped the plugin version and ran `./gradlew ktlintFormat` to auto-fix 85 style violations introduced by new rules in ktlint 14 (`chain-method-continuation`, `argument-list-wrapping`, `class-signature`).

### JUnit 5.11.4 → 6.0.3 (fixes #98)
Version bump only — no API changes affected the codebase and all tests pass without modification.

### Gradle 8.14 → 9.3.1 (fixes #99)
- Updated `gradle-wrapper.properties`
- Added `testRuntimeOnly("org.junit.platform:junit-platform-launcher")` — Gradle 9 no longer adds the JUnit Platform Launcher to the test classpath automatically

## Test plan
- [x] `./gradlew ktlintCheck test` passes clean on Gradle 9.3.1
- [x] All existing tests pass with JUnit 6.0.3
- [x] No new ktlint violations