### PR TITLE
fix: update JVM toolchain to 21 for cloud environment compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,4 +106,4 @@ Use `MutableClock` and `InMemoryPlayerRepository` for deterministic unit tests. 
 
 ## Known Quirks
 
-None currently.
+- **JVM Toolchain version:** The `jvmToolchain()` in `build.gradle.kts` must match the JDK installed in the build environment. Cloud/CI environments typically provide JDK 21. If the build fails with `Cannot find a Java installation … matching: {languageVersion=17}` (and the Foojay toolchain resolver cannot auto-provision due to network/proxy restrictions), update `jvmToolchain(17)` → `jvmToolchain(21)` in `build.gradle.kts`.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,7 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 application {


### PR DESCRIPTION
The Foojay toolchain resolver fails to auto-provision JDK 17 in
environments with proxy/network restrictions. Since JDK 21 is the
standard JDK available in cloud CI environments, update the toolchain
target accordingly. Document the quirk in CLAUDE.md for future sessions.

https://claude.ai/code/session_01KoS6QQUD7XADgb2633myVG