### PR TITLE
feat(items): add use/charges consumables, give command, and docs cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,6 @@ By default the server listens on telnet port `4000` and web port `8080` (configu
 - `RoomId` must be namespaced: `<zone>:<room>`.
 - Multi-zone world loading and cross-zone exits are supported.
 - Loader validates exits, start room, mob/item placement, stats, and slot/direction values.
-- Item placement is exclusive: room or mob (or unplaced), never both.
 - Zone `lifespan` is in minutes; `lifespan <= 0` disables resets. The engine uses `lifespan` to reset a zone's mob/item spawns.
 
 5. Player and persistence invariants

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1001,7 +1001,7 @@ Local IDs (no `:`) are automatically prefixed with the zone name. Fully qualifie
 The loader validates both per-file and cross-file (merged world):
 - All exit targets resolve to existing rooms
 - All mob rooms resolve
-- All item placements resolve (room or mob, never both)
+- Item room placements resolve; deprecated `mob` placement and dual `room`+`mob` placement are rejected by the loader
 - No duplicate room/mob/item IDs across files
 - `lifespan` values are consistent if a zone spans multiple files
 
@@ -1240,9 +1240,10 @@ Edit YAML in `src/main/resources/world/`. If adding a new file, register it in `
 - `YamlPlayerRepository` writes to a temp file then renames atomically
 - Do not replace this with direct file writes
 
-### Item Placement Exclusivity
-- An item can be in a room, on a mob, or unplaced — never more than one
-- Enforced by `WorldLoader` at load time; maintain this in `ItemRegistry`
+### Item Placement Rules (Current Loader Behavior)
+- The loader currently accepts `room` placement or unplaced items
+- `mob` placement is deprecated/rejected, and setting both `room` and `mob` is rejected
+- Treat this as loader behavior (subject to future evolution), not a core engine architecture boundary
 
 ### Per-Tick Processing Caps
 - `CombatSystem`, `MobSystem`, and inbound event handling all have `max*PerTick` limits

--- a/docs/world-zone-yaml-spec.md
+++ b/docs/world-zone-yaml-spec.md
@@ -118,11 +118,27 @@ slot: <string, optional, one of head|body|hand (case-insensitive)>
 damage: <integer, optional, default 0, must be >= 0>
 armor: <integer, optional, default 0, must be >= 0>
 constitution: <integer, optional, default 0, must be >= 0>
+consumable: <boolean, optional, default false>
+charges: <integer, optional, must be > 0 when present>
+onUse: <OnUse, optional>
 room: <room-id string, optional>
 matchByKey: <boolean, optional, default false>
 ```
 
 `matchByKey` is optional (default `false`). When `true`, players must type the exact keyword; substring-based fallback on `displayName` and `description` is disabled.
+
+`OnUse` entry:
+
+```yaml
+healHp: <integer, optional, default 0, must be >= 0>
+grantXp: <long, optional, default 0, must be >= 0>
+```
+
+If `onUse` is present, at least one effect must be positive (`healHp > 0` or `grantXp > 0`).
+
+Charge/consumption notes:
+- If `charges` is set, one charge is spent per use.
+- If `consumable: true`, the item is removed when charges are exhausted (or immediately after use when `charges` is unset).
 
 Location rules for items:
 
@@ -203,9 +219,11 @@ For each file your tool emits:
 4. Restrict exit direction keys to the allowed set.
 5. Use only non-negative integers for `lifespan`, `damage`, `armor`, `constitution`.
 6. For every item, use `room` or omit placement entirely (unplaced). Do not use `mob`.
-7. Ensure all local/qualified references resolve in the merged set of files.
-8. Ensure normalized room/mob/item IDs are globally unique across files.
-9. If splitting one zone across files, keep `lifespan` consistent when repeated.
+7. If `onUse` is present, include at least one positive effect (`healHp` or `grantXp`).
+8. If `charges` is present, it must be > 0.
+9. Ensure all local/qualified references resolve in the merged set of files.
+10. Ensure normalized room/mob/item IDs are globally unique across files.
+11. If splitting one zone across files, keep `lifespan` consistent when repeated.
 
 ## Minimal Valid Example
 

--- a/src/main/kotlin/dev/ambon/domain/items/Item.kt
+++ b/src/main/kotlin/dev/ambon/domain/items/Item.kt
@@ -1,5 +1,12 @@
 package dev.ambon.domain.items
 
+data class ItemUseEffect(
+    val healHp: Int = 0,
+    val grantXp: Long = 0L,
+) {
+    fun hasEffect(): Boolean = healHp > 0 || grantXp > 0L
+}
+
 data class Item(
     val keyword: String,
     val displayName: String,
@@ -8,5 +15,8 @@ data class Item(
     val damage: Int = 0,
     val armor: Int = 0,
     val constitution: Int = 0,
+    val consumable: Boolean = false,
+    val charges: Int? = null,
+    val onUse: ItemUseEffect? = null,
     val matchByKey: Boolean = false,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/data/ItemFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/ItemFile.kt
@@ -1,5 +1,10 @@
 package dev.ambon.domain.world.data
 
+data class ItemOnUseFile(
+    val healHp: Int = 0,
+    val grantXp: Long = 0L,
+)
+
 data class ItemFile(
     val displayName: String,
     val description: String = "",
@@ -8,6 +13,9 @@ data class ItemFile(
     val damage: Int = 0,
     val armor: Int = 0,
     val constitution: Int = 0,
+    val consumable: Boolean = false,
+    val charges: Int? = null,
+    val onUse: ItemOnUseFile? = null,
     val room: String? = null,
     val mob: String? = null,
     val matchByKey: Boolean = false,

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -60,6 +60,15 @@ sealed interface Command {
         val keyword: String,
     ) : Command
 
+    data class Use(
+        val keyword: String,
+    ) : Command
+
+    data class Give(
+        val keyword: String,
+        val playerName: String,
+    ) : Command
+
     data object Inventory : Command
 
     data object Equipment : Command
@@ -203,6 +212,25 @@ object CommandParser {
         matchPrefix(line, listOf("drop")) { rest ->
             val kw = rest.trim()
             if (kw.isEmpty()) Command.Invalid(line, "drop <item>") else Command.Drop(kw)
+        }?.let { return it }
+
+        // use
+        matchPrefix(line, listOf("use")) { rest ->
+            val kw = rest.trim()
+            if (kw.isEmpty()) Command.Invalid(line, "use <item>") else Command.Use(kw)
+        }?.let { return it }
+
+        // give
+        matchPrefix(line, listOf("give")) { rest ->
+            val trimmed = rest.trim()
+            val parts = trimmed.split(Regex("\\s+"))
+            if (parts.size < 2) {
+                Command.Invalid(line, "give <item> <player>")
+            } else {
+                val playerName = parts.last()
+                val keyword = parts.dropLast(1).joinToString(" ").trim()
+                if (keyword.isEmpty()) Command.Invalid(line, "give <item> <player>") else Command.Give(keyword, playerName)
+            }
         }?.let { return it }
 
         // cast / c

--- a/src/main/kotlin/dev/ambon/engine/items/ItemMatching.kt
+++ b/src/main/kotlin/dev/ambon/engine/items/ItemMatching.kt
@@ -1,0 +1,44 @@
+package dev.ambon.engine.items
+
+import dev.ambon.domain.items.Item
+import dev.ambon.domain.items.ItemInstance
+
+private const val SUBSTRING_MATCH_MIN_LENGTH = 3
+
+internal enum class ItemMatchMode {
+    EXACT,
+    SUBSTRING,
+    ;
+
+    fun matches(
+        item: Item,
+        input: String,
+    ): Boolean =
+        when (this) {
+            EXACT -> item.keyword.equals(input, ignoreCase = true)
+            SUBSTRING ->
+                !item.matchByKey &&
+                    (
+                        item.displayName.contains(input, ignoreCase = true) ||
+                            item.description.contains(input, ignoreCase = true)
+                    )
+        }
+}
+
+internal fun itemMatchModes(input: String): List<ItemMatchMode> =
+    if (input.length >= SUBSTRING_MATCH_MIN_LENGTH) {
+        listOf(ItemMatchMode.EXACT, ItemMatchMode.SUBSTRING)
+    } else {
+        listOf(ItemMatchMode.EXACT)
+    }
+
+internal fun findMatchingItemIndex(
+    items: List<ItemInstance>,
+    input: String,
+): Int {
+    for (mode in itemMatchModes(input)) {
+        val idx = items.indexOfFirst { mode.matches(it.item, input) }
+        if (idx >= 0) return idx
+    }
+    return -1
+}

--- a/src/main/kotlin/dev/ambon/metrics/GameMetrics.kt
+++ b/src/main/kotlin/dev/ambon/metrics/GameMetrics.kt
@@ -99,6 +99,8 @@ class GameMetrics(
         Counter.builder("xp_awarded_total").tag("source", "quest").register(registry)
     private val xpAwardedAdminCounter =
         Counter.builder("xp_awarded_total").tag("source", "admin").register(registry)
+    private val xpAwardedItemUseCounter =
+        Counter.builder("xp_awarded_total").tag("source", "item_use").register(registry)
     private val levelUpsCounter = Counter.builder("level_ups_total").register(registry)
     private val playerDeathsCounter = Counter.builder("player_deaths_total").register(registry)
 
@@ -191,6 +193,7 @@ class GameMetrics(
             "kill" -> xpAwardedKillCounter.increment(amount.toDouble())
             "quest" -> xpAwardedQuestCounter.increment(amount.toDouble())
             "admin" -> xpAwardedAdminCounter.increment(amount.toDouble())
+            "item_use" -> xpAwardedItemUseCounter.increment(amount.toDouble())
             else -> xpAwardedKillCounter.increment(amount.toDouble())
         }
     }

--- a/src/main/kotlin/dev/ambon/sharding/HandoffManager.kt
+++ b/src/main/kotlin/dev/ambon/sharding/HandoffManager.kt
@@ -7,6 +7,7 @@ import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.items.Item
 import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.items.ItemSlot
+import dev.ambon.domain.items.ItemUseEffect
 import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.PlayerState
 import dev.ambon.engine.events.OutboundEvent
@@ -333,6 +334,15 @@ class HandoffManager(
                 damage = instance.item.damage,
                 armor = instance.item.armor,
                 constitution = instance.item.constitution,
+                consumable = instance.item.consumable,
+                charges = instance.item.charges,
+                onUse =
+                    instance.item.onUse?.let { effect ->
+                        SerializedItemUseEffect(
+                            healHp = effect.healHp,
+                            grantXp = effect.grantXp,
+                        )
+                    },
                 matchByKey = instance.item.matchByKey,
             )
 
@@ -348,6 +358,15 @@ class HandoffManager(
                         damage = serialized.damage,
                         armor = serialized.armor,
                         constitution = serialized.constitution,
+                        consumable = serialized.consumable,
+                        charges = serialized.charges,
+                        onUse =
+                            serialized.onUse?.let { effect ->
+                                ItemUseEffect(
+                                    healHp = effect.healHp,
+                                    grantXp = effect.grantXp,
+                                )
+                            },
                         matchByKey = serialized.matchByKey,
                     ),
             )

--- a/src/main/kotlin/dev/ambon/sharding/InterEngineMessage.kt
+++ b/src/main/kotlin/dev/ambon/sharding/InterEngineMessage.kt
@@ -116,7 +116,15 @@ data class SerializedItem(
     val damage: Int = 0,
     val armor: Int = 0,
     val constitution: Int = 0,
+    val consumable: Boolean = false,
+    val charges: Int? = null,
+    val onUse: SerializedItemUseEffect? = null,
     val matchByKey: Boolean = false,
+)
+
+data class SerializedItemUseEffect(
+    val healHp: Int = 0,
+    val grantXp: Long = 0L,
 )
 
 /**

--- a/src/main/resources/world/demo_ruins.yaml
+++ b/src/main/resources/world/demo_ruins.yaml
@@ -158,6 +158,10 @@ items:
     displayName: "a mirror-bright apple"
     keyword: "apple"
     description: "Perfectly smooth, reflecting your face like a tiny moon."
+    consumable: true
+    onUse:
+      healHp: 4
+      grantXp: 5
     room: mirror_orchard
 
   mossy_helm:

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
@@ -100,6 +100,24 @@ class CommandParserTest {
     }
 
     @Test
+    fun `parses use command`() {
+        assertEquals(Command.Use("potion"), CommandParser.parse("use potion"))
+    }
+
+    @Test
+    fun `parses give command with multi-word item`() {
+        assertEquals(Command.Give("shimmering potion", "Bob"), CommandParser.parse("give shimmering potion Bob"))
+    }
+
+    @Test
+    fun `give and use validate arguments`() {
+        assertTrue(CommandParser.parse("use") is Command.Invalid)
+        assertTrue(CommandParser.parse("use   ") is Command.Invalid)
+        assertTrue(CommandParser.parse("give coin") is Command.Invalid)
+        assertTrue(CommandParser.parse("give   ") is Command.Invalid)
+    }
+
+    @Test
     fun `parses kill and flee`() {
         assertEquals(Command.Kill("wolf"), CommandParser.parse("kill wolf"))
         assertEquals(Command.Flee, CommandParser.parse("flee"))

--- a/src/test/kotlin/dev/ambon/metrics/GameMetricsTest.kt
+++ b/src/test/kotlin/dev/ambon/metrics/GameMetricsTest.kt
@@ -106,11 +106,13 @@ class GameMetricsTest {
         metrics.onXpAwarded(500L, "kill")
         metrics.onXpAwarded(200L, "quest")
         metrics.onXpAwarded(100L, "admin")
+        metrics.onXpAwarded(75L, "item_use")
         metrics.onXpAwarded(50L, "unknown")
 
         assertEquals(550.0, registry.counter("xp_awarded_total", "source", "kill").count())
         assertEquals(200.0, registry.counter("xp_awarded_total", "source", "quest").count())
         assertEquals(100.0, registry.counter("xp_awarded_total", "source", "admin").count())
+        assertEquals(75.0, registry.counter("xp_awarded_total", "source", "item_use").count())
     }
 
     @Test

--- a/src/test/kotlin/dev/ambon/sharding/HandoffManagerTest.kt
+++ b/src/test/kotlin/dev/ambon/sharding/HandoffManagerTest.kt
@@ -7,6 +7,7 @@ import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.items.Item
 import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.items.ItemSlot
+import dev.ambon.domain.items.ItemUseEffect
 import dev.ambon.engine.PlayerProgression
 import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.PlayerState
@@ -175,6 +176,9 @@ class HandoffManagerTest {
                         damage = 7,
                         armor = 1,
                         constitution = 2,
+                        consumable = true,
+                        charges = 3,
+                        onUse = ItemUseEffect(healHp = 4, grantXp = 12),
                         matchByKey = true,
                     ),
             )
@@ -190,6 +194,9 @@ class HandoffManagerTest {
         assertEquals(original.item.damage, restored.item.damage)
         assertEquals(original.item.armor, restored.item.armor)
         assertEquals(original.item.constitution, restored.item.constitution)
+        assertEquals(original.item.consumable, restored.item.consumable)
+        assertEquals(original.item.charges, restored.item.charges)
+        assertEquals(original.item.onUse, restored.item.onUse)
         assertEquals(original.item.matchByKey, restored.item.matchByKey)
     }
 

--- a/src/test/kotlin/dev/ambon/sharding/InterEngineMessageSerializationTest.kt
+++ b/src/test/kotlin/dev/ambon/sharding/InterEngineMessageSerializationTest.kt
@@ -116,6 +116,9 @@ class InterEngineMessageSerializationTest {
                 damage = 7,
                 armor = 1,
                 constitution = 2,
+                consumable = true,
+                charges = 3,
+                onUse = SerializedItemUseEffect(healHp = 4, grantXp = 12),
                 matchByKey = true,
             )
         val json = mapper.writeValueAsString(item)

--- a/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
@@ -103,6 +103,19 @@ class WorldLoaderTest {
     }
 
     @Test
+    fun `loads item use settings`() {
+        val world = WorldLoader.loadFromResource("world/ok_item_use.yaml")
+        val spawn = world.itemSpawns.single()
+        val potion = spawn.instance.item
+        val effect = requireNotNull(potion.onUse)
+
+        assertTrue(potion.consumable)
+        assertEquals(3, potion.charges)
+        assertEquals(5, effect.healHp)
+        assertEquals(25L, effect.grantXp)
+    }
+
+    @Test
     fun `fails when rooms is empty`() {
         val ex =
             assertThrows(WorldLoadException::class.java) {
@@ -174,6 +187,24 @@ class WorldLoaderTest {
             }
         assertTrue(ex.message!!.contains("deprecated", ignoreCase = true), "Got: ${ex.message}")
         assertTrue(ex.message!!.contains("drops", ignoreCase = true), "Got: ${ex.message}")
+    }
+
+    @Test
+    fun `fails when item charges are non-positive`() {
+        val ex =
+            assertThrows(WorldLoadException::class.java) {
+                WorldLoader.loadFromResource("world/bad_item_charges.yaml")
+            }
+        assertTrue(ex.message!!.contains("charges", ignoreCase = true), "Got: ${ex.message}")
+    }
+
+    @Test
+    fun `fails when item onUse block has no positive effect`() {
+        val ex =
+            assertThrows(WorldLoadException::class.java) {
+                WorldLoader.loadFromResource("world/bad_item_on_use_empty.yaml")
+            }
+        assertTrue(ex.message!!.contains("onUse", ignoreCase = true), "Got: ${ex.message}")
     }
 
     @Test

--- a/src/test/resources/world/bad_item_charges.yaml
+++ b/src/test/resources/world/bad_item_charges.yaml
@@ -1,0 +1,12 @@
+zone: bad_item_charges
+startRoom: a
+rooms:
+  a:
+    title: "Room A"
+    description: "Start."
+items:
+  potion:
+    displayName: "a broken potion"
+    charges: 0
+    onUse:
+      healHp: 1

--- a/src/test/resources/world/bad_item_on_use_empty.yaml
+++ b/src/test/resources/world/bad_item_on_use_empty.yaml
@@ -1,0 +1,10 @@
+zone: bad_item_on_use_empty
+startRoom: a
+rooms:
+  a:
+    title: "Room A"
+    description: "Start."
+items:
+  token:
+    displayName: "an inert token"
+    onUse: {}

--- a/src/test/resources/world/ok_item_use.yaml
+++ b/src/test/resources/world/ok_item_use.yaml
@@ -1,0 +1,15 @@
+zone: ok_item_use
+startRoom: a
+rooms:
+  a:
+    title: "Room A"
+    description: "Start."
+items:
+  potion:
+    displayName: "a novice potion"
+    room: a
+    consumable: true
+    charges: 3
+    onUse:
+      healHp: 5
+      grantXp: 25


### PR DESCRIPTION
## Summary
This PR combines item-system upgrades across `#62`, `#64`, and `#82`.

## Issue Mapping
### #62 - Item Use & Consumables
- Added `use <item>` command support.
- Added item schema/model fields:
  - `onUse` (`healHp`, `grantXp`)
  - `consumable`
  - `charges`
- `use` works from both inventory and equipped items.
- Charges decrement on use; consumables are removed when exhausted.
- `grantXp` uses progression scaling and triggers normal level-up/ability-unlock messaging.
- Added `item_use` source to XP metrics.

### #64 - Player-to-Player Trading / Item Giving
- Added `give <item> <player>` command.
- Enforces same-room requirement.
- Disallows giving to self.
- Supports giving from inventory or equipped items.
- Sends confirmation to both sender and recipient.

### #82 - Item Placement Flexibility (Doc-only)
- Updated docs to remove framing item placement exclusivity as an immutable architecture invariant.
- Clarified current loader behavior as implementation detail (still rejects deprecated `mob` placement and dual `room`+`mob` placement).
- No loader behavior change for #82 in this PR.

## Additional Refactor
- Extracted shared item matching logic so all item-related matching follows the same rules (exact keyword first, substring fallback, `matchByKey` respected).

## Validation
- `./gradlew ktlintCheck test` (via Windows wrapper in local run)
- Added/updated targeted tests for parser, router, item registry, loader, sharding serialization, and metrics.

Closes #62
Closes #64
Closes #82