### PR TITLE
Decouple engine/command tests from production world files

### DIFF
--- a/src/test/kotlin/dev/ambon/engine/GameEngineAnsiBehaviorTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GameEngineAnsiBehaviorTest.kt
@@ -3,7 +3,7 @@ package dev.ambon.engine
 import dev.ambon.bus.LocalInboundBus
 import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.domain.ids.SessionId
-import dev.ambon.domain.world.WorldFactory
+import dev.ambon.domain.world.load.WorldLoader
 import dev.ambon.engine.events.InboundEvent
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
@@ -30,7 +30,7 @@ class GameEngineAnsiBehaviorTest {
             val inbound = LocalInboundBus()
             val outbound = LocalOutboundBus()
 
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val repo = InMemoryPlayerRepository()
             val players =
                 PlayerRegistry(
@@ -116,7 +116,7 @@ class GameEngineAnsiBehaviorTest {
             val inbound = LocalInboundBus()
             val outbound = LocalOutboundBus()
 
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val repo = InMemoryPlayerRepository()
             val players = PlayerRegistry(world.startRoom, repo, ItemRegistry())
 

--- a/src/test/kotlin/dev/ambon/engine/GameEngineIntegrationTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GameEngineIntegrationTest.kt
@@ -3,7 +3,6 @@ package dev.ambon.engine
 import dev.ambon.bus.LocalInboundBus
 import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.domain.ids.SessionId
-import dev.ambon.domain.world.WorldFactory
 import dev.ambon.domain.world.load.WorldLoader
 import dev.ambon.engine.events.InboundEvent
 import dev.ambon.engine.events.OutboundEvent
@@ -32,7 +31,7 @@ class GameEngineIntegrationTest {
             val inbound = LocalInboundBus()
             val outbound = LocalOutboundBus()
 
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val repo = InMemoryPlayerRepository()
             val players = PlayerRegistry(world.startRoom, repo, ItemRegistry())
 
@@ -97,7 +96,7 @@ class GameEngineIntegrationTest {
             val inbound = LocalInboundBus()
             val outbound = LocalOutboundBus()
 
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val repo = InMemoryPlayerRepository()
             val players = PlayerRegistry(world.startRoom, repo, ItemRegistry())
 
@@ -239,7 +238,7 @@ class GameEngineIntegrationTest {
             val inbound = LocalInboundBus()
             val outbound = LocalOutboundBus()
 
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val repo = InMemoryPlayerRepository()
             val players = PlayerRegistry(world.startRoom, repo, ItemRegistry())
 

--- a/src/test/kotlin/dev/ambon/engine/GameEngineLoginFlowTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GameEngineLoginFlowTest.kt
@@ -3,7 +3,6 @@ package dev.ambon.engine
 import dev.ambon.bus.LocalInboundBus
 import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.domain.ids.SessionId
-import dev.ambon.domain.world.WorldFactory
 import dev.ambon.domain.world.load.WorldLoader
 import dev.ambon.engine.events.InboundEvent
 import dev.ambon.engine.events.OutboundEvent
@@ -35,7 +34,7 @@ class GameEngineLoginFlowTest {
             val inbound = LocalInboundBus()
             val outbound = LocalOutboundBus()
 
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val repo = InMemoryPlayerRepository()
             val players = PlayerRegistry(world.startRoom, repo, ItemRegistry())
 
@@ -95,7 +94,7 @@ class GameEngineLoginFlowTest {
             val inbound = LocalInboundBus()
             val outbound = LocalOutboundBus()
 
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val repo = InMemoryPlayerRepository()
             repo.create("Alice", world.startRoom, 0L, BCrypt.hashpw("secret", BCrypt.gensalt()), ansiEnabled = false)
             val players = PlayerRegistry(world.startRoom, repo, ItemRegistry())
@@ -167,7 +166,7 @@ class GameEngineLoginFlowTest {
             val inbound = LocalInboundBus()
             val outbound = LocalOutboundBus()
 
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val repo = InMemoryPlayerRepository()
             repo.create("Alice", world.startRoom, 0L, BCrypt.hashpw("secret", BCrypt.gensalt()), ansiEnabled = false)
             val players = PlayerRegistry(world.startRoom, repo, ItemRegistry())
@@ -259,7 +258,7 @@ class GameEngineLoginFlowTest {
             val inbound = LocalInboundBus()
             val outbound = LocalOutboundBus()
 
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val repo = InMemoryPlayerRepository()
             repo.create("Alice", world.startRoom, 0L, BCrypt.hashpw("secret", BCrypt.gensalt()), ansiEnabled = false)
             val players = PlayerRegistry(world.startRoom, repo, ItemRegistry())
@@ -316,7 +315,7 @@ class GameEngineLoginFlowTest {
             val inbound = LocalInboundBus()
             val outbound = LocalOutboundBus()
 
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val repo = InMemoryPlayerRepository()
             val players = PlayerRegistry(world.startRoom, repo, ItemRegistry())
 
@@ -419,7 +418,7 @@ class GameEngineLoginFlowTest {
             val inbound = LocalInboundBus()
             val outbound = LocalOutboundBus()
 
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val repo = InMemoryPlayerRepository()
             repo.create("Alice", world.startRoom, 0L, BCrypt.hashpw("secret", BCrypt.gensalt()), ansiEnabled = false)
             repo.create("Observer", world.startRoom, 0L, BCrypt.hashpw("pw", BCrypt.gensalt()), ansiEnabled = false)
@@ -508,7 +507,7 @@ class GameEngineLoginFlowTest {
             val inbound = LocalInboundBus()
             val outbound = LocalOutboundBus()
 
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val repo = InMemoryPlayerRepository()
             repo.create("Alice", world.startRoom, 0L, BCrypt.hashpw("secret", BCrypt.gensalt()), ansiEnabled = false)
             val items = ItemRegistry()

--- a/src/test/kotlin/dev/ambon/engine/InterEngineMessageHandlingTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/InterEngineMessageHandlingTest.kt
@@ -3,7 +3,7 @@ package dev.ambon.engine
 import dev.ambon.bus.LocalInboundBus
 import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.domain.ids.SessionId
-import dev.ambon.domain.world.WorldFactory
+import dev.ambon.domain.world.load.WorldLoader
 import dev.ambon.engine.events.InboundEvent
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
@@ -72,7 +72,7 @@ class InterEngineMessageHandlingTest {
         onShutdown: suspend () -> Unit = {},
     ): EngineTestHarness {
         val clock = MutableClock(0L)
-        val world = WorldFactory.demoWorld()
+        val world = WorldLoader.loadFromResource("world/test_world.yaml")
         val items = ItemRegistry()
         val repo = InMemoryPlayerRepository()
         val players = PlayerRegistry(world.startRoom, repo, items, clock = clock)

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterBroadcastTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterBroadcastTest.kt
@@ -2,7 +2,7 @@ package dev.ambon.engine.commands
 
 import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.domain.ids.SessionId
-import dev.ambon.domain.world.WorldFactory
+import dev.ambon.domain.world.load.WorldLoader
 import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.LoginResult
 import dev.ambon.engine.MobRegistry
@@ -22,7 +22,7 @@ class CommandRouterBroadcastTest {
     @Test
     fun `say broadcasts to other players in same room and echoes to sender`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val mobs = MobRegistry()
@@ -53,7 +53,7 @@ class CommandRouterBroadcastTest {
     @Test
     fun `say does not broadcast across rooms`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val mobs = MobRegistry()
@@ -85,7 +85,7 @@ class CommandRouterBroadcastTest {
     @Test
     fun `who lists connected players`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val mobs = MobRegistry()

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterItemsTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterItemsTest.kt
@@ -7,7 +7,7 @@ import dev.ambon.domain.items.Item
 import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.items.ItemSlot
 import dev.ambon.domain.items.ItemUseEffect
-import dev.ambon.domain.world.WorldFactory
+import dev.ambon.domain.world.load.WorldLoader
 import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.LoginResult
 import dev.ambon.engine.MobRegistry
@@ -24,7 +24,7 @@ class CommandRouterItemsTest {
     @Test
     fun `look includes items here line`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             items.setRoomItems(
                 world.startRoom,
@@ -55,7 +55,7 @@ class CommandRouterItemsTest {
     @Test
     fun `get moves item from room to inventory`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             items.setRoomItems(
                 world.startRoom,
@@ -86,7 +86,7 @@ class CommandRouterItemsTest {
     @Test
     fun `inventory shows carried items`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
 
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
@@ -123,7 +123,7 @@ class CommandRouterItemsTest {
     @Test
     fun `drop moves item from inventory to room`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
 
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
@@ -159,7 +159,7 @@ class CommandRouterItemsTest {
     @Test
     fun `wear moves item from inventory to equipment slot`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
 
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
@@ -200,7 +200,7 @@ class CommandRouterItemsTest {
     @Test
     fun `remove moves item from equipment slot back to inventory`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
 
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
@@ -242,7 +242,7 @@ class CommandRouterItemsTest {
     @Test
     fun `wear prefers wearable item when multiple inventory items share keyword`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
 
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
@@ -286,7 +286,7 @@ class CommandRouterItemsTest {
     @Test
     fun `use applies effects and consumes when charges reach zero`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val outbound = LocalOutboundBus()
@@ -338,7 +338,7 @@ class CommandRouterItemsTest {
     @Test
     fun `use can consume equipped item and updates defense`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val outbound = LocalOutboundBus()
@@ -383,7 +383,7 @@ class CommandRouterItemsTest {
     @Test
     fun `give moves item to nearby player inventory`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val outbound = LocalOutboundBus()
@@ -416,7 +416,7 @@ class CommandRouterItemsTest {
     @Test
     fun `give removes equipped item and updates defense`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val outbound = LocalOutboundBus()
@@ -457,7 +457,7 @@ class CommandRouterItemsTest {
     @Test
     fun `give requires target in same room`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val outbound = LocalOutboundBus()

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterScoreTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterScoreTest.kt
@@ -6,7 +6,7 @@ import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.items.Item
 import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.items.ItemSlot
-import dev.ambon.domain.world.WorldFactory
+import dev.ambon.domain.world.load.WorldLoader
 import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.LoginResult
 import dev.ambon.engine.MobRegistry
@@ -23,7 +23,7 @@ class CommandRouterScoreTest {
     @Test
     fun `score shows name level hp and damage range`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val mobs = MobRegistry()
@@ -50,7 +50,7 @@ class CommandRouterScoreTest {
     @Test
     fun `score with equipped armor item lists it in Armor section`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val mobs = MobRegistry()
@@ -76,7 +76,7 @@ class CommandRouterScoreTest {
     @Test
     fun `score at max level shows MAXED for XP`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val mobs = MobRegistry()

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterTest.kt
@@ -3,7 +3,7 @@ package dev.ambon.engine.commands
 import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.world.Direction
-import dev.ambon.domain.world.WorldFactory
+import dev.ambon.domain.world.load.WorldLoader
 import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.LoginResult
 import dev.ambon.engine.MobRegistry
@@ -24,7 +24,7 @@ class CommandRouterTest {
     @Test
     fun `look emits room title description exits and prompt`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val mobs = MobRegistry()
@@ -62,7 +62,7 @@ class CommandRouterTest {
     @Test
     fun `look includes players currently in room`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val mobs = MobRegistry()
@@ -89,7 +89,7 @@ class CommandRouterTest {
     @Test
     fun `move north changes room and then look describes new room`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val mobs = MobRegistry()
@@ -127,7 +127,7 @@ class CommandRouterTest {
     @Test
     fun `move broadcasts leave and enter to room members`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val mobs = MobRegistry()
@@ -172,7 +172,7 @@ class CommandRouterTest {
     @Test
     fun `move blocked emits can't go that way and prompt`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val mobs = MobRegistry()
@@ -201,7 +201,7 @@ class CommandRouterTest {
     @Test
     fun `tell to unknown name emits error to sender only`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val mobs = MobRegistry()
@@ -237,7 +237,7 @@ class CommandRouterTest {
     @Test
     fun `tell delivers to target only and not to third party`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val mobs = MobRegistry()
@@ -282,7 +282,7 @@ class CommandRouterTest {
     @Test
     fun `say broadcasts only to room members and echoes to sender`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val mobs = MobRegistry()
@@ -311,7 +311,7 @@ class CommandRouterTest {
     @Test
     fun `gossip broadcasts to all connected`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val mobs = MobRegistry()
@@ -346,7 +346,7 @@ class CommandRouterTest {
     @Test
     fun `login name uniqueness is case-insensitive`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
 
@@ -363,7 +363,7 @@ class CommandRouterTest {
     @Test
     fun `exits emits exits line and prompt only`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val mobs = MobRegistry()
@@ -386,7 +386,7 @@ class CommandRouterTest {
     @Test
     fun `look dir shows adjacent room title when exit exists`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val mobs = MobRegistry()
@@ -416,7 +416,7 @@ class CommandRouterTest {
     @Test
     fun `look dir shows message when no exit exists`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val mobs = MobRegistry()

--- a/src/test/kotlin/dev/ambon/engine/commands/CrossEngineCommandsTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CrossEngineCommandsTest.kt
@@ -2,7 +2,7 @@ package dev.ambon.engine.commands
 
 import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.domain.ids.SessionId
-import dev.ambon.domain.world.WorldFactory
+import dev.ambon.domain.world.load.WorldLoader
 import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.LoginResult
 import dev.ambon.engine.MobRegistry
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CrossEngineCommandsTest {
-    private val world = WorldFactory.demoWorld()
+    private val world = WorldLoader.loadFromResource("world/test_world.yaml")
     private val items = ItemRegistry()
     private val repo = InMemoryPlayerRepository()
     private val players = PlayerRegistry(world.startRoom, repo, items)

--- a/src/test/kotlin/dev/ambon/engine/commands/NamesTellGossipTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/NamesTellGossipTest.kt
@@ -3,7 +3,7 @@ package dev.ambon.engine.commands
 import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.world.Direction
-import dev.ambon.domain.world.WorldFactory
+import dev.ambon.domain.world.load.WorldLoader
 import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.LoginResult
 import dev.ambon.engine.MobRegistry
@@ -22,7 +22,7 @@ class NamesTellGossipTest {
     @Test
     fun `name sets and who reflects new name`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val mobs = MobRegistry()
@@ -44,7 +44,7 @@ class NamesTellGossipTest {
     @Test
     fun `name must be unique case-insensitively`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
 
@@ -59,7 +59,7 @@ class NamesTellGossipTest {
     @Test
     fun `tell delivers to target only`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val outbound = LocalOutboundBus()
@@ -101,7 +101,7 @@ class NamesTellGossipTest {
     @Test
     fun `gossip broadcasts to all connected`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val mobs = MobRegistry()
@@ -130,7 +130,7 @@ class NamesTellGossipTest {
     @Test
     fun `tell across rooms still works`() =
         runTest {
-            val world = WorldFactory.demoWorld()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
             val items = ItemRegistry()
             val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val mobs = MobRegistry()

--- a/src/test/kotlin/dev/ambon/engine/commands/SocialChannelCommandsTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/SocialChannelCommandsTest.kt
@@ -3,7 +3,7 @@ package dev.ambon.engine.commands
 import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.world.Direction
-import dev.ambon.domain.world.WorldFactory
+import dev.ambon.domain.world.load.WorldLoader
 import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.LoginResult
 import dev.ambon.engine.MobRegistry
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class SocialChannelCommandsTest {
     private fun buildFixture(): Triple<CommandRouter, PlayerRegistry, LocalOutboundBus> {
-        val world = WorldFactory.demoWorld()
+        val world = WorldLoader.loadFromResource("world/test_world.yaml")
         val items = ItemRegistry()
         val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
         val mobs = MobRegistry()

--- a/src/test/kotlin/dev/ambon/grpc/GatewayEngineIntegrationTest.kt
+++ b/src/test/kotlin/dev/ambon/grpc/GatewayEngineIntegrationTest.kt
@@ -6,7 +6,7 @@ import dev.ambon.bus.LocalInboundBus
 import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.config.GatewayReconnectConfig
 import dev.ambon.domain.ids.SessionId
-import dev.ambon.domain.world.WorldFactory
+import dev.ambon.domain.world.load.WorldLoader
 import dev.ambon.engine.GameEngine
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PlayerProgression
@@ -101,7 +101,7 @@ class GatewayEngineIntegrationTest {
         dispatcher.start()
 
         // Start the game engine on its own thread.
-        val world = WorldFactory.demoWorld()
+        val world = WorldLoader.loadFromResource("world/test_world.yaml")
         val repo = InMemoryPlayerRepository()
         val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)
         val items = ItemRegistry()

--- a/src/test/resources/world/test_world.yaml
+++ b/src/test/resources/world/test_world.yaml
@@ -1,0 +1,31 @@
+# Minimal world used exclusively by unit/integration tests.
+# Production world files (tutorial_glade, ambon_hub, etc.) must NOT be required
+# by engine or command tests.  Any change to game content should leave these
+# tests unaffected.
+zone: test_zone
+lifespan: 30
+startRoom: hub
+mobs:
+  grunt:
+    name: "a burly grunt"
+    room: outpost
+    drops:
+      - itemId: badge
+        chance: 0.5
+items:
+  coin:
+    displayName: "a silver coin"
+    room: hub
+  badge:
+    displayName: "a worn badge"
+rooms:
+  hub:
+    title: "Test Hub"
+    description: "A central test room."
+    exits:
+      north: outpost
+  outpost:
+    title: "Test Outpost"
+    description: "A northern test room."
+    exits:
+      south: hub


### PR DESCRIPTION
Tests were fragile because they loaded the full demo world (tutorial_glade, ambon_hub, demo_ruins, noecker_resume) via WorldFactory.demoWorld(), meaning any edit to those files — adding a room, renaming a mob, changing an exit — could silently break unrelated engine or command tests.

Changes:
- Add src/test/resources/world/test_world.yaml: a minimal, self-contained two-room world (test_zone:hub ↔ test_zone:outpost) with a mob and item, used exclusively by unit/integration tests.
- Replace all WorldFactory.demoWorld() calls in engine and command tests with WorldLoader.loadFromResource("world/test_world.yaml").
- CommandRouterAdminTest: update hardcoded production room IDs (demo_ruins:caravan_gate → test_zone:outpost, campfire_ring → hub, gate_scout → grunt, etc.) to use the new test world.
- WorldLoaderTest: remove brittle exact-count assertions on tutorial_glade (28 rooms / 8 mobs / 14 items) that broke whenever content was added; replace the WorldFactory.demoWorld() cross-zone test with one that uses the existing mz_forest/mz_swamp test fixtures, since that feature is already covered by MultiZoneWorldLoaderTest.

