### PR TITLE
Implement phase 1 telnet negotiation support for NAWS and TTYPE

### DIFF
--- a/src/main/kotlin/dev/ambon/transport/TelnetLineDecoder.kt
+++ b/src/main/kotlin/dev/ambon/transport/TelnetLineDecoder.kt
@@ -95,6 +95,7 @@ class TelnetLineDecoder(
                     }
 
                     TelnetProtocol.IAC -> {
+                        // Escaped IAC inside subnegotiation data.
                         appendSubnegotiationByte(TelnetProtocol.IAC)
                         state = State.IAC_SB_DATA
                     }
@@ -166,10 +167,18 @@ sealed interface TelnetControlEvent {
         val option: Int,
     ) : TelnetControlEvent
 
-    data class Subnegotiation(
+    class Subnegotiation(
         val option: Int,
         val payload: ByteArray,
-    ) : TelnetControlEvent
+    ) : TelnetControlEvent {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Subnegotiation) return false
+            return option == other.option && payload.contentEquals(other.payload)
+        }
+
+        override fun hashCode(): Int = 31 * option + payload.contentHashCode()
+    }
 }
 
 object TelnetProtocol {


### PR DESCRIPTION
### Motivation
- Add phase‑1 telnet option handling so the telnet transport can learn client terminal type and window size (NAWS and TTYPE) as part of issue #67.
- Make the telnet decoder robust to subnegotiation payloads and avoid line/output interleaving when sending raw telnet frames.

### Description
- Extend `TelnetLineDecoder` with an explicit IAC/negotiation/subnegotiation state machine, emit structured `TelnetControlEvent` values, and add `TelnetProtocol` constants for `IAC/SB/SE/WILL/WONT/DO/DONT/TTYPE/NAWS`.
- Add a `maxSubnegotiationLen` guard and subnegotiation payload buffering to protect against abusive/oversized frames while preserving existing line decoding behavior.
- Update `NetworkSession` to initiate negotiation (`DO TTYPE`, `DO NAWS`), request `TTYPE SEND` when the client advertises `WILL TTYPE`, parse `TTYPE IS` payload and NAWS window dimensions, and store them in a per‑session `TerminalCapabilities` object.
- Add `outputLock` synchronization around raw telnet writes and the normal outbound writer loop to prevent interleaved bytes between negotiation frames and text frames, and add unit tests for NAWS/TTYPE parsing and subnegotiation bounds in `TelnetLineDecoderTest`.

### Testing
- `./gradlew compileKotlin` completed successfully and verified the code compiles. 
- `./gradlew ktlintCheck` completed successfully and found no lint issues. 
- `./gradlew test` could not complete in this environment due to external dependency resolution failing (Maven Central returned HTTP 403 for `org.apiguardian:apiguardian-api:1.1.2`), so the added unit tests (`dev.ambon.transport.TelnetLineDecoderTest`) could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cc64d03888323b6bd60196efb09be)