### PR TITLE
Update swarm bots for new login flow and ability usage

### DIFF
--- a/swarm/src/main/kotlin/dev/ambon/swarm/SwarmConfig.kt
+++ b/swarm/src/main/kotlin/dev/ambon/swarm/SwarmConfig.kt
@@ -63,7 +63,7 @@ data class BehaviorConfig(
     val weights: BehaviorWeights = BehaviorWeights(),
     val chatPhrases: List<String> = listOf("hello", "lag?", "nice room", "test ping"),
     val movementCommands: List<String> = listOf("north", "south", "east", "west", "look"),
-    val combatCommands: List<String> = listOf("kill rat", "kill goblin", "attack rat"),
+    val combatCommands: List<String> = listOf("kill rat", "kill goblin", "attack rat", "cast magic_missile rat", "cast heal"),
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/swarm/src/main/kotlin/dev/ambon/swarm/SwarmLoginHeuristics.kt
+++ b/swarm/src/main/kotlin/dev/ambon/swarm/SwarmLoginHeuristics.kt
@@ -1,0 +1,35 @@
+package dev.ambon.swarm
+
+private val ansiRegex = Regex("\\u001B\\[[;\\d]*m")
+
+internal fun normalizeSwarmLine(raw: String): String = raw.replace(ansiRegex, "").trim()
+
+internal fun isLoginPrompt(line: String): Boolean {
+    val lower = line.lowercase()
+    return lower == ">" ||
+        "enter your name" in lower ||
+        "no user named" in lower ||
+        "create a new user" in lower ||
+        "please answer yes or no" in lower ||
+        "create a password" in lower ||
+        lower == "password:" ||
+        lower.startsWith("password:") ||
+        "incorrect password" in lower ||
+        "blank password" in lower ||
+        "invalid password" in lower
+}
+
+internal fun isTerminalLoginFailure(line: String): Boolean {
+    val lower = line.lowercase()
+    return "too many failed login attempts" in lower
+}
+
+internal fun isWorldSignal(line: String): Boolean {
+    val lower = line.lowercase()
+    return lower.startsWith("exits:") ||
+        lower.contains("known spells") ||
+        lower.contains("you have learned") ||
+        lower.contains("you attack") ||
+        lower.contains("you say") ||
+        lower.contains("you are transported")
+}

--- a/swarm/src/test/kotlin/dev/ambon/swarm/SwarmLoginHeuristicsTest.kt
+++ b/swarm/src/test/kotlin/dev/ambon/swarm/SwarmLoginHeuristicsTest.kt
@@ -1,0 +1,28 @@
+package dev.ambon.swarm
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SwarmLoginHeuristicsTest {
+    @Test
+    fun `normalizes ansi`() {
+        val normalized = normalizeSwarmLine("\u001B[2m\u001B[96mEnter your name:\u001B[0m")
+        assertTrue(normalized == "Enter your name:")
+    }
+
+    @Test
+    fun `recognizes new login prompts`() {
+        assertTrue(isLoginPrompt("No user named 'foo' was found. Create a new user? (yes/no)"))
+        assertTrue(isLoginPrompt("Please answer yes or no."))
+        assertTrue(isLoginPrompt("Password:"))
+        assertTrue(isLoginPrompt(">"))
+    }
+
+    @Test
+    fun `recognizes world signals`() {
+        assertTrue(isWorldSignal("Exits: north east"))
+        assertTrue(isWorldSignal("Known spells (Mana: 10/10):"))
+        assertFalse(isWorldSignal("Create a password:"))
+    }
+}


### PR DESCRIPTION
### Motivation
- The swarm load tester must follow the repository's updated staged login flow and exercise new ability/skill traffic so load tests remain representative.
- Bots need to tolerate ANSI-decorated login screen output and distinguish login prompts from in-game text reliably.

### Description
- Added `swarm/src/main/kotlin/dev/ambon/swarm/SwarmLoginHeuristics.kt` with `normalizeSwarmLine`, `isLoginPrompt`, `isTerminalLoginFailure`, and `isWorldSignal` to detect login vs world output and strip ANSI sequences. 
- Updated `swarm/src/main/kotlin/dev/ambon/swarm/SwarmRunner.kt` login flow to use those heuristics, proactively send a `look` probe after password submission when needed, and treat prompt-only frames (`> `) as signals; telnet reader parsing was improved to capture prompt frames and emit a standalone `>` token. 
- Extended default combat command mix in `swarm/src/main/kotlin/dev/ambon/swarm/SwarmConfig.kt` to include ability usage (`cast magic_missile rat`, `cast heal`) so traffic covers the new skill system. 
- Added unit tests `swarm/src/test/kotlin/dev/ambon/swarm/SwarmLoginHeuristicsTest.kt` that validate ANSI normalization and the login/world heuristics. 

### Testing
- Added unit tests (`SwarmLoginHeuristicsTest`) covering `normalizeSwarmLine`, `isLoginPrompt`, and `isWorldSignal`; these tests were added to the project but were not executed successfully in this environment. 
- Attempted to run `./gradlew ktlintCheck test` but the Gradle wrapper download failed due to an external network/proxy error (Gradle distribution download returned HTTP 403), so CI/worker execution of `ktlintCheck` and `test` did not complete here.
- The new tests should execute in CI where the Gradle wrapper can download artifacts; they were written to be deterministic and small.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d134c7be48323ac967c4ae35eca01)