### PR TITLE
Harden swarm login automation for updated auth prompts and WS framing

### DIFF
--- a/swarm/src/main/kotlin/dev/ambon/swarm/LoginFlowInterpreter.kt
+++ b/swarm/src/main/kotlin/dev/ambon/swarm/LoginFlowInterpreter.kt
@@ -1,0 +1,53 @@
+package dev.ambon.swarm
+
+internal enum class LoginSignal {
+    SEND_NAME,
+    SEND_YES,
+    SEND_PASSWORD,
+    SUCCESS,
+    NOOP,
+}
+
+internal class LoginFlowInterpreter(
+    private val credential: BotCredential,
+) {
+    private var sentCredential = false
+
+    fun onLine(rawLine: String): LoginSignal {
+        val line = normalize(rawLine)
+        if (line.isEmpty()) return LoginSignal.NOOP
+
+        return when {
+            "enter your name" in line || line.startsWith("name:") -> LoginSignal.SEND_NAME
+            "create a new user" in line || "no user named" in line -> LoginSignal.SEND_YES
+            "create a password" in line || "new password" in line -> {
+                sentCredential = true
+                LoginSignal.SEND_PASSWORD
+            }
+            line.startsWith("password:") || "password:" in line -> {
+                sentCredential = true
+                LoginSignal.SEND_PASSWORD
+            }
+            sentCredential && looksLikeInGameOutput(line) -> LoginSignal.SUCCESS
+            else -> LoginSignal.NOOP
+        }
+    }
+
+    private fun looksLikeInGameOutput(line: String): Boolean =
+        line.startsWith("exits:") ||
+            " hp " in " $line " ||
+            "also online:" in line ||
+            "you are in combat" in line ||
+            " enters." in line ||
+            "leaves." in line
+
+    private fun normalize(input: String): String {
+        val withoutAnsi = ANSI_ESCAPE_REGEX.replace(input, "")
+        val withoutName = withoutAnsi.replace(credential.name.lowercase(), "<bot>")
+        return withoutName.trim().lowercase()
+    }
+
+    private companion object {
+        val ANSI_ESCAPE_REGEX = Regex("\\u001B\\[[0-9;]*[ -/]*[@-~]")
+    }
+}

--- a/swarm/src/test/kotlin/dev/ambon/swarm/LoginFlowInterpreterTest.kt
+++ b/swarm/src/test/kotlin/dev/ambon/swarm/LoginFlowInterpreterTest.kt
@@ -1,0 +1,30 @@
+package dev.ambon.swarm
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LoginFlowInterpreterTest {
+    private val credential = BotCredential(name = "swarm_0001", password = "swarmpass")
+
+    @Test
+    fun `handles create-account prompt sequence`() {
+        val interpreter = LoginFlowInterpreter(credential)
+
+        assertEquals(LoginSignal.SEND_NAME, interpreter.onLine("Enter your name:"))
+        assertEquals(
+            LoginSignal.SEND_YES,
+            interpreter.onLine("No user named 'swarm_0001' was found. Create a new user? (yes/no)"),
+        )
+        assertEquals(LoginSignal.SEND_PASSWORD, interpreter.onLine("Create a password:"))
+        assertEquals(LoginSignal.SUCCESS, interpreter.onLine("Exits: north, south"))
+    }
+
+    @Test
+    fun `handles existing-account prompt and ansi wrapped text`() {
+        val interpreter = LoginFlowInterpreter(credential)
+
+        assertEquals(LoginSignal.SEND_NAME, interpreter.onLine("\u001B[2m\u001B[96mEnter your name:\u001B[0m"))
+        assertEquals(LoginSignal.SEND_PASSWORD, interpreter.onLine("Password:"))
+        assertEquals(LoginSignal.SUCCESS, interpreter.onLine("\u001B[2m\u001B[96mAlso online: Alice\u001B[0m"))
+    }
+}


### PR DESCRIPTION
### Motivation
- The server login flow and UI output changed (new prompts and ANSI-wrapped frames), which made the existing brittle swarm bot login logic fail during swarm testing.
- WebSocket text frames can be fragmented, which caused partial-line delivery that broke bot state transitions.

### Description
- Added `LoginFlowInterpreter` to normalize incoming text (strip ANSI, mask bot name) and emit high-level `LoginSignal`s so bots reliably react to the login state-machine. (`swarm/src/main/kotlin/dev/ambon/swarm/LoginFlowInterpreter.kt`)
- Switched `BotWorker.login()` to use the `LoginFlowInterpreter` instead of inline string checks and used `LoginSignal` to send name/confirmation/password or detect success. (`swarm/src/main/kotlin/dev/ambon/swarm/SwarmRunner.kt`)
- Improved WebSocket inbound parsing by buffering fragmented frames and emitting complete lines so prompts and responses are not split across `onText` callbacks. (`swarm/src/main/kotlin/dev/ambon/swarm/SwarmRunner.kt`)
- Added focused unit tests for the interpreter covering create-account and existing-account flows, including ANSI-wrapped prompt cases. (`swarm/src/test/kotlin/dev/ambon/swarm/LoginFlowInterpreterTest.kt`)
- Change scope is limited to the `:swarm` module and does not modify engine login behavior.

### Testing
- Ran `./gradlew :swarm:ktlintCheck` which succeeded.
- Ran `./gradlew :swarm:compileKotlin` which succeeded.
- Ran `./gradlew :swarm:test` but it failed in this environment due to external Maven dependency resolution returning HTTP 403, preventing full test execution; the new unit tests are present but could not be executed here for that reason.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d134c7be48323ac967c4ae35eca01)