### PR TITLE
Add GMCP support: structured JSON alongside text output

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -31,6 +31,7 @@ class CombatSystem(
     private val strDivisor: Int = 3,
     private val dexDodgePerPoint: Int = 2,
     private val maxDodgePercent: Int = 30,
+    private val markVitalsDirty: (SessionId) -> Unit = {},
 ) {
     private data class Fight(
         val sessionId: SessionId,
@@ -234,6 +235,7 @@ class CombatSystem(
                         armorAbsorbed = 0,
                     )
                 player.hp = (player.hp - mobDamage).coerceAtLeast(0)
+                markVitalsDirty(fight.sessionId)
                 val mobHitText = "${mob.name} hits you for $mobDamage damage$mobFeedbackSuffix."
                 outbound.send(OutboundEvent.SendText(fight.sessionId, mobHitText))
                 if (detailedFeedbackEnabled && detailedFeedbackRoomBroadcastEnabled) {
@@ -401,6 +403,7 @@ class CombatSystem(
         val result = players.grantXp(sessionId, reward, progression) ?: return
         metrics.onXpAwarded(reward, "kill")
         outbound.send(OutboundEvent.SendText(sessionId, "You gain $reward XP."))
+        markVitalsDirty(sessionId)
         if (result.levelsGained <= 0) return
         metrics.onLevelUp()
 

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -1,0 +1,49 @@
+package dev.ambon.engine
+
+import dev.ambon.bus.OutboundBus
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.world.Room
+import dev.ambon.engine.events.OutboundEvent
+
+class GmcpEmitter(
+    private val outbound: OutboundBus,
+    private val supportsPackage: (SessionId, String) -> Boolean,
+) {
+    suspend fun sendCharVitals(
+        sessionId: SessionId,
+        player: PlayerState,
+    ) {
+        if (!supportsPackage(sessionId, "Char.Vitals")) return
+        val json =
+            """{"hp":${player.hp},"maxHp":${player.maxHp},"mana":${player.mana},"maxMana":${player.maxMana},"level":${player.level},"xp":${player.xpTotal}}"""
+        outbound.send(OutboundEvent.GmcpData(sessionId, "Char.Vitals", json))
+    }
+
+    suspend fun sendRoomInfo(
+        sessionId: SessionId,
+        room: Room,
+    ) {
+        if (!supportsPackage(sessionId, "Room.Info")) return
+        val exitsJson =
+            room.exits.entries.joinToString(",") { (dir, roomId) ->
+                """"${dir.name.lowercase()}":"${roomId.value.jsonEscape()}""""
+            }
+        val json =
+            """{"id":"${room.id.value.jsonEscape()}","title":"${room.title.jsonEscape()}","description":"${room.description.jsonEscape()}","zone":"${room.id.zone.jsonEscape()}","exits":{$exitsJson}}"""
+        outbound.send(OutboundEvent.GmcpData(sessionId, "Room.Info", json))
+    }
+
+    suspend fun sendCharStatusVars(sessionId: SessionId) {
+        if (!supportsPackage(sessionId, "Char.StatusVars")) return
+        val json = """{"hp":"HP","maxHp":"Max HP","mana":"Mana","maxMana":"Max Mana","level":"Level","xp":"XP"}"""
+        outbound.send(OutboundEvent.GmcpData(sessionId, "Char.StatusVars", json))
+    }
+
+    private fun String.jsonEscape(): String =
+        this
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t")
+}

--- a/src/main/kotlin/dev/ambon/engine/RegenSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/RegenSystem.kt
@@ -20,6 +20,7 @@ class RegenSystem(
     private val manaRegenAmount: Int = 1,
     private val msPerWisdom: Long = 200L,
     private val metrics: GameMetrics = GameMetrics.noop(),
+    private val markVitalsDirty: (SessionId) -> Unit = {},
 ) {
     private val lastRegenAtMs = mutableMapOf<SessionId, Long>()
     private val lastManaRegenAtMs = mutableMapOf<SessionId, Long>()
@@ -60,6 +61,7 @@ class RegenSystem(
                     val updated = (player.hp + regenAmount).coerceAtMost(player.maxHp)
                     if (updated != player.hp) {
                         player.hp = updated
+                        markVitalsDirty(sessionId)
                     }
                     lastRegenAtMs[sessionId] = now
                     didWork = true
@@ -76,6 +78,7 @@ class RegenSystem(
                     val updated = (player.mana + manaRegenAmount).coerceAtMost(player.maxMana)
                     if (updated != player.mana) {
                         player.mana = updated
+                        markVitalsDirty(sessionId)
                     }
                     lastManaRegenAtMs[sessionId] = now
                     didWork = true

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
@@ -21,6 +21,7 @@ class AbilitySystem(
     private val rng: Random = Random(),
     private val items: ItemRegistry? = null,
     private val intSpellDivisor: Int = 3,
+    private val markVitalsDirty: (SessionId) -> Unit = {},
 ) {
     private val learnedAbilities = mutableMapOf<SessionId, MutableSet<AbilityId>>()
     private val cooldowns = mutableMapOf<SessionId, MutableMap<AbilityId, Long>>()
@@ -92,6 +93,7 @@ class AbilitySystem(
 
                 // 5. Deduct mana
                 player.mana = (player.mana - ability.manaCost).coerceAtLeast(0)
+                markVitalsDirty(sessionId)
 
                 // 6. Set cooldown
                 if (ability.cooldownMs > 0) {
@@ -129,6 +131,7 @@ class AbilitySystem(
             TargetType.SELF -> {
                 // 5. Deduct mana
                 player.mana = (player.mana - ability.manaCost).coerceAtLeast(0)
+                markVitalsDirty(sessionId)
 
                 // 6. Set cooldown
                 if (ability.cooldownMs > 0) {
@@ -143,6 +146,7 @@ class AbilitySystem(
                 val before = player.hp
                 player.hp = (player.hp + healAmount).coerceAtMost(player.maxHp)
                 val healed = player.hp - before
+                if (healed > 0) markVitalsDirty(sessionId)
 
                 outbound.send(
                     OutboundEvent.SendText(

--- a/src/main/kotlin/dev/ambon/engine/events/InboundEvent.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/InboundEvent.kt
@@ -17,4 +17,11 @@ sealed interface InboundEvent {
         val sessionId: SessionId,
         val line: String,
     ) : InboundEvent
+
+    /** Structured GMCP data received from the client. */
+    data class GmcpReceived(
+        val sessionId: SessionId,
+        val gmcpPackage: String,
+        val jsonData: String,
+    ) : InboundEvent
 }

--- a/src/main/kotlin/dev/ambon/engine/events/OutboundEvent.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/OutboundEvent.kt
@@ -51,4 +51,11 @@ sealed interface OutboundEvent {
         val newEngineHost: String,
         val newEnginePort: Int,
     ) : OutboundEvent
+
+    /** Structured GMCP data (package name + raw JSON payload). */
+    data class GmcpData(
+        val sessionId: SessionId,
+        val gmcpPackage: String,
+        val jsonData: String,
+    ) : OutboundEvent
 }

--- a/src/main/kotlin/dev/ambon/gateway/SessionRouter.kt
+++ b/src/main/kotlin/dev/ambon/gateway/SessionRouter.kt
@@ -190,6 +190,7 @@ private fun InboundEvent.sessionId(): SessionId =
     when (this) {
         is InboundEvent.Connected -> sessionId
         is InboundEvent.Disconnected -> sessionId
+        is InboundEvent.GmcpReceived -> sessionId
         is InboundEvent.LineReceived -> sessionId
     }
 

--- a/src/main/kotlin/dev/ambon/grpc/GrpcOutboundDispatcher.kt
+++ b/src/main/kotlin/dev/ambon/grpc/GrpcOutboundDispatcher.kt
@@ -146,6 +146,7 @@ fun OutboundEvent.sessionId(): SessionId =
         is OutboundEvent.SetAnsi -> sessionId
         is OutboundEvent.Close -> sessionId
         is OutboundEvent.ClearScreen -> sessionId
+        is OutboundEvent.GmcpData -> sessionId
         is OutboundEvent.ShowAnsiDemo -> sessionId
         is OutboundEvent.SessionRedirect -> sessionId
     }

--- a/src/main/kotlin/dev/ambon/grpc/OutboundEventPlane.kt
+++ b/src/main/kotlin/dev/ambon/grpc/OutboundEventPlane.kt
@@ -16,6 +16,7 @@ fun OutboundEvent.isControlPlane(): Boolean =
         is OutboundEvent.ClearScreen,
         is OutboundEvent.SessionRedirect,
         -> true
+        is OutboundEvent.GmcpData,
         is OutboundEvent.SendText,
         is OutboundEvent.SendInfo,
         is OutboundEvent.SendError,

--- a/src/main/kotlin/dev/ambon/grpc/ProtoMapper.kt
+++ b/src/main/kotlin/dev/ambon/grpc/ProtoMapper.kt
@@ -7,6 +7,8 @@ import dev.ambon.grpc.proto.ClearScreenProto
 import dev.ambon.grpc.proto.CloseProto
 import dev.ambon.grpc.proto.ConnectedProto
 import dev.ambon.grpc.proto.DisconnectedProto
+import dev.ambon.grpc.proto.GmcpDataProto
+import dev.ambon.grpc.proto.GmcpReceivedProto
 import dev.ambon.grpc.proto.InboundEventProto
 import dev.ambon.grpc.proto.LineReceivedProto
 import dev.ambon.grpc.proto.OutboundEventProto
@@ -52,6 +54,17 @@ fun InboundEvent.toProto(): InboundEventProto =
                         .setLine(line)
                         .build(),
                 ).build()
+        is InboundEvent.GmcpReceived ->
+            InboundEventProto
+                .newBuilder()
+                .setSessionId(sessionId.value)
+                .setGmcpReceived(
+                    GmcpReceivedProto
+                        .newBuilder()
+                        .setGmcpPackage(gmcpPackage)
+                        .setJsonData(jsonData)
+                        .build(),
+                ).build()
     }
 
 /** Converts [InboundEventProto] → domain [InboundEvent], or null if the oneof is not set. */
@@ -72,6 +85,12 @@ fun InboundEventProto.toDomain(): InboundEvent? {
             InboundEvent.LineReceived(
                 sessionId = sid,
                 line = lineReceived.line,
+            )
+        InboundEventProto.EventCase.GMCP_RECEIVED ->
+            InboundEvent.GmcpReceived(
+                sessionId = sid,
+                gmcpPackage = gmcpReceived.gmcpPackage,
+                jsonData = gmcpReceived.jsonData,
             )
         else -> null
     }
@@ -146,6 +165,17 @@ fun OutboundEvent.toProto(): OutboundEventProto =
                         .setNewEnginePort(newEnginePort)
                         .build(),
                 ).build()
+        is OutboundEvent.GmcpData ->
+            OutboundEventProto
+                .newBuilder()
+                .setSessionId(sessionId.value)
+                .setGmcpData(
+                    GmcpDataProto
+                        .newBuilder()
+                        .setGmcpPackage(gmcpPackage)
+                        .setJsonData(jsonData)
+                        .build(),
+                ).build()
     }
 
 /** Converts [OutboundEventProto] → domain [OutboundEvent], or null if the oneof is not set. */
@@ -176,6 +206,12 @@ fun OutboundEventProto.toDomain(): OutboundEvent? {
                 newEngineId = sessionRedirect.newEngineId,
                 newEngineHost = sessionRedirect.newEngineHost,
                 newEnginePort = sessionRedirect.newEnginePort,
+            )
+        OutboundEventProto.EventCase.GMCP_DATA ->
+            OutboundEvent.GmcpData(
+                sessionId = sid,
+                gmcpPackage = gmcpData.gmcpPackage,
+                jsonData = gmcpData.jsonData,
             )
         else -> null
     }

--- a/src/main/kotlin/dev/ambon/transport/BlockingSocketTransport.kt
+++ b/src/main/kotlin/dev/ambon/transport/BlockingSocketTransport.kt
@@ -39,7 +39,7 @@ class BlockingSocketTransport(
                     sock.tcpNoDelay = true
                     val sessionId = sessionIdFactory()
                     log.debug { "New telnet connection: remoteAddress=${sock.remoteSocketAddress} sessionId=$sessionId" }
-                    val outboundQueue = Channel<String>(capacity = sessionOutboundQueueCapacity)
+                    val outboundQueue = Channel<OutboundFrame>(capacity = sessionOutboundQueueCapacity)
                     val session =
                         NetworkSession(
                             sessionId = sessionId,

--- a/src/main/kotlin/dev/ambon/transport/OutboundFrame.kt
+++ b/src/main/kotlin/dev/ambon/transport/OutboundFrame.kt
@@ -1,0 +1,12 @@
+package dev.ambon.transport
+
+sealed interface OutboundFrame {
+    data class Text(
+        val content: String,
+    ) : OutboundFrame
+
+    data class Gmcp(
+        val gmcpPackage: String,
+        val jsonData: String,
+    ) : OutboundFrame
+}

--- a/src/main/kotlin/dev/ambon/transport/TelnetLineDecoder.kt
+++ b/src/main/kotlin/dev/ambon/transport/TelnetLineDecoder.kt
@@ -4,7 +4,7 @@ class TelnetLineDecoder(
     private val maxLineLen: Int = 1024,
     // simple abuse guard
     private val maxNonPrintablePerLine: Int = 32,
-    private val maxSubnegotiationLen: Int = 512,
+    private val maxSubnegotiationLen: Int = 4096,
     private val onControlEvent: (TelnetControlEvent) -> Unit = {},
 ) {
     private val sb = StringBuilder()
@@ -192,6 +192,7 @@ object TelnetProtocol {
 
     const val TTYPE = 24
     const val NAWS = 31
+    const val GMCP = 201
     const val TTYPE_IS = 0
     const val TTYPE_SEND = 1
 }

--- a/src/main/proto/ambonmud/v1/events.proto
+++ b/src/main/proto/ambonmud/v1/events.proto
@@ -13,6 +13,7 @@ message InboundEventProto {
     ConnectedProto connected = 2;
     DisconnectedProto disconnected = 3;
     LineReceivedProto line_received = 4;
+    GmcpReceivedProto gmcp_received = 5;
   }
 }
 
@@ -26,6 +27,11 @@ message DisconnectedProto {
 
 message LineReceivedProto {
   string line = 1;
+}
+
+message GmcpReceivedProto {
+  string gmcp_package = 1;
+  string json_data = 2;
 }
 
 // ── Outbound events (Engine → Gateway) ───────────────────────────────────────
@@ -43,6 +49,7 @@ message OutboundEventProto {
     ClearScreenProto clear_screen = 9;
     ShowAnsiDemoProto show_ansi_demo = 10;
     SessionRedirectProto session_redirect = 11;
+    GmcpDataProto gmcp_data = 12;
   }
 }
 
@@ -78,4 +85,9 @@ message SessionRedirectProto {
   string new_engine_id = 1;
   string new_engine_host = 2;
   int32 new_engine_port = 3;
+}
+
+message GmcpDataProto {
+  string gmcp_package = 1;
+  string json_data = 2;
 }

--- a/src/main/resources/web/index.html
+++ b/src/main/resources/web/index.html
@@ -19,7 +19,33 @@
             <button id="reconnect" type="button">Reconnect</button>
         </div>
     </header>
-    <section id="terminal" aria-label="AmbonMUD terminal"></section>
+    <div class="game-layout">
+        <section id="terminal" aria-label="AmbonMUD terminal"></section>
+        <aside id="sidebar">
+            <div class="sidebar-panel" id="char-panel">
+                <div class="panel-title">Character</div>
+                <div class="bar-label">HP <span id="hp-text">— / —</span></div>
+                <div class="bar-wrap"><div class="bar-fill hp" id="hp-bar" style="width:0%"></div></div>
+                <div class="bar-label">Mana <span id="mana-text">— / —</span></div>
+                <div class="bar-wrap"><div class="bar-fill mana" id="mana-bar" style="width:0%"></div></div>
+                <div class="stat-row">
+                    <span class="stat-key">Level</span>
+                    <span class="stat-val" id="level-val">—</span>
+                </div>
+                <div class="stat-row">
+                    <span class="stat-key">XP</span>
+                    <span class="stat-val" id="xp-val">—</span>
+                </div>
+            </div>
+            <div class="sidebar-panel" id="room-panel">
+                <div class="panel-title">Room</div>
+                <div id="room-title" class="room-title">—</div>
+                <div id="room-desc" class="room-desc"></div>
+                <div class="exits-label">Exits</div>
+                <div id="exits-wrap" class="exits-wrap"></div>
+            </div>
+        </aside>
+    </div>
 </main>
 
 <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.js"></script>

--- a/src/main/resources/web/styles.css
+++ b/src/main/resources/web/styles.css
@@ -93,6 +93,13 @@ button:hover {
     background: #1e3a58;
 }
 
+.game-layout {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+    gap: 0.75rem;
+}
+
 #terminal {
     flex: 1;
     min-height: 0;
@@ -104,6 +111,136 @@ button:hover {
 
 #terminal .xterm-viewport {
     scrollbar-color: #34516b #06101b;
+}
+
+/* ── Sidebar ───────────────────────────────────────────────── */
+
+#sidebar {
+    width: 240px;
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    overflow-y: auto;
+}
+
+.sidebar-panel {
+    border: 1px solid var(--line);
+    border-radius: 0.6rem;
+    background: var(--panel);
+    padding: 0.65rem 0.8rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.panel-title {
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: #7aa8cc;
+    margin-bottom: 0.2rem;
+}
+
+.bar-label {
+    font-size: 0.78rem;
+    display: flex;
+    justify-content: space-between;
+}
+
+.bar-wrap {
+    height: 8px;
+    background: #1a2e42;
+    border-radius: 4px;
+    overflow: hidden;
+    margin-bottom: 0.25rem;
+}
+
+.bar-fill {
+    height: 100%;
+    border-radius: 4px;
+    transition: width 0.3s ease;
+}
+
+.bar-fill.hp {
+    background: #4caf87;
+}
+
+.bar-fill.mana {
+    background: #4a7cc7;
+}
+
+.stat-row {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.8rem;
+}
+
+.stat-key {
+    color: #7aa8cc;
+}
+
+.room-title {
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: #a8d4f0;
+    word-break: break-word;
+}
+
+.room-desc {
+    font-size: 0.76rem;
+    color: #8facc4;
+    line-height: 1.4;
+    word-break: break-word;
+    margin-bottom: 0.2rem;
+}
+
+.exits-label {
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: #7aa8cc;
+}
+
+.exits-wrap {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+}
+
+.exit-btn {
+    border: 1px solid var(--line);
+    border-radius: 0.35rem;
+    background: #152438;
+    color: var(--text);
+    padding: 0.2rem 0.45rem;
+    font-size: 0.75rem;
+    cursor: pointer;
+    text-transform: lowercase;
+}
+
+.exit-btn:hover {
+    background: #1e3a58;
+}
+
+@media (max-width: 900px) {
+    .game-layout {
+        flex-direction: column;
+    }
+
+    #sidebar {
+        width: 100%;
+        flex-direction: row;
+        flex-wrap: wrap;
+        overflow-y: visible;
+    }
+
+    .sidebar-panel {
+        flex: 1;
+        min-width: 200px;
+    }
 }
 
 @media (max-width: 700px) {

--- a/src/test/kotlin/dev/ambon/bus/RedisInboundBusTest.kt
+++ b/src/test/kotlin/dev/ambon/bus/RedisInboundBusTest.kt
@@ -111,8 +111,10 @@ class RedisInboundBusTest {
         defaultAnsiEnabled: Boolean = false,
         reason: String = "",
         line: String = "",
+        gmcpPackage: String = "",
+        jsonData: String = "",
     ): String {
-        val payload = "$instanceId|$type|$sessionId|$defaultAnsiEnabled|$reason|$line"
+        val payload = "$instanceId|$type|$sessionId|$defaultAnsiEnabled|$reason|$line|$gmcpPackage|$jsonData"
         val signature = hmacSha256(sharedSecret, payload)
         return mapper.writeValueAsString(
             mapOf(
@@ -122,6 +124,8 @@ class RedisInboundBusTest {
                 "defaultAnsiEnabled" to defaultAnsiEnabled,
                 "reason" to reason,
                 "line" to line,
+                "gmcpPackage" to gmcpPackage,
+                "jsonData" to jsonData,
                 "signature" to signature,
             ),
         )

--- a/src/test/kotlin/dev/ambon/bus/RedisOutboundBusTest.kt
+++ b/src/test/kotlin/dev/ambon/bus/RedisOutboundBusTest.kt
@@ -89,8 +89,10 @@ class RedisOutboundBusTest {
         text: String = "",
         enabled: Boolean = false,
         reason: String = "",
+        gmcpPackage: String = "",
+        jsonData: String = "",
     ): String {
-        val payload = "$instanceId|$type|$sessionId|$text|$enabled|$reason"
+        val payload = "$instanceId|$type|$sessionId|$text|$enabled|$reason|$gmcpPackage|$jsonData"
         val signature = hmacSha256(sharedSecret, payload)
         return mapper.writeValueAsString(
             mapOf(
@@ -100,6 +102,8 @@ class RedisOutboundBusTest {
                 "text" to text,
                 "enabled" to enabled,
                 "reason" to reason,
+                "gmcpPackage" to gmcpPackage,
+                "jsonData" to jsonData,
                 "signature" to signature,
             ),
         )

--- a/src/test/kotlin/dev/ambon/transport/AnsiRendererTest.kt
+++ b/src/test/kotlin/dev/ambon/transport/AnsiRendererTest.kt
@@ -37,13 +37,13 @@ class AnsiRendererTest {
             val job = router.start()
 
             val sid = SessionId(1)
-            val q = Channel<String>(10)
+            val q = Channel<OutboundFrame>(10)
             router.register(sid, q) { fail("should not close") }
 
             engineOutbound.send(OutboundEvent.SendPrompt(sid))
             runCurrent()
 
-            val ansiPrompt = q.tryReceive().getOrNull()
+            val ansiPrompt = (q.tryReceive().getOrNull() as? OutboundFrame.Text)?.content
             assertTrue(ansiPrompt!!.contains("> "))
             assertFalse(ansiPrompt.contains("PromptSpec"))
 

--- a/src/test/kotlin/dev/ambon/transport/KtorWebSocketTransportTest.kt
+++ b/src/test/kotlin/dev/ambon/transport/KtorWebSocketTransportTest.kt
@@ -53,6 +53,14 @@ class KtorWebSocketTransportTest {
                         withTimeout(3_000) { inbound.awaitReceive() },
                     )
 
+                    // WebSocket transport auto-sends Core.Supports.Set on connect.
+                    val gmcpAutoSend = withTimeout(3_000) { inbound.awaitReceive() }
+                    assertTrue(
+                        gmcpAutoSend is InboundEvent.GmcpReceived &&
+                            gmcpAutoSend.gmcpPackage == "Core.Supports.Set",
+                        "Expected auto Core.Supports.Set, got: $gmcpAutoSend",
+                    )
+
                     send(Frame.Text("look\r\nwho"))
                     assertEquals(
                         InboundEvent.LineReceived(sid, "look"),

--- a/src/test/kotlin/dev/ambon/transport/PlainRendererTest.kt
+++ b/src/test/kotlin/dev/ambon/transport/PlainRendererTest.kt
@@ -38,13 +38,13 @@ class PlainRendererTest {
             val job = router.start()
 
             val sid = SessionId(1)
-            val q = Channel<String>(10)
+            val q = Channel<OutboundFrame>(10)
             router.register(sid, q) { fail("should not close") }
 
             engineOutbound.send(OutboundEvent.SendPrompt(sid))
             runCurrent()
 
-            val prompt = q.tryReceive().getOrNull()
+            val prompt = (q.tryReceive().getOrNull() as? OutboundFrame.Text)?.content
             assertEquals("> ", prompt)
             assertFalse(prompt!!.contains("PromptSpec"))
 


### PR DESCRIPTION
## Summary

- Implements Generic MUD Communication Protocol (telnet option 201) end-to-end so modern clients (Mudlet, CMUD) and the built-in web client receive structured JSON data (room info, character vitals) alongside normal text output
- Introduces `OutboundFrame` sealed interface (`Text | Gmcp`) to carry GMCP frames through per-session queues without sentinel bytes
- Adds `GmcpEmitter` with `Char.Vitals`, `Room.Info`, and `Char.StatusVars` support, gated by per-session package opt-in tracking in the engine
- Web client gets a live sidebar: HP/Mana bars, Level/XP, room title/description, and clickable exit buttons

## Changes by layer

**Transport**
- `TelnetLineDecoder`: `GMCP = 201` constant, `maxSubnegotiationLen` bumped to 4096
- `NetworkSession`: WILL/DO GMCP negotiation, IAC SB GMCP subneg parsing and emission
- `KtorWebSocketTransport`: `{"gmcp":"...","data":...}` JSON envelope; auto-sends `Core.Supports.Set` on connect so WebSocket sessions are opted in immediately
- All per-session queues changed from `Channel<String>` → `Channel<OutboundFrame>`

**Engine**
- New events: `OutboundEvent.GmcpData`, `InboundEvent.GmcpReceived`
- `GameEngine`: per-session package registry (`gmcpSessions`), dirty-vitals set flushed at tick end, `Core.Supports.Set` / `Core.Supports.Remove` / `Core.Hello` handling
- `CommandRouter`: emits `Room.Info` after every `sendLook`
- `CombatSystem`, `RegenSystem`, `AbilitySystem`: call `markVitalsDirty` after HP/mana changes; `Char.Vitals` pushed once per tick per dirty session

**Bus & gRPC**
- Redis envelopes: `gmcpPackage`/`jsonData` fields added to both inbound and outbound; HMAC covers the new fields
- Proto: `GmcpDataProto`, `GmcpReceivedProto` message types at field IDs 12 / 5
- `ProtoMapper`, `GrpcOutboundDispatcher`, `OutboundEventPlane`, `SessionRouter` updated for exhaustive `when`

**Web client**
- Sidebar panel with HP/Mana progress bars, Level, XP, room title/description, and clickable exit direction buttons
- GMCP JSON envelope routing in `app.js` (`handleGmcp` → `updateVitals` / `updateRoomInfo`)
- Responsive: stacks vertically below 900 px

## Test plan

- [ ] All 471 existing tests pass (`./gradlew ktlintCheck test`)
- [ ] Redis bus HMAC helpers updated to include `gmcpPackage`/`jsonData` in payload
- [ ] `OutboundRouterTest`: updated for `Channel<OutboundFrame>`; new `GmcpData event enqueues Gmcp frame` test
- [ ] `KtorWebSocketTransportTest`: accounts for auto `Core.Supports.Set` event on connect
- [ ] Manual: connect via browser, log in, verify sidebar shows HP/Mana bars and room info, click an exit button to navigate
- [ ] Manual (Mudlet): connect via telnet, verify GMCP negotiation, check Char.Vitals and Room.Info in GMCP debug view
- [ ] Manual: enter combat and confirm vitals update in real-time