### PR TITLE
Fix swarm login flow for race/class selection steps

### DIFF
--- a/swarm/example.swarm.yaml
+++ b/swarm/example.swarm.yaml
@@ -38,3 +38,13 @@ behavior:
     - "kill rat"
     - "kill goblin"
     - "attack rat"
+  races:
+    - "human"
+    - "elf"
+    - "dwarf"
+    - "halfling"
+  classes:
+    - "warrior"
+    - "mage"
+    - "cleric"
+    - "rogue"

--- a/swarm/src/main/kotlin/dev/ambon/swarm/SwarmConfig.kt
+++ b/swarm/src/main/kotlin/dev/ambon/swarm/SwarmConfig.kt
@@ -25,6 +25,8 @@ data class SwarmConfig(
             "run.basePassword must be non-blank and <= 72 chars"
         }
         behavior.weights.validated()
+        require(behavior.races.isNotEmpty()) { "behavior.races must not be empty" }
+        require(behavior.classes.isNotEmpty()) { "behavior.classes must not be empty" }
         require(behavior.commandIntervalMs.min in 1..60_000) { "behavior.commandIntervalMs.min must be 1..60000" }
         require(behavior.commandIntervalMs.max in behavior.commandIntervalMs.min..60_000) {
             "behavior.commandIntervalMs.max must be >= min and <= 60000"
@@ -64,6 +66,8 @@ data class BehaviorConfig(
     val chatPhrases: List<String> = listOf("hello", "lag?", "nice room", "test ping"),
     val movementCommands: List<String> = listOf("north", "south", "east", "west", "look"),
     val combatCommands: List<String> = listOf("kill rat", "kill goblin", "attack rat"),
+    val races: List<String> = listOf("human", "elf", "dwarf", "halfling"),
+    val classes: List<String> = listOf("warrior", "mage", "cleric", "rogue"),
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/swarm/src/main/kotlin/dev/ambon/swarm/SwarmMain.kt
+++ b/swarm/src/main/kotlin/dev/ambon/swarm/SwarmMain.kt
@@ -75,6 +75,8 @@ private fun loadConfig(path: String): SwarmConfig {
                     chatPhrases = behavior.strings("chatPhrases", BehaviorConfig().chatPhrases),
                     movementCommands = behavior.strings("movementCommands", BehaviorConfig().movementCommands),
                     combatCommands = behavior.strings("combatCommands", BehaviorConfig().combatCommands),
+                    races = behavior.strings("races", BehaviorConfig().races),
+                    classes = behavior.strings("classes", BehaviorConfig().classes),
                 ),
         )
     return config.validated()

--- a/swarm/src/test/kotlin/dev/ambon/swarm/SwarmConfigTest.kt
+++ b/swarm/src/test/kotlin/dev/ambon/swarm/SwarmConfigTest.kt
@@ -28,4 +28,16 @@ class SwarmConfigTest {
         val config = SwarmConfig(run = RunConfig(namespacePrefix = "abcdefghijk"))
         assertThrows<IllegalArgumentException> { config.validated() }
     }
+
+    @Test
+    fun `empty races list fails validation`() {
+        val config = SwarmConfig(behavior = BehaviorConfig(races = emptyList()))
+        assertThrows<IllegalArgumentException> { config.validated() }
+    }
+
+    @Test
+    fun `empty classes list fails validation`() {
+        val config = SwarmConfig(behavior = BehaviorConfig(classes = emptyList()))
+        assertThrows<IllegalArgumentException> { config.validated() }
+    }
 }


### PR DESCRIPTION
## Summary

- Add `races` and `classes` lists to `BehaviorConfig` (configurable, with game-matching defaults) and wire them through `SwarmMain` config loading and `example.swarm.yaml`
- Add `"choose your race"` and `"choose your class"` handlers in `BotWorker.login()` so new bots no longer get stuck during character creation
- Fix false-positive login-success heuristic: replace `"hp" in lower || "look around" in lower || "exits" in lower` with `"exits:" in lower` — `"hp"` was matching `"+3 HP/lvl"` in the class selection menu
- Strip ANSI escape codes and TELNET IAC replacement chars (`\uFFFD`) from incoming lines via new `cleanLine()` helper, applied to both Telnet and WebSocket readers
- Add validation that `behavior.races` and `behavior.classes` are non-empty, with two new unit tests

## Test plan

- [x] `.\gradlew.bat :swarm:test` — all 6 tests pass (including 2 new)
- [x] `.\gradlew.bat :swarm:ktlintCheck` — no style violations