### PR TITLE
Fix server startup crash: add training zones to application.yaml

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -77,6 +77,10 @@ ambonMUD:
       - world/ambon_hub.yaml
       - world/noecker_resume.yaml
       - world/demo_ruins.yaml
+      - world/low_training_marsh.yaml
+      - world/low_training_highlands.yaml
+      - world/low_training_mines.yaml
+      - world/low_training_barrens.yaml
 
   persistence:
     backend: YAML


### PR DESCRIPTION
## Summary

- **Root cause**: The four training zones added in #130 were included in `WorldFactory.defaultWorldResources` but never added to `application.yaml`'s `world.resources` list. `MudServer` uses the config file list at startup, so the zones were never loaded — causing `ambon_hub:blank_arches`'s cross-zone exits to fail with `WorldLoadException: Room 'ambon_hub:blank_arches' exit 'NORTH' points to missing room 'low_training_marsh:reedwalk_landing'`.
- **Fix**: Add the four missing zone files to `application.yaml`'s `world.resources` list.
- **Regression tests**: Add `ProductionWorldTest` to `WorldLoaderTest` with two tests:
  1. Loads the world via `WorldFactory.demoWorld()` (default resource list) — catches cross-zone reference bugs in production YAML files.
  2. Loads the world using the resource list parsed directly from `application.yaml` — mirrors exactly what `MudServer` does at startup, and would have caught this bug before merging.

## Test plan

- [x] `./gradlew ktlintCheck test` passes
- [x] Both new regression tests pass
- [x] `./gradlew run` no longer crashes on startup