### PR TITLE
Add individual mob respawn timer independent of zone-wide reset

### DIFF
--- a/docs/world-zone-yaml-spec.md
+++ b/docs/world-zone-yaml-spec.md
@@ -62,17 +62,25 @@ Each key is a mob ID (local or fully qualified).
 Each value:
 
 ```yaml
-name:       <string, required>
-room:       <room-id string, required>
-tier:       <string, optional - one of weak|standard|elite|boss (case-insensitive); default standard>
-level:      <integer >= 1, optional; default 1>
-hp:         <integer >= 1, optional - overrides tier-computed hp>
-minDamage:  <integer >= 1, optional - overrides tier-computed minDamage>
-maxDamage:  <integer >= minDamage, optional - overrides tier-computed maxDamage>
-armor:      <integer >= 0, optional - overrides tier baseArmor (flat damage reduction, no level scaling)>
-xpReward:   <long >= 0, optional - overrides tier-computed xpReward>
-drops:      <list<Drop>, optional, default []>
+name:           <string, required>
+room:           <room-id string, required>
+tier:           <string, optional - one of weak|standard|elite|boss (case-insensitive); default standard>
+level:          <integer >= 1, optional; default 1>
+hp:             <integer >= 1, optional - overrides tier-computed hp>
+minDamage:      <integer >= 1, optional - overrides tier-computed minDamage>
+maxDamage:      <integer >= minDamage, optional - overrides tier-computed maxDamage>
+armor:          <integer >= 0, optional - overrides tier baseArmor (flat damage reduction, no level scaling)>
+xpReward:       <long >= 0, optional - overrides tier-computed xpReward>
+drops:          <list<Drop>, optional, default []>
+respawnSeconds: <long > 0, optional - seconds after death before this mob respawns in its origin room;
+                omit to rely on zone-wide reset only>
 ```
+
+`respawnSeconds` notes:
+- When set, the mob is scheduled to respawn independently of any zone-wide reset.
+- The respawn is silently cancelled if the zone resets first (the mob is already back in the registry).
+- If the origin room no longer exists at respawn time the respawn is silently skipped.
+- Players in the origin room see an arrival message when the mob reappears.
 
 `Drop` entry:
 
@@ -224,6 +232,7 @@ For each file your tool emits:
 9. Ensure all local/qualified references resolve in the merged set of files.
 10. Ensure normalized room/mob/item IDs are globally unique across files.
 11. If splitting one zone across files, keep `lifespan` consistent when repeated.
+12. If `respawnSeconds` is present, it must be > 0.
 
 ## Minimal Valid Example
 
@@ -247,6 +256,7 @@ mobs:
   rat:
     name: "a cave rat"
     room: hall
+    respawnSeconds: 30 # reappears 30 s after being killed
     drops:
       - itemId: fang
         chance: 1.0
@@ -255,6 +265,7 @@ mobs:
     room: entry
     tier: elite
     level: 3
+    # no respawnSeconds — relies on zone-wide reset
 
 items:
   helm:

--- a/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
@@ -13,4 +13,5 @@ data class MobSpawn(
     val armor: Int = 0,
     val xpReward: Long = 30L,
     val drops: List<MobDrop> = emptyList(),
+    val respawnSeconds: Long? = null,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/data/MobFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/MobFile.kt
@@ -11,4 +11,5 @@ data class MobFile(
     val armor: Int? = null,
     val xpReward: Long? = null,
     val drops: List<MobDropFile> = emptyList(),
+    val respawnSeconds: Long? = null,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -181,6 +181,11 @@ object WorldLoader {
                     throw WorldLoadException("Mob '${mobId.value}' resolved xpReward must be >= 0")
                 }
 
+                val respawnSeconds = mf.respawnSeconds
+                if (respawnSeconds != null && respawnSeconds <= 0L) {
+                    throw WorldLoadException("Mob '${mobId.value}' respawnSeconds must be > 0 (got $respawnSeconds)")
+                }
+
                 mergedMobs[mobId] =
                     MobSpawn(
                         id = mobId,
@@ -192,6 +197,7 @@ object WorldLoader {
                         armor = resolvedArmor,
                         xpReward = resolvedXpReward,
                         drops = drops,
+                        respawnSeconds = respawnSeconds,
                     )
             }
 

--- a/src/test/kotlin/dev/ambon/engine/MobRespawnTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/MobRespawnTest.kt
@@ -1,0 +1,226 @@
+package dev.ambon.engine
+
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.mob.MobState
+import dev.ambon.domain.world.MobSpawn
+import dev.ambon.domain.world.Room
+import dev.ambon.domain.world.World
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.engine.scheduler.Scheduler
+import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.MutableClock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MobRespawnTest {
+    private val roomId = RoomId("zone:room")
+    private val mobId = MobId("zone:rat")
+
+    /**
+     * Builds the same onMobRemoved lambda that GameEngine wires up, using the provided
+     * components. This lets us test the scheduling logic in isolation.
+     */
+    private fun buildOnMobRemoved(
+        world: World,
+        mobs: MobRegistry,
+        mobSystem: MobSystem,
+        scheduler: Scheduler,
+        players: PlayerRegistry,
+        outbound: LocalOutboundBus,
+    ): (MobId) -> Unit =
+        { id ->
+            mobSystem.onMobRemoved(id)
+            val spawn = world.mobSpawns.find { it.id == id }
+            val respawnMs = spawn?.respawnSeconds?.let { it * 1_000L }
+            if (spawn != null && respawnMs != null) {
+                scheduler.scheduleIn(respawnMs) {
+                    if (mobs.get(spawn.id) != null) return@scheduleIn
+                    if (world.rooms[spawn.roomId] == null) return@scheduleIn
+                    mobs.upsert(
+                        MobState(
+                            id = spawn.id,
+                            name = spawn.name,
+                            roomId = spawn.roomId,
+                            hp = spawn.maxHp,
+                            maxHp = spawn.maxHp,
+                            minDamage = spawn.minDamage,
+                            maxDamage = spawn.maxDamage,
+                            armor = spawn.armor,
+                            xpReward = spawn.xpReward,
+                            drops = spawn.drops,
+                        ),
+                    )
+                    mobSystem.onMobSpawned(spawn.id)
+                    for (p in players.playersInRoom(spawn.roomId)) {
+                        outbound.send(OutboundEvent.SendText(p.sessionId, "${spawn.name} appears."))
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun `mob with respawnSeconds respawns in origin room after delay`() =
+        runTest {
+            val room = Room(roomId, "A Room", "A room.", emptyMap())
+            val spawn = MobSpawn(id = mobId, name = "a rat", roomId = roomId, respawnSeconds = 60L)
+            val world = World(mapOf(roomId to room), roomId, mobSpawns = listOf(spawn))
+
+            val mobs = MobRegistry()
+            val outbound = LocalOutboundBus()
+            val clock = MutableClock(0L)
+            val scheduler = Scheduler(clock)
+            val players = PlayerRegistry(roomId, InMemoryPlayerRepository(), ItemRegistry())
+            val mobSystem = MobSystem(world, mobs, players, outbound, clock = clock)
+
+            val onMobRemoved = buildOnMobRemoved(world, mobs, mobSystem, scheduler, players, outbound)
+
+            mobs.upsert(MobState(mobId, "a rat", roomId))
+            mobs.remove(mobId)
+            onMobRemoved(mobId)
+
+            assertNull(mobs.get(mobId), "Mob should be gone immediately after removal")
+            assertEquals(1, scheduler.size(), "Respawn should be scheduled")
+
+            // Before delay elapses — mob still absent
+            scheduler.runDue()
+            assertNull(mobs.get(mobId), "Mob should not respawn before delay")
+
+            // After delay elapses — mob respawns
+            clock.advance(60_000L)
+            scheduler.runDue()
+
+            val respawned = mobs.get(mobId)
+            assertNotNull(respawned, "Mob should have respawned")
+            assertEquals(roomId, respawned!!.roomId)
+            assertEquals(spawn.maxHp, respawned.hp)
+        }
+
+    @Test
+    fun `respawn is skipped when mob is already in registry at fire time`() =
+        runTest {
+            val room = Room(roomId, "A Room", "A room.", emptyMap())
+            val spawn = MobSpawn(id = mobId, name = "a rat", roomId = roomId, respawnSeconds = 60L)
+            val world = World(mapOf(roomId to room), roomId, mobSpawns = listOf(spawn))
+
+            val mobs = MobRegistry()
+            val outbound = LocalOutboundBus()
+            val clock = MutableClock(0L)
+            val scheduler = Scheduler(clock)
+            val players = PlayerRegistry(roomId, InMemoryPlayerRepository(), ItemRegistry())
+            val mobSystem = MobSystem(world, mobs, players, outbound, clock = clock)
+
+            val onMobRemoved = buildOnMobRemoved(world, mobs, mobSystem, scheduler, players, outbound)
+
+            mobs.upsert(MobState(mobId, "a rat", roomId))
+            mobs.remove(mobId)
+            onMobRemoved(mobId)
+
+            // Simulate zone reset re-adding the mob before the scheduler fires
+            mobs.upsert(MobState(mobId, "a rat", roomId, hp = 5, maxHp = 10))
+
+            clock.advance(60_000L)
+            scheduler.runDue()
+
+            // Mob should still be in registry, but hp should NOT be reset to maxHp
+            // (the guard skipped the respawn, so the zone-reset version is preserved)
+            val mob = mobs.get(mobId)
+            assertNotNull(mob, "Mob from zone reset should still be present")
+            assertEquals(5, mob!!.hp, "Zone-reset mob's hp should be preserved (respawn skipped)")
+        }
+
+    @Test
+    fun `respawn is skipped when origin room no longer exists`() =
+        runTest {
+            val missingRoomId = RoomId("zone:missing")
+            val spawn = MobSpawn(id = mobId, name = "a rat", roomId = missingRoomId, respawnSeconds = 30L)
+            // World does NOT contain the mob's origin room
+            val anchorRoom = Room(roomId, "A Room", "A room.", emptyMap())
+            val world = World(mapOf(roomId to anchorRoom), roomId, mobSpawns = listOf(spawn))
+
+            val mobs = MobRegistry()
+            val outbound = LocalOutboundBus()
+            val clock = MutableClock(0L)
+            val scheduler = Scheduler(clock)
+            val players = PlayerRegistry(roomId, InMemoryPlayerRepository(), ItemRegistry())
+            val mobSystem = MobSystem(world, mobs, players, outbound, clock = clock)
+
+            val onMobRemoved = buildOnMobRemoved(world, mobs, mobSystem, scheduler, players, outbound)
+
+            onMobRemoved(mobId)
+
+            clock.advance(30_000L)
+            scheduler.runDue()
+
+            assertNull(mobs.get(mobId), "Mob should not respawn into a missing room")
+        }
+
+    @Test
+    fun `mob without respawnSeconds does not schedule a respawn`() =
+        runTest {
+            val room = Room(roomId, "A Room", "A room.", emptyMap())
+            val spawn = MobSpawn(id = mobId, name = "a rat", roomId = roomId) // respawnSeconds = null
+            val world = World(mapOf(roomId to room), roomId, mobSpawns = listOf(spawn))
+
+            val mobs = MobRegistry()
+            val outbound = LocalOutboundBus()
+            val clock = MutableClock(0L)
+            val scheduler = Scheduler(clock)
+            val players = PlayerRegistry(roomId, InMemoryPlayerRepository(), ItemRegistry())
+            val mobSystem = MobSystem(world, mobs, players, outbound, clock = clock)
+
+            val onMobRemoved = buildOnMobRemoved(world, mobs, mobSystem, scheduler, players, outbound)
+
+            mobs.upsert(MobState(mobId, "a rat", roomId))
+            mobs.remove(mobId)
+            onMobRemoved(mobId)
+
+            assertEquals(0, scheduler.size(), "No respawn should be scheduled when respawnSeconds is null")
+        }
+
+    @Test
+    fun `arrival message is sent to players in origin room when mob respawns`() =
+        runTest {
+            val room = Room(roomId, "A Room", "A room.", emptyMap())
+            val spawn = MobSpawn(id = mobId, name = "a rat", roomId = roomId, respawnSeconds = 10L)
+            val world = World(mapOf(roomId to room), roomId, mobSpawns = listOf(spawn))
+
+            val mobs = MobRegistry()
+            val outbound = LocalOutboundBus()
+            val clock = MutableClock(0L)
+            val scheduler = Scheduler(clock)
+            val players = PlayerRegistry(roomId, InMemoryPlayerRepository(), ItemRegistry())
+            val mobSystem = MobSystem(world, mobs, players, outbound, clock = clock)
+
+            val onMobRemoved = buildOnMobRemoved(world, mobs, mobSystem, scheduler, players, outbound)
+
+            // Log a player into the origin room (PlayerRegistry startRoom = roomId)
+            val playerSid = SessionId(1L)
+            val loginResult = players.login(playerSid, "Hero", "password")
+            require(loginResult == LoginResult.Ok) { "Login failed: $loginResult" }
+
+            mobs.upsert(MobState(mobId, "a rat", roomId))
+            mobs.remove(mobId)
+            onMobRemoved(mobId)
+
+            clock.advance(10_000L)
+            scheduler.runDue()
+
+            // Drain all messages and find the arrival announcement
+            val messages = mutableListOf<String>()
+            while (true) {
+                val event = outbound.tryReceive().getOrNull() ?: break
+                if (event is OutboundEvent.SendText) messages += event.text
+            }
+            val hasArrival = messages.any { it.contains("a rat appears", ignoreCase = true) }
+            assertEquals(true, hasArrival, "Expected arrival message. Got: $messages")
+        }
+}

--- a/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
@@ -346,6 +346,28 @@ class WorldLoaderTest {
     }
 
     @Test
+    fun `loads mob with respawnSeconds`() {
+        val world = WorldLoader.loadFromResource("world/ok_mob_respawn.yaml")
+        val mobs = world.mobSpawns.associateBy { it.id.value }
+
+        val rat = mobs.getValue("ok_mob_respawn:rat")
+        assertEquals(60L, rat.respawnSeconds)
+
+        val boss = mobs.getValue("ok_mob_respawn:boss")
+        assertEquals(null, boss.respawnSeconds)
+    }
+
+    @Test
+    fun `fails when mob respawnSeconds is zero`() {
+        val ex =
+            assertThrows(WorldLoadException::class.java) {
+                WorldLoader.loadFromResource("world/bad_mob_respawn_zero.yaml")
+            }
+        assertTrue(ex.message!!.contains("respawnSeconds", ignoreCase = true), "Got: ${ex.message}")
+        assertTrue(ex.message!!.contains("> 0", ignoreCase = true), "Got: ${ex.message}")
+    }
+
+    @Test
     fun `loads tutorial glade zone with all rooms mobs and items`() {
         val world =
             WorldLoader.loadFromResources(

--- a/src/test/resources/world/bad_mob_respawn_zero.yaml
+++ b/src/test/resources/world/bad_mob_respawn_zero.yaml
@@ -1,0 +1,11 @@
+zone: bad_mob_respawn_zero
+startRoom: a
+mobs:
+  rat:
+    name: "a small rat"
+    room: a
+    respawnSeconds: 0
+rooms:
+  a:
+    title: "Room A"
+    description: "A room."

--- a/src/test/resources/world/ok_mob_respawn.yaml
+++ b/src/test/resources/world/ok_mob_respawn.yaml
@@ -1,0 +1,16 @@
+zone: ok_mob_respawn
+startRoom: a
+mobs:
+  rat:
+    name: "a small rat"
+    room: a
+    respawnSeconds: 60
+  boss:
+    name: "the boss"
+    room: a
+    tier: boss
+    # no respawnSeconds - relies on zone reset only
+rooms:
+  a:
+    title: "Room A"
+    description: "A room."


### PR DESCRIPTION
Closes #60

## Summary

- Adds an optional `respawnSeconds` field to mob definitions in YAML. When set, the mob is scheduled to reappear in its origin room after that interval — independently of the zone-wide reset timer.
- Mobs without `respawnSeconds` continue to rely on zone-wide reset only (backwards-compatible).
- Two safety guards prevent double-spawning: if the mob is already back in the registry (zone reset fired first) or if its origin room no longer exists, the scheduled respawn is silently skipped.
- Players in the origin room see `"<mob name> appears."` when the mob respawns.

## Files changed

| File | Change |
|------|--------|
| `MobFile.kt` | Add `respawnSeconds: Long? = null` |
| `MobSpawn.kt` | Add `respawnSeconds: Long? = null` |
| `WorldLoader.kt` | Validate `respawnSeconds > 0` when present; pass through to `MobSpawn` |
| `GameEngine.kt` | Extend `onMobRemoved` lambda to schedule per-mob respawn via `Scheduler` |
| `world-zone-yaml-spec.md` | Document `respawnSeconds`, update full-feature example and Generator Checklist |

## Test plan

- [ ] `WorldLoaderTest` — `loads mob with respawnSeconds` passes (60s loaded, null preserved)
- [ ] `WorldLoaderTest` — `fails when mob respawnSeconds is zero` passes (validation rejects 0)
- [ ] `MobRespawnTest` — mob respawns in origin room after delay with arrival message
- [ ] `MobRespawnTest` — zone-reset guard: existing mob in registry prevents double-spawn
- [ ] `MobRespawnTest` — missing-room guard: skips respawn silently
- [ ] `MobRespawnTest` — `null` respawnSeconds schedules nothing
- [ ] Full test suite passes (`./gradlew ktlintCheck test`)

## Example YAML usage

```yaml
mobs:
  rat:
    name: "a cave rat"
    room: hall
    respawnSeconds: 30   # reappears 30 s after being killed
  boss:
    name: "the dungeon boss"
    room: throne
    tier: boss
    level: 10
    # no respawnSeconds — relies on zone-wide reset only
```