### PR TITLE
Fix Netty startup crash on Windows with JDK 21+

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,6 +99,10 @@ fun JavaExec.applyConfigOverrides() {
 
 tasks.named<JavaExec>("run") {
     applyConfigOverrides()
+    // Work around JDK 21+ Windows bug where Netty's NIO selector fails with
+    // "Unable to establish loopback connection" because PipeImpl defaults to
+    // Unix domain sockets which can fail in some environments.
+    jvmArgs("-Djava.net.preferIPv4Stack=true")
 }
 
 tasks.register<JavaExec>("demo") {
@@ -109,6 +113,7 @@ tasks.register<JavaExec>("demo") {
     standardInput = System.`in`
     systemProperty("config.override.ambonMUD.demo.autoLaunchBrowser", "true")
     applyConfigOverrides()
+    jvmArgs("-Djava.net.preferIPv4Stack=true")
 }
 
 // Suppress ktlint violations in protobuf/grpc generated sources.


### PR DESCRIPTION
## Summary
- Add `-Djava.net.preferIPv4Stack=true` JVM arg to `run` and `demo` Gradle tasks
- Works around a JDK 21+ Windows bug where `PipeImpl` defaults to Unix domain sockets for loopback connections, causing Netty's NIO selector to fail with "Unable to establish loopback connection"

## Test plan
- [x] Verified `./gradlew demo` starts successfully on Windows with JDK 21
- [ ] Verify `./gradlew run` starts without the loopback error
- [ ] Confirm no regression on Linux/macOS (flag is a no-op on IPv4-only stacks)