### PR TITLE
Replace flaky fixed delays with polling loops in GrpcOutboundBusTest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This repository is a Kotlin MUD server ("AmbonMUD") with a tick-based event loop
 Use this document as the default engineering playbook when making code or content changes.
 
 ## Environment
-- JDK: 17 toolchain in Gradle (`build.gradle.kts`), CI currently runs on Java 21 (`.github/workflows/ci.yml`).
+- JDK: 21 toolchain in Gradle (`build.gradle.kts`), CI currently runs on Java 21 (`.github/workflows/ci.yml`).
 - Build tool: Gradle wrapper (`gradlew`, `gradlew.bat`).
 - Kotlin style: `kotlin.code.style=official` (`gradle.properties`).
 


### PR DESCRIPTION
## Summary
Replaces unreliable fixed `delay()` calls with deterministic polling loops using `withTimeout` in `GrpcOutboundBusTest`. This makes tests robust in variable-latency environments like cloud CI sessions where short delays (50ms) are insufficient to guarantee async coroutine execution.

## Key Changes
- **Polling-based synchronization:** Replaced `delay(50)` followed by single `tryReceive()` calls with polling loops that retry until events arrive or timeout (2 seconds)
  - Single event test: polls until one event is received
  - Multiple events test: polls until all expected events are collected
- **Negative test adjustment:** Changed `delay(50)` to `delay(200)` in the empty-queue test to ensure sufficient time for any spurious events to arrive before asserting nothing was received
- **Constants:** Added `POLL_TIMEOUT_MS` (2000) and `POLL_INTERVAL_MS` (10) as companion object constants for consistency and maintainability
- **Documentation:** Updated `CLAUDE.md` and `AGENTS.md` to reflect JDK 21 requirement and document cloud environment constraints around timing in tests

## Implementation Details
The polling loops use a simple pattern:
```kotlin
withTimeout(POLL_TIMEOUT_MS) {
    var result: T? = null
    while (result == null) {
        result = bus.tryReceive().getOrNull()
        if (result == null) delay(POLL_INTERVAL_MS)
    }
    result
}
```
This ensures tests wait for actual event arrival rather than relying on arbitrary timing, making them pass reliably regardless of CPU scheduling latency.

https://claude.ai/code/session_01WnydfeTD34AcKgDfQpYLFT