### PR TITLE
Add command aliases and phase command to help text

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/CommandRouter.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandRouter.kt
@@ -92,7 +92,7 @@ class CommandRouter(
                             exits/ex
                             say <msg> or '<msg>
                             emote <msg>
-                            pose <msg>
+                            pose/po <msg>
                             who
                             tell/t <player> <msg>
                             whisper/wh <player> <msg>
@@ -112,6 +112,7 @@ class CommandRouter(
                             cast/c <spell> [target]
                             spells/abilities
                             score/sc
+                            phase/layer [player|#]
                             ansi on/off
                             colors
                             clear


### PR DESCRIPTION
## Summary
Updated the command help text in CommandRouter to include new command aliases and add documentation for the phase command.

## Key Changes
- Added `po` as an alias for the `pose` command (displayed as `pose/po`)
- Added `phase/layer [player|#]` command to the help text, documenting its usage with optional player name or number parameter

## Details
These changes improve command discoverability by:
1. Making the `pose` command more accessible with a shorter `po` alias
2. Documenting the `phase` command (with `layer` as an alternative) which allows players to interact with phase/layer mechanics, optionally targeting a specific player or layer number

https://claude.ai/code/session_011qmyeAtrMPgJ4VcDH5nWaQ