### PR TITLE
Add behavior tree system for mob AI and decision-making

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/mob/MobState.kt
+++ b/src/main/kotlin/dev/ambon/domain/mob/MobState.kt
@@ -3,6 +3,7 @@ package dev.ambon.domain.mob
 import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.world.MobDrop
+import dev.ambon.engine.behavior.BtNode
 import dev.ambon.engine.dialogue.DialogueTree
 
 data class MobState(
@@ -20,4 +21,5 @@ data class MobState(
     val goldMax: Long = 0L,
     val stationary: Boolean = false,
     val dialogue: DialogueTree? = null,
+    val behaviorTree: BtNode? = null,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
@@ -2,6 +2,7 @@ package dev.ambon.domain.world
 
 import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
+import dev.ambon.engine.behavior.BtNode
 import dev.ambon.engine.dialogue.DialogueTree
 
 data class MobSpawn(
@@ -19,4 +20,5 @@ data class MobSpawn(
     val goldMax: Long = 0L,
     val stationary: Boolean = false,
     val dialogue: DialogueTree? = null,
+    val behaviorTree: BtNode? = null,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/data/BehaviorFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/BehaviorFile.kt
@@ -1,0 +1,13 @@
+package dev.ambon.domain.world.data
+
+data class BehaviorFile(
+    val template: String,
+    val params: BehaviorParamsFile = BehaviorParamsFile(),
+)
+
+data class BehaviorParamsFile(
+    val patrolRoute: List<String> = emptyList(),
+    val fleeHpPercent: Int = 20,
+    val aggroMessage: String? = null,
+    val fleeMessage: String? = null,
+)

--- a/src/main/kotlin/dev/ambon/domain/world/data/MobFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/MobFile.kt
@@ -16,4 +16,5 @@ data class MobFile(
     val goldMax: Long? = null,
     val stationary: Boolean = false,
     val dialogue: Map<String, DialogueNodeFile> = emptyMap(),
+    val behavior: BehaviorFile? = null,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -20,6 +20,8 @@ import dev.ambon.domain.world.Room
 import dev.ambon.domain.world.ShopDefinition
 import dev.ambon.domain.world.World
 import dev.ambon.domain.world.data.WorldFile
+import dev.ambon.engine.behavior.BehaviorTemplates
+import dev.ambon.engine.behavior.BtNode
 import dev.ambon.engine.dialogue.DialogueChoice
 import dev.ambon.engine.dialogue.DialogueNode
 import dev.ambon.engine.dialogue.DialogueTree
@@ -203,6 +205,7 @@ object WorldLoader {
                 }
 
                 val dialogue = parseDialogue(mobId, mf.dialogue)
+                val behaviorTree = parseBehavior(mobId, zone, mf.behavior, mf.stationary)
 
                 mergedMobs[mobId] =
                     MobSpawn(
@@ -220,6 +223,7 @@ object WorldLoader {
                         goldMax = resolvedGoldMax,
                         stationary = mf.stationary,
                         dialogue = dialogue,
+                        behaviorTree = behaviorTree,
                     )
             }
 
@@ -566,6 +570,33 @@ object WorldLoader {
             "d", "down" -> Direction.DOWN
             else -> null
         }
+
+    private fun parseBehavior(
+        mobId: MobId,
+        zone: String,
+        behaviorFile: dev.ambon.domain.world.data.BehaviorFile?,
+        stationary: Boolean,
+    ): BtNode? {
+        if (behaviorFile == null) return null
+
+        if (stationary) {
+            throw WorldLoadException(
+                "Mob '${mobId.value}' cannot have both 'stationary: true' and a 'behavior' definition",
+            )
+        }
+
+        val tree =
+            BehaviorTemplates.resolve(
+                behaviorFile.template,
+                behaviorFile.params,
+                zone,
+            ) ?: throw WorldLoadException(
+                "Mob '${mobId.value}' references unknown behavior template '${behaviorFile.template}'. " +
+                    "Known templates: ${BehaviorTemplates.templateNames.sorted().joinToString(", ")}",
+            )
+
+        return tree
+    }
 
     private fun parseDialogue(
         mobId: MobId,

--- a/src/main/kotlin/dev/ambon/engine/MobSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/MobSystem.kt
@@ -19,6 +19,7 @@ class MobSystem(
     private val rng: Random = Random(),
     private var isMobInCombat: (MobId) -> Boolean = { false },
     private var isMobRooted: (MobId) -> Boolean = { false },
+    private var hasBehaviorTree: (MobId) -> Boolean = { false },
     // Tuning knobs (defaults feel “MUD-like”)
     private val minWanderDelayMillis: Long = 5_000L,
     private val maxWanderDelayMillis: Long = 12_000L,
@@ -57,6 +58,12 @@ class MobSystem(
 
             // Stationary mobs never wander
             if (m.stationary) {
+                nextActAtMillis[m.id] = now + randomDelay()
+                continue
+            }
+
+            // Mobs with behavior trees are handled by BehaviorTreeSystem
+            if (hasBehaviorTree(m.id)) {
                 nextActAtMillis[m.id] = now + randomDelay()
                 continue
             }
@@ -100,6 +107,10 @@ class MobSystem(
 
     fun setRootChecker(checker: (MobId) -> Boolean) {
         isMobRooted = checker
+    }
+
+    fun setBehaviorTreeChecker(checker: (MobId) -> Boolean) {
+        hasBehaviorTree = checker
     }
 
     private fun randomDelay(): Long {

--- a/src/main/kotlin/dev/ambon/engine/behavior/BehaviorTemplates.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/BehaviorTemplates.kt
@@ -1,0 +1,138 @@
+package dev.ambon.engine.behavior
+
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.world.data.BehaviorParamsFile
+import dev.ambon.engine.behavior.actions.AggroAction
+import dev.ambon.engine.behavior.actions.FleeAction
+import dev.ambon.engine.behavior.actions.PatrolAction
+import dev.ambon.engine.behavior.actions.SayAction
+import dev.ambon.engine.behavior.actions.StationaryAction
+import dev.ambon.engine.behavior.actions.WanderAction
+import dev.ambon.engine.behavior.conditions.IsHpBelow
+import dev.ambon.engine.behavior.conditions.IsInCombat
+import dev.ambon.engine.behavior.conditions.IsPlayerInRoom
+import dev.ambon.engine.behavior.nodes.SelectorNode
+import dev.ambon.engine.behavior.nodes.SequenceNode
+
+object BehaviorTemplates {
+    val templateNames: Set<String> =
+        setOf(
+            "aggro_guard",
+            "stationary_aggro",
+            "patrol",
+            "patrol_aggro",
+            "wander",
+            "wander_aggro",
+            "coward",
+        )
+
+    fun resolve(
+        name: String,
+        params: BehaviorParamsFile,
+        zone: String,
+    ): BtNode? =
+        when (name.lowercase()) {
+            "aggro_guard" -> aggroGuard(params)
+            "stationary_aggro" -> stationaryAggro(params)
+            "patrol" -> patrol(params, zone)
+            "patrol_aggro" -> patrolAggro(params, zone)
+            "wander" -> wander()
+            "wander_aggro" -> wanderAggro(params)
+            "coward" -> coward(params)
+            else -> null
+        }
+
+    private fun aggroGuard(params: BehaviorParamsFile): BtNode =
+        SelectorNode(
+            listOf(
+                IsInCombat,
+                aggroSequence(params),
+                StationaryAction,
+            ),
+        )
+
+    private fun stationaryAggro(params: BehaviorParamsFile): BtNode =
+        SelectorNode(
+            listOf(
+                IsInCombat,
+                aggroSequence(params),
+                StationaryAction,
+            ),
+        )
+
+    private fun patrol(
+        params: BehaviorParamsFile,
+        zone: String,
+    ): BtNode =
+        SelectorNode(
+            listOf(
+                IsInCombat,
+                PatrolAction(normalizeRoute(params.patrolRoute, zone)),
+            ),
+        )
+
+    private fun patrolAggro(
+        params: BehaviorParamsFile,
+        zone: String,
+    ): BtNode =
+        SelectorNode(
+            listOf(
+                IsInCombat,
+                aggroSequence(params),
+                PatrolAction(normalizeRoute(params.patrolRoute, zone)),
+            ),
+        )
+
+    private fun wander(): BtNode =
+        SelectorNode(
+            listOf(
+                IsInCombat,
+                WanderAction,
+            ),
+        )
+
+    private fun wanderAggro(params: BehaviorParamsFile): BtNode =
+        SelectorNode(
+            listOf(
+                IsInCombat,
+                aggroSequence(params),
+                WanderAction,
+            ),
+        )
+
+    private fun coward(params: BehaviorParamsFile): BtNode {
+        val fleeChildren = mutableListOf<BtNode>()
+        fleeChildren.add(IsInCombat)
+        fleeChildren.add(IsHpBelow(params.fleeHpPercent))
+        if (params.fleeMessage != null) {
+            fleeChildren.add(SayAction(params.fleeMessage))
+        }
+        fleeChildren.add(FleeAction)
+
+        return SelectorNode(
+            listOf(
+                SequenceNode(fleeChildren),
+                WanderAction,
+            ),
+        )
+    }
+
+    private fun aggroSequence(params: BehaviorParamsFile): BtNode {
+        val children = mutableListOf<BtNode>()
+        children.add(IsPlayerInRoom)
+        if (params.aggroMessage != null) {
+            children.add(SayAction(params.aggroMessage))
+        }
+        children.add(AggroAction)
+        return SequenceNode(children)
+    }
+
+    private fun normalizeRoute(
+        route: List<String>,
+        zone: String,
+    ): List<RoomId> =
+        route.map { raw ->
+            val id = if (':' in raw) raw else "$zone:$raw"
+            RoomId(id)
+        }
+}

--- a/src/main/kotlin/dev/ambon/engine/behavior/BehaviorTreeSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/BehaviorTreeSystem.kt
@@ -1,0 +1,102 @@
+package dev.ambon.engine.behavior
+
+import dev.ambon.bus.OutboundBus
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.world.World
+import dev.ambon.engine.GmcpEmitter
+import dev.ambon.engine.MobRegistry
+import dev.ambon.engine.PlayerRegistry
+import dev.ambon.metrics.GameMetrics
+import java.time.Clock
+import java.util.Random
+
+class BehaviorTreeSystem(
+    private val world: World,
+    private val mobs: MobRegistry,
+    private val players: PlayerRegistry,
+    private val outbound: OutboundBus,
+    private val clock: Clock,
+    private val rng: Random = Random(),
+    private val isMobInCombat: (MobId) -> Boolean = { false },
+    private val isMobRooted: (MobId) -> Boolean = { false },
+    private val startMobCombat: suspend (MobId, SessionId) -> Boolean = { _, _ -> false },
+    private val fleeMob: suspend (MobId) -> Boolean = { false },
+    private val gmcpEmitter: GmcpEmitter? = null,
+    private val minActionDelayMs: Long = 2_000L,
+    private val maxActionDelayMs: Long = 5_000L,
+    private val metrics: GameMetrics = GameMetrics.noop(),
+) {
+    private val memories = mutableMapOf<MobId, MobBehaviorMemory>()
+    private val nextActAtMillis = mutableMapOf<MobId, Long>()
+
+    fun hasBehaviorTree(mobId: MobId): Boolean {
+        val mob = mobs.get(mobId) ?: return false
+        return mob.behaviorTree != null
+    }
+
+    suspend fun tick(maxActionsPerTick: Int = 10): Int {
+        val now = clock.millis()
+        var actions = 0
+
+        val mobList = mobs.all().filter { it.behaviorTree != null }.toMutableList()
+        mobList.shuffle(rng)
+
+        for (m in mobList) {
+            if (actions >= maxActionsPerTick) break
+
+            val tree = m.behaviorTree ?: continue
+
+            val dueAt = nextActAtMillis[m.id]
+            if (dueAt == null) {
+                nextActAtMillis[m.id] = now + randomDelay()
+                continue
+            }
+
+            if (now < dueAt) continue
+
+            if (isMobRooted(m.id)) {
+                nextActAtMillis[m.id] = now + randomDelay()
+                continue
+            }
+
+            val memory = memories.getOrPut(m.id) { MobBehaviorMemory() }
+            val ctx =
+                BtContext(
+                    mob = m,
+                    world = world,
+                    mobs = mobs,
+                    players = players,
+                    outbound = outbound,
+                    clock = clock,
+                    rng = rng,
+                    isMobInCombat = isMobInCombat,
+                    startMobCombat = startMobCombat,
+                    fleeMob = fleeMob,
+                    gmcpEmitter = gmcpEmitter,
+                    mobMemory = memory,
+                )
+
+            tree.tick(ctx)
+
+            nextActAtMillis[m.id] = now + randomDelay()
+            actions++
+        }
+        return actions
+    }
+
+    fun onMobRemoved(mobId: MobId) {
+        memories.remove(mobId)
+        nextActAtMillis.remove(mobId)
+    }
+
+    fun onMobSpawned(mobId: MobId) {
+        memories.remove(mobId)
+        nextActAtMillis.remove(mobId)
+    }
+
+    private fun randomDelay(): Long {
+        val range = (maxActionDelayMs - minActionDelayMs + 1).toInt()
+        return if (range <= 0) minActionDelayMs else minActionDelayMs + rng.nextInt(range)
+    }
+}

--- a/src/main/kotlin/dev/ambon/engine/behavior/BtContext.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/BtContext.kt
@@ -1,0 +1,27 @@
+package dev.ambon.engine.behavior
+
+import dev.ambon.bus.OutboundBus
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.mob.MobState
+import dev.ambon.domain.world.World
+import dev.ambon.engine.GmcpEmitter
+import dev.ambon.engine.MobRegistry
+import dev.ambon.engine.PlayerRegistry
+import java.time.Clock
+import java.util.Random
+
+class BtContext(
+    val mob: MobState,
+    val world: World,
+    val mobs: MobRegistry,
+    val players: PlayerRegistry,
+    val outbound: OutboundBus,
+    val clock: Clock,
+    val rng: Random,
+    val isMobInCombat: (MobId) -> Boolean,
+    val startMobCombat: suspend (MobId, SessionId) -> Boolean,
+    val fleeMob: suspend (MobId) -> Boolean,
+    val gmcpEmitter: GmcpEmitter?,
+    val mobMemory: MobBehaviorMemory,
+)

--- a/src/main/kotlin/dev/ambon/engine/behavior/BtNode.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/BtNode.kt
@@ -1,0 +1,5 @@
+package dev.ambon.engine.behavior
+
+interface BtNode {
+    suspend fun tick(ctx: BtContext): BtResult
+}

--- a/src/main/kotlin/dev/ambon/engine/behavior/BtResult.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/BtResult.kt
@@ -1,0 +1,7 @@
+package dev.ambon.engine.behavior
+
+enum class BtResult {
+    SUCCESS,
+    FAILURE,
+    RUNNING,
+}

--- a/src/main/kotlin/dev/ambon/engine/behavior/MobBehaviorMemory.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/MobBehaviorMemory.kt
@@ -1,0 +1,6 @@
+package dev.ambon.engine.behavior
+
+class MobBehaviorMemory {
+    var patrolIndex: Int = 0
+    val cooldownTimestamps: MutableMap<String, Long> = mutableMapOf()
+}

--- a/src/main/kotlin/dev/ambon/engine/behavior/actions/AggroAction.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/actions/AggroAction.kt
@@ -1,0 +1,16 @@
+package dev.ambon.engine.behavior.actions
+
+import dev.ambon.engine.behavior.BtContext
+import dev.ambon.engine.behavior.BtNode
+import dev.ambon.engine.behavior.BtResult
+
+data object AggroAction : BtNode {
+    override suspend fun tick(ctx: BtContext): BtResult {
+        val playersInRoom = ctx.players.playersInRoom(ctx.mob.roomId)
+        for (p in playersInRoom) {
+            val started = ctx.startMobCombat(ctx.mob.id, p.sessionId)
+            if (started) return BtResult.SUCCESS
+        }
+        return BtResult.FAILURE
+    }
+}

--- a/src/main/kotlin/dev/ambon/engine/behavior/actions/FleeAction.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/actions/FleeAction.kt
@@ -1,0 +1,37 @@
+package dev.ambon.engine.behavior.actions
+
+import dev.ambon.engine.behavior.BtContext
+import dev.ambon.engine.behavior.BtNode
+import dev.ambon.engine.behavior.BtResult
+import dev.ambon.engine.events.OutboundEvent
+
+data object FleeAction : BtNode {
+    override suspend fun tick(ctx: BtContext): BtResult {
+        val room = ctx.world.rooms[ctx.mob.roomId] ?: return BtResult.FAILURE
+        val exits = room.exits.values.toList()
+        if (exits.isEmpty()) return BtResult.FAILURE
+
+        // Disengage from combat first
+        ctx.fleeMob(ctx.mob.id)
+
+        // Pick a random exit and move
+        val destination = exits[ctx.rng.nextInt(exits.size)]
+        val from = ctx.mob.roomId
+
+        // Notify players in old room
+        for (p in ctx.players.playersInRoom(from)) {
+            ctx.outbound.send(OutboundEvent.SendText(p.sessionId, "${ctx.mob.name} flees!"))
+            ctx.gmcpEmitter?.sendRoomRemoveMob(p.sessionId, ctx.mob.id.value)
+        }
+
+        ctx.mobs.moveTo(ctx.mob.id, destination)
+
+        // Notify players in new room
+        for (p in ctx.players.playersInRoom(destination)) {
+            ctx.outbound.send(OutboundEvent.SendText(p.sessionId, "${ctx.mob.name} arrives in a panic."))
+            ctx.gmcpEmitter?.sendRoomAddMob(p.sessionId, ctx.mob)
+        }
+
+        return BtResult.SUCCESS
+    }
+}

--- a/src/main/kotlin/dev/ambon/engine/behavior/actions/PatrolAction.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/actions/PatrolAction.kt
@@ -1,0 +1,43 @@
+package dev.ambon.engine.behavior.actions
+
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.engine.behavior.BtContext
+import dev.ambon.engine.behavior.BtNode
+import dev.ambon.engine.behavior.BtResult
+import dev.ambon.engine.events.OutboundEvent
+
+data class PatrolAction(
+    val route: List<RoomId>,
+) : BtNode {
+    override suspend fun tick(ctx: BtContext): BtResult {
+        if (route.isEmpty()) return BtResult.FAILURE
+
+        val memory = ctx.mobMemory
+        val nextWaypoint = route[memory.patrolIndex % route.size]
+        val from = ctx.mob.roomId
+
+        if (from == nextWaypoint) {
+            // Already at waypoint, advance to next
+            memory.patrolIndex = (memory.patrolIndex + 1) % route.size
+            return BtResult.SUCCESS
+        }
+
+        // Move toward the next waypoint (direct move — assumes route is connected)
+        for (p in ctx.players.playersInRoom(from)) {
+            ctx.outbound.send(OutboundEvent.SendText(p.sessionId, "${ctx.mob.name} leaves."))
+            ctx.gmcpEmitter?.sendRoomRemoveMob(p.sessionId, ctx.mob.id.value)
+        }
+
+        ctx.mobs.moveTo(ctx.mob.id, nextWaypoint)
+
+        for (p in ctx.players.playersInRoom(nextWaypoint)) {
+            ctx.outbound.send(OutboundEvent.SendText(p.sessionId, "${ctx.mob.name} enters."))
+            ctx.gmcpEmitter?.sendRoomAddMob(p.sessionId, ctx.mob)
+        }
+
+        // Advance to the next waypoint for the following tick
+        memory.patrolIndex = (memory.patrolIndex + 1) % route.size
+
+        return BtResult.SUCCESS
+    }
+}

--- a/src/main/kotlin/dev/ambon/engine/behavior/actions/SayAction.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/actions/SayAction.kt
@@ -1,0 +1,19 @@
+package dev.ambon.engine.behavior.actions
+
+import dev.ambon.engine.behavior.BtContext
+import dev.ambon.engine.behavior.BtNode
+import dev.ambon.engine.behavior.BtResult
+import dev.ambon.engine.events.OutboundEvent
+
+data class SayAction(
+    val message: String,
+) : BtNode {
+    override suspend fun tick(ctx: BtContext): BtResult {
+        for (p in ctx.players.playersInRoom(ctx.mob.roomId)) {
+            ctx.outbound.send(
+                OutboundEvent.SendText(p.sessionId, "${ctx.mob.name} says, \"$message\""),
+            )
+        }
+        return BtResult.SUCCESS
+    }
+}

--- a/src/main/kotlin/dev/ambon/engine/behavior/actions/StationaryAction.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/actions/StationaryAction.kt
@@ -1,0 +1,9 @@
+package dev.ambon.engine.behavior.actions
+
+import dev.ambon.engine.behavior.BtContext
+import dev.ambon.engine.behavior.BtNode
+import dev.ambon.engine.behavior.BtResult
+
+data object StationaryAction : BtNode {
+    override suspend fun tick(ctx: BtContext): BtResult = BtResult.SUCCESS
+}

--- a/src/main/kotlin/dev/ambon/engine/behavior/actions/WanderAction.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/actions/WanderAction.kt
@@ -1,0 +1,34 @@
+package dev.ambon.engine.behavior.actions
+
+import dev.ambon.engine.behavior.BtContext
+import dev.ambon.engine.behavior.BtNode
+import dev.ambon.engine.behavior.BtResult
+import dev.ambon.engine.events.OutboundEvent
+
+data object WanderAction : BtNode {
+    override suspend fun tick(ctx: BtContext): BtResult {
+        val room = ctx.world.rooms[ctx.mob.roomId] ?: return BtResult.FAILURE
+        val exits = room.exits.values.toList()
+        if (exits.isEmpty()) return BtResult.FAILURE
+
+        val destination = exits[ctx.rng.nextInt(exits.size)]
+        val from = ctx.mob.roomId
+        if (from == destination) return BtResult.SUCCESS
+
+        // Notify players in old room
+        for (p in ctx.players.playersInRoom(from)) {
+            ctx.outbound.send(OutboundEvent.SendText(p.sessionId, "${ctx.mob.name} leaves."))
+            ctx.gmcpEmitter?.sendRoomRemoveMob(p.sessionId, ctx.mob.id.value)
+        }
+
+        ctx.mobs.moveTo(ctx.mob.id, destination)
+
+        // Notify players in new room
+        for (p in ctx.players.playersInRoom(destination)) {
+            ctx.outbound.send(OutboundEvent.SendText(p.sessionId, "${ctx.mob.name} enters."))
+            ctx.gmcpEmitter?.sendRoomAddMob(p.sessionId, ctx.mob)
+        }
+
+        return BtResult.SUCCESS
+    }
+}

--- a/src/main/kotlin/dev/ambon/engine/behavior/conditions/IsHpBelow.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/conditions/IsHpBelow.kt
@@ -1,0 +1,14 @@
+package dev.ambon.engine.behavior.conditions
+
+import dev.ambon.engine.behavior.BtContext
+import dev.ambon.engine.behavior.BtNode
+import dev.ambon.engine.behavior.BtResult
+
+data class IsHpBelow(
+    val percent: Int,
+) : BtNode {
+    override suspend fun tick(ctx: BtContext): BtResult {
+        val threshold = ctx.mob.maxHp * percent / 100
+        return if (ctx.mob.hp <= threshold) BtResult.SUCCESS else BtResult.FAILURE
+    }
+}

--- a/src/main/kotlin/dev/ambon/engine/behavior/conditions/IsInCombat.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/conditions/IsInCombat.kt
@@ -1,0 +1,14 @@
+package dev.ambon.engine.behavior.conditions
+
+import dev.ambon.engine.behavior.BtContext
+import dev.ambon.engine.behavior.BtNode
+import dev.ambon.engine.behavior.BtResult
+
+data object IsInCombat : BtNode {
+    override suspend fun tick(ctx: BtContext): BtResult =
+        if (ctx.isMobInCombat(ctx.mob.id)) {
+            BtResult.SUCCESS
+        } else {
+            BtResult.FAILURE
+        }
+}

--- a/src/main/kotlin/dev/ambon/engine/behavior/conditions/IsPlayerInRoom.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/conditions/IsPlayerInRoom.kt
@@ -1,0 +1,14 @@
+package dev.ambon.engine.behavior.conditions
+
+import dev.ambon.engine.behavior.BtContext
+import dev.ambon.engine.behavior.BtNode
+import dev.ambon.engine.behavior.BtResult
+
+data object IsPlayerInRoom : BtNode {
+    override suspend fun tick(ctx: BtContext): BtResult =
+        if (ctx.players.playersInRoom(ctx.mob.roomId).isNotEmpty()) {
+            BtResult.SUCCESS
+        } else {
+            BtResult.FAILURE
+        }
+}

--- a/src/main/kotlin/dev/ambon/engine/behavior/nodes/CooldownNode.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/nodes/CooldownNode.kt
@@ -1,0 +1,22 @@
+package dev.ambon.engine.behavior.nodes
+
+import dev.ambon.engine.behavior.BtContext
+import dev.ambon.engine.behavior.BtNode
+import dev.ambon.engine.behavior.BtResult
+
+data class CooldownNode(
+    val cooldownMs: Long,
+    val key: String,
+    val child: BtNode,
+) : BtNode {
+    override suspend fun tick(ctx: BtContext): BtResult {
+        val now = ctx.clock.millis()
+        val lastFired = ctx.mobMemory.cooldownTimestamps[key]
+        if (lastFired != null && now - lastFired < cooldownMs) return BtResult.FAILURE
+        val result = child.tick(ctx)
+        if (result == BtResult.SUCCESS) {
+            ctx.mobMemory.cooldownTimestamps[key] = now
+        }
+        return result
+    }
+}

--- a/src/main/kotlin/dev/ambon/engine/behavior/nodes/InverterNode.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/nodes/InverterNode.kt
@@ -1,0 +1,16 @@
+package dev.ambon.engine.behavior.nodes
+
+import dev.ambon.engine.behavior.BtContext
+import dev.ambon.engine.behavior.BtNode
+import dev.ambon.engine.behavior.BtResult
+
+data class InverterNode(
+    val child: BtNode,
+) : BtNode {
+    override suspend fun tick(ctx: BtContext): BtResult =
+        when (child.tick(ctx)) {
+            BtResult.SUCCESS -> BtResult.FAILURE
+            BtResult.FAILURE -> BtResult.SUCCESS
+            BtResult.RUNNING -> BtResult.RUNNING
+        }
+}

--- a/src/main/kotlin/dev/ambon/engine/behavior/nodes/SelectorNode.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/nodes/SelectorNode.kt
@@ -1,0 +1,17 @@
+package dev.ambon.engine.behavior.nodes
+
+import dev.ambon.engine.behavior.BtContext
+import dev.ambon.engine.behavior.BtNode
+import dev.ambon.engine.behavior.BtResult
+
+data class SelectorNode(
+    val children: List<BtNode>,
+) : BtNode {
+    override suspend fun tick(ctx: BtContext): BtResult {
+        for (child in children) {
+            val result = child.tick(ctx)
+            if (result != BtResult.FAILURE) return result
+        }
+        return BtResult.FAILURE
+    }
+}

--- a/src/main/kotlin/dev/ambon/engine/behavior/nodes/SequenceNode.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/nodes/SequenceNode.kt
@@ -1,0 +1,17 @@
+package dev.ambon.engine.behavior.nodes
+
+import dev.ambon.engine.behavior.BtContext
+import dev.ambon.engine.behavior.BtNode
+import dev.ambon.engine.behavior.BtResult
+
+data class SequenceNode(
+    val children: List<BtNode>,
+) : BtNode {
+    override suspend fun tick(ctx: BtContext): BtResult {
+        for (child in children) {
+            val result = child.tick(ctx)
+            if (result != BtResult.SUCCESS) return result
+        }
+        return BtResult.SUCCESS
+    }
+}

--- a/src/main/resources/world/demo_ruins.yaml
+++ b/src/main/resources/world/demo_ruins.yaml
@@ -6,6 +6,10 @@ mobs:
   gate_scout:
     name: "a wary caravan scout"
     room: caravan_gate
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: "The scout shouts: You shouldn't be here!"
     drops:
       - itemId: travel_cloak
         chance: 1.0
@@ -24,21 +28,36 @@ mobs:
   beetle_swarm:
     name: "a swarm of glassy beetles"
     room: beetle_grotto
+    behavior:
+      template: coward
+      params:
+        fleeHpPercent: 40
+        fleeMessage: "The beetles scatter in a panic!"
     drops:
       - itemId: beetle_shell
         chance: 1.0
   stone_sentinel:
     name: "a cracked stone sentinel"
     room: cracked_sanctum
+    behavior:
+      template: patrol
+      params:
+        patrolRoute: [cracked_sanctum, shrine_antechamber, shrine_approach, shrine_antechamber]
   bridge_bandit:
     name: "a bridge bandit"
     room: rope_bridge
+    behavior:
+      template: wander_aggro
+      params:
+        aggroMessage: "The bandit snarls: Your coin or your life!"
     drops:
       - itemId: bandit_dagger
         chance: 1.0
   drowned_warder:
     name: "a drowned warder"
     room: flooded_steps
+    behavior:
+      template: stationary_aggro
   orchard_keeper:
     name: "an orchard keeper"
     room: mirror_orchard

--- a/src/test/kotlin/dev/ambon/engine/behavior/BehaviorTreeSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/behavior/BehaviorTreeSystemTest.kt
@@ -1,0 +1,545 @@
+package dev.ambon.engine.behavior
+
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.mob.MobState
+import dev.ambon.domain.world.Direction
+import dev.ambon.domain.world.Room
+import dev.ambon.domain.world.World
+import dev.ambon.domain.world.data.BehaviorParamsFile
+import dev.ambon.engine.CombatSystem
+import dev.ambon.engine.MobRegistry
+import dev.ambon.engine.PlayerRegistry
+import dev.ambon.engine.behavior.actions.AggroAction
+import dev.ambon.engine.behavior.actions.FleeAction
+import dev.ambon.engine.behavior.actions.PatrolAction
+import dev.ambon.engine.behavior.actions.SayAction
+import dev.ambon.engine.behavior.actions.StationaryAction
+import dev.ambon.engine.behavior.actions.WanderAction
+import dev.ambon.engine.behavior.conditions.IsHpBelow
+import dev.ambon.engine.behavior.conditions.IsInCombat
+import dev.ambon.engine.behavior.conditions.IsPlayerInRoom
+import dev.ambon.engine.behavior.nodes.CooldownNode
+import dev.ambon.engine.behavior.nodes.InverterNode
+import dev.ambon.engine.behavior.nodes.SelectorNode
+import dev.ambon.engine.behavior.nodes.SequenceNode
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.MutableClock
+import dev.ambon.test.drainAll
+import dev.ambon.test.loginOrFail
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.Random
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BehaviorTreeSystemTest {
+    private val roomA = Room(RoomId("zone:a"), "Room A", "desc", mapOf(Direction.NORTH to RoomId("zone:b")))
+    private val roomB =
+        Room(
+            RoomId("zone:b"),
+            "Room B",
+            "desc",
+            mapOf(Direction.SOUTH to RoomId("zone:a"), Direction.EAST to RoomId("zone:c")),
+        )
+    private val roomC = Room(RoomId("zone:c"), "Room C", "desc", mapOf(Direction.WEST to RoomId("zone:b")))
+    private val world = World(mapOf(roomA.id to roomA, roomB.id to roomB, roomC.id to roomC), roomA.id)
+
+    private fun env(
+        mobRoom: RoomId = roomA.id,
+        behaviorTree: BtNode? = null,
+    ): TestEnv {
+        val mobs = MobRegistry()
+        val items = ItemRegistry()
+        val players = PlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
+        val outbound = LocalOutboundBus()
+        val clock = MutableClock(0L)
+        val rng = Random(42)
+
+        val mob =
+            MobState(
+                MobId("zone:guard"),
+                "a guard",
+                mobRoom,
+                hp = 100,
+                maxHp = 100,
+                behaviorTree = behaviorTree,
+            )
+        mobs.upsert(mob)
+
+        val combat =
+            CombatSystem(
+                players = players,
+                mobs = mobs,
+                items = items,
+                outbound = outbound,
+                clock = clock,
+                rng = rng,
+            )
+
+        val system =
+            BehaviorTreeSystem(
+                world = world,
+                mobs = mobs,
+                players = players,
+                outbound = outbound,
+                clock = clock,
+                rng = rng,
+                isMobInCombat = combat::isMobInCombat,
+                startMobCombat = combat::startMobCombat,
+                fleeMob = combat::fleeMob,
+                minActionDelayMs = 100L,
+                maxActionDelayMs = 100L,
+            )
+
+        return TestEnv(mobs, players, outbound, clock, combat, system, mob.id)
+    }
+
+    data class TestEnv(
+        val mobs: MobRegistry,
+        val players: PlayerRegistry,
+        val outbound: LocalOutboundBus,
+        val clock: MutableClock,
+        val combat: CombatSystem,
+        val system: BehaviorTreeSystem,
+        val mobId: MobId,
+    )
+
+    // --- Sequence / Selector node tests ---
+
+    @Test
+    fun `SequenceNode succeeds when all children succeed`() =
+        runTest {
+            val node = SequenceNode(listOf(StationaryAction, StationaryAction))
+            val ctx = makeBareContext()
+            assertEquals(BtResult.SUCCESS, node.tick(ctx))
+        }
+
+    @Test
+    fun `SequenceNode fails on first failure`() =
+        runTest {
+            val node =
+                SequenceNode(
+                    listOf(
+                        IsPlayerInRoom, // FAILURE — no players
+                        StationaryAction,
+                    ),
+                )
+            val ctx = makeBareContext()
+            assertEquals(BtResult.FAILURE, node.tick(ctx))
+        }
+
+    @Test
+    fun `SelectorNode succeeds on first success`() =
+        runTest {
+            val node =
+                SelectorNode(
+                    listOf(
+                        IsPlayerInRoom, // FAILURE — no players
+                        StationaryAction, // SUCCESS
+                    ),
+                )
+            val ctx = makeBareContext()
+            assertEquals(BtResult.SUCCESS, node.tick(ctx))
+        }
+
+    @Test
+    fun `SelectorNode fails when all children fail`() =
+        runTest {
+            val node =
+                SelectorNode(
+                    listOf(
+                        IsPlayerInRoom, // FAILURE
+                        IsInCombat, // FAILURE
+                    ),
+                )
+            val ctx = makeBareContext()
+            assertEquals(BtResult.FAILURE, node.tick(ctx))
+        }
+
+    @Test
+    fun `InverterNode swaps SUCCESS to FAILURE`() =
+        runTest {
+            val node = InverterNode(StationaryAction)
+            val ctx = makeBareContext()
+            assertEquals(BtResult.FAILURE, node.tick(ctx))
+        }
+
+    @Test
+    fun `InverterNode swaps FAILURE to SUCCESS`() =
+        runTest {
+            val node = InverterNode(IsPlayerInRoom) // no players → FAILURE → inverted to SUCCESS
+            val ctx = makeBareContext()
+            assertEquals(BtResult.SUCCESS, node.tick(ctx))
+        }
+
+    // --- Aggro tests ---
+
+    @Test
+    fun `aggro guard attacks player in same room`() =
+        runTest {
+            val tree =
+                SelectorNode(
+                    listOf(
+                        IsInCombat,
+                        SequenceNode(listOf(IsPlayerInRoom, AggroAction)),
+                        StationaryAction,
+                    ),
+                )
+            val e = env(behaviorTree = tree)
+            val sid = SessionId(1L)
+            e.players.loginOrFail(sid, "Tester")
+
+            e.outbound.drainAll() // clear login messages
+
+            // First tick schedules the mob (dueAt goes from null → now+delay)
+            e.system.tick()
+            // Advance clock past the scheduled time
+            e.clock.advance(200)
+            // Second tick actually executes the behavior tree
+            e.system.tick()
+
+            // Mob should now be in combat with the player
+            assertTrue(e.combat.isMobInCombat(e.mobId))
+            assertTrue(e.combat.isInCombat(sid))
+
+            val messages = e.outbound.drainAll()
+            assertTrue(messages.any { it is OutboundEvent.SendText && (it as OutboundEvent.SendText).text.contains("attacks you") })
+        }
+
+    @Test
+    fun `aggro guard does nothing when no player in room`() =
+        runTest {
+            val tree =
+                SelectorNode(
+                    listOf(
+                        IsInCombat,
+                        SequenceNode(listOf(IsPlayerInRoom, AggroAction)),
+                        StationaryAction,
+                    ),
+                )
+            val e = env(behaviorTree = tree)
+            // No player logged in
+
+            e.system.tick() // schedule
+            e.clock.advance(200)
+            e.system.tick() // execute
+
+            assertFalse(e.combat.isMobInCombat(e.mobId))
+        }
+
+    @Test
+    fun `aggro does not attack player already in combat`() =
+        runTest {
+            val tree =
+                SelectorNode(
+                    listOf(
+                        IsInCombat,
+                        SequenceNode(listOf(IsPlayerInRoom, AggroAction)),
+                        StationaryAction,
+                    ),
+                )
+            val e = env(behaviorTree = tree)
+            val sid = SessionId(1L)
+            e.players.loginOrFail(sid, "Tester")
+
+            // Manually start combat first
+            e.combat.startCombat(sid, "guard")
+            e.outbound.drainAll()
+
+            e.system.tick() // schedule
+            e.clock.advance(200)
+            e.system.tick() // execute
+
+            // Should still be in combat from the original fight — IsInCombat returns SUCCESS,
+            // selector stops there
+            assertTrue(e.combat.isMobInCombat(e.mobId))
+        }
+
+    // --- Patrol tests ---
+
+    @Test
+    fun `patrol action cycles through waypoints`() =
+        runTest {
+            val route = listOf(roomB.id, roomC.id, roomA.id)
+            val tree = PatrolAction(route)
+            val e = env(mobRoom = roomA.id, behaviorTree = tree)
+
+            // Schedule tick (dueAt null → sets future time)
+            e.system.tick()
+
+            // First tick: mob is at roomA, next waypoint is roomB → moves to roomB
+            e.clock.advance(200)
+            e.system.tick()
+            assertEquals(roomB.id, e.mobs.get(e.mobId)!!.roomId)
+
+            // Second tick: move to roomC
+            e.clock.advance(200)
+            e.system.tick()
+            assertEquals(roomC.id, e.mobs.get(e.mobId)!!.roomId)
+
+            // Third tick: cycle back to roomA
+            e.clock.advance(200)
+            e.system.tick()
+            assertEquals(roomA.id, e.mobs.get(e.mobId)!!.roomId)
+        }
+
+    // --- Flee tests ---
+
+    @Test
+    fun `flee action disengages combat and moves mob`() =
+        runTest {
+            val tree =
+                SelectorNode(
+                    listOf(
+                        SequenceNode(listOf(IsInCombat, IsHpBelow(50), FleeAction)),
+                        StationaryAction,
+                    ),
+                )
+            val e = env(behaviorTree = tree)
+            val sid = SessionId(1L)
+            e.players.loginOrFail(sid, "Tester")
+
+            // Start combat
+            e.combat.startCombat(sid, "guard")
+            e.outbound.drainAll()
+
+            // Set mob HP low
+            val mob = e.mobs.get(e.mobId)!!
+            mob.hp = 30 // 30% of 100
+
+            e.system.tick() // schedule
+            e.clock.advance(200)
+            e.system.tick() // execute
+
+            // Mob should no longer be in combat
+            assertFalse(e.combat.isMobInCombat(e.mobId))
+            // Mob should have moved to a different room
+            val newRoom = e.mobs.get(e.mobId)!!.roomId
+            assertTrue(newRoom != roomA.id, "Mob should have fled to a different room")
+
+            val messages = e.outbound.drainAll()
+            assertTrue(messages.any { it is OutboundEvent.SendText && (it as OutboundEvent.SendText).text.contains("flees") })
+        }
+
+    @Test
+    fun `flee does not trigger when HP above threshold`() =
+        runTest {
+            val tree =
+                SelectorNode(
+                    listOf(
+                        SequenceNode(listOf(IsInCombat, IsHpBelow(50), FleeAction)),
+                        StationaryAction,
+                    ),
+                )
+            val e = env(behaviorTree = tree)
+            val sid = SessionId(1L)
+            e.players.loginOrFail(sid, "Tester")
+
+            e.combat.startCombat(sid, "guard")
+            e.outbound.drainAll()
+
+            // HP still at 100 — above 50% threshold
+            e.system.tick() // schedule
+            e.clock.advance(200)
+            e.system.tick() // execute
+
+            // Mob should still be in combat, didn't flee
+            assertTrue(e.combat.isMobInCombat(e.mobId))
+            assertEquals(roomA.id, e.mobs.get(e.mobId)!!.roomId)
+        }
+
+    // --- Wander tests ---
+
+    @Test
+    fun `wander action moves mob to random adjacent room`() =
+        runTest {
+            val tree = WanderAction
+            val e = env(behaviorTree = tree)
+
+            e.system.tick() // schedule
+            e.clock.advance(200)
+            e.system.tick() // execute
+
+            // Mob should have moved (roomA only has exit to roomB)
+            assertEquals(roomB.id, e.mobs.get(e.mobId)!!.roomId)
+        }
+
+    // --- Say action tests ---
+
+    @Test
+    fun `say action broadcasts message to players in room`() =
+        runTest {
+            val tree = SayAction("Halt! Who goes there?")
+            val e = env(behaviorTree = tree)
+            val sid = SessionId(1L)
+            e.players.loginOrFail(sid, "Tester")
+            e.outbound.drainAll()
+
+            e.system.tick() // schedule
+            e.clock.advance(200)
+            e.system.tick() // execute
+
+            val messages = e.outbound.drainAll()
+            assertTrue(
+                messages.any { ev ->
+                    ev is OutboundEvent.SendText &&
+                        ev.text.contains("Halt! Who goes there?")
+                },
+            )
+        }
+
+    // --- CooldownNode tests ---
+
+    @Test
+    fun `cooldown node gates child execution`() =
+        runTest {
+            var callCount = 0
+            val countingNode =
+                object : BtNode {
+                    override suspend fun tick(ctx: BtContext): BtResult {
+                        callCount++
+                        return BtResult.SUCCESS
+                    }
+                }
+
+            val tree = CooldownNode(cooldownMs = 1000L, key = "test", child = countingNode)
+            val e = env(behaviorTree = tree)
+
+            // Schedule tick (dueAt null → sets future time)
+            e.system.tick()
+
+            // First tick: should execute
+            e.clock.advance(200)
+            e.system.tick()
+            assertEquals(1, callCount)
+
+            // Second tick immediately: cooldown not elapsed, should not execute
+            e.clock.advance(200)
+            e.system.tick()
+            // CooldownNode returns FAILURE, but tree still ticked — callCount stays 1
+            assertEquals(1, callCount)
+
+            // Advance past cooldown
+            e.clock.advance(1000)
+            e.system.tick()
+            assertEquals(2, callCount)
+        }
+
+    // --- BehaviorTreeSystem lifecycle tests ---
+
+    @Test
+    fun `mobs without behavior tree are not ticked by BehaviorTreeSystem`() =
+        runTest {
+            val e = env(behaviorTree = null) // no BT
+            val sid = SessionId(1L)
+            e.players.loginOrFail(sid, "Tester")
+            e.outbound.drainAll()
+
+            e.system.tick() // schedule (no-op for null BT)
+            e.clock.advance(200)
+            val actions = e.system.tick()
+
+            assertEquals(0, actions)
+            assertFalse(e.combat.isMobInCombat(e.mobId))
+        }
+
+    @Test
+    fun `hasBehaviorTree returns correct value`() {
+        val e = env(behaviorTree = StationaryAction)
+        assertTrue(e.system.hasBehaviorTree(e.mobId))
+    }
+
+    @Test
+    fun `hasBehaviorTree returns false for mob without BT`() {
+        val e = env(behaviorTree = null)
+        assertFalse(e.system.hasBehaviorTree(e.mobId))
+    }
+
+    @Test
+    fun `onMobRemoved cleans up memory`() =
+        runTest {
+            val tree = PatrolAction(listOf(roomA.id, roomB.id))
+            val e = env(behaviorTree = tree)
+
+            e.system.tick() // schedule
+            e.clock.advance(200)
+            e.system.tick() // creates memory entry
+
+            e.system.onMobRemoved(e.mobId)
+            // After removal, hasBehaviorTree depends on mob existing in registry
+            // The internal state (memory, timing) should be cleaned
+            // We can verify by re-spawning and checking patrol index resets
+            e.system.onMobSpawned(e.mobId)
+        }
+
+    // --- BehaviorTemplates tests ---
+
+    @Test
+    fun `BehaviorTemplates resolves known template`() {
+        val result =
+            BehaviorTemplates.resolve(
+                "aggro_guard",
+                BehaviorParamsFile(),
+                "zone",
+            )
+        assertTrue(result != null)
+    }
+
+    @Test
+    fun `BehaviorTemplates returns null for unknown template`() {
+        val result =
+            BehaviorTemplates.resolve(
+                "nonexistent_template",
+                BehaviorParamsFile(),
+                "zone",
+            )
+        assertTrue(result == null)
+    }
+
+    @Test
+    fun `BehaviorTemplates resolves all known templates`() {
+        for (name in BehaviorTemplates.templateNames) {
+            val params =
+                BehaviorParamsFile(
+                    patrolRoute = listOf("a", "b"),
+                )
+            val result = BehaviorTemplates.resolve(name, params, "zone")
+            assertTrue(result != null, "Template '$name' should resolve")
+        }
+    }
+
+    // --- Helper to create bare BtContext for unit testing nodes ---
+
+    private fun makeBareContext(): BtContext {
+        val mobs = MobRegistry()
+        val items = ItemRegistry()
+        val players = PlayerRegistry(roomA.id, InMemoryPlayerRepository(), items)
+        val outbound = LocalOutboundBus()
+        val clock = MutableClock(0L)
+        val mob = MobState(MobId("zone:test"), "a test mob", roomA.id)
+        mobs.upsert(mob)
+
+        return BtContext(
+            mob = mob,
+            world = world,
+            mobs = mobs,
+            players = players,
+            outbound = outbound,
+            clock = clock,
+            rng = Random(42),
+            isMobInCombat = { false },
+            startMobCombat = { _, _ -> false },
+            fleeMob = { false },
+            gmcpEmitter = null,
+            mobMemory = MobBehaviorMemory(),
+        )
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/behavior/BehaviorYamlParsingTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/behavior/BehaviorYamlParsingTest.kt
@@ -1,0 +1,56 @@
+package dev.ambon.engine.behavior
+
+import dev.ambon.domain.world.load.WorldLoadException
+import dev.ambon.domain.world.load.WorldLoader
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class BehaviorYamlParsingTest {
+    @Test
+    fun `valid behavior YAML loads successfully`() {
+        val world = WorldLoader.loadFromResource("world/ok_behavior.yaml")
+
+        val guard = world.mobSpawns.find { it.id.value == "behavior_test:guard" }
+        assertNotNull(guard, "guard mob should exist")
+        assertNotNull(guard!!.behaviorTree, "guard should have a behavior tree")
+
+        val sentry = world.mobSpawns.find { it.id.value == "behavior_test:sentry" }
+        assertNotNull(sentry, "sentry mob should exist")
+        assertNotNull(sentry!!.behaviorTree, "sentry should have a behavior tree")
+
+        val rat = world.mobSpawns.find { it.id.value == "behavior_test:rat" }
+        assertNotNull(rat, "rat mob should exist")
+        assertNotNull(rat!!.behaviorTree, "rat should have a behavior tree")
+    }
+
+    @Test
+    fun `mob without behavior has null behaviorTree`() {
+        val world = WorldLoader.loadFromResource("world/ok_dialogue.yaml")
+        for (mob in world.mobSpawns) {
+            assertNull(mob.behaviorTree, "mob ${mob.id.value} should not have a behavior tree")
+        }
+    }
+
+    @Test
+    fun `unknown behavior template causes load error`() {
+        val ex =
+            assertThrows<WorldLoadException> {
+                WorldLoader.loadFromResource("world/bad_behavior_unknown_template.yaml")
+            }
+        assertTrue(ex.message!!.contains("unknown behavior template"))
+        assertTrue(ex.message!!.contains("nonexistent_behavior"))
+    }
+
+    @Test
+    fun `behavior with stationary true causes load error`() {
+        val ex =
+            assertThrows<WorldLoadException> {
+                WorldLoader.loadFromResource("world/bad_behavior_stationary_conflict.yaml")
+            }
+        assertTrue(ex.message!!.contains("stationary"))
+        assertTrue(ex.message!!.contains("behavior"))
+    }
+}

--- a/src/test/resources/world/bad_behavior_stationary_conflict.yaml
+++ b/src/test/resources/world/bad_behavior_stationary_conflict.yaml
@@ -1,0 +1,15 @@
+zone: bad_bt2
+startRoom: room
+
+rooms:
+  room:
+    title: "A Room"
+    description: "desc"
+
+mobs:
+  test:
+    name: "a test mob"
+    room: room
+    stationary: true
+    behavior:
+      template: aggro_guard

--- a/src/test/resources/world/bad_behavior_unknown_template.yaml
+++ b/src/test/resources/world/bad_behavior_unknown_template.yaml
@@ -1,0 +1,14 @@
+zone: bad_bt
+startRoom: room
+
+rooms:
+  room:
+    title: "A Room"
+    description: "desc"
+
+mobs:
+  test:
+    name: "a test mob"
+    room: room
+    behavior:
+      template: nonexistent_behavior

--- a/src/test/resources/world/ok_behavior.yaml
+++ b/src/test/resources/world/ok_behavior.yaml
@@ -1,0 +1,51 @@
+zone: behavior_test
+startRoom: plaza
+
+rooms:
+  plaza:
+    title: "Town Plaza"
+    description: "A bustling town plaza."
+    exits:
+      north: gate
+  gate:
+    title: "Town Gate"
+    description: "The fortified gate."
+    exits:
+      south: plaza
+      east: road
+  road:
+    title: "East Road"
+    description: "A dusty road."
+    exits:
+      west: gate
+
+mobs:
+  guard:
+    name: "a gate guard"
+    room: gate
+    tier: elite
+    level: 3
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: "The guard draws a sword!"
+  sentry:
+    name: "a patrolling sentry"
+    room: plaza
+    behavior:
+      template: patrol_aggro
+      params:
+        patrolRoute:
+          - plaza
+          - gate
+          - road
+          - gate
+  rat:
+    name: "a timid rat"
+    room: plaza
+    tier: weak
+    behavior:
+      template: coward
+      params:
+        fleeHpPercent: 30
+        fleeMessage: "The rat squeals!"


### PR DESCRIPTION
## Summary
Implements a complete behavior tree (BT) system for mob AI, enabling configurable, composable decision-making and action execution. Mobs can now patrol routes, aggro on sight, flee when wounded, wander, and say dialogue—all driven by declarative behavior tree definitions loaded from YAML.

## Key Changes

**Core Behavior Tree Framework**
- Added `BtNode` interface and `BtResult` enum for tree node abstraction
- Implemented `BtContext` to pass world state, registries, and callbacks to nodes
- Added `MobBehaviorMemory` for per-mob state (patrol index, cooldown tracking)

**Composite Nodes**
- `SequenceNode`: succeeds only if all children succeed (AND logic)
- `SelectorNode`: succeeds on first child success (OR logic)
- `InverterNode`: inverts SUCCESS/FAILURE results
- `CooldownNode`: gates child execution with configurable cooldown periods

**Condition Nodes**
- `IsPlayerInRoom`: checks if any player is in mob's current room
- `IsInCombat`: checks if mob is actively fighting
- `IsHpBelow`: checks if mob HP is below a percentage threshold

**Action Nodes**
- `AggroAction`: initiates combat with players in the room
- `PatrolAction`: cycles through waypoints on a defined route
- `FleeAction`: disengages from combat and moves to random adjacent room
- `WanderAction`: moves to random adjacent room
- `SayAction`: broadcasts a message to players in the room
- `StationaryAction`: no-op action (always succeeds)

**Behavior Templates & YAML Integration**
- `BehaviorTemplates` object provides 7 pre-built templates: `aggro_guard`, `stationary_aggro`, `patrol`, `patrol_aggro`, `wander`, `wander_aggro`, `coward`
- Templates are parameterized (patrol routes, flee thresholds, custom messages)
- `BehaviorFile` and `BehaviorParamsFile` data classes for YAML deserialization
- `WorldLoader` extended to parse behavior definitions and instantiate trees

**BehaviorTreeSystem**
- Manages tick scheduling with configurable action delays (default 2–5 seconds)
- Maintains per-mob execution state and memory
- Integrates with `CombatSystem` via callbacks (`isMobInCombat`, `startMobCombat`, `fleeMob`)
- Respects mob rooting and skips mobs without behavior trees
- Cleans up state on mob removal/respawn

**CombatSystem Extensions**
- Added `startMobCombat()` to allow mobs to initiate fights
- Added `fleeMob()` to allow mobs to disengage and flee

**GameEngine Integration**
- `BehaviorTreeSystem` instantiated and ticked in main game loop
- Cleanup hooks on mob removal/spawn

## Notable Implementation Details

- Behavior trees are loaded once at world startup and stored in `MobSpawn` objects
- Each mob instance gets its own `MobBehaviorMemory` for stateful nodes (patrol progress, cooldowns)
- Action execution is rate-limited per mob to prevent spam; scheduling uses a two-phase tick (schedule → execute)
- YAML validation ensures unknown templates are rejected at load time
- Comprehensive test suite (545 lines) covers all node types, templates, and edge cases
- Demo world updated with example mobs using various behavior templates

https://claude.ai/code/session_01V1myMaedVpEuJT1dFF1yGc