### PR TITLE
Add multi-instance local testing setup with 2 engines and 2 gateways

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -180,3 +180,65 @@ tasks.register("swarmRun") {
     description = "Runs the swarm load-testing utility (use :swarm:run with --args for arguments)."
     dependsOn(":swarm:run")
 }
+
+// ---------------------------------------------------------------------------
+// Multi-instance local test configurations
+//
+// These tasks wire up a two-engine / two-gateway topology on localhost:
+//
+//   runEngine1   ENGINE  gRPC :9091  zones: tutorial_glade, ambon_hub, demo_ruins,
+//                                          low_training_marsh, low_training_highlands
+//   runEngine2   ENGINE  gRPC :9092  zones: noecker_resume, low_training_mines,
+//                                          low_training_barrens
+//   runGateway1  GATEWAY telnet :4000  web :8080  connects to engine-1 + engine-2
+//   runGateway2  GATEWAY telnet :4001  web :8081  connects to engine-1 + engine-2
+//
+// Start order: engines first, then gateways. Each task runs in a separate terminal.
+// The profile YAML files live in src/main/resources/application-{profile}.yaml and
+// are loaded as a higher-priority overlay on top of application.yaml.
+// You can still append -Pconfig.* overrides to any of these tasks.
+// ---------------------------------------------------------------------------
+
+tasks.register<JavaExec>("runEngine1") {
+    group = "application"
+    description = "Run Engine 1 (gRPC :9091) for multi-instance local testing."
+    mainClass.set(application.mainClass)
+    classpath = project.extensions.getByType(org.gradle.api.tasks.SourceSetContainer::class.java)["main"].runtimeClasspath
+    standardInput = System.`in`
+    jvmArgs("-Djava.net.preferIPv4Stack=true")
+    systemProperty("ambon.profile", "engine1")
+    applyConfigOverrides()
+}
+
+tasks.register<JavaExec>("runEngine2") {
+    group = "application"
+    description = "Run Engine 2 (gRPC :9092) for multi-instance local testing."
+    mainClass.set(application.mainClass)
+    classpath = project.extensions.getByType(org.gradle.api.tasks.SourceSetContainer::class.java)["main"].runtimeClasspath
+    standardInput = System.`in`
+    jvmArgs("-Djava.net.preferIPv4Stack=true")
+    systemProperty("ambon.profile", "engine2")
+    applyConfigOverrides()
+}
+
+tasks.register<JavaExec>("runGateway1") {
+    group = "application"
+    description = "Run Gateway 1 (telnet :4000, web :8080) for multi-instance local testing."
+    mainClass.set(application.mainClass)
+    classpath = project.extensions.getByType(org.gradle.api.tasks.SourceSetContainer::class.java)["main"].runtimeClasspath
+    standardInput = System.`in`
+    jvmArgs("-Djava.net.preferIPv4Stack=true")
+    systemProperty("ambon.profile", "gw1")
+    applyConfigOverrides()
+}
+
+tasks.register<JavaExec>("runGateway2") {
+    group = "application"
+    description = "Run Gateway 2 (telnet :4001, web :8081) for multi-instance local testing."
+    mainClass.set(application.mainClass)
+    classpath = project.extensions.getByType(org.gradle.api.tasks.SourceSetContainer::class.java)["main"].runtimeClasspath
+    standardInput = System.`in`
+    jvmArgs("-Djava.net.preferIPv4Stack=true")
+    systemProperty("ambon.profile", "gw2")
+    applyConfigOverrides()
+}

--- a/src/main/kotlin/dev/ambon/config/AppConfigLoader.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfigLoader.kt
@@ -21,6 +21,12 @@ object AppConfigLoader {
         for (source in extraSources) {
             builder = builder.addSource(source)
         }
+
+        val profileName = System.getProperty("ambon.profile")
+        if (profileName != null) {
+            builder = builder.addSource(PropertySource.resource("/application-$profileName.yaml", optional = true))
+        }
+
         builder = builder.addResourceSource(resourcePath, optional = false)
 
         return builder

--- a/src/main/resources/application-engine1.yaml
+++ b/src/main/resources/application-engine1.yaml
@@ -1,0 +1,40 @@
+# Engine 1 profile for multi-instance local testing.
+# Run with: ./gradlew runEngine1
+# Owns: tutorial_glade, ambon_hub, demo_ruins, low_training_marsh, low_training_highlands
+# gRPC server: 9091  |  metrics: 9191
+ambonMUD:
+  mode: ENGINE
+  sharding:
+    enabled: true
+    engineId: engine-1
+    zones:
+      - tutorial_glade
+      - ambon_hub
+      - demo_ruins
+      - low_training_marsh
+      - low_training_highlands
+    advertiseHost: localhost
+    registry:
+      type: STATIC
+      assignments:
+        - engineId: engine-1
+          host: localhost
+          port: 9091
+          zones:
+            - tutorial_glade
+            - ambon_hub
+            - demo_ruins
+            - low_training_marsh
+            - low_training_highlands
+        - engineId: engine-2
+          host: localhost
+          port: 9092
+          zones:
+            - noecker_resume
+            - low_training_mines
+            - low_training_barrens
+  grpc:
+    server:
+      port: 9091
+  observability:
+    metricsHttpPort: 9191

--- a/src/main/resources/application-engine2.yaml
+++ b/src/main/resources/application-engine2.yaml
@@ -1,0 +1,38 @@
+# Engine 2 profile for multi-instance local testing.
+# Run with: ./gradlew runEngine2
+# Owns: noecker_resume, low_training_mines, low_training_barrens
+# gRPC server: 9092  |  metrics: 9192
+ambonMUD:
+  mode: ENGINE
+  sharding:
+    enabled: true
+    engineId: engine-2
+    zones:
+      - noecker_resume
+      - low_training_mines
+      - low_training_barrens
+    advertiseHost: localhost
+    registry:
+      type: STATIC
+      assignments:
+        - engineId: engine-1
+          host: localhost
+          port: 9091
+          zones:
+            - tutorial_glade
+            - ambon_hub
+            - demo_ruins
+            - low_training_marsh
+            - low_training_highlands
+        - engineId: engine-2
+          host: localhost
+          port: 9092
+          zones:
+            - noecker_resume
+            - low_training_mines
+            - low_training_barrens
+  grpc:
+    server:
+      port: 9092
+  observability:
+    metricsHttpPort: 9192

--- a/src/main/resources/application-gw1.yaml
+++ b/src/main/resources/application-gw1.yaml
@@ -1,0 +1,20 @@
+# Gateway 1 profile for multi-instance local testing.
+# Run with: ./gradlew runGateway1
+# Telnet: 4000  |  Web: 8080  |  metrics: 9180
+# Connects to engine-1 (:9091) and engine-2 (:9092)
+ambonMUD:
+  mode: GATEWAY
+  gateway:
+    id: 0
+    engines:
+      - id: engine-1
+        host: localhost
+        port: 9091
+      - id: engine-2
+        host: localhost
+        port: 9092
+  server:
+    telnetPort: 4000
+    webPort: 8080
+  observability:
+    metricsHttpPort: 9180

--- a/src/main/resources/application-gw2.yaml
+++ b/src/main/resources/application-gw2.yaml
@@ -1,0 +1,20 @@
+# Gateway 2 profile for multi-instance local testing.
+# Run with: ./gradlew runGateway2
+# Telnet: 4001  |  Web: 8081  |  metrics: 9181
+# Connects to engine-1 (:9091) and engine-2 (:9092)
+ambonMUD:
+  mode: GATEWAY
+  gateway:
+    id: 1
+    engines:
+      - id: engine-1
+        host: localhost
+        port: 9091
+      - id: engine-2
+        host: localhost
+        port: 9092
+  server:
+    telnetPort: 4001
+    webPort: 8081
+  observability:
+    metricsHttpPort: 9181


### PR DESCRIPTION
## Summary
This PR adds a complete multi-instance local testing configuration that allows developers to run a two-engine / two-gateway topology on localhost for testing distributed scenarios.

## Key Changes
- **Gradle tasks**: Added four new `JavaExec` tasks (`runEngine1`, `runEngine2`, `runGateway1`, `runGateway2`) to easily spin up each component in separate terminals
- **Profile YAML files**: Created four Spring profile configuration files:
  - `application-engine1.yaml`: Engine 1 listening on gRPC :9091, owns 5 zones (tutorial_glade, ambon_hub, demo_ruins, low_training_marsh, low_training_highlands)
  - `application-engine2.yaml`: Engine 2 listening on gRPC :9092, owns 3 zones (noecker_resume, low_training_mines, low_training_barrens)
  - `application-gw1.yaml`: Gateway 1 with telnet :4000 and web :8080, connects to both engines
  - `application-gw2.yaml`: Gateway 2 with telnet :4001 and web :8081, connects to both engines
- **Config loader enhancement**: Modified `AppConfigLoader.kt` to support dynamic profile loading via `ambon.profile` system property, allowing profile YAML files to be loaded as higher-priority overlays on the base `application.yaml`

## Implementation Details
- Each component has its own metrics port (9191, 9192, 9180, 9181) for independent observability
- Static service registry configuration allows engines and gateways to discover each other on localhost
- All tasks support additional `-Pconfig.*` overrides for further customization
- IPv4 stack preference is enforced via JVM args for consistent networking behavior

https://claude.ai/code/session_015pJKovLj3bANJEtL1FaVML