### PR TITLE
Expand CLAUDE.md with comprehensive architecture and playbook docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 > The full engineering playbook is in `AGENTS.md`. This file summarizes the most important points for quick orientation.
 
+## Agent Directives
+
+- **Do not launch planning agents for tasks. Write plans directly.**
+- **Avoid re-reading files you've already examined in this session.**
+- **Prefer acting over gathering more context. If you've read the relevant module, start working.**
+
 ## Cloud/Remote Mode
 
 In cloud/remote mode, GitHub API tools (gh CLI, curl to GitHub API) do not work for creating PRs or interacting with GitHub issues. Instead, just push the code to the branch and notify the user — they will create the PR themselves.
@@ -23,6 +29,11 @@ Run a single test class:
 ./gradlew test --tests "dev.ambon.engine.commands.CommandParserTest"
 ```
 
+Run tests matching a pattern:
+```bash
+./gradlew test --tests "*CommandRouter*"
+```
+
 Override any config value at runtime with `-Pconfig.<key>=<value>`:
 ```bash
 ./gradlew run -Pconfig.ambonMUD.logging.level=DEBUG
@@ -31,16 +42,28 @@ Override any config value at runtime with `-Pconfig.<key>=<value>`:
 ./gradlew run -Pconfig.ambonMUD.persistence.backend=POSTGRES  # connection defaults match docker compose
 ```
 
+Multi-instance local testing (start engines first, then gateways):
+```bash
+./gradlew runEngine1     # ENGINE mode, gRPC :9091
+./gradlew runEngine2     # ENGINE mode, gRPC :9092
+./gradlew runGateway1    # GATEWAY mode, telnet :4000, web :8080
+./gradlew runGateway2    # GATEWAY mode, telnet :4001, web :8081
+```
+
 On Windows use `.\gradlew.bat` instead of `./gradlew`.
 
 ## Architecture
 
-AmbonMUD supports three deployment modes (set via `ambonMUD.mode`):
+AmbonMUD is a Kotlin MUD server with a tick-based event loop, telnet + WebSocket transports (with GMCP structured data), YAML world loading, class-based character progression with spell/ability and status-effect systems, shop/economy, NPC behavior trees, dialogue trees, quests, achievements, group play, and a layered persistence stack with selectable YAML or PostgreSQL backends and optional Redis caching/pub-sub.
+
+### Deployment Modes
+
+Three deployment modes (set via `ambonMUD.mode`):
 - **`STANDALONE`** (default): single-process, all components in-process.
 - **`ENGINE`**: GameEngine + persistence + gRPC server; gateways connect remotely.
 - **`GATEWAY`**: transports + gRPC client; game logic runs on a remote engine.
 
-The core design separates gameplay from transport:
+### Layered Architecture
 
 ```
 Transports (telnet / WebSocket)
@@ -51,8 +74,10 @@ InboundBus / OutboundBus  (interface layer; Local* impls in single-process mode)
     │                      (Grpc* impls for gateway ↔ engine gRPC streaming)
     ▼
 GameEngine  (single-threaded coroutine dispatcher, 100ms tick)
-    │  CommandRouter, CombatSystem, AbilitySystem, MobSystem, RegenSystem,
-    │  Scheduler, PlayerProgression, GmcpEmitter, Registries
+    │  CommandRouter, CombatSystem, AbilitySystem, StatusEffectSystem,
+    │  MobSystem, BehaviorTreeSystem, RegenSystem, DialogueSystem,
+    │  QuestSystem, AchievementSystem, GroupSystem, Scheduler,
+    │  PlayerProgression, GmcpEmitter, Registries
     ▼
 OutboundRouter  (per-session queues, backpressure, prompt coalescing)
     │  AnsiRenderer / PlainRenderer
@@ -60,54 +85,201 @@ OutboundRouter  (per-session queues, backpressure, prompt coalescing)
 Sessions
 ```
 
-**Critical contracts:**
-- Engine communicates only via `InboundEvent` / `OutboundEvent` — no transport code in engine, no gameplay code in transport.
-- `GameEngine` is single-threaded. Never call blocking I/O inside engine systems. Use the injected `Clock` instead of wall-clock calls.
-- `RoomId` must be namespaced: `<zone>:<room>`.
-- Player name: 2–16 chars, alnum/underscore, cannot start with a digit.
-- Password: non-blank, max 72 chars (BCrypt limit).
-- YAML player files use atomic writes — preserve this in any persistence changes.
-- Persistence flows through the full chain: `WriteCoalescingPlayerRepository` → `RedisCachingPlayerRepository` (if enabled) → `YamlPlayerRepository` or `PostgresPlayerRepository` (selected via `ambonMUD.persistence.backend`).
+### Critical Contracts
 
-## Key Locations
+- **Engine boundary:** Engine communicates only via `InboundEvent` / `OutboundEvent` — no transport code in engine, no gameplay code in transport.
+- **Single-threaded engine:** `GameEngine` runs on a dedicated single-thread `engineDispatcher`. Never call blocking I/O inside engine systems. Use the injected `Clock` instead of wall-clock calls.
+- **RoomId format:** Must be namespaced as `<zone>:<room>`.
+- **Player name:** 2–16 chars, alnum/underscore, cannot start with a digit.
+- **Password:** non-blank, max 72 chars (BCrypt limit).
+- **Persistence chain:** `WriteCoalescingPlayerRepository` → `RedisCachingPlayerRepository` (if enabled) → `YamlPlayerRepository` or `PostgresPlayerRepository` (selected via `ambonMUD.persistence.backend`). YAML uses atomic writes; preserve this in any persistence changes.
+- **Event bus:** `InboundBus`/`OutboundBus` are interfaces — never pass raw `Channel` references to engine code. All bus impls (Local, Redis, gRPC) are interchangeable.
+- **Outbound routing:** `OutboundRouter` applies backpressure (slow clients may be disconnected). Consecutive prompts coalesce. `Close` sends final text then closes via callback.
+
+### Event Types
+
+**InboundEvent** (sealed interface in `engine/events/InboundEvent.kt`):
+- `Connected(sessionId, defaultAnsiEnabled)` — new session
+- `Disconnected(sessionId, reason)` — session lost
+- `LineReceived(sessionId, line)` — player typed a line
+- `GmcpReceived(sessionId, gmcpPackage, jsonData)` — GMCP data from client
+
+**OutboundEvent** (sealed interface in `engine/events/OutboundEvent.kt`):
+- `SendText`, `SendInfo`, `SendError` — text to player
+- `SendPrompt` — prompt line
+- `ShowLoginScreen`, `SetAnsi`, `ClearScreen`, `ShowAnsiDemo` — UI control
+- `Close(sessionId, reason)` — disconnect session
+- `SessionRedirect` — cross-engine handoff
+- `GmcpData(sessionId, gmcpPackage, jsonData)` — GMCP telemetry to client
+
+### Command System
+
+`CommandParser.kt` transforms raw input into a sealed `Command` hierarchy. `CommandRouter.kt` dispatches each variant. Key command categories:
+- **Navigation:** Move, Look, LookDir, Exits
+- **Communication:** Say, Tell, Whisper, Gossip, Shout, Ooc, Pose, Emote, Gtell
+- **Combat:** Kill, Flee, Cast, Dispel
+- **Items:** Get, Drop, Use, Give, Wear, Remove, Inventory, Equipment
+- **Progression:** Score, Spells, Effects, Balance, QuestLog, QuestInfo, QuestAccept, QuestAbandon, AchievementList, TitleSet, TitleClear
+- **NPCs:** Talk, DialogueChoice, ShopList, Buy, Sell
+- **Groups:** GroupCmd (Invite, Accept, Leave, Kick, List)
+- **Sharding:** Phase (instance switching)
+- **Staff:** Goto, Transfer, Spawn, Smite, Kick, Shutdown
+- **Utility:** Help, Clear, Colors, Who, AnsiOn, AnsiOff
+- **Meta:** Invalid (with usage hint), Unknown, Noop (empty input)
+
+### Persistence Model
+
+`PlayerRecord` (in `persistence/PlayerRecord.kt`) is the persistence DTO. Key fields: `id` (PlayerId), `name`, `roomId`, `level`, `xpTotal`, `hp`/`maxHp`, `mana`/`maxMana`, `strength`/`dexterity`/`constitution`/`intelligence`/`wisdom`/`charisma`, `race`, `playerClass`, `gold`, `isStaff`, `activeQuests`, `completedQuestIds`, `unlockedAchievementIds`, `achievementProgress`, `activeTitle`, `passwordHash`, `ansiEnabled`.
+
+`PlayerState` (in `engine/PlayerState.kt`) is the runtime in-memory version, maintained by the engine and periodically flushed back to `PlayerRecord` via the repository chain.
+
+`PlayerRepository` interface: `findByName(name)`, `findById(id)`, `create(request)`, `save(record)`. All lookups are case-insensitive.
+
+### Wiring / Dependency Injection
+
+`MudServer.kt` is the composition root for STANDALONE/ENGINE modes. `GatewayServer.kt` for GATEWAY mode. No DI framework — all dependencies are manually wired via constructor injection in these files. `Main.kt` dispatches to the appropriate root based on `config.mode`.
+
+## Project Map
+
+### Source Files (~163 Kotlin files in main, ~78 test files)
+
+| Package | Purpose | Key Files |
+|---------|---------|-----------|
+| `dev.ambon` | Entry point, wiring | `Main.kt` (bootstrap), `MudServer.kt` (25K, composition root), `CoroutineExtensions.kt` |
+| `dev.ambon.config` | Configuration | `AppConfig.kt` (33K, full schema + `validated()`), `AppConfigLoader.kt` |
+| `dev.ambon.engine` | Core game logic | `GameEngine.kt` (62K, tick loop), `PlayerRegistry.kt`, `PlayerState.kt`, `CombatSystem.kt` (25K), `MobSystem.kt`, `MobRegistry.kt`, `RegenSystem.kt`, `PlayerProgression.kt`, `GmcpEmitter.kt` (12K), `GroupSystem.kt` (12K), `QuestSystem.kt` (12K), `AchievementSystem.kt` (11K), `ThreatTable.kt`, `ShopRegistry.kt`, `EngineUtil.kt` |
+| `dev.ambon.engine.commands` | Command parsing/routing | `CommandParser.kt` (17K, sealed Command hierarchy), `CommandRouter.kt` (74K, all command handlers) |
+| `dev.ambon.engine.abilities` | Ability/spell system | `AbilitySystem.kt` (16K), `AbilityRegistry.kt`, `AbilityRegistryLoader.kt`, `AbilityDefinition.kt` |
+| `dev.ambon.engine.status` | Status effects | `StatusEffectSystem.kt` (13K), `StatusEffectRegistry.kt`, `StatusEffectRegistryLoader.kt`, `StatusEffectDefinition.kt`, `ActiveEffect.kt` |
+| `dev.ambon.engine.behavior` | Mob behavior trees | `BehaviorTreeSystem.kt`, `BtNode.kt`, `BtResult.kt`, `BtContext.kt`, `BehaviorTemplates.kt`, `MobBehaviorMemory.kt`; nodes/conditions/actions subdirs |
+| `dev.ambon.engine.dialogue` | NPC dialogue | `DialogueSystem.kt`, `DialogueTree.kt` |
+| `dev.ambon.engine.items` | Item management | `ItemRegistry.kt` (17K), `ItemMatching.kt` |
+| `dev.ambon.engine.scheduler` | Delayed actions | `Scheduler.kt` |
+| `dev.ambon.engine.events` | Event types | `InboundEvent.kt`, `OutboundEvent.kt` |
+| `dev.ambon.bus` | Event bus abstractions | `InboundBus.kt`, `OutboundBus.kt` (interfaces); `Local*Bus.kt`, `Redis*Bus.kt`, `Grpc*Bus.kt` (impls); `DepthTrackingChannel.kt` |
+| `dev.ambon.domain` | Domain model | `PlayerClass.kt`, `Race.kt`; sub-packages: `ids/`, `items/`, `mob/`, `quest/`, `achievement/`, `world/` |
+| `dev.ambon.domain.world` | World model | `Room.kt`, `Direction.kt`, `World.kt`, `WorldFactory.kt`, `ShopDefinition.kt`, `MobSpawn.kt`, `ItemSpawn.kt`, `MobDrop.kt` |
+| `dev.ambon.domain.world.data` | YAML DTOs | `WorldFile.kt`, `RoomFile.kt`, `MobFile.kt`, `ItemFile.kt`, `ShopFile.kt`, `MobDropFile.kt`, `BehaviorFile.kt`, `DialogueNodeFile.kt`, `QuestFile.kt` |
+| `dev.ambon.domain.world.load` | World loading | `WorldLoader.kt` (30K, YAML parsing + validation) |
+| `dev.ambon.persistence` | Player persistence | `PlayerRepository.kt` (interface), `PlayerRecord.kt`, `PlayerDto.kt`, `PlayerCreationRequest.kt`; `WriteCoalescingPlayerRepository.kt`, `RedisCachingPlayerRepository.kt`, `YamlPlayerRepository.kt`, `PostgresPlayerRepository.kt`, `PlayersTable.kt`, `DatabaseManager.kt`, `PersistenceWorker.kt`, `StringCache.kt` |
+| `dev.ambon.transport` | Network I/O | `Transport.kt`, `BlockingSocketTransport.kt` (telnet), `KtorWebSocketTransport.kt` (13K, WebSocket), `NetworkSession.kt` (12K), `OutboundRouter.kt` (9K), `AnsiRenderer.kt`, `PlainRenderer.kt`, `TelnetLineDecoder.kt` (6K) |
+| `dev.ambon.grpc` | gRPC engine/gateway | `EngineGrpcServer.kt`, `EngineServer.kt` (21K), `EngineServiceImpl.kt`, `GrpcOutboundDispatcher.kt`, `ProtoMapper.kt` (8.6K), `OutboundEventPlane.kt` |
+| `dev.ambon.gateway` | Gateway-mode root | `GatewayServer.kt` (23K), `SessionRouter.kt` |
+| `dev.ambon.sharding` | Zone sharding | `ZoneRegistry.kt`, `StaticZoneRegistry.kt`, `RedisZoneRegistry.kt`, `InterEngineBus.kt`, `LocalInterEngineBus.kt`, `RedisInterEngineBus.kt`, `InterEngineMessage.kt`, `HandoffManager.kt` (16K), `PlayerLocationIndex.kt`, `RedisPlayerLocationIndex.kt`, `InstanceSelector.kt`, `LoadBalancedInstanceSelector.kt`, `InstanceScaler.kt`, `ThresholdInstanceScaler.kt`, `ScaleDecisionPublisher.kt`, `ZoneInstance.kt` |
+| `dev.ambon.session` | Session IDs | `SessionIdFactory.kt`, `AtomicSessionIdFactory.kt`, `SnowflakeSessionIdFactory.kt`, `GatewayIdLeaseManager.kt` |
+| `dev.ambon.redis` | Redis infra | `RedisConnectionManager.kt`, `JsonSupport.kt` |
+| `dev.ambon.metrics` | Observability | `GameMetrics.kt` (13K), `MetricsHttpServer.kt` |
+| `dev.ambon.admin` | Admin dashboard | `AdminHttpServer.kt` (34K) |
+| `dev.ambon.ui.login` | Login screen | `LoginScreen.kt`, `LoginScreenLoader.kt`, `LoginScreenRenderer.kt` |
+
+### Resources
 
 | What | Where |
 |------|-------|
-| Entry point / wiring | `src/main/kotlin/dev/ambon/Main.kt`, `MudServer.kt` |
-| Config schema + defaults | `src/main/kotlin/dev/ambon/config/AppConfig.kt`, `src/main/resources/application.yaml` |
-| Game engine + subsystems | `src/main/kotlin/dev/ambon/engine/` (includes `AbilitySystem`, `GmcpEmitter`) |
-| Command parsing + routing | `src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt`, `CommandRouter.kt` |
-| Zone sharding + instancing | `src/main/kotlin/dev/ambon/sharding/` (ZoneRegistry, InterEngineBus, HandoffManager, InstanceSelector) |
-| Event bus interfaces + impls | `src/main/kotlin/dev/ambon/bus/` (Local*, Redis*, Grpc*) |
-| gRPC server + engine-mode root | `src/main/kotlin/dev/ambon/grpc/` |
-| Gateway-mode composition root | `src/main/kotlin/dev/ambon/gateway/GatewayServer.kt` |
-| Proto definitions | `src/main/proto/ambonmud/v1/` |
-| Redis connection + JSON support | `src/main/kotlin/dev/ambon/redis/` |
-| Session ID allocation | `src/main/kotlin/dev/ambon/session/` |
-| Metrics (Micrometer/Prometheus) | `src/main/kotlin/dev/ambon/metrics/` |
-| Transport adapters | `src/main/kotlin/dev/ambon/transport/` |
-| World YAML content | `src/main/resources/world/` |
-| World loader + validation | `src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt` |
-| World YAML format spec | `docs/world-zone-yaml-spec.md` |
-| Persistence (YAML + Postgres) | `src/main/kotlin/dev/ambon/persistence/` |
-| Flyway migrations | `src/main/resources/db/migration/` |
-| Tests | `src/test/kotlin/` (fixtures: `src/test/resources/world/`) |
+| Default config | `src/main/resources/application.yaml` |
+| Multi-instance profiles | `src/main/resources/application-{engine1,engine2,gw1,gw2}.yaml` |
+| World zones (9 YAML files) | `src/main/resources/world/` (ambon_hub, tutorial_glade, demo_ruins, noecker_resume, 4 training zones, achievements) |
+| Login banner + styles | `src/main/resources/login.txt`, `src/main/resources/login.styles.yaml` |
+| Flyway migrations | `src/main/resources/db/migration/` (V1–V7: players table through achievements) |
+| Proto definitions | `src/main/proto/ambonmud/v1/engine_service.proto`, `events.proto` |
 | Web demo client (static) | `src/main/resources/web/` |
+| World YAML format spec | `docs/world-zone-yaml-spec.md` |
 | Runtime player saves | `data/players/` (git-ignored, do not commit) |
 
-## Change Playbooks (summary)
+### Tests (~78 test files)
 
-- **New command:** parse in `CommandParser.kt` → implement in `CommandRouter.kt` → add tests.
-- **Staff command:** add to `CommandParser.kt`; gate with `playerState.isStaff` check in `CommandRouter.kt`.
-- **Combat/mob/item:** edit `CombatSystem`, `MobSystem`, `MobRegistry`, `ItemRegistry`; preserve `max*PerTick` caps.
-- **World content only:** edit YAML in `src/main/resources/world/`; no code change needed.
-- **Config:** update `AppConfig.kt` and `application.yaml` together; keep `validated()` strict.
-- **Persistence:** work through the `PlayerRepository` interface; maintain case-insensitive lookup and atomic writes (YAML) or unique-index enforcement (Postgres). The chain is `WriteCoalescing → RedisCache → Yaml/Postgres` — changes to `PlayerRecord` must survive all three layers. When adding columns to the Postgres backend, add a new Flyway migration in `src/main/resources/db/migration/` and update `PlayersTable.kt`.
-- **Bus/Redis/gRPC:** `InboundBus`/`OutboundBus` are the engine boundaries; do not pass raw channels to engine code. Redis and gRPC variants are optional wrappers — always test with both `LocalInboundBus` and the mock bus in unit tests. When adding new event variants, update both the Redis bus envelope and the proto definitions + `ProtoMapper`.
+| Area | Files | Key Tests |
+|------|-------|-----------|
+| Engine core | `GameEngineIntegrationTest`, `GameEngineLoginFlowTest` (29K), `GameEngineAnsiBehaviorTest` | Full login/play/quit flows, ANSI |
+| Commands | `CommandParserTest` (15K), `CommandRouterTest` (19K), `CommandRouterAdminTest` (23K), `CommandRouterItemsTest` (21K), `CommandRouterShopTest`, `CommandRouterBroadcastTest`, `CommandRouterScoreTest`, `CrossEngineCommandsTest`, `NamesTellGossipTest`, `SocialChannelCommandsTest`, `PhaseCommandTest` | Every command category |
+| Combat/mobs | `CombatSystemTest` (42K), `MobRespawnTest`, `MobRegistryTest`, `MobSystemTest`, `ThreatTableTest` | Damage, threat, death, respawn |
+| Abilities/status | `AbilitySystemTest` (20K), `StatusEffectSystemTest` (23K) | Cast, cooldown, DOT/HOT/stun/root |
+| Behavior trees | `BehaviorTreeSystemTest` (18K), `BehaviorYamlParsingTest` | Mob AI, YAML-driven behaviors |
+| Dialogue/quests/achievements | `DialogueSystemTest` (14K), `QuestSystemTest` (13K), `AchievementSystemTest` (20K) | NPC conversations, quest tracking |
+| Groups | `GroupSystemTest` (15K) | Party invite/leave/kick, XP sharing |
+| Persistence | `YamlPlayerRepositoryTest`, `PostgresPlayerRepositoryTest`, `RedisCachingPlayerRepositoryTest`, `WriteCoalescingPlayerRepositoryTest`, `PersistenceWorkerTest` | Atomic writes, H2 Postgres mode, cache layers |
+| Bus | `LocalInboundBusTest`, `LocalOutboundBusTest`, `RedisInboundBusTest`, `RedisOutboundBusTest`, `GrpcInboundBusTest`, `GrpcOutboundBusTest` | All bus variants |
+| Transport | `OutboundRouterTest` (11K), `OutboundRouterAnsiControlsTest`, `OutboundRouterPromptCoalescingTest`, `AnsiRendererTest`, `PlainRendererTest`, `TelnetLineDecoderTest`, `KtorWebSocketTransportTest` | Backpressure, ANSI, protocol |
+| Sharding | `HandoffManagerTest` (18K), `StaticZoneRegistryTest`, `LoadBalancedInstanceSelectorTest`, `ThresholdInstanceScalerTest`, `InterEngineMessageSerializationTest`, `LocalInterEngineBusTest` | Zone handoff, scaling |
+| gRPC | `EngineGrpcServerTest`, `EngineServiceImplTest`, `GatewayEngineIntegrationTest` (16K), `GrpcOutboundDispatcherTest`, `ProtoMapperTest` | End-to-end gateway-engine |
+| Other | `AppConfigLoaderTest`, `GameMetricsTest`, `MetricsHttpServerTest`, `AdminModuleTest` (15K), `GmcpEmitterTest` (20K), `PlayerProgressionTest`, `SchedulerTest`, `SchedulerDropsTest`, `LoginScreenLoaderTest`, `LoginScreenRendererTest`, `WorldLoaderTest` (26K), `SessionIdFactory` tests | Config, metrics, admin, world loading |
+
+### Test Utilities
+
+| Utility | Location | Purpose |
+|---------|----------|---------|
+| `MutableClock` | `src/test/kotlin/dev/ambon/test/MutableClock.kt` | Deterministic time via `advance(ms)` and `set(ms)` — use instead of wall-clock |
+| `InMemoryPlayerRepository` | `src/test/kotlin/dev/ambon/persistence/InMemoryPlayerRepository.kt` | Fast in-memory `PlayerRepository` with case-insensitive lookup and `clear()` |
+| `EngineTestHelpers` | `src/test/kotlin/dev/ambon/test/EngineTestHelpers.kt` | `LocalOutboundBus.drainAll()`, `PlayerRegistry.loginOrFail()` |
+| `RedisBusTestFixtures` | `src/test/kotlin/dev/ambon/bus/RedisBusTestFixtures.kt` | `FakePublisher`, `FakeSubscriberSetup` for testing Redis bus without Redis |
+| World fixtures | `src/test/resources/world/` | `test_world.yaml`, `ok_*.yaml` (valid), `bad_*.yaml` (40+ invalid YAML for error testing), `mz_*.yaml` / `split_zone_*.yaml` (multi-zone) |
+
+### Infrastructure
+
+| What | Where |
+|------|-------|
+| Docker Compose | `docker-compose.yml` (Prometheus, Grafana, Redis, Postgres) |
+| CI workflow | `.github/workflows/ci.yml` (Java 21, `ktlintCheck test`) |
+| CodeQL analysis | `.github/workflows/codeql.yml` (weekly + on main) |
+| Load testing | `swarm/` subproject (`:swarm:run`) |
+
+## Build Configuration
+
+- **Kotlin:** 2.3.10, JVM toolchain 21
+- **Gradle:** wrapper with `-Xmx2g`, daemon idle timeout 10 minutes
+- **Key dependencies:** Ktor 3.4.0 (WebSocket server), kotlinx-coroutines 1.10.2, Jackson 2.21.0 (YAML), Hoplite 2.9.0 (config), Logback 1.5.18, BCrypt 0.4, Micrometer 1.16.3 (Prometheus), Lettuce 7.4.0 (Redis), Exposed 0.58.0 (SQL), HikariCP 6.2.1, PostgreSQL 42.7.5, Flyway 11.3.0, gRPC 1.79.0, Protobuf 3.25.5
+- **Test deps:** JUnit Jupiter 6.0.3, kotlinx-coroutines-test, H2 2.3.232 (Postgres compat mode), Ktor test host, gRPC testing/in-process
+
+## Change Playbooks
+
+### New command
+1. Add variant to `Command` sealed interface in `CommandParser.kt`.
+2. Add parse logic in `CommandParser.parse()` (use `matchPrefix()` for prefix matching, `requiredArg()` if arguments needed).
+3. Implement handler in `CommandRouter.kt`.
+4. Preserve prompt behavior for success/failure paths (`outbound.send(SendPrompt(...))`).
+5. Add parser tests in `CommandParserTest` and router tests in `CommandRouterTest` (or a dedicated test file).
+
+### Staff command
+Same as above, plus gate with `if (!playerState.isStaff)` check in `CommandRouter.kt`. Test in `CommandRouterAdminTest`.
+
+### Combat/mob/item
+Edit `CombatSystem`, `MobSystem`, `MobRegistry`, `ItemRegistry`; preserve `max*PerTick` caps to avoid tick starvation.
+
+### Ability/spell
+Add definition in `application.yaml` under `engine.abilities.definitions`. If new effect type needed, update `AbilityRegistryLoader`. Class restriction via `classRestriction` field. Test in `AbilitySystemTest`.
+
+### Status effect
+Add definition in `application.yaml` under `engine.statusEffects.definitions`. If new effect mechanic, update `EffectType` enum and tick branches in `StatusEffectSystem`. Keep `CombatSystem` call sites in sync (`getPlayerStatMods`, `hasMobEffect(STUN)`, `absorbPlayerDamage`).
+
+### World content only
+Edit YAML in `src/main/resources/world/`; no code change needed. See `docs/world-zone-yaml-spec.md` for schema.
+
+### Config
+Update `AppConfig.kt` and `application.yaml` together; keep `validated()` strict with `require()` checks.
+
+### Persistence (adding a field to PlayerRecord)
+1. Add field with default to `PlayerRecord` data class.
+2. Verify YAML round-trip (Jackson handles new defaults for existing files).
+3. Verify Redis JSON round-trip (`RedisCachingPlayerRepositoryTest`).
+4. For Postgres: add a new Flyway migration (`V<N>__description.sql` in `src/main/resources/db/migration/`), update `PlayersTable.kt` column and `PostgresPlayerRepository.kt` mapping (`toPlayerRecord()`, `insert`, `upsert`).
+5. If the field is runtime state, update `PlayerState` and the `PlayerRegistry` sync logic.
+
+### Bus/Redis/gRPC (adding a new event variant)
+1. Add variant to `InboundEvent` or `OutboundEvent`.
+2. Add type discriminator + data class in `RedisInboundBus`/`RedisOutboundBus`.
+3. Add proto message in `src/main/proto/ambonmud/v1/events.proto`.
+4. Add mapping in `ProtoMapper.kt`.
+5. Test with both `LocalInboundBus` and mock bus.
+
+### Sharding / inter-engine messaging
+When adding new `InterEngineMessage` variants, update serialization in `InterEngineMessage.kt` and add tests. Update both `LocalInterEngineBus` and `RedisInterEngineBus`.
+
+### GMCP
+Update `GmcpEmitter.kt` and the web client's `app.js` handler. Telnet negotiation is in `NetworkSession.kt` (WILL GMCP) and `TelnetLineDecoder.kt`.
 
 ## Kotlin Style (ktlint)
 
-This project uses **ktlint 1.5.0** with `kotlin.code.style=official`. Rule overrides live in the root `.editorconfig`. The following rules are **disabled** to reduce formatting friction (see `.editorconfig` for rationale):
+This project uses **ktlint 1.5.0** with `kotlin.code.style=official`. Rule overrides live in the root `.editorconfig`. The following rules are **disabled** to reduce formatting friction:
 
 - `multiline-expression-wrapping` — no forced newline after `=` for multiline RHS.
 - `string-template-indent` — disabled as a dependency of the above.
@@ -120,12 +292,12 @@ All other standard rules remain enforced. The most important ones to know:
    ```kotlin
    class Foo(
        val bar: String,
-       val baz: Int,      // ← trailing comma
+       val baz: Int,      // <- trailing comma
    )
 
    doSomething(
        first = 1,
-       second = 2,        // ← trailing comma
+       second = 2,        // <- trailing comma
    )
    ```
 
@@ -143,9 +315,41 @@ All other standard rules remain enforced. The most important ones to know:
 
 8. **No blank line before first declaration in a class** — The first property/function starts immediately after the opening brace (or after the constructor closing parenthesis).
 
-## Testing
+## Testing Patterns
 
-Use `MutableClock` and `InMemoryPlayerRepository` for deterministic unit tests. Run `ktlintCheck test` before finalizing any change.
+### General
+- Run `ktlintCheck test` before finalizing any change.
+- Add tests for every behavioral change; this codebase treats tests as design constraints.
+- Prefer focused test runs while iterating (`--tests "ClassName"`), then run full suite before finalizing.
+
+### Deterministic time
+Always use `MutableClock` for code that depends on time. Never use `System.currentTimeMillis()` or similar in production code — use the injected `Clock`.
+
+### Async/coroutine tests
+```kotlin
+@OptIn(ExperimentalCoroutinesApi::class)
+fun `test name`() = runTest {
+    val engine = GameEngine(inbound, outbound, ...)
+    val engineJob = launch { engine.run() }
+
+    inbound.send(InboundEvent.Connected(sid))
+    runCurrent()           // let engine process events
+    advanceTimeBy(100)     // advance virtual time
+    runCurrent()
+
+    val events = outbound.drainAll()  // collect all outbound events
+    // assertions...
+    engineJob.cancel()
+}
+```
+
+### Database tests
+Postgres tests use H2 in PostgreSQL-compatibility mode (`jdbc:h2:mem:test;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE`). No Docker required.
+
+### Test isolation
+- `@TempDir` for file-based tests (YAML persistence).
+- `@BeforeEach` for database cleanup.
+- `InMemoryPlayerRepository.clear()` between tests.
 
 ## Cloud / CI Environment
 
@@ -156,7 +360,13 @@ When running in Claude Code cloud sessions (claude.ai/code), be aware of these c
 - **GitHub CLI (`gh`) is not available:** The `gh` command is not installed in cloud sessions. Use `git` commands directly for all repository operations (push, fetch, branch). Git remotes are wired through a local proxy that handles authentication automatically.
 - **No hardcoded timing in tests:** Cloud environments have variable CPU scheduling latency. Never use short `delay()` calls (e.g. `delay(50)`) to synchronize with async coroutines launched on `Dispatchers.Default`. Instead, use polling loops with `withTimeout` and a generous timeout (e.g. 2 seconds), or use proper coroutine synchronization primitives (channels, `CompletableDeferred`). For negative tests (asserting nothing arrives), use at least `delay(200)`.
 - **First build is slow:** The Gradle wrapper downloads the distribution and all dependencies on first run. Subsequent builds use the cached daemon.
+- **Test timeout:** Individual tests timeout after 30 seconds (`junit-platform.properties`). Entire suite times out after 5 minutes (Gradle backstop).
 
 ## Known Quirks
 
 - **Compiler warnings in tests:** Several test files produce "No cast needed" warnings (e.g. `InterEngineMessageHandlingTest.kt`, `CrossEngineCommandsTest.kt`). These are harmless and do not affect test results.
+- **Largest files:** `CommandRouter.kt` (74K) and `GameEngine.kt` (62K) are intentionally large — they are the central dispatch hubs. Navigate by command/event name.
+- **Generated sources:** Protobuf/gRPC generates code under `build/generated/`. A child `.editorconfig` suppresses ktlint for these files.
+- **Gradle daemon idle timeout:** Set to 10 minutes (`gradle.properties`) to reclaim stale daemons faster than the 3-hour default.
+- **Staff access:** Granted by editing `isStaff: true` in the player YAML file (or `is_staff` column in Postgres) — there is no in-game promotion command.
+- **Metrics package:** Uses `io.micrometer.prometheusmetrics` (not the deprecated `io.micrometer.prometheus`).


### PR DESCRIPTION
## Summary

This PR significantly expands `CLAUDE.md` with detailed architecture documentation, a complete project map, comprehensive testing patterns, and refined change playbooks. The goal is to provide Claude Code with a single authoritative reference for understanding the codebase structure, making informed decisions about where to implement changes, and following established patterns.

## Key Changes

- **Agent Directives:** Added explicit guidance to avoid planning agents, re-reading files, and to prefer action over context-gathering.

- **Build & Test Commands:** Expanded the quick-start section with pattern-based test filtering (`--tests "*CommandRouter*"`) and multi-instance local testing setup (runEngine1/2, runGateway1/2).

- **Architecture Overview:** Rewrote the architecture section with:
  - A one-sentence summary of AmbonMUD's feature set
  - Explicit subsections for Deployment Modes, Layered Architecture, and Critical Contracts
  - Detailed event type documentation (InboundEvent and OutboundEvent variants)
  - Command system overview with all command categories
  - Persistence model explanation (PlayerRecord vs. PlayerState)
  - Wiring/DI explanation (MudServer.kt, GatewayServer.kt as composition roots)

- **Project Map:** Added a comprehensive table-based map covering:
  - ~163 Kotlin source files organized by package with key files and purposes
  - ~78 test files with test categories and key test classes
  - Test utilities (MutableClock, InMemoryPlayerRepository, EngineTestHelpers, etc.)
  - Infrastructure (Docker Compose, CI workflows, load testing)
  - Build configuration (Kotlin 2.3.10, key dependencies, versions)

- **Change Playbooks:** Expanded from brief notes to detailed step-by-step procedures for:
  - New commands (parse → implement → test)
  - Staff commands (with gating pattern)
  - Combat/mob/item changes
  - Ability/spell additions
  - Status effect additions
  - World content (YAML-only)
  - Config changes
  - Persistence field additions (YAML, Redis, Postgres with Flyway)
  - Bus/Redis/gRPC event variants
  - Sharding and inter-engine messaging
  - GMCP updates

- **Testing Patterns:** Added dedicated section with:
  - General testing guidance (ktlintCheck, test-driven design)
  - Deterministic time patterns (MutableClock usage)
  - Async/coroutine test template with runTest, runCurrent, advanceTimeBy
  - Database testing notes (H2 PostgreSQL mode, no Docker)
  - Test isolation patterns (@TempDir, @BeforeEach, clear())

- **Cloud/CI Environment:** Clarified test timeout behavior (30s per test, 5min suite) and added note about Gradle daemon idle timeout.

- **Known Quirks:** Added notes on largest files (CommandRouter.kt 74K, GameEngine.kt 62K), generated sources, Gradle daemon tuning, staff access mechanism, and Micrometer package naming.

## Notable Implementation Details

- The project map uses tables for easy scanning and cross-referencing.
- Change playbooks now include specific file paths and code patterns (e.g., `matchPrefix()`, `requiredArg()` for command parsing).
- Persistence playbook explicitly covers all three layers (YAML, Redis, Postgres) and Flyway migration workflow.
- Testing section includes a runnable async/coroutine test template to reduce boilerplate in new tests.
- Architecture section now explicitly documents the event bus as an interface boundary and explains why raw channels must never be passed to engine code.

https://claude.ai/code/session_018h18o9Lb1sE18noUV5zFP8