### PR TITLE
Add time budget for inbound event processing per tick

### DIFF
--- a/src/main/kotlin/dev/ambon/MudServer.kt
+++ b/src/main/kotlin/dev/ambon/MudServer.kt
@@ -517,6 +517,7 @@ class MudServer(
                     tickMillis = tickMillis,
                     scheduler = scheduler,
                     maxInboundEventsPerTick = config.server.maxInboundEventsPerTick,
+                    inboundBudgetMs = config.server.inboundBudgetMs,
                     loginConfig = config.login,
                     engineConfig = config.engine,
                     progression = progression,

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -46,6 +46,8 @@ data class AppConfig(
         require(server.sessionOutboundQueueCapacity > 0) { "ambonMUD.server.sessionOutboundQueueCapacity must be > 0" }
         require(server.maxInboundEventsPerTick > 0) { "ambonMUD.server.maxInboundEventsPerTick must be > 0" }
         require(server.tickMillis > 0L) { "ambonMUD.server.tickMillis must be > 0" }
+        require(server.inboundBudgetMs > 0L) { "ambonMUD.server.inboundBudgetMs must be > 0" }
+        require(server.inboundBudgetMs < server.tickMillis) { "ambonMUD.server.inboundBudgetMs must be < tickMillis" }
 
         require(world.resources.isNotEmpty()) { "ambonMUD.world.resources must not be empty" }
         require(world.resources.all { it.isNotBlank() }) { "ambonMUD.world.resources entries must be non-blank" }
@@ -327,6 +329,7 @@ data class ServerConfig(
     val sessionOutboundQueueCapacity: Int = 200,
     val maxInboundEventsPerTick: Int = 1_000,
     val tickMillis: Long = 100L,
+    val inboundBudgetMs: Long = 30L,
 )
 
 data class WorldConfig(

--- a/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
+++ b/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
@@ -426,6 +426,7 @@ class EngineServer(
                     tickMillis = config.server.tickMillis,
                     scheduler = scheduler,
                     maxInboundEventsPerTick = config.server.maxInboundEventsPerTick,
+                    inboundBudgetMs = config.server.inboundBudgetMs,
                     loginConfig = config.login,
                     engineConfig = config.engine,
                     progression = progression,

--- a/src/main/kotlin/dev/ambon/metrics/GameMetrics.kt
+++ b/src/main/kotlin/dev/ambon/metrics/GameMetrics.kt
@@ -68,6 +68,8 @@ class GameMetrics(
     private val engineTickOverrunCounter = Counter.builder("engine_tick_overrun_total").register(registry)
     private val inboundEventsProcessedCounter =
         Counter.builder("engine_inbound_events_processed_total").register(registry)
+    private val inboundDrainBudgetExceededCounter =
+        Counter.builder("engine_inbound_drain_budget_exceeded_total").register(registry)
 
     val mobSystemTickTimer: Timer =
         Timer
@@ -176,6 +178,8 @@ class GameMetrics(
     fun onEngineTickOverrun() = engineTickOverrunCounter.increment()
 
     fun onInboundEventsProcessed(count: Int) = inboundEventsProcessedCounter.increment(count.toDouble())
+
+    fun onInboundDrainBudgetExceeded() = inboundDrainBudgetExceededCounter.increment()
 
     fun onMobMoves(count: Int) = mobMovesCounter.increment(count.toDouble())
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -84,6 +84,7 @@ ambonMUD:
     sessionOutboundQueueCapacity: 200
     maxInboundEventsPerTick: 1000
     tickMillis: 100
+    inboundBudgetMs: 30
 
   world:
     resources:

--- a/src/test/kotlin/dev/ambon/config/AppConfigLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/config/AppConfigLoaderTest.kt
@@ -61,6 +61,30 @@ class AppConfigLoaderTest {
     }
 
     @Test
+    fun `validation rejects inboundBudgetMs of zero`() {
+        val invalid = AppConfig(server = ServerConfig(inboundBudgetMs = 0L))
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
+
+    @Test
+    fun `validation rejects inboundBudgetMs equal to tickMillis`() {
+        val invalid = AppConfig(server = ServerConfig(tickMillis = 100L, inboundBudgetMs = 100L))
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
+
+    @Test
+    fun `validation rejects inboundBudgetMs greater than tickMillis`() {
+        val invalid = AppConfig(server = ServerConfig(tickMillis = 100L, inboundBudgetMs = 101L))
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
+
+    @Test
+    fun `validation accepts valid inboundBudgetMs`() {
+        val valid = AppConfig(server = ServerConfig(tickMillis = 100L, inboundBudgetMs = 30L))
+        valid.validated() // should not throw
+    }
+
+    @Test
     fun `redis validation skipped when disabled`() {
         val config = AppConfig(redis = RedisConfig(enabled = false, uri = ""))
         config.validated()

--- a/src/test/kotlin/dev/ambon/engine/GameEngineInboundBudgetTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GameEngineInboundBudgetTest.kt
@@ -1,0 +1,142 @@
+package dev.ambon.engine
+
+import dev.ambon.bus.LocalInboundBus
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.world.load.WorldLoader
+import dev.ambon.engine.events.InboundEvent
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.engine.scheduler.Scheduler
+import dev.ambon.persistence.InMemoryPlayerRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+
+/**
+ * A [Clock] whose [millis] advances by [stepMs] on every call, simulating elapsed wall time
+ * during event processing without requiring real wall-clock delays.
+ */
+private class TickingClock(
+    private var nowMs: Long = 0L,
+    private val stepMs: Long = 1L,
+) : Clock() {
+    override fun millis(): Long {
+        val current = nowMs
+        nowMs += stepMs
+        return current
+    }
+
+    override fun instant(): Instant = Instant.ofEpochMilli(nowMs)
+
+    override fun getZone(): ZoneId = ZoneId.of("UTC")
+
+    override fun withZone(zone: ZoneId): Clock = TickingClock(nowMs, stepMs)
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GameEngineInboundBudgetTest {
+    /**
+     * When the inbound drain budget is exhausted mid-tick, unprocessed events remain
+     * in the queue and will be handled in a subsequent tick.
+     *
+     * The [TickingClock] advances 1 ms on every [Clock.millis] call, so with
+     * [inboundBudgetMs] = 3:
+     *   - tickStart = 0  → deadline = 3
+     *   - budget check 1: clock = 1 (< 3) → process event 1
+     *   - budget check 2: clock = 2 (< 3) → process event 2
+     *   - budget check 3: clock = 3 (>= 3) → budget exceeded, break
+     * Two events are processed; 8 remain for the next tick.
+     */
+    @Test
+    fun `inbound drain stops at time budget leaving remaining events for next tick`() =
+        runTest {
+            val inbound = LocalInboundBus()
+            val outbound = LocalOutboundBus()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
+            val repo = InMemoryPlayerRepository()
+            val items = ItemRegistry()
+            val players = PlayerRegistry(world.startRoom, repo, items)
+            val mobs = MobRegistry()
+            val clock = TickingClock(nowMs = 0L, stepMs = 1L)
+            val scheduler = Scheduler(clock)
+
+            val engine =
+                GameEngine(
+                    inbound = inbound,
+                    outbound = outbound,
+                    players = players,
+                    world = world,
+                    mobs = mobs,
+                    items = items,
+                    clock = clock,
+                    tickMillis = 100_000L,
+                    scheduler = scheduler,
+                    inboundBudgetMs = 3L,
+                )
+
+            // Queue 10 events for a session that is not connected; the engine handles them
+            // by returning early (no session state found), so clock.millis() is not called
+            // inside handle() and the advancing pattern stays predictable.
+            val dummySid = SessionId(999L)
+            repeat(10) { inbound.trySend(InboundEvent.LineReceived(dummySid, "noop")) }
+            assertEquals(10, inbound.depth())
+
+            val engineJob = launch { engine.run() }
+            runCurrent() // run one tick up to the first delay()
+
+            val remaining = inbound.depth()
+            assertTrue(remaining > 0, "Expected events to remain in queue after budget cap, but got depth=$remaining")
+
+            engineJob.cancel()
+        }
+
+    /**
+     * When the clock does not advance (fixed time, [MutableClock]-style), the time budget
+     * never fires and all events up to [maxInboundEventsPerTick] are drained in a single tick.
+     */
+    @Test
+    fun `inbound drain processes all events when clock is fixed and budget never fires`() =
+        runTest {
+            val inbound = LocalInboundBus()
+            val outbound = LocalOutboundBus()
+            val world = WorldLoader.loadFromResource("world/test_world.yaml")
+            val repo = InMemoryPlayerRepository()
+            val items = ItemRegistry()
+            val players = PlayerRegistry(world.startRoom, repo, items)
+            val mobs = MobRegistry()
+            // Fixed clock: millis() always returns 0, so 0 < deadline always → budget never fires.
+            val clock = Clock.fixed(Instant.EPOCH, ZoneId.of("UTC"))
+            val scheduler = Scheduler(clock)
+
+            val engine =
+                GameEngine(
+                    inbound = inbound,
+                    outbound = outbound,
+                    players = players,
+                    world = world,
+                    mobs = mobs,
+                    items = items,
+                    clock = clock,
+                    tickMillis = 1_000L,
+                    scheduler = scheduler,
+                    inboundBudgetMs = 30L,
+                )
+
+            val dummySid = SessionId(999L)
+            repeat(10) { inbound.trySend(InboundEvent.LineReceived(dummySid, "noop")) }
+
+            val engineJob = launch { engine.run() }
+            runCurrent()
+
+            assertEquals(0, inbound.depth(), "Expected all events to be drained when clock is fixed")
+
+            engineJob.cancel()
+        }
+}


### PR DESCRIPTION
## Summary
Implements a configurable time budget for inbound event draining in the game engine to ensure that event processing doesn't consume the entire tick duration, leaving adequate time for simulation and other game logic.

## Key Changes
- **GameEngine**: Added `inboundBudgetMs` parameter to limit inbound event processing time per tick. The engine now checks elapsed time against a deadline and breaks out of the event drain loop when the budget is exceeded, deferring remaining events to the next tick.
- **Configuration**: Added `inboundBudgetMs` to `ServerConfig` with validation rules:
  - Must be greater than 0
  - Must be strictly less than `tickMillis` (cannot equal or exceed the tick duration)
- **Metrics**: Added `engine_inbound_drain_budget_exceeded_total` counter to track when the time budget is exceeded during a tick
- **Default Configuration**: Set `inboundBudgetMs` to 30ms in `application.yaml` with a default `tickMillis` of 100ms
- **Tests**: Added comprehensive test suite (`GameEngineInboundBudgetTest`) covering:
  - Budget enforcement with a `TickingClock` that advances time on each call, verifying events are deferred when budget expires
  - Fixed clock behavior where budget never fires and all events are drained in a single tick
  - Configuration validation tests for the new parameter

## Implementation Details
- The time budget is checked before processing each inbound event using `clock.millis() >= deadline`
- The same deadline is applied to both inbound events and inter-engine messages
- The `TickingClock` test utility advances by 1ms per `millis()` call to simulate realistic time progression during event processing without requiring actual delays

https://claude.ai/code/session_01FaRrEWGqEPzr8g9zDPbq4U