### PR TITLE
perf(engine): remove per-tick zone reset map copy

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -537,7 +537,7 @@ class GameEngine(
         if (zoneResetDueAtMillis.isEmpty()) return
 
         val now = clock.millis()
-        for ((zone, dueAtMillis) in zoneResetDueAtMillis.toMap()) {
+        for ((zone, dueAtMillis) in zoneResetDueAtMillis) {
             if (now < dueAtMillis) continue
 
             resetZone(zone)


### PR DESCRIPTION
### Motivation
- Avoid an unnecessary per-tick allocation when zone lifespans are enabled by eliminating a full-map snapshot during the zone-reset pass.

### Description
- Iterate the existing `zoneResetDueAtMillis` map directly in `GameEngine.resetZonesIfDue()` instead of calling `zoneResetDueAtMillis.toMap()`, preserving the in-place due-time updates and reset semantics (change in `src/main/kotlin/dev/ambon/engine/GameEngine.kt`).

### Testing
- `./gradlew test --tests "dev.ambon.engine.GameEngineIntegrationTest.zone reset notifies players and restores spawn state 

------
