### PR TITLE
Optimize jsonEscape() method with StringBuilder

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -260,11 +260,18 @@ class GmcpEmitter(
         return """{"id":"$id","name":"$name","slot":$slot,"damage":${item.item.damage},"armor":${item.item.armor}}"""
     }
 
-    private fun String.jsonEscape(): String =
-        this
-            .replace("\\", "\\\\")
-            .replace("\"", "\\\"")
-            .replace("\n", "\\n")
-            .replace("\r", "\\r")
-            .replace("\t", "\\t")
+    private fun String.jsonEscape(): String {
+        val sb = StringBuilder(length + 4)
+        for (ch in this) {
+            when (ch) {
+                '\\' -> sb.append("\\\\")
+                '"' -> sb.append("\\\"")
+                '\n' -> sb.append("\\n")
+                '\r' -> sb.append("\\r")
+                '\t' -> sb.append("\\t")
+                else -> sb.append(ch)
+            }
+        }
+        return sb.toString()
+    }
 }


### PR DESCRIPTION
## Summary
Refactored the `jsonEscape()` method in `GmcpEmitter` to use a more efficient implementation with `StringBuilder` instead of chained string replacements.

## Key Changes
- Replaced multiple chained `replace()` calls with a single iteration through the string characters
- Implemented character-by-character processing using a `when` expression for escape sequence handling
- Used `StringBuilder` with pre-allocated capacity to reduce memory allocations and improve performance

## Implementation Details
- The new implementation iterates through each character once, eliminating the overhead of multiple string traversals
- `StringBuilder` is initialized with `length + 4` capacity to account for typical escape sequences
- All escape sequences are preserved: `\\`, `\"`, `\n`, `\r`, `\t`
- Non-special characters are appended directly without modification
- This approach provides better performance characteristics, especially for strings with many characters requiring escaping

https://claude.ai/code/session_01WMUGckCKrwBQ6MshAViGF4