### PR TITLE
Refactor equipment bonus calculations into centralized method

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/items/ItemRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/items/ItemRegistry.kt
@@ -166,6 +166,31 @@ class ItemRegistry {
 
     fun equipment(sessionId: SessionId): Map<ItemSlot, ItemInstance> = equippedItems[sessionId]?.toMap() ?: emptyMap()
 
+    data class EquipmentBonuses(
+        val attack: Int = 0,
+        val armor: Int = 0,
+        val strength: Int = 0,
+        val dexterity: Int = 0,
+        val charisma: Int = 0,
+    )
+
+    fun equipmentBonuses(sessionId: SessionId): EquipmentBonuses {
+        val equipped = equippedItems[sessionId]?.values ?: return EquipmentBonuses()
+        var attack = 0
+        var armor = 0
+        var strength = 0
+        var dexterity = 0
+        var charisma = 0
+        for (inst in equipped) {
+            attack += inst.item.damage
+            armor += inst.item.armor
+            strength += inst.item.strength
+            dexterity += inst.item.dexterity
+            charisma += inst.item.charisma
+        }
+        return EquipmentBonuses(attack, armor, strength, dexterity, charisma)
+    }
+
     fun addMobItem(
         mobId: MobId,
         item: ItemInstance,


### PR DESCRIPTION
## Summary
Refactored equipment bonus calculations in the combat system to use a centralized `equipmentBonuses()` method instead of repeatedly querying and summing equipment values across multiple locations.

## Key Changes
- Created `EquipmentBonuses` data class in `ItemRegistry` to encapsulate all equipment stat bonuses (attack, armor, strength, dexterity, charisma)
- Added `equipmentBonuses(sessionId)` method to `ItemRegistry` that calculates all bonuses in a single pass
- Removed individual equipment calculation methods: `equippedAttack()`, `equippedDefense()`
- Updated `strDamageBonus()` and `dodgeChance()` to accept pre-calculated equipment bonuses as parameters instead of looking them up internally
- Modified `syncPlayerDefense()` to accept armor bonus as a parameter
- Updated all call sites in `CombatSystem` to use the new centralized method, reducing redundant equipment lookups during combat loops

## Implementation Details
- The `equipmentBonuses()` method iterates through equipped items once and accumulates all stat bonuses, improving efficiency
- Combat loop now calculates bonuses once per player turn and reuses them for both damage and dodge calculations
- This change reduces the number of equipment map lookups and iterations, particularly beneficial during active combat scenarios

https://claude.ai/code/session_01MXA7b9NyFPBpCctSARVzAz