### PR TITLE
Refactor AnsiRenderer to use buildString and extract color constants

### DIFF
--- a/src/main/kotlin/dev/ambon/transport/AnsiRenderer.kt
+++ b/src/main/kotlin/dev/ambon/transport/AnsiRenderer.kt
@@ -6,6 +6,7 @@ class AnsiRenderer : TextRenderer {
     private val brightGreen = "\u001B[92m"
     private val brightCyan = "\u001B[96m"
     private val brightRed = "\u001B[91m"
+    private val infoPrefix = dim + brightCyan
 
     override fun renderLine(
         text: String,
@@ -14,11 +15,22 @@ class AnsiRenderer : TextRenderer {
         val prefix =
             when (kind) {
                 TextKind.NORMAL -> reset
-                TextKind.INFO -> dim + brightCyan
+                TextKind.INFO -> infoPrefix
                 TextKind.ERROR -> brightRed
             }
-        return prefix + text + reset + "\r\n"
+        return buildString {
+            append(prefix)
+            append(text)
+            append(reset)
+            append("\r\n")
+        }
     }
 
-    override fun renderPrompt(prompt: PromptSpec): String = dim + brightGreen + prompt.text + reset
+    override fun renderPrompt(prompt: PromptSpec): String =
+        buildString {
+            append(dim)
+            append(brightGreen)
+            append(prompt.text)
+            append(reset)
+        }
 }


### PR DESCRIPTION
## Summary
Improved code maintainability and readability in the AnsiRenderer class by extracting a repeated color constant and refactoring string concatenation to use the `buildString` builder function.

## Key Changes
- Extracted `infoPrefix` as a private constant combining `dim` and `brightCyan` colors, eliminating duplication in the `renderLine` method
- Refactored `renderLine` method to use `buildString` instead of string concatenation for better performance and readability
- Refactored `renderPrompt` method to use `buildString` for consistency with the updated `renderLine` implementation

## Implementation Details
- The `infoPrefix` constant reduces duplication and makes the color scheme easier to maintain
- Using `buildString` is more efficient than string concatenation with the `+` operator, especially when combining multiple strings
- The refactoring maintains identical output behavior while improving code clarity

https://claude.ai/code/session_01Gsp1RNPqKnqKuvWo4TF1Do