### PR TITLE
Add event queue latency metrics for inbound and outbound

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -510,6 +510,7 @@ class GameEngine(
                         // Drain any auth results that have arrived since the last event.
                         drainPendingAuthResults()
                         val ev = inbound.tryReceive().getOrNull() ?: break
+                        metrics.recordInboundLatency(clock.millis() - ev.enqueuedAt)
                         handle(ev)
                         // Yield so that launched auth coroutines (BCrypt / DB) can post
                         // their results before we process the next event for this session.

--- a/src/main/kotlin/dev/ambon/engine/events/InboundEvent.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/InboundEvent.kt
@@ -3,25 +3,35 @@ package dev.ambon.engine.events
 import dev.ambon.domain.ids.SessionId
 
 sealed interface InboundEvent {
+    val enqueuedAt: Long
+
     data class Connected(
         val sessionId: SessionId,
         val defaultAnsiEnabled: Boolean = false,
-    ) : InboundEvent
+    ) : InboundEvent {
+        override val enqueuedAt: Long = System.currentTimeMillis()
+    }
 
     data class Disconnected(
         val sessionId: SessionId,
         val reason: String,
-    ) : InboundEvent
+    ) : InboundEvent {
+        override val enqueuedAt: Long = System.currentTimeMillis()
+    }
 
     data class LineReceived(
         val sessionId: SessionId,
         val line: String,
-    ) : InboundEvent
+    ) : InboundEvent {
+        override val enqueuedAt: Long = System.currentTimeMillis()
+    }
 
     /** Structured GMCP data received from the client. */
     data class GmcpReceived(
         val sessionId: SessionId,
         val gmcpPackage: String,
         val jsonData: String,
-    ) : InboundEvent
+    ) : InboundEvent {
+        override val enqueuedAt: Long = System.currentTimeMillis()
+    }
 }

--- a/src/main/kotlin/dev/ambon/transport/BlockingSocketTransport.kt
+++ b/src/main/kotlin/dev/ambon/transport/BlockingSocketTransport.kt
@@ -48,7 +48,7 @@ class BlockingSocketTransport(
                             outboundQueue = outboundQueue,
                             onDisconnected = { outboundRouter.unregister(sessionId) },
                             scope = scope,
-                            onOutboundFrameWritten = { outboundRouter.onSessionQueueFrameConsumed(sessionId) },
+                            onOutboundFrameWritten = { enqueuedAt -> outboundRouter.onSessionQueueFrameConsumed(sessionId, enqueuedAt) },
                             maxLineLen = maxLineLen,
                             maxNonPrintablePerLine = maxNonPrintablePerLine,
                             maxInboundBackpressureFailures = maxInboundBackpressureFailures,

--- a/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
+++ b/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
@@ -193,7 +193,7 @@ private suspend fun DefaultWebSocketServerSession.bridgeWebSocketSession(
                             send(Frame.Text("""{"gmcp":"$pkg","data":$data}"""))
                         }
                     }
-                    outboundRouter.onSessionQueueFrameConsumed(sessionId)
+                    outboundRouter.onSessionQueueFrameConsumed(sessionId, frame.enqueuedAt)
                 }
             } catch (_: Throwable) {
                 // best effort

--- a/src/main/kotlin/dev/ambon/transport/NetworkSession.kt
+++ b/src/main/kotlin/dev/ambon/transport/NetworkSession.kt
@@ -26,7 +26,7 @@ class NetworkSession(
     private val outboundQueue: Channel<OutboundFrame>,
     private val onDisconnected: () -> Unit,
     private val scope: CoroutineScope,
-    private val onOutboundFrameWritten: () -> Unit = {},
+    private val onOutboundFrameWritten: (enqueuedAt: Long) -> Unit = {},
     private val maxLineLen: Int = 1024,
     private val maxNonPrintablePerLine: Int = 32,
     private val maxInboundBackpressureFailures: Int = 3,
@@ -272,7 +272,7 @@ class NetworkSession(
         output: java.io.OutputStream,
         frame: OutboundFrame,
     ): Boolean {
-        onOutboundFrameWritten()
+        onOutboundFrameWritten(frame.enqueuedAt)
         return when (frame) {
             is OutboundFrame.Text -> {
                 val bytes = frame.content.toByteArray(Charsets.UTF_8)

--- a/src/main/kotlin/dev/ambon/transport/OutboundFrame.kt
+++ b/src/main/kotlin/dev/ambon/transport/OutboundFrame.kt
@@ -1,12 +1,18 @@
 package dev.ambon.transport
 
 sealed interface OutboundFrame {
+    val enqueuedAt: Long
+
     data class Text(
         val content: String,
-    ) : OutboundFrame
+    ) : OutboundFrame {
+        override val enqueuedAt: Long = System.currentTimeMillis()
+    }
 
     data class Gmcp(
         val gmcpPackage: String,
         val jsonData: String,
-    ) : OutboundFrame
+    ) : OutboundFrame {
+        override val enqueuedAt: Long = System.currentTimeMillis()
+    }
 }

--- a/src/main/kotlin/dev/ambon/transport/OutboundRouter.kt
+++ b/src/main/kotlin/dev/ambon/transport/OutboundRouter.kt
@@ -285,8 +285,12 @@ class OutboundRouter(
         }
     }
 
-    fun onSessionQueueFrameConsumed(sessionId: SessionId) {
+    fun onSessionQueueFrameConsumed(
+        sessionId: SessionId,
+        enqueuedAt: Long,
+    ) {
         sinks[sessionId]?.queueDepth?.updateAndGet { current -> (current - 1).coerceAtLeast(0) }
+        metrics.recordOutboundLatency(sessionId, System.currentTimeMillis() - enqueuedAt)
     }
 
     private fun disconnectSlowClient(sessionId: SessionId) {


### PR DESCRIPTION
## Summary
This PR adds latency tracking for inbound and outbound event queues to measure the time events spend queued before processing. This enables monitoring of queue delays and identifying potential bottlenecks in the event processing pipeline.

## Key Changes
- **GameMetrics**: Added two new Timer metrics:
  - `inbound_event_queue_age_seconds`: Tracks age of inbound events from enqueue to engine processing
  - `outbound_event_queue_age_seconds`: Tracks age of outbound frames from enqueue to flush
  - Added `recordInboundLatency()` and `recordOutboundLatency()` methods to record measurements

- **InboundEvent**: Added `enqueuedAt` property to all event types (Connected, Disconnected, LineReceived, GmcpReceived) that captures the current timestamp when the event is created

- **OutboundFrame**: Added `enqueuedAt` property to all frame types (Text, Gmcp) that captures the current timestamp when the frame is created

- **GameEngine**: Records inbound event latency by calculating the time delta between event enqueue and processing

- **OutboundRouter**: Records outbound frame latency when frames are consumed from the queue, passing the enqueued timestamp through the callback chain

- **NetworkSession & Transport Layers**: Updated to pass the `enqueuedAt` timestamp through the frame writing callback:
  - Modified `onOutboundFrameWritten` callback signature to accept `enqueuedAt: Long`
  - Updated BlockingSocketTransport and KtorWebSocketTransport to pass frame enqueue time

- **Tests**: Added comprehensive test coverage for both latency recording methods

## Implementation Details
- Timestamps are captured at event/frame creation time using `System.currentTimeMillis()`
- Latency is calculated as the delta between current time and enqueue time at processing/flush points
- Metrics use Micrometer's Timer with percentile histogram publishing for detailed latency distribution analysis
- The `sessionId` parameter in `recordOutboundLatency()` is prepared for future per-session latency tracking

https://claude.ai/code/session_01KRcgMq7HepMjmz6ZygPpsF