### PR TITLE
fix: handle socket disconnections gracefully without error logging

### DIFF
--- a/src/main/kotlin/dev/ambon/transport/NetworkSession.kt
+++ b/src/main/kotlin/dev/ambon/transport/NetworkSession.kt
@@ -90,6 +90,10 @@ class NetworkSession(
             log.warn { "Telnet session disconnected due to protocol violation: sessionId=$sessionId message=${v.message}" }
             metrics.onTelnetDisconnected("error")
             inbound.send(InboundEvent.Disconnected(sessionId, "protocol violation: ${v.message}"))
+        } catch (s: java.net.SocketException) {
+            log.debug { "Telnet session connection reset: sessionId=$sessionId" }
+            metrics.onTelnetDisconnected("connection reset")
+            inbound.send(InboundEvent.Disconnected(sessionId, "connection reset"))
         } catch (t: Throwable) {
             log.error(t) { "Unexpected read error: sessionId=$sessionId" }
             metrics.onTelnetDisconnected("error")


### PR DESCRIPTION
## Summary
Fixes ERROR-level logging when clients disconnect unexpectedly. Socket connection resets are normal network events, not exceptional errors.

## Changes
- Added dedicated catch clause for `java.net.SocketException` in `NetworkSession.readLoop()`
- Changed logging from ERROR (with full stacktrace) to DEBUG level
- Treats connection resets consistently with EOF handling
- Properly notifies engine of disconnection without error spam

## Test plan
- [x] ktlintCheck passes
- [x] Full test suite passes
- Manual verification: connection resets now log at DEBUG level instead of ERROR