### PR TITLE
Enhance admin dashboard UI and add richer filtering controls

### DIFF
--- a/src/test/kotlin/dev/ambon/admin/AdminModuleTest.kt
+++ b/src/test/kotlin/dev/ambon/admin/AdminModuleTest.kt
@@ -97,6 +97,14 @@ class AdminModuleTest {
         }
 
     @Test
+    fun `GET overview page shows zone activity table`() =
+        testAdmin {
+            val body = client.get("/") { header(HttpHeaders.Authorization, authHeader) }.bodyAsText()
+            assertTrue(body.contains("Zone Activity"), "Should show zone activity section")
+            assertTrue(body.contains("Staff Online"), "Should show staff online stat")
+        }
+
+    @Test
     fun `GET overview page shows Grafana link when configured`() =
         testAdmin {
             val body = client.get("/") { header(HttpHeaders.Authorization, authHeader) }.bodyAsText()
@@ -125,6 +133,15 @@ class AdminModuleTest {
             val resp = client.get("/players") { header(HttpHeaders.Authorization, authHeader) }
             assertEquals(HttpStatusCode.OK, resp.status)
             assertTrue(resp.bodyAsText().contains("Players"))
+        }
+
+    @Test
+    fun `GET players page includes filtering controls`() =
+        testAdmin {
+            val body = client.get("/players") { header(HttpHeaders.Authorization, authHeader) }.bodyAsText()
+            assertTrue(body.contains("Online only"))
+            assertTrue(body.contains("Staff only"))
+            assertTrue(body.contains("Sort"))
         }
 
     @Test
@@ -259,6 +276,13 @@ class AdminModuleTest {
         testAdmin {
             val resp = client.get("/world/nozone") { header(HttpHeaders.Authorization, authHeader) }
             assertEquals(HttpStatusCode.NotFound, resp.status)
+        }
+
+    @Test
+    fun `GET world page with non matching filter shows empty-state row`() =
+        testAdmin {
+            val body = client.get("/world?q=missing") { header(HttpHeaders.Authorization, authHeader) }.bodyAsText()
+            assertTrue(body.contains("No zones matched that filter."))
         }
 
     // ── JSON API - world ──────────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Improve the admin dashboard usability and provide more actionable at-a-glance information for operators monitoring live servers. 
- Make player and world inspection workflows faster by adding simple server-side filtering/sorting controls and clearer empty-state feedback.

### Description
- Added a new `Staff Online` stat card and a `Zone Activity` table to the Overview showing players/mobs/rooms per zone, sorted by activity. (changes in `AdminHttpServer.kt` overview handler)
- Extended the Players page with checkbox filters for `Online only` and `Staff only`, a `Sort` selector (`name`, `level`, `class`), and an online/staff summary line; server-side sorting is implemented via a new `playerComparator` helper. (changes in `AdminHttpServer.kt` players handler + new `playerComparator` function)
- Added zone filtering on the World page via `q` query parameter and an explicit empty-state row when no zones match. (changes in `AdminHttpServer.kt` world handler)
- Updated CSS in the embedded admin HTML to style the new controls (`select`, wrapped search row, label styling, and a `.muted` helper). (changes in `AdminHttpServer.kt` HTML/CSS block)
- Added/updated unit tests in `AdminModuleTest.kt` to check rendering of the new Overview zone activity/staff metric, Players filter controls, and the World filter empty-state.

### Testing
- Ran linter checks with `./gradlew ktlintMainSourceSetCheck ktlintTestSourceSetCheck --no-daemon` which completed successfully. 
- Attempted full test run with `./gradlew ktlintCheck test --no-daemon` but it failed in this environment due to external dependency fetch errors (HTTP 403 from Maven Central) during `:swarm:compileTestKotlin`, so the full test-suite could not be completed here. 
- Attempted to run the admin module tests specifically with `./gradlew :test --tests dev.ambon.admin.AdminModuleTest --no-daemon` but execution also failed in this environment for the same external dependency resolution issue. 
- The changes include targeted test additions for the admin module (new tests added to `AdminModuleTest`), which should pass in CI where dependencies are available and network access to Maven Central is permitted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a006892eb88323b1908ab6f2d77743)