### PR TITLE
Fix combat pacing by gating player attacks to combat
  tick

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -487,7 +487,7 @@ data class MobEngineConfig(
 
 data class CombatEngineConfig(
     val maxCombatsPerTick: Int = 20,
-    val tickMillis: Long = 1_000L,
+    val tickMillis: Long = 2_000L,
     val minDamage: Int = 1,
     val maxDamage: Int = 4,
     val feedback: CombatFeedbackConfig = CombatFeedbackConfig(),

--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -266,6 +266,12 @@ class CombatSystem(
         playerEntries.shuffle(rng)
         for ((sessionId, mobId) in playerEntries) {
             if (ran >= maxCombatsPerTick) break
+            val mobState = activeMobs[mobId]
+            if (mobState == null) {
+                removePlayerFromCombat(sessionId)
+                continue
+            }
+            if (now < mobState.nextTickAtMs) continue
 
             val player = players.get(sessionId)
             val mob = mobs.get(mobId)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -170,7 +170,7 @@ ambonMUD:
           goldPerLevel: 15
     combat:
       maxCombatsPerTick: 20
-      tickMillis: 1000
+      tickMillis: 2000
       minDamage: 1
       maxDamage: 4
       feedback:


### PR DESCRIPTION
  ## Summary
  - Fix combat pacing bug where player attacks executed every engine tick.
  - Gate player attacks by the same 
extTickAtMs timing used for mob combat ticks.
  - Slow default combat cadence from 1000ms to 2000ms in config defaults and pplication.yaml.
  - Add regression test ensuring no combat damage occurs before the combat tick interval elapses.

  ## Testing
  - .\gradlew.bat test --tests dev.ambon.engine.CombatSystemTest -x swarm:test
  - .\gradlew.bat test --tests dev.ambon.config.AppConfigLoaderTest -x swarm:test
  @
