### PR TITLE
Fix mana regen timer initialization for depleted players

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/RegenSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/RegenSystem.kt
@@ -57,7 +57,7 @@ class RegenSystem(
             if (player.hp >= player.maxHp) {
                 lastRegenAtMs[sessionId] = now
             } else {
-                val last = lastRegenAtMs[sessionId] ?: now
+                val last = lastRegenAtMs.getOrPut(sessionId) { now }
                 val interval = regenIntervalMs(player)
                 if (now - last >= interval) {
                     val updated = (player.hp + regenAmount).coerceAtMost(player.maxHp)
@@ -74,7 +74,7 @@ class RegenSystem(
             if (player.mana >= player.maxMana) {
                 lastManaRegenAtMs[sessionId] = now
             } else {
-                val lastMana = lastManaRegenAtMs[sessionId] ?: now
+                val lastMana = lastManaRegenAtMs.getOrPut(sessionId) { now }
                 val interval = manaRegenIntervalMs(player)
                 if (now - lastMana >= interval) {
                     val updated = (player.mana + manaRegenAmount).coerceAtMost(player.maxMana)

--- a/src/test/kotlin/dev/ambon/engine/RegenSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/RegenSystemTest.kt
@@ -90,6 +90,26 @@ class RegenSystemTest {
         }
 
     @Test
+    fun `players with depleted mana at login still regen after interval`() =
+        runTest {
+            val players = makeRegistry()
+            val clock = MutableClock(0L)
+            val regen = makeRegen(players, clock)
+
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Eve")
+
+            val player = players.get(sid)!!
+            player.mana = player.maxMana - 5
+
+            regen.tick()
+            clock.advance(3_000L)
+            regen.tick()
+
+            assertEquals(player.maxMana - 4, player.mana, "Expected one mana regen tick (+1 mana)")
+        }
+
+    @Test
     fun `players at full hp do not regen past max`() =
         runTest {
             val players = makeRegistry()


### PR DESCRIPTION
## Summary\n- fix regen timer initialization so players who start below max mana/HP can actually regen\n- use getOrPut for first-seen regen timestamps instead of transient ?: now\n- add regression test covering login with depleted mana\n\n## Testing\n- .\\gradlew.bat test --tests dev.ambon.engine.RegenSystemTest -x swarm:test