### PR TITLE
ci: add frontend job for web-v3 lint and build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,19 @@ jobs:
           java-version: 21
       - run: chmod +x ./gradlew
       - run: ./gradlew ktlintCheck test
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web-v3
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+          cache: true
+          cache-dependency-path: web-v3/bun.lock
+      - run: bun install --frozen-lockfile
+      - run: bun run lint
+      - run: bun run build


### PR DESCRIPTION
Adds a frontend CI job that runs in parallel with test. Covers ESLint (bun run lint) and Vite build +
  TypeScript typecheck (bun run build). Uses oven-sh/setup-bun@v2 with lockfile-keyed caching. Closes the gap noted in
  WEB_CLIENT_V3.md.