### PR TITLE
refactor: extract sendIfError helper to eliminate error-propagation b…

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/CombatHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/CombatHandler.kt
@@ -32,17 +32,11 @@ class CombatHandler(
         cmd: Command.Kill,
     ) {
         dialogueSystem?.endConversation(sessionId)
-        val err = combat.startCombat(sessionId, cmd.target)
-        if (err != null) {
-            outbound.send(OutboundEvent.SendError(sessionId, err))
-        }
+        outbound.sendIfError(sessionId, combat.startCombat(sessionId, cmd.target))
     }
 
     private suspend fun handleFlee(sessionId: SessionId) {
-        val err = combat.flee(sessionId)
-        if (err != null) {
-            outbound.send(OutboundEvent.SendError(sessionId, err))
-        }
+        outbound.sendIfError(sessionId, combat.flee(sessionId))
     }
 
     private suspend fun handleCast(
@@ -53,9 +47,6 @@ class CombatHandler(
             outbound.send(OutboundEvent.SendError(sessionId, "Abilities are not available."))
             return
         }
-        val err = abilitySystem.cast(sessionId, cmd.spellName, cmd.target)
-        if (err != null) {
-            outbound.send(OutboundEvent.SendError(sessionId, err))
-        }
+        outbound.sendIfError(sessionId, abilitySystem.cast(sessionId, cmd.spellName, cmd.target))
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestHandler.kt
@@ -45,10 +45,7 @@ class DialogueQuestHandler(
             outbound.send(OutboundEvent.SendError(sessionId, "Nobody here wants to talk."))
             return
         }
-        val err = dialogueSystem.startConversation(sessionId, cmd.target)
-        if (err != null) {
-            outbound.send(OutboundEvent.SendError(sessionId, err))
-        }
+        outbound.sendIfError(sessionId, dialogueSystem.startConversation(sessionId, cmd.target))
         if (questSystem != null && me != null) {
             val targetLower = cmd.target.trim().lowercase()
             val mob = mobs.mobsInRoom(me.roomId).firstOrNull { m -> m.name.lowercase().contains(targetLower) }
@@ -70,10 +67,7 @@ class DialogueQuestHandler(
             outbound.send(OutboundEvent.SendText(sessionId, "Huh?"))
             return
         }
-        val err = dialogueSystem.selectChoice(sessionId, cmd.optionNumber)
-        if (err != null) {
-            outbound.send(OutboundEvent.SendError(sessionId, err))
-        }
+        outbound.sendIfError(sessionId, dialogueSystem.selectChoice(sessionId, cmd.optionNumber))
     }
 
     private suspend fun handleQuestLog(sessionId: SessionId) {
@@ -96,8 +90,7 @@ class DialogueQuestHandler(
         if (questSystem == null) {
             outbound.send(OutboundEvent.SendError(sessionId, "Quest system is not available."))
         } else {
-            val err = questSystem.abandonQuest(sessionId, cmd.nameHint)
-            if (err != null) outbound.send(OutboundEvent.SendError(sessionId, err))
+            outbound.sendIfError(sessionId, questSystem.abandonQuest(sessionId, cmd.nameHint))
         }
     }
 
@@ -127,8 +120,7 @@ class DialogueQuestHandler(
                     ),
                 )
             } else {
-                val err = questSystem.acceptQuest(sessionId, matchingQuest.id)
-                if (err != null) outbound.send(OutboundEvent.SendError(sessionId, err))
+                outbound.sendIfError(sessionId, questSystem.acceptQuest(sessionId, matchingQuest.id))
             }
         }
     }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/GroupHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/GroupHandler.kt
@@ -39,9 +39,7 @@ class GroupHandler(
                 is Command.GroupCmd.Kick -> groupSystem.kick(sessionId, cmd.target)
                 Command.GroupCmd.List -> groupSystem.list(sessionId)
             }
-        if (err != null) {
-            outbound.send(OutboundEvent.SendError(sessionId, err))
-        }
+        outbound.sendIfError(sessionId, err)
     }
 
     private suspend fun handleGtell(
@@ -52,9 +50,6 @@ class GroupHandler(
             outbound.send(OutboundEvent.SendError(sessionId, "Groups are not available."))
             return
         }
-        val err = groupSystem.gtell(sessionId, cmd.message)
-        if (err != null) {
-            outbound.send(OutboundEvent.SendError(sessionId, err))
-        }
+        outbound.sendIfError(sessionId, groupSystem.gtell(sessionId, cmd.message))
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -147,6 +147,16 @@ internal suspend fun broadcastToRoomExcept(
     }
 }
 
+/**
+ * Sends a [OutboundEvent.SendError] to [sessionId] if [error] is non-null; no-op otherwise.
+ *
+ * Reduces the repeated `if (err != null) { outbound.send(SendError(sessionId, err)) }` pattern
+ * at system call sites to a single expression.
+ */
+internal suspend fun OutboundBus.sendIfError(sessionId: SessionId, error: String?) {
+    if (error != null) send(OutboundEvent.SendError(sessionId, error))
+}
+
 /** Checks if [sessionId] has staff privileges; sends an error and returns false if not. */
 internal suspend fun requireStaff(
     sessionId: SessionId,


### PR DESCRIPTION
Adds OutboundBus.sendIfError(sessionId, error) to HandlerHelpers.kt — sends SendError when the error string is
   non-null, no-op otherwise. Replaces 9 identical 3-line blocks across CombatHandler, GroupHandler, and
  DialogueQuestHandler. Net: +10 / -31 lines. No behavioral changes.
