### PR TITLE
HP/mana clamping extension functions (266)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -312,7 +312,7 @@ class CombatSystem(
                         armorAbsorbed = playerArmorAbsorbed,
                         clampedToMinimum = playerMinDamageClamped,
                     )
-                mob.hp = (mob.hp - effectivePlayerDamage).coerceAtLeast(0)
+                mob.takeDamage(effectivePlayerDamage)
                 markMobHpDirty(mob.id)
 
                 // Add threat (damage * class multiplier)
@@ -388,7 +388,7 @@ class CombatSystem(
                         armorAbsorbed = 0,
                         shieldAbsorbed = shieldAbsorbed,
                     )
-                target.hp = (target.hp - mobDamage).coerceAtLeast(0)
+                target.takeDamage(mobDamage)
                 markVitalsDirty(targetSid)
                 val mobHitText =
                     if (shieldAbsorbed > 0 && mobDamage == 0) {

--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -3,6 +3,7 @@ package dev.ambon.engine
 import dev.ambon.domain.achievement.AchievementState
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.mob.MobState
 import dev.ambon.domain.quest.QuestState
 import dev.ambon.persistence.PlayerId
 
@@ -59,4 +60,41 @@ data class PlayerState(
             "activeQuests=${activeQuests.keys}, completedQuestIds=$completedQuestIds, " +
             "unlockedAchievementIds=$unlockedAchievementIds, activeTitle=$activeTitle, " +
             "createdAtEpochMs=$createdAtEpochMs, passwordHash=<redacted>)"
+}
+
+/** Increases HP by [amount], clamped to [maxHp]. Returns `true` if HP actually changed. */
+fun PlayerState.healHp(amount: Int): Boolean {
+    val new = (hp + amount).coerceAtMost(maxHp)
+    return if (new != hp) {
+        hp = new
+        true
+    } else {
+        false
+    }
+}
+
+/** Decreases HP by [amount], clamped to 0. */
+fun PlayerState.takeDamage(amount: Int) {
+    hp = (hp - amount).coerceAtLeast(0)
+}
+
+/** Increases mana by [amount], clamped to [maxMana]. Returns `true` if mana actually changed. */
+fun PlayerState.healMana(amount: Int): Boolean {
+    val new = (mana + amount).coerceAtMost(maxMana)
+    return if (new != mana) {
+        mana = new
+        true
+    } else {
+        false
+    }
+}
+
+/** Decreases mana by [amount], clamped to 0. */
+fun PlayerState.spendMana(amount: Int) {
+    mana = (mana - amount).coerceAtLeast(0)
+}
+
+/** Decreases mob HP by [amount], clamped to 0. */
+fun MobState.takeDamage(amount: Int) {
+    hp = (hp - amount).coerceAtLeast(0)
 }

--- a/src/main/kotlin/dev/ambon/engine/RegenSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/RegenSystem.kt
@@ -60,9 +60,7 @@ class RegenSystem(
                 val last = lastRegenAtMs.getOrPut(sessionId) { now }
                 val interval = regenIntervalMs(player)
                 if (now - last >= interval) {
-                    val updated = (player.hp + regenAmount).coerceAtMost(player.maxHp)
-                    if (updated != player.hp) {
-                        player.hp = updated
+                    if (player.healHp(regenAmount)) {
                         markVitalsDirty(sessionId)
                     }
                     lastRegenAtMs[sessionId] = now
@@ -77,9 +75,7 @@ class RegenSystem(
                 val lastMana = lastManaRegenAtMs.getOrPut(sessionId) { now }
                 val interval = manaRegenIntervalMs(player)
                 if (now - lastMana >= interval) {
-                    val updated = (player.mana + manaRegenAmount).coerceAtMost(player.maxMana)
-                    if (updated != player.mana) {
-                        player.mana = updated
+                    if (player.healMana(manaRegenAmount)) {
                         markVitalsDirty(sessionId)
                     }
                     lastManaRegenAtMs[sessionId] = now

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ItemHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ItemHandler.kt
@@ -10,6 +10,7 @@ import dev.ambon.engine.commands.Command
 import dev.ambon.engine.commands.CommandRouter
 import dev.ambon.engine.commands.on
 import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.healHp
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.metrics.GameMetrics
 
@@ -176,7 +177,7 @@ class ItemHandler(
                     outbound.send(OutboundEvent.SendInfo(sessionId, "You use ${result.item.item.displayName}."))
                     if (effect.healHp > 0) {
                         val previousHp = me.hp
-                        me.hp = (me.hp + effect.healHp).coerceAtMost(me.maxHp)
+                        me.healHp(effect.healHp)
                         val healed = (me.hp - previousHp).coerceAtLeast(0)
                         if (healed > 0) {
                             outbound.send(OutboundEvent.SendInfo(sessionId, "You recover $healed HP."))

--- a/src/main/kotlin/dev/ambon/engine/status/StatusEffectSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/status/StatusEffectSystem.kt
@@ -6,7 +6,9 @@ import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.healHp
 import dev.ambon.engine.rollRange
+import dev.ambon.engine.takeDamage
 import java.time.Clock
 import java.util.Random
 
@@ -134,7 +136,7 @@ class StatusEffectSystem(
                     val value = rollRange(rng, def.tickMinValue, def.tickMaxValue)
                     when (def.effectType) {
                         EffectType.DOT -> {
-                            player.hp = (player.hp - value).coerceAtLeast(0)
+                            player.takeDamage(value)
                             markVitalsDirty(sessionId)
                             outbound.send(
                                 OutboundEvent.SendText(
@@ -145,7 +147,7 @@ class StatusEffectSystem(
                         }
                         EffectType.HOT -> {
                             val before = player.hp
-                            player.hp = (player.hp + value).coerceAtMost(player.maxHp)
+                            player.healHp(value)
                             val healed = player.hp - before
                             if (healed > 0) {
                                 markVitalsDirty(sessionId)
@@ -189,7 +191,7 @@ class StatusEffectSystem(
                 ) {
                     effect.lastTickAtMs = nowMs
                     val value = rollRange(rng, def.tickMinValue, def.tickMaxValue)
-                    mob.hp = (mob.hp - value).coerceAtLeast(0)
+                    mob.takeDamage(value)
                     markMobHpDirty(mobId)
                     // Notify the player who applied it
                     val source = effect.sourceSessionId


### PR DESCRIPTION
Issue #266 — HP/mana clamping extension functions

  Added 5 extension functions to PlayerState.kt (package dev.ambon.engine):
  - PlayerState.healHp(Int): Boolean — clamp to maxHp, returns true if HP changed
  - PlayerState.takeDamage(Int) — clamp to 0
  - PlayerState.healMana(Int): Boolean — clamp to maxMana, returns true if mana changed
  - PlayerState.spendMana(Int) — clamp to 0
  - MobState.takeDamage(Int) — clamp to 0 (co-located to share the dev.ambon.engine package)

  Call sites updated across CombatSystem, AbilitySystem, StatusEffectSystem, RegenSystem, and ItemHandler. RegenSystem
  additionally benefits from the boolean return to skip markVitalsDirty when nothing actually changed.
  
  Closes 266