### PR TITLE
refactor: introduce test fixture classes for combat/ability/status tests

### DIFF
--- a/src/test/kotlin/dev/ambon/engine/abilities/AbilitySystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/abilities/AbilitySystemTest.kt
@@ -16,7 +16,7 @@ import dev.ambon.engine.status.StatusEffectDefinition
 import dev.ambon.engine.status.StatusEffectId
 import dev.ambon.engine.status.StatusEffectRegistry
 import dev.ambon.engine.status.StatusEffectSystem
-import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.AbilityTestFixture
 import dev.ambon.test.MutableClock
 import dev.ambon.test.drainAll
 import dev.ambon.test.loginOrFail
@@ -38,20 +38,7 @@ class AbilitySystemTest {
         clock: MutableClock = MutableClock(0L),
         rng: Random = Random(42),
     ): TestHarness {
-        val items = ItemRegistry()
-        val players = PlayerRegistry(roomId, InMemoryPlayerRepository(), items)
-        val mobs = MobRegistry()
-        val outbound = LocalOutboundBus()
-        val combat =
-            CombatSystem(
-                players = players,
-                mobs = mobs,
-                items = items,
-                outbound = outbound,
-                clock = clock,
-                rng = rng,
-                tickMillis = 1_000L,
-            )
+        val fixture = AbilityTestFixture(roomId = roomId, clock = clock, rng = rng)
         val registry = AbilityRegistry()
         registry.register(
             AbilityDefinition(
@@ -89,24 +76,16 @@ class AbilitySystemTest {
                 effect = AbilityEffect.DirectDamage(minDamage = 10, maxDamage = 10),
             ),
         )
-        val abilitySystem =
-            AbilitySystem(
-                players = players,
-                registry = registry,
-                outbound = outbound,
-                combat = combat,
-                clock = clock,
-                rng = rng,
-            )
+        val abilitySystem = fixture.buildAbilitySystem(registry = registry)
         return TestHarness(
-            players = players,
-            mobs = mobs,
-            items = items,
-            outbound = outbound,
-            combat = combat,
+            players = fixture.players,
+            mobs = fixture.mobs,
+            items = fixture.items,
+            outbound = fixture.outbound,
+            combat = fixture.combat,
             registry = registry,
             abilitySystem = abilitySystem,
-            clock = clock,
+            clock = fixture.clock,
         )
     }
 
@@ -419,20 +398,7 @@ class AbilitySystemTest {
         clock: MutableClock = MutableClock(0L),
         rng: Random = Random(42),
     ): TestHarness {
-        val items = ItemRegistry()
-        val players = PlayerRegistry(roomId, InMemoryPlayerRepository(), items)
-        val mobs = MobRegistry()
-        val outbound = LocalOutboundBus()
-        val combat =
-            CombatSystem(
-                players = players,
-                mobs = mobs,
-                items = items,
-                outbound = outbound,
-                clock = clock,
-                rng = rng,
-                tickMillis = 1_000L,
-            )
+        val fixture = AbilityTestFixture(roomId = roomId, clock = clock, rng = rng)
         val registry = AbilityRegistry()
         registry.register(
             AbilityDefinition(
@@ -458,25 +424,16 @@ class AbilitySystemTest {
                 effect = AbilityEffect.Taunt(flatThreat = 50.0, margin = 10.0),
             ),
         )
-        val abilitySystem =
-            AbilitySystem(
-                players = players,
-                registry = registry,
-                outbound = outbound,
-                combat = combat,
-                clock = clock,
-                rng = rng,
-                mobs = mobs,
-            )
+        val abilitySystem = fixture.buildAbilitySystem(registry = registry, mobsForAbility = fixture.mobs)
         return TestHarness(
-            players = players,
-            mobs = mobs,
-            items = items,
-            outbound = outbound,
-            combat = combat,
+            players = fixture.players,
+            mobs = fixture.mobs,
+            items = fixture.items,
+            outbound = fixture.outbound,
+            combat = fixture.combat,
             registry = registry,
             abilitySystem = abilitySystem,
-            clock = clock,
+            clock = fixture.clock,
         )
     }
 
@@ -484,20 +441,7 @@ class AbilitySystemTest {
         clock: MutableClock = MutableClock(0L),
         rng: Random = Random(42),
     ): StatusTestHarness {
-        val items = ItemRegistry()
-        val players = PlayerRegistry(roomId, InMemoryPlayerRepository(), items)
-        val mobs = MobRegistry()
-        val outbound = LocalOutboundBus()
-        val combat =
-            CombatSystem(
-                players = players,
-                mobs = mobs,
-                items = items,
-                outbound = outbound,
-                clock = clock,
-                rng = rng,
-                tickMillis = 1_000L,
-            )
+        val fixture = AbilityTestFixture(roomId = roomId, clock = clock, rng = rng)
         val statusRegistry = StatusEffectRegistry()
         statusRegistry.register(
             StatusEffectDefinition(
@@ -523,10 +467,10 @@ class AbilitySystemTest {
         val statusEffects =
             StatusEffectSystem(
                 registry = statusRegistry,
-                players = players,
-                mobs = mobs,
-                outbound = outbound,
-                clock = clock,
+                players = fixture.players,
+                mobs = fixture.mobs,
+                outbound = fixture.outbound,
+                clock = fixture.clock,
                 rng = rng,
                 markVitalsDirty = {},
                 markMobHpDirty = {},
@@ -557,23 +501,14 @@ class AbilitySystemTest {
                 effect = AbilityEffect.ApplyStatus(StatusEffectId("shield")),
             ),
         )
-        val abilitySystem =
-            AbilitySystem(
-                players = players,
-                registry = registry,
-                outbound = outbound,
-                combat = combat,
-                clock = clock,
-                rng = rng,
-                statusEffects = statusEffects,
-            )
+        val abilitySystem = fixture.buildAbilitySystem(registry = registry, statusEffects = statusEffects)
         return StatusTestHarness(
-            players = players,
-            mobs = mobs,
-            outbound = outbound,
+            players = fixture.players,
+            mobs = fixture.mobs,
+            outbound = fixture.outbound,
             abilitySystem = abilitySystem,
             statusEffects = statusEffects,
-            clock = clock,
+            clock = fixture.clock,
         )
     }
 

--- a/src/test/kotlin/dev/ambon/test/AbilityTestFixture.kt
+++ b/src/test/kotlin/dev/ambon/test/AbilityTestFixture.kt
@@ -1,0 +1,91 @@
+package dev.ambon.test
+
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.mob.MobState
+import dev.ambon.engine.CombatSystem
+import dev.ambon.engine.MobRegistry
+import dev.ambon.engine.PlayerRegistry
+import dev.ambon.engine.abilities.AbilityRegistry
+import dev.ambon.engine.abilities.AbilitySystem
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.engine.status.StatusEffectSystem
+import dev.ambon.persistence.InMemoryPlayerRepository
+import java.util.Random
+
+class AbilityTestFixture(
+    val roomId: RoomId = RoomId("zone:room"),
+    val clock: MutableClock = MutableClock(0L),
+    val rng: Random = Random(42),
+    val items: ItemRegistry = ItemRegistry(),
+    val repo: InMemoryPlayerRepository = InMemoryPlayerRepository(),
+    val players: PlayerRegistry = PlayerRegistry(roomId, repo, items),
+    val mobs: MobRegistry = MobRegistry(),
+    val outbound: LocalOutboundBus = LocalOutboundBus(),
+) {
+    val combat: CombatSystem =
+        CombatSystem(
+            players = players,
+            mobs = mobs,
+            items = items,
+            outbound = outbound,
+            clock = clock,
+            rng = rng,
+            tickMillis = 1_000L,
+        )
+
+    fun buildAbilitySystem(
+        registry: AbilityRegistry,
+        statusEffects: StatusEffectSystem? = null,
+        markVitalsDirty: (SessionId) -> Unit = {},
+        markMobHpDirty: (MobId) -> Unit = {},
+        markStatusDirty: (SessionId) -> Unit = {},
+        mobsForAbility: MobRegistry? = null,
+    ): AbilitySystem =
+        AbilitySystem(
+            players = players,
+            registry = registry,
+            outbound = outbound,
+            combat = combat,
+            clock = clock,
+            rng = rng,
+            statusEffects = statusEffects,
+            markVitalsDirty = markVitalsDirty,
+            markMobHpDirty = markMobHpDirty,
+            markStatusDirty = markStatusDirty,
+            mobs = mobsForAbility ?: mobs,
+        )
+
+    suspend fun loginPlayer(
+        sessionId: SessionId,
+        name: String,
+        password: String = "password",
+    ) {
+        players.loginOrFail(sessionId, name, password)
+    }
+
+    fun spawnMob(
+        id: MobId,
+        name: String,
+        hp: Int = 20,
+        maxHp: Int = hp,
+        minDamage: Int = 1,
+        maxDamage: Int = 4,
+        roomId: RoomId = this.roomId,
+    ): MobState {
+        val mob =
+            MobState(
+                id = id,
+                name = name,
+                roomId = roomId,
+                hp = hp,
+                maxHp = maxHp,
+                minDamage = minDamage,
+                maxDamage = maxDamage,
+            )
+        mobs.upsert(mob)
+        return mob
+    }
+}

--- a/src/test/kotlin/dev/ambon/test/CombatTestFixture.kt
+++ b/src/test/kotlin/dev/ambon/test/CombatTestFixture.kt
@@ -1,0 +1,129 @@
+package dev.ambon.test
+
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.bus.OutboundBus
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.mob.MobState
+import dev.ambon.engine.CombatSystem
+import dev.ambon.engine.GroupSystem
+import dev.ambon.engine.MobRegistry
+import dev.ambon.engine.PlayerProgression
+import dev.ambon.engine.PlayerRegistry
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.engine.status.StatusEffectSystem
+import dev.ambon.metrics.GameMetrics
+import dev.ambon.persistence.InMemoryPlayerRepository
+import java.time.Clock
+import java.util.Random
+
+class CombatTestFixture(
+    val roomId: RoomId = RoomId("zone:room"),
+    val clock: MutableClock = MutableClock(0L),
+    val items: ItemRegistry = ItemRegistry(),
+    val repo: InMemoryPlayerRepository = InMemoryPlayerRepository(),
+    val players: PlayerRegistry = PlayerRegistry(roomId, repo, items),
+    val mobs: MobRegistry = MobRegistry(),
+    val outbound: LocalOutboundBus = LocalOutboundBus(),
+) {
+    fun buildCombat(
+        players: PlayerRegistry = this.players,
+        mobs: MobRegistry = this.mobs,
+        items: ItemRegistry = this.items,
+        outbound: OutboundBus = this.outbound,
+        clock: Clock = this.clock,
+        rng: Random = Random(),
+        tickMillis: Long = 1_000L,
+        minDamage: Int = 1,
+        maxDamage: Int = 4,
+        detailedFeedbackEnabled: Boolean = false,
+        detailedFeedbackRoomBroadcastEnabled: Boolean = false,
+        onMobRemoved: suspend (MobId, RoomId) -> Unit = { _, _ -> },
+        progression: PlayerProgression = PlayerProgression(),
+        metrics: GameMetrics = GameMetrics.noop(),
+        onLevelUp: suspend (SessionId, Int) -> Unit = { _, _ -> },
+        strDivisor: Int = 3,
+        dexDodgePerPoint: Int = 2,
+        maxDodgePercent: Int = 30,
+        markVitalsDirty: (SessionId) -> Unit = {},
+        markMobHpDirty: (MobId) -> Unit = {},
+        statusEffects: StatusEffectSystem? = null,
+        onMobKilledByPlayer: suspend (SessionId, String) -> Unit = { _, _ -> },
+        groupSystem: GroupSystem? = null,
+        groupXpBonusPerMember: Double = 0.10,
+        threatMultiplierWarrior: Double = 1.5,
+        threatMultiplierDefault: Double = 1.0,
+        healingThreatMultiplier: Double = 0.5,
+        onRoomItemsChanged: suspend (RoomId) -> Unit = { _ -> },
+    ): CombatSystem =
+        CombatSystem(
+            players = players,
+            mobs = mobs,
+            items = items,
+            outbound = outbound,
+            clock = clock,
+            rng = rng,
+            tickMillis = tickMillis,
+            minDamage = minDamage,
+            maxDamage = maxDamage,
+            detailedFeedbackEnabled = detailedFeedbackEnabled,
+            detailedFeedbackRoomBroadcastEnabled = detailedFeedbackRoomBroadcastEnabled,
+            onMobRemoved = onMobRemoved,
+            progression = progression,
+            metrics = metrics,
+            onLevelUp = onLevelUp,
+            strDivisor = strDivisor,
+            dexDodgePerPoint = dexDodgePerPoint,
+            maxDodgePercent = maxDodgePercent,
+            markVitalsDirty = markVitalsDirty,
+            markMobHpDirty = markMobHpDirty,
+            statusEffects = statusEffects,
+            onMobKilledByPlayer = onMobKilledByPlayer,
+            groupSystem = groupSystem,
+            groupXpBonusPerMember = groupXpBonusPerMember,
+            threatMultiplierWarrior = threatMultiplierWarrior,
+            threatMultiplierDefault = threatMultiplierDefault,
+            healingThreatMultiplier = healingThreatMultiplier,
+            onRoomItemsChanged = onRoomItemsChanged,
+        )
+
+    suspend fun loginPlayer(
+        sessionId: SessionId,
+        name: String,
+        password: String = "password",
+    ) {
+        players.loginOrFail(sessionId, name, password)
+    }
+
+    fun spawnMob(
+        id: MobId,
+        name: String,
+        hp: Int = 10,
+        maxHp: Int = hp,
+        minDamage: Int = 1,
+        maxDamage: Int = 4,
+        armor: Int = 0,
+        xpReward: Long = 30L,
+        goldMin: Long = 0L,
+        goldMax: Long = 0L,
+        roomId: RoomId = this.roomId,
+    ): MobState {
+        val mob =
+            MobState(
+                id = id,
+                name = name,
+                roomId = roomId,
+                hp = hp,
+                maxHp = maxHp,
+                minDamage = minDamage,
+                maxDamage = maxDamage,
+                armor = armor,
+                xpReward = xpReward,
+                goldMin = goldMin,
+                goldMax = goldMax,
+            )
+        mobs.upsert(mob)
+        return mob
+    }
+}

--- a/src/test/kotlin/dev/ambon/test/StatusEffectTestFixture.kt
+++ b/src/test/kotlin/dev/ambon/test/StatusEffectTestFixture.kt
@@ -1,0 +1,76 @@
+package dev.ambon.test
+
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.mob.MobState
+import dev.ambon.engine.MobRegistry
+import dev.ambon.engine.PlayerRegistry
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.engine.status.StatusEffectRegistry
+import dev.ambon.engine.status.StatusEffectSystem
+import dev.ambon.persistence.InMemoryPlayerRepository
+import java.util.Random
+
+class StatusEffectTestFixture(
+    val roomId: RoomId = RoomId("zone:room"),
+    val clock: MutableClock = MutableClock(0L),
+    val rng: Random = Random(42),
+    val items: ItemRegistry = ItemRegistry(),
+    val repo: InMemoryPlayerRepository = InMemoryPlayerRepository(),
+    val players: PlayerRegistry = PlayerRegistry(roomId, repo, items),
+    val mobs: MobRegistry = MobRegistry(),
+    val outbound: LocalOutboundBus = LocalOutboundBus(),
+) {
+    val registry = StatusEffectRegistry()
+    val vitalsDirty = mutableListOf<SessionId>()
+    val mobHpDirty = mutableListOf<MobId>()
+    val statusDirty = mutableListOf<SessionId>()
+
+    val system: StatusEffectSystem =
+        StatusEffectSystem(
+            registry = registry,
+            players = players,
+            mobs = mobs,
+            outbound = outbound,
+            clock = clock,
+            rng = rng,
+            markVitalsDirty = { vitalsDirty.add(it) },
+            markMobHpDirty = { mobHpDirty.add(it) },
+            markStatusDirty = { statusDirty.add(it) },
+        )
+
+    suspend fun loginPlayer(
+        sessionId: SessionId,
+        name: String,
+        password: String = "password",
+        defaultAnsiEnabled: Boolean = false,
+    ) {
+        val result = players.login(sessionId, name, password, defaultAnsiEnabled)
+        check(result == dev.ambon.engine.LoginResult.Ok) { "Login failed: $result" }
+    }
+
+    fun spawnMob(
+        id: MobId,
+        name: String,
+        hp: Int = 50,
+        maxHp: Int = hp,
+        minDamage: Int = 1,
+        maxDamage: Int = 2,
+        roomId: RoomId = this.roomId,
+    ): MobState {
+        val mob =
+            MobState(
+                id = id,
+                name = name,
+                roomId = roomId,
+                hp = hp,
+                maxHp = maxHp,
+                minDamage = minDamage,
+                maxDamage = maxDamage,
+            )
+        mobs.upsert(mob)
+        return mob
+    }
+}


### PR DESCRIPTION
## Summary
- add shared fixtures under src/test/kotlin/dev/ambon/test/ for Combat, Ability, and StatusEffect systems
- refactor CombatSystemTest, AbilitySystemTest, and StatusEffectSystemTest to use fixture-based setup
- reduce duplicated registry/bus/clock wiring and centralize constructor dependency setup

## Verification
- ./gradlew.bat test --tests dev.ambon.engine.CombatSystemTest --tests dev.ambon.engine.abilities.AbilitySystemTest --tests dev.ambon.engine.status.StatusEffectSystemTest -x swarm:test
- ./gradlew.bat ktlintCheck -x swarm:test
- ./gradlew.bat test -x swarm:test

Closes #267