### PR TITLE
refactor(commands): route communication room broadcasts through helpers

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/CommunicationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/CommunicationHandler.kt
@@ -45,10 +45,7 @@ class CommunicationHandler(
             val members = players.playersInRoom(roomId)
 
             outbound.send(OutboundEvent.SendText(sessionId, "You say: ${cmd.message}"))
-            for (other in members) {
-                if (other == me) continue
-                outbound.send(OutboundEvent.SendText(other.sessionId, "${me.name} says: ${cmd.message}"))
-            }
+            broadcastToRoomExcept(roomId, sessionId, "${me.name} says: ${cmd.message}", players, outbound)
             for (member in members) {
                 gmcpEmitter?.sendCommChannel(member.sessionId, "say", me.name, cmd.message)
             }
@@ -61,10 +58,7 @@ class CommunicationHandler(
     ) {
         players.withPlayer(sessionId) { me ->
             val roomId = me.roomId
-            val members = players.playersInRoom(roomId)
-            for (other in members) {
-                outbound.send(OutboundEvent.SendText(other.sessionId, "${me.name} ${cmd.message}"))
-            }
+            broadcastToRoom(roomId, "${me.name} ${cmd.message}", players, outbound)
         }
     }
 
@@ -200,10 +194,7 @@ class CommunicationHandler(
                 return
             }
             val roomId = me.roomId
-            val members = players.playersInRoom(roomId)
-            for (other in members) {
-                outbound.send(OutboundEvent.SendText(other.sessionId, cmd.message))
-            }
+            broadcastToRoom(roomId, cmd.message, players, outbound)
         }
     }
 

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -147,6 +147,29 @@ internal suspend fun broadcastToRoomExcept(
     }
 }
 
+/** Broadcasts [message] to every player in [roomId], including the sender. */
+internal suspend fun broadcastToRoom(
+    roomId: RoomId,
+    message: String,
+    players: PlayerRegistry,
+    outbound: OutboundBus,
+) {
+    for (other in players.playersInRoom(roomId)) {
+        outbound.send(OutboundEvent.SendText(other.sessionId, message))
+    }
+}
+
+/** Broadcasts [message] to all provided [memberSessionIds], useful for group chat. */
+internal suspend fun broadcastToGroup(
+    memberSessionIds: Iterable<SessionId>,
+    message: String,
+    outbound: OutboundBus,
+) {
+    for (sid in memberSessionIds) {
+        outbound.send(OutboundEvent.SendText(sid, message))
+    }
+}
+
 /**
  * Sends a [OutboundEvent.SendError] to [sessionId] if [error] is non-null; no-op otherwise.
  *


### PR DESCRIPTION
## Summary
- add roadcastToRoom(...) helper in HandlerHelpers.kt for room broadcasts that include sender
- add roadcastToGroup(...) helper in HandlerHelpers.kt for group-targeted broadcast paths
- refactor CommunicationHandler to remove inline room-member loops and use helpers for say, emote, and pose

## Why
This unifies room broadcast behavior into shared helper code so any future filtering/muting logic can be changed in one place.

## Verification
- ./gradlew.bat test --tests dev.ambon.engine.commands.CommandRouterBroadcastTest --tests dev.ambon.engine.commands.SocialChannelCommandsTest --tests dev.ambon.engine.commands.NamesTellGossipTest --tests dev.ambon.engine.commands.CommandRouterTest -x swarm:test
- ./gradlew.bat ktlintCheck -x swarm:test

Closes #271