### PR TITLE
refactor: introduce EffectiveStats to unify stat calculation across s…

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -5,6 +5,8 @@ import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.mob.MobState
 import dev.ambon.domain.quest.QuestState
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.engine.status.StatModifiers
 import dev.ambon.persistence.PlayerId
 
 data class PlayerState(
@@ -98,3 +100,28 @@ fun PlayerState.spendMana(amount: Int) {
 fun MobState.takeDamage(amount: Int) {
     hp = (hp - amount).coerceAtLeast(0)
 }
+
+/** Resolved stat totals for a player: base + equipment bonuses + status-effect modifiers. */
+data class EffectiveStats(
+    val str: Int,
+    val dex: Int,
+    val con: Int,
+    val int: Int,
+    val wis: Int,
+    val cha: Int,
+)
+
+/** Combines [player] base stats with [equip] bonuses and optional status-effect [mods]. */
+fun resolveEffectiveStats(
+    player: PlayerState,
+    equip: ItemRegistry.EquipmentBonuses,
+    mods: StatModifiers = StatModifiers.ZERO,
+): EffectiveStats =
+    EffectiveStats(
+        str = player.strength + equip.strength + mods.str,
+        dex = player.dexterity + equip.dexterity + mods.dex,
+        con = player.constitution + equip.constitution + mods.con,
+        int = player.intelligence + equip.intelligence + mods.int,
+        wis = player.wisdom + equip.wisdom + mods.wis,
+        cha = player.charisma + equip.charisma + mods.cha,
+    )


### PR DESCRIPTION
…ystems

Adds EffectiveStats (str/dex/con/int/wis/cha) and resolveEffectiveStats() to PlayerState.kt. Three private helpers that each re-derived a single stat from base + equip + statusMod are replaced with a single EffectiveStats resolved once per operation:

- CombatSystem: strDamageBonus() and dodgeChance() removed; EffectiveStats computed once inside the !stunned block and the mob-attack dodge path
- RegenSystem: totalConstitution() removed; equipmentBonuses() called once per player per tick and passed to symmetric regenIntervalMs/manaRegen helpers
- AbilitySystem: intSpellBonus() removed; EffectiveStats resolved once at the top of handleEnemyCast() and used for DirectDamage and AreaDamage branches, now correctly including status-effect int modifiers in spell damage

Closes #268