### PR TITLE
fix(web): correct help formatting in xterm client

### DIFF
--- a/src/main/kotlin/dev/ambon/transport/AnsiRenderer.kt
+++ b/src/main/kotlin/dev/ambon/transport/AnsiRenderer.kt
@@ -20,7 +20,7 @@ class AnsiRenderer : TextRenderer {
             }
         return buildString {
             append(prefix)
-            append(text)
+            append(text.normalizeToCrlf())
             append(reset)
             append("\r\n")
         }

--- a/src/main/kotlin/dev/ambon/transport/LineEndings.kt
+++ b/src/main/kotlin/dev/ambon/transport/LineEndings.kt
@@ -1,0 +1,5 @@
+package dev.ambon.transport
+
+private val lineBreakRegex = Regex("\r\n|\n|\r")
+
+internal fun String.normalizeToCrlf(): String = replace(lineBreakRegex, "\r\n")

--- a/src/main/kotlin/dev/ambon/transport/PlainRenderer.kt
+++ b/src/main/kotlin/dev/ambon/transport/PlainRenderer.kt
@@ -4,7 +4,7 @@ class PlainRenderer : TextRenderer {
     override fun renderLine(
         text: String,
         kind: TextKind,
-    ): String = text + "\r\n"
+    ): String = text.normalizeToCrlf() + "\r\n"
 
     override fun renderPrompt(prompt: PromptSpec): String = prompt.text
 }

--- a/src/test/kotlin/dev/ambon/transport/AnsiRendererTest.kt
+++ b/src/test/kotlin/dev/ambon/transport/AnsiRendererTest.kt
@@ -28,6 +28,14 @@ class AnsiRendererTest {
         assertTrue(line.endsWith("\r\n"))
     }
 
+    @Test
+    fun `renderLine normalizes embedded newlines to CRLF`() {
+        val r = AnsiRenderer()
+        val line = r.renderLine("a\nb\rc\r\nd", TextKind.INFO)
+        assertTrue(line.contains("a\r\nb\r\nc\r\nd"))
+        assertTrue(line.endsWith("\r\n"))
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `prompt rendering uses PromptSpec text not toString`() =

--- a/src/test/kotlin/dev/ambon/transport/PlainRendererTest.kt
+++ b/src/test/kotlin/dev/ambon/transport/PlainRendererTest.kt
@@ -29,6 +29,13 @@ class PlainRendererTest {
         assertTrue(line.endsWith("\r\n"))
     }
 
+    @Test
+    fun `renderLine normalizes embedded newlines to CRLF`() {
+        val r = PlainRenderer()
+        val line = r.renderLine("a\nb\rc\r\nd", TextKind.INFO)
+        assertEquals("a\r\nb\r\nc\r\nd\r\n", line)
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `prompt rendering uses PromptSpec text not toString`() =


### PR DESCRIPTION
## Summary
- normalize embedded line endings to CRLF for all enderLine output in both PlainRenderer and AnsiRenderer
- add shared 
ormalizeToCrlf() helper in transport package
- add regression tests for renderer newline normalization and outbound router multiline framing

## Root Cause
help is emitted as a multiline SendInfo payload containing bare \n. The web client terminal runs xterm with convertEol=false, so bare LF advances to the next row without returning to column 0, causing command lines to appear scattered across the screen.

## Verification
- ./gradlew.bat test --tests dev.ambon.transport.PlainRendererTest --tests dev.ambon.transport.AnsiRendererTest --tests dev.ambon.transport.OutboundRouterTest -x swarm:test
- ./gradlew.bat ktlintCheck -x swarm:test
