### PR TITLE
refactor(persistence): extract player repository chain factory

### DIFF
--- a/src/main/kotlin/dev/ambon/persistence/PlayerRepositoryFactory.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayerRepositoryFactory.kt
@@ -1,0 +1,64 @@
+package dev.ambon.persistence
+
+import dev.ambon.config.PersistenceBackend
+import dev.ambon.config.PersistenceConfig
+import dev.ambon.config.RedisConfig
+import dev.ambon.metrics.GameMetrics
+import dev.ambon.redis.RedisConnectionManager
+import org.jetbrains.exposed.sql.Database
+import java.nio.file.Paths
+
+data class PlayerRepositoryChain(
+    val repository: PlayerRepository,
+    val coalescingRepository: WriteCoalescingPlayerRepository?,
+)
+
+object PlayerRepositoryFactory {
+    fun buildChain(
+        persistence: PersistenceConfig,
+        redis: RedisConfig,
+        redisManager: RedisConnectionManager?,
+        database: Database?,
+        metrics: GameMetrics,
+    ): PlayerRepositoryChain {
+        val backendRepository: PlayerRepository =
+            when (persistence.backend) {
+                PersistenceBackend.YAML ->
+                    YamlPlayerRepository(
+                        rootDir = Paths.get(persistence.rootDir),
+                        metrics = metrics,
+                    )
+                PersistenceBackend.POSTGRES ->
+                    PostgresPlayerRepository(
+                        database =
+                            requireNotNull(database) {
+                                "Database must be configured when persistence.backend=POSTGRES"
+                            },
+                        metrics = metrics,
+                    )
+            }
+
+        val cachedRepository: PlayerRepository =
+            if (redis.enabled && redisManager != null) {
+                RedisCachingPlayerRepository(
+                    delegate = backendRepository,
+                    cache = redisManager,
+                    cacheTtlSeconds = redis.cacheTtlSeconds,
+                )
+            } else {
+                backendRepository
+            }
+
+        val coalescingRepository: WriteCoalescingPlayerRepository? =
+            if (persistence.worker.enabled) {
+                WriteCoalescingPlayerRepository(cachedRepository)
+            } else {
+                null
+            }
+
+        return PlayerRepositoryChain(
+            repository = coalescingRepository ?: cachedRepository,
+            coalescingRepository = coalescingRepository,
+        )
+    }
+}

--- a/src/test/kotlin/dev/ambon/persistence/PlayerRepositoryFactoryTest.kt
+++ b/src/test/kotlin/dev/ambon/persistence/PlayerRepositoryFactoryTest.kt
@@ -1,0 +1,128 @@
+package dev.ambon.persistence
+
+import dev.ambon.config.PersistenceBackend
+import dev.ambon.config.PersistenceConfig
+import dev.ambon.config.PersistenceWorkerConfig
+import dev.ambon.config.RedisConfig
+import dev.ambon.metrics.GameMetrics
+import dev.ambon.redis.RedisConnectionManager
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+class PlayerRepositoryFactoryTest {
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `yaml backend with redis and worker disabled returns bare repository`() {
+        val persistence =
+            PersistenceConfig(
+                backend = PersistenceBackend.YAML,
+                rootDir = tempDir.toString(),
+                worker = PersistenceWorkerConfig(enabled = false),
+            )
+
+        val chain =
+            PlayerRepositoryFactory.buildChain(
+                persistence = persistence,
+                redis = RedisConfig(enabled = false),
+                redisManager = null,
+                database = null,
+                metrics = GameMetrics.noop(),
+            )
+
+        assertTrue(chain.repository is YamlPlayerRepository)
+        assertNull(chain.coalescingRepository)
+    }
+
+    @Test
+    fun `redis enabled wraps backend repository with cache layer`() {
+        val persistence =
+            PersistenceConfig(
+                backend = PersistenceBackend.YAML,
+                rootDir = tempDir.toString(),
+                worker = PersistenceWorkerConfig(enabled = false),
+            )
+        val redisConfig = RedisConfig(enabled = true, cacheTtlSeconds = 90L)
+        val redisManager = RedisConnectionManager(redisConfig)
+
+        try {
+            val chain =
+                PlayerRepositoryFactory.buildChain(
+                    persistence = persistence,
+                    redis = redisConfig,
+                    redisManager = redisManager,
+                    database = null,
+                    metrics = GameMetrics.noop(),
+                )
+
+            assertTrue(chain.repository is RedisCachingPlayerRepository)
+            assertNull(chain.coalescingRepository)
+        } finally {
+            redisManager.close()
+        }
+    }
+
+    @Test
+    fun `worker enabled adds write coalescing as outermost layer`() {
+        val persistence =
+            PersistenceConfig(
+                backend = PersistenceBackend.YAML,
+                rootDir = tempDir.toString(),
+                worker = PersistenceWorkerConfig(enabled = true),
+            )
+        val redisConfig = RedisConfig(enabled = true, cacheTtlSeconds = 90L)
+        val redisManager = RedisConnectionManager(redisConfig)
+
+        try {
+            val chain =
+                PlayerRepositoryFactory.buildChain(
+                    persistence = persistence,
+                    redis = redisConfig,
+                    redisManager = redisManager,
+                    database = null,
+                    metrics = GameMetrics.noop(),
+                )
+
+            val coalescing = chain.coalescingRepository
+            assertTrue(coalescing is WriteCoalescingPlayerRepository)
+            assertSame(coalescing, chain.repository)
+
+            val delegate = delegatedRepositoryOf(coalescing!!)
+            assertTrue(delegate is RedisCachingPlayerRepository)
+        } finally {
+            redisManager.close()
+        }
+    }
+
+    @Test
+    fun `postgres backend requires a configured database`() {
+        val persistence =
+            PersistenceConfig(
+                backend = PersistenceBackend.POSTGRES,
+                rootDir = tempDir.toString(),
+                worker = PersistenceWorkerConfig(enabled = false),
+            )
+
+        assertThrows(IllegalArgumentException::class.java) {
+            PlayerRepositoryFactory.buildChain(
+                persistence = persistence,
+                redis = RedisConfig(enabled = false),
+                redisManager = null,
+                database = null,
+                metrics = GameMetrics.noop(),
+            )
+        }
+    }
+
+    private fun delegatedRepositoryOf(repo: Any): PlayerRepository {
+        val field = DelegatingPlayerRepository::class.java.getDeclaredField("delegate")
+        field.isAccessible = true
+        return field.get(repo) as PlayerRepository
+    }
+}


### PR DESCRIPTION
## Summary
- add PlayerRepositoryFactory with an explicit ackend -> cache -> coalesce chain builder
- add PlayerRepositoryChain to return both the composed repository and optional coalescing wrapper
- replace imperative chain wiring in MudServer with a single factory call while preserving existing worker/metrics hooks
- add PlayerRepositoryFactoryTest coverage for YAML/postgres guardrails and layer ordering

## Verification
- ./gradlew.bat test --tests dev.ambon.persistence.PlayerRepositoryFactoryTest -x swarm:test
- ./gradlew.bat ktlintCheck -x swarm:test

Closes #274