### PR TITLE
feat: class-specific starting rooms for new characters

### DIFF
--- a/src/main/kotlin/dev/ambon/MudServer.kt
+++ b/src/main/kotlin/dev/ambon/MudServer.kt
@@ -12,6 +12,8 @@ import dev.ambon.bus.RedisOutboundBus
 import dev.ambon.config.AppConfig
 import dev.ambon.config.PersistenceBackend
 import dev.ambon.config.ShardingRegistryType
+import dev.ambon.domain.PlayerClass
+import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.world.WorldFactory
 import dev.ambon.engine.GameEngine
 import dev.ambon.engine.MobRegistry
@@ -210,9 +212,15 @@ class MudServer(
             port = config.sharding.advertisePort ?: config.server.telnetPort,
         )
 
+    private val classStartRooms: Map<PlayerClass, RoomId> =
+        config.engine.classStartRooms
+            .mapNotNull { (key, value) -> PlayerClass.fromString(key)?.to(RoomId(value)) }
+            .toMap()
+
     private val players =
         PlayerRegistry(
             startRoom = world.startRoom,
+            classStartRooms = classStartRooms,
             repo = playerRepo,
             items = items,
             clock = clock,

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -374,6 +374,8 @@ data class EngineConfig(
     val statusEffects: StatusEffectEngineConfig = StatusEffectEngineConfig(),
     val economy: EconomyConfig = EconomyConfig(),
     val group: GroupConfig = GroupConfig(),
+    /** Maps class name (e.g. "WARRIOR") to a fully-qualified RoomId string for new-character placement. */
+    val classStartRooms: Map<String, String> = emptyMap(),
 )
 
 data class ProgressionConfig(

--- a/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
@@ -78,6 +78,7 @@ internal sealed interface CreateAccountPrep {
 
 class PlayerRegistry(
     private val startRoom: RoomId,
+    private val classStartRooms: Map<PlayerClass, RoomId> = emptyMap(),
     private val repo: PlayerRepository,
     private val items: ItemRegistry,
     private val clock: Clock = Clock.systemUTC(),
@@ -169,7 +170,7 @@ class PlayerRegistry(
             repo.create(
                 PlayerCreationRequest(
                     name = name,
-                    startRoomId = startRoom,
+                    startRoomId = classStartRooms[playerClass] ?: startRoom,
                     nowEpochMs = now,
                     passwordHash = hash,
                     ansiEnabled = defaultAnsiEnabled,
@@ -275,7 +276,7 @@ class PlayerRegistry(
             repo.create(
                 PlayerCreationRequest(
                     name = name,
-                    startRoomId = startRoom,
+                    startRoomId = classStartRooms[playerClass] ?: startRoom,
                     nowEpochMs = now,
                     passwordHash = withContext(hashingContext) { passwordHasher.hash(password) },
                     ansiEnabled = defaultAnsiEnabled,

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1580,6 +1580,12 @@ ambonMUD:
             minDamage: 44
             maxDamage: 68
 
+    classStartRooms:
+      WARRIOR: tutorial_glade:warrior_barracks
+      MAGE: tutorial_glade:mage_study
+      CLERIC: tutorial_glade:cleric_chapel
+      ROGUE: tutorial_glade:rogue_hideout
+
   progression:
     maxLevel: 50
     xp:

--- a/src/main/resources/world/tutorial_glade.yaml
+++ b/src/main/resources/world/tutorial_glade.yaml
@@ -357,3 +357,29 @@ rooms:
     description: "The deepest recess of the wolf's den. Trinkets and torn cloth lie tangled among old bones. Something useful has been dragged here and half-buried beneath a pile of leaves."
     exits:
       w: wolf_den
+
+  # --- Class Starting Rooms ---
+
+  warrior_barracks:
+    title: "Training Barracks"
+    description: "A spartan chamber that smells of iron and sawdust. Weapon racks line the walls — blunted swords, practice spears, and a battered shield or two. A straw dummy in the corner has been punched into a lopsided slouch. Through the open archway to the south, sunlight spills across a grassy clearing."
+    exits:
+      s: awakening_clearing
+
+  mage_study:
+    title: "The Arcane Alcove"
+    description: "A circular chamber etched floor to ceiling with softly glowing runes. A leather-bound tome floats at chest height, its pages turning on their own. The air carries the sharp tang of ozone and old parchment, and faint sparks drift upward from a brass brazier. A narrow passage opens to the south."
+    exits:
+      s: awakening_clearing
+
+  cleric_chapel:
+    title: "The Wayside Chapel"
+    description: "A modest stone chapel where candlelight throws warm shadows across the walls. A low altar bears offerings of dried wildflowers, smooth river pebbles, and a folded cloth. The silence here is deep and deliberate. A doorway to the south leads into open air."
+    exits:
+      s: awakening_clearing
+
+  rogue_hideout:
+    title: "The Shadow Den"
+    description: "A cramped hideout tucked beneath the roots of a massive oak. The only light filters through gaps in the bark overhead, picking out coils of rope, lockpicks, and a battered satchel hanging from a peg. Someone has scratched a rough map into the dirt floor. A concealed passage slopes south toward daylight."
+    exits:
+      s: awakening_clearing

--- a/src/test/kotlin/dev/ambon/test/TestFixtures.kt
+++ b/src/test/kotlin/dev/ambon/test/TestFixtures.kt
@@ -3,6 +3,7 @@ package dev.ambon.test
 import dev.ambon.bus.LocalInboundBus
 import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.config.EconomyConfig
+import dev.ambon.domain.PlayerClass
 import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
@@ -58,9 +59,11 @@ fun buildTestPlayerRegistry(
     progression: PlayerProgression = PlayerProgression(),
     hashingContext: CoroutineContext = EmptyCoroutineContext,
     passwordHasher: PasswordHasher = TestPasswordHasher,
+    classStartRooms: Map<PlayerClass, RoomId> = emptyMap(),
 ): PlayerRegistry =
     PlayerRegistry(
         startRoom = startRoom,
+        classStartRooms = classStartRooms,
         repo = repo,
         items = items,
         clock = clock,


### PR DESCRIPTION
## Summary

- Adds four class-themed starter rooms to `tutorial_glade` (warrior barracks, arcane alcove, wayside chapel, shadow den), each with flavor text and a south exit into `awakening_clearing`
- New characters are routed to their class room at creation time; existing characters and all current tests are unaffected
- Routing is config-driven via `ambonMUD.engine.classStartRooms` — a missing key falls back to `world.startRoom`

## Changes

| File | What changed |
|---|---|
| `tutorial_glade.yaml` | 4 new class starting rooms |
| `AppConfig.kt` | `classStartRooms: Map<String, String>` added to `EngineConfig` |
| `application.yaml` | WARRIOR/MAGE/CLERIC/ROGUE entries under `engine.classStartRooms` |
| `PlayerRegistry.kt` | `classStartRooms` constructor param; `prepareCreateAccount` and `create` both use `classStartRooms[playerClass] ?: startRoom` |
| `MudServer.kt` | Parses config map and passes to `PlayerRegistry` |
| `TestFixtures.kt` | `buildTestPlayerRegistry` gains optional `classStartRooms` param (default empty) |
| `GameEngineLoginFlowTest.kt` | Two new tests: class-override routing and fallback-to-default routing |

## Test plan

- [ ] `./gradlew ktlintCheck test` passes (verified locally)
- [ ] New warrior character lands in `tutorial_glade:warrior_barracks`
- [ ] New rogue (no override configured for rogue in test) falls back to `world.startRoom`
- [ ] Existing login flow tests unaffected