### PR TITLE
Move world storage to Postgres and add admin reimport

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError
 kotlin.daemon.jvmargs=-Xmx2g
+kotlin.compiler.execution.strategy=in-process
 # Reclaim stale daemon processes after 10 minutes of idle (default is 3 hours).
 # Prevents file locks from accumulating when tests hang and leave zombie daemons.
 org.gradle.daemon.idletimeout=600000

--- a/src/main/kotlin/dev/ambon/MudServer.kt
+++ b/src/main/kotlin/dev/ambon/MudServer.kt
@@ -13,15 +13,13 @@ import dev.ambon.config.AppConfig
 import dev.ambon.config.PersistenceBackend
 import dev.ambon.config.ShardingRegistryType
 import dev.ambon.config.WorldStorageBackend
-import dev.ambon.domain.PlayerClass
-import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.world.WorldFactory
 import dev.ambon.domain.world.load.PostgresWorldBootstrapper
 import dev.ambon.engine.GameEngine
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PlayerProgression
-import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.WorldStateRegistry
+import dev.ambon.engine.createPlayerRegistry
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.engine.scheduler.Scheduler
 import dev.ambon.metrics.GameMetrics
@@ -232,15 +230,10 @@ class MudServer(
             port = config.sharding.advertisePort ?: config.server.telnetPort,
         )
 
-    private val classStartRooms: Map<PlayerClass, RoomId> =
-        config.engine.classStartRooms
-            .mapNotNull { (key, value) -> PlayerClass.fromString(key)?.to(RoomId(value)) }
-            .toMap()
-
     private val players =
-        PlayerRegistry(
+        createPlayerRegistry(
             startRoom = world.startRoom,
-            classStartRooms = classStartRooms,
+            engineConfig = config.engine,
             repo = playerRepo,
             items = items,
             clock = clock,

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -406,8 +406,13 @@ data class EngineConfig(
     val statusEffects: StatusEffectEngineConfig = StatusEffectEngineConfig(),
     val economy: EconomyConfig = EconomyConfig(),
     val group: GroupConfig = GroupConfig(),
+    val debug: EngineDebugConfig = EngineDebugConfig(),
     /** Maps class name (e.g. "WARRIOR") to a fully-qualified RoomId string for new-character placement. */
     val classStartRooms: Map<String, String> = emptyMap(),
+)
+
+data class EngineDebugConfig(
+    val enableSwarmClass: Boolean = false,
 )
 
 data class ProgressionConfig(

--- a/src/main/kotlin/dev/ambon/domain/PlayerClass.kt
+++ b/src/main/kotlin/dev/ambon/domain/PlayerClass.kt
@@ -4,14 +4,19 @@ enum class PlayerClass(
     val displayName: String,
     val hpPerLevel: Int,
     val manaPerLevel: Int,
+    val debugOnly: Boolean = false,
 ) {
     WARRIOR("Warrior", hpPerLevel = 3, manaPerLevel = 2),
     MAGE("Mage", hpPerLevel = 1, manaPerLevel = 8),
     CLERIC("Cleric", hpPerLevel = 2, manaPerLevel = 6),
     ROGUE("Rogue", hpPerLevel = 2, manaPerLevel = 4),
+    SWARM("Swarm", hpPerLevel = 2, manaPerLevel = 3, debugOnly = true),
     ;
 
     companion object {
         fun fromString(s: String): PlayerClass? = entries.firstOrNull { it.name.equals(s, ignoreCase = true) }
+
+        fun selectable(debugClassesEnabled: Boolean = false): List<PlayerClass> =
+            entries.filter { !it.debugOnly || debugClassesEnabled }
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -4,6 +4,7 @@ import dev.ambon.bus.InboundBus
 import dev.ambon.bus.OutboundBus
 import dev.ambon.config.EngineConfig
 import dev.ambon.config.LoginConfig
+import dev.ambon.domain.PlayerClass
 import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
@@ -119,6 +120,7 @@ class GameEngine(
             handoffManager = handoffManager,
             getEngineScope = { engineScope },
             metrics = metrics,
+            availableClasses = PlayerClass.selectable(engineConfig.debug.enableSwarmClass),
             maxWrongPasswordRetries = loginConfig.maxWrongPasswordRetries,
             maxFailedLoginAttemptsBeforeDisconnect = loginConfig.maxFailedAttemptsBeforeDisconnect,
         )

--- a/src/main/kotlin/dev/ambon/engine/PlayerRegistryFactory.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerRegistryFactory.kt
@@ -1,0 +1,33 @@
+package dev.ambon.engine
+
+import dev.ambon.config.EngineConfig
+import dev.ambon.domain.PlayerClass
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.persistence.PlayerRepository
+import java.time.Clock
+import kotlin.coroutines.CoroutineContext
+
+fun resolveClassStartRooms(engineConfig: EngineConfig): Map<PlayerClass, RoomId> =
+    engineConfig.classStartRooms
+        .mapNotNull { (key, value) -> PlayerClass.fromString(key)?.to(RoomId(value)) }
+        .toMap()
+
+fun createPlayerRegistry(
+    startRoom: RoomId,
+    engineConfig: EngineConfig,
+    repo: PlayerRepository,
+    items: ItemRegistry,
+    clock: Clock,
+    progression: PlayerProgression,
+    hashingContext: CoroutineContext,
+): PlayerRegistry =
+    PlayerRegistry(
+        startRoom = startRoom,
+        classStartRooms = resolveClassStartRooms(engineConfig),
+        repo = repo,
+        items = items,
+        clock = clock,
+        progression = progression,
+        hashingContext = hashingContext,
+    )

--- a/src/main/kotlin/dev/ambon/engine/events/LoginFlowHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/LoginFlowHandler.kt
@@ -121,6 +121,7 @@ internal class LoginFlowHandler(
     private val handoffManager: HandoffManager?,
     private val getEngineScope: () -> CoroutineScope,
     private val metrics: GameMetrics,
+    private val availableClasses: List<PlayerClass>,
     maxWrongPasswordRetries: Int,
     maxFailedLoginAttemptsBeforeDisconnect: Int,
 ) {
@@ -280,11 +281,11 @@ internal class LoginFlowHandler(
         state: LoginState.AwaitingClassSelection,
     ) {
         val input = line.trim()
-        val classes = PlayerClass.entries
+        val classes = availableClasses
         val playerClass =
             input.toIntOrNull()?.let { num ->
                 if (num in 1..classes.size) classes[num - 1] else null
-            } ?: PlayerClass.fromString(input)
+            } ?: classes.firstOrNull { it.name.equals(input, ignoreCase = true) }
 
         if (playerClass == null) {
             outbound.send(OutboundEvent.SendError(sessionId, "Invalid choice. Enter a number or class name."))
@@ -574,7 +575,7 @@ internal class LoginFlowHandler(
 
     private suspend fun promptForClassSelection(sessionId: SessionId) {
         outbound.send(OutboundEvent.SendInfo(sessionId, "Choose your class:"))
-        for ((index, pc) in PlayerClass.entries.withIndex()) {
+        for ((index, pc) in availableClasses.withIndex()) {
             outbound.send(
                 OutboundEvent.SendInfo(
                     sessionId,

--- a/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
+++ b/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
@@ -15,7 +15,7 @@ import dev.ambon.domain.world.load.PostgresWorldBootstrapper
 import dev.ambon.engine.GameEngine
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PlayerProgression
-import dev.ambon.engine.PlayerRegistry
+import dev.ambon.engine.createPlayerRegistry
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.engine.scheduler.Scheduler
 import dev.ambon.metrics.GameMetrics
@@ -205,8 +205,9 @@ class EngineServer(
         )
 
     private val players =
-        PlayerRegistry(
+        createPlayerRegistry(
             startRoom = world.startRoom,
+            engineConfig = config.engine,
             repo = playerRepo,
             items = items,
             clock = clock,

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1584,11 +1584,15 @@ ambonMUD:
             minDamage: 44
             maxDamage: 68
 
+    debug:
+      enableSwarmClass: false
+
     classStartRooms:
       WARRIOR: tutorial_glade:warrior_barracks
       MAGE: tutorial_glade:mage_study
       CLERIC: tutorial_glade:cleric_chapel
       ROGUE: tutorial_glade:rogue_hideout
+      SWARM: labyrinth:cell_00_00
 
   progression:
     maxLevel: 50

--- a/src/test/kotlin/dev/ambon/config/AppConfigLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/config/AppConfigLoaderTest.kt
@@ -33,6 +33,8 @@ class AppConfigLoaderTest {
         assertEquals(PersistenceBackend.POSTGRES, config.persistence.backend)
         assertEquals(WorldStorageBackend.POSTGRES, config.world.storage.backend)
         assertTrue(config.redis.enabled)
+        assertTrue(!config.engine.debug.enableSwarmClass)
+        assertEquals("labyrinth:cell_00_00", config.engine.classStartRooms["SWARM"])
     }
 
     @Test

--- a/src/test/kotlin/dev/ambon/engine/PlayerRegistryFactoryTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/PlayerRegistryFactoryTest.kt
@@ -1,0 +1,55 @@
+package dev.ambon.engine
+
+import dev.ambon.config.EngineConfig
+import dev.ambon.domain.PlayerClass
+import dev.ambon.domain.Race
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.persistence.InMemoryPlayerRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import java.time.Clock
+
+class PlayerRegistryFactoryTest {
+    @Test
+    fun `createPlayerRegistry applies configured class start rooms`() =
+        runTest {
+            val world = dev.ambon.test.TestWorlds.testWorld
+            val warriorRoom = RoomId("test_zone:outpost")
+            val repo = InMemoryPlayerRepository()
+            val items = ItemRegistry()
+            val registry =
+                createPlayerRegistry(
+                    startRoom = world.startRoom,
+                    engineConfig =
+                        EngineConfig(
+                            classStartRooms =
+                                mapOf(
+                                    "WARRIOR" to warriorRoom.value,
+                                ),
+                        ),
+                    repo = repo,
+                    items = items,
+                    clock = Clock.systemUTC(),
+                    progression = PlayerProgression(),
+                    hashingContext = coroutineContext,
+                )
+
+            val result =
+                registry.create(
+                    sessionId = SessionId(1),
+                    nameRaw = "WarriorSpawn",
+                    passwordRaw = "password",
+                    race = Race.HUMAN,
+                    playerClass = PlayerClass.WARRIOR,
+                )
+
+            assertEquals(CreateResult.Ok, result)
+            val player = registry.get(SessionId(1))
+            assertNotNull(player)
+            assertEquals(warriorRoom, player!!.roomId)
+        }
+}


### PR DESCRIPTION
## Summary
- move static world storage to Postgres with staged YAML import and admin re-import support
- default runtime persistence to Postgres + Redis and add a repo-local Gradle cache/home for sandbox-friendly builds
- fix engine-mode class-specific spawn wiring and add a debug-gated Swarm class that starts in labyrinth:cell_00_00

## Testing
- .\\gradlew.bat test --tests dev.ambon.engine.commands.CommandParserTest --tests dev.ambon.engine.commands.CommandRouterAdminTest --tests dev.ambon.domain.world.load.PostgresWorldBootstrapperTest
- .\\gradlew.bat test --tests dev.ambon.engine.GameEngineLoginFlowTest --tests dev.ambon.engine.PlayerRegistryFactoryTest --tests dev.ambon.config.AppConfigLoaderTest
- .\\gradlew.bat ktlintCheck
- .\\gradlew.bat test
- .\\gradlew.bat integrationTest