### PR TITLE
Make staged world imports additive

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -114,7 +114,10 @@ tasks.check {
 fun JavaExec.applyConfigOverrides() {
     project.properties
         .filter { (k, _) -> k.startsWith("config.") }
-        .forEach { (k, v) -> systemProperty("config.override.$k", v.toString()) }
+        .forEach { (k, v) ->
+            val configKey = k.removePrefix("config.")
+            systemProperty("config.override.$configKey", v.toString())
+        }
 }
 
 tasks.named<JavaExec>("run") {


### PR DESCRIPTION
## Summary
- change staged world imports to merge with existing Postgres world content instead of replacing the full world snapshot
- keep replacement semantics only when a staged file has the same source name as an existing stored document
- fix Gradle run config override mapping so -Pconfig.* properties actually reach the app at runtime

## Testing
- .\\gradlew.bat test --tests dev.ambon.domain.world.load.PostgresWorldBootstrapperTest --tests dev.ambon.config.AppConfigLoaderTest
- .\\gradlew.bat ktlintCheck
- .\\gradlew.bat test