### PR TITLE
Auto-bootstrap world from bundled resources when DB is empty

### DIFF
--- a/src/main/kotlin/dev/ambon/MudServer.kt
+++ b/src/main/kotlin/dev/ambon/MudServer.kt
@@ -196,6 +196,7 @@ class MudServer(
                 repository = PostgresWorldContentRepository(databaseManager!!.database),
                 storage = config.world.storage,
                 tiers = config.engine.mob.tiers,
+                resources = config.world.resources,
                 clock = clock,
             )
         } else {

--- a/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
+++ b/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
@@ -172,6 +172,7 @@ class EngineServer(
                 repository = PostgresWorldContentRepository(databaseManager!!.database),
                 storage = config.world.storage,
                 tiers = config.engine.mob.tiers,
+                resources = config.world.resources,
                 clock = clock,
             )
         } else {


### PR DESCRIPTION
## Summary

- `PostgresWorldBootstrapper` now falls back to the classpath resources in `world.resources` when the Postgres world DB is empty and no staged import files are present
- On first boot the bundled YAML files are read, parsed, and persisted to DB — subsequent startups read from Postgres as normal (no re-bootstrap)
- `MudServer` and `EngineServer` both pass `config.world.resources` to the bootstrapper so the default 8-zone world loads automatically out of the box
- Two new tests cover the bootstrap path and the "skip if DB already populated" guard; existing tests unchanged

## Why

Distributing the server previously required a manual import step after spinning up a fresh DB. With this change, a clean install just works — the bundled world files act as a base world seed that gets promoted to Postgres on first run.

## Test plan

- [ ] `PostgresWorldBootstrapperTest` — all 7 tests pass including the two new ones
- [ ] Fresh Postgres DB (or wiped `world_content` table): server starts and loads the full world without any staged files in `data/world-import`
- [ ] Existing populated DB: bootstrap is skipped, world loads from Postgres as before
