### PR TITLE
Add player-to-player mail system

### DIFF
--- a/src/main/kotlin/dev/ambon/MudServer.kt
+++ b/src/main/kotlin/dev/ambon/MudServer.kt
@@ -12,8 +12,6 @@ import dev.ambon.bus.RedisOutboundBus
 import dev.ambon.config.AppConfig
 import dev.ambon.config.PersistenceBackend
 import dev.ambon.config.ShardingRegistryType
-import dev.ambon.domain.PlayerClass
-import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.world.WorldFactory
 import dev.ambon.engine.GameEngine
 import dev.ambon.engine.MobRegistry

--- a/src/main/kotlin/dev/ambon/domain/mail/MailMessage.kt
+++ b/src/main/kotlin/dev/ambon/domain/mail/MailMessage.kt
@@ -1,0 +1,9 @@
+package dev.ambon.domain.mail
+
+data class MailMessage(
+    val id: String,
+    val fromName: String,
+    val body: String,
+    val sentAtEpochMs: Long,
+    val read: Boolean = false,
+)

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -26,6 +26,7 @@ import dev.ambon.engine.commands.handlers.DialogueQuestHandler
 import dev.ambon.engine.commands.handlers.EngineContext
 import dev.ambon.engine.commands.handlers.GroupHandler
 import dev.ambon.engine.commands.handlers.ItemHandler
+import dev.ambon.engine.commands.handlers.MailHandler
 import dev.ambon.engine.commands.handlers.NavigationHandler
 import dev.ambon.engine.commands.handlers.ProgressionHandler
 import dev.ambon.engine.commands.handlers.ShopHandler
@@ -165,7 +166,13 @@ class GameEngine(
                 outbound.send(OutboundEvent.SendInfo(sid, "You are between zones. Please wait..."))
                 outbound.send(OutboundEvent.SendPrompt(sid))
             },
-            routeCommandLine = { sid, line -> router.handle(sid, CommandParser.parse(line)) },
+            routeCommandLine = { sid, line ->
+                if (players.get(sid)?.mailCompose != null) {
+                    mailHandler.handleComposeLine(sid, line)
+                } else {
+                    router.handle(sid, CommandParser.parse(line))
+                }
+            },
             metrics = metrics,
         )
     }
@@ -484,6 +491,7 @@ class GameEngine(
         )
 
     private val router = CommandRouter(outbound = outbound, players = players)
+    private lateinit var mailHandler: MailHandler
 
     init {
         val crossZoneMove: (suspend (SessionId, RoomId) -> Unit)? = if (handoffManager != null) ::handleCrossZoneMove else null
@@ -576,6 +584,9 @@ class GameEngine(
                 onPhase = phaseCallback,
             ),
         ).forEach { it.register(router) }
+
+        mailHandler = MailHandler(ctx = ctx, clock = clock)
+        mailHandler.register(router)
     }
 
     /**

--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -3,6 +3,7 @@ package dev.ambon.engine
 import dev.ambon.domain.achievement.AchievementState
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.mail.MailMessage
 import dev.ambon.domain.mob.MobState
 import dev.ambon.domain.quest.QuestState
 import dev.ambon.engine.items.ItemRegistry
@@ -41,7 +42,15 @@ data class PlayerState(
     var unlockedAchievementIds: Set<String> = emptySet(),
     var achievementProgress: Map<String, AchievementState> = emptyMap(),
     var activeTitle: String? = null,
+    var inbox: MutableList<MailMessage> = mutableListOf(),
+    /** Non-null while the player is composing an outgoing mail message. */
+    var mailCompose: MailComposeState? = null,
 ) {
+    data class MailComposeState(
+        val recipientName: String,
+        val lines: MutableList<String> = mutableListOf(),
+    )
+
     companion object {
         const val BASE_MAX_HP = 10
         const val BASE_MANA = 20

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/MailHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/MailHandler.kt
@@ -1,0 +1,187 @@
+package dev.ambon.engine.commands.handlers
+
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.mail.MailMessage
+import dev.ambon.engine.PlayerState
+import dev.ambon.engine.commands.Command
+import dev.ambon.engine.commands.CommandHandler
+import dev.ambon.engine.commands.CommandRouter
+import dev.ambon.engine.commands.on
+import dev.ambon.engine.events.OutboundEvent
+import java.time.Clock
+import java.time.ZoneOffset
+import java.util.UUID
+
+class MailHandler(
+    ctx: EngineContext,
+    private val clock: Clock = Clock.systemUTC(),
+) : CommandHandler {
+    private val players = ctx.players
+    private val outbound = ctx.outbound
+
+    override fun register(router: CommandRouter) {
+        router.on<Command.Mail.List> { sid, _ -> handleList(sid) }
+        router.on<Command.Mail.Read> { sid, cmd -> handleRead(sid, cmd) }
+        router.on<Command.Mail.Delete> { sid, cmd -> handleDelete(sid, cmd) }
+        router.on<Command.Mail.Send> { sid, cmd -> handleSend(sid, cmd) }
+        router.on<Command.Mail.Abort> { sid, _ -> handleAbort(sid) }
+    }
+
+    /** Called by the engine before command routing when the player has an active compose state. */
+    suspend fun handleComposeLine(
+        sessionId: SessionId,
+        line: String,
+    ) {
+        val ps = players.get(sessionId) ?: return
+        val compose = ps.mailCompose ?: return
+
+        if (line.trim() == ".") {
+            finishCompose(sessionId, ps, compose)
+        } else {
+            compose.lines.add(line)
+            outbound.send(OutboundEvent.SendInfo(sessionId, "> "))
+        }
+    }
+
+    private suspend fun handleList(sessionId: SessionId) {
+        players.withPlayer(sessionId) { me ->
+            if (me.inbox.isEmpty()) {
+                outbound.send(OutboundEvent.SendInfo(sessionId, "Your inbox is empty."))
+                return@withPlayer
+            }
+            outbound.send(OutboundEvent.SendInfo(sessionId, "-- Inbox (${me.inbox.size} message(s)) --"))
+            me.inbox.forEachIndexed { index, msg ->
+                val marker = if (!msg.read) "[NEW] " else "      "
+                val date = java.time.Instant.ofEpochMilli(msg.sentAtEpochMs)
+                    .atZone(ZoneOffset.UTC)
+                    .toLocalDate()
+                outbound.send(OutboundEvent.SendInfo(sessionId, "${index + 1}. $marker From: ${msg.fromName}  ($date)"))
+            }
+            outbound.send(OutboundEvent.SendInfo(sessionId, "Type 'mail read <n>' to read a message."))
+        }
+    }
+
+    private suspend fun handleRead(
+        sessionId: SessionId,
+        cmd: Command.Mail.Read,
+    ) {
+        players.withPlayer(sessionId) { me ->
+            val msg = me.inbox.getOrNull(cmd.index - 1)
+            if (msg == null) {
+                outbound.send(OutboundEvent.SendError(sessionId, "No message at index ${cmd.index}."))
+                return@withPlayer
+            }
+            val date = java.time.Instant.ofEpochMilli(msg.sentAtEpochMs).atZone(ZoneOffset.UTC)
+            outbound.send(OutboundEvent.SendInfo(sessionId, "-- Message ${cmd.index} --"))
+            outbound.send(OutboundEvent.SendInfo(sessionId, "From : ${msg.fromName}"))
+            outbound.send(OutboundEvent.SendInfo(sessionId, "Sent : $date"))
+            outbound.send(OutboundEvent.SendInfo(sessionId, ""))
+            outbound.send(OutboundEvent.SendInfo(sessionId, msg.body))
+            outbound.send(OutboundEvent.SendInfo(sessionId, "-- End of message --"))
+
+            if (!msg.read) {
+                me.inbox[cmd.index - 1] = msg.copy(read = true)
+                players.persistPlayer(sessionId)
+            }
+        }
+    }
+
+    private suspend fun handleDelete(
+        sessionId: SessionId,
+        cmd: Command.Mail.Delete,
+    ) {
+        players.withPlayer(sessionId) { me ->
+            if (cmd.index < 1 || cmd.index > me.inbox.size) {
+                outbound.send(OutboundEvent.SendError(sessionId, "No message at index ${cmd.index}."))
+                return@withPlayer
+            }
+            me.inbox.removeAt(cmd.index - 1)
+            outbound.send(OutboundEvent.SendInfo(sessionId, "Message ${cmd.index} deleted."))
+            players.persistPlayer(sessionId)
+        }
+    }
+
+    private suspend fun handleSend(
+        sessionId: SessionId,
+        cmd: Command.Mail.Send,
+    ) {
+        players.withPlayer(sessionId) { me ->
+            if (me.mailCompose != null) {
+                outbound.send(
+                    OutboundEvent.SendError(
+                        sessionId,
+                        "You are already composing a message. Type '.' to send or 'mail abort' to cancel.",
+                    ),
+                )
+                return@withPlayer
+            }
+            me.mailCompose = PlayerState.MailComposeState(recipientName = cmd.recipientName)
+            outbound.send(OutboundEvent.SendInfo(sessionId, "Composing mail to ${cmd.recipientName}."))
+            outbound.send(
+                OutboundEvent.SendInfo(sessionId, "Enter your message line by line. Type '.' alone to send, or 'mail abort' to cancel."),
+            )
+            outbound.send(OutboundEvent.SendInfo(sessionId, "> "))
+        }
+    }
+
+    private suspend fun handleAbort(sessionId: SessionId) {
+        players.withPlayer(sessionId) { me ->
+            if (me.mailCompose == null) {
+                outbound.send(OutboundEvent.SendError(sessionId, "You are not composing a message."))
+                return@withPlayer
+            }
+            me.mailCompose = null
+            outbound.send(OutboundEvent.SendInfo(sessionId, "Message composition cancelled."))
+        }
+    }
+
+    private suspend fun finishCompose(
+        sessionId: SessionId,
+        sender: PlayerState,
+        compose: PlayerState.MailComposeState,
+    ) {
+        sender.mailCompose = null
+
+        if (compose.lines.isEmpty()) {
+            outbound.send(OutboundEvent.SendError(sessionId, "Message is empty. Mail not sent."))
+            outbound.send(OutboundEvent.SendPrompt(sessionId))
+            return
+        }
+
+        val message = MailMessage(
+            id = UUID.randomUUID().toString(),
+            fromName = sender.name,
+            body = compose.lines.joinToString("\n"),
+            sentAtEpochMs = clock.millis(),
+        )
+
+        val recipientOnline = players.getByName(compose.recipientName)
+        if (recipientOnline != null) {
+            recipientOnline.inbox.add(message)
+            players.persistPlayer(recipientOnline.sessionId)
+            outbound.send(OutboundEvent.SendInfo(sessionId, "Mail delivered to ${recipientOnline.name}."))
+            if (recipientOnline.sessionId != sessionId) {
+                outbound.send(
+                    OutboundEvent.SendInfo(
+                        recipientOnline.sessionId,
+                        "You have new mail from ${sender.name}. Type 'mail' to read it.",
+                    ),
+                )
+            }
+        } else {
+            val delivered = players.deliverMailOffline(compose.recipientName, message)
+            if (!delivered) {
+                outbound.send(
+                    OutboundEvent.SendError(
+                        sessionId,
+                        "No player named '${compose.recipientName}' found. Mail not sent.",
+                    ),
+                )
+                outbound.send(OutboundEvent.SendPrompt(sessionId))
+                return
+            }
+            outbound.send(OutboundEvent.SendInfo(sessionId, "Mail delivered to ${compose.recipientName}."))
+        }
+        outbound.send(OutboundEvent.SendPrompt(sessionId))
+    }
+}

--- a/src/main/kotlin/dev/ambon/engine/events/LoginFlowHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/LoginFlowHandler.kt
@@ -485,6 +485,16 @@ internal class LoginFlowHandler(
             gmcpEmitter.sendGroupInfo(sessionId, leader, members)
         }
         router.handle(sessionId, Command.Look)
+
+        val unread = me.inbox.count { !it.read }
+        if (unread > 0) {
+            outbound.send(
+                OutboundEvent.SendInfo(
+                    sessionId,
+                    "You have $unread unread mail message(s). Type 'mail' to read.",
+                ),
+            )
+        }
     }
 
     private suspend fun ensureLoginRoomAvailable(

--- a/src/main/kotlin/dev/ambon/persistence/PlayerDto.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayerDto.kt
@@ -2,6 +2,7 @@ package dev.ambon.persistence
 
 import dev.ambon.domain.achievement.AchievementState
 import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.mail.MailMessage
 import dev.ambon.domain.quest.QuestState
 
 /**
@@ -36,6 +37,7 @@ internal data class PlayerDto(
     val unlockedAchievementIds: Set<String> = emptySet(),
     val achievementProgress: Map<String, AchievementState> = emptyMap(),
     val activeTitle: String? = null,
+    val inbox: List<MailMessage> = emptyList(),
 ) {
     fun toDomain(): PlayerRecord {
         // Legacy migration: old files/cache stored constitution=0; remap to base 10
@@ -67,6 +69,7 @@ internal data class PlayerDto(
             unlockedAchievementIds = unlockedAchievementIds,
             achievementProgress = achievementProgress,
             activeTitle = activeTitle,
+            inbox = inbox,
         )
     }
 
@@ -99,6 +102,7 @@ internal data class PlayerDto(
                 unlockedAchievementIds = record.unlockedAchievementIds,
                 achievementProgress = record.achievementProgress,
                 activeTitle = record.activeTitle,
+                inbox = record.inbox,
             )
     }
 }

--- a/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
@@ -2,6 +2,7 @@ package dev.ambon.persistence
 
 import dev.ambon.domain.achievement.AchievementState
 import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.mail.MailMessage
 import dev.ambon.domain.quest.QuestState
 
 @JvmInline
@@ -36,4 +37,5 @@ data class PlayerRecord(
     val unlockedAchievementIds: Set<String> = emptySet(),
     val achievementProgress: Map<String, AchievementState> = emptyMap(),
     val activeTitle: String? = null,
+    val inbox: List<MailMessage> = emptyList(),
 )

--- a/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
@@ -30,6 +30,7 @@ object PlayersTable : Table("players") {
     val unlockedAchievementIds = text("unlocked_achievement_ids").default("[]")
     val achievementProgress = text("achievement_progress").default("{}")
     val activeTitle = varchar("active_title", 64).nullable()
+    val mailInbox = text("mail_inbox").default("[]")
 
     override val primaryKey = PrimaryKey(id)
 }

--- a/src/main/kotlin/dev/ambon/persistence/PostgresPlayerRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PostgresPlayerRepository.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import dev.ambon.domain.achievement.AchievementState
+import dev.ambon.domain.mail.MailMessage
 import dev.ambon.domain.quest.QuestState
 import dev.ambon.metrics.GameMetrics
 import kotlinx.coroutines.Dispatchers
@@ -21,6 +22,7 @@ private val activeQuestsType = object : TypeReference<Map<String, QuestState>>()
 private val completedQuestIdsType = object : TypeReference<Set<String>>() {}
 private val unlockedAchievementIdsType = object : TypeReference<Set<String>>() {}
 private val achievementProgressType = object : TypeReference<Map<String, AchievementState>>() {}
+private val mailInboxType = object : TypeReference<List<MailMessage>>() {}
 
 class PostgresPlayerRepository(
     private val database: Database,
@@ -114,6 +116,7 @@ class PostgresPlayerRepository(
                     it[unlockedAchievementIds] = questMapper.writeValueAsString(dto.unlockedAchievementIds)
                     it[achievementProgress] = questMapper.writeValueAsString(dto.achievementProgress)
                     it[activeTitle] = dto.activeTitle
+                    it[mailInbox] = questMapper.writeValueAsString(dto.inbox)
                 }
             }
         }
@@ -159,5 +162,9 @@ class PostgresPlayerRepository(
                     questMapper.readValue(this[PlayersTable.achievementProgress], achievementProgressType)
                 }.getOrDefault(emptyMap()),
             activeTitle = this[PlayersTable.activeTitle],
+            inbox =
+                runCatching {
+                    questMapper.readValue(this[PlayersTable.mailInbox], mailInboxType)
+                }.getOrDefault(emptyList()),
         ).toDomain()
 }

--- a/src/main/resources/db/migration/V9__add_player_mail.sql
+++ b/src/main/resources/db/migration/V9__add_player_mail.sql
@@ -1,0 +1,1 @@
+ALTER TABLE players ADD COLUMN mail_inbox TEXT NOT NULL DEFAULT '[]';

--- a/src/test/kotlin/dev/ambon/engine/commands/MailHandlerTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/MailHandlerTest.kt
@@ -1,0 +1,379 @@
+package dev.ambon.engine.commands
+
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.mail.MailMessage
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.CommandRouterHarness
+import dev.ambon.test.MutableClock
+import dev.ambon.test.TestWorlds
+import dev.ambon.test.buildTestPlayerRegistry
+import dev.ambon.test.createTestPlayer
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MailHandlerTest {
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private fun harness(repo: InMemoryPlayerRepository = InMemoryPlayerRepository()): CommandRouterHarness {
+        val players = buildTestPlayerRegistry(TestWorlds.testWorld.startRoom, repo)
+        return CommandRouterHarness.create(players = players, repo = repo)
+    }
+
+    // -------------------------------------------------------------------------
+    // mail list
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `mail list shows empty inbox message when no messages`() =
+        runTest {
+            val h = harness()
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Alice")
+            h.drain()
+
+            h.router.handle(sid, Command.Mail.List)
+
+            val texts = h.drain().filterIsInstance<OutboundEvent.SendInfo>().map { it.text }
+            assertTrue(texts.any { it.contains("empty", ignoreCase = true) }, "Expected empty-inbox message. got=$texts")
+        }
+
+    @Test
+    fun `mail list shows messages with unread markers`() =
+        runTest {
+            val h = harness()
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Alice")
+            val ps = h.players.get(sid)!!
+
+            ps.inbox.add(MailMessage(id = "1", fromName = "Bob", body = "Hello!", sentAtEpochMs = 1000L, read = false))
+            ps.inbox.add(MailMessage(id = "2", fromName = "Eve", body = "Hey", sentAtEpochMs = 2000L, read = true))
+            h.drain()
+
+            h.router.handle(sid, Command.Mail.List)
+
+            val texts = h.drain().filterIsInstance<OutboundEvent.SendInfo>().map { it.text }
+            assertTrue(texts.any { it.contains("[NEW]") && it.contains("Bob") }, "Expected [NEW] marker for unread. got=$texts")
+            assertTrue(texts.any { it.contains("Eve") && !it.contains("[NEW]") }, "Expected no marker for read. got=$texts")
+        }
+
+    // -------------------------------------------------------------------------
+    // mail read
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `mail read displays message body and marks it as read`() =
+        runTest {
+            val h = harness()
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Alice")
+            val ps = h.players.get(sid)!!
+            ps.inbox.add(MailMessage(id = "1", fromName = "Bob", body = "Hi there!", sentAtEpochMs = 0L, read = false))
+            h.drain()
+
+            h.router.handle(sid, Command.Mail.Read(1))
+
+            val texts = h.drain().filterIsInstance<OutboundEvent.SendInfo>().map { it.text }
+            assertTrue(texts.any { it.contains("Hi there!") }, "Expected message body. got=$texts")
+            assertTrue(ps.inbox[0].read, "Message should be marked as read")
+        }
+
+    @Test
+    fun `mail read returns error for out-of-range index`() =
+        runTest {
+            val h = harness()
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Alice")
+            h.drain()
+
+            h.router.handle(sid, Command.Mail.Read(99))
+
+            val errors = h.drain().filterIsInstance<OutboundEvent.SendError>()
+            assertTrue(errors.isNotEmpty(), "Expected error for invalid index")
+        }
+
+    // -------------------------------------------------------------------------
+    // mail delete
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `mail delete removes message at given index`() =
+        runTest {
+            val h = harness()
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Alice")
+            val ps = h.players.get(sid)!!
+            ps.inbox.add(MailMessage(id = "1", fromName = "Bob", body = "Delete me", sentAtEpochMs = 0L))
+            ps.inbox.add(MailMessage(id = "2", fromName = "Eve", body = "Keep me", sentAtEpochMs = 0L))
+            h.drain()
+
+            h.router.handle(sid, Command.Mail.Delete(1))
+
+            assertEquals(1, ps.inbox.size, "Inbox should have 1 message after delete")
+            assertEquals("Eve", ps.inbox[0].fromName, "Remaining message should be from Eve")
+            val texts = h.drain().filterIsInstance<OutboundEvent.SendInfo>().map { it.text }
+            assertTrue(texts.any { it.contains("deleted", ignoreCase = true) }, "Expected deletion confirmation. got=$texts")
+        }
+
+    @Test
+    fun `mail delete returns error for out-of-range index`() =
+        runTest {
+            val h = harness()
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Alice")
+            h.drain()
+
+            h.router.handle(sid, Command.Mail.Delete(5))
+
+            val errors = h.drain().filterIsInstance<OutboundEvent.SendError>()
+            assertTrue(errors.isNotEmpty(), "Expected error for invalid delete index")
+        }
+
+    // -------------------------------------------------------------------------
+    // compose flow: mail send → lines → .
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `mail send starts compose mode`() =
+        runTest {
+            val h = harness()
+            val alice = SessionId(1)
+            val bob = SessionId(2)
+            h.loginPlayer(alice, "Alice")
+            h.loginPlayer(bob, "Bob")
+            h.drain()
+
+            h.router.handle(alice, Command.Mail.Send("Bob"))
+
+            val alicePs = h.players.get(alice)!!
+            assertNotNull(alicePs.mailCompose, "Alice should be in compose mode")
+            assertEquals("Bob", alicePs.mailCompose?.recipientName)
+        }
+
+    @Test
+    fun `compose lines accumulate until dot terminates and delivers to online recipient`() =
+        runTest {
+            val repo = InMemoryPlayerRepository()
+            val clock = MutableClock(1000L)
+            val players = buildTestPlayerRegistry(TestWorlds.testWorld.startRoom, repo, clock = clock)
+            val h = CommandRouterHarness.create(players = players, repo = repo)
+
+            val alice = SessionId(1)
+            val bob = SessionId(2)
+            h.loginPlayer(alice, "Alice")
+            h.loginPlayer(bob, "Bob")
+            h.drain()
+
+            // Start compose
+            h.router.handle(alice, Command.Mail.Send("Bob"))
+            h.drain()
+
+            // Simulate compose lines via the mail handler directly
+            val mailHandler = dev.ambon.engine.commands.handlers.MailHandler(
+                ctx = dev.ambon.engine.commands.handlers.EngineContext(
+                    players = players,
+                    mobs = h.mobs,
+                    world = h.world,
+                    items = h.items,
+                    outbound = h.outbound,
+                    combat = h.combat,
+                    gmcpEmitter = null,
+                    worldState = null,
+                ),
+                clock = clock,
+            )
+            mailHandler.handleComposeLine(alice, "Hello Bob,")
+            mailHandler.handleComposeLine(alice, "How are you?")
+            mailHandler.handleComposeLine(alice, ".")
+
+            val bobPs = h.players.get(bob)!!
+            assertEquals(1, bobPs.inbox.size, "Bob should have 1 message")
+            assertEquals("Alice", bobPs.inbox[0].fromName)
+            assertEquals("Hello Bob,\nHow are you?", bobPs.inbox[0].body)
+            assertFalse(bobPs.inbox[0].read, "Message should be unread")
+
+            val alicePs = h.players.get(alice)!!
+            assertEquals(null, alicePs.mailCompose, "Alice should not be in compose mode after sending")
+        }
+
+    @Test
+    fun `dot with empty body does not send mail`() =
+        runTest {
+            val h = harness()
+            val alice = SessionId(1)
+            val bob = SessionId(2)
+            h.loginPlayer(alice, "Alice")
+            h.loginPlayer(bob, "Bob")
+            h.drain()
+
+            h.router.handle(alice, Command.Mail.Send("Bob"))
+            h.drain()
+
+            val mailHandler = dev.ambon.engine.commands.handlers.MailHandler(
+                ctx = dev.ambon.engine.commands.handlers.EngineContext(
+                    players = h.players,
+                    mobs = h.mobs,
+                    world = h.world,
+                    items = h.items,
+                    outbound = h.outbound,
+                    combat = h.combat,
+                    gmcpEmitter = null,
+                    worldState = null,
+                ),
+            )
+            mailHandler.handleComposeLine(alice, ".")
+
+            val bobPs = h.players.get(bob)!!
+            assertEquals(0, bobPs.inbox.size, "Bob should have 0 messages for empty body")
+
+            val errors = h.drain().filterIsInstance<OutboundEvent.SendError>()
+            assertTrue(errors.any { it.text.contains("empty", ignoreCase = true) }, "Expected empty-body error. got=$errors")
+        }
+
+    // -------------------------------------------------------------------------
+    // mail abort
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `mail abort cancels in-progress compose`() =
+        runTest {
+            val h = harness()
+            val alice = SessionId(1)
+            val bob = SessionId(2)
+            h.loginPlayer(alice, "Alice")
+            h.loginPlayer(bob, "Bob")
+            h.drain()
+
+            h.router.handle(alice, Command.Mail.Send("Bob"))
+            h.drain()
+
+            h.router.handle(alice, Command.Mail.Abort)
+
+            val alicePs = h.players.get(alice)!!
+            assertEquals(null, alicePs.mailCompose, "Compose state should be cleared after abort")
+            val texts = h.drain().filterIsInstance<OutboundEvent.SendInfo>().map { it.text }
+            assertTrue(texts.any { it.contains("cancel", ignoreCase = true) }, "Expected cancellation message. got=$texts")
+        }
+
+    @Test
+    fun `mail abort when not composing returns error`() =
+        runTest {
+            val h = harness()
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Alice")
+            h.drain()
+
+            h.router.handle(sid, Command.Mail.Abort)
+
+            val errors = h.drain().filterIsInstance<OutboundEvent.SendError>()
+            assertTrue(errors.isNotEmpty(), "Expected error when aborting without active compose")
+        }
+
+    // -------------------------------------------------------------------------
+    // Offline delivery
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `mail delivers to offline player via repository`() =
+        runTest {
+            val repo = InMemoryPlayerRepository()
+            // Pre-create offline player record
+            repo.createTestPlayer("Bob", TestWorlds.testWorld.startRoom)
+
+            val players = buildTestPlayerRegistry(TestWorlds.testWorld.startRoom, repo)
+            val h = CommandRouterHarness.create(players = players, repo = repo)
+
+            val alice = SessionId(1)
+            h.loginPlayer(alice, "Alice")
+            h.drain()
+
+            h.router.handle(alice, Command.Mail.Send("Bob"))
+            h.drain()
+
+            val mailHandler = dev.ambon.engine.commands.handlers.MailHandler(
+                ctx = dev.ambon.engine.commands.handlers.EngineContext(
+                    players = players,
+                    mobs = h.mobs,
+                    world = h.world,
+                    items = h.items,
+                    outbound = h.outbound,
+                    combat = h.combat,
+                    gmcpEmitter = null,
+                    worldState = null,
+                ),
+            )
+            mailHandler.handleComposeLine(alice, "Offline message")
+            mailHandler.handleComposeLine(alice, ".")
+
+            val bobRecord = repo.findByName("Bob")
+            assertNotNull(bobRecord, "Bob's record should still exist")
+            assertEquals(1, bobRecord!!.inbox.size, "Bob's record should have 1 mail")
+            assertEquals("Alice", bobRecord.inbox[0].fromName)
+            assertEquals("Offline message", bobRecord.inbox[0].body)
+        }
+
+    @Test
+    fun `mail to unknown player returns error`() =
+        runTest {
+            val h = harness()
+            val alice = SessionId(1)
+            h.loginPlayer(alice, "Alice")
+            h.drain()
+
+            h.router.handle(alice, Command.Mail.Send("NoSuchPlayer"))
+            h.drain()
+
+            val mailHandler = dev.ambon.engine.commands.handlers.MailHandler(
+                ctx = dev.ambon.engine.commands.handlers.EngineContext(
+                    players = h.players,
+                    mobs = h.mobs,
+                    world = h.world,
+                    items = h.items,
+                    outbound = h.outbound,
+                    combat = h.combat,
+                    gmcpEmitter = null,
+                    worldState = null,
+                ),
+            )
+            mailHandler.handleComposeLine(alice, "Hello?")
+            mailHandler.handleComposeLine(alice, ".")
+
+            val errors = h.drain().filterIsInstance<OutboundEvent.SendError>()
+            assertTrue(
+                errors.any { it.text.contains("not found", ignoreCase = true) || it.text.contains("No player", ignoreCase = true) },
+                "Expected not-found error. got=$errors",
+            )
+        }
+
+    // -------------------------------------------------------------------------
+    // Double-compose guard
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `mail send while already composing returns error`() =
+        runTest {
+            val h = harness()
+            val alice = SessionId(1)
+            val bob = SessionId(2)
+            h.loginPlayer(alice, "Alice")
+            h.loginPlayer(bob, "Bob")
+            h.drain()
+
+            h.router.handle(alice, Command.Mail.Send("Bob"))
+            h.drain()
+
+            // Try to start another compose while one is active
+            h.router.handle(alice, Command.Mail.Send("Bob"))
+
+            val errors = h.drain().filterIsInstance<OutboundEvent.SendError>()
+            assertTrue(errors.isNotEmpty(), "Expected error when starting compose while already composing")
+        }
+}

--- a/src/test/kotlin/dev/ambon/engine/commands/RouterTestHelper.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/RouterTestHelper.kt
@@ -20,6 +20,7 @@ import dev.ambon.engine.commands.handlers.DialogueQuestHandler
 import dev.ambon.engine.commands.handlers.EngineContext
 import dev.ambon.engine.commands.handlers.GroupHandler
 import dev.ambon.engine.commands.handlers.ItemHandler
+import dev.ambon.engine.commands.handlers.MailHandler
 import dev.ambon.engine.commands.handlers.NavigationHandler
 import dev.ambon.engine.commands.handlers.ProgressionHandler
 import dev.ambon.engine.commands.handlers.ShopHandler
@@ -85,6 +86,7 @@ internal fun buildTestRouter(
         DialogueQuestHandler(ctx = ctx),
         GroupHandler(ctx = ctx, groupSystem = groupSystem),
         WorldFeaturesHandler(ctx = ctx),
+        MailHandler(ctx = ctx),
         AdminHandler(
             ctx = ctx,
             onShutdown = onShutdown,

--- a/src/test/kotlin/dev/ambon/persistence/YamlPlayerRepositoryTest.kt
+++ b/src/test/kotlin/dev/ambon/persistence/YamlPlayerRepositoryTest.kt
@@ -283,4 +283,27 @@ class YamlPlayerRepositoryTest {
                 assertTrue(error!!.message!!.contains("taken", ignoreCase = true))
             }
         }
+
+    @Test
+    fun `save and reload preserves mail inbox`() =
+        runTest {
+            val repo = YamlPlayerRepository(tmp)
+            val r = repo.create(PlayerCreationRequest("Alice", RoomId("test:a"), 0L, testHash, ansiEnabled = false))
+            val mail =
+                dev.ambon.domain.mail.MailMessage(
+                    id = "abc123",
+                    fromName = "Bob",
+                    body = "Hello Alice!",
+                    sentAtEpochMs = 9000L,
+                    read = false,
+                )
+            repo.save(r.copy(inbox = listOf(mail)))
+
+            val loaded = repo.findById(r.id)!!
+            assertEquals(1, loaded.inbox.size)
+            assertEquals("abc123", loaded.inbox[0].id)
+            assertEquals("Bob", loaded.inbox[0].fromName)
+            assertEquals("Hello Alice!", loaded.inbox[0].body)
+            assertFalse(loaded.inbox[0].read)
+        }
 }


### PR DESCRIPTION
  Adds a persistent in-game mail system so players can leave messages for each other, even when the recipient is offline.

  Commands:
  - mail / mail list — list inbox with [NEW] markers for unread messages
  - mail read <n> — display a message and mark it read
  - mail delete <n> — remove a message
  - mail send <player> — enter multi-line compose mode; . alone sends, mail abort cancels

  Implementation highlights:
  - MailMessage domain type in dev.ambon.domain.mail
  - inbox field on PlayerRecord (persisted to YAML/Postgres) and PlayerState (runtime)
  - Compose state tracked in PlayerState.MailComposeState; GameEngine.routeCommandLine intercepts lines during compose mode
  - PlayerRegistry.deliverMailOffline handles delivery to offline players via the repository
  - Login notification for unread messages
  - Flyway V9 migration adds mail_inbox JSON column to Postgres
  - 12 unit tests covering all commands, compose flow, offline delivery, and edge cases