### PR TITLE
Add inn recall system

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/world/data/DialogueNodeFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/DialogueNodeFile.kt
@@ -10,4 +10,5 @@ data class DialogueChoiceFile(
     val next: String? = null,
     val minLevel: Int? = null,
     val requiredClass: String? = null,
+    val action: String? = null,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -894,6 +894,7 @@ object WorldLoader {
                         nextNodeId = nextNodeId,
                         minLevel = choiceFile.minLevel,
                         requiredClass = choiceFile.requiredClass,
+                        action = choiceFile.action,
                     )
                 }
             nodes[key] = DialogueNode(text = nodeFile.text, choices = choices)

--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -45,6 +45,9 @@ data class PlayerState(
     var inbox: MutableList<MailMessage> = mutableListOf(),
     /** Non-null while the player is composing an outgoing mail message. */
     var mailCompose: MailComposeState? = null,
+    var recallRoomId: RoomId? = null,
+    /** Epoch-ms timestamp after which recall is available again. Runtime-only; not persisted. */
+    var recallCooldownUntilMs: Long = 0L,
 ) {
     data class MailComposeState(
         val recipientName: String,

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -87,6 +87,8 @@ sealed interface Command {
 
     data object Flee : Command
 
+    data object Recall : Command
+
     data object Score : Command
 
     data class Goto(
@@ -601,6 +603,7 @@ object CommandParser {
             "d", "down" -> Command.Move(Direction.DOWN)
             "exits", "ex" -> Command.Exits
             "flee" -> Command.Flee
+            "recall" -> Command.Recall
             "score", "sc" -> Command.Score
             "spells", "abilities", "skills" -> Command.Spells
             "effects", "buffs", "debuffs" -> Command.Effects

--- a/src/main/kotlin/dev/ambon/engine/dialogue/DialogueOutcome.kt
+++ b/src/main/kotlin/dev/ambon/engine/dialogue/DialogueOutcome.kt
@@ -1,0 +1,14 @@
+package dev.ambon.engine.dialogue
+
+/** Result of [DialogueSystem.selectChoice]. */
+sealed interface DialogueOutcome {
+    /** The choice was processed; [action] is non-null if the choice carries a side-effect. */
+    data class Ok(
+        val action: String? = null,
+    ) : DialogueOutcome
+
+    /** The choice could not be processed; [message] describes why. */
+    data class Err(
+        val message: String,
+    ) : DialogueOutcome
+}

--- a/src/main/kotlin/dev/ambon/engine/dialogue/DialogueTree.kt
+++ b/src/main/kotlin/dev/ambon/engine/dialogue/DialogueTree.kt
@@ -15,4 +15,5 @@ data class DialogueChoice(
     val nextNodeId: String?,
     val minLevel: Int?,
     val requiredClass: String?,
+    val action: String? = null,
 )

--- a/src/main/kotlin/dev/ambon/persistence/PlayerDto.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayerDto.kt
@@ -38,6 +38,7 @@ internal data class PlayerDto(
     val achievementProgress: Map<String, AchievementState> = emptyMap(),
     val activeTitle: String? = null,
     val inbox: List<MailMessage> = emptyList(),
+    val recallRoomId: String? = null,
 ) {
     fun toDomain(): PlayerRecord {
         // Legacy migration: old files/cache stored constitution=0; remap to base 10
@@ -70,6 +71,7 @@ internal data class PlayerDto(
             achievementProgress = achievementProgress,
             activeTitle = activeTitle,
             inbox = inbox,
+            recallRoomId = recallRoomId?.let { RoomId(it) },
         )
     }
 
@@ -103,6 +105,7 @@ internal data class PlayerDto(
                 achievementProgress = record.achievementProgress,
                 activeTitle = record.activeTitle,
                 inbox = record.inbox,
+                recallRoomId = record.recallRoomId?.value,
             )
     }
 }

--- a/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
@@ -38,4 +38,5 @@ data class PlayerRecord(
     val achievementProgress: Map<String, AchievementState> = emptyMap(),
     val activeTitle: String? = null,
     val inbox: List<MailMessage> = emptyList(),
+    val recallRoomId: RoomId? = null,
 )

--- a/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
@@ -31,6 +31,7 @@ object PlayersTable : Table("players") {
     val achievementProgress = text("achievement_progress").default("{}")
     val activeTitle = varchar("active_title", 64).nullable()
     val mailInbox = text("mail_inbox").default("[]")
+    val recallRoomId = varchar("recall_room_id", 128).nullable()
 
     override val primaryKey = PrimaryKey(id)
 }

--- a/src/main/kotlin/dev/ambon/persistence/PostgresPlayerRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PostgresPlayerRepository.kt
@@ -117,6 +117,7 @@ class PostgresPlayerRepository(
                     it[achievementProgress] = questMapper.writeValueAsString(dto.achievementProgress)
                     it[activeTitle] = dto.activeTitle
                     it[mailInbox] = questMapper.writeValueAsString(dto.inbox)
+                    it[recallRoomId] = dto.recallRoomId
                 }
             }
         }
@@ -166,5 +167,6 @@ class PostgresPlayerRepository(
                 runCatching {
                     questMapper.readValue(this[PlayersTable.mailInbox], mailInboxType)
                 }.getOrDefault(emptyList()),
+            recallRoomId = this[PlayersTable.recallRoomId],
         ).toDomain()
 }

--- a/src/main/resources/db/migration/V10__add_player_recall_room.sql
+++ b/src/main/resources/db/migration/V10__add_player_recall_room.sql
@@ -1,0 +1,1 @@
+ALTER TABLE players ADD COLUMN recall_room_id VARCHAR(128);

--- a/src/main/resources/world/ambon_hub.yaml
+++ b/src/main/resources/world/ambon_hub.yaml
@@ -3,6 +3,30 @@ lifespan: 0
 startRoom: hall_of_portals
 
 mobs:
+  innkeeper:
+    name: "the Innkeeper"
+    room: wanderers_inn
+    dialogue:
+      root:
+        text: "Welcome to the Wanderer's Inn! We offer comfortable beds for weary travelers. Would you like to rent a room?"
+        choices:
+          - text: "Yes, I'd like to rent a room."
+            next: confirm
+            action: set_recall
+          - text: "What is a recall point?"
+            next: explain
+          - text: "No thanks, just passing through."
+      confirm:
+        text: "Excellent! Your room is ready whenever you need it. Type 'recall' at any time to return here instantly."
+        choices:
+          - text: "Thank you!"
+      explain:
+        text: "If you rent a room here, this inn becomes your recall point. Type 'recall' anywhere in the world to teleport back. Very handy when you're lost or in trouble!"
+        choices:
+          - text: "I'd like to rent a room, then."
+            next: confirm
+            action: set_recall
+          - text: "I'll think about it."
   portal_keeper:
     name: "the Portal Keeper"
     room: hall_of_portals
@@ -61,7 +85,14 @@ rooms:
 
   wayfinder_gallery:
     title: "Wayfinder Gallery"
-    description: "A narrow gallery lined with relief maps of places that don't exist yet. A brass needle floats over each plaque, twitching toward the hall as if eager to be used."
+    description: "A narrow gallery lined with relief maps of places that don't exist yet. A brass needle floats over each plaque, twitching toward the hall as if eager to be used. A warm glow spills from a doorway to the north."
     exits:
       e: hall_of_portals
       w: blank_arches
+      n: wanderers_inn
+
+  wanderers_inn:
+    title: "The Wanderer's Inn"
+    description: "A cozy common room filled with the scent of woodsmoke and fresh bread. Low beams cross the ceiling, hung with dried herbs. A fire crackles in a broad hearth and mismatched chairs cluster around worn tables. The innkeeper stands behind a short counter, ready to help. A sign on the wall reads: 'RENT A ROOM — type recall anytime to return here.'"
+    exits:
+      s: wayfinder_gallery

--- a/src/test/kotlin/dev/ambon/engine/commands/RecallCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/RecallCommandTest.kt
@@ -1,0 +1,207 @@
+package dev.ambon.engine.commands
+
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.mob.MobState
+import dev.ambon.engine.commands.handlers.NavigationHandler
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.test.CommandRouterHarness
+import dev.ambon.test.MutableClock
+import dev.ambon.test.buildTestPlayerRegistry
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RecallCommandTest {
+    private val startRoom = RoomId("test_zone:hub")
+    private val outpost = RoomId("test_zone:outpost")
+
+    @Test
+    fun `recall blocked while in combat`() =
+        runTest {
+            val clock = MutableClock(0L)
+            val h = CommandRouterHarness.create(clock = clock)
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Hero")
+
+            // Put mob in same room and start combat
+            val mobId = dev.ambon.domain.ids.MobId("test_zone:grunt")
+            h.mobs.upsert(MobState(id = mobId, name = "a grunt", roomId = startRoom, hp = 10, maxHp = 10))
+            h.router.handle(sid, Command.Kill("grunt"))
+            h.drain()
+
+            h.router.handle(sid, Command.Recall)
+            val outs = h.drain()
+
+            assertTrue(
+                outs.any { it is OutboundEvent.SendText && it.text.contains("cannot recall") },
+                "Expected combat-block message. got=$outs",
+            )
+            // Player should not have moved
+            assertTrue(h.players.get(sid)!!.roomId == startRoom)
+        }
+
+    @Test
+    fun `recall teleports to class start room when no recall point set`() =
+        runTest {
+            val clock = MutableClock(0L)
+            val h = CommandRouterHarness.create(clock = clock)
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Hero")
+
+            // Move player to outpost
+            h.players.moveTo(sid, outpost)
+            h.drain()
+
+            h.router.handle(sid, Command.Recall)
+            val outs = h.drain()
+
+            // Should end up back at startRoom (no recall set → falls back to start room)
+            assertTrue(
+                h.players.get(sid)!!.roomId == startRoom,
+                "Expected player to be at startRoom after recall. got=${h.players.get(sid)!!.roomId}",
+            )
+            assertTrue(
+                outs.any { it is OutboundEvent.SendText && it.text.contains("recall point") },
+                "Expected arrival message. got=$outs",
+            )
+        }
+
+    @Test
+    fun `recall teleports to saved recall room`() =
+        runTest {
+            val clock = MutableClock(0L)
+            val h = CommandRouterHarness.create(clock = clock)
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Hero")
+
+            // Set recall room to outpost while standing there
+            h.players.moveTo(sid, outpost)
+            h.players.setRecallRoom(sid, outpost)
+            h.drain()
+
+            // Move back to hub
+            h.players.moveTo(sid, startRoom)
+            h.drain()
+
+            h.router.handle(sid, Command.Recall)
+
+            assertTrue(
+                h.players.get(sid)!!.roomId == outpost,
+                "Expected player at saved recall room. got=${h.players.get(sid)!!.roomId}",
+            )
+        }
+
+    @Test
+    fun `recall blocked during cooldown`() =
+        runTest {
+            val clock = MutableClock(0L)
+            val h = CommandRouterHarness.create(clock = clock)
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Hero")
+            h.drain()
+
+            // First recall — succeeds and starts cooldown
+            h.router.handle(sid, Command.Recall)
+            h.drain()
+
+            // Second recall immediately — should be blocked
+            h.router.handle(sid, Command.Recall)
+            val outs = h.drain()
+
+            assertTrue(
+                outs.any { it is OutboundEvent.SendText && it.text.contains("seconds remaining") },
+                "Expected cooldown message. got=$outs",
+            )
+        }
+
+    @Test
+    fun `recall available again after cooldown expires`() =
+        runTest {
+            val clock = MutableClock(0L)
+            val h = CommandRouterHarness.create(clock = clock)
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Hero")
+
+            // Move to outpost and set it as recall
+            h.players.moveTo(sid, outpost)
+            h.players.setRecallRoom(sid, outpost)
+
+            // Move back to hub
+            h.players.moveTo(sid, startRoom)
+            h.drain()
+
+            // First recall — succeeds, cooldown starts
+            h.router.handle(sid, Command.Recall)
+            h.drain()
+            assertTrue(h.players.get(sid)!!.roomId == outpost)
+
+            // Move back to hub again
+            h.players.moveTo(sid, startRoom)
+            h.drain()
+
+            // Advance past cooldown
+            clock.advance(NavigationHandler.RECALL_COOLDOWN_MS + 1L)
+
+            // Second recall — should succeed
+            h.router.handle(sid, Command.Recall)
+            val outs = h.drain()
+
+            assertTrue(
+                h.players.get(sid)!!.roomId == outpost,
+                "Expected player at recall room after cooldown. got=${h.players.get(sid)!!.roomId}",
+            )
+            assertFalse(
+                outs.any { it is OutboundEvent.SendText && it.text.contains("seconds remaining") },
+                "Should not show cooldown message after cooldown expires. got=$outs",
+            )
+        }
+
+    @Test
+    fun `set_recall dialogue action sets recall room`() =
+        runTest {
+            val clock = MutableClock(0L)
+            val players = buildTestPlayerRegistry(startRoom)
+            val h = CommandRouterHarness.create(players = players, clock = clock)
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Hero")
+            h.drain()
+
+            // Directly set recall room via PlayerRegistry
+            h.players.moveTo(sid, outpost)
+            h.players.setRecallRoom(sid, outpost)
+
+            assertTrue(
+                h.players.get(sid)!!.recallRoomId == outpost,
+                "Expected recallRoomId to be outpost. got=${h.players.get(sid)!!.recallRoomId}",
+            )
+        }
+
+    @Test
+    fun `recall cooldown shows correct seconds remaining`() =
+        runTest {
+            val clock = MutableClock(0L)
+            val h = CommandRouterHarness.create(clock = clock)
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Hero")
+            h.drain()
+
+            // Trigger first recall to start cooldown
+            h.router.handle(sid, Command.Recall)
+            h.drain()
+
+            // Advance only 60 seconds (240 seconds remaining)
+            clock.advance(60_000L)
+
+            h.router.handle(sid, Command.Recall)
+            val outs = h.drain()
+
+            assertTrue(
+                outs.any { it is OutboundEvent.SendText && it.text.contains("240 seconds remaining") },
+                "Expected '240 seconds remaining'. got=$outs",
+            )
+        }
+}

--- a/src/test/kotlin/dev/ambon/engine/commands/RouterTestHelper.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/RouterTestHelper.kt
@@ -29,6 +29,7 @@ import dev.ambon.engine.commands.handlers.WorldFeaturesHandler
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.sharding.InterEngineBus
 import dev.ambon.sharding.PlayerLocationIndex
+import java.time.Clock
 
 /**
  * Builds a fully-wired [CommandRouter] suitable for use in unit tests.
@@ -54,6 +55,7 @@ internal fun buildTestRouter(
     onPhase: (suspend (SessionId, String?) -> PhaseResult)? = null,
     onCrossZoneMove: (suspend (SessionId, RoomId) -> Unit)? = null,
     worldState: WorldStateRegistry? = null,
+    clock: Clock = Clock.systemUTC(),
     shopRegistry: ShopRegistry? = null,
     economyConfig: EconomyConfig = EconomyConfig(),
 ): CommandRouter {
@@ -78,7 +80,7 @@ internal fun buildTestRouter(
             engineId = engineId,
             onRemoteWho = onRemoteWho,
         ),
-        NavigationHandler(ctx = ctx, onCrossZoneMove = onCrossZoneMove),
+        NavigationHandler(ctx = ctx, onCrossZoneMove = onCrossZoneMove, clock = clock),
         CombatHandler(ctx = ctx),
         ProgressionHandler(ctx = ctx, progression = progression, groupSystem = groupSystem),
         ItemHandler(ctx = ctx),

--- a/src/test/kotlin/dev/ambon/engine/dialogue/DialogueSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/dialogue/DialogueSystemTest.kt
@@ -201,8 +201,8 @@ class DialogueSystemTest {
             env.system.startConversation(sid, "sage")
             env.drain()
 
-            val err = env.system.selectChoice(sid, 1) // "Tell me more."
-            assertNull(err)
+            val outcome = env.system.selectChoice(sid, 1) // "Tell me more."
+            assertTrue(outcome is DialogueOutcome.Ok, "Expected Ok outcome. got=$outcome")
 
             val outs = env.drain()
             assertTrue(
@@ -220,8 +220,8 @@ class DialogueSystemTest {
             env.system.startConversation(sid, "sage")
             env.drain()
 
-            val err = env.system.selectChoice(sid, 2) // "Goodbye." (null next)
-            assertNull(err)
+            val outcome = env.system.selectChoice(sid, 2) // "Goodbye." (null next)
+            assertTrue(outcome is DialogueOutcome.Ok, "Expected Ok outcome. got=$outcome")
             assertFalse(env.system.isInConversation(sid))
         }
 
@@ -234,8 +234,11 @@ class DialogueSystemTest {
             env.system.startConversation(sid, "sage")
             env.drain()
 
-            val err = env.system.selectChoice(sid, 5)
-            assertTrue(err != null && err.contains("between"), "Expected range error. got=$err")
+            val outcome = env.system.selectChoice(sid, 5)
+            assertTrue(
+                outcome is DialogueOutcome.Err && outcome.message.contains("between"),
+                "Expected range error. got=$outcome",
+            )
         }
 
     @Test
@@ -400,10 +403,10 @@ class DialogueSystemTest {
             val env = createEnv()
             val sid = env.loginPlayer()
 
-            val err = env.system.selectChoice(sid, 1)
+            val outcome = env.system.selectChoice(sid, 1)
             assertTrue(
-                err != null && err.contains("not in a conversation"),
-                "Expected error. got=$err",
+                outcome is DialogueOutcome.Err && outcome.message.contains("not in a conversation"),
+                "Expected error. got=$outcome",
             )
         }
 }

--- a/src/test/kotlin/dev/ambon/test/TestFixtures.kt
+++ b/src/test/kotlin/dev/ambon/test/TestFixtures.kt
@@ -138,6 +138,7 @@ class CommandRouterHarness private constructor(
             onPhase: (suspend (SessionId, String?) -> PhaseResult)? = null,
             onCrossZoneMove: (suspend (SessionId, RoomId) -> Unit)? = null,
             economyConfig: EconomyConfig = EconomyConfig(),
+            clock: Clock = Clock.systemUTC(),
         ): CommandRouterHarness {
             val combat = CombatSystem(players, mobs, items, outbound)
             val router =
@@ -159,6 +160,7 @@ class CommandRouterHarness private constructor(
                     onPhase = onPhase,
                     onCrossZoneMove = onCrossZoneMove,
                     economyConfig = economyConfig,
+                    clock = clock,
                 )
             return CommandRouterHarness(world, repo, items, players, mobs, outbound, progression, groupSystem, combat, router)
         }


### PR DESCRIPTION
## Summary

- Players can talk to the **Innkeeper** at the new **Wanderer's Inn** in `ambon_hub` and select "rent a room" to set a recall point
- `recall` command teleports the player back to their saved recall point (falls back to class start room if none set)
- Recall is **blocked in combat** and has a **5-minute cooldown**
- Extends the dialogue system with a general-purpose `action` field on choices (`set_recall` is the first use)

## Changes

**Persistence**
- `recallRoomId: RoomId?` added to `PlayerRecord`, `PlayerState`, `PlayerDto`
- Flyway migration `V10__add_player_recall_room.sql` (nullable column)
- `PlayersTable` and `PostgresPlayerRepository` updated; YAML backend handles it automatically via Jackson defaults

**Engine**
- `PlayerRegistry.setRecallRoom()` + `recallTarget()` (fallback chain: saved room → class start room → world start room)
- `Command.Recall` added to `CommandParser`; `NavigationHandler.handleRecall()` implements the teleport + cooldown logic with an injectable `Clock`

**Dialogue system**
- `DialogueChoiceFile` / `DialogueChoice` gain an optional `action: String?` field
- `selectChoice()` now returns `DialogueOutcome` (`Ok(action?)` / `Err(message)`) instead of `String?`
- `DialogueQuestHandler` dispatches `"set_recall"` → `PlayerRegistry.setRecallRoom()`

**World content**
- New `wanderers_inn` room added to `ambon_hub.yaml`, connected north from the Wayfinder Gallery
- Innkeeper NPC with a multi-node dialogue (explain recall, rent a room)

## Test plan

- [x] `RecallCommandTest` — 6 tests: combat block, cooldown block, cooldown expiry, fallback to start room, saved recall room, cooldown countdown message
- [x] `DialogueSystemTest` — updated for `DialogueOutcome` return type
- [x] `RouterTestHelper` / `CommandRouterHarness` accept injectable `Clock` for deterministic cooldown tests
- [x] Full suite passes (`ktlintCheck test`)