### PR TITLE
Fix login concurrency bottlenecks identified by load testing

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
-org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError -Dkotlinx.coroutines.io.parallelism=256
 kotlin.daemon.jvmargs=-Xmx2g
 kotlin.compiler.execution.strategy=in-process
 # Reclaim stale daemon processes after 10 minutes of idle (default is 3 hours).

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -64,6 +64,8 @@ data class AppConfig(
         require(login.maxFailedAttemptsBeforeDisconnect > 0) {
             "ambonMUD.login.maxFailedAttemptsBeforeDisconnect must be > 0"
         }
+        require(login.maxConcurrentLogins > 0) { "ambonMUD.login.maxConcurrentLogins must be > 0" }
+        require(login.authThreads > 0) { "ambonMUD.login.authThreads must be > 0" }
 
         require(engine.mob.minActionDelayMillis >= 0L) { "ambonMUD.engine.mob.minActionDelayMillis must be >= 0" }
         require(engine.mob.maxActionDelayMillis >= engine.mob.minActionDelayMillis) {
@@ -159,6 +161,7 @@ data class AppConfig(
         require(transport.telnet.maxNonPrintablePerLine >= 0) {
             "ambonMUD.transport.telnet.maxNonPrintablePerLine must be >= 0"
         }
+        require(transport.telnet.socketBacklog > 0) { "ambonMUD.transport.telnet.socketBacklog must be > 0" }
         require(transport.maxInboundBackpressureFailures > 0) {
             "ambonMUD.transport.maxInboundBackpressureFailures must be > 0"
         }
@@ -358,6 +361,10 @@ data class DatabaseConfig(
 data class LoginConfig(
     val maxWrongPasswordRetries: Int = 3,
     val maxFailedAttemptsBeforeDisconnect: Int = 3,
+    /** Maximum number of sessions simultaneously progressing through the login/auth funnel. */
+    val maxConcurrentLogins: Int = 50,
+    /** Thread-pool size for BCrypt hashing, isolated from the shared Dispatchers.IO pool. */
+    val authThreads: Int = Runtime.getRuntime().availableProcessors(),
 )
 
 data class EconomyConfig(
@@ -598,6 +605,8 @@ data class TransportConfig(
 data class TelnetTransportConfig(
     val maxLineLen: Int = 1024,
     val maxNonPrintablePerLine: Int = 32,
+    /** OS-level TCP accept backlog for the telnet ServerSocket (default 256 vs JVM default of 50). */
+    val socketBacklog: Int = 256,
 )
 
 data class WebSocketTransportConfig(

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -128,6 +128,7 @@ class GameEngine(
             availableClasses = PlayerClass.selectable(engineConfig.debug.enableSwarmClass),
             maxWrongPasswordRetries = loginConfig.maxWrongPasswordRetries,
             maxFailedLoginAttemptsBeforeDisconnect = loginConfig.maxFailedAttemptsBeforeDisconnect,
+            maxConcurrentLogins = loginConfig.maxConcurrentLogins,
             onAfterLogin = { sid -> guildSystem?.onPlayerLogin(sid) },
         )
     }
@@ -136,7 +137,10 @@ class GameEngine(
         SessionEventHandler(
             players = players,
             markAwaitingName = { sid -> loginFlowHandler.pendingLogins[sid] = LoginState.AwaitingName },
-            clearLoginState = { sid -> loginFlowHandler.pendingLogins.remove(sid) },
+            clearLoginState = { sid ->
+                loginFlowHandler.pendingLogins.remove(sid)
+                loginFlowHandler.releasePermitIfHeld(sid)
+            },
             failedLoginAttempts = loginFlowHandler.failedLoginAttempts,
             sessionAnsiDefaults = loginFlowHandler.sessionAnsiDefaults,
             gmcpSessions = gmcpSessions,

--- a/src/main/kotlin/dev/ambon/transport/BlockingSocketTransport.kt
+++ b/src/main/kotlin/dev/ambon/transport/BlockingSocketTransport.kt
@@ -24,13 +24,14 @@ class BlockingSocketTransport(
     private val maxLineLen: Int = 1024,
     private val maxNonPrintablePerLine: Int = 32,
     private val maxInboundBackpressureFailures: Int = 3,
+    private val socketBacklog: Int = 256,
     private val metrics: GameMetrics = GameMetrics.noop(),
 ) : Transport {
     private var serverSocket: ServerSocket? = null
     private var acceptJob: Job? = null
 
     override suspend fun start() {
-        serverSocket = ServerSocket(port)
+        serverSocket = ServerSocket(port, socketBacklog)
         log.info { "Telnet listening on port $port" }
         acceptJob =
             scope.launch(Dispatchers.IO) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -114,6 +114,12 @@ ambonMUD:
   login:
     maxWrongPasswordRetries: 3
     maxFailedAttemptsBeforeDisconnect: 3
+    # Maximum sessions simultaneously in the auth funnel (name lookup → BCrypt → world entry).
+    # Sessions beyond this limit receive an immediate "server busy" message rather than timing out.
+    maxConcurrentLogins: 50
+    # Thread-pool size for BCrypt hashing, isolated from Dispatchers.IO to avoid starving socket I/O.
+    # Defaults to availableProcessors at runtime if not set; tune based on measured BCrypt throughput.
+    authThreads: 4
 
   engine:
     mob:
@@ -1608,6 +1614,8 @@ ambonMUD:
     telnet:
       maxLineLen: 1024
       maxNonPrintablePerLine: 32
+      # OS-level TCP accept backlog (JVM default is 50; raise to absorb burst connection storms).
+      socketBacklog: 256
     websocket:
       host: 0.0.0.0
       stopGraceMillis: 1000


### PR DESCRIPTION
## Summary

Load testing revealed that the game engine was completely healthy (tick <1ms, zero overruns, CPU <1%) while the login/entry layer rejected connections under load. Four targeted fixes address the root causes without restructuring the transport layer.

- **Fix 1 — Dedicated BCrypt dispatcher**: BCrypt hashing now runs on an isolated `ambon-auth` fixed thread pool (`authThreads`, default = `availableProcessors`) instead of `Dispatchers.IO`. Prevents auth CPU work from evicting socket read/write loops and player repo lookups from the shared IO pool — eliminating the 10ms→25ms `Player Repo Load Duration` creep seen under load.
- **Fix 2 — Raise `Dispatchers.IO` ceiling**: Added `-Dkotlinx.coroutines.io.parallelism=256` to JVM args. The default cap of 64 threads was being hit by ~80 connections × 2 threads/connection, causing `Dispatchers.IO` launches to queue. This gives immediate headroom without restructuring the transport.
- **Fix 3 — Larger `ServerSocket` backlog**: Changed from the JVM default of 50 to a configurable 256 (`ambonMUD.transport.telnet.socketBacklog`). Prevents the OS from silently dropping SYN packets during burst connection storms before `accept()` processes them.
- **Fix 4 — `maxConcurrentLogins` semaphore**: A `Semaphore` in `LoginFlowHandler` bounds concurrent sessions in the auth funnel. Sessions beyond the cap (`ambonMUD.login.maxConcurrentLogins`, default 50) receive an immediate "server is currently at maximum login capacity" message and a clean close, instead of sitting in the FSM for 60 seconds until the load-tester timeout fires. The slot is held across password retries and released on successful login, max-failure disconnect, or TCP disconnect.

The long-term architectural fix (eliminate thread-per-connection via JVM virtual threads) is tracked in a separate issue.

## Test plan

- [x] `./gradlew ktlintCheck test` — all tests pass, no lint errors
- [ ] Re-run load test with 80 concurrent bots; verify FSM no longer times out in `WAIT_ROOM_INFO` and JVM thread count stays bounded
- [ ] Confirm "server busy" message appears when `maxConcurrentLogins` is hit (set it low in a dev run and flood with connections)
- [ ] Verify `authThreads` pool appears in thread dump as `ambon-auth` threads, separate from `Dispatchers.IO` worker threads
