### PR TITLE
Fix RegenSystem tick cap to count inspected players, not just healed ones

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/RegenSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/RegenSystem.kt
@@ -49,9 +49,9 @@ class RegenSystem(
         for (i in list.indices) {
             if (ran >= maxPlayersPerTick) break
             val player = list[(start + i) % list.size]
+            ran++
 
             val sessionId = player.sessionId
-            var didWork = false
 
             val bonuses = items.equipmentBonuses(sessionId)
 
@@ -66,7 +66,6 @@ class RegenSystem(
                         dirtyNotifier.playerVitalsDirty(sessionId)
                     }
                     lastRegenAtMs[sessionId] = now
-                    didWork = true
                 }
             }
 
@@ -81,11 +80,8 @@ class RegenSystem(
                         dirtyNotifier.playerVitalsDirty(sessionId)
                     }
                     lastManaRegenAtMs[sessionId] = now
-                    didWork = true
                 }
             }
-
-            if (didWork) ran++
         }
     }
 


### PR DESCRIPTION
## Summary

- **Root cause of regen scaling bug:** `ran` only incremented in `RegenSystem.tick()` when a player actually *received* regen (`if (didWork) ran++`). Players at full HP were free to inspect without consuming the budget, so the loop iterated every active player unconditionally regardless of `maxPlayersPerTick`.
- **Impact at 150 players:** All 150 players were inspected (and `equipmentBonuses()` queried) every tick, producing ~3 ms sustained regen cost even though `maxPlayersPerTick: 50` was configured. This was the primary engine scaling bottleneck identified in the February 2026 load tests.
- **Fix:** Move `ran++` to fire for every player the loop enters, immediately at the top of the loop body. This makes the cap a true budget on player *inspections*, not just regen *applications*.
- **Expected result:** At 150 players with `maxPlayersPerTick: 50`, regen visits 50 players/tick instead of 150. The full population rotates in 3 ticks (~300 ms), well inside the 5-second regen interval. Sustained regen tick cost should drop from ~3 ms to ~1 ms.

## Files changed

| File | Change |
|------|--------|
| `src/main/kotlin/dev/ambon/engine/RegenSystem.kt` | Move `ran++` to top of loop; remove `didWork` variable (no longer needed) |
| `src/test/kotlin/dev/ambon/engine/RegenSystemTest.kt` | Add regression test: full-HP players consume the budget, preventing a damaged player outside the cap window from being reached |

## Test plan

- [x] Existing `maxPlayersPerTick limits how many players are healed per tick` test still passes
- [x] New regression test `maxPlayersPerTick counts every inspected player not just healed players` passes
- [x] Full `ktlintCheck test` suite passes
- [ ] Load test at 150 players to confirm regen tick avg drops from ~3 ms to ~1 ms