### PR TITLE
Simplify: eliminate N+1 lookups in sendLook, extract ShopHandler.findShop

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -98,17 +98,17 @@ internal suspend fun sendLook(
         outbound.send(OutboundEvent.SendInfo(sessionId, "Items here: $list"))
     }
 
+    val rawRoomPlayers = players.playersInRoom(roomId)
     val roomPlayers =
-        players
-            .playersInRoom(roomId)
+        rawRoomPlayers
             .map { p ->
                 val t = p.activeTitle
                 if (t != null) "[$t] ${p.name}" else p.name
             }.sorted()
 
+    val rawRoomMobs = mobs.mobsInRoom(roomId)
     val roomMobs =
-        mobs
-            .mobsInRoom(roomId)
+        rawRoomMobs
             .map { it.name }
             .sorted()
 
@@ -127,9 +127,9 @@ internal suspend fun sendLook(
     )
 
     gmcpEmitter?.sendRoomInfo(sessionId, room)
-    gmcpEmitter?.sendRoomPlayers(sessionId, players.playersInRoom(roomId).toList())
-    gmcpEmitter?.sendRoomMobs(sessionId, mobs.mobsInRoom(roomId))
-    gmcpEmitter?.sendRoomItems(sessionId, items.itemsInRoom(roomId))
+    gmcpEmitter?.sendRoomPlayers(sessionId, rawRoomPlayers)
+    gmcpEmitter?.sendRoomMobs(sessionId, rawRoomMobs)
+    gmcpEmitter?.sendRoomItems(sessionId, here)
 }
 
 /** Broadcasts [message] to every player in [roomId] except [excludeSessionId]. */

--- a/src/test/kotlin/dev/ambon/engine/RegenSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/RegenSystemTest.kt
@@ -186,8 +186,9 @@ class RegenSystemTest {
             regen.tick()
 
             // Damage only sid1 (index 0 in the list)
-            val damagedHp = players.get(sids[0])!!.maxHp - 1
-            players.get(sids[0])!!.hp = damagedHp
+            val damagedPlayer = players.get(sids[0])!!
+            val damagedHp = damagedPlayer.maxHp - 1
+            damagedPlayer.hp = damagedHp
 
             clock.advance(200L)
 
@@ -197,7 +198,7 @@ class RegenSystemTest {
 
             assertEquals(
                 damagedHp,
-                players.get(sids[0])!!.hp,
+                damagedPlayer.hp,
                 "Damaged player must not be healed when cap is consumed by full-HP players",
             )
         }


### PR DESCRIPTION
## Summary

- **`HandlerHelpers.sendLook`** — `playersInRoom()`, `mobsInRoom()`, and `itemsInRoom()` were each called twice per `look` command: once to build the display strings and again for GMCP emission. Captured as `rawRoomPlayers`, `rawRoomMobs`, and `here` once and reused for both paths. Cuts 3 redundant registry traversals on every `look`.
- **`ShopHandler`** — The 3-line `shopRegistry?.shopInRoom / if null → error + return` guard was copy-pasted identically in `handleShopList`, `handleBuy`, and `handleSell`. Extracted into a private `findShop()` helper; call sites reduce to a single `?: return`.
- **`RegenSystemTest`** — Triple `players.get(sids[0])!!` lookup in the new tick-cap test consolidated into a single `damagedPlayer` val reused for setup and assertion.

## Test plan

- [ ] `./gradlew ktlintCheck test` passes (verified locally before push)