### PR TITLE
Switch telnet I/O to JVM virtual threads (#301)

### DIFF
--- a/src/main/kotlin/dev/ambon/transport/BlockingSocketTransport.kt
+++ b/src/main/kotlin/dev/ambon/transport/BlockingSocketTransport.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import java.net.ServerSocket
+import kotlin.coroutines.CoroutineContext
 
 private val log = KotlinLogging.logger {}
 
@@ -26,6 +27,7 @@ class BlockingSocketTransport(
     private val maxInboundBackpressureFailures: Int = 3,
     private val socketBacklog: Int = 256,
     private val metrics: GameMetrics = GameMetrics.noop(),
+    private val sessionDispatcher: CoroutineContext = Dispatchers.IO,
 ) : Transport {
     private var serverSocket: ServerSocket? = null
     private var acceptJob: Job? = null
@@ -54,6 +56,7 @@ class BlockingSocketTransport(
                             maxNonPrintablePerLine = maxNonPrintablePerLine,
                             maxInboundBackpressureFailures = maxInboundBackpressureFailures,
                             metrics = metrics,
+                            dispatcher = sessionDispatcher,
                         )
                     outboundRouter.register(
                         sessionId = sessionId,


### PR DESCRIPTION
## Summary

- **`NetworkSession`**: add `dispatcher: CoroutineContext = Dispatchers.IO` parameter; `start()` launches read/write loops on that dispatcher instead of hardcoded `Dispatchers.IO`; replace `synchronized(outputLock)` (JVM monitor → pins virtual-thread carriers) with `ReentrantLock.withLock` at all four call sites.
- **`BlockingSocketTransport`**: add `sessionDispatcher: CoroutineContext = Dispatchers.IO` parameter; threads it through to `NetworkSession`.
- **`MudServer` / `GatewayServer`**: create `telnetDispatcher` from `Executors.newVirtualThreadPerTaskExecutor()`; pass as `sessionDispatcher` to `BlockingSocketTransport`; close in `stop()`.

Default parameter values keep all existing tests and call sites working without change.

## Motivation

Load testing (issue #301) revealed that `BlockingSocketTransport` + `NetworkSession` create **two `Dispatchers.IO` OS threads per connected client** — roughly 1000 OS threads and ~500 MB of stack space at 500 connections. JDK 21 virtual threads unmount from carrier threads on blocking I/O, so the carrier pool stays near `CPU_count × 2` regardless of connection count.

The `synchronized` → `ReentrantLock` swap is required because a JVM monitor held by a virtual thread prevents it from unmounting (pinning), defeating the scaling benefit.

## Test plan

- [x] `./gradlew ktlintCheck` — passes
- [x] `./gradlew test` — full suite passes (86 test files, including `NetworkSessionGmcpBatchTest`, `OutboundRouterTest`, `KtorWebSocketTransportTest`)
- [ ] Manual smoke test: `./gradlew run`, telnet to `:4000`, verify login/play works