### PR TITLE
Align `login.styles.yaml` lineStyles with updated `login.txt` banner

### DIFF
--- a/src/main/resources/login.styles.yaml
+++ b/src/main/resources/login.styles.yaml
@@ -45,7 +45,6 @@ lineStyles:
   - body
   - body
   - plain
-  - plain
   - tower
   - tower
   - tower


### PR DESCRIPTION
### Motivation
- The ASCII login banner was updated and the per-line ANSI style mapping fell out of sync, causing incorrect coloration and potential strict-loader failures.

### Description
- Removed one extra `plain` entry from `lineStyles` in `src/main/resources/login.styles.yaml` so the style list length matches the `src/main/resources/login.txt` lines and restores intended per-line ANSI coloring.

### Testing
- Ran the targeted login UI tests with `./gradlew test --tests dev.ambon.ui.login.LoginScreenLoaderTest --tests dev.ambon.ui.login.LoginScreenRendererTest`, but the build failed due to external dependency resolution (Maven Central returned HTTP 403 for `ch.qos.logback:logback-classic`), not because of the YAML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d5d975d883238828ae19f9e65662)