### PR TITLE
build(deps): upgrade protobuf from 3.25.5 to 4.34.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ val hopliteVersion = "2.9.0"
 val micrometerVersion = "1.16.3"
 val grpcVersion = "1.79.0"
 val grpcKotlinVersion = "1.5.0"
-val protobufVersion = "3.25.5"
+val protobufVersion = "4.34.0"
 val exposedVersion = "0.58.0"
 
 dependencies {
@@ -54,6 +54,7 @@ dependencies {
     implementation("org.flywaydb:flyway-database-postgresql:12.0.3")
 
     // gRPC / Protobuf
+    implementation("com.google.protobuf:protobuf-java:$protobufVersion")
     implementation("io.grpc:grpc-netty-shaded:$grpcVersion")
     implementation("io.grpc:grpc-protobuf:$grpcVersion")
     implementation("io.grpc:grpc-stub:$grpcVersion")


### PR DESCRIPTION
Supersedes Dependabot PR #315.

## What changed

- `protobufVersion` bumped from `3.25.5` → `4.34.0`
- Added explicit `implementation("com.google.protobuf:protobuf-java:$protobufVersion")` dependency

## Why the extra dep is needed

Dependabot's PR only bumped the `protoc` code-generator artifact. Without the explicit runtime pin, `grpc-protobuf:1.79.0` would pull in `protobuf-java:3.25.8`, which is missing 4.x-only APIs the new generator emits (`RuntimeVersion`, `GeneratedFile`, `GeneratedMessage.isStringEmpty`, changed `parseUnknownField` signature, etc.), causing a compilation error.

Adding `protobuf-java:4.34.0` explicitly lets Gradle's highest-version-wins resolution override the transitive `3.25.8`, aligning the generator and runtime on the same major version.

## Testing

`./gradlew ktlintCheck test` passes locally (all ~78 test files green, 1m 30s).