### PR TITLE
ci: add pre-flight variable checks to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,17 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     steps:
+      - name: Check required variables
+        run: |
+          missing=""
+          [ -z "${{ vars.AWS_CDK_DEPLOY_ROLE_ARN }}" ] && missing="$missing AWS_CDK_DEPLOY_ROLE_ARN"
+          [ -z "${{ vars.AWS_REGION }}" ]              && missing="$missing AWS_REGION"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing required GitHub Actions repository variables:$missing"
+            echo "::error::See docs/DEPLOYMENT.md §3 (One-Time AWS Bootstrap) for setup instructions."
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
 
       - name: Resolve image tag
@@ -98,6 +109,18 @@ jobs:
       github.event_name == 'workflow_dispatch' &&
       inputs.environment == 'production'
     steps:
+      - name: Check required variables
+        run: |
+          missing=""
+          [ -z "${{ vars.AWS_CDK_DEPLOY_ROLE_ARN_PROD }}" ] && missing="$missing AWS_CDK_DEPLOY_ROLE_ARN_PROD"
+          [ -z "${{ vars.AWS_REGION }}" ]                   && missing="$missing AWS_REGION"
+          [ -z "${{ vars.DOMAIN }}" ]                       && missing="$missing DOMAIN"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing required GitHub Actions repository variables:$missing"
+            echo "::error::See docs/DEPLOYMENT.md §3 (One-Time AWS Bootstrap) for setup instructions."
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
 
       - name: Configure AWS credentials (OIDC)


### PR DESCRIPTION
## Problem

When `AWS_CDK_DEPLOY_ROLE_ARN` is not set as a GitHub Actions repository variable, `aws-actions/configure-aws-credentials@v4` receives an empty `role-to-assume`, skips OIDC, exhausts the ambient credential provider chain, and emits:

```
Credentials could not be loaded, please check your action inputs:
Could not load credentials from any providers
```

This message gives no indication of what is missing or how to fix it.

## Fix

Add a **"Check required variables"** step at the top of each deploy job that explicitly checks for the required `vars.*` entries and fails immediately with a named list of what is missing and a pointer to `docs/DEPLOYMENT.md §3`.

## To actually fix the deploys

Set these GitHub Actions variables under **Settings → Secrets and variables → Actions → Variables**:

| Variable | Description |
|---|---|
| `AWS_CDK_DEPLOY_ROLE_ARN` | ARN of the `github-actions-cdk-deploy` IAM role (staging) |
| `AWS_CDK_DEPLOY_ROLE_ARN_PROD` | ARN of the CDK deploy role for production |
| `AWS_REGION` | e.g. `us-east-1` |

The IAM role needs an OIDC trust policy for `token.actions.githubusercontent.com` scoped to `repo:jnoecker/AmbonMUD:*`. Full instructions in `docs/DEPLOYMENT.md §3`.