### PR TITLE
ci: default staging deploy to ec2 topology

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,14 +18,15 @@ on:
       topology:
         description: "Deployment topology"
         required: true
-        default: split
+        default: ec2
         type: choice
         options:
+          - ec2
           - standalone
           - split
       tier:
-        description: "Scale tier"
-        required: true
+        description: "Scale tier (ignored for ec2 topology)"
+        required: false
         default: hobby
         type: choice
         options:
@@ -95,7 +96,7 @@ jobs:
         working-directory: infra
         run: |
           npx cdk deploy --all --require-approval never \
-            --context topology=${{ inputs.topology || 'split' }} \
+            --context topology=${{ inputs.topology || 'ec2' }} \
             --context tier=${{ inputs.tier || 'hobby' }} \
             --context imageTag=${{ steps.tag.outputs.tag }} \
             --context ecrRepo=${{ vars.ECR_REPO_NAME || 'ambonmud/app' }}


### PR DESCRIPTION
## Problem

The deploy workflow was defaulting to `topology=split` for all auto-triggered deploys (and as the pre-selected option in manual dispatches). That topology spins up ECS Fargate, RDS Postgres, ElastiCache Redis, NLB, and ALB — none of which are intended for this server.

The intended deployment is the EC2 resume-display stack (`topology=ec2`): a single t4g.nano with YAML persistence, ~$4-5/mo.

`ec2` was not even listed as an option in the `workflow_dispatch` topology input.

## Changes

- Topology dispatch input: `ec2` added as first/default option, default changed from `split` → `ec2`
- CDK deploy command fallback: `inputs.topology || 'split'` → `inputs.topology || 'ec2'`  
- Tier input marked as not required (it is silently ignored for the `ec2` topology by CDK)

`standalone` and `split` remain available for manual dispatches.

## Follow-up

If any `AmbonMUD-split-hobby-*` or `AmbonMUD-standalone-hobby-*` CloudFormation stacks were created by the erroneous deploys, they should be destroyed to stop any ongoing costs:
```bash
cd infra && npm ci
npx cdk destroy --all --context topology=split --context tier=hobby
```