### PR TITLE
refactor: extract RedisEventBus base to eliminate ~80 lines of duplicated bus code

### DIFF
--- a/src/main/kotlin/dev/ambon/bus/RedisEventBus.kt
+++ b/src/main/kotlin/dev/ambon/bus/RedisEventBus.kt
@@ -1,0 +1,71 @@
+package dev.ambon.bus
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Common fields that every Redis bus envelope must carry for routing and integrity checking.
+ */
+internal interface RedisEnvelope {
+    val instanceId: String
+    val type: String
+    val signature: String
+}
+
+/**
+ * Shared subscribe/publish infrastructure for Redis-backed event buses.
+ *
+ * Subclasses supply the event-type-specific [deserializeEnvelope], [EnvelopeT.toEvent],
+ * [EventT.toEnvelope], [EnvelopeT.payloadToSign], and [EnvelopeT.withSignature] implementations.
+ * All HMAC signing, instance-ID filtering, and error handling live here.
+ */
+internal abstract class RedisEventBus<EventT : Any, EnvelopeT : RedisEnvelope>(
+    protected val publisher: BusPublisher,
+    protected val subscriberSetup: BusSubscriberSetup,
+    protected val channelName: String,
+    protected val instanceId: String,
+    protected val mapper: ObjectMapper,
+    protected val sharedSecret: String,
+    private val direction: String,
+) {
+    protected abstract fun deserializeEnvelope(json: String): EnvelopeT
+
+    protected abstract fun EnvelopeT.toEvent(): EventT?
+
+    /** Returns the envelope for [this] event, or null to skip publishing (e.g. control-plane events). */
+    protected abstract fun EventT.toEnvelope(): EnvelopeT?
+
+    protected abstract fun EnvelopeT.payloadToSign(): String
+
+    protected abstract fun EnvelopeT.withSignature(sig: String): EnvelopeT
+
+    protected fun startListening(dispatch: (EventT) -> Unit) {
+        subscriberSetup.startListening(channelName) { message ->
+            try {
+                val env = deserializeEnvelope(message)
+                if (env.instanceId == instanceId) return@startListening
+                if (!isValidHmac(sharedSecret, env.payloadToSign(), env.signature)) {
+                    log.warn { "Dropping $direction Redis event with invalid signature (type=${env.type})" }
+                    return@startListening
+                }
+                val event = env.toEvent() ?: return@startListening
+                dispatch(event)
+            } catch (e: Exception) {
+                log.warn(e) { "Failed to deserialize $direction event from Redis" }
+            }
+        }
+        log.info { "Redis $direction bus subscribed to '$channelName' (instanceId=$instanceId)" }
+    }
+
+    protected fun publishEvent(event: EventT) {
+        try {
+            val env = event.toEnvelope() ?: return
+            val signed = env.withSignature(hmacSha256(sharedSecret, env.payloadToSign()))
+            publisher.publish(channelName, mapper.writeValueAsString(signed))
+        } catch (e: Exception) {
+            log.warn(e) { "Failed to publish $direction event to Redis" }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #309.

## What changed

**New file: `RedisEventBus.kt`**
- `RedisEnvelope` interface — common fields every envelope must carry: `instanceId`, `type`, `signature`.
- `RedisEventBus<EventT, EnvelopeT : RedisEnvelope>` abstract class — shared infrastructure:
  - `startListening(dispatch)` — subscriber loop: deserialize → check instance ID → verify HMAC → dispatch. Single source of truth for all error handling and logging.
  - `publishEvent(event)` — publish flow: `toEnvelope()` → sign → serialize → publish. Returns early for `null` envelopes (e.g. `SessionRedirect`).
  - Constructor takes a `direction` string (`"inbound"` / `"outbound"`) used in log messages.

**`RedisInboundBus` / `RedisOutboundBus`** — now thin subclasses. Each supplies:
- Its own `Envelope` data class (implementing `RedisEnvelope`) — field names and `payloadToSign` strings unchanged.
- `deserializeEnvelope(json)` — one line.
- `EnvelopeT.toEvent()` — the `when` dispatch, same as before.
- `EventT.toEnvelope()` — the reverse mapping, same as before.
- `EnvelopeT.payloadToSign()` / `withSignature()` — two one-liners.

Both classes changed from `public` to `internal` (they were only ever instantiated from `MudServer.kt` within the same module; this was required to allow `protected` abstract methods to reference `internal Envelope` types).

## What was removed

~80 lines of duplicated code — the entire subscriber setup loop and publish try/catch existed verbatim in both buses. Any future change to HMAC signing, error handling, or the subscribe loop now only needs to be made once.

## Wire format

Unchanged. Each bus retains its own `Envelope` data class with the same fields in the same order, and the same `payloadToSign()` string format. Existing signed messages will continue to verify correctly.

## Test plan
- [ ] `ktlintCheck` passes
- [ ] All existing Redis bus tests pass (`RedisInboundBusTest`, `RedisOutboundBusTest`)
- [ ] Full test suite passes