### PR TITLE
refactor(engine): group GameEngine sharding/persistence params into context objects

### DIFF
--- a/src/main/kotlin/dev/ambon/MudServer.kt
+++ b/src/main/kotlin/dev/ambon/MudServer.kt
@@ -16,7 +16,9 @@ import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.world.WorldFactory
 import dev.ambon.engine.GameEngine
 import dev.ambon.engine.MobRegistry
+import dev.ambon.engine.PersistenceContext
 import dev.ambon.engine.PlayerProgression
+import dev.ambon.engine.ShardingContext
 import dev.ambon.engine.WorldStateRegistry
 import dev.ambon.engine.createPlayerRegistry
 import dev.ambon.engine.items.ItemRegistry
@@ -525,25 +527,29 @@ class MudServer(
                     progression = progression,
                     metrics = gameMetrics,
                     onShutdown = { shutdownSignal.complete(Unit) },
-                    handoffManager = handoffManager,
-                    interEngineBus = interEngineBus,
-                    engineId = engineId,
-                    playerLocationIndex = playerLocationIndex,
-                    zoneRegistry = zoneRegistry,
-                    peerEngineCount = {
-                        zoneRegistry
-                            ?.allAssignments()
-                            ?.values
-                            ?.map { it.engineId }
-                            ?.filter { it != engineId }
-                            ?.toSet()
-                            ?.size
-                            ?: 0
-                    },
                     worldState = worldState,
-                    worldStateRepository = worldStateRepo,
-                    guildRepo = guildRepo,
-                    playerRepo = playerRepo,
+                    sharding = ShardingContext(
+                        engineId = engineId,
+                        handoffManager = handoffManager,
+                        interEngineBus = interEngineBus,
+                        peerEngineCount = {
+                            zoneRegistry
+                                ?.allAssignments()
+                                ?.values
+                                ?.map { it.engineId }
+                                ?.filter { it != engineId }
+                                ?.toSet()
+                                ?.size
+                                ?: 0
+                        },
+                        playerLocationIndex = playerLocationIndex,
+                        zoneRegistry = zoneRegistry,
+                    ),
+                    persistence = PersistenceContext(
+                        worldStateRepository = worldStateRepo,
+                        guildRepo = guildRepo,
+                        playerRepo = playerRepo,
+                    ),
                 ).run()
             }
 

--- a/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
+++ b/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
@@ -13,6 +13,7 @@ import dev.ambon.domain.world.WorldFactory
 import dev.ambon.engine.GameEngine
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PlayerProgression
+import dev.ambon.engine.ShardingContext
 import dev.ambon.engine.createPlayerRegistry
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.engine.scheduler.Scheduler
@@ -438,21 +439,23 @@ class EngineServer(
                     progression = progression,
                     metrics = gameMetrics,
                     onShutdown = { shutdownSignal.complete(Unit) },
-                    handoffManager = handoffManager,
-                    interEngineBus = interEngineBus,
-                    engineId = engineId,
-                    playerLocationIndex = playerLocationIndex,
-                    zoneRegistry = zoneRegistry,
-                    peerEngineCount = {
-                        zoneRegistry
-                            ?.allAssignments()
-                            ?.values
-                            ?.map { it.engineId }
-                            ?.filter { it != engineId }
-                            ?.toSet()
-                            ?.size
-                            ?: 0
-                    },
+                    sharding = ShardingContext(
+                        engineId = engineId,
+                        handoffManager = handoffManager,
+                        interEngineBus = interEngineBus,
+                        peerEngineCount = {
+                            zoneRegistry
+                                ?.allAssignments()
+                                ?.values
+                                ?.map { it.engineId }
+                                ?.filter { it != engineId }
+                                ?.toSet()
+                                ?.size
+                                ?: 0
+                        },
+                        playerLocationIndex = playerLocationIndex,
+                        zoneRegistry = zoneRegistry,
+                    ),
                 ).run()
             }
 

--- a/src/test/kotlin/dev/ambon/engine/InterEngineMessageHandlingTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/InterEngineMessageHandlingTest.kt
@@ -91,9 +91,11 @@ class InterEngineMessageHandlingTest {
                 clock = clock,
                 tickMillis = 100L,
                 scheduler = scheduler,
-                interEngineBus = bus,
-                engineId = engineId,
                 onShutdown = onShutdown,
+                sharding = ShardingContext(
+                    engineId = engineId,
+                    interEngineBus = bus,
+                ),
             )
 
         return EngineTestHarness(engine, inbound, outbound, bus, players, clock)


### PR DESCRIPTION
## Summary

Continues issue #308 (excessive constructor parameters on core engine types).

- Introduces `ShardingContext` data class grouping 6 multi-engine params: `engineId`, `handoffManager`, `interEngineBus`, `peerEngineCount`, `playerLocationIndex`, `zoneRegistry`
- Introduces `PersistenceContext` data class grouping 3 optional repo params: `worldStateRepository`, `guildRepo`, `playerRepo`
- `GameEngine` constructor shrinks from 28 → 21 parameters
- Private getter aliases in the class body (`private val handoffManager get() = sharding.handoffManager`, etc.) keep all existing internal references compiling without modification
- Call sites updated: `MudServer`, `EngineServer`, `InterEngineMessageHandlingTest`

## Test plan

- [x] `./gradlew ktlintCheck` passes
- [x] `./gradlew test` passes (78 test files, all green)