### PR TITLE
refactor: extract requireSystem helper, eliminate repeated null-guard pattern (closes #310)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/CombatHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/CombatHandler.kt
@@ -7,7 +7,6 @@ import dev.ambon.engine.commands.CommandHandler
 import dev.ambon.engine.commands.CommandRouter
 import dev.ambon.engine.commands.on
 import dev.ambon.engine.dialogue.DialogueSystem
-import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.status.StatusEffectSystem
 
 class CombatHandler(
@@ -43,10 +42,7 @@ class CombatHandler(
         sessionId: SessionId,
         cmd: Command.Cast,
     ) {
-        if (abilitySystem == null) {
-            outbound.send(OutboundEvent.SendError(sessionId, "Abilities are not available."))
-            return
-        }
-        outbound.sendIfError(sessionId, abilitySystem.cast(sessionId, cmd.spellName, cmd.target))
+        if (!requireSystem(sessionId, abilitySystem != null, "Abilities", outbound)) return
+        outbound.sendIfError(sessionId, abilitySystem!!.cast(sessionId, cmd.spellName, cmd.target))
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/GroupHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/GroupHandler.kt
@@ -6,7 +6,6 @@ import dev.ambon.engine.commands.Command
 import dev.ambon.engine.commands.CommandHandler
 import dev.ambon.engine.commands.CommandRouter
 import dev.ambon.engine.commands.on
-import dev.ambon.engine.events.OutboundEvent
 
 class GroupHandler(
     ctx: EngineContext,
@@ -27,17 +26,15 @@ class GroupHandler(
         sessionId: SessionId,
         cmd: Command.GroupCmd,
     ) {
-        if (groupSystem == null) {
-            outbound.send(OutboundEvent.SendError(sessionId, "Groups are not available."))
-            return
-        }
+        if (!requireSystem(sessionId, groupSystem != null, "Groups", outbound)) return
+        val gs = groupSystem!!
         val err =
             when (cmd) {
-                is Command.GroupCmd.Invite -> groupSystem.invite(sessionId, cmd.target)
-                Command.GroupCmd.Accept -> groupSystem.accept(sessionId)
-                Command.GroupCmd.Leave -> groupSystem.leave(sessionId)
-                is Command.GroupCmd.Kick -> groupSystem.kick(sessionId, cmd.target)
-                Command.GroupCmd.List -> groupSystem.list(sessionId)
+                is Command.GroupCmd.Invite -> gs.invite(sessionId, cmd.target)
+                Command.GroupCmd.Accept -> gs.accept(sessionId)
+                Command.GroupCmd.Leave -> gs.leave(sessionId)
+                is Command.GroupCmd.Kick -> gs.kick(sessionId, cmd.target)
+                Command.GroupCmd.List -> gs.list(sessionId)
             }
         outbound.sendIfError(sessionId, err)
     }
@@ -46,10 +43,7 @@ class GroupHandler(
         sessionId: SessionId,
         cmd: Command.Gtell,
     ) {
-        if (groupSystem == null) {
-            outbound.send(OutboundEvent.SendError(sessionId, "Groups are not available."))
-            return
-        }
-        outbound.sendIfError(sessionId, groupSystem.gtell(sessionId, cmd.message))
+        if (!requireSystem(sessionId, groupSystem != null, "Groups", outbound)) return
+        outbound.sendIfError(sessionId, groupSystem!!.gtell(sessionId, cmd.message))
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/GuildHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/GuildHandler.kt
@@ -6,7 +6,6 @@ import dev.ambon.engine.commands.Command
 import dev.ambon.engine.commands.CommandHandler
 import dev.ambon.engine.commands.CommandRouter
 import dev.ambon.engine.commands.on
-import dev.ambon.engine.events.OutboundEvent
 
 class GuildHandler(
     ctx: EngineContext,
@@ -33,23 +32,21 @@ class GuildHandler(
         sessionId: SessionId,
         cmd: Command.Guild,
     ) {
-        if (guildSystem == null) {
-            outbound.send(OutboundEvent.SendError(sessionId, "Guilds are not available."))
-            return
-        }
+        if (!requireSystem(sessionId, guildSystem != null, "Guilds", outbound)) return
+        val gs = guildSystem!!
         val err =
             when (cmd) {
-                is Command.Guild.Create -> guildSystem.create(sessionId, cmd.name, cmd.tag)
-                Command.Guild.Disband -> guildSystem.disband(sessionId)
-                is Command.Guild.Invite -> guildSystem.invite(sessionId, cmd.target)
-                Command.Guild.Accept -> guildSystem.accept(sessionId)
-                Command.Guild.Leave -> guildSystem.leave(sessionId)
-                is Command.Guild.Kick -> guildSystem.kick(sessionId, cmd.target)
-                is Command.Guild.Promote -> guildSystem.promote(sessionId, cmd.target)
-                is Command.Guild.Demote -> guildSystem.demote(sessionId, cmd.target)
-                is Command.Guild.Motd -> guildSystem.setMotd(sessionId, cmd.message)
-                Command.Guild.Roster -> guildSystem.roster(sessionId)
-                Command.Guild.Info -> guildSystem.info(sessionId)
+                is Command.Guild.Create -> gs.create(sessionId, cmd.name, cmd.tag)
+                Command.Guild.Disband -> gs.disband(sessionId)
+                is Command.Guild.Invite -> gs.invite(sessionId, cmd.target)
+                Command.Guild.Accept -> gs.accept(sessionId)
+                Command.Guild.Leave -> gs.leave(sessionId)
+                is Command.Guild.Kick -> gs.kick(sessionId, cmd.target)
+                is Command.Guild.Promote -> gs.promote(sessionId, cmd.target)
+                is Command.Guild.Demote -> gs.demote(sessionId, cmd.target)
+                is Command.Guild.Motd -> gs.setMotd(sessionId, cmd.message)
+                Command.Guild.Roster -> gs.roster(sessionId)
+                Command.Guild.Info -> gs.info(sessionId)
             }
         outbound.sendIfError(sessionId, err)
     }
@@ -58,10 +55,7 @@ class GuildHandler(
         sessionId: SessionId,
         cmd: Command.Gchat,
     ) {
-        if (guildSystem == null) {
-            outbound.send(OutboundEvent.SendError(sessionId, "Guilds are not available."))
-            return
-        }
-        outbound.sendIfError(sessionId, guildSystem.gchat(sessionId, cmd.message))
+        if (!requireSystem(sessionId, guildSystem != null, "Guilds", outbound)) return
+        outbound.sendIfError(sessionId, guildSystem!!.gchat(sessionId, cmd.message))
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -180,6 +180,22 @@ internal suspend fun OutboundBus.sendIfError(sessionId: SessionId, error: String
     if (error != null) send(OutboundEvent.SendError(sessionId, error))
 }
 
+/**
+ * Guards an optional system: sends a [OutboundEvent.SendError] and returns `false` when
+ * [available] is false, so callers can write `if (!requireSystem(...)) return`.
+ */
+internal suspend fun requireSystem(
+    sessionId: SessionId,
+    available: Boolean,
+    name: String,
+    outbound: OutboundBus,
+): Boolean {
+    if (!available) {
+        outbound.send(OutboundEvent.SendError(sessionId, "$name are not available on this server."))
+    }
+    return available
+}
+
 /** Checks if [sessionId] has staff privileges; sends an error and returns false if not. */
 internal suspend fun requireStaff(
     sessionId: SessionId,


### PR DESCRIPTION
## Summary

- Adds `requireSystem(sessionId, available, name, outbound): Boolean` to `HandlerHelpers.kt`
- Replaces 10 identical 3-line null-guard blocks across 5 handlers with a single-line call: `if (!requireSystem(sessionId, systemX != null, "Name", outbound)) return`
- Also converts 3 inline `?: "X system is not available."` fallbacks in `DialogueQuestHandler` to the same guard pattern, making all unavailable-system paths send `SendError` consistently
- Error messages unified: `"X are not available on this server."` across all handlers
- Removes now-unused `OutboundEvent` imports from `CombatHandler` and `GroupHandler`/`GuildHandler`

## Handlers updated

| Handler | Guards replaced |
|---|---|
| `CombatHandler` | ability system ×1 |
| `ProgressionHandler` | ability system ×1 |
| `GroupHandler` | group system ×2 |
| `GuildHandler` | guild system ×2 |
| `DialogueQuestHandler` | quest system ×4, achievement system ×2 |

## Test plan

- [x] `./gradlew ktlintCheck` passes
- [x] `./gradlew test` passes (all existing command router tests green)