### PR TITLE
fix(#320): rename root config field/key to `ambonmud` so Hoplite env-var mapping works

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,10 +36,10 @@ Run tests matching a pattern:
 
 Override any config value at runtime with `-Pconfig.<key>=<value>`:
 ```bash
-./gradlew run -Pconfig.ambonMUD.logging.level=DEBUG
-./gradlew run -Pconfig.ambonMUD.logging.packageLevels.dev.ambon.transport=DEBUG
-./gradlew run -Pconfig.ambonMUD.server.telnetPort=5000
-./gradlew run -Pconfig.ambonMUD.persistence.backend=POSTGRES  # connection defaults match docker compose
+./gradlew run -Pconfig.ambonmud.logging.level=DEBUG
+./gradlew run -Pconfig.ambonmud.logging.packageLevels.dev.ambon.transport=DEBUG
+./gradlew run -Pconfig.ambonmud.server.telnetPort=5000
+./gradlew run -Pconfig.ambonmud.persistence.backend=POSTGRES  # connection defaults match docker compose
 ```
 
 Multi-instance local testing (start engines first, then gateways):

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -16,7 +16,7 @@ enum class DeploymentMode {
 }
 
 data class AmbonMUDRootConfig(
-    val ambonMUD: AppConfig = AppConfig(),
+    val ambonmud: AppConfig = AppConfig(),
 )
 
 data class AppConfig(

--- a/src/main/kotlin/dev/ambon/config/AppConfigLoader.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfigLoader.kt
@@ -10,15 +10,17 @@ object AppConfigLoader {
     private const val DEFAULT_RESOURCE_PATH = "/application.yaml"
 
     // Environment variable naming convention for container deployments:
-    //   AMBONMUD_MODE              → ambonMUD.mode
-    //   AMBONMUD_PERSISTENCE_BACKEND → ambonMUD.persistence.backend
-    //   AMBONMUD_DATABASE_JDBCURL  → ambonMUD.database.jdbcUrl
-    //   AMBONMUD_REDIS_URI         → ambonMUD.redis.uri
-    //   AMBONMUD_REDIS_BUS_ENABLED → ambonMUD.redis.bus.enabled
-    //   AMBONMUD_SHARDING_ENABLED  → ambonMUD.sharding.enabled
-    //   AMBONMUD_SHARDING_REGISTRY_TYPE → ambonMUD.sharding.registry.type
-    //   AMBONMUD_GRPC_CLIENT_ENGINEHOST → ambonMUD.grpc.client.engineHost
+    //   AMBONMUD_MODE              → ambonmud.mode
+    //   AMBONMUD_PERSISTENCE_BACKEND → ambonmud.persistence.backend
+    //   AMBONMUD_DATABASE_JDBCURL  → ambonmud.database.jdbcUrl
+    //   AMBONMUD_REDIS_URI         → ambonmud.redis.uri
+    //   AMBONMUD_REDIS_BUS_ENABLED → ambonmud.redis.bus.enabled
+    //   AMBONMUD_SHARDING_ENABLED  → ambonmud.sharding.enabled
+    //   AMBONMUD_SHARDING_REGISTRY_TYPE → ambonmud.sharding.registry.type
+    //   AMBONMUD_GRPC_CLIENT_ENGINEHOST → ambonmud.grpc.client.engineHost
     // Hoplite lowercases all keys and replaces _ with . for path segments.
+    // NOTE: The root YAML key and AmbonMUDRootConfig field are both `ambonmud`
+    // (all-lowercase) so that Hoplite's env-var normalisation resolves correctly.
     @OptIn(ExperimentalHoplite::class)
     fun load(
         resourcePath: String = DEFAULT_RESOURCE_PATH,
@@ -45,7 +47,7 @@ object AppConfigLoader {
         return builder
             .build()
             .loadConfigOrThrow<AmbonMUDRootConfig>()
-            .ambonMUD
+            .ambonmud
             .validated()
     }
 }

--- a/src/main/resources/application-demo.yaml
+++ b/src/main/resources/application-demo.yaml
@@ -1,7 +1,7 @@
 # Demo profile — loaded when JAVA_TOOL_OPTIONS=-Dambon.profile=demo is set.
 # Overrides that make the live EC2 instance start new players in the
 # noecker_resume zone instead of the tutorial glade.
-ambonMUD:
+ambonmud:
   engine:
     classStartRooms:
       WARRIOR: noecker_resume:lobby

--- a/src/main/resources/application-engine1.yaml
+++ b/src/main/resources/application-engine1.yaml
@@ -2,7 +2,7 @@
 # Run with: ./gradlew runEngine1
 # Owns: tutorial_glade, ambon_hub, demo_ruins, low_training_marsh, low_training_highlands
 # gRPC server: 9091  |  metrics: 9191
-ambonMUD:
+ambonmud:
   mode: ENGINE
   sharding:
     enabled: true

--- a/src/main/resources/application-engine2.yaml
+++ b/src/main/resources/application-engine2.yaml
@@ -2,7 +2,7 @@
 # Run with: ./gradlew runEngine2
 # Owns: noecker_resume, low_training_mines, low_training_barrens
 # gRPC server: 9092  |  metrics: 9192
-ambonMUD:
+ambonmud:
   mode: ENGINE
   sharding:
     enabled: true

--- a/src/main/resources/application-gw1.yaml
+++ b/src/main/resources/application-gw1.yaml
@@ -2,7 +2,7 @@
 # Run with: ./gradlew runGateway1
 # Telnet: 4000  |  Web: 8080  |  metrics: 9180
 # Connects to engine-1 (:9091) and engine-2 (:9092)
-ambonMUD:
+ambonmud:
   mode: GATEWAY
   gateway:
     id: 0

--- a/src/main/resources/application-gw2.yaml
+++ b/src/main/resources/application-gw2.yaml
@@ -2,7 +2,7 @@
 # Run with: ./gradlew runGateway2
 # Telnet: 4001  |  Web: 8081  |  metrics: 9181
 # Connects to engine-1 (:9091) and engine-2 (:9092)
-ambonMUD:
+ambonmud:
   mode: GATEWAY
   gateway:
     id: 1

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,4 +1,4 @@
-ambonMUD:
+ambonmud:
   mode: STANDALONE
 
   sharding:

--- a/src/test/resources/test-application.yaml
+++ b/src/test/resources/test-application.yaml
@@ -1,4 +1,4 @@
-ambonMUD:
+ambonmud:
   world:
     resources:
       - world/test_world.yaml


### PR DESCRIPTION
## Problem

`AMBONMUD_*` env vars passed to `docker run` were silently ignored. Hoplite normalises env vars by lowercasing and replacing `_` with `.`, so `AMBONMUD_PERSISTENCE_BACKEND` becomes `ambonmud.persistence.backend`. However the root config field was named `ambonMUD` — the interior uppercase run caused Hoplite's key normalisation to produce `ambon-mud` (kebab-case) rather than `ambonmud`, so the path lookup never resolved.

Closes #320.

## Fix

Rename `AmbonMUDRootConfig.ambonMUD` → `ambonmud` and the YAML root key in all config files from `ambonMUD:` → `ambonmud:`. Now the env-var path `ambonmud.*` matches the field name exactly.

## Changes

- **`AppConfig.kt`** — field rename `ambonMUD` → `ambonmud`
- **`AppConfigLoader.kt`** — access `.ambonmud`; update comment block to show corrected paths; add note explaining the all-lowercase choice
- **`application.yaml` + all 5 profile YAMLs + `test-application.yaml`** — root key `ambonMUD:` → `ambonmud:`
- **`AppConfigLoaderTest.kt`** — fix system-property override key (`ambonMUD` → `ambonmud`); add regression test that injects `ambonmud.persistence.backend=POSTGRES` via `PropertySource.map` and asserts it overrides the default
- **`CLAUDE.md`** — update `-Pconfig.ambonMUD.*` examples to `-Pconfig.ambonmud.*`

## Test plan

- [ ] `AppConfigLoaderTest` passes (all existing + new regression test)
- [ ] `./gradlew ktlintCheck test` passes (CI parity)
- [ ] Deploy to EC2 and verify `AMBONMUD_PERSISTENCE_BACKEND=YAML AMBONMUD_REDIS_ENABLED=false` are respected without needing the `application.yaml` defaults workaround