### PR TITLE
fix: persist player data across container restarts and handle duplica…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,13 @@ RUN mkdir -p /app/data \
 
 USER ambonmud
 
+# Persist player data (YAML backend) across container restarts.
+# Without this, container recreation loses all player files and players
+# must re-create their characters.  For production use, prefer mounting
+# a named volume (e.g. -v ambondata:/app/data) or switching to the
+# Postgres backend via AMBONMUD_PERSISTENCE_BACKEND=POSTGRES.
+VOLUME /app/data
+
 # Telnet, WebSocket/HTTP, Metrics/Admin, gRPC
 EXPOSE 4000 8080 9090 9091
 

--- a/src/test/kotlin/dev/ambon/engine/PlayerRegistryFactoryTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/PlayerRegistryFactoryTest.kt
@@ -7,6 +7,10 @@ import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.persistence.PlayerCreationRequest
+import dev.ambon.persistence.PlayerId
+import dev.ambon.persistence.PlayerRecord
+import dev.ambon.persistence.PlayerRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -51,5 +55,101 @@ class PlayerRegistryFactoryTest {
             val player = registry.get(SessionId(1))
             assertNotNull(player)
             assertEquals(warriorRoom, player!!.roomId)
+        }
+
+    @Test
+    fun `prepareCreateAccount returns Taken when repo throws duplicate name`() =
+        runTest {
+            val startRoom = dev.ambon.test.TestWorlds.testWorld.startRoom
+            val inner = InMemoryPlayerRepository()
+
+            // Pre-populate "Alice" in the underlying repo
+            inner.create(
+                PlayerCreationRequest(
+                    name = "Alice",
+                    startRoomId = startRoom,
+                    nowEpochMs = 0L,
+                    passwordHash = "hash",
+                    ansiEnabled = false,
+                ),
+            )
+
+            // Wrap repo so findByName always misses — simulating the TOCTOU race window
+            val racyRepo =
+                object : PlayerRepository {
+                    override suspend fun findByName(name: String): PlayerRecord? = null
+
+                    override suspend fun findById(id: PlayerId): PlayerRecord? = inner.findById(id)
+
+                    override suspend fun create(request: PlayerCreationRequest): PlayerRecord = inner.create(request)
+
+                    override suspend fun save(record: PlayerRecord) = inner.save(record)
+                }
+
+            val registry =
+                dev.ambon.test.buildTestPlayerRegistry(startRoom, racyRepo, ItemRegistry())
+
+            val result =
+                registry.prepareCreateAccount(
+                    "Alice",
+                    "password",
+                    false,
+                    Race.HUMAN,
+                    PlayerClass.WARRIOR,
+                )
+
+            assertEquals(
+                CreateAccountPrep.Taken,
+                result,
+                "prepareCreateAccount should return Taken when repo.create throws PlayerPersistenceException",
+            )
+        }
+
+    @Test
+    fun `create returns Taken when repo throws duplicate name`() =
+        runTest {
+            val startRoom = dev.ambon.test.TestWorlds.testWorld.startRoom
+            val inner = InMemoryPlayerRepository()
+
+            // Pre-populate "Alice" in the underlying repo
+            inner.create(
+                PlayerCreationRequest(
+                    name = "Alice",
+                    startRoomId = startRoom,
+                    nowEpochMs = 0L,
+                    passwordHash = "hash",
+                    ansiEnabled = false,
+                ),
+            )
+
+            // Wrap repo so findByName always misses — simulating the TOCTOU race window
+            val racyRepo =
+                object : PlayerRepository {
+                    override suspend fun findByName(name: String): PlayerRecord? = null
+
+                    override suspend fun findById(id: PlayerId): PlayerRecord? = inner.findById(id)
+
+                    override suspend fun create(request: PlayerCreationRequest): PlayerRecord = inner.create(request)
+
+                    override suspend fun save(record: PlayerRecord) = inner.save(record)
+                }
+
+            val registry =
+                dev.ambon.test.buildTestPlayerRegistry(startRoom, racyRepo, ItemRegistry())
+
+            val result =
+                registry.create(
+                    sessionId = SessionId(1),
+                    nameRaw = "Alice",
+                    passwordRaw = "password",
+                    race = Race.HUMAN,
+                    playerClass = PlayerClass.WARRIOR,
+                )
+
+            assertEquals(
+                CreateResult.Taken,
+                result,
+                "create should return Taken when repo.create throws PlayerPersistenceException",
+            )
         }
 }

--- a/src/test/kotlin/dev/ambon/persistence/InMemoryPlayerRepository.kt
+++ b/src/test/kotlin/dev/ambon/persistence/InMemoryPlayerRepository.kt
@@ -11,6 +11,10 @@ class InMemoryPlayerRepository : PlayerRepository {
     override suspend fun findById(id: PlayerId): PlayerRecord? = players[id]
 
     override suspend fun create(request: PlayerCreationRequest): PlayerRecord {
+        val trimmed = request.name.trim()
+        if (players.values.any { it.name.equals(trimmed, ignoreCase = true) }) {
+            throw PlayerPersistenceException("Name already taken: '$trimmed'")
+        }
         val id = PlayerId(nextId.getAndIncrement())
         val record = request.toNewPlayerRecord(id)
         players[id] = record


### PR DESCRIPTION
…te creation

The YAML player data directory was not declared as a Docker VOLUME, so container recreation (common on EC2/ECS deployments) lost all player files.  After restart, findByName returned null and users could re-create characters with the same name.

Changes:
- Add VOLUME /app/data to Dockerfile so Docker auto-creates a persistent volume for player data files across container restarts
- Catch PlayerPersistenceException in PlayerRegistry.prepareCreateAccount and PlayerRegistry.create to handle the TOCTOU race between findByName and repo.create — prevents background coroutines from crashing when two sessions create the same name concurrently
- Add duplicate-name guard to InMemoryPlayerRepository.create so tests exercise the same uniqueness constraint as YAML/Postgres repos
- Add unit tests verifying both prepareCreateAccount and create return Taken (not throw) when the repository rejects a duplicate name
- Add integration test for two sessions creating the same name through the full engine login flow

https://claude.ai/code/session_018YaavodpUKswP2757CqXHR