### PR TITLE
feat: add setlevel staff command

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -114,6 +114,11 @@ sealed interface Command {
         val playerName: String,
     ) : Command
 
+    data class SetLevel(
+        val playerName: String,
+        val level: Int,
+    ) : Command
+
     data class Cast(
         val spellName: String,
         val target: String?,
@@ -603,6 +608,18 @@ object CommandParser {
 
         // kick
         requiredArg(line, listOf("kick"), "kick <player>", { Command.Kick(it) })?.let { return it }
+
+        // setlevel
+        matchPrefix(line, listOf("setlevel")) { rest ->
+            val parts = rest.trim().split(Regex("\\s+"), limit = 2)
+            val levelStr = parts.getOrNull(1)?.trim()
+            val level = levelStr?.toIntOrNull()
+            when {
+                parts[0].isBlank() || levelStr == null -> Command.Invalid(line, "setlevel <player> <level>")
+                level == null -> Command.Invalid(line, "setlevel <player> <level>")
+                else -> Command.SetLevel(parts[0], level)
+            }
+        }?.let { return it }
 
         // phase/layer — switch zone instance
         matchPrefix(line, listOf("phase", "layer")) { rest ->

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
@@ -221,6 +221,19 @@ class CommandParserTest {
     }
 
     @Test
+    fun `parses setlevel with player and level`() {
+        assertEquals(Command.SetLevel("Alice", 50), CommandParser.parse("setlevel Alice 50"))
+        assertEquals(Command.SetLevel("Bob", 1), CommandParser.parse("setlevel Bob 1"))
+    }
+
+    @Test
+    fun `setlevel with missing args returns Invalid`() {
+        assertTrue(CommandParser.parse("setlevel") is Command.Invalid)
+        assertTrue(CommandParser.parse("setlevel Alice") is Command.Invalid)
+        assertTrue(CommandParser.parse("setlevel Alice notanumber") is Command.Invalid)
+    }
+
+    @Test
     fun `parses cast with spell and target`() {
         assertEquals(Command.Cast("fireball", "rat"), CommandParser.parse("cast fireball rat"))
         assertEquals(Command.Cast("fireball", "rat"), CommandParser.parse("c fireball rat"))


### PR DESCRIPTION
## Summary

- Adds `setlevel <player> <level>` as a staff-only command
- Sets the target player's XP to the floor for the requested level, then recalculates HP, mana, and all derived stats in-memory — bypasses the YAML/cache layer entirely
- Sends a notification to the target and a confirmation to the staff member; emits GMCP vitals update

## Motivation

Editing `xpTotal` directly in the player YAML file doesn't work reliably because the `WriteCoalescingPlayerRepository` cache serves stale data on re-login and the persistence worker can overwrite manual edits. This command provides the correct in-memory path.

## Changes

- `CommandParser.kt` — new `Command.SetLevel(playerName, level)` variant + parse logic
- `PlayerRegistry.kt` — new `setLevel(sessionId, level)` method + exposed `maxLevel` property
- `AdminHandler.kt` — `handleSetLevel` wired to `Command.SetLevel`
- `CommandParserTest.kt` — parse tests for valid input and error cases
- `CommandRouterAdminTest.kt` — router tests: happy path, out-of-range level, offline player, non-staff rejection

## Test plan

- [x] `./gradlew ktlintCheck test --tests "CommandParserTest" --tests "CommandRouterAdminTest"` passes
- [ ] Deploy to demo and verify `setlevel Ambuoroko 50` sets level and persists across re-login