### PR TITLE
Increase HP/mana scaling and regen to be more reasonable

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/PlayerClass.kt
+++ b/src/main/kotlin/dev/ambon/domain/PlayerClass.kt
@@ -6,10 +6,10 @@ enum class PlayerClass(
     val manaPerLevel: Int,
     val debugOnly: Boolean = false,
 ) {
-    WARRIOR("Warrior", hpPerLevel = 3, manaPerLevel = 2),
-    MAGE("Mage", hpPerLevel = 1, manaPerLevel = 8),
-    CLERIC("Cleric", hpPerLevel = 2, manaPerLevel = 6),
-    ROGUE("Rogue", hpPerLevel = 2, manaPerLevel = 4),
+    WARRIOR("Warrior", hpPerLevel = 8, manaPerLevel = 4),
+    MAGE("Mage", hpPerLevel = 4, manaPerLevel = 16),
+    CLERIC("Cleric", hpPerLevel = 6, manaPerLevel = 12),
+    ROGUE("Rogue", hpPerLevel = 5, manaPerLevel = 8),
     SWARM("Swarm", hpPerLevel = 2, manaPerLevel = 3, debugOnly = true),
     ;
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -186,11 +186,11 @@ ambonmud:
       baseIntervalMillis: 5000
       minIntervalMillis: 1000
       msPerConstitution: 200
-      regenAmount: 1
+      regenAmount: 4
       mana:
         baseIntervalMillis: 3000
         minIntervalMillis: 1000
-        regenAmount: 1
+        regenAmount: 4
         msPerWisdom: 200
     scheduler:
       maxActionsPerTick: 100

--- a/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
@@ -480,8 +480,8 @@ class CombatSystemTest {
             assertNotNull(player)
             assertEquals(2, player!!.level)
             assertEquals(50L, player.xpTotal)
-            assertEquals(13, player.maxHp)
-            assertEquals(13, player.hp)
+            assertEquals(18, player.maxHp)
+            assertEquals(18, player.hp)
 
             val messages =
                 outbound
@@ -490,7 +490,7 @@ class CombatSystemTest {
                     .filter { it.sessionId == sid }
                     .map { it.text }
             assertTrue(messages.contains("You gain 50 XP."))
-            assertTrue(messages.contains("You reached level 2! (+3 max HP, +2 max Mana)"))
+            assertTrue(messages.contains("You reached level 2! (+8 max HP, +4 max Mana)"))
         }
 
     private fun equipItem(

--- a/src/test/kotlin/dev/ambon/engine/PlayerProgressionTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/PlayerProgressionTest.kt
@@ -143,10 +143,10 @@ class PlayerProgressionTest {
         progression.grantXp(warrior, 100L) // level 1 → 2
         progression.grantXp(mage, 100L) // level 1 → 2
 
-        // Warrior: hpPerLevel=3 → 10 + 3 = 13
-        assertEquals(13, warrior.maxHp, "Warrior HP should use class hpPerLevel=3")
-        // Mage: hpPerLevel=1 → 10 + 1 = 11
-        assertEquals(11, mage.maxHp, "Mage HP should use class hpPerLevel=1")
+        // Warrior: hpPerLevel=8 → 10 + 8 = 18
+        assertEquals(18, warrior.maxHp, "Warrior HP should use class hpPerLevel=8")
+        // Mage: hpPerLevel=4 → 10 + 4 = 14
+        assertEquals(14, mage.maxHp, "Mage HP should use class hpPerLevel=4")
     }
 
     @Test
@@ -189,10 +189,10 @@ class PlayerProgressionTest {
         progression.grantXp(warrior, 100L) // level 1 → 2
         progression.grantXp(mage, 100L) // level 1 → 2
 
-        // Warrior: manaPerLevel=2 → 20 + 2 = 22
-        assertEquals(22, warrior.maxMana, "Warrior mana should use class manaPerLevel=2")
-        // Mage: manaPerLevel=8 → 20 + 8 = 28
-        assertEquals(28, mage.maxMana, "Mage mana should use class manaPerLevel=8")
+        // Warrior: manaPerLevel=4 → 20 + 4 = 24
+        assertEquals(24, warrior.maxMana, "Warrior mana should use class manaPerLevel=4")
+        // Mage: manaPerLevel=16 → 20 + 16 = 36
+        assertEquals(36, mage.maxMana, "Mage mana should use class manaPerLevel=16")
     }
 
     @Test


### PR DESCRIPTION
Class per-level rates were too low, leaving a max-level Mage at only 59 HP after 50 levels. New values give ~3-4x more HP/mana at level cap:

  Warrior: HP 3→8/lvl, Mana 2→4/lvl  (level 50: 402 HP, 216 mana)
  Mage:    HP 1→4/lvl, Mana 8→16/lvl  (level 50: 206 HP, 804 mana)
  Cleric:  HP 2→6/lvl, Mana 6→12/lvl  (level 50: 304 HP, 608 mana)
  Rogue:   HP 2→5/lvl, Mana 4→8/lvl   (level 50: 255 HP, 412 mana)

HP and mana regen amounts also increased 1→4 per tick to keep recovery time proportional to the larger pools.

https://claude.ai/code/session_01Ghran8ML12mco1ypwTkzdB