### PR TITLE
refactor: collapse identical saveQuestState/saveAchievementState (#366)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/AchievementSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/AchievementSystem.kt
@@ -187,7 +187,7 @@ class AchievementSystem(
         }
 
         if (persistNeeded) {
-            players.saveAchievementState(sessionId)
+            players.persistPlayer(sessionId)
         }
     }
 

--- a/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
@@ -484,16 +484,6 @@ class PlayerRegistry(
         persistIfClaimed(ps)
     }
 
-    suspend fun saveQuestState(sessionId: SessionId) {
-        val ps = players[sessionId] ?: return
-        persistIfClaimed(ps)
-    }
-
-    suspend fun saveAchievementState(sessionId: SessionId) {
-        val ps = players[sessionId] ?: return
-        persistIfClaimed(ps)
-    }
-
     suspend fun setDisplayTitle(
         sessionId: SessionId,
         title: String?,

--- a/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
@@ -270,7 +270,7 @@ class QuestSystem(
     }
 
     private suspend fun persistPlayer(ps: dev.ambon.engine.PlayerState) {
-        players.saveQuestState(ps.sessionId)
+        players.persistPlayer(ps.sessionId)
     }
 
     private fun findActiveQuestId(


### PR DESCRIPTION
## Summary
- Removed duplicate `saveQuestState` and `saveAchievementState` methods from `PlayerRegistry` that were byte-for-byte identical to the existing `persistPlayer(sessionId)` method
- Updated callers in `QuestSystem` and `AchievementSystem` to use `persistPlayer` directly

## Test plan
- [x] `ktlintCheck` passes
- [x] Full test suite passes

Closes #366