### PR TITLE
refactor: extract generic enumFromString utility (#363)

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/EnumUtil.kt
+++ b/src/main/kotlin/dev/ambon/domain/EnumUtil.kt
@@ -1,0 +1,4 @@
+package dev.ambon.domain
+
+internal inline fun <reified T : Enum<T>> enumFromString(s: String): T? =
+    enumValues<T>().firstOrNull { it.name.equals(s, ignoreCase = true) }

--- a/src/main/kotlin/dev/ambon/domain/PlayerClass.kt
+++ b/src/main/kotlin/dev/ambon/domain/PlayerClass.kt
@@ -14,7 +14,7 @@ enum class PlayerClass(
     ;
 
     companion object {
-        fun fromString(s: String): PlayerClass? = entries.firstOrNull { it.name.equals(s, ignoreCase = true) }
+        fun fromString(s: String): PlayerClass? = enumFromString(s)
 
         fun selectable(debugClassesEnabled: Boolean = false): List<PlayerClass> =
             entries.filter { !it.debugOnly || debugClassesEnabled }

--- a/src/main/kotlin/dev/ambon/domain/Race.kt
+++ b/src/main/kotlin/dev/ambon/domain/Race.kt
@@ -16,6 +16,6 @@ enum class Race(
     ;
 
     companion object {
-        fun fromString(s: String): Race? = entries.firstOrNull { it.name.equals(s, ignoreCase = true) }
+        fun fromString(s: String): Race? = enumFromString(s)
     }
 }


### PR DESCRIPTION
## Summary

- Both `PlayerClass` and `Race` had an identical `fromString` implementation: `entries.firstOrNull { it.name.equals(s, ignoreCase = true) }`.
- Extracts a single `internal inline fun <reified T : Enum<T>> enumFromString(s: String): T?` utility in a new file `EnumUtil.kt` in the `dev.ambon.domain` package.
- Updates `PlayerClass.fromString` and `Race.fromString` to delegate to the utility, eliminating the duplication.

## Files Changed

- **New:** `src/main/kotlin/dev/ambon/domain/EnumUtil.kt` — the generic utility function
- **Updated:** `src/main/kotlin/dev/ambon/domain/PlayerClass.kt` — delegates to `enumFromString(s)`
- **Updated:** `src/main/kotlin/dev/ambon/domain/Race.kt` — delegates to `enumFromString(s)`

## Test plan

- [ ] `ktlintCheck` passes (verified locally: BUILD SUCCESSFUL)
- [ ] Full test suite passes (verified locally: BUILD SUCCESSFUL, tests UP-TO-DATE)
- [ ] No new behavior changes — `fromString` semantics are identical (case-insensitive enum name match)