### PR TITLE
refactor: remove unnecessary ItemOnUseFile DTO (#365)

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/world/data/ItemFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/ItemFile.kt
@@ -1,9 +1,6 @@
 package dev.ambon.domain.world.data
 
-data class ItemOnUseFile(
-    val healHp: Int = 0,
-    val grantXp: Long = 0L,
-)
+import dev.ambon.domain.items.ItemUseEffect
 
 data class ItemFile(
     val displayName: String,
@@ -20,7 +17,7 @@ data class ItemFile(
     val charisma: Int = 0,
     val consumable: Boolean = false,
     val charges: Int? = null,
-    val onUse: ItemOnUseFile? = null,
+    val onUse: ItemUseEffect? = null,
     val room: String? = null,
     val mob: String? = null,
     val matchByKey: Boolean = false,

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -12,7 +12,6 @@ import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.items.Item
 import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.items.ItemSlot
-import dev.ambon.domain.items.ItemUseEffect
 import dev.ambon.domain.quest.CompletionType
 import dev.ambon.domain.quest.ObjectiveType
 import dev.ambon.domain.quest.QuestDef
@@ -329,22 +328,17 @@ object WorldLoader {
                 }
 
                 val onUse =
-                    itemFile.onUse?.let { effectFile ->
-                        if (effectFile.healHp < 0) {
+                    itemFile.onUse?.also { effect ->
+                        if (effect.healHp < 0) {
                             throw WorldLoadException("Item '${itemId.value}' onUse.healHp cannot be negative")
                         }
-                        if (effectFile.grantXp < 0L) {
+                        if (effect.grantXp < 0L) {
                             throw WorldLoadException("Item '${itemId.value}' onUse.grantXp cannot be negative")
                         }
-                        ItemUseEffect(
-                            healHp = effectFile.healHp,
-                            grantXp = effectFile.grantXp,
-                        ).also { effect ->
-                            if (!effect.hasEffect()) {
-                                throw WorldLoadException(
-                                    "Item '${itemId.value}' onUse must define at least one positive effect",
-                                )
-                            }
+                        if (!effect.hasEffect()) {
+                            throw WorldLoadException(
+                                "Item '${itemId.value}' onUse must define at least one positive effect",
+                            )
                         }
                     }
 


### PR DESCRIPTION
## Summary
- Deleted `ItemOnUseFile` data class (was identical to `ItemUseEffect`)
- Changed `ItemFile.onUse` field type from `ItemOnUseFile?` to `ItemUseEffect?` — Jackson deserializes directly
- Simplified `WorldLoader` mapping to skip the manual field-by-field copy

## Test plan
- [x] `ktlintCheck` passes
- [x] Full test suite passes

Closes #365