### PR TITLE
refactor: introduce generic DefinitionRegistry base class (#360)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/DefinitionRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/DefinitionRegistry.kt
@@ -1,0 +1,17 @@
+package dev.ambon.engine
+
+open class DefinitionRegistry<Id, Def>(
+    private val idExtractor: (Def) -> Id,
+) {
+    private val map = mutableMapOf<Id, Def>()
+
+    fun register(def: Def) {
+        map[idExtractor(def)] = def
+    }
+
+    fun get(id: Id): Def? = map[id]
+
+    fun all(): Collection<Def> = map.values
+
+    protected fun entries(): Map<Id, Def> = map
+}

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilityRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilityRegistry.kt
@@ -1,33 +1,27 @@
 package dev.ambon.engine.abilities
 
 import dev.ambon.domain.PlayerClass
+import dev.ambon.engine.DefinitionRegistry
 
-class AbilityRegistry {
-    private val abilities = mutableMapOf<AbilityId, AbilityDefinition>()
-
-    fun register(ability: AbilityDefinition) {
-        abilities[ability.id] = ability
-    }
-
-    fun get(id: AbilityId): AbilityDefinition? = abilities[id]
-
+class AbilityRegistry : DefinitionRegistry<AbilityId, AbilityDefinition>({ it.id }) {
     fun findByKeyword(keyword: String): AbilityDefinition? {
         val lower = keyword.lowercase()
+        val values = all()
         // Exact id match first
-        abilities[AbilityId(lower)]?.let { return it }
+        get(AbilityId(lower))?.let { return it }
         // Exact displayName match (case-insensitive)
-        abilities.values.firstOrNull { it.displayName.equals(keyword, ignoreCase = true) }?.let { return it }
+        values.firstOrNull { it.displayName.equals(keyword, ignoreCase = true) }?.let { return it }
         // Prefix match on id
-        abilities.values.firstOrNull { it.id.value.startsWith(lower) }?.let { return it }
+        values.firstOrNull { it.id.value.startsWith(lower) }?.let { return it }
         // Substring match on displayName (case-insensitive, min 3 chars)
         if (lower.length >= 3) {
-            abilities.values.firstOrNull { it.displayName.lowercase().contains(lower) }?.let { return it }
+            values.firstOrNull { it.displayName.lowercase().contains(lower) }?.let { return it }
         }
         return null
     }
 
     fun abilitiesForLevel(level: Int): List<AbilityDefinition> =
-        abilities.values
+        all()
             .filter { it.levelRequired <= level }
             .sortedBy { it.levelRequired }
 
@@ -35,9 +29,7 @@ class AbilityRegistry {
         level: Int,
         playerClass: PlayerClass?,
     ): List<AbilityDefinition> =
-        abilities.values
+        all()
             .filter { it.levelRequired <= level && (it.requiredClass == null || it.requiredClass == playerClass) }
             .sortedBy { it.levelRequired }
-
-    fun all(): Collection<AbilityDefinition> = abilities.values
 }

--- a/src/main/kotlin/dev/ambon/engine/status/StatusEffectRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/status/StatusEffectRegistry.kt
@@ -1,15 +1,7 @@
 package dev.ambon.engine.status
 
-class StatusEffectRegistry {
-    private val definitions = mutableMapOf<StatusEffectId, StatusEffectDefinition>()
+import dev.ambon.engine.DefinitionRegistry
 
-    fun register(definition: StatusEffectDefinition) {
-        definitions[definition.id] = definition
-    }
-
-    fun get(id: StatusEffectId): StatusEffectDefinition? = definitions[id]
-
-    fun contains(id: StatusEffectId): Boolean = definitions.containsKey(id)
-
-    fun all(): Collection<StatusEffectDefinition> = definitions.values
+class StatusEffectRegistry : DefinitionRegistry<StatusEffectId, StatusEffectDefinition>({ it.id }) {
+    fun contains(id: StatusEffectId): Boolean = get(id) != null
 }


### PR DESCRIPTION
## Summary
- Created `DefinitionRegistry<Id, Def>` open base class with `register/get/all` contract
- Refactored `AbilityRegistry` to extend it — removed duplicate `register/get/all` methods and private map
- Refactored `StatusEffectRegistry` to extend it — same treatment
- `ShopRegistry` intentionally left alone (different keying strategy)
- Subclass-specific methods (`findByKeyword`, `abilitiesForLevel`, `contains`, etc.) preserved

## Test plan
- [x] `ktlintCheck` passes
- [x] Full test suite passes (1 pre-existing failure on main unrelated to this change)

Closes #360