### PR TITLE
fix: update CombatSystemTest hp expectation after rollRange refactor

### DIFF
--- a/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
@@ -218,7 +218,7 @@ class CombatSystemTest {
             val player = players.get(sid)
             assertNotNull(player)
             assertEquals(12, player!!.maxHp)
-            assertEquals(11, player.hp)
+            assertEquals(9, player.hp)
         }
 
     @Test


### PR DESCRIPTION
## Summary

- Fixes the CI failure introduced by #382's `rollRange()` refactor
- The new `rollRange()` short-circuits when `max <= min` (skipping `rng.nextInt()`), while the old `rollDamage()` always consumed an RNG call — this shifted the mob's subsequent damage roll in the seeded-RNG test
- Updates the expected `player.hp` from 11 to 9 in the "defense bonus increases max hp pool" test to match the new RNG sequence

## Test plan

- [x] `CombatSystemTest.defense bonus increases max hp pool` passes locally
- [x] Full `ktlintCheck test` suite passes (881+ tests, 0 failures)