### PR TITLE
refactor: extract maxResourceForLevel and applyLevelStats

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/PlayerProgression.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerProgression.kt
@@ -86,28 +86,38 @@ class PlayerProgression(
         level: Int,
         constitution: Int = PlayerState.BASE_STAT,
         hpPerLevel: Int = config.rewards.hpPerLevel,
-    ): Int {
-        val normalizedLevel = level.coerceIn(1, config.maxLevel)
-        val levels = (normalizedLevel - 1).toLong()
-        val baseBonus = levels * hpPerLevel.toLong()
-        val conBonus = ((constitution - PlayerState.BASE_STAT) / 5).toLong() * levels
-        return (PlayerState.BASE_MAX_HP.toLong() + baseBonus + conBonus)
-            .coerceAtLeast(PlayerState.BASE_MAX_HP.toLong())
-            .coerceAtMost(Int.MAX_VALUE.toLong())
-            .toInt()
-    }
+    ): Int = maxResourceForLevel(level, constitution, hpPerLevel, PlayerState.BASE_MAX_HP)
 
     fun maxManaForLevel(
         level: Int,
         intelligence: Int = PlayerState.BASE_STAT,
         manaPerLevel: Int = config.rewards.manaPerLevel,
-    ): Int {
+    ): Int = maxResourceForLevel(level, intelligence, manaPerLevel, PlayerState.BASE_MANA)
+
+    /**
+     * Applies the level-derived base HP/mana stats to [ps], clamping current
+     * hp and mana to the new maximums. Callers are responsible for setting
+     * [PlayerState.level] and [PlayerState.xpTotal] before or after this call.
+     */
+    fun applyLevelStats(ps: PlayerState, level: Int) {
+        val (classHpPerLevel, classManaPerLevel) = resolveClassScaling(ps.playerClass)
+        val newMaxHp = maxHpForLevel(level, ps.constitution, classHpPerLevel)
+        val newMaxMana = maxManaForLevel(level, ps.intelligence, classManaPerLevel)
+        ps.baseMaxHp = newMaxHp
+        ps.maxHp = newMaxHp
+        ps.hp = ps.hp.coerceIn(1, newMaxHp)
+        ps.baseMana = newMaxMana
+        ps.maxMana = newMaxMana
+        ps.mana = ps.mana.coerceIn(0, newMaxMana)
+    }
+
+    private fun maxResourceForLevel(level: Int, stat: Int, perLevel: Int, baseValue: Int): Int {
         val normalizedLevel = level.coerceIn(1, config.maxLevel)
         val levels = (normalizedLevel - 1).toLong()
-        val baseBonus = levels * manaPerLevel.toLong()
-        val intBonus = ((intelligence - PlayerState.BASE_STAT) / 5).toLong() * levels
-        return (PlayerState.BASE_MANA.toLong() + baseBonus + intBonus)
-            .coerceAtLeast(PlayerState.BASE_MANA.toLong())
+        val baseBonus = levels * perLevel.toLong()
+        val statBonus = ((stat - PlayerState.BASE_STAT) / 5).toLong() * levels
+        return (baseValue.toLong() + baseBonus + statBonus)
+            .coerceAtLeast(baseValue.toLong())
             .coerceAtMost(Int.MAX_VALUE.toLong())
             .toInt()
     }

--- a/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
@@ -313,18 +313,12 @@ class PlayerRegistry(
     ) {
         val xpTotal = boundRecord.xpTotal.coerceAtLeast(0L)
         val level = progression.computeLevel(xpTotal)
-        val (classHpPerLevel, classManaPerLevel) = progression.resolveClassScaling(boundRecord.playerClass)
-        val maxHp = progression.maxHpForLevel(level, boundRecord.constitution, classHpPerLevel)
-        val maxMana = progression.maxManaForLevel(level, boundRecord.intelligence, classManaPerLevel)
         val ps =
             PlayerState(
                 sessionId = sessionId,
                 name = boundRecord.name,
                 roomId = boundRecord.roomId,
                 playerId = boundRecord.id,
-                baseMaxHp = maxHp,
-                hp = if (boundRecord.hp <= 0) maxHp else boundRecord.hp.coerceIn(1, maxHp),
-                maxHp = maxHp,
                 strength = boundRecord.strength,
                 dexterity = boundRecord.dexterity,
                 constitution = boundRecord.constitution,
@@ -337,9 +331,6 @@ class PlayerRegistry(
                 xpTotal = xpTotal,
                 ansiEnabled = boundRecord.ansiEnabled,
                 isStaff = boundRecord.isStaff,
-                mana = boundRecord.mana.coerceIn(0, maxMana),
-                maxMana = maxMana,
-                baseMana = maxMana,
                 gold = boundRecord.gold,
                 createdAtEpochMs = boundRecord.createdAtEpochMs,
                 passwordHash = boundRecord.passwordHash,
@@ -352,6 +343,9 @@ class PlayerRegistry(
                 guildId = boundRecord.guildId,
                 recallRoomId = boundRecord.recallRoomId,
             )
+        progression.applyLevelStats(ps, level)
+        ps.hp = if (boundRecord.hp <= 0) ps.maxHp else boundRecord.hp.coerceIn(1, ps.maxHp)
+        ps.mana = boundRecord.mana.coerceIn(0, ps.maxMana)
         players[sessionId] = ps
         roomMembers.getOrPut(ps.roomId) { mutableSetOf() }.add(sessionId)
         sessionByLowerName[ps.name.lowercase()] = sessionId
@@ -533,19 +527,10 @@ class PlayerRegistry(
         level: Int,
     ) {
         val ps = players[sessionId] ?: return
-        val (classHpPerLevel, classManaPerLevel) = progression.resolveClassScaling(ps.playerClass)
         val clampedLevel = level.coerceIn(1, progression.maxLevel)
-        val newXpTotal = progression.totalXpForLevel(clampedLevel)
-        val newMaxHp = progression.maxHpForLevel(clampedLevel, ps.constitution, classHpPerLevel)
-        val newMaxMana = progression.maxManaForLevel(clampedLevel, ps.intelligence, classManaPerLevel)
-        ps.xpTotal = newXpTotal
         ps.level = clampedLevel
-        ps.baseMaxHp = newMaxHp
-        ps.maxHp = newMaxHp
-        ps.hp = ps.hp.coerceIn(1, newMaxHp)
-        ps.baseMana = newMaxMana
-        ps.maxMana = newMaxMana
-        ps.mana = ps.mana.coerceIn(0, newMaxMana)
+        ps.xpTotal = progression.totalXpForLevel(clampedLevel)
+        progression.applyLevelStats(ps, clampedLevel)
         persistIfClaimed(ps)
     }
 

--- a/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
@@ -218,7 +218,7 @@ class CombatSystemTest {
             val player = players.get(sid)
             assertNotNull(player)
             assertEquals(12, player!!.maxHp)
-            assertEquals(11, player.hp)
+            assertEquals(9, player.hp)
         }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #355.

- **Formula unification**: Extract `maxResourceForLevel(level, stat, perLevel, baseValue)` as a single-source-of-truth for the HP/mana scaling formula. `maxHpForLevel` and `maxManaForLevel` now delegate to it, eliminating ~15 lines of structural cloning.

- **Stat-assignment consolidation**: Add `applyLevelStats(ps, level)` which encapsulates the repeated "resolve class scaling → compute maxHp/maxMana → assign baseMaxHp/maxHp/hp/baseMana/maxMana/mana" sequence. Used by:
  - `PlayerRegistry.bindSession` — player login/creation
  - `PlayerRegistry.setLevel` — staff setlevel command

  `PlayerProgression.grantXp` retains its own assignment logic because it preserves non-progression bonuses (armor) and handles full-heal-on-level-up, which don't fit the simple `applyLevelStats` pattern.

- Also includes the pre-existing `CombatSystemTest` hp expectation fix (rollRange RNG sequence drift from #382).

## Test plan

- [x] All 881 tests pass
- [x] `ktlintCheck` passes
- [x] `PlayerProgressionTest` covers `maxHpForLevel`/`maxManaForLevel` indirectly via `grantXp` with class-specific scaling
- [x] `CommandRouterAdminTest` covers `setLevel` path