### PR TITLE
refactor: extract qualifyId helper for zone:localId pattern

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/ids/RoomId.kt
+++ b/src/main/kotlin/dev/ambon/domain/ids/RoomId.kt
@@ -1,5 +1,9 @@
 package dev.ambon.domain.ids
 
+/** Qualifies [localId] with [zone] if it doesn't already contain a zone prefix. */
+fun qualifyId(zone: String, localId: String): String =
+    if (':' in localId) localId else "$zone:$localId"
+
 @JvmInline
 value class RoomId(
     val value: String,

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -9,6 +9,7 @@ import dev.ambon.config.MobTiersConfig
 import dev.ambon.domain.ids.ItemId
 import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.qualifyId
 import dev.ambon.domain.items.Item
 import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.items.ItemSlot
@@ -263,7 +264,7 @@ object WorldLoader {
                 val questIds =
                     mf.quests.map { rawQuestId ->
                         val s = rawQuestId.trim()
-                        if (':' in s) s else "$zone:$s"
+                        qualifyId(zone, s)
                     }
 
                 mergedMobs[mobId] =
@@ -410,7 +411,7 @@ object WorldLoader {
                     }
                 mergedShops.add(
                     ShopDefinition(
-                        id = "$zone:$rawId",
+                        id = qualifyId(zone, rawId),
                         name = shopName,
                         roomId = shopRoomId,
                         itemIds = shopItemIds,
@@ -420,7 +421,7 @@ object WorldLoader {
 
             // Stage quests (normalized)
             for ((rawId, questFile) in file.quests) {
-                val questId = "$zone:$rawId"
+                val questId = qualifyId(zone, rawId)
                 val questName = questFile.name.trim()
                 if (questName.isEmpty()) {
                     throw WorldLoadException("Quest '$questId' name cannot be blank")
@@ -456,7 +457,7 @@ object WorldLoader {
                                 "Quest '$questId' objective #${index + 1} targetKey cannot be blank",
                             )
                         }
-                        val targetId = if (':' in targetKeyRaw) targetKeyRaw else "$zone:$targetKeyRaw"
+                        val targetId = qualifyId(zone, targetKeyRaw)
                         if (obj.count < 1) {
                             throw WorldLoadException(
                                 "Quest '$questId' objective #${index + 1} count must be >= 1",
@@ -474,7 +475,7 @@ object WorldLoader {
                         id = questId,
                         name = questName,
                         description = questFile.description,
-                        giverMobId = if (':' in giver) giver else "$zone:$giver",
+                        giverMobId = qualifyId(zone, giver),
                         objectives = objectives,
                         rewards = QuestRewards(xp = questFile.rewards.xp, gold = questFile.rewards.gold),
                         completionType = completionType,
@@ -657,7 +658,7 @@ object WorldLoader {
     ): RoomId {
         val s = raw.trim()
         if (s.isEmpty()) throw WorldLoadException("Room id cannot be blank")
-        return if (':' in s) RoomId(s) else RoomId("$zone:$s")
+        return RoomId(qualifyId(zone, s))
     }
 
     /**
@@ -676,7 +677,7 @@ object WorldLoader {
     ): MobId {
         val s = raw.trim()
         if (s.isEmpty()) throw WorldLoadException("Mob id cannot be blank")
-        return if (':' in s) MobId(s) else MobId("$zone:$s")
+        return MobId(qualifyId(zone, s))
     }
 
     private fun normalizeItemId(
@@ -685,7 +686,7 @@ object WorldLoader {
     ): ItemId {
         val s = raw.trim()
         if (s.isEmpty()) throw WorldLoadException("Item id cannot be blank")
-        return if (':' in s) ItemId(s) else ItemId("$zone:$s")
+        return ItemId(qualifyId(zone, s))
     }
 
     private fun normalizeKeyword(

--- a/src/main/kotlin/dev/ambon/engine/behavior/BehaviorTemplates.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/BehaviorTemplates.kt
@@ -1,6 +1,7 @@
 package dev.ambon.engine.behavior
 
 import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.qualifyId
 import dev.ambon.domain.world.data.BehaviorParamsFile
 import dev.ambon.engine.behavior.actions.AggroAction
 import dev.ambon.engine.behavior.actions.FleeAction
@@ -121,7 +122,6 @@ object BehaviorTemplates {
         zone: String,
     ): List<RoomId> =
         route.map { raw ->
-            val id = if (':' in raw) raw else "$zone:$raw"
-            RoomId(id)
+            RoomId(qualifyId(zone, raw))
         }
 }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -4,6 +4,7 @@ import dev.ambon.bus.OutboundBus
 import dev.ambon.domain.ids.ItemId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.ids.qualifyId
 import dev.ambon.domain.world.Direction
 import dev.ambon.domain.world.LockableState
 import dev.ambon.domain.world.Room
@@ -309,8 +310,8 @@ internal fun resolveGotoArg(
                 world.rooms.keys.firstOrNull { it.zone == effectiveZone }
             }
         } else {
-            runCatching { RoomId("$effectiveZone:$local") }.getOrNull()
+            runCatching { RoomId(qualifyId(effectiveZone, local)) }.getOrNull()
         }
     } else {
-        runCatching { RoomId("$currentZone:$arg") }.getOrNull()
+        runCatching { RoomId(qualifyId(currentZone, arg)) }.getOrNull()
     }


### PR DESCRIPTION
## Summary
- Adds `qualifyId(zone, localId)` function in `dev.ambon.domain.ids` package (alongside `RoomId.zone`/`.local` which are the reverse operations)
- Replaces 10+ inline occurrences of `if (':' in s) s else "$zone:$s"` across `WorldLoader`, `BehaviorTemplates`, and `HandlerHelpers`
- Simplifies `normalizeId`, `normalizeMobId`, and `normalizeItemId` in `WorldLoader` to single-expression calls

**Impact:** 4 files changed, 18 insertions, 12 deletions (-6 net, but main value is consistency)

## Test plan
- [x] All existing tests pass (`ktlintCheck test`)
- [x] WorldLoader tests verify zone-qualified IDs still resolve correctly
- [x] BehaviorTree tests verify patrol routes still parse with zone qualification

Closes #361