### PR TITLE
refactor: consolidate PlayerRecord/PlayerDto/PlayerState field mapping

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
@@ -596,43 +596,8 @@ class PlayerRegistry(
     }
 
     private suspend fun persistIfClaimed(ps: PlayerState) {
-        val pid = ps.playerId ?: return
-        val now = clock.millis()
-
-        repo.save(
-            PlayerRecord(
-                id = pid,
-                name = ps.name,
-                roomId = ps.roomId,
-                strength = ps.strength,
-                dexterity = ps.dexterity,
-                constitution = ps.constitution,
-                intelligence = ps.intelligence,
-                wisdom = ps.wisdom,
-                charisma = ps.charisma,
-                race = ps.race,
-                playerClass = ps.playerClass,
-                level = ps.level,
-                xpTotal = ps.xpTotal,
-                createdAtEpochMs = ps.createdAtEpochMs,
-                lastSeenEpochMs = now,
-                passwordHash = ps.passwordHash,
-                ansiEnabled = ps.ansiEnabled,
-                isStaff = ps.isStaff,
-                hp = ps.hp,
-                mana = ps.mana,
-                maxMana = ps.maxMana,
-                gold = ps.gold,
-                activeQuests = ps.activeQuests,
-                completedQuestIds = ps.completedQuestIds,
-                unlockedAchievementIds = ps.unlockedAchievementIds,
-                achievementProgress = ps.achievementProgress,
-                activeTitle = ps.activeTitle,
-                inbox = ps.inbox.toList(),
-                guildId = ps.guildId,
-                recallRoomId = ps.recallRoomId,
-            ),
-        )
+        if (ps.playerId == null) return
+        repo.save(ps.toPlayerRecord(lastSeenEpochMs = clock.millis()))
     }
 
     private fun isValidPassword(password: String): Boolean {

--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -10,6 +10,7 @@ import dev.ambon.domain.quest.QuestState
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.engine.status.StatModifiers
 import dev.ambon.persistence.PlayerId
+import dev.ambon.persistence.PlayerRecord
 
 data class PlayerState(
     val sessionId: SessionId,
@@ -110,6 +111,43 @@ fun PlayerState.healMana(amount: Int): Boolean {
 /** Decreases mana by [amount], clamped to 0. */
 fun PlayerState.spendMana(amount: Int) {
     mana = (mana - amount).coerceAtLeast(0)
+}
+
+/** Converts this runtime state to a [PlayerRecord] for persistence. */
+fun PlayerState.toPlayerRecord(lastSeenEpochMs: Long): PlayerRecord {
+    val pid = playerId ?: error("Cannot persist a PlayerState without a playerId")
+    return PlayerRecord(
+        id = pid,
+        name = name,
+        roomId = roomId,
+        strength = strength,
+        dexterity = dexterity,
+        constitution = constitution,
+        intelligence = intelligence,
+        wisdom = wisdom,
+        charisma = charisma,
+        race = race,
+        playerClass = playerClass,
+        level = level,
+        xpTotal = xpTotal,
+        createdAtEpochMs = createdAtEpochMs,
+        lastSeenEpochMs = lastSeenEpochMs,
+        passwordHash = passwordHash,
+        ansiEnabled = ansiEnabled,
+        isStaff = isStaff,
+        hp = hp,
+        mana = mana,
+        maxMana = maxMana,
+        gold = gold,
+        activeQuests = activeQuests,
+        completedQuestIds = completedQuestIds,
+        unlockedAchievementIds = unlockedAchievementIds,
+        achievementProgress = achievementProgress,
+        activeTitle = activeTitle,
+        inbox = inbox.toList(),
+        guildId = guildId,
+        recallRoomId = recallRoomId,
+    )
 }
 
 /** Clears all guild-related fields on this player. */

--- a/src/main/kotlin/dev/ambon/persistence/PostgresPlayerRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PostgresPlayerRepository.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import dev.ambon.domain.achievement.AchievementState
+import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.mail.MailMessage
 import dev.ambon.domain.quest.QuestState
 import dev.ambon.metrics.GameMetrics
@@ -91,52 +92,53 @@ class PostgresPlayerRepository(
     override suspend fun save(record: PlayerRecord) {
         metrics.timedSave {
             newSuspendedTransaction(Dispatchers.IO, database) {
-                val dto = PlayerDto.from(record)
                 PlayersTable.upsert(PlayersTable.id) {
-                    it[id] = dto.id
-                    it[name] = dto.name
-                    it[nameLower] = dto.name.lowercase()
-                    it[roomId] = dto.roomId
-                    it[strength] = dto.strength
-                    it[dexterity] = dto.dexterity
-                    it[constitution] = dto.constitution
-                    it[intelligence] = dto.intelligence
-                    it[wisdom] = dto.wisdom
-                    it[charisma] = dto.charisma
-                    it[race] = dto.race
-                    it[playerClass] = dto.playerClass
-                    it[level] = dto.level
-                    it[xpTotal] = dto.xpTotal
-                    it[createdAtEpochMs] = dto.createdAtEpochMs
-                    it[lastSeenEpochMs] = dto.lastSeenEpochMs
-                    it[passwordHash] = dto.passwordHash
-                    it[ansiEnabled] = dto.ansiEnabled
-                    it[isStaff] = dto.isStaff
-                    it[hp] = dto.hp
-                    it[mana] = dto.mana
-                    it[maxMana] = dto.maxMana
-                    it[gold] = dto.gold
-                    it[activeQuests] = questMapper.writeValueAsString(dto.activeQuests)
-                    it[completedQuestIds] = questMapper.writeValueAsString(dto.completedQuestIds)
-                    it[unlockedAchievementIds] = questMapper.writeValueAsString(dto.unlockedAchievementIds)
-                    it[achievementProgress] = questMapper.writeValueAsString(dto.achievementProgress)
-                    it[activeTitle] = dto.activeTitle
-                    it[mailInbox] = questMapper.writeValueAsString(dto.inbox)
-                    it[guildId] = dto.guildId
-                    it[recallRoomId] = dto.recallRoomId
+                    it[id] = record.id.value
+                    it[name] = record.name
+                    it[nameLower] = record.name.lowercase()
+                    it[roomId] = record.roomId.value
+                    it[strength] = record.strength
+                    it[dexterity] = record.dexterity
+                    it[constitution] = record.constitution
+                    it[intelligence] = record.intelligence
+                    it[wisdom] = record.wisdom
+                    it[charisma] = record.charisma
+                    it[race] = record.race
+                    it[playerClass] = record.playerClass
+                    it[level] = record.level
+                    it[xpTotal] = record.xpTotal
+                    it[createdAtEpochMs] = record.createdAtEpochMs
+                    it[lastSeenEpochMs] = record.lastSeenEpochMs
+                    it[passwordHash] = record.passwordHash
+                    it[ansiEnabled] = record.ansiEnabled
+                    it[isStaff] = record.isStaff
+                    it[hp] = record.hp
+                    it[mana] = record.mana
+                    it[maxMana] = record.maxMana
+                    it[gold] = record.gold
+                    it[activeQuests] = questMapper.writeValueAsString(record.activeQuests)
+                    it[completedQuestIds] = questMapper.writeValueAsString(record.completedQuestIds)
+                    it[unlockedAchievementIds] = questMapper.writeValueAsString(record.unlockedAchievementIds)
+                    it[achievementProgress] = questMapper.writeValueAsString(record.achievementProgress)
+                    it[activeTitle] = record.activeTitle
+                    it[mailInbox] = questMapper.writeValueAsString(record.inbox)
+                    it[guildId] = record.guildId
+                    it[recallRoomId] = record.recallRoomId?.value
                 }
             }
         }
     }
 
-    private fun ResultRow.toPlayerRecord(): PlayerRecord =
-        PlayerDto(
-            id = this[PlayersTable.id],
+    private fun ResultRow.toPlayerRecord(): PlayerRecord {
+        // Legacy migration: old rows stored constitution=0; remap to base 10
+        val rawCon = this[PlayersTable.constitution]
+        return PlayerRecord(
+            id = PlayerId(this[PlayersTable.id]),
             name = this[PlayersTable.name],
-            roomId = this[PlayersTable.roomId],
+            roomId = RoomId(this[PlayersTable.roomId]),
             strength = this[PlayersTable.strength],
             dexterity = this[PlayersTable.dexterity],
-            constitution = this[PlayersTable.constitution],
+            constitution = if (rawCon == 0) 10 else rawCon,
             intelligence = this[PlayersTable.intelligence],
             wisdom = this[PlayersTable.wisdom],
             charisma = this[PlayersTable.charisma],
@@ -160,6 +162,7 @@ class PostgresPlayerRepository(
             activeTitle = this[PlayersTable.activeTitle],
             inbox = safeReadJson(this[PlayersTable.mailInbox], mailInboxType, emptyList()),
             guildId = this[PlayersTable.guildId],
-            recallRoomId = this[PlayersTable.recallRoomId],
-        ).toDomain()
+            recallRoomId = this[PlayersTable.recallRoomId]?.let { RoomId(it) },
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Closes #347

- **Add `PlayerState.toPlayerRecord()` extension** — centralizes the PlayerState → PlayerRecord conversion that was previously inlined as a 30-line field-by-field copy in `PlayerRegistry.persistIfClaimed()`
- **Eliminate `PlayerDto` intermediary in Postgres path** — `PostgresPlayerRepository.save()` now maps `PlayerRecord` fields directly to Exposed columns instead of first converting to `PlayerDto`. `toPlayerRecord()` constructs `PlayerRecord` directly from `ResultRow` instead of going through `PlayerDto.toDomain()`
- **Preserve legacy migration** — the constitution=0 → 10 fixup is retained in both the Postgres and YAML/Redis deserialization paths

`PlayerDto` remains for its legitimate use cases (YAML serialization via Jackson and Redis JSON caching) but is no longer used as an unnecessary intermediary in the Postgres path.

## Test plan

- [x] `ktlintCheck` passes
- [x] Full test suite passes (including `PostgresPlayerRepositoryTest`, `YamlPlayerRepositoryTest`, `RedisCachingPlayerRepositoryTest`, `WriteCoalescingPlayerRepositoryTest`, and all engine integration tests)
