### PR TITLE
Introduce test harnesses to reduce boilerplate in test setup

### DIFF
--- a/src/test/kotlin/dev/ambon/engine/GameEngineLoginFlowTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GameEngineLoginFlowTest.kt
@@ -12,6 +12,9 @@ import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.engine.scheduler.Scheduler
 import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.GameEngineHarness
+import dev.ambon.test.TestWorlds
+import dev.ambon.test.buildTestPlayerRegistry
 import dev.ambon.test.createTestPlayer
 import dev.ambon.test.drainAll
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -35,40 +38,17 @@ class GameEngineLoginFlowTest {
     @Test
     fun `connect shows login screen before name prompt`() =
         runTest {
-            val inbound = LocalInboundBus()
-            val outbound = LocalOutboundBus()
-
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val repo = InMemoryPlayerRepository()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, repo, ItemRegistry())
-
             val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)
-            val mobs = MobRegistry()
-            val items = ItemRegistry()
-            val scheduler = Scheduler(clock)
-            val tickMillis = 10L
-            val engine =
-                GameEngine(
-                    inbound = inbound,
-                    outbound = outbound,
-                    players = players,
-                    world = world,
-                    clock = clock,
-                    tickMillis = tickMillis,
-                    scheduler = scheduler,
-                    mobs = mobs,
-                    items = items,
-                )
-            val engineJob = launch { engine.run() }
+            val h = GameEngineHarness.start(scope = this, clock = clock)
 
             val sid = SessionId(99L)
             runCurrent()
 
-            inbound.send(InboundEvent.Connected(sid))
-            advanceTimeBy(tickMillis)
+            h.inbound.send(InboundEvent.Connected(sid))
+            advanceTimeBy(h.tickMillis)
             runCurrent()
 
-            val outs = outbound.drainAll()
+            val outs = h.outbound.drainAll()
             val loginIndex = outs.indexOfFirst { it is OutboundEvent.ShowLoginScreen && it.sessionId == sid }
             val namePromptIndex =
                 outs.indexOfFirst {
@@ -87,52 +67,28 @@ class GameEngineLoginFlowTest {
                 "Expected a prompt after connect. got=$outs",
             )
 
-            engineJob.cancel()
-            inbound.close()
-            outbound.close()
+            h.close()
         }
 
     @Test
     fun `blank password returns to name prompt`() =
         runTest {
-            val inbound = LocalInboundBus()
-            val outbound = LocalOutboundBus()
-
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val repo = InMemoryPlayerRepository()
-            repo.createTestPlayer("Alice", world.startRoom, password = "secret", ansiEnabled = false)
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, repo, ItemRegistry())
-
             val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)
-            val mobs = MobRegistry()
-            val items = ItemRegistry()
-            val scheduler = Scheduler(clock)
-            val tickMillis = 10L
-            val engine =
-                GameEngine(
-                    inbound = inbound,
-                    outbound = outbound,
-                    players = players,
-                    world = world,
-                    clock = clock,
-                    tickMillis = tickMillis,
-                    scheduler = scheduler,
-                    mobs = mobs,
-                    items = items,
-                )
-            val engineJob = launch { engine.run() }
+            val repo = InMemoryPlayerRepository()
+            repo.createTestPlayer("Alice", TestWorlds.testWorld.startRoom, password = "secret", ansiEnabled = false)
+            val h = GameEngineHarness.start(scope = this, clock = clock, repo = repo)
 
             val sid = SessionId(1L)
             runCurrent()
 
-            inbound.send(InboundEvent.Connected(sid))
-            inbound.send(InboundEvent.LineReceived(sid, "Alice"))
-            inbound.send(InboundEvent.LineReceived(sid, ""))
+            h.inbound.send(InboundEvent.Connected(sid))
+            h.inbound.send(InboundEvent.LineReceived(sid, "Alice"))
+            h.inbound.send(InboundEvent.LineReceived(sid, ""))
 
-            advanceTimeBy(tickMillis)
+            advanceTimeBy(h.tickMillis)
             runCurrent()
 
-            val outs = outbound.drainAll()
+            val outs = h.outbound.drainAll()
 
             assertTrue(
                 outs.any { it is OutboundEvent.SendInfo && it.sessionId == sid && it.text == "Password:" },
@@ -159,52 +115,28 @@ class GameEngineLoginFlowTest {
                 "Did not expect disconnect after one blank password. got=$outs",
             )
 
-            engineJob.cancel()
-            inbound.close()
-            outbound.close()
+            h.close()
         }
 
     @Test
     fun `fourth wrong password returns to login`() =
         runTest {
-            val inbound = LocalInboundBus()
-            val outbound = LocalOutboundBus()
-
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val repo = InMemoryPlayerRepository()
-            repo.createTestPlayer("Alice", world.startRoom, password = "secret", ansiEnabled = false)
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, repo, ItemRegistry())
-
             val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)
-            val mobs = MobRegistry()
-            val items = ItemRegistry()
-            val scheduler = Scheduler(clock)
-            val tickMillis = 10L
-            val engine =
-                GameEngine(
-                    inbound = inbound,
-                    outbound = outbound,
-                    players = players,
-                    world = world,
-                    clock = clock,
-                    tickMillis = tickMillis,
-                    scheduler = scheduler,
-                    mobs = mobs,
-                    items = items,
-                )
-            val engineJob = launch { engine.run() }
+            val repo = InMemoryPlayerRepository()
+            repo.createTestPlayer("Alice", TestWorlds.testWorld.startRoom, password = "secret", ansiEnabled = false)
+            val h = GameEngineHarness.start(scope = this, clock = clock, repo = repo)
 
             val sid = SessionId(1L)
             runCurrent()
 
-            inbound.send(InboundEvent.Connected(sid))
-            inbound.send(InboundEvent.LineReceived(sid, "Alice"))
-            repeat(4) { inbound.send(InboundEvent.LineReceived(sid, "wrong")) }
+            h.inbound.send(InboundEvent.Connected(sid))
+            h.inbound.send(InboundEvent.LineReceived(sid, "Alice"))
+            repeat(4) { h.inbound.send(InboundEvent.LineReceived(sid, "wrong")) }
 
-            advanceTimeBy(tickMillis)
+            advanceTimeBy(h.tickMillis)
             runCurrent()
 
-            val outs = outbound.drainAll()
+            val outs = h.outbound.drainAll()
 
             assertTrue(
                 outs.any {
@@ -251,106 +183,57 @@ class GameEngineLoginFlowTest {
                 "Did not expect disconnect after first failed login cycle. got=$outs",
             )
 
-            engineJob.cancel()
-            inbound.close()
-            outbound.close()
+            h.close()
         }
 
     @Test
     fun `disconnects after three failed login cycles`() =
         runTest {
-            val inbound = LocalInboundBus()
-            val outbound = LocalOutboundBus()
-
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val repo = InMemoryPlayerRepository()
-            repo.createTestPlayer("Alice", world.startRoom, password = "secret", ansiEnabled = false)
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, repo, ItemRegistry())
-
             val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)
-            val mobs = MobRegistry()
-            val items = ItemRegistry()
-            val scheduler = Scheduler(clock)
-            val tickMillis = 10L
-            val engine =
-                GameEngine(
-                    inbound = inbound,
-                    outbound = outbound,
-                    players = players,
-                    world = world,
-                    clock = clock,
-                    tickMillis = tickMillis,
-                    scheduler = scheduler,
-                    mobs = mobs,
-                    items = items,
-                )
-            val engineJob = launch { engine.run() }
+            val repo = InMemoryPlayerRepository()
+            repo.createTestPlayer("Alice", TestWorlds.testWorld.startRoom, password = "secret", ansiEnabled = false)
+            val h = GameEngineHarness.start(scope = this, clock = clock, repo = repo)
 
             val sid = SessionId(1L)
             runCurrent()
 
-            inbound.send(InboundEvent.Connected(sid))
+            h.inbound.send(InboundEvent.Connected(sid))
             repeat(3) {
-                inbound.send(InboundEvent.LineReceived(sid, "Alice"))
-                repeat(4) { inbound.send(InboundEvent.LineReceived(sid, "wrong")) }
+                h.inbound.send(InboundEvent.LineReceived(sid, "Alice"))
+                repeat(4) { h.inbound.send(InboundEvent.LineReceived(sid, "wrong")) }
             }
 
-            advanceTimeBy(tickMillis)
+            advanceTimeBy(h.tickMillis)
             runCurrent()
 
             val got = mutableListOf<OutboundEvent>()
             withTimeout(500) {
                 while (got.none { it is OutboundEvent.Close && it.sessionId == sid }) {
-                    got += outbound.asReceiveChannel().receive()
+                    got += h.outbound.asReceiveChannel().receive()
                 }
             }
 
             val close = got.filterIsInstance<OutboundEvent.Close>().first { it.sessionId == sid }
             assertEquals("Too many failed login attempts.", close.reason)
 
-            engineJob.cancel()
-            inbound.close()
-            outbound.close()
+            h.close()
         }
 
     @Test
     fun `new user requires confirmation before password prompt`() =
         runTest {
-            val inbound = LocalInboundBus()
-            val outbound = LocalOutboundBus()
-
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val repo = InMemoryPlayerRepository()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, repo, ItemRegistry())
-
             val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)
-            val mobs = MobRegistry()
-            val items = ItemRegistry()
-            val scheduler = Scheduler(clock)
-            val tickMillis = 10L
-            val engine =
-                GameEngine(
-                    inbound = inbound,
-                    outbound = outbound,
-                    players = players,
-                    world = world,
-                    clock = clock,
-                    tickMillis = tickMillis,
-                    scheduler = scheduler,
-                    mobs = mobs,
-                    items = items,
-                )
-            val engineJob = launch { engine.run() }
+            val h = GameEngineHarness.start(scope = this, clock = clock)
 
             val sid = SessionId(1L)
             runCurrent()
 
-            inbound.send(InboundEvent.Connected(sid))
-            inbound.send(InboundEvent.LineReceived(sid, "NewUser"))
-            advanceTimeBy(tickMillis)
+            h.inbound.send(InboundEvent.Connected(sid))
+            h.inbound.send(InboundEvent.LineReceived(sid, "NewUser"))
+            advanceTimeBy(h.tickMillis)
             runCurrent()
 
-            val beforeConfirm = outbound.drainAll()
+            val beforeConfirm = h.outbound.drainAll()
             assertTrue(
                 beforeConfirm.any {
                     it is OutboundEvent.SendInfo &&
@@ -368,11 +251,11 @@ class GameEngineLoginFlowTest {
                 "Did not expect password prompt before create confirmation. got=$beforeConfirm",
             )
 
-            inbound.send(InboundEvent.LineReceived(sid, "no"))
-            advanceTimeBy(tickMillis)
+            h.inbound.send(InboundEvent.LineReceived(sid, "no"))
+            advanceTimeBy(h.tickMillis)
             runCurrent()
 
-            val afterNo = outbound.drainAll()
+            val afterNo = h.outbound.drainAll()
             assertTrue(
                 afterNo.any {
                     it is OutboundEvent.SendInfo &&
@@ -382,12 +265,12 @@ class GameEngineLoginFlowTest {
                 "Expected return to name prompt after declining account creation. got=$afterNo",
             )
 
-            inbound.send(InboundEvent.LineReceived(sid, "NewUser"))
-            inbound.send(InboundEvent.LineReceived(sid, "yes"))
-            advanceTimeBy(tickMillis)
+            h.inbound.send(InboundEvent.LineReceived(sid, "NewUser"))
+            h.inbound.send(InboundEvent.LineReceived(sid, "yes"))
+            advanceTimeBy(h.tickMillis)
             runCurrent()
 
-            val afterYes = outbound.drainAll()
+            val afterYes = h.outbound.drainAll()
             assertTrue(
                 afterYes.any {
                     it is OutboundEvent.SendInfo &&
@@ -405,11 +288,11 @@ class GameEngineLoginFlowTest {
                 "Did not expect existing-user password prompt for new-account flow. got=$afterYes",
             )
 
-            inbound.send(InboundEvent.LineReceived(sid, "password"))
-            advanceTimeBy(tickMillis)
+            h.inbound.send(InboundEvent.LineReceived(sid, "password"))
+            advanceTimeBy(h.tickMillis)
             runCurrent()
 
-            val afterPassword = outbound.drainAll()
+            val afterPassword = h.outbound.drainAll()
             assertTrue(
                 afterPassword.any {
                     it is OutboundEvent.SendInfo &&
@@ -419,11 +302,11 @@ class GameEngineLoginFlowTest {
                 "Expected race selection prompt after password. got=$afterPassword",
             )
 
-            inbound.send(InboundEvent.LineReceived(sid, "1"))
-            advanceTimeBy(tickMillis)
+            h.inbound.send(InboundEvent.LineReceived(sid, "1"))
+            advanceTimeBy(h.tickMillis)
             runCurrent()
 
-            val afterRace = outbound.drainAll()
+            val afterRace = h.outbound.drainAll()
             assertTrue(
                 afterRace.any {
                     it is OutboundEvent.SendInfo &&
@@ -433,11 +316,11 @@ class GameEngineLoginFlowTest {
                 "Expected class selection prompt after race. got=$afterRace",
             )
 
-            inbound.send(InboundEvent.LineReceived(sid, "1"))
-            advanceTimeBy(tickMillis)
+            h.inbound.send(InboundEvent.LineReceived(sid, "1"))
+            advanceTimeBy(h.tickMillis)
             runCurrent()
 
-            val ps = players.get(sid)
+            val ps = h.players.get(sid)
             assertNotNull(ps)
             assertEquals("NewUser", ps!!.name)
             // Human race (choice 1): STR +1, CHA +1, all others +0
@@ -450,9 +333,7 @@ class GameEngineLoginFlowTest {
             assertEquals("HUMAN", ps.race)
             assertEquals("WARRIOR", ps.playerClass)
 
-            engineJob.cancel()
-            inbound.close()
-            outbound.close()
+            h.close()
         }
 
     @Test
@@ -556,45 +437,22 @@ class GameEngineLoginFlowTest {
     @Test
     fun `elf mage creation applies correct racial modifiers and class`() =
         runTest {
-            val inbound = LocalInboundBus()
-            val outbound = LocalOutboundBus()
-
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val repo = InMemoryPlayerRepository()
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, repo, items)
-
             val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)
-            val mobs = MobRegistry()
-            val scheduler = Scheduler(clock)
-            val tickMillis = 10L
-            val engine =
-                GameEngine(
-                    inbound = inbound,
-                    outbound = outbound,
-                    players = players,
-                    world = world,
-                    clock = clock,
-                    tickMillis = tickMillis,
-                    scheduler = scheduler,
-                    mobs = mobs,
-                    items = items,
-                )
-            val engineJob = launch { engine.run() }
+            val h = GameEngineHarness.start(scope = this, clock = clock)
 
             val sid = SessionId(1L)
             runCurrent()
 
-            inbound.send(InboundEvent.Connected(sid))
-            inbound.send(InboundEvent.LineReceived(sid, "ElfMage"))
-            inbound.send(InboundEvent.LineReceived(sid, "yes"))
-            inbound.send(InboundEvent.LineReceived(sid, "password"))
-            inbound.send(InboundEvent.LineReceived(sid, "2")) // race: Elf
-            inbound.send(InboundEvent.LineReceived(sid, "2")) // class: Mage
-            advanceTimeBy(tickMillis)
+            h.inbound.send(InboundEvent.Connected(sid))
+            h.inbound.send(InboundEvent.LineReceived(sid, "ElfMage"))
+            h.inbound.send(InboundEvent.LineReceived(sid, "yes"))
+            h.inbound.send(InboundEvent.LineReceived(sid, "password"))
+            h.inbound.send(InboundEvent.LineReceived(sid, "2")) // race: Elf
+            h.inbound.send(InboundEvent.LineReceived(sid, "2")) // class: Mage
+            advanceTimeBy(h.tickMillis)
             runCurrent()
 
-            val ps = players.get(sid)
+            val ps = h.players.get(sid)
             assertNotNull(ps)
             // Elf: STR -1, DEX +2, CON -2, INT +1, WIS +0, CHA +0
             assertEquals(9, ps!!.strength, "Elf STR should be BASE_STAT - 1")
@@ -606,9 +464,7 @@ class GameEngineLoginFlowTest {
             assertEquals("ELF", ps.race)
             assertEquals("MAGE", ps.playerClass)
 
-            engineJob.cancel()
-            inbound.close()
-            outbound.close()
+            h.close()
         }
 
     @Test
@@ -701,33 +557,11 @@ class GameEngineLoginFlowTest {
     @Test
     fun `second login with correct password kicks first session and observer sees flicker`() =
         runTest {
-            val inbound = LocalInboundBus()
-            val outbound = LocalOutboundBus()
-
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val repo = InMemoryPlayerRepository()
-            repo.createTestPlayer("Alice", world.startRoom, password = "secret", ansiEnabled = false)
-            repo.createTestPlayer("Observer", world.startRoom, password = "pw", ansiEnabled = false)
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, repo, items)
-
             val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)
-            val mobs = MobRegistry()
-            val scheduler = Scheduler(clock)
-            val tickMillis = 10L
-            val engine =
-                GameEngine(
-                    inbound = inbound,
-                    outbound = outbound,
-                    players = players,
-                    world = world,
-                    clock = clock,
-                    tickMillis = tickMillis,
-                    scheduler = scheduler,
-                    mobs = mobs,
-                    items = items,
-                )
-            val engineJob = launch { engine.run() }
+            val repo = InMemoryPlayerRepository()
+            repo.createTestPlayer("Alice", TestWorlds.testWorld.startRoom, password = "secret", ansiEnabled = false)
+            repo.createTestPlayer("Observer", TestWorlds.testWorld.startRoom, password = "pw", ansiEnabled = false)
+            val h = GameEngineHarness.start(scope = this, clock = clock, repo = repo)
 
             val sid1 = SessionId(1L)
             val sid2 = SessionId(2L)
@@ -735,28 +569,28 @@ class GameEngineLoginFlowTest {
             runCurrent()
 
             // Login Observer (sid3) and Alice (sid1) — both land in start room
-            inbound.send(InboundEvent.Connected(sid3))
-            inbound.send(InboundEvent.LineReceived(sid3, "Observer"))
-            inbound.send(InboundEvent.LineReceived(sid3, "pw"))
-            inbound.send(InboundEvent.Connected(sid1))
-            inbound.send(InboundEvent.LineReceived(sid1, "Alice"))
-            inbound.send(InboundEvent.LineReceived(sid1, "secret"))
+            h.inbound.send(InboundEvent.Connected(sid3))
+            h.inbound.send(InboundEvent.LineReceived(sid3, "Observer"))
+            h.inbound.send(InboundEvent.LineReceived(sid3, "pw"))
+            h.inbound.send(InboundEvent.Connected(sid1))
+            h.inbound.send(InboundEvent.LineReceived(sid1, "Alice"))
+            h.inbound.send(InboundEvent.LineReceived(sid1, "secret"))
 
-            advanceTimeBy(tickMillis)
+            advanceTimeBy(h.tickMillis)
             runCurrent()
 
-            assertEquals("Alice", players.get(sid1)?.name, "Expected Alice logged in on sid1")
-            outbound.drainAll()
+            assertEquals("Alice", h.players.get(sid1)?.name, "Expected Alice logged in on sid1")
+            h.outbound.drainAll()
 
             // Second session takes over Alice with correct password
-            inbound.send(InboundEvent.Connected(sid2))
-            inbound.send(InboundEvent.LineReceived(sid2, "Alice"))
-            inbound.send(InboundEvent.LineReceived(sid2, "secret"))
+            h.inbound.send(InboundEvent.Connected(sid2))
+            h.inbound.send(InboundEvent.LineReceived(sid2, "Alice"))
+            h.inbound.send(InboundEvent.LineReceived(sid2, "secret"))
 
-            advanceTimeBy(tickMillis)
+            advanceTimeBy(h.tickMillis)
             runCurrent()
 
-            val outs = outbound.drainAll()
+            val outs = h.outbound.drainAll()
 
             // Old session is closed with kick message
             val kick = outs.filterIsInstance<OutboundEvent.Close>().firstOrNull { it.sessionId == sid1 }
@@ -778,69 +612,45 @@ class GameEngineLoginFlowTest {
             )
 
             // New session now owns Alice; old session is gone
-            assertNull(players.get(sid1), "Expected old session removed from registry")
-            assertEquals("Alice", players.get(sid2)?.name)
-            assertEquals(sid2, players.findSessionByName("Alice"))
+            assertNull(h.players.get(sid1), "Expected old session removed from registry")
+            assertEquals("Alice", h.players.get(sid2)?.name)
+            assertEquals(sid2, h.players.findSessionByName("Alice"))
 
-            engineJob.cancel()
-            inbound.close()
-            outbound.close()
+            h.close()
         }
 
     @Test
     fun `wrong password on live name does not kick original session`() =
         runTest {
-            val inbound = LocalInboundBus()
-            val outbound = LocalOutboundBus()
-
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val repo = InMemoryPlayerRepository()
-            repo.createTestPlayer("Alice", world.startRoom, password = "secret", ansiEnabled = false)
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, repo, items)
-
             val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)
-            val mobs = MobRegistry()
-            val scheduler = Scheduler(clock)
-            val tickMillis = 10L
-            val engine =
-                GameEngine(
-                    inbound = inbound,
-                    outbound = outbound,
-                    players = players,
-                    world = world,
-                    clock = clock,
-                    tickMillis = tickMillis,
-                    scheduler = scheduler,
-                    mobs = mobs,
-                    items = items,
-                )
-            val engineJob = launch { engine.run() }
+            val repo = InMemoryPlayerRepository()
+            repo.createTestPlayer("Alice", TestWorlds.testWorld.startRoom, password = "secret", ansiEnabled = false)
+            val h = GameEngineHarness.start(scope = this, clock = clock, repo = repo)
 
             val sid1 = SessionId(1L)
             val sid2 = SessionId(2L)
             runCurrent()
 
             // Login Alice on sid1
-            inbound.send(InboundEvent.Connected(sid1))
-            inbound.send(InboundEvent.LineReceived(sid1, "Alice"))
-            inbound.send(InboundEvent.LineReceived(sid1, "secret"))
+            h.inbound.send(InboundEvent.Connected(sid1))
+            h.inbound.send(InboundEvent.LineReceived(sid1, "Alice"))
+            h.inbound.send(InboundEvent.LineReceived(sid1, "secret"))
 
-            advanceTimeBy(tickMillis)
+            advanceTimeBy(h.tickMillis)
             runCurrent()
 
-            assertEquals("Alice", players.get(sid1)?.name)
-            outbound.drainAll()
+            assertEquals("Alice", h.players.get(sid1)?.name)
+            h.outbound.drainAll()
 
             // Second session attempts takeover with wrong password
-            inbound.send(InboundEvent.Connected(sid2))
-            inbound.send(InboundEvent.LineReceived(sid2, "Alice"))
-            inbound.send(InboundEvent.LineReceived(sid2, "wrongpassword"))
+            h.inbound.send(InboundEvent.Connected(sid2))
+            h.inbound.send(InboundEvent.LineReceived(sid2, "Alice"))
+            h.inbound.send(InboundEvent.LineReceived(sid2, "wrongpassword"))
 
-            advanceTimeBy(tickMillis)
+            advanceTimeBy(h.tickMillis)
             runCurrent()
 
-            val outs = outbound.drainAll()
+            val outs = h.outbound.drainAll()
 
             // Original session is NOT closed
             assertFalse(
@@ -849,78 +659,54 @@ class GameEngineLoginFlowTest {
             )
 
             // Original session still owns Alice
-            assertEquals("Alice", players.get(sid1)?.name)
-            assertNull(players.get(sid2), "Expected sid2 not logged in after wrong password")
+            assertEquals("Alice", h.players.get(sid1)?.name)
+            assertNull(h.players.get(sid2), "Expected sid2 not logged in after wrong password")
 
-            engineJob.cancel()
-            inbound.close()
-            outbound.close()
+            h.close()
         }
 
     @Test
     fun `combat is inherited after session takeover`() =
         runTest {
-            val inbound = LocalInboundBus()
-            val outbound = LocalOutboundBus()
-
             // ok_small world: start room 'ok_small:a', mob 'rat' in 'ok_small:b', exit north from a to b
-            val world = dev.ambon.test.TestWorlds.okSmall
-            val repo = InMemoryPlayerRepository()
-            repo.createTestPlayer("Alice", world.startRoom, password = "secret", ansiEnabled = false)
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, repo, items)
-
             val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)
-            val mobs = MobRegistry()
-            val scheduler = Scheduler(clock)
-            val tickMillis = 10L
-            val engine =
-                GameEngine(
-                    inbound = inbound,
-                    outbound = outbound,
-                    players = players,
-                    world = world,
-                    clock = clock,
-                    tickMillis = tickMillis,
-                    scheduler = scheduler,
-                    mobs = mobs,
-                    items = items,
-                )
-            val engineJob = launch { engine.run() }
+            val repo = InMemoryPlayerRepository()
+            repo.createTestPlayer("Alice", TestWorlds.okSmall.startRoom, password = "secret", ansiEnabled = false)
+            val h = GameEngineHarness.start(scope = this, world = TestWorlds.okSmall, clock = clock, repo = repo)
 
             val sid1 = SessionId(1L)
             val sid2 = SessionId(2L)
             runCurrent()
 
             // Login Alice, move to rat's room, start combat
-            inbound.send(InboundEvent.Connected(sid1))
-            inbound.send(InboundEvent.LineReceived(sid1, "Alice"))
-            inbound.send(InboundEvent.LineReceived(sid1, "secret"))
-            inbound.send(InboundEvent.LineReceived(sid1, "n"))
-            inbound.send(InboundEvent.LineReceived(sid1, "kill rat"))
+            h.inbound.send(InboundEvent.Connected(sid1))
+            h.inbound.send(InboundEvent.LineReceived(sid1, "Alice"))
+            h.inbound.send(InboundEvent.LineReceived(sid1, "secret"))
+            h.inbound.send(InboundEvent.LineReceived(sid1, "n"))
+            h.inbound.send(InboundEvent.LineReceived(sid1, "kill rat"))
 
-            advanceTimeBy(tickMillis)
+            advanceTimeBy(h.tickMillis)
             runCurrent()
 
-            outbound.drainAll()
+            h.outbound.drainAll()
 
             // Take over Alice on sid2
-            inbound.send(InboundEvent.Connected(sid2))
-            inbound.send(InboundEvent.LineReceived(sid2, "Alice"))
-            inbound.send(InboundEvent.LineReceived(sid2, "secret"))
+            h.inbound.send(InboundEvent.Connected(sid2))
+            h.inbound.send(InboundEvent.LineReceived(sid2, "Alice"))
+            h.inbound.send(InboundEvent.LineReceived(sid2, "secret"))
 
-            advanceTimeBy(tickMillis)
+            advanceTimeBy(h.tickMillis)
             runCurrent()
 
-            outbound.drainAll()
+            h.outbound.drainAll()
 
             // Flee on sid2 — succeeds only if combat was inherited
-            inbound.send(InboundEvent.LineReceived(sid2, "flee"))
+            h.inbound.send(InboundEvent.LineReceived(sid2, "flee"))
 
-            advanceTimeBy(tickMillis)
+            advanceTimeBy(h.tickMillis)
             runCurrent()
 
-            val outs = outbound.drainAll()
+            val outs = h.outbound.drainAll()
 
             assertFalse(
                 outs.any { it is OutboundEvent.SendError && it.sessionId == sid2 && it.text == "You are not in combat." },
@@ -933,9 +719,7 @@ class GameEngineLoginFlowTest {
                 "Expected 'You flee from...' message on new session. got=$outs",
             )
 
-            engineJob.cancel()
-            inbound.close()
-            outbound.close()
+            h.close()
         }
 
     @Test
@@ -950,7 +734,7 @@ class GameEngineLoginFlowTest {
             val repo = InMemoryPlayerRepository()
             val items = ItemRegistry()
             val players =
-                dev.ambon.test.buildTestPlayerRegistry(
+                buildTestPlayerRegistry(
                     startRoom = world.startRoom,
                     repo = repo,
                     items = items,
@@ -984,7 +768,7 @@ class GameEngineLoginFlowTest {
             val repo = InMemoryPlayerRepository()
             val items = ItemRegistry()
             val players =
-                dev.ambon.test.buildTestPlayerRegistry(
+                buildTestPlayerRegistry(
                     startRoom = world.startRoom,
                     repo = repo,
                     items = items,
@@ -1010,81 +794,58 @@ class GameEngineLoginFlowTest {
     @Test
     fun `two sessions creating same name concurrently does not crash`() =
         runTest {
-            val inbound = LocalInboundBus()
-            val outbound = LocalOutboundBus()
-
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val repo = InMemoryPlayerRepository()
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, repo, items)
-
             val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)
-            val mobs = MobRegistry()
-            val scheduler = Scheduler(clock)
-            val tickMillis = 10L
-            val engine =
-                GameEngine(
-                    inbound = inbound,
-                    outbound = outbound,
-                    players = players,
-                    world = world,
-                    clock = clock,
-                    tickMillis = tickMillis,
-                    scheduler = scheduler,
-                    mobs = mobs,
-                    items = items,
-                )
-            val engineJob = launch { engine.run() }
+            val h = GameEngineHarness.start(scope = this, clock = clock)
 
             val sid1 = SessionId(1L)
             val sid2 = SessionId(2L)
             runCurrent()
 
             // Both sessions connect and enter the same name
-            inbound.send(InboundEvent.Connected(sid1))
-            inbound.send(InboundEvent.Connected(sid2))
-            advanceTimeBy(tickMillis)
+            h.inbound.send(InboundEvent.Connected(sid1))
+            h.inbound.send(InboundEvent.Connected(sid2))
+            advanceTimeBy(h.tickMillis)
             runCurrent()
-            outbound.drainAll()
+            h.outbound.drainAll()
 
-            inbound.send(InboundEvent.LineReceived(sid1, "DupeName"))
-            inbound.send(InboundEvent.LineReceived(sid2, "DupeName"))
-            advanceTimeBy(tickMillis)
+            h.inbound.send(InboundEvent.LineReceived(sid1, "DupeName"))
+            h.inbound.send(InboundEvent.LineReceived(sid2, "DupeName"))
+            advanceTimeBy(h.tickMillis)
             runCurrent()
-            outbound.drainAll()
+            h.outbound.drainAll()
 
             // Both confirm "yes" to create
-            inbound.send(InboundEvent.LineReceived(sid1, "yes"))
-            inbound.send(InboundEvent.LineReceived(sid2, "yes"))
-            advanceTimeBy(tickMillis)
+            h.inbound.send(InboundEvent.LineReceived(sid1, "yes"))
+            h.inbound.send(InboundEvent.LineReceived(sid2, "yes"))
+            advanceTimeBy(h.tickMillis)
             runCurrent()
-            outbound.drainAll()
+            h.outbound.drainAll()
 
             // Both enter passwords
-            inbound.send(InboundEvent.LineReceived(sid1, "password"))
-            inbound.send(InboundEvent.LineReceived(sid2, "password"))
-            advanceTimeBy(tickMillis)
+            h.inbound.send(InboundEvent.LineReceived(sid1, "password"))
+            h.inbound.send(InboundEvent.LineReceived(sid2, "password"))
+            advanceTimeBy(h.tickMillis)
             runCurrent()
-            outbound.drainAll()
+            h.outbound.drainAll()
 
             // Both pick race (1 = Human)
-            inbound.send(InboundEvent.LineReceived(sid1, "1"))
-            inbound.send(InboundEvent.LineReceived(sid2, "1"))
-            advanceTimeBy(tickMillis)
+            h.inbound.send(InboundEvent.LineReceived(sid1, "1"))
+            h.inbound.send(InboundEvent.LineReceived(sid2, "1"))
+            advanceTimeBy(h.tickMillis)
             runCurrent()
-            outbound.drainAll()
+            h.outbound.drainAll()
 
             // Both pick class (1 = Warrior) — triggers prepareCreateAccount
-            inbound.send(InboundEvent.LineReceived(sid1, "1"))
-            inbound.send(InboundEvent.LineReceived(sid2, "1"))
-            advanceTimeBy(tickMillis)
+            h.inbound.send(InboundEvent.LineReceived(sid1, "1"))
+            h.inbound.send(InboundEvent.LineReceived(sid2, "1"))
+            advanceTimeBy(h.tickMillis)
             runCurrent()
 
-            val outs = outbound.drainAll()
+            val outs = h.outbound.drainAll()
 
             // Exactly one session should be logged in, the other should see "name taken"
-            val loggedIn1 = players.get(sid1) != null
-            val loggedIn2 = players.get(sid2) != null
+            val loggedIn1 = h.players.get(sid1) != null
+            val loggedIn2 = h.players.get(sid2) != null
 
             assertTrue(
                 loggedIn1 || loggedIn2,
@@ -1106,8 +867,6 @@ class GameEngineLoginFlowTest {
                 "The duplicate session should receive a 'name taken' error. got=$outs",
             )
 
-            engineJob.cancel()
-            inbound.close()
-            outbound.close()
+            h.close()
         }
 }

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterAdminTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterAdminTest.kt
@@ -1,16 +1,13 @@
 package dev.ambon.engine.commands
 
 import dev.ambon.bus.LocalOutboundBus
-import dev.ambon.bus.OutboundBus
 import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.mob.MobState
 import dev.ambon.engine.CombatSystem
-import dev.ambon.engine.LoginResult
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.MobRemovalCoordinator
 import dev.ambon.engine.MobSystem
-import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.behavior.BehaviorTreeSystem
 import dev.ambon.engine.dialogue.DialogueSystem
 import dev.ambon.engine.events.OutboundEvent
@@ -18,6 +15,10 @@ import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.engine.status.StatusEffectRegistry
 import dev.ambon.engine.status.StatusEffectSystem
 import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.CommandRouterHarness
+import dev.ambon.test.MutableClock
+import dev.ambon.test.TestWorlds
+import dev.ambon.test.buildTestPlayerRegistry
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -28,75 +29,18 @@ import org.junit.jupiter.api.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CommandRouterAdminTest {
-    // ── helpers ────────────────────────────────────────────────────────────────
-
-    private fun drain(ch: LocalOutboundBus): List<OutboundEvent> {
-        val out = mutableListOf<OutboundEvent>()
-        while (true) {
-            val ev = ch.tryReceive().getOrNull() ?: break
-            out += ev
-        }
-        return out
-    }
-
-    private suspend fun login(
-        players: PlayerRegistry,
-        sessionId: SessionId,
-        name: String,
-    ) {
-        val res = players.login(sessionId, name, "password")
-        require(res == LoginResult.Ok) { "Login failed: $res" }
-    }
-
-    private suspend fun loginStaff(
-        players: PlayerRegistry,
-        sessionId: SessionId,
-        name: String,
-    ) {
-        login(players, sessionId, name)
-        players.get(sessionId)!!.isStaff = true
-    }
-
-    private fun makeRouter(
-        players: PlayerRegistry,
-        mobs: MobRegistry,
-        items: ItemRegistry,
-        outbound: OutboundBus,
-        onShutdown: suspend () -> Unit = {},
-        mobRemovalCoordinator: MobRemovalCoordinator? = null,
-    ): CommandRouter {
-        val world = dev.ambon.test.TestWorlds.testWorld
-        val combat = CombatSystem(players, mobs, items, outbound)
-        return buildTestRouter(
-            world = world,
-            players = players,
-            mobs = mobs,
-            items = items,
-            combat = combat,
-            outbound = outbound,
-            onShutdown = onShutdown,
-            mobRemovalCoordinator = mobRemovalCoordinator,
-        )
-    }
-
-    // ── staff guard ────────────────────────────────────────────────────────────
+    // ── staff guard ────────────────────────────────────────────────────────────────
 
     @Test
     fun `non-staff player receives error on goto`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = makeRouter(players, mobs, items, outbound)
-
+            val h = CommandRouterHarness.create()
             val sid = SessionId(1)
-            login(players, sid, "Alice")
-            drain(outbound)
+            h.loginPlayer(sid, "Alice")
+            h.drain()
 
-            router.handle(sid, Command.Goto("test_zone:outpost"))
-            val outs = drain(outbound)
+            h.router.handle(sid, Command.Goto("test_zone:outpost"))
+            val outs = h.drain()
 
             assertTrue(
                 outs.any { it is OutboundEvent.SendError && it.sessionId == sid && it.text.contains("not staff") },
@@ -110,86 +54,62 @@ class CommandRouterAdminTest {
     @Test
     fun `goto moves staff player to exact room`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = makeRouter(players, mobs, items, outbound)
-
+            val h = CommandRouterHarness.create()
             val sid = SessionId(1)
-            loginStaff(players, sid, "Alice")
-            drain(outbound)
+            h.loginStaff(sid, "Alice")
+            h.drain()
 
             val target = "test_zone:outpost"
-            router.handle(sid, Command.Goto(target))
-            drain(outbound)
+            h.router.handle(sid, Command.Goto(target))
+            h.drain()
 
-            assertEquals(target, players.get(sid)!!.roomId.value)
+            assertEquals(target, h.players.get(sid)!!.roomId.value)
         }
 
     @Test
     fun `goto with local room resolves in current zone`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = makeRouter(players, mobs, items, outbound)
-
+            val h = CommandRouterHarness.create()
             val sid = SessionId(1)
-            loginStaff(players, sid, "Alice")
-            drain(outbound)
+            h.loginStaff(sid, "Alice")
+            h.drain()
 
             // First teleport to test_zone zone
-            router.handle(sid, Command.Goto("test_zone:outpost"))
-            drain(outbound)
+            h.router.handle(sid, Command.Goto("test_zone:outpost"))
+            h.drain()
 
             // Now goto a local room name only — should resolve in test_zone
-            router.handle(sid, Command.Goto("hub"))
-            drain(outbound)
+            h.router.handle(sid, Command.Goto("hub"))
+            h.drain()
 
-            assertEquals("test_zone:hub", players.get(sid)!!.roomId.value)
+            assertEquals("test_zone:hub", h.players.get(sid)!!.roomId.value)
         }
 
     @Test
     fun `goto zone-colon resolves to a room in that zone`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = makeRouter(players, mobs, items, outbound)
-
+            val h = CommandRouterHarness.create()
             val sid = SessionId(1)
-            loginStaff(players, sid, "Alice")
-            drain(outbound)
+            h.loginStaff(sid, "Alice")
+            h.drain()
 
-            router.handle(sid, Command.Goto("test_zone:"))
-            drain(outbound)
+            h.router.handle(sid, Command.Goto("test_zone:"))
+            h.drain()
 
-            val roomId = players.get(sid)!!.roomId
+            val roomId = h.players.get(sid)!!.roomId
             assertEquals("test_zone", roomId.zone, "Should have landed in test_zone zone. got=$roomId")
         }
 
     @Test
     fun `goto unknown room emits error and prompt`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = makeRouter(players, mobs, items, outbound)
-
+            val h = CommandRouterHarness.create()
             val sid = SessionId(1)
-            loginStaff(players, sid, "Alice")
-            drain(outbound)
+            h.loginStaff(sid, "Alice")
+            h.drain()
 
-            router.handle(sid, Command.Goto("nonexistent:fakery"))
-            val outs = drain(outbound)
+            h.router.handle(sid, Command.Goto("nonexistent:fakery"))
+            val outs = h.drain()
 
             assertTrue(
                 outs.any { it is OutboundEvent.SendError && it.sessionId == sid },
@@ -203,23 +123,17 @@ class CommandRouterAdminTest {
     @Test
     fun `transfer moves target player and sends them a look`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = makeRouter(players, mobs, items, outbound)
-
+            val h = CommandRouterHarness.create()
             val staffSid = SessionId(1)
             val bobSid = SessionId(2)
-            loginStaff(players, staffSid, "Admin")
-            login(players, bobSid, "Bob")
-            drain(outbound)
+            h.loginStaff(staffSid, "Admin")
+            h.loginPlayer(bobSid, "Bob")
+            h.drain()
 
-            router.handle(staffSid, Command.Transfer("Bob", "test_zone:outpost"))
-            val outs = drain(outbound)
+            h.router.handle(staffSid, Command.Transfer("Bob", "test_zone:outpost"))
+            val outs = h.drain()
 
-            assertEquals("test_zone:outpost", players.get(bobSid)!!.roomId.value, "Bob should be in new room")
+            assertEquals("test_zone:outpost", h.players.get(bobSid)!!.roomId.value, "Bob should be in new room")
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && it.sessionId == bobSid && it.text.contains("divine hand") },
                 "Bob should receive divine transport message. got=$outs",
@@ -233,19 +147,13 @@ class CommandRouterAdminTest {
     @Test
     fun `transfer unknown player emits error`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = makeRouter(players, mobs, items, outbound)
-
+            val h = CommandRouterHarness.create()
             val staffSid = SessionId(1)
-            loginStaff(players, staffSid, "Admin")
-            drain(outbound)
+            h.loginStaff(staffSid, "Admin")
+            h.drain()
 
-            router.handle(staffSid, Command.Transfer("Ghost", "test_zone:outpost"))
-            val outs = drain(outbound)
+            h.router.handle(staffSid, Command.Transfer("Ghost", "test_zone:outpost"))
+            val outs = h.drain()
 
             assertTrue(
                 outs.any { it is OutboundEvent.SendError && it.sessionId == staffSid },
@@ -258,22 +166,16 @@ class CommandRouterAdminTest {
     @Test
     fun `spawn creates mob in staff room`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = makeRouter(players, mobs, items, outbound)
-
+            val h = CommandRouterHarness.create()
             val staffSid = SessionId(1)
-            loginStaff(players, staffSid, "Admin")
-            val staffRoom = players.get(staffSid)!!.roomId
-            drain(outbound)
+            h.loginStaff(staffSid, "Admin")
+            val staffRoom = h.players.get(staffSid)!!.roomId
+            h.drain()
 
-            router.handle(staffSid, Command.Spawn("grunt"))
-            val outs = drain(outbound)
+            h.router.handle(staffSid, Command.Spawn("grunt"))
+            val outs = h.drain()
 
-            val spawned = mobs.mobsInRoom(staffRoom)
+            val spawned = h.mobs.mobsInRoom(staffRoom)
             assertTrue(spawned.isNotEmpty(), "Expected a mob to be spawned in staff room")
             assertTrue(
                 outs.any { it is OutboundEvent.SendInfo && it.sessionId == staffSid },
@@ -284,40 +186,28 @@ class CommandRouterAdminTest {
     @Test
     fun `spawn with fully qualified name works`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = makeRouter(players, mobs, items, outbound)
-
+            val h = CommandRouterHarness.create()
             val staffSid = SessionId(1)
-            loginStaff(players, staffSid, "Admin")
-            val staffRoom = players.get(staffSid)!!.roomId
-            drain(outbound)
+            h.loginStaff(staffSid, "Admin")
+            val staffRoom = h.players.get(staffSid)!!.roomId
+            h.drain()
 
-            router.handle(staffSid, Command.Spawn("test_zone:grunt"))
-            drain(outbound)
+            h.router.handle(staffSid, Command.Spawn("test_zone:grunt"))
+            h.drain()
 
-            assertTrue(mobs.mobsInRoom(staffRoom).isNotEmpty(), "Expected a mob to be spawned in staff room")
+            assertTrue(h.mobs.mobsInRoom(staffRoom).isNotEmpty(), "Expected a mob to be spawned in staff room")
         }
 
     @Test
     fun `spawn unknown template emits error`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = makeRouter(players, mobs, items, outbound)
-
+            val h = CommandRouterHarness.create()
             val staffSid = SessionId(1)
-            loginStaff(players, staffSid, "Admin")
-            drain(outbound)
+            h.loginStaff(staffSid, "Admin")
+            h.drain()
 
-            router.handle(staffSid, Command.Spawn("nonexistent_mob"))
-            val outs = drain(outbound)
+            h.router.handle(staffSid, Command.Spawn("nonexistent_mob"))
+            val outs = h.drain()
 
             assertTrue(
                 outs.any { it is OutboundEvent.SendError && it.sessionId == staffSid },
@@ -330,22 +220,16 @@ class CommandRouterAdminTest {
     @Test
     fun `shutdown broadcasts to all players and calls onShutdown callback`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
             var shutdownCalled = false
-            val router = makeRouter(players, mobs, items, outbound, onShutdown = { shutdownCalled = true })
-
+            val h = CommandRouterHarness.create(onShutdown = { shutdownCalled = true })
             val staffSid = SessionId(1)
             val bobSid = SessionId(2)
-            loginStaff(players, staffSid, "Admin")
-            login(players, bobSid, "Bob")
-            drain(outbound)
+            h.loginStaff(staffSid, "Admin")
+            h.loginPlayer(bobSid, "Bob")
+            h.drain()
 
-            router.handle(staffSid, Command.Shutdown)
-            val outs = drain(outbound)
+            h.router.handle(staffSid, Command.Shutdown)
+            val outs = h.drain()
 
             assertTrue(shutdownCalled, "onShutdown callback should have been invoked")
             assertTrue(
@@ -361,19 +245,13 @@ class CommandRouterAdminTest {
     @Test
     fun `non-staff cannot trigger shutdown`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
             var shutdownCalled = false
-            val router = makeRouter(players, mobs, items, outbound, onShutdown = { shutdownCalled = true })
-
+            val h = CommandRouterHarness.create(onShutdown = { shutdownCalled = true })
             val sid = SessionId(1)
-            login(players, sid, "Alice")
-            drain(outbound)
+            h.loginPlayer(sid, "Alice")
+            h.drain()
 
-            router.handle(sid, Command.Shutdown)
+            h.router.handle(sid, Command.Shutdown)
             assertFalse(shutdownCalled, "onShutdown should not be called for non-staff")
         }
 
@@ -382,48 +260,36 @@ class CommandRouterAdminTest {
     @Test
     fun `smite player sets hp to 1 and moves to start room`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = makeRouter(players, mobs, items, outbound)
-
+            val h = CommandRouterHarness.create()
             val staffSid = SessionId(1)
             val bobSid = SessionId(2)
-            loginStaff(players, staffSid, "Admin")
-            login(players, bobSid, "Bob")
-            drain(outbound)
+            h.loginStaff(staffSid, "Admin")
+            h.loginPlayer(bobSid, "Bob")
+            h.drain()
 
             // Move Bob to a different room first
-            players.moveTo(bobSid, world.rooms.keys.first { it != world.startRoom })
+            h.players.moveTo(bobSid, h.world.rooms.keys.first { it != h.world.startRoom })
 
-            router.handle(staffSid, Command.Smite("Bob"))
-            drain(outbound)
+            h.router.handle(staffSid, Command.Smite("Bob"))
+            h.drain()
 
-            val bob = players.get(bobSid)!!
+            val bob = h.players.get(bobSid)!!
             assertEquals(1, bob.hp, "Bob's HP should be 1 after smite")
-            assertEquals(world.startRoom, bob.roomId, "Bob should be at start room after smite")
+            assertEquals(h.world.startRoom, bob.roomId, "Bob should be at start room after smite")
         }
 
     @Test
     fun `smite player sends divine message to target`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = makeRouter(players, mobs, items, outbound)
-
+            val h = CommandRouterHarness.create()
             val staffSid = SessionId(1)
             val bobSid = SessionId(2)
-            loginStaff(players, staffSid, "Admin")
-            login(players, bobSid, "Bob")
-            drain(outbound)
+            h.loginStaff(staffSid, "Admin")
+            h.loginPlayer(bobSid, "Bob")
+            h.drain()
 
-            router.handle(staffSid, Command.Smite("Bob"))
-            val outs = drain(outbound)
+            h.router.handle(staffSid, Command.Smite("Bob"))
+            val outs = h.drain()
 
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && it.sessionId == bobSid && it.text.contains("divine") },
@@ -434,13 +300,14 @@ class CommandRouterAdminTest {
     @Test
     fun `smite mob removes it from registry`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
+            val world = TestWorlds.testWorld
+            val repo = InMemoryPlayerRepository()
             val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
+            val players = buildTestPlayerRegistry(world.startRoom, repo, items)
             val mobs = MobRegistry()
             val outbound = LocalOutboundBus()
             val combat = CombatSystem(players, mobs, items, outbound)
-            val clock = dev.ambon.test.MutableClock(nowMs = 0L)
+            val clock = MutableClock(nowMs = 0L)
             val coordinator = MobRemovalCoordinator(
                 combatSystem = combat,
                 dialogueSystem = DialogueSystem(mobs, players, outbound),
@@ -455,19 +322,27 @@ class CommandRouterAdminTest {
                     clock,
                 ),
             )
-            val router = makeRouter(players, mobs, items, outbound, mobRemovalCoordinator = coordinator)
+            val h = CommandRouterHarness.create(
+                world = world,
+                repo = repo,
+                items = items,
+                players = players,
+                mobs = mobs,
+                outbound = outbound,
+                mobRemovalCoordinator = coordinator,
+            )
 
             val staffSid = SessionId(1)
-            loginStaff(players, staffSid, "Admin")
-            val staffRoom = players.get(staffSid)!!.roomId
-            drain(outbound)
+            h.loginStaff(staffSid, "Admin")
+            val staffRoom = h.players.get(staffSid)!!.roomId
+            h.drain()
 
             // Place a mob in the same room as staff
             val mobId = MobId("test_zone:test_grunt")
             mobs.upsert(MobState(id = mobId, name = "a wary caravan scout", roomId = staffRoom))
 
-            router.handle(staffSid, Command.Smite("scout"))
-            drain(outbound)
+            h.router.handle(staffSid, Command.Smite("scout"))
+            h.drain()
 
             assertNull(mobs.get(mobId), "Mob should be removed from registry after smite")
         }
@@ -475,19 +350,13 @@ class CommandRouterAdminTest {
     @Test
     fun `smite mob not found emits error`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = makeRouter(players, mobs, items, outbound)
-
+            val h = CommandRouterHarness.create()
             val staffSid = SessionId(1)
-            loginStaff(players, staffSid, "Admin")
-            drain(outbound)
+            h.loginStaff(staffSid, "Admin")
+            h.drain()
 
-            router.handle(staffSid, Command.Smite("ghost_mob"))
-            val outs = drain(outbound)
+            h.router.handle(staffSid, Command.Smite("ghost_mob"))
+            val outs = h.drain()
 
             assertTrue(
                 outs.any { it is OutboundEvent.SendError && it.sessionId == staffSid },
@@ -500,21 +369,15 @@ class CommandRouterAdminTest {
     @Test
     fun `kick sends Close event to target session`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = makeRouter(players, mobs, items, outbound)
-
+            val h = CommandRouterHarness.create()
             val staffSid = SessionId(1)
             val bobSid = SessionId(2)
-            loginStaff(players, staffSid, "Admin")
-            login(players, bobSid, "Bob")
-            drain(outbound)
+            h.loginStaff(staffSid, "Admin")
+            h.loginPlayer(bobSid, "Bob")
+            h.drain()
 
-            router.handle(staffSid, Command.Kick("Bob"))
-            val outs = drain(outbound)
+            h.router.handle(staffSid, Command.Kick("Bob"))
+            val outs = h.drain()
 
             assertTrue(
                 outs.any { it is OutboundEvent.Close && it.sessionId == bobSid },
@@ -529,19 +392,13 @@ class CommandRouterAdminTest {
     @Test
     fun `kick self emits error`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = makeRouter(players, mobs, items, outbound)
-
+            val h = CommandRouterHarness.create()
             val staffSid = SessionId(1)
-            loginStaff(players, staffSid, "Admin")
-            drain(outbound)
+            h.loginStaff(staffSid, "Admin")
+            h.drain()
 
-            router.handle(staffSid, Command.Kick("Admin"))
-            val outs = drain(outbound)
+            h.router.handle(staffSid, Command.Kick("Admin"))
+            val outs = h.drain()
 
             assertTrue(
                 outs.any { it is OutboundEvent.SendError && it.sessionId == staffSid },
@@ -556,19 +413,13 @@ class CommandRouterAdminTest {
     @Test
     fun `kick unknown player emits error`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = makeRouter(players, mobs, items, outbound)
-
+            val h = CommandRouterHarness.create()
             val staffSid = SessionId(1)
-            loginStaff(players, staffSid, "Admin")
-            drain(outbound)
+            h.loginStaff(staffSid, "Admin")
+            h.drain()
 
-            router.handle(staffSid, Command.Kick("Ghost"))
-            val outs = drain(outbound)
+            h.router.handle(staffSid, Command.Kick("Ghost"))
+            val outs = h.drain()
 
             assertTrue(
                 outs.any { it is OutboundEvent.SendError && it.sessionId == staffSid },
@@ -581,23 +432,17 @@ class CommandRouterAdminTest {
     @Test
     fun `setlevel updates target player level and xpTotal`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = makeRouter(players, mobs, items, outbound)
-
+            val h = CommandRouterHarness.create()
             val staffSid = SessionId(1)
             val bobSid = SessionId(2)
-            loginStaff(players, staffSid, "Admin")
-            login(players, bobSid, "Bob")
-            drain(outbound)
+            h.loginStaff(staffSid, "Admin")
+            h.loginPlayer(bobSid, "Bob")
+            h.drain()
 
-            router.handle(staffSid, Command.SetLevel("Bob", 10))
-            val outs = drain(outbound)
+            h.router.handle(staffSid, Command.SetLevel("Bob", 10))
+            val outs = h.drain()
 
-            val bob = players.get(bobSid)!!
+            val bob = h.players.get(bobSid)!!
             assertEquals(10, bob.level, "Bob's level should be 10 after setlevel")
             assertTrue(bob.xpTotal > 0, "Bob's xpTotal should be > 0 after setlevel to 10")
             assertTrue(
@@ -613,45 +458,33 @@ class CommandRouterAdminTest {
     @Test
     fun `setlevel rejects out-of-range level`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = makeRouter(players, mobs, items, outbound)
-
+            val h = CommandRouterHarness.create()
             val staffSid = SessionId(1)
             val bobSid = SessionId(2)
-            loginStaff(players, staffSid, "Admin")
-            login(players, bobSid, "Bob")
-            drain(outbound)
+            h.loginStaff(staffSid, "Admin")
+            h.loginPlayer(bobSid, "Bob")
+            h.drain()
 
-            router.handle(staffSid, Command.SetLevel("Bob", 99))
-            val outs = drain(outbound)
+            h.router.handle(staffSid, Command.SetLevel("Bob", 99))
+            val outs = h.drain()
 
             assertTrue(
                 outs.any { it is OutboundEvent.SendError && it.sessionId == staffSid },
                 "Expected error for out-of-range level. got=$outs",
             )
-            assertEquals(1, players.get(bobSid)!!.level, "Bob's level should be unchanged")
+            assertEquals(1, h.players.get(bobSid)!!.level, "Bob's level should be unchanged")
         }
 
     @Test
     fun `setlevel for offline player emits error`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = makeRouter(players, mobs, items, outbound)
-
+            val h = CommandRouterHarness.create()
             val staffSid = SessionId(1)
-            loginStaff(players, staffSid, "Admin")
-            drain(outbound)
+            h.loginStaff(staffSid, "Admin")
+            h.drain()
 
-            router.handle(staffSid, Command.SetLevel("Ghost", 10))
-            val outs = drain(outbound)
+            h.router.handle(staffSid, Command.SetLevel("Ghost", 10))
+            val outs = h.drain()
 
             assertTrue(
                 outs.any { it is OutboundEvent.SendError && it.sessionId == staffSid },
@@ -662,21 +495,15 @@ class CommandRouterAdminTest {
     @Test
     fun `setlevel requires staff`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = makeRouter(players, mobs, items, outbound)
-
+            val h = CommandRouterHarness.create()
             val bobSid = SessionId(1)
-            login(players, bobSid, "Bob")
-            drain(outbound)
+            h.loginPlayer(bobSid, "Bob")
+            h.drain()
 
-            router.handle(bobSid, Command.SetLevel("Bob", 10))
-            val outs = drain(outbound)
+            h.router.handle(bobSid, Command.SetLevel("Bob", 10))
+            val outs = h.drain()
 
-            assertEquals(1, players.get(bobSid)!!.level, "Non-staff should not be able to setlevel")
+            assertEquals(1, h.players.get(bobSid)!!.level, "Non-staff should not be able to setlevel")
             assertTrue(
                 outs.any { it is OutboundEvent.SendError && it.sessionId == bobSid },
                 "Non-staff should receive error. got=$outs",

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterBroadcastTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterBroadcastTest.kt
@@ -2,12 +2,13 @@ package dev.ambon.engine.commands
 
 import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.domain.ids.SessionId
-import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.GroupSystem
-import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.CommandRouterHarness
+import dev.ambon.test.TestWorlds
+import dev.ambon.test.buildTestPlayerRegistry
 import dev.ambon.test.drainAll
 import dev.ambon.test.loginOrFail
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -22,21 +23,15 @@ class CommandRouterBroadcastTest {
     @Test
     fun `say broadcasts to other players in same room and echoes to sender`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = buildTestRouter(world, players, mobs, items, CombatSystem(players, mobs, items, outbound), outbound)
-
+            val h = CommandRouterHarness.create()
             val a = SessionId(1)
             val b = SessionId(2)
-            players.loginOrFail(a, "Player1")
-            players.loginOrFail(b, "Player2")
+            h.players.loginOrFail(a, "Player1")
+            h.players.loginOrFail(b, "Player2")
 
-            router.handle(a, Command.Say("hello"))
+            h.router.handle(a, Command.Say("hello"))
 
-            val outs = outbound.drainAll()
+            val outs = h.outbound.drainAll()
 
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && it.sessionId == a && it.text == "You say: hello" },
@@ -53,24 +48,18 @@ class CommandRouterBroadcastTest {
     @Test
     fun `say does not broadcast across rooms`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = buildTestRouter(world, players, mobs, items, CombatSystem(players, mobs, items, outbound), outbound)
-
+            val h = CommandRouterHarness.create()
             val a = SessionId(1)
             val b = SessionId(2)
-            players.loginOrFail(a, "Player1")
-            players.loginOrFail(b, "Player2")
+            h.players.loginOrFail(a, "Player1")
+            h.players.loginOrFail(b, "Player2")
 
             // Move b north into a different room
-            router.handle(b, Command.Move(dev.ambon.domain.world.Direction.NORTH))
-            outbound.drainAll() // ignore look output
+            h.router.handle(b, Command.Move(dev.ambon.domain.world.Direction.NORTH))
+            h.outbound.drainAll() // ignore look output
 
-            router.handle(a, Command.Say("psst"))
-            val outs = outbound.drainAll()
+            h.router.handle(a, Command.Say("psst"))
+            val outs = h.outbound.drainAll()
 
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && it.sessionId == a && it.text == "You say: psst" },
@@ -85,20 +74,14 @@ class CommandRouterBroadcastTest {
     @Test
     fun `who lists connected players`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = buildTestRouter(world, players, mobs, items, CombatSystem(players, mobs, items, outbound), outbound)
-
+            val h = CommandRouterHarness.create()
             val a = SessionId(1)
             val b = SessionId(2)
-            players.loginOrFail(a, "Player1")
-            players.loginOrFail(b, "Player2")
+            h.players.loginOrFail(a, "Player1")
+            h.players.loginOrFail(b, "Player2")
 
-            router.handle(a, Command.Who)
-            val outs = outbound.drainAll()
+            h.router.handle(a, Command.Who)
+            val outs = h.outbound.drainAll()
 
             val msg =
                 outs
@@ -114,37 +97,35 @@ class CommandRouterBroadcastTest {
     @Test
     fun `who shows G indicator for grouped players`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
+            val world = TestWorlds.testWorld
+            val repo = InMemoryPlayerRepository()
             val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
+            val players = buildTestPlayerRegistry(world.startRoom, repo, items)
             val outbound = LocalOutboundBus()
             val groupSystem = GroupSystem(players, outbound)
-            val router =
-                buildTestRouter(
-                    world,
-                    players,
-                    mobs,
-                    items,
-                    CombatSystem(players, mobs, items, outbound),
-                    outbound,
-                    groupSystem = groupSystem,
-                )
+            val h = CommandRouterHarness.create(
+                world = world,
+                repo = repo,
+                items = items,
+                players = players,
+                outbound = outbound,
+                groupSystem = groupSystem,
+            )
 
             val a = SessionId(1)
             val b = SessionId(2)
             val c = SessionId(3)
-            players.loginOrFail(a, "Alice")
-            players.loginOrFail(b, "Bob")
-            players.loginOrFail(c, "Charlie")
-            outbound.drainAll()
+            h.players.loginOrFail(a, "Alice")
+            h.players.loginOrFail(b, "Bob")
+            h.players.loginOrFail(c, "Charlie")
+            h.outbound.drainAll()
 
             groupSystem.invite(a, "Bob")
             groupSystem.accept(b)
-            outbound.drainAll()
+            h.outbound.drainAll()
 
-            router.handle(c, Command.Who)
-            val outs = outbound.drainAll()
+            h.router.handle(c, Command.Who)
+            val outs = h.outbound.drainAll()
 
             val msg =
                 outs

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterItemsTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterItemsTest.kt
@@ -1,19 +1,13 @@
 package dev.ambon.engine.commands
 
-import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.domain.ids.ItemId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.items.Item
 import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.items.ItemSlot
 import dev.ambon.domain.items.ItemUseEffect
-import dev.ambon.engine.CombatSystem
-import dev.ambon.engine.LoginResult
-import dev.ambon.engine.MobRegistry
-import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.events.OutboundEvent
-import dev.ambon.engine.items.ItemRegistry
-import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.CommandRouterHarness
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -23,24 +17,18 @@ class CommandRouterItemsTest {
     @Test
     fun `look includes items here line`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            items.setRoomItems(
-                world.startRoom,
+            val h = CommandRouterHarness.create()
+            h.items.setRoomItems(
+                h.world.startRoom,
                 listOf(ItemInstance(ItemId("test:lantern"), Item(keyword = "lantern", displayName = "a brass lantern"))),
             )
 
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val outbound = LocalOutboundBus()
-            val mobs = MobRegistry()
-            val router = buildTestRouter(world, players, mobs, items, CombatSystem(players, mobs, items, outbound), outbound)
-
             val sid = SessionId(1L)
-            login(players, sid, "Player1")
+            h.loginPlayer(sid, "Player1")
 
-            router.handle(sid, Command.Look)
+            h.router.handle(sid, Command.Look)
 
-            val outs = drain(outbound)
+            val outs = h.drain()
             assertTrue(
                 outs.any {
                     it is OutboundEvent.SendInfo &&
@@ -54,28 +42,22 @@ class CommandRouterItemsTest {
     @Test
     fun `get moves item from room to inventory`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            items.setRoomItems(
-                world.startRoom,
+            val h = CommandRouterHarness.create()
+            h.items.setRoomItems(
+                h.world.startRoom,
                 listOf(ItemInstance(ItemId("test:note"), Item(keyword = "note", displayName = "a crumpled note"))),
             )
 
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val outbound = LocalOutboundBus()
-            val mobs = MobRegistry()
-            val router = buildTestRouter(world, players, mobs, items, CombatSystem(players, mobs, items, outbound), outbound)
-
             val sid = SessionId(2L)
-            login(players, sid, "Player2")
+            h.loginPlayer(sid, "Player2")
 
-            router.handle(sid, Command.Get("note"))
+            h.router.handle(sid, Command.Get("note"))
 
-            assertEquals(0, items.itemsInRoom(world.startRoom).size)
-            assertEquals(1, items.inventory(sid).size)
-            assertEquals("note", items.inventory(sid)[0].item.keyword)
+            assertEquals(0, h.items.itemsInRoom(h.world.startRoom).size)
+            assertEquals(1, h.items.inventory(sid).size)
+            assertEquals("note", h.items.inventory(sid)[0].item.keyword)
 
-            val outs = drain(outbound)
+            val outs = h.drain()
             assertTrue(
                 outs.any { it is OutboundEvent.SendInfo && it.text.contains("pick up") },
                 "Missing pickup message. got=$outs",
@@ -85,30 +67,24 @@ class CommandRouterItemsTest {
     @Test
     fun `inventory shows carried items`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val outbound = LocalOutboundBus()
-            val mobs = MobRegistry()
-            val router = buildTestRouter(world, players, mobs, items, CombatSystem(players, mobs, items, outbound), outbound)
+            val h = CommandRouterHarness.create()
 
             val sid = SessionId(3L)
-            login(players, sid, "Player3")
+            h.loginPlayer(sid, "Player3")
 
             // give an item via registry
-            items.dropToRoom(sid, world.startRoom, "lantern") // no-op, not in inv
-            items.takeFromRoom(sid, world.startRoom, "lantern") // no-op
+            h.items.dropToRoom(sid, h.world.startRoom, "lantern") // no-op, not in inv
+            h.items.takeFromRoom(sid, h.world.startRoom, "lantern") // no-op
             // simplest: just set inventory by taking from a room
-            items.setRoomItems(
-                world.startRoom,
+            h.items.setRoomItems(
+                h.world.startRoom,
                 listOf(ItemInstance(ItemId("test:lantern"), Item(keyword = "lantern", displayName = "a brass lantern"))),
             )
-            items.takeFromRoom(sid, world.startRoom, "lantern")
+            h.items.takeFromRoom(sid, h.world.startRoom, "lantern")
 
-            router.handle(sid, Command.Inventory)
+            h.router.handle(sid, Command.Inventory)
 
-            val outs = drain(outbound)
+            val outs = h.drain()
             assertTrue(
                 outs.any {
                     it is OutboundEvent.SendInfo &&
@@ -122,33 +98,27 @@ class CommandRouterItemsTest {
     @Test
     fun `drop moves item from inventory to room`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val outbound = LocalOutboundBus()
-            val mobs = MobRegistry()
-            val router = buildTestRouter(world, players, mobs, items, CombatSystem(players, mobs, items, outbound), outbound)
+            val h = CommandRouterHarness.create()
 
             val sid = SessionId(4L)
-            login(players, sid, "Player4")
+            h.loginPlayer(sid, "Player4")
 
             // Put item into inventory by taking it from the room
-            items.setRoomItems(
-                world.startRoom,
+            h.items.setRoomItems(
+                h.world.startRoom,
                 listOf(ItemInstance(ItemId("test:note"), Item(keyword = "note", displayName = "a crumpled note"))),
             )
-            items.takeFromRoom(sid, world.startRoom, "note")
-            assertEquals(1, items.inventory(sid).size)
-            assertEquals(0, items.itemsInRoom(world.startRoom).size)
+            h.items.takeFromRoom(sid, h.world.startRoom, "note")
+            assertEquals(1, h.items.inventory(sid).size)
+            assertEquals(0, h.items.itemsInRoom(h.world.startRoom).size)
 
-            router.handle(sid, Command.Drop("note"))
+            h.router.handle(sid, Command.Drop("note"))
 
-            assertEquals(0, items.inventory(sid).size)
-            assertEquals(1, items.itemsInRoom(world.startRoom).size)
-            assertEquals("note", items.itemsInRoom(world.startRoom)[0].item.keyword)
+            assertEquals(0, h.items.inventory(sid).size)
+            assertEquals(1, h.items.itemsInRoom(h.world.startRoom).size)
+            assertEquals("note", h.items.itemsInRoom(h.world.startRoom)[0].item.keyword)
 
-            val outs = drain(outbound)
+            val outs = h.drain()
             assertTrue(
                 outs.any { it is OutboundEvent.SendInfo && it.text.contains("You drop") },
                 "Missing drop message. got=$outs",
@@ -158,19 +128,13 @@ class CommandRouterItemsTest {
     @Test
     fun `wear moves item from inventory to equipment slot`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val outbound = LocalOutboundBus()
-            val mobs = MobRegistry()
-            val router = buildTestRouter(world, players, mobs, items, CombatSystem(players, mobs, items, outbound), outbound)
+            val h = CommandRouterHarness.create()
 
             val sid = SessionId(5L)
-            login(players, sid, "Player5")
+            h.loginPlayer(sid, "Player5")
 
-            items.setRoomItems(
-                world.startRoom,
+            h.items.setRoomItems(
+                h.world.startRoom,
                 listOf(
                     ItemInstance(
                         ItemId("test:cap"),
@@ -178,18 +142,18 @@ class CommandRouterItemsTest {
                     ),
                 ),
             )
-            items.takeFromRoom(sid, world.startRoom, "cap")
+            h.items.takeFromRoom(sid, h.world.startRoom, "cap")
 
-            router.handle(sid, Command.Wear("cap"))
+            h.router.handle(sid, Command.Wear("cap"))
 
-            assertEquals(0, items.inventory(sid).size)
-            val equipped = items.equipment(sid)
+            assertEquals(0, h.items.inventory(sid).size)
+            val equipped = h.items.equipment(sid)
             assertEquals("cap", equipped.getValue(ItemSlot.HEAD).item.keyword)
-            val player = players.get(sid)
+            val player = h.players.get(sid)
             assertEquals(11, player!!.maxHp)
             assertEquals(11, player.hp)
 
-            val outs = drain(outbound)
+            val outs = h.drain()
             assertTrue(
                 outs.any { it is OutboundEvent.SendInfo && it.text.contains("You wear") },
                 "Missing wear message. got=$outs",
@@ -199,19 +163,13 @@ class CommandRouterItemsTest {
     @Test
     fun `remove moves item from equipment slot back to inventory`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val outbound = LocalOutboundBus()
-            val mobs = MobRegistry()
-            val router = buildTestRouter(world, players, mobs, items, CombatSystem(players, mobs, items, outbound), outbound)
+            val h = CommandRouterHarness.create()
 
             val sid = SessionId(6L)
-            login(players, sid, "Player6")
+            h.loginPlayer(sid, "Player6")
 
-            items.setRoomItems(
-                world.startRoom,
+            h.items.setRoomItems(
+                h.world.startRoom,
                 listOf(
                     ItemInstance(
                         ItemId("test:cap"),
@@ -219,19 +177,19 @@ class CommandRouterItemsTest {
                     ),
                 ),
             )
-            items.takeFromRoom(sid, world.startRoom, "cap")
-            router.handle(sid, Command.Wear("cap"))
-            drain(outbound)
+            h.items.takeFromRoom(sid, h.world.startRoom, "cap")
+            h.router.handle(sid, Command.Wear("cap"))
+            h.drain()
 
-            router.handle(sid, Command.Remove(ItemSlot.HEAD))
+            h.router.handle(sid, Command.Remove(ItemSlot.HEAD))
 
-            assertEquals(1, items.inventory(sid).size)
-            assertTrue(items.equipment(sid).isEmpty())
-            val player = players.get(sid)
+            assertEquals(1, h.items.inventory(sid).size)
+            assertTrue(h.items.equipment(sid).isEmpty())
+            val player = h.players.get(sid)
             assertEquals(10, player!!.maxHp)
             assertEquals(10, player.hp)
 
-            val outs = drain(outbound)
+            val outs = h.drain()
             assertTrue(
                 outs.any { it is OutboundEvent.SendInfo && it.text.contains("You remove") },
                 "Missing remove message. got=$outs",
@@ -241,19 +199,13 @@ class CommandRouterItemsTest {
     @Test
     fun `wear prefers wearable item when multiple inventory items share keyword`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val outbound = LocalOutboundBus()
-            val mobs = MobRegistry()
-            val router = buildTestRouter(world, players, mobs, items, CombatSystem(players, mobs, items, outbound), outbound)
+            val h = CommandRouterHarness.create()
 
             val sid = SessionId(7L)
-            login(players, sid, "Player7")
+            h.loginPlayer(sid, "Player7")
 
-            items.setRoomItems(
-                world.startRoom,
+            h.items.setRoomItems(
+                h.world.startRoom,
                 listOf(
                     ItemInstance(
                         ItemId("test:ring_plain"),
@@ -265,17 +217,17 @@ class CommandRouterItemsTest {
                     ),
                 ),
             )
-            items.takeFromRoom(sid, world.startRoom, "ring")
-            items.takeFromRoom(sid, world.startRoom, "ring")
+            h.items.takeFromRoom(sid, h.world.startRoom, "ring")
+            h.items.takeFromRoom(sid, h.world.startRoom, "ring")
 
-            router.handle(sid, Command.Wear("ring"))
+            h.router.handle(sid, Command.Wear("ring"))
 
-            val equipped = items.equipment(sid)
+            val equipped = h.items.equipment(sid)
             assertEquals("ring", equipped.getValue(ItemSlot.HAND).item.keyword)
-            assertEquals(1, items.inventory(sid).size)
-            assertEquals("ring", items.inventory(sid)[0].item.keyword)
+            assertEquals(1, h.items.inventory(sid).size)
+            assertEquals("ring", h.items.inventory(sid)[0].item.keyword)
 
-            val outs = drain(outbound)
+            val outs = h.drain()
             assertTrue(
                 outs.any { it is OutboundEvent.SendInfo && it.text.contains("You wear") },
                 "Missing wear message. got=$outs",
@@ -285,19 +237,13 @@ class CommandRouterItemsTest {
     @Test
     fun `use applies effects and consumes when charges reach zero`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val outbound = LocalOutboundBus()
-            val mobs = MobRegistry()
-            val router = buildTestRouter(world, players, mobs, items, CombatSystem(players, mobs, items, outbound), outbound)
-
+            val h = CommandRouterHarness.create()
             val sid = SessionId(8L)
-            login(players, sid, "Player8")
-            players.get(sid)!!.hp = 5
+            h.loginPlayer(sid, "Player8")
+            h.players.get(sid)!!.hp = 5
 
-            items.setRoomItems(
-                world.startRoom,
+            h.items.setRoomItems(
+                h.world.startRoom,
                 listOf(
                     ItemInstance(
                         ItemId("test:potion"),
@@ -311,44 +257,38 @@ class CommandRouterItemsTest {
                     ),
                 ),
             )
-            items.takeFromRoom(sid, world.startRoom, "potion")
+            h.items.takeFromRoom(sid, h.world.startRoom, "potion")
 
-            router.handle(sid, Command.Use("potion"))
+            h.router.handle(sid, Command.Use("potion"))
 
-            assertEquals(8, players.get(sid)!!.hp)
-            assertEquals(1, items.inventory(sid).size)
-            val remainingPotion = items.inventory(sid).single()
+            assertEquals(8, h.players.get(sid)!!.hp)
+            assertEquals(1, h.items.inventory(sid).size)
+            val remainingPotion = h.items.inventory(sid).single()
             assertEquals(1, remainingPotion.item.charges)
 
-            var outs = drain(outbound)
+            var outs = h.drain()
             assertTrue(outs.any { it is OutboundEvent.SendInfo && it.text.contains("You use a red potion") })
             assertTrue(outs.any { it is OutboundEvent.SendInfo && it.text.contains("recover 3 HP") })
             assertTrue(outs.any { it is OutboundEvent.SendInfo && it.text.contains("1 charge") })
 
-            router.handle(sid, Command.Use("potion"))
+            h.router.handle(sid, Command.Use("potion"))
 
-            assertEquals(10, players.get(sid)!!.hp)
-            assertTrue(items.inventory(sid).isEmpty())
+            assertEquals(10, h.players.get(sid)!!.hp)
+            assertTrue(h.items.inventory(sid).isEmpty())
 
-            outs = drain(outbound)
+            outs = h.drain()
             assertTrue(outs.any { it is OutboundEvent.SendInfo && it.text.contains("is consumed") })
         }
 
     @Test
     fun `use can consume equipped item and updates defense`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val outbound = LocalOutboundBus()
-            val mobs = MobRegistry()
-            val router = buildTestRouter(world, players, mobs, items, CombatSystem(players, mobs, items, outbound), outbound)
-
+            val h = CommandRouterHarness.create()
             val sid = SessionId(9L)
-            login(players, sid, "Player9")
+            h.loginPlayer(sid, "Player9")
 
-            items.setRoomItems(
-                world.startRoom,
+            h.items.setRoomItems(
+                h.world.startRoom,
                 listOf(
                     ItemInstance(
                         ItemId("test:blessed_cap"),
@@ -364,17 +304,17 @@ class CommandRouterItemsTest {
                     ),
                 ),
             )
-            items.takeFromRoom(sid, world.startRoom, "cap")
-            router.handle(sid, Command.Wear("cap"))
-            drain(outbound)
+            h.items.takeFromRoom(sid, h.world.startRoom, "cap")
+            h.router.handle(sid, Command.Wear("cap"))
+            h.drain()
 
-            assertEquals(11, players.get(sid)!!.maxHp)
-            router.handle(sid, Command.Use("cap"))
+            assertEquals(11, h.players.get(sid)!!.maxHp)
+            h.router.handle(sid, Command.Use("cap"))
 
-            assertTrue(items.equipment(sid).isEmpty())
-            assertEquals(10, players.get(sid)!!.maxHp)
+            assertTrue(h.items.equipment(sid).isEmpty())
+            assertEquals(10, h.players.get(sid)!!.maxHp)
 
-            val outs = drain(outbound)
+            val outs = h.drain()
             assertTrue(outs.any { it is OutboundEvent.SendInfo && it.text.contains("You use a blessed cap") })
             assertTrue(outs.any { it is OutboundEvent.SendInfo && it.text.contains("is consumed") })
         }
@@ -382,32 +322,26 @@ class CommandRouterItemsTest {
     @Test
     fun `give moves item to nearby player inventory`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val outbound = LocalOutboundBus()
-            val mobs = MobRegistry()
-            val router = buildTestRouter(world, players, mobs, items, CombatSystem(players, mobs, items, outbound), outbound)
-
+            val h = CommandRouterHarness.create()
             val aliceSid = SessionId(10L)
             val bobSid = SessionId(11L)
-            login(players, aliceSid, "Alice")
-            login(players, bobSid, "Bob")
+            h.loginPlayer(aliceSid, "Alice")
+            h.loginPlayer(bobSid, "Bob")
 
-            items.setRoomItems(
-                world.startRoom,
+            h.items.setRoomItems(
+                h.world.startRoom,
                 listOf(ItemInstance(ItemId("test:coin"), Item(keyword = "coin", displayName = "a silver coin"))),
             )
-            items.takeFromRoom(aliceSid, world.startRoom, "coin")
+            h.items.takeFromRoom(aliceSid, h.world.startRoom, "coin")
 
-            router.handle(aliceSid, Command.Give("coin", "Bob"))
+            h.router.handle(aliceSid, Command.Give("coin", "Bob"))
 
-            assertTrue(items.inventory(aliceSid).isEmpty())
-            assertEquals(1, items.inventory(bobSid).size)
-            val bobsItem = items.inventory(bobSid).single()
+            assertTrue(h.items.inventory(aliceSid).isEmpty())
+            assertEquals(1, h.items.inventory(bobSid).size)
+            val bobsItem = h.items.inventory(bobSid).single()
             assertEquals("coin", bobsItem.item.keyword)
 
-            val outs = drain(outbound)
+            val outs = h.drain()
             assertTrue(outs.any { it is OutboundEvent.SendInfo && it.sessionId == aliceSid && it.text.contains("You give") })
             assertTrue(outs.any { it is OutboundEvent.SendInfo && it.sessionId == bobSid && it.text.contains("gives you") })
         }
@@ -415,20 +349,14 @@ class CommandRouterItemsTest {
     @Test
     fun `give removes equipped item and updates defense`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val outbound = LocalOutboundBus()
-            val mobs = MobRegistry()
-            val router = buildTestRouter(world, players, mobs, items, CombatSystem(players, mobs, items, outbound), outbound)
-
+            val h = CommandRouterHarness.create()
             val aliceSid = SessionId(12L)
             val bobSid = SessionId(13L)
-            login(players, aliceSid, "Alice2")
-            login(players, bobSid, "Bob2")
+            h.loginPlayer(aliceSid, "Alice2")
+            h.loginPlayer(bobSid, "Bob2")
 
-            items.setRoomItems(
-                world.startRoom,
+            h.items.setRoomItems(
+                h.world.startRoom,
                 listOf(
                     ItemInstance(
                         ItemId("test:cap"),
@@ -436,19 +364,19 @@ class CommandRouterItemsTest {
                     ),
                 ),
             )
-            items.takeFromRoom(aliceSid, world.startRoom, "cap")
-            router.handle(aliceSid, Command.Wear("cap"))
-            drain(outbound)
+            h.items.takeFromRoom(aliceSid, h.world.startRoom, "cap")
+            h.router.handle(aliceSid, Command.Wear("cap"))
+            h.drain()
 
-            assertEquals(11, players.get(aliceSid)!!.maxHp)
-            router.handle(aliceSid, Command.Give("cap", "Bob2"))
+            assertEquals(11, h.players.get(aliceSid)!!.maxHp)
+            h.router.handle(aliceSid, Command.Give("cap", "Bob2"))
 
-            assertTrue(items.equipment(aliceSid).isEmpty())
-            assertEquals(10, players.get(aliceSid)!!.maxHp)
-            val bobsItem = items.inventory(bobSid).single()
+            assertTrue(h.items.equipment(aliceSid).isEmpty())
+            assertEquals(10, h.players.get(aliceSid)!!.maxHp)
+            val bobsItem = h.items.inventory(bobSid).single()
             assertEquals("cap", bobsItem.item.keyword)
 
-            val outs = drain(outbound)
+            val outs = h.drain()
             assertTrue(outs.any { it is OutboundEvent.SendInfo && it.sessionId == aliceSid && it.text.contains("You give") })
             assertTrue(outs.any { it is OutboundEvent.SendInfo && it.sessionId == bobSid && it.text.contains("gives you") })
         }
@@ -456,52 +384,28 @@ class CommandRouterItemsTest {
     @Test
     fun `give requires target in same room`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val outbound = LocalOutboundBus()
-            val mobs = MobRegistry()
-            val router = buildTestRouter(world, players, mobs, items, CombatSystem(players, mobs, items, outbound), outbound)
-
+            val h = CommandRouterHarness.create()
             val aliceSid = SessionId(14L)
             val bobSid = SessionId(15L)
-            login(players, aliceSid, "Alice3")
-            login(players, bobSid, "Bob3")
+            h.loginPlayer(aliceSid, "Alice3")
+            h.loginPlayer(bobSid, "Bob3")
 
-            val startRoom = world.rooms.getValue(world.startRoom)
+            val startRoom = h.world.rooms.getValue(h.world.startRoom)
             val targetRoom = startRoom.exits.values.first()
-            players.moveTo(bobSid, targetRoom)
+            h.players.moveTo(bobSid, targetRoom)
 
-            items.setRoomItems(
-                world.startRoom,
+            h.items.setRoomItems(
+                h.world.startRoom,
                 listOf(ItemInstance(ItemId("test:coin"), Item(keyword = "coin", displayName = "a silver coin"))),
             )
-            items.takeFromRoom(aliceSid, world.startRoom, "coin")
+            h.items.takeFromRoom(aliceSid, h.world.startRoom, "coin")
 
-            router.handle(aliceSid, Command.Give("coin", "Bob3"))
+            h.router.handle(aliceSid, Command.Give("coin", "Bob3"))
 
-            assertEquals(1, items.inventory(aliceSid).size)
-            assertTrue(items.inventory(bobSid).isEmpty())
+            assertEquals(1, h.items.inventory(aliceSid).size)
+            assertTrue(h.items.inventory(bobSid).isEmpty())
 
-            val outs = drain(outbound)
+            val outs = h.drain()
             assertTrue(outs.any { it is OutboundEvent.SendError && it.text.contains("not here") })
         }
-
-    private fun drain(ch: LocalOutboundBus): List<OutboundEvent> {
-        val out = mutableListOf<OutboundEvent>()
-        while (true) {
-            val v = ch.tryReceive().getOrNull() ?: break
-            out.add(v)
-        }
-        return out
-    }
-
-    private suspend fun login(
-        players: PlayerRegistry,
-        sessionId: SessionId,
-        name: String,
-    ) {
-        val res = players.login(sessionId, name, "password")
-        require(res == LoginResult.Ok) { "Login failed: $res" }
-    }
 }

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterScoreTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterScoreTest.kt
@@ -2,6 +2,7 @@ package dev.ambon.engine.commands
 
 import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.domain.ids.ItemId
+import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.items.Item
 import dev.ambon.domain.items.ItemInstance
@@ -9,13 +10,15 @@ import dev.ambon.domain.items.ItemSlot
 import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.CombatSystemConfig
 import dev.ambon.engine.GroupSystem
-import dev.ambon.engine.LoginResult
 import dev.ambon.engine.MobRegistry
-import dev.ambon.engine.PlayerProgression
-import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.CommandRouterHarness
+import dev.ambon.test.TestWorlds
+import dev.ambon.test.buildTestPlayerRegistry
+import dev.ambon.test.drainAll
+import dev.ambon.test.loginOrFail
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -24,21 +27,22 @@ class CommandRouterScoreTest {
     @Test
     fun `score shows name level hp and damage range`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
+            // Needs CombatSystemConfig to assert specific damage range in score output
+            val world = TestWorlds.testWorld
             val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
+            val players = buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
             val mobs = MobRegistry()
             val outbound = LocalOutboundBus()
             val combat = CombatSystem(players, mobs, items, outbound, config = CombatSystemConfig(minDamage = 1, maxDamage = 4))
             val router = buildTestRouter(world, players, mobs, items, combat, outbound)
 
             val sid = SessionId(1)
-            login(players, sid, "Arandel")
-            drain(outbound)
+            players.loginOrFail(sid, "Arandel")
+            outbound.drainAll()
 
             router.handle(sid, Command.Score)
 
-            val outs = drain(outbound)
+            val outs = outbound.drainAll()
             val text = outs.filterIsInstance<OutboundEvent.SendInfo>().joinToString("\n") { it.text }
             assertTrue(text.contains("Arandel"), "Missing name. text=$text")
             assertTrue(text.contains("Level 1"), "Missing level. text=$text")
@@ -51,24 +55,17 @@ class CommandRouterScoreTest {
     @Test
     fun `score with equipped armor item lists it in Armor section`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val combat = CombatSystem(players, mobs, items, outbound, config = CombatSystemConfig(minDamage = 1, maxDamage = 4))
-            val router = buildTestRouter(world, players, mobs, items, combat, outbound)
-
+            val h = CommandRouterHarness.create()
             val sid = SessionId(2)
-            login(players, sid, "Brenna")
-            drain(outbound)
+            h.loginPlayer(sid, "Brenna")
+            h.drain()
 
-            equipItem(items, sid, ItemId("test:helm"), Item(keyword = "helm", displayName = "iron helm", slot = ItemSlot.HEAD, armor = 3))
-            combat.syncPlayerDefense(sid)
+            equipItem(h.items, sid, ItemId("test:helm"), Item(keyword = "helm", displayName = "iron helm", slot = ItemSlot.HEAD, armor = 3))
+            h.combat.syncPlayerDefense(sid)
 
-            router.handle(sid, Command.Score)
+            h.router.handle(sid, Command.Score)
 
-            val outs = drain(outbound)
+            val outs = h.drain()
             val text = outs.filterIsInstance<OutboundEvent.SendInfo>().joinToString("\n") { it.text }
             assertTrue(text.contains("+3"), "Expected armor total +3. text=$text")
             assertTrue(text.contains("iron helm"), "Expected item name in armor detail. text=$text")
@@ -77,82 +74,53 @@ class CommandRouterScoreTest {
     @Test
     fun `score at max level shows MAXED for XP`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val combat = CombatSystem(players, mobs, items, outbound)
-            val progression = PlayerProgression()
-            val router = buildTestRouter(world, players, mobs, items, combat, outbound, progression = progression)
-
+            val h = CommandRouterHarness.create()
             val sid = SessionId(3)
-            login(players, sid, "Zara")
-            drain(outbound)
+            h.loginPlayer(sid, "Zara")
+            h.drain()
 
             // Grant enough XP to reach max level
-            val maxXp = progression.totalXpForLevel(progression.maxLevel)
-            players.grantXp(sid, maxXp, progression)
+            val maxXp = h.progression.totalXpForLevel(h.progression.maxLevel)
+            h.players.grantXp(sid, maxXp, h.progression)
 
-            router.handle(sid, Command.Score)
+            h.router.handle(sid, Command.Score)
 
-            val outs = drain(outbound)
+            val outs = h.drain()
             val text = outs.filterIsInstance<OutboundEvent.SendInfo>().joinToString("\n") { it.text }
             assertTrue(text.contains("MAXED"), "Expected MAXED at max level. text=$text")
         }
 
-    private fun drain(ch: LocalOutboundBus): List<OutboundEvent> {
-        val out = mutableListOf<OutboundEvent>()
-        while (true) {
-            val ev = ch.tryReceive().getOrNull() ?: break
-            out += ev
-        }
-        return out
-    }
-
-    private suspend fun login(
-        players: PlayerRegistry,
-        sessionId: SessionId,
-        name: String,
-    ) {
-        val res = players.login(sessionId, name, "password")
-        require(res == LoginResult.Ok) { "Login failed: $res" }
-    }
-
     @Test
     fun `score shows group info when in a group`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
+            val world = TestWorlds.testWorld
+            val repo = InMemoryPlayerRepository()
             val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
+            val players = buildTestPlayerRegistry(world.startRoom, repo, items)
             val outbound = LocalOutboundBus()
             val groupSystem = GroupSystem(players, outbound)
-            val combat = CombatSystem(players, mobs, items, outbound)
-            val router =
-                buildTestRouter(
-                    world,
-                    players,
-                    mobs,
-                    items,
-                    combat,
-                    outbound,
-                    groupSystem = groupSystem,
-                )
+            val h = CommandRouterHarness.create(
+                world = world,
+                repo = repo,
+                items = items,
+                players = players,
+                outbound = outbound,
+                groupSystem = groupSystem,
+            )
 
             val sid1 = SessionId(1)
             val sid2 = SessionId(2)
-            login(players, sid1, "Alice")
-            login(players, sid2, "Bob")
-            drain(outbound)
+            h.players.loginOrFail(sid1, "Alice")
+            h.players.loginOrFail(sid2, "Bob")
+            h.outbound.drainAll()
 
             groupSystem.invite(sid1, "Bob")
             groupSystem.accept(sid2)
-            drain(outbound)
+            h.outbound.drainAll()
 
-            router.handle(sid1, Command.Score)
+            h.router.handle(sid1, Command.Score)
 
-            val outs = drain(outbound)
+            val outs = h.outbound.drainAll()
             val text = outs.filterIsInstance<OutboundEvent.SendInfo>().joinToString("\n") { it.text }
             assertTrue(text.contains("Group"), "Expected Group line. text=$text")
             assertTrue(text.contains("2 members"), "Expected member count. text=$text")
@@ -162,31 +130,28 @@ class CommandRouterScoreTest {
     @Test
     fun `score does not show group line when ungrouped`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
+            val world = TestWorlds.testWorld
+            val repo = InMemoryPlayerRepository()
             val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
+            val players = buildTestPlayerRegistry(world.startRoom, repo, items)
             val outbound = LocalOutboundBus()
             val groupSystem = GroupSystem(players, outbound)
-            val combat = CombatSystem(players, mobs, items, outbound)
-            val router =
-                buildTestRouter(
-                    world,
-                    players,
-                    mobs,
-                    items,
-                    combat,
-                    outbound,
-                    groupSystem = groupSystem,
-                )
+            val h = CommandRouterHarness.create(
+                world = world,
+                repo = repo,
+                items = items,
+                players = players,
+                outbound = outbound,
+                groupSystem = groupSystem,
+            )
 
             val sid = SessionId(1)
-            login(players, sid, "Alice")
-            drain(outbound)
+            h.players.loginOrFail(sid, "Alice")
+            h.outbound.drainAll()
 
-            router.handle(sid, Command.Score)
+            h.router.handle(sid, Command.Score)
 
-            val outs = drain(outbound)
+            val outs = h.outbound.drainAll()
             val text = outs.filterIsInstance<OutboundEvent.SendInfo>().joinToString("\n") { it.text }
             assertTrue(!text.contains("Group:"), "Should not contain Group line. text=$text")
         }
@@ -200,14 +165,12 @@ class CommandRouterScoreTest {
         val instance = ItemInstance(itemId, item)
         items.ensurePlayer(sessionId)
         items.addRoomItem(
-            dev.ambon.domain.ids
-                .RoomId("test:room"),
+            RoomId("test:room"),
             instance,
         )
         items.takeFromRoom(
             sessionId,
-            dev.ambon.domain.ids
-                .RoomId("test:room"),
+            RoomId("test:room"),
             item.keyword,
         )
         items.equipFromInventory(sessionId, item.keyword)

--- a/src/test/kotlin/dev/ambon/engine/commands/CrossEngineCommandsTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CrossEngineCommandsTest.kt
@@ -3,15 +3,15 @@ package dev.ambon.engine.commands
 import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.CombatSystem
-import dev.ambon.engine.LoginResult
 import dev.ambon.engine.MobRegistry
-import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.persistence.InMemoryPlayerRepository
 import dev.ambon.sharding.BroadcastType
 import dev.ambon.sharding.InterEngineMessage
 import dev.ambon.sharding.LocalInterEngineBus
+import dev.ambon.test.drainAll
+import dev.ambon.test.loginOrFail
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -45,13 +45,13 @@ class CrossEngineCommandsTest {
     fun `gossip broadcasts GlobalBroadcast via inter-engine bus`() =
         runTest {
             val sid = SessionId(1)
-            login(players, sid, "Alice")
-            drain(outbound)
+            players.loginOrFail(sid, "Alice")
+            outbound.drainAll()
 
             router.handle(sid, Command.Gossip("hello world"))
 
             // Local delivery still works
-            val outs = drain(outbound)
+            val outs = outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && it.sessionId == sid && "You gossip" in (it as OutboundEvent.SendText).text },
             )
@@ -70,13 +70,13 @@ class CrossEngineCommandsTest {
     fun `tell to unknown player sends TellMessage via bus`() =
         runTest {
             val sid = SessionId(1)
-            login(players, sid, "Alice")
-            drain(outbound)
+            players.loginOrFail(sid, "Alice")
+            outbound.drainAll()
 
             router.handle(sid, Command.Tell("Bob", "hey bob"))
 
             // Sender should see confirmation (not error)
-            val outs = drain(outbound)
+            val outs = outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && "You tell Bob" in (it as OutboundEvent.SendText).text },
             )
@@ -109,11 +109,11 @@ class CrossEngineCommandsTest {
                 )
 
             val sid = SessionId(1)
-            login(players, sid, "Alice")
-            drain(outbound)
+            players.loginOrFail(sid, "Alice")
+            outbound.drainAll()
 
             noBusRouter.handle(sid, Command.Tell("Bob", "hey bob"))
-            val outs = drain(outbound)
+            val outs = outbound.drainAll()
 
             assertTrue(
                 outs.any { it is OutboundEvent.SendError && "No such player" in (it as OutboundEvent.SendError).text },
@@ -124,13 +124,13 @@ class CrossEngineCommandsTest {
     fun `kick unknown player sends KickRequest via bus`() =
         runTest {
             val sid = SessionId(1)
-            login(players, sid, "Alice")
+            players.loginOrFail(sid, "Alice")
             players.get(sid)!!.isStaff = true
-            drain(outbound)
+            outbound.drainAll()
 
             router.handle(sid, Command.Kick("Bob"))
 
-            val outs = drain(outbound)
+            val outs = outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendInfo && "Kick request sent" in (it as OutboundEvent.SendInfo).text },
             )
@@ -144,9 +144,9 @@ class CrossEngineCommandsTest {
     fun `shutdown broadcasts GlobalBroadcast SHUTDOWN via bus`() =
         runTest {
             val sid = SessionId(1)
-            login(players, sid, "Admin")
+            players.loginOrFail(sid, "Admin")
             players.get(sid)!!.isStaff = true
-            drain(outbound)
+            outbound.drainAll()
 
             var shutdownCalled = false
             val shutdownRouter =
@@ -177,13 +177,13 @@ class CrossEngineCommandsTest {
     fun `transfer unknown player sends TransferRequest via bus`() =
         runTest {
             val sid = SessionId(1)
-            login(players, sid, "Admin")
+            players.loginOrFail(sid, "Admin")
             players.get(sid)!!.isStaff = true
-            drain(outbound)
+            outbound.drainAll()
 
             router.handle(sid, Command.Transfer("Bob", "forest:clearing"))
 
-            val outs = drain(outbound)
+            val outs = outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendInfo && "Transfer request sent" in (it as OutboundEvent.SendInfo).text },
             )
@@ -196,30 +196,12 @@ class CrossEngineCommandsTest {
             assertEquals("forest:clearing", transfer.targetRoomId)
         }
 
-    private fun drain(ch: LocalOutboundBus): List<OutboundEvent> {
-        val out = mutableListOf<OutboundEvent>()
-        while (true) {
-            val ev = ch.tryReceive().getOrNull() ?: break
-            out += ev
-        }
-        return out
-    }
-
-    private suspend fun login(
-        players: PlayerRegistry,
-        sessionId: SessionId,
-        name: String,
-    ) {
-        val res = players.login(sessionId, name, "password")
-        require(res == LoginResult.Ok) { "Login failed: $res" }
-    }
-
     @Test
     fun `tell to unknown player uses sendTo when player index returns target engine`() =
         runTest {
             val sid = SessionId(1)
-            login(players, sid, "Alice")
-            drain(outbound)
+            players.loginOrFail(sid, "Alice")
+            outbound.drainAll()
 
             val capturingBus = CapturingInterEngineBus()
             val index = MapPlayerLocationIndex(mapOf("bob" to "engine-2"))
@@ -238,7 +220,7 @@ class CrossEngineCommandsTest {
 
             indexRouter.handle(sid, Command.Tell("Bob", "hello from alice"))
 
-            val outs = drain(outbound)
+            val outs = outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && "You tell Bob" in (it as OutboundEvent.SendText).text },
             )
@@ -256,8 +238,8 @@ class CrossEngineCommandsTest {
     fun `tell falls back to broadcast when player index returns null`() =
         runTest {
             val sid = SessionId(1)
-            login(players, sid, "Alice")
-            drain(outbound)
+            players.loginOrFail(sid, "Alice")
+            outbound.drainAll()
 
             val capturingBus = CapturingInterEngineBus()
             val emptyIndex = MapPlayerLocationIndex(emptyMap())
@@ -285,8 +267,8 @@ class CrossEngineCommandsTest {
     fun `tell falls back to broadcast when player index returns own engine`() =
         runTest {
             val sid = SessionId(1)
-            login(players, sid, "Alice")
-            drain(outbound)
+            players.loginOrFail(sid, "Alice")
+            outbound.drainAll()
 
             val capturingBus = CapturingInterEngineBus()
             // index says "Bob" is on engine-1 (same engine), should still broadcast

--- a/src/test/kotlin/dev/ambon/engine/commands/NamesTellGossipTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/NamesTellGossipTest.kt
@@ -1,15 +1,12 @@
 package dev.ambon.engine.commands
 
-import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.world.Direction
-import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.LoginResult
-import dev.ambon.engine.MobRegistry
-import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.events.OutboundEvent
-import dev.ambon.engine.items.ItemRegistry
-import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.CommandRouterHarness
+import dev.ambon.test.drainAll
+import dev.ambon.test.loginOrFail
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -21,18 +18,12 @@ class NamesTellGossipTest {
     @Test
     fun `name sets and who reflects new name`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = buildTestRouter(world, players, mobs, items, CombatSystem(players, mobs, items, outbound), outbound)
-
+            val h = CommandRouterHarness.create()
             val a = SessionId(1)
-            login(players, a, "Alice")
-            router.handle(a, Command.Who)
+            h.players.loginOrFail(a, "Alice")
+            h.router.handle(a, Command.Who)
 
-            val outs = drain(outbound)
+            val outs = h.outbound.drainAll()
 
             assertTrue(
                 outs.any { it is OutboundEvent.SendInfo && it.sessionId == a && it.text.contains("Alice") && it.text.contains("Online:") },
@@ -43,38 +34,29 @@ class NamesTellGossipTest {
     @Test
     fun `name must be unique case-insensitively`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-
+            val h = CommandRouterHarness.create()
             val a = SessionId(1)
             val b = SessionId(2)
-            login(players, a, "Alice")
+            h.players.loginOrFail(a, "Alice")
 
-            val res = players.login(b, "alice", "password")
+            val res = h.players.login(b, "alice", "password")
             assertTrue(res is LoginResult.Takeover, "Expected Takeover for duplicate login with correct password. got=$res")
         }
 
     @Test
     fun `tell delivers to target only`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val outbound = LocalOutboundBus()
-            val mobs = MobRegistry()
-            val router = buildTestRouter(world, players, mobs, items, CombatSystem(players, mobs, items, outbound), outbound)
-
+            val h = CommandRouterHarness.create()
             val a = SessionId(1)
             val b = SessionId(2)
             val c = SessionId(3)
-            login(players, a, "Alice")
-            login(players, b, "Bob")
-            login(players, c, "Eve")
-            drain(outbound)
+            h.players.loginOrFail(a, "Alice")
+            h.players.loginOrFail(b, "Bob")
+            h.players.loginOrFail(c, "Eve")
+            h.outbound.drainAll()
 
-            router.handle(a, Command.Tell("Bob", "hi there"))
-            val outs = drain(outbound)
+            h.router.handle(a, Command.Tell("Bob", "hi there"))
+            val outs = h.outbound.drainAll()
 
             assertTrue(
                 outs.any {
@@ -100,21 +82,15 @@ class NamesTellGossipTest {
     @Test
     fun `gossip broadcasts to all connected`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = buildTestRouter(world, players, mobs, items, CombatSystem(players, mobs, items, outbound), outbound)
-
+            val h = CommandRouterHarness.create()
             val a = SessionId(1)
             val b = SessionId(2)
-            login(players, a, "Alice")
-            login(players, b, "Bob")
-            drain(outbound)
+            h.players.loginOrFail(a, "Alice")
+            h.players.loginOrFail(b, "Bob")
+            h.outbound.drainAll()
 
-            router.handle(a, Command.Gossip("hello everyone"))
-            val outs = drain(outbound)
+            h.router.handle(a, Command.Gossip("hello everyone"))
+            val outs = h.outbound.drainAll()
 
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && it.sessionId == a && it.text.contains("You gossip: hello everyone") },
@@ -129,44 +105,20 @@ class NamesTellGossipTest {
     @Test
     fun `tell across rooms still works`() =
         runTest {
-            val world = dev.ambon.test.TestWorlds.testWorld
-            val items = ItemRegistry()
-            val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
-            val mobs = MobRegistry()
-            val outbound = LocalOutboundBus()
-            val router = buildTestRouter(world, players, mobs, items, CombatSystem(players, mobs, items, outbound), outbound)
-
+            val h = CommandRouterHarness.create()
             val a = SessionId(1)
             val b = SessionId(2)
-            login(players, a, "Alice")
-            login(players, b, "Bob")
-            drain(outbound)
+            h.players.loginOrFail(a, "Alice")
+            h.players.loginOrFail(b, "Bob")
+            h.outbound.drainAll()
 
             // Move Bob north so he is not in Alice's room
-            router.handle(b, Command.Move(Direction.NORTH))
-            drain(outbound)
+            h.router.handle(b, Command.Move(Direction.NORTH))
+            h.outbound.drainAll()
 
-            router.handle(a, Command.Tell("Bob", "still works"))
-            val outs = drain(outbound)
+            h.router.handle(a, Command.Tell("Bob", "still works"))
+            val outs = h.outbound.drainAll()
 
             assertTrue(outs.any { it is OutboundEvent.SendText && it.sessionId == b && it.text.contains("still works") })
         }
-
-    private fun drain(ch: LocalOutboundBus): List<OutboundEvent> {
-        val out = mutableListOf<OutboundEvent>()
-        while (true) {
-            val ev = ch.tryReceive().getOrNull() ?: break
-            out += ev
-        }
-        return out
-    }
-
-    private suspend fun login(
-        players: PlayerRegistry,
-        sessionId: SessionId,
-        name: String,
-    ) {
-        val res = players.login(sessionId, name, "password")
-        require(res == LoginResult.Ok) { "Login failed: $res" }
-    }
 }


### PR DESCRIPTION
## Summary
This PR introduces reusable test harness classes (`GameEngineHarness` and `CommandRouterHarness`) to eliminate repetitive test setup code across the test suite. These harnesses encapsulate common initialization patterns and provide convenient access to frequently-used test components.

## Key Changes

- **New `GameEngineHarness` class**: Encapsulates GameEngine setup including inbound/outbound buses, player registry, world, clock, scheduler, and mob/item registries. Provides a `start()` factory method and `close()` cleanup method.

- **New `CommandRouterHarness` class**: Encapsulates CommandRouter setup with all dependencies (players, mobs, items, combat system, etc.). Includes helper methods `loginPlayer()` and `loginStaff()` for common test scenarios, plus `drain()` for consuming outbound events.

- **Refactored `GameEngineLoginFlowTest`**: Replaced ~40 lines of boilerplate setup per test with single `GameEngineHarness.start()` calls. All 5 test methods now use the harness, reducing code duplication and improving readability.

- **Refactored `CommandRouterAdminTest`**: Replaced manual router construction and login helpers with `CommandRouterHarness.create()`. Removed ~50 lines of helper methods (`drain()`, `login()`, `loginStaff()`, `makeRouter()`).

- **Refactored `CommandRouterItemsTest`**: Simplified all 6 test methods to use `CommandRouterHarness.create()` instead of manual setup.

- **Refactored `CommandRouterScoreTest`**: Updated to use harness while preserving custom `CombatSystemConfig` setup where needed.

- **Refactored `NamesTellGossipTest`**: Replaced manual setup with harness; leveraged existing test utilities like `loginOrFail()` and `drainAll()`.

- **Refactored `CommandRouterBroadcastTest`**: Simplified test setup using harness pattern.

- **Refactored `CrossEngineCommandsTest`**: Updated to use test utility functions `loginOrFail()` and `drainAll()`.

## Implementation Details

- Harnesses are designed to be composable—tests can still customize specific components (e.g., passing a custom `InMemoryPlayerRepository` or `CombatSystemConfig`) while benefiting from reduced boilerplate.
- The `GameEngineHarness.start()` method accepts optional parameters for `clock` and `repo` to support test-specific customization.
- Cleanup is centralized in harness `close()` methods, ensuring proper resource management.
- Existing test utility functions (`drainAll()`, `loginOrFail()`, `buildTestPlayerRegistry()`, `TestWorlds`) are leveraged and integrated with the new harnesses.

https://claude.ai/code/session_01Fue6cMPoRzMpXoMjkYxxnr