### PR TITLE
refactor: extract shared infrastructure from MudServer/GatewayServer

### DIFF
--- a/src/main/kotlin/dev/ambon/MudServer.kt
+++ b/src/main/kotlin/dev/ambon/MudServer.kt
@@ -57,7 +57,6 @@ import dev.ambon.transport.BlockingSocketTransport
 import dev.ambon.transport.KtorWebSocketTransport
 import dev.ambon.transport.OutboundRouter
 import io.github.oshai.kotlinlogging.KotlinLogging
-import io.micrometer.prometheusmetrics.PrometheusConfig
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -70,7 +69,6 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import java.nio.file.Paths
 import java.time.Clock
-import java.util.UUID
 import java.util.concurrent.Executors
 
 private val log = KotlinLogging.logger {}
@@ -98,17 +96,10 @@ class MudServer(
     private val clock = Clock.systemUTC()
 
     private val prometheusRegistry: PrometheusMeterRegistry? =
-        if (config.observability.metricsEnabled) {
-            PrometheusMeterRegistry(PrometheusConfig.DEFAULT).also { reg ->
-                reg.config().commonTags("service", "ambonmud")
-                config.observability.staticTags.forEach { (k, v) -> reg.config().commonTags(k, v) }
-            }
-        } else {
-            null
-        }
+        ServerInfrastructure.createPrometheusRegistry(config, "ambonmud")
 
     private val gameMetrics: GameMetrics =
-        if (prometheusRegistry != null) GameMetrics(prometheusRegistry) else GameMetrics.noop()
+        ServerInfrastructure.createGameMetrics(prometheusRegistry)
 
     private val databaseManager: DatabaseManager? =
         if (config.persistence.backend == PersistenceBackend.POSTGRES) {
@@ -118,7 +109,7 @@ class MudServer(
         }
 
     private val redisManager: RedisConnectionManager? =
-        if (config.redis.enabled) RedisConnectionManager(config.redis) else null
+        ServerInfrastructure.createRedisManager(config)
 
     private val playerRepoChain =
         PlayerRepositoryFactory.buildChain(
@@ -160,8 +151,7 @@ class MudServer(
         }
 
     private val instanceId: String =
-        config.redis.bus.instanceId
-            .takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
+        ServerInfrastructure.generateInstanceId(config)
 
     private val inbound: InboundBus =
         if (config.redis.enabled && config.redis.bus.enabled && redisManager != null) {
@@ -373,27 +363,8 @@ class MudServer(
         coalescingRepo?.let { gameMetrics.bindWriteCoalescerDirtyCount(it::dirtyCount) }
     }
 
-    private fun bindQueueMetrics() {
-        when (val bus = inbound) {
-            is LocalInboundBus -> {
-                gameMetrics.bindInboundBusQueue(bus::depth) { bus.capacity }
-            }
-            is RedisInboundBus -> {
-                val delegate = bus.delegateForMetrics()
-                gameMetrics.bindInboundBusQueue(delegate::depth) { delegate.capacity }
-            }
-        }
-
-        when (val bus = outbound) {
-            is LocalOutboundBus -> {
-                gameMetrics.bindOutboundBusQueue(bus::depth) { bus.capacity }
-            }
-            is RedisOutboundBus -> {
-                val delegate = bus.delegateForMetrics()
-                gameMetrics.bindOutboundBusQueue(delegate::depth) { delegate.capacity }
-            }
-        }
-    }
+    private fun bindQueueMetrics() =
+        ServerInfrastructure.bindQueueMetrics(inbound, outbound, gameMetrics)
 
     suspend fun start() {
         if (config.redis.enabled && config.redis.bus.enabled) {
@@ -552,41 +523,26 @@ class MudServer(
                 ).run()
             }
 
-        telnetTransport =
-            BlockingSocketTransport(
-                port = config.server.telnetPort,
-                inbound = inbound,
-                outboundRouter = outboundRouter,
-                sessionIdFactory = sessionIdFactory::allocate,
-                scope = scope,
-                sessionOutboundQueueCapacity = config.server.sessionOutboundQueueCapacity,
-                maxLineLen = config.transport.telnet.maxLineLen,
-                maxNonPrintablePerLine = config.transport.telnet.maxNonPrintablePerLine,
-                maxInboundBackpressureFailures = config.transport.maxInboundBackpressureFailures,
-                socketBacklog = config.transport.telnet.socketBacklog,
-                metrics = gameMetrics,
-                sessionDispatcher = telnetDispatcher,
-            )
+        telnetTransport = ServerInfrastructure.createTelnetTransport(
+            config = config,
+            inbound = inbound,
+            outboundRouter = outboundRouter,
+            sessionIdFactory = sessionIdFactory::allocate,
+            scope = scope,
+            metrics = gameMetrics,
+            sessionDispatcher = telnetDispatcher,
+        )
         telnetTransport.start()
         log.info { "Telnet transport bound on port ${config.server.telnetPort}" }
 
-        webTransport =
-            KtorWebSocketTransport(
-                port = config.server.webPort,
-                inbound = inbound,
-                outboundRouter = outboundRouter,
-                sessionIdFactory = sessionIdFactory::allocate,
-                host = config.transport.websocket.host,
-                sessionOutboundQueueCapacity = config.server.sessionOutboundQueueCapacity,
-                stopGraceMillis = config.transport.websocket.stopGraceMillis,
-                stopTimeoutMillis = config.transport.websocket.stopTimeoutMillis,
-                maxLineLen = config.transport.telnet.maxLineLen,
-                maxNonPrintablePerLine = config.transport.telnet.maxNonPrintablePerLine,
-                maxInboundBackpressureFailures = config.transport.maxInboundBackpressureFailures,
-                prometheusRegistry = prometheusRegistry,
-                metricsEndpoint = config.observability.metricsEndpoint,
-                metrics = gameMetrics,
-            )
+        webTransport = ServerInfrastructure.createWebTransport(
+            config = config,
+            inbound = inbound,
+            outboundRouter = outboundRouter,
+            sessionIdFactory = sessionIdFactory::allocate,
+            prometheusRegistry = prometheusRegistry,
+            metrics = gameMetrics,
+        )
         webTransport.start()
         log.info { "WebSocket transport bound on ${config.transport.websocket.host}:${config.server.webPort}" }
         if (config.observability.metricsEnabled) {

--- a/src/main/kotlin/dev/ambon/ServerInfrastructure.kt
+++ b/src/main/kotlin/dev/ambon/ServerInfrastructure.kt
@@ -1,0 +1,123 @@
+package dev.ambon
+
+import dev.ambon.bus.GrpcInboundBus
+import dev.ambon.bus.GrpcOutboundBus
+import dev.ambon.bus.InboundBus
+import dev.ambon.bus.LocalInboundBus
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.bus.OutboundBus
+import dev.ambon.bus.RedisInboundBus
+import dev.ambon.bus.RedisOutboundBus
+import dev.ambon.config.AppConfig
+import dev.ambon.metrics.GameMetrics
+import dev.ambon.redis.RedisConnectionManager
+import dev.ambon.transport.BlockingSocketTransport
+import dev.ambon.transport.KtorWebSocketTransport
+import dev.ambon.transport.OutboundRouter
+import io.micrometer.prometheusmetrics.PrometheusConfig
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import kotlinx.coroutines.CoroutineScope
+import java.util.UUID
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Shared factory functions for infrastructure that both [MudServer] and
+ * [dev.ambon.gateway.GatewayServer] construct identically.
+ */
+object ServerInfrastructure {
+    fun createPrometheusRegistry(
+        config: AppConfig,
+        serviceName: String,
+    ): PrometheusMeterRegistry? =
+        if (config.observability.metricsEnabled) {
+            PrometheusMeterRegistry(PrometheusConfig.DEFAULT).also { reg ->
+                reg.config().commonTags("service", serviceName)
+                config.observability.staticTags.forEach { (k, v) -> reg.config().commonTags(k, v) }
+            }
+        } else {
+            null
+        }
+
+    fun createGameMetrics(registry: PrometheusMeterRegistry?): GameMetrics =
+        if (registry != null) GameMetrics(registry) else GameMetrics.noop()
+
+    fun generateInstanceId(config: AppConfig): String =
+        config.redis.bus.instanceId
+            .takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
+
+    fun createRedisManager(config: AppConfig): RedisConnectionManager? =
+        if (config.redis.enabled) RedisConnectionManager(config.redis) else null
+
+    fun createTelnetTransport(
+        config: AppConfig,
+        inbound: InboundBus,
+        outboundRouter: OutboundRouter,
+        sessionIdFactory: () -> dev.ambon.domain.ids.SessionId,
+        scope: CoroutineScope,
+        metrics: GameMetrics,
+        sessionDispatcher: CoroutineContext,
+    ): BlockingSocketTransport =
+        BlockingSocketTransport(
+            port = config.server.telnetPort,
+            inbound = inbound,
+            outboundRouter = outboundRouter,
+            sessionIdFactory = sessionIdFactory,
+            scope = scope,
+            sessionOutboundQueueCapacity = config.server.sessionOutboundQueueCapacity,
+            maxLineLen = config.transport.telnet.maxLineLen,
+            maxNonPrintablePerLine = config.transport.telnet.maxNonPrintablePerLine,
+            maxInboundBackpressureFailures = config.transport.maxInboundBackpressureFailures,
+            socketBacklog = config.transport.telnet.socketBacklog,
+            metrics = metrics,
+            sessionDispatcher = sessionDispatcher,
+        )
+
+    fun createWebTransport(
+        config: AppConfig,
+        inbound: InboundBus,
+        outboundRouter: OutboundRouter,
+        sessionIdFactory: () -> dev.ambon.domain.ids.SessionId,
+        prometheusRegistry: PrometheusMeterRegistry?,
+        metrics: GameMetrics,
+    ): KtorWebSocketTransport =
+        KtorWebSocketTransport(
+            port = config.server.webPort,
+            inbound = inbound,
+            outboundRouter = outboundRouter,
+            sessionIdFactory = sessionIdFactory,
+            host = config.transport.websocket.host,
+            sessionOutboundQueueCapacity = config.server.sessionOutboundQueueCapacity,
+            stopGraceMillis = config.transport.websocket.stopGraceMillis,
+            stopTimeoutMillis = config.transport.websocket.stopTimeoutMillis,
+            maxLineLen = config.transport.telnet.maxLineLen,
+            maxNonPrintablePerLine = config.transport.telnet.maxNonPrintablePerLine,
+            maxInboundBackpressureFailures = config.transport.maxInboundBackpressureFailures,
+            prometheusRegistry = prometheusRegistry,
+            metricsEndpoint = config.observability.metricsEndpoint,
+            metrics = metrics,
+        )
+
+    fun bindQueueMetrics(
+        inbound: InboundBus,
+        outbound: OutboundBus,
+        metrics: GameMetrics,
+    ) {
+        val inboundLocal =
+            when (inbound) {
+                is LocalInboundBus -> inbound
+                is RedisInboundBus -> inbound.delegateForMetrics()
+                is GrpcInboundBus -> inbound.delegateForMetrics()
+                else -> null
+            }
+        inboundLocal?.let { metrics.bindInboundBusQueue(it::depth) { it.capacity } }
+
+        val outboundLocal =
+            when (outbound) {
+                is LocalOutboundBus -> outbound
+                is RedisOutboundBus -> outbound.delegateForMetrics()
+                is GrpcOutboundBus -> outbound.delegateForMetrics()
+                else -> null
+            }
+        outboundLocal?.let { metrics.bindOutboundBusQueue(it::depth) { it.capacity } }
+    }
+}

--- a/src/main/kotlin/dev/ambon/gateway/GatewayServer.kt
+++ b/src/main/kotlin/dev/ambon/gateway/GatewayServer.kt
@@ -31,7 +31,6 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.grpc.ManagedChannel
 import io.grpc.ManagedChannelBuilder
 import io.lettuce.core.SetArgs
-import io.micrometer.prometheusmetrics.PrometheusConfig
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -45,7 +44,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
-import java.util.UUID
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.random.Random
@@ -74,24 +72,16 @@ class GatewayServer(
     private val multiEngine = config.gateway.engines.isNotEmpty()
 
     private val prometheusRegistry: PrometheusMeterRegistry? =
-        if (config.observability.metricsEnabled) {
-            PrometheusMeterRegistry(PrometheusConfig.DEFAULT).also { reg ->
-                reg.config().commonTags("service", "ambonmud-gateway")
-                config.observability.staticTags.forEach { (k, v) -> reg.config().commonTags(k, v) }
-            }
-        } else {
-            null
-        }
+        dev.ambon.ServerInfrastructure.createPrometheusRegistry(config, "ambonmud-gateway")
 
     private val gameMetrics: GameMetrics =
-        if (prometheusRegistry != null) GameMetrics(prometheusRegistry) else GameMetrics.noop()
+        dev.ambon.ServerInfrastructure.createGameMetrics(prometheusRegistry)
 
     private val instanceId: String =
-        config.redis.bus.instanceId
-            .takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
+        dev.ambon.ServerInfrastructure.generateInstanceId(config)
 
     private val redisManager: RedisConnectionManager? =
-        if (config.redis.enabled) RedisConnectionManager(config.redis) else null
+        dev.ambon.ServerInfrastructure.createRedisManager(config)
 
     private val sessionIdFactory: SessionIdFactory =
         SnowflakeSessionIdFactory(
@@ -171,40 +161,26 @@ class GatewayServer(
         outboundRouter = OutboundRouter(engineOutbound = activeOutbound, scope = scope, metrics = gameMetrics)
         scope.launch { outboundRouter.start() }
 
-        telnetTransport =
-            BlockingSocketTransport(
-                port = config.server.telnetPort,
-                inbound = activeInbound,
-                outboundRouter = outboundRouter,
-                sessionIdFactory = sessionIdFactory::allocate,
-                scope = scope,
-                sessionOutboundQueueCapacity = config.server.sessionOutboundQueueCapacity,
-                maxLineLen = config.transport.telnet.maxLineLen,
-                maxNonPrintablePerLine = config.transport.telnet.maxNonPrintablePerLine,
-                maxInboundBackpressureFailures = config.transport.maxInboundBackpressureFailures,
-                metrics = gameMetrics,
-                sessionDispatcher = telnetDispatcher,
-            )
+        telnetTransport = dev.ambon.ServerInfrastructure.createTelnetTransport(
+            config = config,
+            inbound = activeInbound,
+            outboundRouter = outboundRouter,
+            sessionIdFactory = sessionIdFactory::allocate,
+            scope = scope,
+            metrics = gameMetrics,
+            sessionDispatcher = telnetDispatcher,
+        )
         telnetTransport.start()
         log.info { "Gateway telnet transport bound on port ${config.server.telnetPort}" }
 
-        webTransport =
-            KtorWebSocketTransport(
-                port = config.server.webPort,
-                inbound = activeInbound,
-                outboundRouter = outboundRouter,
-                sessionIdFactory = sessionIdFactory::allocate,
-                host = config.transport.websocket.host,
-                sessionOutboundQueueCapacity = config.server.sessionOutboundQueueCapacity,
-                stopGraceMillis = config.transport.websocket.stopGraceMillis,
-                stopTimeoutMillis = config.transport.websocket.stopTimeoutMillis,
-                maxLineLen = config.transport.telnet.maxLineLen,
-                maxNonPrintablePerLine = config.transport.telnet.maxNonPrintablePerLine,
-                maxInboundBackpressureFailures = config.transport.maxInboundBackpressureFailures,
-                prometheusRegistry = prometheusRegistry,
-                metricsEndpoint = config.observability.metricsEndpoint,
-                metrics = gameMetrics,
-            )
+        webTransport = dev.ambon.ServerInfrastructure.createWebTransport(
+            config = config,
+            inbound = activeInbound,
+            outboundRouter = outboundRouter,
+            sessionIdFactory = sessionIdFactory::allocate,
+            prometheusRegistry = prometheusRegistry,
+            metrics = gameMetrics,
+        )
         webTransport.start()
 
         bindQueueMetrics()
@@ -222,23 +198,8 @@ class GatewayServer(
         }
     }
 
-    private fun bindQueueMetrics() {
-        when (val bus = activeInbound) {
-            is LocalInboundBus -> gameMetrics.bindInboundBusQueue(bus::depth) { bus.capacity }
-            is GrpcInboundBus -> {
-                val delegate = bus.delegateForMetrics()
-                gameMetrics.bindInboundBusQueue(delegate::depth) { delegate.capacity }
-            }
-        }
-
-        when (val bus = activeOutbound) {
-            is LocalOutboundBus -> gameMetrics.bindOutboundBusQueue(bus::depth) { bus.capacity }
-            is GrpcOutboundBus -> {
-                val delegate = bus.delegateForMetrics()
-                gameMetrics.bindOutboundBusQueue(delegate::depth) { delegate.capacity }
-            }
-        }
-    }
+    private fun bindQueueMetrics() =
+        dev.ambon.ServerInfrastructure.bindQueueMetrics(activeInbound, activeOutbound, gameMetrics)
 
     private suspend fun startSingleEngine() {
         val managedChannel =


### PR DESCRIPTION
## Summary
- Adds `ServerInfrastructure` object with shared factory functions for infrastructure that both composition roots construct identically:
  - `createPrometheusRegistry(config, serviceName)` — Prometheus setup with common tags
  - `createGameMetrics(registry)` — GameMetrics with noop fallback
  - `generateInstanceId(config)` — instance ID from config or UUID
  - `createRedisManager(config)` — optional Redis connection
  - `createTelnetTransport(...)` — BlockingSocketTransport from config
  - `createWebTransport(...)` — KtorWebSocketTransport from config
  - `bindQueueMetrics(inbound, outbound, metrics)` — unified handler for all bus types (Local, Redis, gRPC)
- Both `MudServer` and `GatewayServer` now delegate to these shared factories
- Transport and metrics config changes are now single-site edits

**Impact:** 3 files changed, 169 insertions, 129 deletions. The net increase is the new file; each server individually shrunk.

## Test plan
- [x] All existing tests pass (`ktlintCheck test`)
- [x] GatewayEngineIntegrationTest verifies gateway transport construction
- [x] GameEngineIntegrationTest verifies standalone transport construction

Closes #348