### PR TITLE
refactor: reduce event variant discrimination sites (#351)

### DIFF
--- a/src/main/kotlin/dev/ambon/bus/RedisInboundBus.kt
+++ b/src/main/kotlin/dev/ambon/bus/RedisInboundBus.kt
@@ -58,37 +58,19 @@ internal class RedisInboundBus(
         }
     }
 
+    private fun baseEnvelope(type: String, sessionId: SessionId) =
+        Envelope(instanceId = instanceId, type = type, sessionId = sessionId.value)
+
     override fun InboundEvent.toEnvelope(): Envelope? =
         when (this) {
             is InboundEvent.Connected ->
-                Envelope(
-                    instanceId = instanceId,
-                    type = "Connected",
-                    sessionId = sessionId.value,
-                    defaultAnsiEnabled = defaultAnsiEnabled,
-                )
+                baseEnvelope("Connected", sessionId).copy(defaultAnsiEnabled = defaultAnsiEnabled)
             is InboundEvent.Disconnected ->
-                Envelope(
-                    instanceId = instanceId,
-                    type = "Disconnected",
-                    sessionId = sessionId.value,
-                    reason = reason,
-                )
+                baseEnvelope("Disconnected", sessionId).copy(reason = reason)
             is InboundEvent.LineReceived ->
-                Envelope(
-                    instanceId = instanceId,
-                    type = "LineReceived",
-                    sessionId = sessionId.value,
-                    line = line,
-                )
+                baseEnvelope("LineReceived", sessionId).copy(line = line)
             is InboundEvent.GmcpReceived ->
-                Envelope(
-                    instanceId = instanceId,
-                    type = "GmcpReceived",
-                    sessionId = sessionId.value,
-                    gmcpPackage = gmcpPackage,
-                    jsonData = jsonData,
-                )
+                baseEnvelope("GmcpReceived", sessionId).copy(gmcpPackage = gmcpPackage, jsonData = jsonData)
         }
 
     override fun Envelope.payloadToSign(): String =

--- a/src/main/kotlin/dev/ambon/bus/RedisOutboundBus.kt
+++ b/src/main/kotlin/dev/ambon/bus/RedisOutboundBus.kt
@@ -65,35 +65,23 @@ internal class RedisOutboundBus(
         }
     }
 
+    private fun baseEnvelope(type: String, sessionId: SessionId) =
+        Envelope(instanceId = instanceId, type = type, sessionId = sessionId.value)
+
     override fun OutboundEvent.toEnvelope(): Envelope? =
         when (this) {
-            is OutboundEvent.SendText ->
-                Envelope(instanceId = instanceId, type = "SendText", sessionId = sessionId.value, text = text)
-            is OutboundEvent.SendInfo ->
-                Envelope(instanceId = instanceId, type = "SendInfo", sessionId = sessionId.value, text = text)
-            is OutboundEvent.SendError ->
-                Envelope(instanceId = instanceId, type = "SendError", sessionId = sessionId.value, text = text)
-            is OutboundEvent.SendPrompt ->
-                Envelope(instanceId = instanceId, type = "SendPrompt", sessionId = sessionId.value)
-            is OutboundEvent.ShowLoginScreen ->
-                Envelope(instanceId = instanceId, type = "ShowLoginScreen", sessionId = sessionId.value)
-            is OutboundEvent.SetAnsi ->
-                Envelope(instanceId = instanceId, type = "SetAnsi", sessionId = sessionId.value, enabled = enabled)
-            is OutboundEvent.Close ->
-                Envelope(instanceId = instanceId, type = "Close", sessionId = sessionId.value, reason = reason)
-            is OutboundEvent.ClearScreen ->
-                Envelope(instanceId = instanceId, type = "ClearScreen", sessionId = sessionId.value)
-            is OutboundEvent.ShowAnsiDemo ->
-                Envelope(instanceId = instanceId, type = "ShowAnsiDemo", sessionId = sessionId.value)
+            is OutboundEvent.SendText -> baseEnvelope("SendText", sessionId).copy(text = text)
+            is OutboundEvent.SendInfo -> baseEnvelope("SendInfo", sessionId).copy(text = text)
+            is OutboundEvent.SendError -> baseEnvelope("SendError", sessionId).copy(text = text)
+            is OutboundEvent.SendPrompt -> baseEnvelope("SendPrompt", sessionId)
+            is OutboundEvent.ShowLoginScreen -> baseEnvelope("ShowLoginScreen", sessionId)
+            is OutboundEvent.SetAnsi -> baseEnvelope("SetAnsi", sessionId).copy(enabled = enabled)
+            is OutboundEvent.Close -> baseEnvelope("Close", sessionId).copy(reason = reason)
+            is OutboundEvent.ClearScreen -> baseEnvelope("ClearScreen", sessionId)
+            is OutboundEvent.ShowAnsiDemo -> baseEnvelope("ShowAnsiDemo", sessionId)
             is OutboundEvent.SessionRedirect -> null // control-plane event, not published to Redis
             is OutboundEvent.GmcpData ->
-                Envelope(
-                    instanceId = instanceId,
-                    type = "GmcpData",
-                    sessionId = sessionId.value,
-                    gmcpPackage = gmcpPackage,
-                    jsonData = jsonData,
-                )
+                baseEnvelope("GmcpData", sessionId).copy(gmcpPackage = gmcpPackage, jsonData = jsonData)
         }
 
     override fun Envelope.payloadToSign(): String =

--- a/src/main/kotlin/dev/ambon/engine/events/InboundEvent.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/InboundEvent.kt
@@ -2,6 +2,13 @@ package dev.ambon.engine.events
 
 import dev.ambon.domain.ids.SessionId
 
+/**
+ * Adding a new [InboundEvent] variant? Update these files:
+ *  1. [dev.ambon.bus.RedisInboundBus]   — toEnvelope() + toEvent() + Envelope fields + payloadToSign()
+ *  2. [dev.ambon.grpc.ProtoMapper]      — toProto() + toDomain() + per-variant proto helper
+ *  3. `src/main/proto/ambonmud/v1/events.proto` — add proto message + oneof field
+ *  4. Tests: RedisInboundBusTest (round-trip), ProtoMapperTest (round-trip)
+ */
 sealed interface InboundEvent {
     val enqueuedAt: Long
 

--- a/src/main/kotlin/dev/ambon/engine/events/OutboundEvent.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/OutboundEvent.kt
@@ -2,6 +2,14 @@ package dev.ambon.engine.events
 
 import dev.ambon.domain.ids.SessionId
 
+/**
+ * Adding a new [OutboundEvent] variant? Update these files:
+ *  1. [dev.ambon.bus.RedisOutboundBus]  — toEnvelope() + toEvent() + Envelope fields + payloadToSign()
+ *  2. [dev.ambon.grpc.ProtoMapper]      — toProto() + toDomain() + per-variant proto helper
+ *  3. `src/main/proto/ambonmud/v1/events.proto` — add proto message + oneof field
+ *  4. [dev.ambon.transport.OutboundRouter] — handle the new variant
+ *  5. Tests: RedisOutboundBusTest (round-trip), ProtoMapperTest (round-trip)
+ */
 sealed interface OutboundEvent {
     val sessionId: SessionId
 

--- a/src/test/kotlin/dev/ambon/bus/RedisInboundBusTest.kt
+++ b/src/test/kotlin/dev/ambon/bus/RedisInboundBusTest.kt
@@ -82,6 +82,78 @@ class RedisInboundBusTest {
         assertFalse(delegate.tryReceive().isSuccess)
     }
 
+    // ── Round-trip tests for every variant ─────────────────────────────────
+    // These catch missing deserialize branches (string-matching with else → null).
+
+    @Test
+    fun `Connected round-trips through Redis`() {
+        roundTrip(
+            expected = InboundEvent.Connected(SessionId(5), defaultAnsiEnabled = true),
+            sessionId = 5,
+            type = "Connected",
+            defaultAnsiEnabled = true,
+        )
+    }
+
+    @Test
+    fun `Disconnected round-trips through Redis`() {
+        roundTrip(
+            expected = InboundEvent.Disconnected(SessionId(6), reason = "timeout"),
+            sessionId = 6,
+            type = "Disconnected",
+            reason = "timeout",
+        )
+    }
+
+    @Test
+    fun `LineReceived round-trips through Redis`() {
+        roundTrip(
+            expected = InboundEvent.LineReceived(SessionId(7), line = "look"),
+            sessionId = 7,
+            type = "LineReceived",
+            line = "look",
+        )
+    }
+
+    @Test
+    fun `GmcpReceived round-trips through Redis`() {
+        roundTrip(
+            expected = InboundEvent.GmcpReceived(SessionId(8), gmcpPackage = "Char.Vitals", jsonData = "{\"hp\":10}"),
+            sessionId = 8,
+            type = "GmcpReceived",
+            gmcpPackage = "Char.Vitals",
+            jsonData = "{\"hp\":10}",
+        )
+    }
+
+    private fun roundTrip(
+        expected: InboundEvent,
+        sessionId: Long,
+        type: String,
+        defaultAnsiEnabled: Boolean = false,
+        reason: String = "",
+        line: String = "",
+        gmcpPackage: String = "",
+        jsonData: String = "",
+    ) {
+        fakeSubscriber.inject(
+            signedInboundJson(
+                instanceId = "server-2",
+                type = type,
+                sessionId = sessionId,
+                defaultAnsiEnabled = defaultAnsiEnabled,
+                reason = reason,
+                line = line,
+                gmcpPackage = gmcpPackage,
+                jsonData = jsonData,
+            ),
+        )
+
+        val received = delegate.tryReceive()
+        assertTrue(received.isSuccess, "Expected $type to deserialize successfully")
+        assertEquals(expected, received.getOrNull())
+    }
+
     @Test
     fun `trySend does not publish when delegate channel is full`() {
         val fullDelegate = LocalInboundBus(capacity = 1)

--- a/src/test/kotlin/dev/ambon/bus/RedisOutboundBusTest.kt
+++ b/src/test/kotlin/dev/ambon/bus/RedisOutboundBusTest.kt
@@ -82,6 +82,144 @@ class RedisOutboundBusTest {
         assertFalse(delegate.tryReceive().isSuccess)
     }
 
+    // ── Round-trip tests for every variant ─────────────────────────────────
+    // These catch missing deserialize branches (string-matching with else → null).
+
+    @Test
+    fun `SendText round-trips through Redis`() {
+        roundTrip(
+            expected = OutboundEvent.SendText(SessionId(10), text = "hello"),
+            sessionId = 10,
+            type = "SendText",
+            text = "hello",
+        )
+    }
+
+    @Test
+    fun `SendInfo round-trips through Redis`() {
+        roundTrip(
+            expected = OutboundEvent.SendInfo(SessionId(11), text = "info msg"),
+            sessionId = 11,
+            type = "SendInfo",
+            text = "info msg",
+        )
+    }
+
+    @Test
+    fun `SendError round-trips through Redis`() {
+        roundTrip(
+            expected = OutboundEvent.SendError(SessionId(12), text = "error msg"),
+            sessionId = 12,
+            type = "SendError",
+            text = "error msg",
+        )
+    }
+
+    @Test
+    fun `SendPrompt round-trips through Redis`() {
+        roundTrip(
+            expected = OutboundEvent.SendPrompt(SessionId(13)),
+            sessionId = 13,
+            type = "SendPrompt",
+        )
+    }
+
+    @Test
+    fun `ShowLoginScreen round-trips through Redis`() {
+        roundTrip(
+            expected = OutboundEvent.ShowLoginScreen(SessionId(14)),
+            sessionId = 14,
+            type = "ShowLoginScreen",
+        )
+    }
+
+    @Test
+    fun `SetAnsi round-trips through Redis`() {
+        roundTrip(
+            expected = OutboundEvent.SetAnsi(SessionId(15), enabled = true),
+            sessionId = 15,
+            type = "SetAnsi",
+            enabled = true,
+        )
+    }
+
+    @Test
+    fun `Close round-trips through Redis`() {
+        roundTrip(
+            expected = OutboundEvent.Close(SessionId(16), reason = "kicked"),
+            sessionId = 16,
+            type = "Close",
+            reason = "kicked",
+        )
+    }
+
+    @Test
+    fun `ClearScreen round-trips through Redis`() {
+        roundTrip(
+            expected = OutboundEvent.ClearScreen(SessionId(17)),
+            sessionId = 17,
+            type = "ClearScreen",
+        )
+    }
+
+    @Test
+    fun `ShowAnsiDemo round-trips through Redis`() {
+        roundTrip(
+            expected = OutboundEvent.ShowAnsiDemo(SessionId(18)),
+            sessionId = 18,
+            type = "ShowAnsiDemo",
+        )
+    }
+
+    @Test
+    fun `GmcpData round-trips through Redis`() {
+        roundTrip(
+            expected = OutboundEvent.GmcpData(SessionId(19), gmcpPackage = "Room.Info", jsonData = "{\"id\":\"z:r\"}"),
+            sessionId = 19,
+            type = "GmcpData",
+            gmcpPackage = "Room.Info",
+            jsonData = "{\"id\":\"z:r\"}",
+        )
+    }
+
+    @Test
+    fun `SessionRedirect is not published to Redis`() =
+        runTest {
+            val event = OutboundEvent.SessionRedirect(SessionId(20), "engine-2", "host2", 9092)
+            bus.send(event)
+
+            // SessionRedirect is control-plane only — should not appear on Redis
+            assertTrue(fakePublisher.messages.isEmpty())
+        }
+
+    private fun roundTrip(
+        expected: OutboundEvent,
+        sessionId: Long,
+        type: String,
+        text: String = "",
+        enabled: Boolean = false,
+        reason: String = "",
+        gmcpPackage: String = "",
+        jsonData: String = "",
+    ) {
+        fakeSubscriber.inject(
+            signedOutboundJson(
+                instanceId = "server-2",
+                type = type,
+                sessionId = sessionId,
+                text = text,
+                enabled = enabled,
+                reason = reason,
+                gmcpPackage = gmcpPackage,
+                jsonData = jsonData,
+            ),
+        )
+
+        val received = delegate.tryReceive()
+        assertTrue(received.isSuccess, "Expected $type to deserialize successfully")
+        assertEquals(expected, received.getOrNull())
+    }
+
     private fun signedOutboundJson(
         instanceId: String,
         type: String,


### PR DESCRIPTION
## Summary

Closes #351

- Extract `baseEnvelope(type, sessionId)` helpers in `RedisInboundBus` and `RedisOutboundBus` to eliminate repeated `instanceId = instanceId, type = "...", sessionId = sessionId.value` boilerplate (~14 constructor calls reduced to one-liner `.copy()` calls)
- Add variant-update checklist comments to `InboundEvent.kt` and `OutboundEvent.kt` listing all files that must be updated when adding a new event variant
- Add comprehensive Redis round-trip tests for every `InboundEvent` (4 variants) and `OutboundEvent` (10 publishable + 1 control-plane) variant, catching the string-matching deserialization gap where new variants could be silently dropped via `else → null`

## Test plan

- [x] All existing tests pass (`ktlintCheck test`)
- [x] New round-trip tests verify every event variant serializes → deserializes correctly through the Redis envelope path
- [x] `SessionRedirect` confirmed as control-plane-only (not published to Redis)