### PR TITLE
refactor: extract player/mob movement notification helpers

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/behavior/BtContext.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/BtContext.kt
@@ -2,12 +2,14 @@ package dev.ambon.engine.behavior
 
 import dev.ambon.bus.OutboundBus
 import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.mob.MobState
 import dev.ambon.domain.world.World
 import dev.ambon.engine.GmcpEmitter
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PlayerRegistry
+import dev.ambon.engine.events.OutboundEvent
 import java.time.Clock
 import java.util.Random
 
@@ -25,3 +27,24 @@ class BtContext(
     val gmcpEmitter: GmcpEmitter?,
     val mobMemory: MobBehaviorMemory,
 )
+
+/**
+ * Notifies old-room players of departure, moves the mob, then notifies new-room players of arrival.
+ * Emits GMCP room-mob add/remove events.
+ */
+suspend fun BtContext.moveMobWithNotify(
+    destination: RoomId,
+    departMsg: String = "${mob.name} leaves.",
+    arriveMsg: String = "${mob.name} enters.",
+) {
+    val from = mob.roomId
+    for (p in players.playersInRoom(from)) {
+        outbound.send(OutboundEvent.SendText(p.sessionId, departMsg))
+        gmcpEmitter?.sendRoomRemoveMob(p.sessionId, mob.id.value)
+    }
+    mobs.moveTo(mob.id, destination)
+    for (p in players.playersInRoom(destination)) {
+        outbound.send(OutboundEvent.SendText(p.sessionId, arriveMsg))
+        gmcpEmitter?.sendRoomAddMob(p.sessionId, mob)
+    }
+}

--- a/src/main/kotlin/dev/ambon/engine/behavior/actions/FleeAction.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/actions/FleeAction.kt
@@ -3,7 +3,7 @@ package dev.ambon.engine.behavior.actions
 import dev.ambon.engine.behavior.BtContext
 import dev.ambon.engine.behavior.BtNode
 import dev.ambon.engine.behavior.BtResult
-import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.behavior.moveMobWithNotify
 
 data object FleeAction : BtNode {
     override suspend fun tick(ctx: BtContext): BtResult {
@@ -16,21 +16,12 @@ data object FleeAction : BtNode {
 
         // Pick a random exit and move
         val destination = exits[ctx.rng.nextInt(exits.size)]
-        val from = ctx.mob.roomId
 
-        // Notify players in old room
-        for (p in ctx.players.playersInRoom(from)) {
-            ctx.outbound.send(OutboundEvent.SendText(p.sessionId, "${ctx.mob.name} flees!"))
-            ctx.gmcpEmitter?.sendRoomRemoveMob(p.sessionId, ctx.mob.id.value)
-        }
-
-        ctx.mobs.moveTo(ctx.mob.id, destination)
-
-        // Notify players in new room
-        for (p in ctx.players.playersInRoom(destination)) {
-            ctx.outbound.send(OutboundEvent.SendText(p.sessionId, "${ctx.mob.name} arrives in a panic."))
-            ctx.gmcpEmitter?.sendRoomAddMob(p.sessionId, ctx.mob)
-        }
+        ctx.moveMobWithNotify(
+            destination,
+            departMsg = "${ctx.mob.name} flees!",
+            arriveMsg = "${ctx.mob.name} arrives in a panic.",
+        )
 
         return BtResult.SUCCESS
     }

--- a/src/main/kotlin/dev/ambon/engine/behavior/actions/PatrolAction.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/actions/PatrolAction.kt
@@ -4,7 +4,7 @@ import dev.ambon.domain.ids.RoomId
 import dev.ambon.engine.behavior.BtContext
 import dev.ambon.engine.behavior.BtNode
 import dev.ambon.engine.behavior.BtResult
-import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.behavior.moveMobWithNotify
 
 data class PatrolAction(
     val route: List<RoomId>,
@@ -23,17 +23,7 @@ data class PatrolAction(
         }
 
         // Move toward the next waypoint (direct move — assumes route is connected)
-        for (p in ctx.players.playersInRoom(from)) {
-            ctx.outbound.send(OutboundEvent.SendText(p.sessionId, "${ctx.mob.name} leaves."))
-            ctx.gmcpEmitter?.sendRoomRemoveMob(p.sessionId, ctx.mob.id.value)
-        }
-
-        ctx.mobs.moveTo(ctx.mob.id, nextWaypoint)
-
-        for (p in ctx.players.playersInRoom(nextWaypoint)) {
-            ctx.outbound.send(OutboundEvent.SendText(p.sessionId, "${ctx.mob.name} enters."))
-            ctx.gmcpEmitter?.sendRoomAddMob(p.sessionId, ctx.mob)
-        }
+        ctx.moveMobWithNotify(nextWaypoint)
 
         // Advance to the next waypoint for the following tick
         memory.patrolIndex = (memory.patrolIndex + 1) % route.size

--- a/src/main/kotlin/dev/ambon/engine/behavior/actions/WanderAction.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/actions/WanderAction.kt
@@ -3,7 +3,7 @@ package dev.ambon.engine.behavior.actions
 import dev.ambon.engine.behavior.BtContext
 import dev.ambon.engine.behavior.BtNode
 import dev.ambon.engine.behavior.BtResult
-import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.behavior.moveMobWithNotify
 
 data object WanderAction : BtNode {
     override suspend fun tick(ctx: BtContext): BtResult {
@@ -13,22 +13,9 @@ data object WanderAction : BtNode {
         if (exits.isEmpty()) return BtResult.FAILURE
 
         val destination = exits[ctx.rng.nextInt(exits.size)]
-        val from = ctx.mob.roomId
-        if (from == destination) return BtResult.SUCCESS
+        if (ctx.mob.roomId == destination) return BtResult.SUCCESS
 
-        // Notify players in old room
-        for (p in ctx.players.playersInRoom(from)) {
-            ctx.outbound.send(OutboundEvent.SendText(p.sessionId, "${ctx.mob.name} leaves."))
-            ctx.gmcpEmitter?.sendRoomRemoveMob(p.sessionId, ctx.mob.id.value)
-        }
-
-        ctx.mobs.moveTo(ctx.mob.id, destination)
-
-        // Notify players in new room
-        for (p in ctx.players.playersInRoom(destination)) {
-            ctx.outbound.send(OutboundEvent.SendText(p.sessionId, "${ctx.mob.name} enters."))
-            ctx.gmcpEmitter?.sendRoomAddMob(p.sessionId, ctx.mob)
-        }
+        ctx.moveMobWithNotify(destination)
 
         return BtResult.SUCCESS
     }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -189,6 +189,34 @@ internal suspend fun <T> requireSystemOrNull(
     return system
 }
 
+/**
+ * Notifies old-room players of departure, moves the player, then notifies new-room players of arrival.
+ * Also fires [dialogueSystem] movement callbacks and emits GMCP room-player add/remove.
+ */
+internal suspend fun movePlayerWithNotify(
+    sessionId: SessionId,
+    from: RoomId,
+    to: RoomId,
+    departMsg: String,
+    arriveMsg: String,
+    players: PlayerRegistry,
+    outbound: OutboundBus,
+    gmcpEmitter: GmcpEmitter?,
+    dialogueSystem: dev.ambon.engine.dialogue.DialogueSystem? = null,
+) {
+    val me = players.get(sessionId) ?: return
+    for (other in players.playersInRoom(from).filter { it.sessionId != me.sessionId }) {
+        outbound.send(OutboundEvent.SendText(other.sessionId, "${me.name} $departMsg"))
+        gmcpEmitter?.sendRoomRemovePlayer(other.sessionId, me.name)
+    }
+    dialogueSystem?.onPlayerMoved(sessionId)
+    players.moveTo(sessionId, to)
+    for (other in players.playersInRoom(to).filter { it.sessionId != me.sessionId }) {
+        outbound.send(OutboundEvent.SendText(other.sessionId, "${me.name} $arriveMsg"))
+        gmcpEmitter?.sendRoomAddPlayer(other.sessionId, me)
+    }
+}
+
 /** Checks if [sessionId] has staff privileges; sends an error and returns false if not. */
 internal suspend fun requireStaff(
     sessionId: SessionId,

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
@@ -93,18 +93,17 @@ class NavigationHandler(
                 }
             }
 
-            val oldMembers = players.playersInRoom(from).filter { it.sessionId != me.sessionId }
-            for (other in oldMembers) {
-                outbound.send(OutboundEvent.SendText(other.sessionId, "${me.name} leaves."))
-                gmcpEmitter?.sendRoomRemovePlayer(other.sessionId, me.name)
-            }
-            dialogueSystem?.onPlayerMoved(sessionId)
-            players.moveTo(sessionId, to)
-            val newMembers = players.playersInRoom(to).filter { it.sessionId != me.sessionId }
-            for (other in newMembers) {
-                outbound.send(OutboundEvent.SendText(other.sessionId, "${me.name} enters."))
-                gmcpEmitter?.sendRoomAddPlayer(other.sessionId, me)
-            }
+            movePlayerWithNotify(
+                sessionId,
+                from,
+                to,
+                "leaves.",
+                "enters.",
+                players,
+                outbound,
+                gmcpEmitter,
+                dialogueSystem,
+            )
             sendLook(sessionId, world, players, mobs, items, worldState, outbound, gmcpEmitter)
         }
     }
@@ -134,17 +133,18 @@ class NavigationHandler(
             return
         }
         val from = me.roomId
-        for (other in players.playersInRoom(from).filter { it.sessionId != me.sessionId }) {
-            outbound.send(OutboundEvent.SendText(other.sessionId, "${me.name} vanishes in a flash of light."))
-            gmcpEmitter?.sendRoomRemovePlayer(other.sessionId, me.name)
-        }
-        dialogueSystem?.onPlayerMoved(sessionId)
-        players.moveTo(sessionId, target)
+        movePlayerWithNotify(
+            sessionId,
+            from,
+            target,
+            "vanishes in a flash of light.",
+            "appears in a flash of light.",
+            players,
+            outbound,
+            gmcpEmitter,
+            dialogueSystem,
+        )
         outbound.send(OutboundEvent.SendText(sessionId, "You feel a familiar warmth and find yourself back at your recall point."))
-        for (other in players.playersInRoom(target).filter { it.sessionId != me.sessionId }) {
-            outbound.send(OutboundEvent.SendText(other.sessionId, "${me.name} appears in a flash of light."))
-            gmcpEmitter?.sendRoomAddPlayer(other.sessionId, me)
-        }
         sendLook(sessionId, world, players, mobs, items, worldState, outbound, gmcpEmitter)
     }
 


### PR DESCRIPTION
## Summary

Closes #353

- Extract `movePlayerWithNotify()` in `HandlerHelpers.kt` — consolidates the "notify old room → move player → notify new room" pattern (with GMCP + dialogue callbacks) used by `handleMove` and `handleRecall` in `NavigationHandler`
- Extract `BtContext.moveMobWithNotify()` extension in `BtContext.kt` — consolidates the equivalent mob movement notification pattern used by `PatrolAction`, `WanderAction`, and `FleeAction`
- ~40 lines eliminated across 5 files; new movement features (teleport spells, etc.) automatically get consistent room notifications

## Test plan

- [x] All existing tests pass (movement, recall, patrol, wander, flee behaviors)
- [x] `ktlintCheck` passes