### PR TITLE
refactor: introduce GameSystem interface for session lifecycle

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -50,7 +50,7 @@ class CombatSystem(
     private val groupSystem: GroupSystem? = null,
     private val config: CombatSystemConfig = CombatSystemConfig(),
     private val callbacks: CombatSystemCallbacks = CombatSystemCallbacks(),
-) {
+) : GameSystem {
     // Per-mob combat state (tracks tick timing)
     private data class MobCombatState(
         val mobId: MobId,
@@ -142,7 +142,7 @@ class CombatSystem(
         return null
     }
 
-    fun remapSession(
+    override fun remapSession(
         oldSid: SessionId,
         newSid: SessionId,
     ) {
@@ -151,10 +151,10 @@ class CombatSystem(
             playerTarget[newSid] = mobId
         }
         threatTable.remapSession(oldSid, newSid)
-        defenseByPlayer.remove(oldSid)?.let { defenseByPlayer[newSid] = it }
+        defenseByPlayer.remapKey(oldSid, newSid)
     }
 
-    fun onPlayerDisconnected(sessionId: SessionId) {
+    override suspend fun onPlayerDisconnected(sessionId: SessionId) {
         removePlayerFromCombat(sessionId)
         defenseByPlayer.remove(sessionId)
     }

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -540,13 +540,15 @@ class GameEngine(
         )
 
     private val sessionLifecycleCoordinator = SessionLifecycleCoordinator(
-        combatSystem = combatSystem,
-        regenSystem = regenSystem,
-        abilitySystem = abilitySystem,
-        statusEffectSystem = statusEffectSystem,
-        dialogueSystem = dialogueSystem,
-        groupSystem = groupSystem,
-        guildSystem = guildSystem,
+        listOfNotNull(
+            combatSystem,
+            regenSystem,
+            abilitySystem,
+            statusEffectSystem,
+            dialogueSystem,
+            groupSystem,
+            guildSystem,
+        ),
     )
 
     private val mobRemovalCoordinator = MobRemovalCoordinator(

--- a/src/main/kotlin/dev/ambon/engine/GameSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameSystem.kt
@@ -1,0 +1,38 @@
+package dev.ambon.engine
+
+import dev.ambon.domain.ids.SessionId
+
+/**
+ * Common lifecycle contract for engine subsystems that track per-session state.
+ *
+ * Every subsystem that maintains session-keyed maps should implement this
+ * interface so [SessionLifecycleCoordinator] can iterate them uniformly.
+ */
+interface GameSystem {
+    /** Cleans up all per-session state when a player disconnects. */
+    suspend fun onPlayerDisconnected(sessionId: SessionId)
+
+    /**
+     * Transfers all per-session state from [oldSid] to [newSid] during a
+     * session takeover (same account logging in from a second connection).
+     *
+     * The default no-op is appropriate for subsystems whose state should not
+     * survive a takeover (e.g. active dialogue conversations).
+     */
+    fun remapSession(oldSid: SessionId, newSid: SessionId) {}
+}
+
+/** Moves the value at [oldKey] to [newKey], if present. */
+internal fun <V> MutableMap<SessionId, V>.remapKey(oldKey: SessionId, newKey: SessionId) {
+    remove(oldKey)?.let { this[newKey] = it }
+}
+
+/**
+ * Removes [value] from the set at [key], then removes the entry entirely
+ * if the set is now empty. This is the canonical room-membership cleanup.
+ */
+internal fun <K, V> MutableMap<K, MutableSet<V>>.removeFromSet(key: K, value: V) {
+    val set = this[key] ?: return
+    set.remove(value)
+    if (set.isEmpty()) remove(key)
+}

--- a/src/main/kotlin/dev/ambon/engine/GroupSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/GroupSystem.kt
@@ -28,7 +28,7 @@ class GroupSystem(
     private val maxGroupSize: Int = 5,
     private val inviteTimeoutMs: Long = 60_000L,
     private val markGroupDirty: (SessionId) -> Unit = {},
-) {
+) : GameSystem {
     private val groupBySession = mutableMapOf<SessionId, Group>()
     private val pendingInvites = mutableMapOf<SessionId, PendingInvite>()
 
@@ -281,7 +281,7 @@ class GroupSystem(
         return null
     }
 
-    suspend fun onPlayerDisconnected(sessionId: SessionId) {
+    override suspend fun onPlayerDisconnected(sessionId: SessionId) {
         // Remove pending invites where this player is invitee
         pendingInvites.remove(sessionId)
         // Remove pending invites where this player is inviter
@@ -301,7 +301,7 @@ class GroupSystem(
         }
     }
 
-    fun remapSession(
+    override fun remapSession(
         oldSid: SessionId,
         newSid: SessionId,
     ) {

--- a/src/main/kotlin/dev/ambon/engine/GuildSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/GuildSystem.kt
@@ -27,7 +27,7 @@ class GuildSystem(
     private val maxSize: Int = 50,
     private val inviteTimeoutMs: Long = 60_000L,
     private val markPlayerDirty: suspend (SessionId) -> Unit = {},
-) {
+) : GameSystem {
     private val guildsById = mutableMapOf<String, GuildRecord>()
     private val pendingInvites = mutableMapOf<SessionId, PendingGuildInvite>()
 
@@ -39,7 +39,7 @@ class GuildSystem(
         log.info { "GuildSystem initialized with ${guildsById.size} guild(s)" }
     }
 
-    fun onPlayerDisconnected(sessionId: SessionId) {
+    override suspend fun onPlayerDisconnected(sessionId: SessionId) {
         pendingInvites.remove(sessionId)
     }
 

--- a/src/main/kotlin/dev/ambon/engine/MobRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/MobRegistry.kt
@@ -16,8 +16,7 @@ class MobRegistry {
         } else {
             // update fields but preserve membership maps properly if room changes
             if (existing.roomId != mob.roomId) {
-                roomMembers[existing.roomId]?.remove(mob.id)
-                if (roomMembers[existing.roomId]?.isEmpty() == true) roomMembers.remove(existing.roomId)
+                roomMembers.removeFromSet(existing.roomId, mob.id)
                 roomMembers.getOrPut(mob.roomId) { mutableSetOf() }.add(mob.id)
             }
             existing.name = mob.name
@@ -39,16 +38,14 @@ class MobRegistry {
     ) {
         val m = mobs[mobId] ?: return
         if (m.roomId == newRoom) return
-        roomMembers[m.roomId]?.remove(mobId)
-        if (roomMembers[m.roomId]?.isEmpty() == true) roomMembers.remove(m.roomId)
+        roomMembers.removeFromSet(m.roomId, mobId)
         m.roomId = newRoom
         roomMembers.getOrPut(newRoom) { mutableSetOf() }.add(mobId)
     }
 
     fun remove(mobId: MobId): MobState? {
         val m = mobs.remove(mobId) ?: return null
-        roomMembers[m.roomId]?.remove(mobId)
-        if (roomMembers[m.roomId]?.isEmpty() == true) roomMembers.remove(m.roomId)
+        roomMembers.removeFromSet(m.roomId, mobId)
         return m
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
@@ -319,8 +319,7 @@ class PlayerRegistry(
         // Persist last seen + room for claimed players
         persistIfClaimed(ps)
 
-        roomMembers[ps.roomId]?.remove(sessionId)
-        if (roomMembers[ps.roomId]?.isEmpty() == true) roomMembers.remove(ps.roomId)
+        roomMembers.removeFromSet(ps.roomId, sessionId)
         sessionByLowerName.remove(ps.name.lowercase())
         items.removePlayer(sessionId)
     }
@@ -350,8 +349,7 @@ class PlayerRegistry(
         // Persist with target room before removing
         persistIfClaimed(ps)
 
-        roomMembers[ps.roomId]?.remove(sessionId)
-        if (roomMembers[ps.roomId]?.isEmpty() == true) roomMembers.remove(ps.roomId)
+        roomMembers.removeFromSet(ps.roomId, sessionId)
         sessionByLowerName.remove(ps.name.lowercase())
         items.removePlayer(sessionId)
         return ps
@@ -420,8 +418,7 @@ class PlayerRegistry(
         val ps = players[sessionId] ?: return
         if (ps.roomId == newRoom) return
 
-        roomMembers[ps.roomId]?.remove(sessionId)
-        if (roomMembers[ps.roomId]?.isEmpty() == true) roomMembers.remove(ps.roomId)
+        roomMembers.removeFromSet(ps.roomId, sessionId)
 
         ps.roomId = newRoom
         roomMembers.getOrPut(newRoom) { mutableSetOf() }.add(sessionId)

--- a/src/main/kotlin/dev/ambon/engine/RegenSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/RegenSystem.kt
@@ -21,19 +21,19 @@ class RegenSystem(
     private val msPerWisdom: Long = 200L,
     private val metrics: GameMetrics = GameMetrics.noop(),
     private val dirtyNotifier: DirtyNotifier = DirtyNotifier.NO_OP,
-) {
+) : GameSystem {
     private val lastRegenAtMs = mutableMapOf<SessionId, Long>()
     private val lastManaRegenAtMs = mutableMapOf<SessionId, Long>()
 
-    fun remapSession(
+    override fun remapSession(
         oldSid: SessionId,
         newSid: SessionId,
     ) {
-        lastRegenAtMs.remove(oldSid)?.let { lastRegenAtMs[newSid] = it }
-        lastManaRegenAtMs.remove(oldSid)?.let { lastManaRegenAtMs[newSid] = it }
+        lastRegenAtMs.remapKey(oldSid, newSid)
+        lastManaRegenAtMs.remapKey(oldSid, newSid)
     }
 
-    fun onPlayerDisconnected(sessionId: SessionId) {
+    override suspend fun onPlayerDisconnected(sessionId: SessionId) {
         lastRegenAtMs.remove(sessionId)
         lastManaRegenAtMs.remove(sessionId)
     }

--- a/src/main/kotlin/dev/ambon/engine/SessionLifecycleCoordinator.kt
+++ b/src/main/kotlin/dev/ambon/engine/SessionLifecycleCoordinator.kt
@@ -1,34 +1,22 @@
 package dev.ambon.engine
 
 import dev.ambon.domain.ids.SessionId
-import dev.ambon.engine.abilities.AbilitySystem
-import dev.ambon.engine.dialogue.DialogueSystem
-import dev.ambon.engine.status.StatusEffectSystem
 
 /**
  * Centralises per-session lifecycle calls that must fan out to every subsystem.
  *
- * Adding a new subsystem that tracks per-session state? Wire it here and the
- * disconnect / remap cascades are updated everywhere at once.
+ * Adding a new subsystem that tracks per-session state? Have it implement
+ * [GameSystem] and add it to the [systems] list — the disconnect / remap
+ * cascades are updated everywhere at once.
  */
 class SessionLifecycleCoordinator(
-    private val combatSystem: CombatSystem,
-    private val regenSystem: RegenSystem,
-    private val abilitySystem: AbilitySystem,
-    private val statusEffectSystem: StatusEffectSystem,
-    private val dialogueSystem: DialogueSystem,
-    private val groupSystem: GroupSystem,
-    private val guildSystem: GuildSystem?,
+    private val systems: List<GameSystem>,
 ) {
     /** Cleans up all per-session state across every subsystem. */
     suspend fun onPlayerDisconnected(sessionId: SessionId) {
-        combatSystem.onPlayerDisconnected(sessionId)
-        regenSystem.onPlayerDisconnected(sessionId)
-        abilitySystem.onPlayerDisconnected(sessionId)
-        statusEffectSystem.onPlayerDisconnected(sessionId)
-        dialogueSystem.onPlayerDisconnected(sessionId)
-        groupSystem.onPlayerDisconnected(sessionId)
-        guildSystem?.onPlayerDisconnected(sessionId)
+        for (system in systems) {
+            system.onPlayerDisconnected(sessionId)
+        }
     }
 
     /**
@@ -36,10 +24,8 @@ class SessionLifecycleCoordinator(
      * during a session takeover (same account logging in from a second connection).
      */
     fun remapSession(oldSessionId: SessionId, newSessionId: SessionId) {
-        combatSystem.remapSession(oldSessionId, newSessionId)
-        regenSystem.remapSession(oldSessionId, newSessionId)
-        abilitySystem.remapSession(oldSessionId, newSessionId)
-        statusEffectSystem.remapSession(oldSessionId, newSessionId)
-        groupSystem.remapSession(oldSessionId, newSessionId)
+        for (system in systems) {
+            system.remapSession(oldSessionId, newSessionId)
+        }
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
@@ -5,6 +5,7 @@ import dev.ambon.domain.PlayerClass
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.DirtyNotifier
+import dev.ambon.engine.GameSystem
 import dev.ambon.engine.GroupSystem
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PlayerRegistry
@@ -13,6 +14,7 @@ import dev.ambon.engine.broadcastToRoom
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.healHp
 import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.engine.remapKey
 import dev.ambon.engine.resolveEffectiveStats
 import dev.ambon.engine.rollRange
 import dev.ambon.engine.spendMana
@@ -35,7 +37,7 @@ class AbilitySystem(
     private val statusEffects: StatusEffectSystem? = null,
     private val groupSystem: GroupSystem? = null,
     private val mobs: MobRegistry? = null,
-) {
+) : GameSystem {
     private val learnedAbilities = mutableMapOf<SessionId, MutableSet<AbilityId>>()
     private val cooldowns = mutableMapOf<SessionId, MutableMap<AbilityId, Long>>()
 
@@ -405,16 +407,16 @@ class AbilitySystem(
         return (expiresAt - clock.millis()).coerceAtLeast(0L)
     }
 
-    fun onPlayerDisconnected(sessionId: SessionId) {
+    override suspend fun onPlayerDisconnected(sessionId: SessionId) {
         learnedAbilities.remove(sessionId)
         cooldowns.remove(sessionId)
     }
 
-    fun remapSession(
+    override fun remapSession(
         oldSid: SessionId,
         newSid: SessionId,
     ) {
-        learnedAbilities.remove(oldSid)?.let { learnedAbilities[newSid] = it }
-        cooldowns.remove(oldSid)?.let { cooldowns[newSid] = it }
+        learnedAbilities.remapKey(oldSid, newSid)
+        cooldowns.remapKey(oldSid, newSid)
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/dialogue/DialogueSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/dialogue/DialogueSystem.kt
@@ -4,6 +4,7 @@ import dev.ambon.bus.OutboundBus
 import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.engine.GameSystem
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.events.OutboundEvent
@@ -12,7 +13,7 @@ class DialogueSystem(
     private val mobs: MobRegistry,
     private val players: PlayerRegistry,
     private val outbound: OutboundBus,
-) {
+) : GameSystem {
     data class ConversationState(
         val mobId: MobId,
         val currentNodeId: String,
@@ -111,7 +112,7 @@ class DialogueSystem(
         conversations.remove(sessionId)
     }
 
-    fun onPlayerDisconnected(sessionId: SessionId) {
+    override suspend fun onPlayerDisconnected(sessionId: SessionId) {
         conversations.remove(sessionId)
     }
 

--- a/src/main/kotlin/dev/ambon/engine/status/StatusEffectSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/status/StatusEffectSystem.kt
@@ -4,10 +4,12 @@ import dev.ambon.bus.OutboundBus
 import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.DirtyNotifier
+import dev.ambon.engine.GameSystem
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.healHp
+import dev.ambon.engine.remapKey
 import dev.ambon.engine.rollRange
 import dev.ambon.engine.takeDamage
 import java.time.Clock
@@ -21,7 +23,7 @@ class StatusEffectSystem(
     private val clock: Clock,
     private val rng: Random = Random(),
     private val dirtyNotifier: DirtyNotifier = DirtyNotifier.NO_OP,
-) {
+) : GameSystem {
     private val playerEffects = mutableMapOf<SessionId, MutableList<ActiveEffect>>()
     private val mobEffects = mutableMapOf<MobId, MutableList<ActiveEffect>>()
 
@@ -287,7 +289,7 @@ class StatusEffectSystem(
 
     // ── Cleanup ────────────────────────────────────────────────────────
 
-    fun onPlayerDisconnected(sessionId: SessionId) {
+    override suspend fun onPlayerDisconnected(sessionId: SessionId) {
         playerEffects.remove(sessionId)
     }
 
@@ -304,11 +306,11 @@ class StatusEffectSystem(
         mobEffects.remove(mobId)
     }
 
-    fun remapSession(
+    override fun remapSession(
         oldSid: SessionId,
         newSid: SessionId,
     ) {
-        playerEffects.remove(oldSid)?.let { playerEffects[newSid] = it }
+        playerEffects.remapKey(oldSid, newSid)
     }
 
     /**

--- a/src/test/kotlin/dev/ambon/engine/status/StatusEffectSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/status/StatusEffectSystemTest.kt
@@ -454,7 +454,7 @@ class StatusEffectSystemTest {
     // ── Cleanup Tests ──
 
     @Test
-    fun `onPlayerDisconnected clears effects`() {
+    fun `onPlayerDisconnected clears effects`() = runTest {
         val h = buildSystem()
         h.loginPlayer()
         h.registerStun(durationMs = 5000)


### PR DESCRIPTION
## Summary
- Introduces a `GameSystem` interface (`onPlayerDisconnected` / `remapSession`) implemented by all session-tracking subsystems (CombatSystem, RegenSystem, AbilitySystem, StatusEffectSystem, DialogueSystem, GroupSystem, GuildSystem)
- `SessionLifecycleCoordinator` now iterates a `List<GameSystem>` instead of calling each system individually — new systems get correct lifecycle behavior automatically
- Adds `remapKey()` extension to eliminate the repeated `map.remove(old)?.let { map[new] = it }` idiom (~8 sites)
- Adds `removeFromSet()` extension for the room-membership cleanup pattern in `PlayerRegistry` and `MobRegistry` (~6 sites)

Net: -69 lines added, +94 lines removed across 13 files.

Closes #356

## Test plan
- [x] `ktlintCheck` passes
- [x] Full test suite passes (all existing tests verify same behavior)
- [x] One test updated to match new `suspend` signature (`StatusEffectSystemTest`)