### PR TITLE
refactor: eliminate SerializedItem, use Jackson serialization for Item

### DIFF
--- a/src/main/kotlin/dev/ambon/sharding/HandoffManager.kt
+++ b/src/main/kotlin/dev/ambon/sharding/HandoffManager.kt
@@ -1,13 +1,10 @@
 package dev.ambon.sharding
 
 import dev.ambon.bus.OutboundBus
-import dev.ambon.domain.ids.ItemId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
-import dev.ambon.domain.items.Item
 import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.items.ItemSlot
-import dev.ambon.domain.items.ItemUseEffect
 import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.PlayerState
 import dev.ambon.engine.events.OutboundEvent
@@ -261,11 +258,11 @@ class HandoffManager(
             players.bindFromHandoff(sessionId, ps)
 
             for (item in state.inventoryItems) {
-                items.addToInventory(sessionId, deserializeItem(item))
+                items.addToInventory(sessionId, item)
             }
             for ((slotName, item) in state.equippedItems) {
                 val slot = ItemSlot.parse(slotName) ?: continue
-                items.setEquippedItem(sessionId, slot, deserializeItem(item))
+                items.setEquippedItem(sessionId, slot, item)
             }
 
             for (other in players.playersInRoom(targetRoom)) {
@@ -347,68 +344,8 @@ class HandoffManager(
                 mana = player.mana,
                 maxMana = player.maxMana,
                 baseMana = player.baseMana,
-                inventoryItems = inventory.map { serializeItem(it) },
-                equippedItems =
-                    equipment
-                        .mapKeys { (slot, _) -> slot.name }
-                        .mapValues { (_, instance) -> serializeItem(instance) },
-            )
-
-        fun serializeItem(instance: ItemInstance): SerializedItem =
-            SerializedItem(
-                id = instance.id.value,
-                keyword = instance.item.keyword,
-                displayName = instance.item.displayName,
-                description = instance.item.description,
-                slot = instance.item.slot?.name,
-                damage = instance.item.damage,
-                armor = instance.item.armor,
-                constitution = instance.item.constitution,
-                strength = instance.item.strength,
-                dexterity = instance.item.dexterity,
-                intelligence = instance.item.intelligence,
-                wisdom = instance.item.wisdom,
-                charisma = instance.item.charisma,
-                consumable = instance.item.consumable,
-                charges = instance.item.charges,
-                onUse =
-                    instance.item.onUse?.let { effect ->
-                        SerializedItemUseEffect(
-                            healHp = effect.healHp,
-                            grantXp = effect.grantXp,
-                        )
-                    },
-                matchByKey = instance.item.matchByKey,
-            )
-
-        fun deserializeItem(serialized: SerializedItem): ItemInstance =
-            ItemInstance(
-                id = ItemId(serialized.id),
-                item =
-                    Item(
-                        keyword = serialized.keyword,
-                        displayName = serialized.displayName,
-                        description = serialized.description,
-                        slot = serialized.slot?.let { ItemSlot.parse(it) },
-                        damage = serialized.damage,
-                        armor = serialized.armor,
-                        constitution = serialized.constitution,
-                        strength = serialized.strength,
-                        dexterity = serialized.dexterity,
-                        intelligence = serialized.intelligence,
-                        wisdom = serialized.wisdom,
-                        charisma = serialized.charisma,
-                        consumable = serialized.consumable,
-                        charges = serialized.charges,
-                        onUse =
-                            serialized.onUse?.let { effect ->
-                                ItemUseEffect(
-                                    healHp = effect.healHp,
-                                    grantXp = effect.grantXp,
-                                )
-                            },
-                        matchByKey = serialized.matchByKey,
-                    ),
+                inventoryItems = inventory,
+                equippedItems = equipment.mapKeys { (slot, _) -> slot.name },
             )
     }
 }

--- a/src/main/kotlin/dev/ambon/sharding/InterEngineMessage.kt
+++ b/src/main/kotlin/dev/ambon/sharding/InterEngineMessage.kt
@@ -2,6 +2,7 @@ package dev.ambon.sharding
 
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import dev.ambon.domain.items.ItemInstance
 import dev.ambon.engine.PlayerState
 
 /**
@@ -104,35 +105,6 @@ data class PlayerSummary(
 )
 
 /**
- * Serialized item data for cross-zone handoff. Carries the full item definition
- * so that the target engine can reconstruct items without needing the source zone's templates.
- */
-data class SerializedItem(
-    val id: String = "",
-    val keyword: String = "",
-    val displayName: String = "",
-    val description: String = "",
-    val slot: String? = null,
-    val damage: Int = 0,
-    val armor: Int = 0,
-    val constitution: Int = 0,
-    val strength: Int = 0,
-    val dexterity: Int = 0,
-    val intelligence: Int = 0,
-    val wisdom: Int = 0,
-    val charisma: Int = 0,
-    val consumable: Boolean = false,
-    val charges: Int? = null,
-    val onUse: SerializedItemUseEffect? = null,
-    val matchByKey: Boolean = false,
-)
-
-data class SerializedItemUseEffect(
-    val healHp: Int = 0,
-    val grantXp: Long = 0L,
-)
-
-/**
  * Full player state for cross-zone handoff. Serialized as JSON for transport.
  */
 data class SerializedPlayerState(
@@ -160,7 +132,7 @@ data class SerializedPlayerState(
     val mana: Int = PlayerState.BASE_MANA,
     val maxMana: Int = PlayerState.BASE_MANA,
     val baseMana: Int = PlayerState.BASE_MANA,
-    val inventoryItems: List<SerializedItem> = emptyList(),
+    val inventoryItems: List<ItemInstance> = emptyList(),
     // slot name → item
-    val equippedItems: Map<String, SerializedItem> = emptyMap(),
+    val equippedItems: Map<String, ItemInstance> = emptyMap(),
 )

--- a/src/test/kotlin/dev/ambon/sharding/HandoffManagerTest.kt
+++ b/src/test/kotlin/dev/ambon/sharding/HandoffManagerTest.kt
@@ -151,18 +151,33 @@ class HandoffManagerTest {
         assertTrue(serialized.ansiEnabled)
 
         assertEquals(1, serialized.inventoryItems.size)
-        assertEquals("forest:coin", serialized.inventoryItems[0].id)
-        assertEquals("coin", serialized.inventoryItems[0].keyword)
+        assertEquals(ItemId("forest:coin"), serialized.inventoryItems[0].id)
+        assertEquals("coin", serialized.inventoryItems[0].item.keyword)
 
         assertEquals(2, serialized.equippedItems.size)
-        assertEquals("forest:sword", serialized.equippedItems["HAND"]?.id)
-        assertEquals(5, serialized.equippedItems["HAND"]?.damage)
-        assertEquals("forest:shield", serialized.equippedItems["BODY"]?.id)
-        assertEquals(2, serialized.equippedItems["BODY"]?.armor)
+        assertEquals(ItemId("forest:sword"), serialized.equippedItems["HAND"]?.id)
+        assertEquals(5, serialized.equippedItems["HAND"]?.item?.damage)
+        assertEquals(ItemId("forest:shield"), serialized.equippedItems["BODY"]?.id)
+        assertEquals(2, serialized.equippedItems["BODY"]?.item?.armor)
     }
 
     @Test
-    fun `serializeItem and deserializeItem round-trip`() {
+    fun `serializePlayer preserves ItemInstance directly`() {
+        val player =
+            PlayerState(
+                sessionId = sid,
+                name = "Alice",
+                roomId = RoomId("forest:clearing"),
+                playerId = PlayerId(42L),
+                hp = 20,
+                maxHp = 20,
+                baseMaxHp = 20,
+                level = 1,
+                xpTotal = 0L,
+                ansiEnabled = false,
+                isStaff = false,
+            )
+
         val original =
             ItemInstance(
                 id = ItemId("zone:magic_staff"),
@@ -182,21 +197,16 @@ class HandoffManagerTest {
                     ),
             )
 
-        val serialized = HandoffManager.serializeItem(original)
-        val restored = HandoffManager.deserializeItem(serialized)
+        val serialized =
+            HandoffManager.serializePlayer(
+                player = player,
+                targetRoomId = targetRoom,
+                inventory = listOf(original),
+                equipment = mapOf(ItemSlot.HAND to original),
+            )
 
-        assertEquals(original.id, restored.id)
-        assertEquals(original.item.keyword, restored.item.keyword)
-        assertEquals(original.item.displayName, restored.item.displayName)
-        assertEquals(original.item.description, restored.item.description)
-        assertEquals(original.item.slot, restored.item.slot)
-        assertEquals(original.item.damage, restored.item.damage)
-        assertEquals(original.item.armor, restored.item.armor)
-        assertEquals(original.item.constitution, restored.item.constitution)
-        assertEquals(original.item.consumable, restored.item.consumable)
-        assertEquals(original.item.charges, restored.item.charges)
-        assertEquals(original.item.onUse, restored.item.onUse)
-        assertEquals(original.item.matchByKey, restored.item.matchByKey)
+        assertEquals(original, serialized.inventoryItems[0])
+        assertEquals(original, serialized.equippedItems["HAND"])
     }
 
     @Test
@@ -349,21 +359,17 @@ class HandoffManagerTest {
                             lastSeenEpochMs = 2_000L,
                             inventoryItems =
                                 listOf(
-                                    SerializedItem(
-                                        id = "forest:coin",
-                                        keyword = "coin",
-                                        displayName = "a gold coin",
+                                    ItemInstance(
+                                        id = ItemId("forest:coin"),
+                                        item = Item(keyword = "coin", displayName = "a gold coin"),
                                     ),
                                 ),
                             equippedItems =
                                 mapOf(
                                     "HAND" to
-                                        SerializedItem(
-                                            id = "forest:sword",
-                                            keyword = "sword",
-                                            displayName = "a sharp sword",
-                                            slot = "HAND",
-                                            damage = 5,
+                                        ItemInstance(
+                                            id = ItemId("forest:sword"),
+                                            item = Item(keyword = "sword", displayName = "a sharp sword", slot = ItemSlot.HAND, damage = 5),
                                         ),
                                 ),
                         ),

--- a/src/test/kotlin/dev/ambon/sharding/InterEngineMessageSerializationTest.kt
+++ b/src/test/kotlin/dev/ambon/sharding/InterEngineMessageSerializationTest.kt
@@ -1,6 +1,11 @@
 package dev.ambon.sharding
 
 import com.fasterxml.jackson.module.kotlin.readValue
+import dev.ambon.domain.ids.ItemId
+import dev.ambon.domain.items.Item
+import dev.ambon.domain.items.ItemInstance
+import dev.ambon.domain.items.ItemSlot
+import dev.ambon.domain.items.ItemUseEffect
 import dev.ambon.redis.redisObjectMapper
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -64,30 +69,21 @@ class InterEngineMessageSerializationTest {
                 lastSeenEpochMs = 2000L,
                 inventoryItems =
                     listOf(
-                        SerializedItem(
-                            id = "zone:sword",
-                            keyword = "sword",
-                            displayName = "a sharp sword",
-                            slot = "HAND",
-                            damage = 5,
+                        ItemInstance(
+                            id = ItemId("zone:sword"),
+                            item = Item(keyword = "sword", displayName = "a sharp sword", slot = ItemSlot.HAND, damage = 5),
                         ),
-                        SerializedItem(
-                            id = "zone:shield",
-                            keyword = "shield",
-                            displayName = "a wooden shield",
-                            slot = "BODY",
-                            armor = 2,
+                        ItemInstance(
+                            id = ItemId("zone:shield"),
+                            item = Item(keyword = "shield", displayName = "a wooden shield", slot = ItemSlot.BODY, armor = 2),
                         ),
                     ),
                 equippedItems =
                     mapOf(
                         "HAND" to
-                            SerializedItem(
-                                id = "zone:sword",
-                                keyword = "sword",
-                                displayName = "a sharp sword",
-                                slot = "HAND",
-                                damage = 5,
+                            ItemInstance(
+                                id = ItemId("zone:sword"),
+                                item = Item(keyword = "sword", displayName = "a sharp sword", slot = ItemSlot.HAND, damage = 5),
                             ),
                     ),
             )
@@ -105,24 +101,27 @@ class InterEngineMessageSerializationTest {
     }
 
     @Test
-    fun `SerializedItem round-trips through JSON`() {
+    fun `ItemInstance round-trips through JSON`() {
         val item =
-            SerializedItem(
-                id = "zone:magic_staff",
-                keyword = "staff",
-                displayName = "a glowing staff",
-                description = "It hums with power.",
-                slot = "HAND",
-                damage = 7,
-                armor = 1,
-                constitution = 2,
-                consumable = true,
-                charges = 3,
-                onUse = SerializedItemUseEffect(healHp = 4, grantXp = 12),
-                matchByKey = true,
+            ItemInstance(
+                id = ItemId("zone:magic_staff"),
+                item =
+                    Item(
+                        keyword = "staff",
+                        displayName = "a glowing staff",
+                        description = "It hums with power.",
+                        slot = ItemSlot.HAND,
+                        damage = 7,
+                        armor = 1,
+                        constitution = 2,
+                        consumable = true,
+                        charges = 3,
+                        onUse = ItemUseEffect(healHp = 4, grantXp = 12),
+                        matchByKey = true,
+                    ),
             )
         val json = mapper.writeValueAsString(item)
-        val deserialized = mapper.readValue<SerializedItem>(json)
+        val deserialized = mapper.readValue<ItemInstance>(json)
         assertEquals(item, deserialized)
     }
 


### PR DESCRIPTION
## Summary

- Remove `SerializedItem` and `SerializedItemUseEffect` intermediate DTOs from `InterEngineMessage.kt`
- Use `ItemInstance` directly in `SerializedPlayerState`, relying on Jackson's native handling of `Item`, `ItemUseEffect`, `ItemSlot` (enum), and `ItemId` (value class)
- Remove `serializeItem()` and `deserializeItem()` mapping functions from `HandoffManager`
- Net reduction of ~86 lines; adding a new item field no longer requires updating the serialization DTO

Closes #358

## Test plan

- [x] `InterEngineMessageSerializationTest` — all round-trip tests pass with `ItemInstance` directly
- [x] `HandoffManagerTest` — serialize/accept handoff tests pass with `ItemInstance`
- [x] Full `ktlintCheck test` suite passes