### PR TITLE
refactor: extract shared TestFixtureBase for spawnMob/loginPlayer

### DIFF
--- a/src/test/kotlin/dev/ambon/engine/status/StatusEffectSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/status/StatusEffectSystemTest.kt
@@ -3,7 +3,6 @@ package dev.ambon.engine.status
 import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
-import dev.ambon.domain.mob.MobState
 import dev.ambon.test.MutableClock
 import dev.ambon.test.StatusEffectTestFixture
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -31,24 +30,6 @@ class StatusEffectSystemTest {
                 players.login(sid, "TestPlayer", "pass", defaultAnsiEnabled = false)
             }
         assertEquals(dev.ambon.engine.LoginResult.Ok, result)
-    }
-
-    private fun StatusEffectTestFixture.spawnMob(
-        hp: Int = 50,
-        id: MobId = mobId,
-    ): MobState {
-        val mob =
-            MobState(
-                id = id,
-                name = "Goblin",
-                roomId = roomId,
-                hp = hp,
-                maxHp = hp,
-                minDamage = 1,
-                maxDamage = 2,
-            )
-        mobs.upsert(mob)
-        return mob
     }
 
     private fun StatusEffectTestFixture.registerDot(
@@ -182,7 +163,7 @@ class StatusEffectSystemTest {
         runTest {
             val h = buildSystem()
             h.loginPlayer()
-            val mob = h.spawnMob(hp = 50)
+            val mob = h.spawnMob(id = mobId, name = "Goblin", hp = 50)
             h.registerDot(durationMs = 6000, tickIntervalMs = 2000, minVal = 5, maxVal = 5)
 
             h.system.applyToMob(mobId, StatusEffectId("ignite"), sid)
@@ -344,7 +325,7 @@ class StatusEffectSystemTest {
     @Test
     fun `ROOT hasMobEffect returns true`() {
         val h = buildSystem()
-        h.spawnMob()
+        h.spawnMob(id = mobId, name = "Goblin")
         h.registerRoot(durationMs = 4000)
 
         h.system.applyToMob(mobId, StatusEffectId("frost_grip"))
@@ -468,7 +449,7 @@ class StatusEffectSystemTest {
     @Test
     fun `onMobRemoved clears effects`() {
         val h = buildSystem()
-        h.spawnMob()
+        h.spawnMob(id = mobId, name = "Goblin")
         h.registerRoot(durationMs = 5000)
         h.system.applyToMob(mobId, StatusEffectId("frost_grip"))
 
@@ -515,7 +496,7 @@ class StatusEffectSystemTest {
         runTest {
             val h = buildSystem()
             h.loginPlayer()
-            val mob = h.spawnMob(hp = 3)
+            val mob = h.spawnMob(id = mobId, name = "Goblin", hp = 3)
             h.registerDot(durationMs = 6000, tickIntervalMs = 2000, minVal = 5, maxVal = 5)
 
             h.system.applyToMob(mobId, StatusEffectId("ignite"), sid)
@@ -547,7 +528,7 @@ class StatusEffectSystemTest {
     @Test
     fun `activeMobEffects returns correct snapshot`() {
         val h = buildSystem()
-        h.spawnMob()
+        h.spawnMob(id = mobId, name = "Goblin")
         h.registerRoot(durationMs = 4000)
         h.system.applyToMob(mobId, StatusEffectId("frost_grip"))
 

--- a/src/test/kotlin/dev/ambon/test/AbilityTestFixture.kt
+++ b/src/test/kotlin/dev/ambon/test/AbilityTestFixture.kt
@@ -1,10 +1,7 @@
 package dev.ambon.test
 
 import dev.ambon.bus.LocalOutboundBus
-import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
-import dev.ambon.domain.ids.SessionId
-import dev.ambon.domain.mob.MobState
 import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.CombatSystemConfig
 import dev.ambon.engine.DirtyNotifier
@@ -18,15 +15,15 @@ import dev.ambon.persistence.InMemoryPlayerRepository
 import java.util.Random
 
 class AbilityTestFixture(
-    val roomId: RoomId = RoomId("zone:room"),
+    override val roomId: RoomId = RoomId("zone:room"),
     val clock: MutableClock = MutableClock(0L),
     val rng: Random = Random(42),
     val items: ItemRegistry = ItemRegistry(),
     val repo: InMemoryPlayerRepository = InMemoryPlayerRepository(),
-    val players: PlayerRegistry = buildTestPlayerRegistry(roomId, repo, items, clock = clock),
-    val mobs: MobRegistry = MobRegistry(),
+    override val players: PlayerRegistry = buildTestPlayerRegistry(roomId, repo, items, clock = clock),
+    override val mobs: MobRegistry = MobRegistry(),
     val outbound: LocalOutboundBus = LocalOutboundBus(),
-) {
+) : TestFixtureBase {
     val combat: CombatSystem =
         CombatSystem(
             players = players,
@@ -55,35 +52,4 @@ class AbilityTestFixture(
             dirtyNotifier = dirtyNotifier,
             mobs = mobsForAbility ?: mobs,
         )
-
-    suspend fun loginPlayer(
-        sessionId: SessionId,
-        name: String,
-        password: String = "password",
-    ) {
-        players.loginOrFail(sessionId, name, password)
-    }
-
-    fun spawnMob(
-        id: MobId,
-        name: String,
-        hp: Int = 20,
-        maxHp: Int = hp,
-        minDamage: Int = 1,
-        maxDamage: Int = 4,
-        roomId: RoomId = this.roomId,
-    ): MobState {
-        val mob =
-            MobState(
-                id = id,
-                name = name,
-                roomId = roomId,
-                hp = hp,
-                maxHp = maxHp,
-                minDamage = minDamage,
-                maxDamage = maxDamage,
-            )
-        mobs.upsert(mob)
-        return mob
-    }
 }

--- a/src/test/kotlin/dev/ambon/test/CombatTestFixture.kt
+++ b/src/test/kotlin/dev/ambon/test/CombatTestFixture.kt
@@ -5,7 +5,6 @@ import dev.ambon.bus.OutboundBus
 import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
-import dev.ambon.domain.mob.MobState
 import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.CombatSystemCallbacks
 import dev.ambon.engine.CombatSystemConfig
@@ -22,14 +21,14 @@ import java.time.Clock
 import java.util.Random
 
 class CombatTestFixture(
-    val roomId: RoomId = RoomId("zone:room"),
+    override val roomId: RoomId = RoomId("zone:room"),
     val clock: MutableClock = MutableClock(0L),
     val items: ItemRegistry = ItemRegistry(),
     val repo: InMemoryPlayerRepository = InMemoryPlayerRepository(),
-    val players: PlayerRegistry = buildTestPlayerRegistry(roomId, repo, items, clock = clock),
-    val mobs: MobRegistry = MobRegistry(),
+    override val players: PlayerRegistry = buildTestPlayerRegistry(roomId, repo, items, clock = clock),
+    override val mobs: MobRegistry = MobRegistry(),
     val outbound: LocalOutboundBus = LocalOutboundBus(),
-) {
+) : TestFixtureBase {
     fun buildCombat(
         players: PlayerRegistry = this.players,
         mobs: MobRegistry = this.mobs,
@@ -92,43 +91,4 @@ class CombatTestFixture(
                 onRoomItemsChanged = onRoomItemsChanged,
             ),
         )
-
-    suspend fun loginPlayer(
-        sessionId: SessionId,
-        name: String,
-        password: String = "password",
-    ) {
-        players.loginOrFail(sessionId, name, password)
-    }
-
-    fun spawnMob(
-        id: MobId,
-        name: String,
-        hp: Int = 10,
-        maxHp: Int = hp,
-        minDamage: Int = 1,
-        maxDamage: Int = 4,
-        armor: Int = 0,
-        xpReward: Long = 30L,
-        goldMin: Long = 0L,
-        goldMax: Long = 0L,
-        roomId: RoomId = this.roomId,
-    ): MobState {
-        val mob =
-            MobState(
-                id = id,
-                name = name,
-                roomId = roomId,
-                hp = hp,
-                maxHp = maxHp,
-                minDamage = minDamage,
-                maxDamage = maxDamage,
-                armor = armor,
-                xpReward = xpReward,
-                goldMin = goldMin,
-                goldMax = goldMax,
-            )
-        mobs.upsert(mob)
-        return mob
-    }
 }

--- a/src/test/kotlin/dev/ambon/test/StatusEffectTestFixture.kt
+++ b/src/test/kotlin/dev/ambon/test/StatusEffectTestFixture.kt
@@ -4,7 +4,6 @@ import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
-import dev.ambon.domain.mob.MobState
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.items.ItemRegistry
@@ -14,15 +13,15 @@ import dev.ambon.persistence.InMemoryPlayerRepository
 import java.util.Random
 
 class StatusEffectTestFixture(
-    val roomId: RoomId = RoomId("zone:room"),
+    override val roomId: RoomId = RoomId("zone:room"),
     val clock: MutableClock = MutableClock(0L),
     val rng: Random = Random(42),
     val items: ItemRegistry = ItemRegistry(),
     val repo: InMemoryPlayerRepository = InMemoryPlayerRepository(),
-    val players: PlayerRegistry = buildTestPlayerRegistry(roomId, repo, items, clock = clock),
-    val mobs: MobRegistry = MobRegistry(),
+    override val players: PlayerRegistry = buildTestPlayerRegistry(roomId, repo, items, clock = clock),
+    override val mobs: MobRegistry = MobRegistry(),
     val outbound: LocalOutboundBus = LocalOutboundBus(),
-) {
+) : TestFixtureBase {
     val registry = StatusEffectRegistry()
     val vitalsDirty = mutableListOf<SessionId>()
     val mobHpDirty = mutableListOf<MobId>()
@@ -52,37 +51,4 @@ class StatusEffectTestFixture(
             rng = rng,
             dirtyNotifier = dirtyNotifier,
         )
-
-    suspend fun loginPlayer(
-        sessionId: SessionId,
-        name: String,
-        password: String = "password",
-        defaultAnsiEnabled: Boolean = false,
-    ) {
-        val result = players.login(sessionId, name, password, defaultAnsiEnabled)
-        check(result == dev.ambon.engine.LoginResult.Ok) { "Login failed: $result" }
-    }
-
-    fun spawnMob(
-        id: MobId,
-        name: String,
-        hp: Int = 50,
-        maxHp: Int = hp,
-        minDamage: Int = 1,
-        maxDamage: Int = 2,
-        roomId: RoomId = this.roomId,
-    ): MobState {
-        val mob =
-            MobState(
-                id = id,
-                name = name,
-                roomId = roomId,
-                hp = hp,
-                maxHp = maxHp,
-                minDamage = minDamage,
-                maxDamage = maxDamage,
-            )
-        mobs.upsert(mob)
-        return mob
-    }
 }

--- a/src/test/kotlin/dev/ambon/test/TestFixtureBase.kt
+++ b/src/test/kotlin/dev/ambon/test/TestFixtureBase.kt
@@ -1,0 +1,53 @@
+package dev.ambon.test
+
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.mob.MobState
+import dev.ambon.engine.MobRegistry
+import dev.ambon.engine.PlayerRegistry
+
+interface TestFixtureBase {
+    val players: PlayerRegistry
+    val mobs: MobRegistry
+    val roomId: RoomId
+
+    suspend fun loginPlayer(
+        sessionId: SessionId,
+        name: String,
+        password: String = "password",
+    ) {
+        players.loginOrFail(sessionId, name, password)
+    }
+
+    fun spawnMob(
+        id: MobId,
+        name: String,
+        hp: Int = 10,
+        maxHp: Int = hp,
+        minDamage: Int = 1,
+        maxDamage: Int = 4,
+        armor: Int = 0,
+        xpReward: Long = 30L,
+        goldMin: Long = 0L,
+        goldMax: Long = 0L,
+        roomId: RoomId = this.roomId,
+    ): MobState {
+        val mob =
+            MobState(
+                id = id,
+                name = name,
+                roomId = roomId,
+                hp = hp,
+                maxHp = maxHp,
+                minDamage = minDamage,
+                maxDamage = maxDamage,
+                armor = armor,
+                xpReward = xpReward,
+                goldMin = goldMin,
+                goldMax = goldMax,
+            )
+        mobs.upsert(mob)
+        return mob
+    }
+}


### PR DESCRIPTION
## Summary\n\nCloses #359.\n\n- Extracts a shared `TestFixtureBase` interface with default `loginPlayer()` and `spawnMob()` implementations\n- `CombatTestFixture`, `AbilityTestFixture`, and `StatusEffectTestFixture` now implement `TestFixtureBase`, removing their individual duplicate methods\n- `StatusEffectTestFixture.loginPlayer` now uses `loginOrFail()` (consistent with the other fixtures) instead of calling `players.login()` directly\n- Removes the inline `spawnMob` extension in `StatusEffectSystemTest` that shadowed the fixture method, updating 5 call sites to use the inherited method\n- Net: +70 / -144 lines (~130 lines of duplication eliminated)\n\n## Test plan\n\n- [x] `./gradlew ktlintCheck test` passes (all tests green, no lint violations)"