### PR TITLE
refactor: split RedisZoneRegistry into Classic/Instanced strategy classes

### DIFF
--- a/src/main/kotlin/dev/ambon/MudServer.kt
+++ b/src/main/kotlin/dev/ambon/MudServer.kt
@@ -37,9 +37,11 @@ import dev.ambon.persistence.YamlWorldStateRepository
 import dev.ambon.redis.RedisConnectionManager
 import dev.ambon.redis.redisObjectMapper
 import dev.ambon.session.AtomicSessionIdFactory
+import dev.ambon.sharding.ClassicRedisZoneRegistry
 import dev.ambon.sharding.EngineAddress
 import dev.ambon.sharding.HandoffManager
 import dev.ambon.sharding.InstanceSelector
+import dev.ambon.sharding.InstancedRedisZoneRegistry
 import dev.ambon.sharding.InterEngineBus
 import dev.ambon.sharding.LoadBalancedInstanceSelector
 import dev.ambon.sharding.LocalInterEngineBus
@@ -48,7 +50,6 @@ import dev.ambon.sharding.PlayerLocationIndex
 import dev.ambon.sharding.RedisInterEngineBus
 import dev.ambon.sharding.RedisPlayerLocationIndex
 import dev.ambon.sharding.RedisScaleDecisionPublisher
-import dev.ambon.sharding.RedisZoneRegistry
 import dev.ambon.sharding.ScaleDecisionPublisher
 import dev.ambon.sharding.StaticZoneRegistry
 import dev.ambon.sharding.ThresholdInstanceScaler
@@ -245,13 +246,20 @@ class MudServer(
                         requireNotNull(redisManager) {
                             "Sharding registry type REDIS requires ambonMUD.redis.enabled=true"
                         }
-                    RedisZoneRegistry(
-                        redis = manager,
-                        mapper = redisObjectMapper,
-                        leaseTtlSeconds = config.sharding.registry.leaseTtlSeconds,
-                        instancing = config.sharding.instancing.enabled,
-                        defaultCapacity = config.sharding.instancing.defaultCapacity,
-                    )
+                    if (config.sharding.instancing.enabled) {
+                        InstancedRedisZoneRegistry(
+                            redis = manager,
+                            mapper = redisObjectMapper,
+                            leaseTtlSeconds = config.sharding.registry.leaseTtlSeconds,
+                            defaultCapacity = config.sharding.instancing.defaultCapacity,
+                        )
+                    } else {
+                        ClassicRedisZoneRegistry(
+                            redis = manager,
+                            mapper = redisObjectMapper,
+                            leaseTtlSeconds = config.sharding.registry.leaseTtlSeconds,
+                        )
+                    }
                 }
 
                 ShardingRegistryType.STATIC -> {

--- a/src/main/kotlin/dev/ambon/gateway/GatewayServer.kt
+++ b/src/main/kotlin/dev/ambon/gateway/GatewayServer.kt
@@ -22,8 +22,8 @@ import dev.ambon.session.GatewayIdLeaseManager
 import dev.ambon.session.SessionIdFactory
 import dev.ambon.session.SnowflakeSessionIdFactory
 import dev.ambon.sharding.InstanceSelector
+import dev.ambon.sharding.InstancedRedisZoneRegistry
 import dev.ambon.sharding.LoadBalancedInstanceSelector
-import dev.ambon.sharding.RedisZoneRegistry
 import dev.ambon.transport.BlockingSocketTransport
 import dev.ambon.transport.KtorWebSocketTransport
 import dev.ambon.transport.OutboundRouter
@@ -269,11 +269,10 @@ class GatewayServer(
         if (!config.sharding.instancing.enabled) return null
         val rm = redisManager ?: return null
         val registry =
-            RedisZoneRegistry(
+            InstancedRedisZoneRegistry(
                 redis = rm,
                 mapper = redisObjectMapper,
                 leaseTtlSeconds = config.sharding.registry.leaseTtlSeconds,
-                instancing = true,
                 defaultCapacity = config.sharding.instancing.defaultCapacity,
             )
         return LoadBalancedInstanceSelector(registry)

--- a/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
+++ b/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
@@ -28,9 +28,11 @@ import dev.ambon.persistence.WriteCoalescingPlayerRepository
 import dev.ambon.persistence.YamlPlayerRepository
 import dev.ambon.redis.RedisConnectionManager
 import dev.ambon.redis.redisObjectMapper
+import dev.ambon.sharding.ClassicRedisZoneRegistry
 import dev.ambon.sharding.EngineAddress
 import dev.ambon.sharding.HandoffManager
 import dev.ambon.sharding.InstanceSelector
+import dev.ambon.sharding.InstancedRedisZoneRegistry
 import dev.ambon.sharding.InterEngineBus
 import dev.ambon.sharding.LoadBalancedInstanceSelector
 import dev.ambon.sharding.LocalInterEngineBus
@@ -39,7 +41,6 @@ import dev.ambon.sharding.PlayerLocationIndex
 import dev.ambon.sharding.RedisInterEngineBus
 import dev.ambon.sharding.RedisPlayerLocationIndex
 import dev.ambon.sharding.RedisScaleDecisionPublisher
-import dev.ambon.sharding.RedisZoneRegistry
 import dev.ambon.sharding.ScaleDecisionPublisher
 import dev.ambon.sharding.StaticZoneRegistry
 import dev.ambon.sharding.ThresholdInstanceScaler
@@ -209,13 +210,20 @@ class EngineServer(
                         requireNotNull(redisManager) {
                             "Sharding registry type REDIS requires ambonMUD.redis.enabled=true"
                         }
-                    RedisZoneRegistry(
-                        redis = manager,
-                        mapper = redisObjectMapper,
-                        leaseTtlSeconds = config.sharding.registry.leaseTtlSeconds,
-                        instancing = config.sharding.instancing.enabled,
-                        defaultCapacity = config.sharding.instancing.defaultCapacity,
-                    )
+                    if (config.sharding.instancing.enabled) {
+                        InstancedRedisZoneRegistry(
+                            redis = manager,
+                            mapper = redisObjectMapper,
+                            leaseTtlSeconds = config.sharding.registry.leaseTtlSeconds,
+                            defaultCapacity = config.sharding.instancing.defaultCapacity,
+                        )
+                    } else {
+                        ClassicRedisZoneRegistry(
+                            redis = manager,
+                            mapper = redisObjectMapper,
+                            leaseTtlSeconds = config.sharding.registry.leaseTtlSeconds,
+                        )
+                    }
                 }
 
                 ShardingRegistryType.STATIC -> {

--- a/src/main/kotlin/dev/ambon/sharding/ClassicRedisZoneRegistry.kt
+++ b/src/main/kotlin/dev/ambon/sharding/ClassicRedisZoneRegistry.kt
@@ -1,0 +1,89 @@
+package dev.ambon.sharding
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import dev.ambon.redis.RedisConnectionManager
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Zone registry backed by Redis keys with TTL, classic (non-instanced) mode.
+ * Each zone maps to exactly one engine via a simple key-value pair.
+ *
+ * Redis key scheme:
+ * - `zone:owner:<zone>` → JSON [EngineAddress] (TTL = leaseTtlSeconds)
+ */
+class ClassicRedisZoneRegistry(
+    private val redis: RedisConnectionManager,
+    private val mapper: ObjectMapper,
+    private val leaseTtlSeconds: Long = 30L,
+    private val keyPrefix: String = "zone:owner:",
+) : ZoneRegistry {
+    override fun ownerOf(zone: String): EngineAddress? {
+        val json = redis.get("$keyPrefix$zone") ?: return null
+        return try {
+            mapper.readValue<EngineAddress>(json)
+        } catch (e: Exception) {
+            log.warn(e) { "Failed to deserialize zone owner for '$zone'" }
+            null
+        }
+    }
+
+    override fun claimZones(
+        engineId: String,
+        address: EngineAddress,
+        zones: Set<String>,
+    ) {
+        val json = mapper.writeValueAsString(address)
+        for (zone in zones) {
+            redis.setEx("$keyPrefix$zone", leaseTtlSeconds, json)
+        }
+        log.info { "Engine '$engineId' claimed zones: $zones (TTL=${leaseTtlSeconds}s)" }
+    }
+
+    override fun renewLease(engineId: String) {
+        val commands = redis.commands ?: return
+        val cursor =
+            commands.scan(
+                io.lettuce.core.ScanArgs.Builder
+                    .matches("$keyPrefix*")
+                    .limit(100),
+            )
+        for (key in cursor.keys) {
+            val json = commands.get(key) ?: continue
+            val addr =
+                try {
+                    mapper.readValue<EngineAddress>(json)
+                } catch (_: Exception) {
+                    continue
+                }
+            if (addr.engineId == engineId) {
+                commands.expire(key, leaseTtlSeconds)
+            }
+        }
+    }
+
+    override fun allAssignments(): Map<String, EngineAddress> {
+        val commands = redis.commands ?: return emptyMap()
+        val result = mutableMapOf<String, EngineAddress>()
+        val cursor =
+            commands.scan(
+                io.lettuce.core.ScanArgs.Builder
+                    .matches("$keyPrefix*")
+                    .limit(1000),
+            )
+        for (key in cursor.keys) {
+            val zone = key.removePrefix(keyPrefix)
+            val json = commands.get(key) ?: continue
+            val addr =
+                try {
+                    mapper.readValue<EngineAddress>(json)
+                } catch (_: Exception) {
+                    continue
+                }
+            result[zone] = addr
+        }
+        return result
+    }
+}

--- a/src/main/kotlin/dev/ambon/sharding/InstancedRedisZoneRegistry.kt
+++ b/src/main/kotlin/dev/ambon/sharding/InstancedRedisZoneRegistry.kt
@@ -8,70 +8,27 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 private val log = KotlinLogging.logger {}
 
 /**
- * Zone registry backed by Redis keys with TTL. Each engine writes its zone
- * claims as Redis keys and refreshes them periodically. If an engine dies,
- * its leases expire after [leaseTtlSeconds].
+ * Zone registry backed by Redis hashes with per-engine lease keys, instanced mode.
+ * Multiple engines may claim the same zone; each (zone, engineId) pair is a
+ * distinct [ZoneInstance] with its own player count and capacity.
  *
- * When [instancing] is `true`, multiple engines may claim the same zone.
- * Instance data (including player counts) is stored in Redis hashes keyed
- * by zone, with one field per engine.
- *
- * Redis key scheme (classic, non-instanced):
- * - `zone:owner:<zone>` → JSON [EngineAddress] (TTL = leaseTtlSeconds)
- *
- * Redis key scheme (instanced):
+ * Redis key scheme:
  * - `zone:instances:<zone>` → HASH { engineId → JSON [ZoneInstance] }
  * - `zone:lease:<zone>:<engineId>` → "1" (TTL = leaseTtlSeconds)
  */
-class RedisZoneRegistry(
+class InstancedRedisZoneRegistry(
     private val redis: RedisConnectionManager,
     private val mapper: ObjectMapper,
     private val leaseTtlSeconds: Long = 30L,
-    private val keyPrefix: String = "zone:owner:",
-    private val instancing: Boolean = false,
     private val defaultCapacity: Int = ZoneInstance.DEFAULT_CAPACITY,
 ) : ZoneRegistry {
     private val instanceHashPrefix = "zone:instances:"
     private val leasePrefix = "zone:lease:"
 
-    override fun ownerOf(zone: String): EngineAddress? {
-        if (instancing) {
-            return instancesOf(zone).firstOrNull()?.address
-        }
-        val json = redis.get("$keyPrefix$zone") ?: return null
-        return try {
-            mapper.readValue<EngineAddress>(json)
-        } catch (e: Exception) {
-            log.warn(e) { "Failed to deserialize zone owner for '$zone'" }
-            null
-        }
-    }
+    override fun ownerOf(zone: String): EngineAddress? =
+        instancesOf(zone).firstOrNull()?.address
 
     override fun claimZones(
-        engineId: String,
-        address: EngineAddress,
-        zones: Set<String>,
-    ) {
-        if (instancing) {
-            claimZonesInstanced(engineId, address, zones)
-        } else {
-            claimZonesClassic(engineId, address, zones)
-        }
-    }
-
-    private fun claimZonesClassic(
-        engineId: String,
-        address: EngineAddress,
-        zones: Set<String>,
-    ) {
-        val json = mapper.writeValueAsString(address)
-        for (zone in zones) {
-            redis.setEx("$keyPrefix$zone", leaseTtlSeconds, json)
-        }
-        log.info { "Engine '$engineId' claimed zones: $zones (TTL=${leaseTtlSeconds}s)" }
-    }
-
-    private fun claimZonesInstanced(
         engineId: String,
         address: EngineAddress,
         zones: Set<String>,
@@ -94,41 +51,6 @@ class RedisZoneRegistry(
 
     override fun renewLease(engineId: String) {
         val commands = redis.commands ?: return
-        if (instancing) {
-            renewLeaseInstanced(engineId, commands)
-        } else {
-            renewLeaseClassic(engineId, commands)
-        }
-    }
-
-    private fun renewLeaseClassic(
-        engineId: String,
-        commands: io.lettuce.core.api.sync.RedisCommands<String, String>,
-    ) {
-        val cursor =
-            commands.scan(
-                io.lettuce.core.ScanArgs.Builder
-                    .matches("$keyPrefix*")
-                    .limit(100),
-            )
-        for (key in cursor.keys) {
-            val json = commands.get(key) ?: continue
-            val addr =
-                try {
-                    mapper.readValue<EngineAddress>(json)
-                } catch (_: Exception) {
-                    continue
-                }
-            if (addr.engineId == engineId) {
-                commands.expire(key, leaseTtlSeconds)
-            }
-        }
-    }
-
-    private fun renewLeaseInstanced(
-        engineId: String,
-        commands: io.lettuce.core.api.sync.RedisCommands<String, String>,
-    ) {
         val cursor =
             commands.scan(
                 io.lettuce.core.ScanArgs.Builder
@@ -141,36 +63,6 @@ class RedisZoneRegistry(
     }
 
     override fun allAssignments(): Map<String, EngineAddress> {
-        if (instancing) {
-            return allAssignmentsInstanced()
-        }
-        return allAssignmentsClassic()
-    }
-
-    private fun allAssignmentsClassic(): Map<String, EngineAddress> {
-        val commands = redis.commands ?: return emptyMap()
-        val result = mutableMapOf<String, EngineAddress>()
-        val cursor =
-            commands.scan(
-                io.lettuce.core.ScanArgs.Builder
-                    .matches("$keyPrefix*")
-                    .limit(1000),
-            )
-        for (key in cursor.keys) {
-            val zone = key.removePrefix(keyPrefix)
-            val json = commands.get(key) ?: continue
-            val addr =
-                try {
-                    mapper.readValue<EngineAddress>(json)
-                } catch (_: Exception) {
-                    continue
-                }
-            result[zone] = addr
-        }
-        return result
-    }
-
-    private fun allAssignmentsInstanced(): Map<String, EngineAddress> {
         val commands = redis.commands ?: return emptyMap()
         val result = mutableMapOf<String, EngineAddress>()
         val cursor =
@@ -183,7 +75,6 @@ class RedisZoneRegistry(
             val zone = key.removePrefix(instanceHashPrefix)
             val entries = commands.hgetall(key) ?: continue
             for ((engineId, json) in entries.toSortedMap()) {
-                // Only include if lease is still alive
                 val leaseKey = "$leasePrefix$zone:$engineId"
                 if (commands.exists(leaseKey) > 0) {
                     val instance =
@@ -192,7 +83,6 @@ class RedisZoneRegistry(
                         } catch (_: Exception) {
                             continue
                         }
-                    // First live instance wins for allAssignments (1:1 compat)
                     result.putIfAbsent(zone, instance.address)
                 }
             }
@@ -201,13 +91,6 @@ class RedisZoneRegistry(
     }
 
     override fun instancesOf(zone: String): List<ZoneInstance> {
-        if (!instancing) {
-            return listOfNotNull(
-                ownerOf(zone)?.let {
-                    ZoneInstance(engineId = it.engineId, address = it, zone = zone)
-                },
-            )
-        }
         val commands = redis.commands ?: return emptyList()
         val entries = commands.hgetall("$instanceHashPrefix$zone") ?: return emptyList()
         return entries
@@ -226,7 +109,6 @@ class RedisZoneRegistry(
         engineId: String,
         zoneCounts: Map<String, Int>,
     ) {
-        if (!instancing) return
         val commands = redis.commands ?: return
         for ((zone, count) in zoneCounts) {
             val hashKey = "$instanceHashPrefix$zone"
@@ -242,5 +124,5 @@ class RedisZoneRegistry(
         }
     }
 
-    override fun instancingEnabled(): Boolean = instancing
+    override fun instancingEnabled(): Boolean = true
 }


### PR DESCRIPTION
## Summary

Closes #370.

- Replaces `RedisZoneRegistry` (which branched on `instancing` in every public method) with two focused strategy classes:
  - **`ClassicRedisZoneRegistry`**: simple key-value zone ownership (`zone:owner:<zone>` → `EngineAddress`)
  - **`InstancedRedisZoneRegistry`**: hash-based multi-engine zone instances with per-engine lease keys
- Both implement `ZoneRegistry`; the composition roots (`MudServer`, `EngineServer`, `GatewayServer`) select the right class at construction time based on `config.sharding.instancing.enabled`
- `ClassicRedisZoneRegistry` relies on `ZoneRegistry` interface defaults for `instancesOf`, `reportLoad`, and `instancingEnabled` — no need to override
- Eliminates 6 `if (instancing)` runtime branches and the cognitive overhead of interleaved classic/instanced logic

## Test plan

- [x] `ktlintCheck` passes
- [x] Full test suite passes