### PR TITLE
refactor: extract GMCP item-sync and handler context helpers

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/CommunicationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/CommunicationHandler.kt
@@ -106,20 +106,13 @@ class CommunicationHandler(
         cmd: Command.Whisper,
     ) {
         players.withPlayer(sessionId) { me ->
-            val targetSid = players.findSessionByName(cmd.target)
-            if (targetSid == null) {
-                outbound.send(OutboundEvent.SendError(sessionId, "No such player: ${cmd.target}"))
-                return
-            }
+            val targetSid = requirePlayerOnline(sessionId, cmd.target, players, outbound) ?: return
             if (targetSid == sessionId) {
                 outbound.send(OutboundEvent.SendInfo(sessionId, "You whisper to yourself: ${cmd.message}"))
                 return
             }
             players.withPlayer(targetSid) { target ->
-                if (target.roomId != me.roomId) {
-                    outbound.send(OutboundEvent.SendError(sessionId, "${target.name} is not here."))
-                    return
-                }
+                if (!requireSameRoom(sessionId, me, target, outbound)) return
                 outbound.send(OutboundEvent.SendText(sessionId, "You whisper to ${target.name}: ${cmd.message}"))
                 outbound.send(OutboundEvent.SendText(targetSid, "${me.name} whispers to you: ${cmd.message}"))
                 gmcpEmitter?.sendCommChannel(sessionId, "whisper", me.name, cmd.message)

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -10,6 +10,7 @@ import dev.ambon.domain.world.LockableState
 import dev.ambon.domain.world.Room
 import dev.ambon.domain.world.RoomFeature
 import dev.ambon.domain.world.World
+import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.GmcpEmitter
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PlayerRegistry
@@ -31,6 +32,57 @@ internal inline fun PlayerRegistry.withPlayer(
 ) {
     val player = get(sessionId) ?: return
     block(player)
+}
+
+/** Sends the full GMCP Char.Items list (inventory + equipment) for [sessionId]. */
+internal suspend fun syncItemsGmcp(
+    sessionId: SessionId,
+    items: ItemRegistry,
+    gmcpEmitter: GmcpEmitter?,
+) {
+    gmcpEmitter?.sendCharItemsList(sessionId, items.inventory(sessionId), items.equipment(sessionId))
+}
+
+/** Syncs player defense stats and sends the GMCP items list after an equip/unequip change. */
+internal suspend fun afterEquipChange(
+    sessionId: SessionId,
+    combat: CombatSystem,
+    items: ItemRegistry,
+    gmcpEmitter: GmcpEmitter?,
+) {
+    combat.syncPlayerDefense(sessionId)
+    syncItemsGmcp(sessionId, items, gmcpEmitter)
+}
+
+/**
+ * Finds an online player by [name], or sends "No such player" and returns null.
+ * Callers can use non-local return from the enclosing inline [PlayerRegistry.withPlayer].
+ */
+internal suspend fun requirePlayerOnline(
+    sessionId: SessionId,
+    name: String,
+    players: PlayerRegistry,
+    outbound: OutboundBus,
+): SessionId? {
+    val targetSid = players.findSessionByName(name)
+    if (targetSid == null) {
+        outbound.send(OutboundEvent.SendError(sessionId, "No such player: $name"))
+    }
+    return targetSid
+}
+
+/** Checks that [target] is in the same room as [me]; sends an error and returns false otherwise. */
+internal suspend fun requireSameRoom(
+    sessionId: SessionId,
+    me: PlayerState,
+    target: PlayerState,
+    outbound: OutboundBus,
+): Boolean {
+    if (target.roomId != me.roomId) {
+        outbound.send(OutboundEvent.SendError(sessionId, "${target.name} is not here."))
+        return false
+    }
+    return true
 }
 
 /** Sends a full room description (title, description, exits, items, players, mobs) to [sessionId]. */

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ItemHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ItemHandler.kt
@@ -82,8 +82,7 @@ class ItemHandler(
                             "You wear ${result.item.item.displayName} on your ${result.slot.label()}.",
                         ),
                     )
-                    combat.syncPlayerDefense(sessionId)
-                    gmcpEmitter?.sendCharItemsList(sessionId, items.inventory(sessionId), items.equipment(sessionId))
+                    afterEquipChange(sessionId, combat, items, gmcpEmitter)
                 }
                 is ItemRegistry.EquipResult.NotFound ->
                     outbound.send(OutboundEvent.SendError(sessionId, "You aren't carrying '${cmd.keyword}'."))
@@ -113,8 +112,7 @@ class ItemHandler(
                             "You remove ${result.item.item.displayName} from your ${result.slot.label()}.",
                         ),
                     )
-                    combat.syncPlayerDefense(sessionId)
-                    gmcpEmitter?.sendCharItemsList(sessionId, items.inventory(sessionId), items.equipment(sessionId))
+                    afterEquipChange(sessionId, combat, items, gmcpEmitter)
                 }
                 is ItemRegistry.UnequipResult.SlotEmpty ->
                     outbound.send(
@@ -194,7 +192,7 @@ class ItemHandler(
                         if (result.location == ItemRegistry.HeldItemLocation.EQUIPPED) {
                             combat.syncPlayerDefense(sessionId)
                         }
-                        gmcpEmitter?.sendCharItemsList(sessionId, items.inventory(me.sessionId), items.equipment(me.sessionId))
+                        syncItemsGmcp(sessionId, items, gmcpEmitter)
                     } else if (result.remainingCharges != null) {
                         outbound.send(
                             OutboundEvent.SendInfo(
@@ -224,20 +222,13 @@ class ItemHandler(
         cmd: Command.Give,
     ) {
         players.withPlayer(sessionId) { me ->
-            val targetSid = players.findSessionByName(cmd.playerName)
-            if (targetSid == null) {
-                outbound.send(OutboundEvent.SendError(sessionId, "No such player: ${cmd.playerName}"))
-                return
-            }
+            val targetSid = requirePlayerOnline(sessionId, cmd.playerName, players, outbound) ?: return
             if (targetSid == sessionId) {
                 outbound.send(OutboundEvent.SendError(sessionId, "You cannot give items to yourself."))
                 return
             }
             players.withPlayer(targetSid) { target ->
-                if (target.roomId != me.roomId) {
-                    outbound.send(OutboundEvent.SendError(sessionId, "${target.name} is not here."))
-                    return
-                }
+                if (!requireSameRoom(sessionId, me, target, outbound)) return
                 when (val result = items.giveToPlayer(me.sessionId, targetSid, cmd.keyword)) {
                     is ItemRegistry.GiveResult.Given -> {
                         if (result.location == ItemRegistry.HeldItemLocation.EQUIPPED) {

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ShopHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ShopHandler.kt
@@ -93,7 +93,7 @@ class ShopHandler(
             items.addToInventory(sessionId, newItem)
             markVitalsDirty(sessionId)
             outbound.send(OutboundEvent.SendText(sessionId, "You buy ${item.displayName} for $buyPrice gold."))
-            gmcpEmitter?.sendCharItemsList(sessionId, items.inventory(sessionId), items.equipment(sessionId))
+            syncItemsGmcp(sessionId, items, gmcpEmitter)
         }
     }
 
@@ -128,7 +128,7 @@ class ShopHandler(
             me.gold += sellPrice
             markVitalsDirty(sessionId)
             outbound.send(OutboundEvent.SendText(sessionId, "You sell ${removed.item.displayName} for $sellPrice gold."))
-            gmcpEmitter?.sendCharItemsList(sessionId, items.inventory(sessionId), items.equipment(sessionId))
+            syncItemsGmcp(sessionId, items, gmcpEmitter)
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `syncItemsGmcp()` helper — wraps the repeated `gmcpEmitter?.sendCharItemsList(sessionId, items.inventory(sessionId), items.equipment(sessionId))` call (5 sites across ItemHandler and ShopHandler)
- Add `afterEquipChange()` helper — combines `combat.syncPlayerDefense` + `syncItemsGmcp` for equip/unequip changes (2 sites in ItemHandler)
- Add `requirePlayerOnline()` helper — `findSessionByName` + "No such player" error guard (2 sites: CommunicationHandler whisper, ItemHandler give)
- Add `requireSameRoom()` helper — same-room check with error message (2 sites: CommunicationHandler whisper, ItemHandler give)

Closes #371

## Test plan

- [x] `ktlintCheck` passes
- [x] Full test suite passes (all existing handler tests cover these code paths)