### PR TITLE
refactor: extract collectUntil utility for engine integration tests

### DIFF
--- a/src/test/kotlin/dev/ambon/engine/GameEngineIntegrationTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GameEngineIntegrationTest.kt
@@ -9,13 +9,13 @@ import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.engine.scheduler.Scheduler
 import dev.ambon.persistence.InMemoryPlayerRepository
 import dev.ambon.test.MutableClock
+import dev.ambon.test.collectUntil
 import dev.ambon.test.drainAll
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Tag
@@ -74,12 +74,8 @@ class GameEngineIntegrationTest {
             runCurrent()
 
             // Collect events deterministically
-            val got = mutableListOf<OutboundEvent>()
-
-            withTimeout(500) {
-                while (got.none { it is OutboundEvent.Close && it.sessionId == sid }) {
-                    got += outbound.asReceiveChannel().receive()
-                }
+            val got = outbound.collectUntil { events ->
+                events.any { it is OutboundEvent.Close && it.sessionId == sid }
             }
 
             assertTrue(got.any { it is OutboundEvent.SendText && it.sessionId == sid }, "Expected SendText; got=$got")
@@ -143,11 +139,8 @@ class GameEngineIntegrationTest {
             advanceTimeBy(5)
             runCurrent()
 
-            val got = mutableListOf<OutboundEvent>()
-            withTimeout(500) {
-                while (got.none { it is OutboundEvent.SendText && it.sessionId == sid1 && it.text == "Bob enters." }) {
-                    got += outbound.asReceiveChannel().receive()
-                }
+            outbound.collectUntil { events ->
+                events.any { it is OutboundEvent.SendText && it.sessionId == sid1 && it.text == "Bob enters." }
             }
 
             inbound.send(InboundEvent.Disconnected(sid2, "test"))
@@ -155,10 +148,8 @@ class GameEngineIntegrationTest {
             advanceTimeBy(5)
             runCurrent()
 
-            withTimeout(500) {
-                while (got.none { it is OutboundEvent.SendText && it.sessionId == sid1 && it.text == "Bob leaves." }) {
-                    got += outbound.asReceiveChannel().receive()
-                }
+            outbound.collectUntil { events ->
+                events.any { it is OutboundEvent.SendText && it.sessionId == sid1 && it.text == "Bob leaves." }
             }
 
             engineJob.cancel()

--- a/src/test/kotlin/dev/ambon/test/EngineTestHelpers.kt
+++ b/src/test/kotlin/dev/ambon/test/EngineTestHelpers.kt
@@ -5,6 +5,7 @@ import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.LoginResult
 import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.events.OutboundEvent
+import kotlinx.coroutines.withTimeout
 
 fun LocalOutboundBus.drainAll(): List<OutboundEvent> {
     val out = mutableListOf<OutboundEvent>()
@@ -13,6 +14,19 @@ fun LocalOutboundBus.drainAll(): List<OutboundEvent> {
         out += ev
     }
     return out
+}
+
+suspend fun LocalOutboundBus.collectUntil(
+    timeoutMs: Long = 500,
+    predicate: (List<OutboundEvent>) -> Boolean,
+): List<OutboundEvent> {
+    val events = mutableListOf<OutboundEvent>()
+    withTimeout(timeoutMs) {
+        while (!predicate(events)) {
+            events += asReceiveChannel().receive()
+        }
+    }
+    return events
 }
 
 suspend fun PlayerRegistry.loginOrFail(


### PR DESCRIPTION
## Summary
- Adds `LocalOutboundBus.collectUntil()` extension to `EngineTestHelpers.kt` — collects events until a predicate is satisfied, with a configurable timeout (default 500ms)
- Replaces 3 repeated `withTimeout` + `mutableListOf` + `while` collect loops in `GameEngineIntegrationTest` with calls to the new utility

Closes #375

## Test plan
- [x] `ktlintCheck` passes
- [x] `integrationTest` passes (all 4 tests in `GameEngineIntegrationTest`)
- [x] Full `test` suite passes