### PR TITLE
refactor: extract GrpcDeliveryPolicy and cancelJobWithTimeout helpers

### DIFF
--- a/src/main/kotlin/dev/ambon/bus/GrpcOutboundBus.kt
+++ b/src/main/kotlin/dev/ambon/bus/GrpcOutboundBus.kt
@@ -2,6 +2,9 @@ package dev.ambon.bus
 
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.grpc.DeliveryOutcome
+import dev.ambon.grpc.cancelJobWithTimeout
+import dev.ambon.grpc.deliverWithBackpressure
 import dev.ambon.grpc.isControlPlane
 import dev.ambon.grpc.toDomain
 import dev.ambon.metrics.GameMetrics
@@ -9,14 +12,11 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.ChannelResult
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
 
 private val log = KotlinLogging.logger {}
 
@@ -72,42 +72,7 @@ class GrpcOutboundBus(
                             log.warn { "Received unrecognised OutboundEventProto from engine: $proto" }
                             return@collect
                         }
-                        val fastPath = delegate.trySend(event)
-                        if (fastPath.isSuccess) {
-                            return@collect
-                        }
-
-                        if (!event.isControlPlane()) {
-                            metrics.onGrpcDataPlaneDrop("gateway_local_queue_full")
-                            when (event) {
-                                is OutboundEvent.SendPrompt ->
-                                    log.debug { "Dropped SendPrompt for session ${event.sessionId} (gateway local queue full)" }
-                                else ->
-                                    log.warn {
-                                        "Dropped ${event::class.simpleName} for session ${event.sessionId} " +
-                                            "(gateway local queue full)"
-                                    }
-                            }
-                            return@collect
-                        }
-
-                        try {
-                            withTimeout(controlPlaneSendTimeoutMs) {
-                                delegate.send(event)
-                            }
-                            metrics.onGrpcControlPlaneFallbackSend()
-                        } catch (_: TimeoutCancellationException) {
-                            metrics.onGrpcControlPlaneDrop("gateway_local_queue_full_timeout")
-                            metrics.onGrpcForcedDisconnectDueToControlDeliveryFailure("gateway_local_queue_full_timeout")
-                            notifyFailure(
-                                GrpcOutboundFailure.ControlPlaneDeliveryFailure(
-                                    sessionId = event.sessionId,
-                                    eventType = event::class.simpleName ?: "UnknownOutboundEvent",
-                                    reason = "gateway_local_queue_full_timeout",
-                                ),
-                            )
-                            return@collect
-                        }
+                        deliverToDelegate(event)
                     }
                     throw IllegalStateException("Engine gRPC outbound stream completed unexpectedly")
                 } catch (e: CancellationException) {
@@ -118,6 +83,44 @@ class GrpcOutboundBus(
                 }
             }
         log.info { "GrpcOutboundBus receiver started" }
+    }
+
+    private suspend fun deliverToDelegate(event: OutboundEvent) {
+        when (
+            val outcome =
+                deliverWithBackpressure(
+                    trySend = { delegate.trySend(event) },
+                    suspendSend = { delegate.send(event) },
+                    isControlPlane = event.isControlPlane(),
+                    controlPlaneSendTimeoutMs = controlPlaneSendTimeoutMs,
+                )
+        ) {
+            DeliveryOutcome.Delivered -> {}
+            DeliveryOutcome.DeliveredWithFallback -> metrics.onGrpcControlPlaneFallbackSend()
+            is DeliveryOutcome.DroppedDataPlane -> {
+                metrics.onGrpcDataPlaneDrop("gateway_local_queue_full")
+                when (event) {
+                    is OutboundEvent.SendPrompt ->
+                        log.debug { "Dropped SendPrompt for session ${event.sessionId} (gateway local queue full)" }
+                    else ->
+                        log.warn {
+                            "Dropped ${event::class.simpleName} for session ${event.sessionId} " +
+                                "(gateway local queue full)"
+                        }
+                }
+            }
+            is DeliveryOutcome.ControlPlaneFailure -> {
+                metrics.onGrpcControlPlaneDrop("gateway_local_queue_full_timeout")
+                metrics.onGrpcForcedDisconnectDueToControlDeliveryFailure("gateway_local_queue_full_timeout")
+                notifyFailure(
+                    GrpcOutboundFailure.ControlPlaneDeliveryFailure(
+                        sessionId = event.sessionId,
+                        eventType = event::class.simpleName ?: "UnknownOutboundEvent",
+                        reason = "gateway_local_queue_full_timeout",
+                    ),
+                )
+            }
+        }
     }
 
     private fun notifyFailure(failure: GrpcOutboundFailure) {
@@ -148,14 +151,7 @@ class GrpcOutboundBus(
     fun isReceiverActive(): Boolean = receiverJob?.isActive == true
 
     fun stopReceiving() {
-        runBlocking {
-            try {
-                withTimeout(STOP_TIMEOUT_MS) { receiverJob?.cancelAndJoin() }
-            } catch (_: TimeoutCancellationException) {
-                log.warn { "GrpcOutboundBus receiver did not stop within ${STOP_TIMEOUT_MS}ms; forcing cancel" }
-                receiverJob?.cancel()
-            }
-        }
+        cancelJobWithTimeout(receiverJob, STOP_TIMEOUT_MS, "GrpcOutboundBus receiver")
     }
 
     override suspend fun send(event: OutboundEvent) = delegate.send(event)

--- a/src/main/kotlin/dev/ambon/grpc/DeliveryOutcome.kt
+++ b/src/main/kotlin/dev/ambon/grpc/DeliveryOutcome.kt
@@ -1,0 +1,76 @@
+package dev.ambon.grpc
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.channels.ChannelResult
+import kotlinx.coroutines.withTimeout
+
+/**
+ * Standardised outcome of attempting to deliver an event through a gRPC-adjacent channel.
+ *
+ * Both the engine-side [GrpcOutboundDispatcher] and the gateway-side `GrpcOutboundBus` use
+ * [deliverWithBackpressure] to get one of these outcomes, then apply their own side-specific
+ * reactions (forced disconnect, failure callback, metrics tagging, etc.).
+ */
+sealed interface DeliveryOutcome {
+    /** Fast-path [trySend] succeeded. */
+    data object Delivered : DeliveryOutcome
+
+    /** Control-plane fallback suspending send succeeded after the fast path failed. */
+    data object DeliveredWithFallback : DeliveryOutcome
+
+    /** Data-plane event could not be enqueued; safe to drop. */
+    data class DroppedDataPlane(
+        val channelClosed: Boolean,
+    ) : DeliveryOutcome
+
+    /** Control-plane event could not be delivered; caller must handle the failure. */
+    data class ControlPlaneFailure(
+        val reason: String,
+    ) : DeliveryOutcome
+}
+
+/**
+ * Shared delivery algorithm for gRPC outbound backpressure.
+ *
+ * 1. Attempts a non-blocking [trySend].
+ * 2. If the channel is full and the event is **data-plane**, returns [DeliveryOutcome.DroppedDataPlane].
+ * 3. If the channel is full and the event is **control-plane**, falls back to a bounded suspending
+ *    [suspendSend] with [controlPlaneSendTimeoutMs]. Returns [DeliveryOutcome.DeliveredWithFallback]
+ *    on success, or [DeliveryOutcome.ControlPlaneFailure] on timeout/close.
+ */
+suspend fun deliverWithBackpressure(
+    trySend: () -> ChannelResult<Unit>,
+    suspendSend: suspend () -> Unit,
+    isControlPlane: Boolean,
+    controlPlaneSendTimeoutMs: Long,
+): DeliveryOutcome {
+    val result = trySend()
+    if (result.isSuccess) return DeliveryOutcome.Delivered
+
+    if (!isControlPlane) {
+        return DeliveryOutcome.DroppedDataPlane(channelClosed = result.isClosed)
+    }
+
+    if (result.isClosed) {
+        return DeliveryOutcome.ControlPlaneFailure("stream_closed")
+    }
+
+    val delivered =
+        try {
+            withTimeout(controlPlaneSendTimeoutMs) { suspendSend() }
+            true
+        } catch (_: TimeoutCancellationException) {
+            false
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            false
+        }
+
+    return if (delivered) {
+        DeliveryOutcome.DeliveredWithFallback
+    } else {
+        DeliveryOutcome.ControlPlaneFailure("stream_full_timeout")
+    }
+}

--- a/src/main/kotlin/dev/ambon/grpc/GrpcLifecycle.kt
+++ b/src/main/kotlin/dev/ambon/grpc/GrpcLifecycle.kt
@@ -1,0 +1,32 @@
+package dev.ambon.grpc
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Cancel a [Job] with a bounded timeout, logging a warning and forcing cancellation if the
+ * graceful path takes too long.
+ *
+ * Used by both [GrpcOutboundDispatcher] and `GrpcOutboundBus` to stop their background
+ * coroutines with consistent semantics.
+ */
+fun cancelJobWithTimeout(
+    job: Job?,
+    timeoutMs: Long,
+    componentName: String,
+) {
+    runBlocking {
+        try {
+            withTimeout(timeoutMs) { job?.cancelAndJoin() }
+        } catch (_: TimeoutCancellationException) {
+            log.warn { "$componentName did not stop within ${timeoutMs}ms; forcing cancel" }
+            job?.cancel()
+        }
+    }
+}

--- a/src/main/kotlin/dev/ambon/grpc/GrpcOutboundDispatcher.kt
+++ b/src/main/kotlin/dev/ambon/grpc/GrpcOutboundDispatcher.kt
@@ -4,14 +4,9 @@ import dev.ambon.bus.OutboundBus
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.metrics.GameMetrics
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
 
 private val log = KotlinLogging.logger {}
 
@@ -48,14 +43,7 @@ class GrpcOutboundDispatcher(
     }
 
     fun stop() {
-        runBlocking {
-            try {
-                withTimeout(STOP_TIMEOUT_MS) { job?.cancelAndJoin() }
-            } catch (_: TimeoutCancellationException) {
-                log.warn { "GrpcOutboundDispatcher job did not stop within ${STOP_TIMEOUT_MS}ms; forcing cancel" }
-                job?.cancel()
-            }
-        }
+        cancelJobWithTimeout(job, STOP_TIMEOUT_MS, "GrpcOutboundDispatcher job")
         log.info { "GrpcOutboundDispatcher stopped" }
     }
 
@@ -72,63 +60,45 @@ class GrpcOutboundDispatcher(
             return
         }
         val proto = event.toProto()
-        val result = streamChannel.trySend(proto)
-        if (result.isSuccess) {
-            return
-        }
-
-        if (!event.isControlPlane()) {
-            if (result.isClosed) {
-                serviceImpl.sessionToStream.remove(sid)
-                metrics.onGrpcDataPlaneDrop("stream_closed")
-                log.info { "Gateway stream for session $sid is closed; removed from routing table" }
-            } else {
-                metrics.onGrpcDataPlaneDrop("stream_full")
-                when (event) {
-                    is OutboundEvent.SendPrompt ->
-                        log.debug { "Dropped SendPrompt for session $sid (gateway stream full)" }
-                    else ->
-                        log.warn { "Gateway stream for session $sid is full; dropped ${event::class.simpleName}" }
-                }
-            }
-            return
-        }
-
-        val controlFailureReason =
-            if (result.isClosed) {
-                "stream_closed"
-            } else {
-                val delivered =
-                    try {
-                        withTimeout(controlPlaneSendTimeoutMs) {
-                            streamChannel.send(proto)
-                        }
-                        true
-                    } catch (_: TimeoutCancellationException) {
-                        false
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (_: Exception) {
-                        false
+        when (
+            val outcome =
+                deliverWithBackpressure(
+                    trySend = { streamChannel.trySend(proto) },
+                    suspendSend = { streamChannel.send(proto) },
+                    isControlPlane = event.isControlPlane(),
+                    controlPlaneSendTimeoutMs = controlPlaneSendTimeoutMs,
+                )
+        ) {
+            DeliveryOutcome.Delivered -> {}
+            DeliveryOutcome.DeliveredWithFallback -> metrics.onGrpcControlPlaneFallbackSend()
+            is DeliveryOutcome.DroppedDataPlane -> {
+                if (outcome.channelClosed) {
+                    serviceImpl.sessionToStream.remove(sid)
+                    metrics.onGrpcDataPlaneDrop("stream_closed")
+                    log.info { "Gateway stream for session $sid is closed; removed from routing table" }
+                } else {
+                    metrics.onGrpcDataPlaneDrop("stream_full")
+                    when (event) {
+                        is OutboundEvent.SendPrompt ->
+                            log.debug { "Dropped SendPrompt for session $sid (gateway stream full)" }
+                        else ->
+                            log.warn { "Gateway stream for session $sid is full; dropped ${event::class.simpleName}" }
                     }
-
-                if (delivered) {
-                    metrics.onGrpcControlPlaneFallbackSend()
-                    return
                 }
-                "stream_full_timeout"
             }
-
-        metrics.onGrpcControlPlaneDrop(controlFailureReason)
-        metrics.onGrpcForcedDisconnectDueToControlDeliveryFailure(controlFailureReason)
-        log.warn {
-            "Control-plane delivery failed for session $sid (${event::class.simpleName}, " +
-                "reason=$controlFailureReason); forcing disconnect"
+            is DeliveryOutcome.ControlPlaneFailure -> {
+                metrics.onGrpcControlPlaneDrop(outcome.reason)
+                metrics.onGrpcForcedDisconnectDueToControlDeliveryFailure(outcome.reason)
+                log.warn {
+                    "Control-plane delivery failed for session $sid (${event::class.simpleName}, " +
+                        "reason=${outcome.reason}); forcing disconnect"
+                }
+                serviceImpl.forceDisconnectSession(
+                    sessionId = sid,
+                    reason = "control-plane-delivery-failed:${outcome.reason}",
+                )
+            }
         }
-        serviceImpl.forceDisconnectSession(
-            sessionId = sid,
-            reason = "control-plane-delivery-failed:$controlFailureReason",
-        )
     }
 }
 

--- a/src/test/kotlin/dev/ambon/grpc/DeliveryOutcomeTest.kt
+++ b/src/test/kotlin/dev/ambon/grpc/DeliveryOutcomeTest.kt
@@ -1,0 +1,115 @@
+package dev.ambon.grpc
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class DeliveryOutcomeTest {
+    @Test
+    fun `fast-path success returns Delivered`() =
+        runBlocking {
+            val ch = Channel<Int>(1)
+            val outcome =
+                deliverWithBackpressure(
+                    trySend = { ch.trySend(1) },
+                    suspendSend = { ch.send(1) },
+                    isControlPlane = false,
+                    controlPlaneSendTimeoutMs = 50L,
+                )
+            assertEquals(DeliveryOutcome.Delivered, outcome)
+            ch.close()
+        }
+
+    @Test
+    fun `data-plane drop on full channel returns DroppedDataPlane with channelClosed false`() =
+        runBlocking {
+            val ch = Channel<Int>(Channel.RENDEZVOUS)
+            val outcome =
+                deliverWithBackpressure(
+                    trySend = { ch.trySend(1) },
+                    suspendSend = { ch.send(1) },
+                    isControlPlane = false,
+                    controlPlaneSendTimeoutMs = 50L,
+                )
+            assertTrue(outcome is DeliveryOutcome.DroppedDataPlane)
+            assertFalse((outcome as DeliveryOutcome.DroppedDataPlane).channelClosed)
+            ch.close()
+        }
+
+    @Test
+    fun `data-plane drop on closed channel returns DroppedDataPlane with channelClosed true`() =
+        runBlocking {
+            val ch = Channel<Int>(1)
+            ch.close()
+            val outcome =
+                deliverWithBackpressure(
+                    trySend = { ch.trySend(1) },
+                    suspendSend = { ch.send(1) },
+                    isControlPlane = false,
+                    controlPlaneSendTimeoutMs = 50L,
+                )
+            assertTrue(outcome is DeliveryOutcome.DroppedDataPlane)
+            assertTrue((outcome as DeliveryOutcome.DroppedDataPlane).channelClosed)
+        }
+
+    @Test
+    fun `control-plane on closed channel returns ControlPlaneFailure with stream_closed`() =
+        runBlocking {
+            val ch = Channel<Int>(1)
+            ch.close()
+            val outcome =
+                deliverWithBackpressure(
+                    trySend = { ch.trySend(1) },
+                    suspendSend = { ch.send(1) },
+                    isControlPlane = true,
+                    controlPlaneSendTimeoutMs = 50L,
+                )
+            assertEquals(DeliveryOutcome.ControlPlaneFailure("stream_closed"), outcome)
+        }
+
+    @Test
+    fun `control-plane fallback send succeeds returns DeliveredWithFallback`() =
+        runBlocking {
+            val ch = Channel<Int>(1)
+            // Fill the channel so trySend fails, but a suspending send will succeed once we drain.
+            ch.trySend(0)
+            var trySendCalled = false
+            val outcome =
+                deliverWithBackpressure(
+                    trySend = {
+                        if (!trySendCalled) {
+                            trySendCalled = true
+                            ch.trySend(1) // fails — channel full
+                        } else {
+                            ch.trySend(1)
+                        }
+                    },
+                    suspendSend = {
+                        ch.receive() // drain the pre-filled element
+                        ch.send(1) // now succeeds
+                    },
+                    isControlPlane = true,
+                    controlPlaneSendTimeoutMs = 1_000L,
+                )
+            assertEquals(DeliveryOutcome.DeliveredWithFallback, outcome)
+            ch.close()
+        }
+
+    @Test
+    fun `control-plane timeout returns ControlPlaneFailure with stream_full_timeout`() =
+        runBlocking {
+            val ch = Channel<Int>(Channel.RENDEZVOUS)
+            val outcome =
+                deliverWithBackpressure(
+                    trySend = { ch.trySend(1) },
+                    suspendSend = { ch.send(1) }, // will suspend forever — timeout kicks in
+                    isControlPlane = true,
+                    controlPlaneSendTimeoutMs = 25L,
+                )
+            assertEquals(DeliveryOutcome.ControlPlaneFailure("stream_full_timeout"), outcome)
+            ch.close()
+        }
+}


### PR DESCRIPTION
## Summary\n\n- Extract `DeliveryOutcome` sealed interface and `deliverWithBackpressure()` function into `DeliveryOutcome.kt`, replacing the near-identical trySend → control/data-plane classification → timeout-fallback algorithms duplicated between `GrpcOutboundDispatcher` (engine-side) and `GrpcOutboundBus` (gateway-side)\n- Extract `cancelJobWithTimeout()` utility into `GrpcLifecycle.kt`, replacing identical `runBlocking + withTimeout + cancelAndJoin` stop patterns in both classes\n- Add `DeliveryOutcomeTest` covering all outcome branches (delivered, fallback, data-plane drop, control-plane closed/timeout)\n\nCloses #393\n\n## Test plan\n\n- [x] New `DeliveryOutcomeTest` covers all 6 delivery outcome branches\n- [x] Existing `GrpcOutboundDispatcherTest` passes unchanged (behavior preserved)\n- [x] Existing `GrpcOutboundBusTest` passes unchanged (behavior preserved)\n- [x] Existing `GrpcInboundBusTest` passes unchanged (no changes to inbound bus)\n- [x] Full test suite passes\n- [x] ktlintCheck passes"