### PR TITLE
refactor: normalize local bus wrappers and introduce DepthAware trait

### DIFF
--- a/src/main/kotlin/dev/ambon/ServerInfrastructure.kt
+++ b/src/main/kotlin/dev/ambon/ServerInfrastructure.kt
@@ -1,13 +1,8 @@
 package dev.ambon
 
-import dev.ambon.bus.GrpcInboundBus
-import dev.ambon.bus.GrpcOutboundBus
+import dev.ambon.bus.DepthAware
 import dev.ambon.bus.InboundBus
-import dev.ambon.bus.LocalInboundBus
-import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.bus.OutboundBus
-import dev.ambon.bus.RedisInboundBus
-import dev.ambon.bus.RedisOutboundBus
 import dev.ambon.config.AppConfig
 import dev.ambon.metrics.GameMetrics
 import dev.ambon.redis.RedisConnectionManager
@@ -102,22 +97,7 @@ object ServerInfrastructure {
         outbound: OutboundBus,
         metrics: GameMetrics,
     ) {
-        val inboundLocal =
-            when (inbound) {
-                is LocalInboundBus -> inbound
-                is RedisInboundBus -> inbound.delegateForMetrics()
-                is GrpcInboundBus -> inbound.delegateForMetrics()
-                else -> null
-            }
-        inboundLocal?.let { metrics.bindInboundBusQueue(it::depth) { it.capacity } }
-
-        val outboundLocal =
-            when (outbound) {
-                is LocalOutboundBus -> outbound
-                is RedisOutboundBus -> outbound.delegateForMetrics()
-                is GrpcOutboundBus -> outbound.delegateForMetrics()
-                else -> null
-            }
-        outboundLocal?.let { metrics.bindOutboundBusQueue(it::depth) { it.capacity } }
+        (inbound as? DepthAware)?.let { metrics.bindInboundBusQueue(it::depth) { it.capacity } }
+        (outbound as? DepthAware)?.let { metrics.bindOutboundBusQueue(it::depth) { it.capacity } }
     }
 }

--- a/src/main/kotlin/dev/ambon/bus/DepthAware.kt
+++ b/src/main/kotlin/dev/ambon/bus/DepthAware.kt
@@ -1,0 +1,8 @@
+package dev.ambon.bus
+
+/** Capability trait for bus implementations that can report queue depth and capacity. */
+interface DepthAware {
+    fun depth(): Int
+
+    val capacity: Int
+}

--- a/src/main/kotlin/dev/ambon/bus/DepthTrackingChannel.kt
+++ b/src/main/kotlin/dev/ambon/bus/DepthTrackingChannel.kt
@@ -7,7 +7,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * A [Channel] wrapper that maintains an approximate depth count.
- * Used by [LocalInboundBus] and [LocalOutboundBus] to expose queue depth metrics.
+ * Used by [LocalBusChannel] to expose queue depth metrics.
  */
 internal class DepthTrackingChannel<T>(
     val capacity: Int = Channel.UNLIMITED,

--- a/src/main/kotlin/dev/ambon/bus/GrpcInboundBus.kt
+++ b/src/main/kotlin/dev/ambon/bus/GrpcInboundBus.kt
@@ -32,7 +32,8 @@ private const val FORWARD_SEND_TIMEOUT_MS = 5_000L
 class GrpcInboundBus(
     private val delegate: LocalInboundBus,
     grpcSendChannel: SendChannel<InboundEventProto>,
-) : InboundBus {
+) : InboundBus,
+    DepthAware {
     @Volatile
     private var grpcSendChannel: SendChannel<InboundEventProto> = grpcSendChannel
 
@@ -74,5 +75,5 @@ class GrpcInboundBus(
 
     override fun depth(): Int = delegate.depth()
 
-    fun delegateForMetrics(): LocalInboundBus = delegate
+    override val capacity: Int get() = delegate.capacity
 }

--- a/src/main/kotlin/dev/ambon/bus/GrpcOutboundBus.kt
+++ b/src/main/kotlin/dev/ambon/bus/GrpcOutboundBus.kt
@@ -50,7 +50,8 @@ class GrpcOutboundBus(
     private val metrics: GameMetrics = GameMetrics.noop(),
     private val controlPlaneSendTimeoutMs: Long = DEFAULT_CONTROL_PLANE_SEND_TIMEOUT_MS,
     private val onFailure: (GrpcOutboundFailure) -> Unit = {},
-) : OutboundBus {
+) : OutboundBus,
+    DepthAware {
     init {
         require(controlPlaneSendTimeoutMs > 0L) {
             "controlPlaneSendTimeoutMs must be > 0"
@@ -168,7 +169,9 @@ class GrpcOutboundBus(
         delegate.close()
     }
 
-    fun delegateForMetrics(): LocalOutboundBus = delegate
+    override fun depth(): Int = delegate.depth()
+
+    override val capacity: Int get() = delegate.capacity
 }
 
 private const val DEFAULT_CONTROL_PLANE_SEND_TIMEOUT_MS = 250L

--- a/src/main/kotlin/dev/ambon/bus/LocalBusChannel.kt
+++ b/src/main/kotlin/dev/ambon/bus/LocalBusChannel.kt
@@ -1,0 +1,28 @@
+package dev.ambon.bus
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ChannelResult
+import kotlinx.coroutines.channels.ReceiveChannel
+
+/**
+ * Generic depth-tracking channel wrapper shared by [LocalInboundBus] and [LocalOutboundBus].
+ *
+ * Provides [DepthAware] queue metrics and delegates all operations to a [DepthTrackingChannel].
+ */
+open class LocalBusChannel<T>(
+    override val capacity: Int = Channel.UNLIMITED,
+) : DepthAware {
+    private val channel = DepthTrackingChannel<T>(capacity)
+
+    open suspend fun send(event: T) = channel.send(event)
+
+    open fun trySend(event: T): ChannelResult<Unit> = channel.trySend(event)
+
+    open fun tryReceive(): ChannelResult<T> = channel.tryReceive()
+
+    open fun asReceiveChannel(): ReceiveChannel<T> = channel.asReceiveChannel()
+
+    open fun close() = channel.close()
+
+    override fun depth(): Int = channel.depth()
+}

--- a/src/main/kotlin/dev/ambon/bus/LocalInboundBus.kt
+++ b/src/main/kotlin/dev/ambon/bus/LocalInboundBus.kt
@@ -2,20 +2,10 @@ package dev.ambon.bus
 
 import dev.ambon.engine.events.InboundEvent
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.ChannelResult
 
 class LocalInboundBus(
-    val capacity: Int = Channel.UNLIMITED,
-) : InboundBus {
-    private val channel = DepthTrackingChannel<InboundEvent>(capacity)
-
-    override suspend fun send(event: InboundEvent) = channel.send(event)
-
-    override fun trySend(event: InboundEvent): ChannelResult<Unit> = channel.trySend(event)
-
-    override fun tryReceive(): ChannelResult<InboundEvent> = channel.tryReceive()
-
-    override fun close() = channel.close()
-
-    override fun depth(): Int = channel.depth()
+    capacity: Int = Channel.UNLIMITED,
+) : LocalBusChannel<InboundEvent>(capacity),
+    InboundBus {
+    override fun depth(): Int = super<LocalBusChannel>.depth()
 }

--- a/src/main/kotlin/dev/ambon/bus/LocalOutboundBus.kt
+++ b/src/main/kotlin/dev/ambon/bus/LocalOutboundBus.kt
@@ -2,23 +2,10 @@ package dev.ambon.bus
 
 import dev.ambon.engine.events.OutboundEvent
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.ChannelResult
-import kotlinx.coroutines.channels.ReceiveChannel
 
 class LocalOutboundBus(
-    val capacity: Int = Channel.UNLIMITED,
-) : OutboundBus {
-    private val channel = DepthTrackingChannel<OutboundEvent>(capacity)
-
-    override suspend fun send(event: OutboundEvent) = channel.send(event)
-
-    fun trySend(event: OutboundEvent): ChannelResult<Unit> = channel.trySend(event)
-
-    override fun tryReceive(): ChannelResult<OutboundEvent> = channel.tryReceive()
-
-    override fun asReceiveChannel(): ReceiveChannel<OutboundEvent> = channel.asReceiveChannel()
-
-    override fun close() = channel.close()
-
-    fun depth(): Int = channel.depth()
+    capacity: Int = Channel.UNLIMITED,
+) : LocalBusChannel<OutboundEvent>(capacity),
+    OutboundBus {
+    override fun depth(): Int = super<LocalBusChannel>.depth()
 }

--- a/src/main/kotlin/dev/ambon/bus/OutboundBus.kt
+++ b/src/main/kotlin/dev/ambon/bus/OutboundBus.kt
@@ -12,4 +12,7 @@ interface OutboundBus {
     fun asReceiveChannel(): ReceiveChannel<OutboundEvent>
 
     fun close()
+
+    /** Returns the current number of events waiting in the queue. Defaults to 0 for implementations that do not track depth. */
+    fun depth(): Int = 0
 }

--- a/src/main/kotlin/dev/ambon/bus/RedisInboundBus.kt
+++ b/src/main/kotlin/dev/ambon/bus/RedisInboundBus.kt
@@ -25,7 +25,8 @@ internal class RedisInboundBus(
         sharedSecret = sharedSecret,
         direction = "inbound",
     ),
-    InboundBus {
+    InboundBus,
+    DepthAware {
     internal data class Envelope(
         override val instanceId: String = "",
         override val type: String = "",
@@ -95,5 +96,5 @@ internal class RedisInboundBus(
 
     override fun depth(): Int = delegate.depth()
 
-    fun delegateForMetrics(): LocalInboundBus = delegate
+    override val capacity: Int get() = delegate.capacity
 }

--- a/src/main/kotlin/dev/ambon/bus/RedisOutboundBus.kt
+++ b/src/main/kotlin/dev/ambon/bus/RedisOutboundBus.kt
@@ -26,7 +26,8 @@ internal class RedisOutboundBus(
         sharedSecret = sharedSecret,
         direction = "outbound",
     ),
-    OutboundBus {
+    OutboundBus,
+    DepthAware {
     internal data class Envelope(
         override val instanceId: String = "",
         override val type: String = "",
@@ -100,5 +101,7 @@ internal class RedisOutboundBus(
 
     override fun close() = delegate.close()
 
-    fun delegateForMetrics(): LocalOutboundBus = delegate
+    override fun depth(): Int = delegate.depth()
+
+    override val capacity: Int get() = delegate.capacity
 }


### PR DESCRIPTION
## Summary
- Extracts `LocalBusChannel<T>` generic base class to eliminate duplicated `DepthTrackingChannel` delegation boilerplate in `LocalInboundBus`/`LocalOutboundBus`
- Introduces `DepthAware` capability trait (`depth()` + `capacity`) so metrics code no longer depends on concrete bus types
- Adds `depth()` default to `OutboundBus`, matching `InboundBus` symmetry
- All bus variants (Local, Grpc, Redis) implement `DepthAware`
- Simplifies `ServerInfrastructure.bindQueueMetrics` from exhaustive concrete-type `when` dispatch to a single `as? DepthAware` check
- Removes `delegateForMetrics()` from all Grpc/Redis bus wrappers

Net: -63 lines removed, +67 added (including 2 new files); concrete-type leakage in adapter/metrics code eliminated.

Closes #394

## Test plan
- [x] `ktlintCheck` passes
- [x] Full `test` suite passes (all existing bus, transport, engine, and grpc tests)