### PR TITLE
test: add persistence field-coverage safety-net test

### DIFF
--- a/src/main/kotlin/dev/ambon/persistence/PostgresPlayerRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PostgresPlayerRepository.kt
@@ -1,6 +1,7 @@
 package dev.ambon.persistence
 
 import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import dev.ambon.domain.achievement.AchievementState
@@ -17,7 +18,9 @@ import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransacti
 import org.jetbrains.exposed.sql.upsert
 
 private val questMapper: ObjectMapper =
-    ObjectMapper().registerModule(KotlinModule.Builder().build())
+    ObjectMapper()
+        .registerModule(KotlinModule.Builder().build())
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
 private val activeQuestsType = object : TypeReference<Map<String, QuestState>>() {}
 private val completedQuestIdsType = object : TypeReference<Set<String>>() {}

--- a/src/test/kotlin/dev/ambon/persistence/PersistenceFieldCoverageTest.kt
+++ b/src/test/kotlin/dev/ambon/persistence/PersistenceFieldCoverageTest.kt
@@ -1,0 +1,238 @@
+package dev.ambon.persistence
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import dev.ambon.domain.Progress
+import dev.ambon.domain.achievement.AchievementState
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.mail.MailMessage
+import dev.ambon.domain.quest.QuestState
+import kotlinx.coroutines.test.runTest
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.deleteAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import kotlin.reflect.full.memberProperties
+
+/**
+ * Safety-net tests that verify every [PlayerRecord] field is correctly wired through
+ * all persistence layers. When a new field is added to [PlayerRecord] but not propagated
+ * to the DTO, DB table, or Redis serialization, one of these tests will fail at CI time.
+ *
+ * All fields in the test record are set to **non-default** values so that a mapping
+ * omission (which would silently fall back to the default) is caught as a mismatch.
+ */
+@Tag("integration")
+class PersistenceFieldCoverageTest {
+    companion object {
+        private lateinit var hikari: HikariDataSource
+        private lateinit var database: Database
+
+        /**
+         * A [PlayerRecord] with every field set to a non-default value.
+         * If a new field is added to [PlayerRecord] with a default, the compiler won't
+         * force it to appear here — but the round-trip assertions will fail because the
+         * loaded record will carry the default instead of the non-default sentinel.
+         */
+        val FULLY_POPULATED: PlayerRecord =
+            PlayerRecord(
+                id = PlayerId(42L),
+                name = "TestHero",
+                roomId = RoomId("zone:room"),
+                strength = 15,
+                dexterity = 14,
+                constitution = 13,
+                intelligence = 18,
+                wisdom = 16,
+                charisma = 12,
+                race = "ELF",
+                playerClass = "MAGE",
+                level = 7,
+                xpTotal = 1234L,
+                createdAtEpochMs = 1000L,
+                lastSeenEpochMs = 2000L,
+                passwordHash = "bcrypt_hash",
+                ansiEnabled = true,
+                isStaff = true,
+                hp = 55,
+                mana = 80,
+                maxMana = 100,
+                gold = 500L,
+                activeQuests = mapOf(
+                    "quest1" to QuestState(
+                        questId = "quest1",
+                        acceptedAtEpochMs = 900L,
+                        objectives = listOf(Progress(current = 2, required = 5)),
+                    ),
+                ),
+                completedQuestIds = setOf("quest0"),
+                unlockedAchievementIds = setOf("ach1"),
+                achievementProgress = mapOf(
+                    "ach2" to AchievementState(
+                        achievementId = "ach2",
+                        progress = listOf(Progress(current = 1, required = 3)),
+                    ),
+                ),
+                activeTitle = "Dragon Slayer",
+                inbox = listOf(
+                    MailMessage(
+                        id = "mail1",
+                        fromName = "Admin",
+                        body = "Welcome!",
+                        sentAtEpochMs = 1500L,
+                        read = true,
+                    ),
+                ),
+                guildId = "knights",
+                recallRoomId = RoomId("town:square"),
+            )
+
+        @BeforeAll
+        @JvmStatic
+        fun setup() {
+            val config =
+                HikariConfig().apply {
+                    jdbcUrl = "jdbc:h2:mem:fieldcov;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE"
+                    username = "sa"
+                    password = ""
+                }
+            hikari = HikariDataSource(config)
+            database = Database.connect(hikari)
+            transaction(database) {
+                SchemaUtils.create(PlayersTable)
+                exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_players_name_lower ON players (name_lower)")
+            }
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun teardown() {
+            hikari.close()
+        }
+    }
+
+    @BeforeEach
+    fun reset() {
+        transaction(database) { PlayersTable.deleteAll() }
+    }
+
+    // -----------------------------------------------------------------------
+    // 1. Reflective property-count guards
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `PlayerRecord and PlayerDto have the same properties`() {
+        val recordProps = PlayerRecord::class.memberProperties.map { it.name }.toSortedSet()
+        val dtoProps = PlayerDto::class.memberProperties.map { it.name }.toSortedSet()
+
+        assertEquals(recordProps, dtoProps, "PlayerRecord and PlayerDto properties must match")
+    }
+
+    @Test
+    fun `PlayersTable has one column per PlayerRecord field plus nameLower`() {
+        val recordProps = PlayerRecord::class.memberProperties.map { it.name }.toSet()
+        val tableColumns = PlayersTable.columns.map { it.name }.toSet()
+
+        // Known mapping differences:
+        //   PlayersTable.nameLower  → derived, no PlayerRecord field
+        //   PlayersTable.mailInbox  → maps to PlayerRecord.inbox
+        val expectedExtra = setOf("name_lower")
+        val nameMapping = mapOf("mail_inbox" to "inbox")
+
+        val normalised =
+            tableColumns
+                .minus(expectedExtra)
+                .map { col -> nameMapping[col] ?: col.snakeToCamel() }
+                .toSet()
+
+        val missing = recordProps - normalised
+        val extra = normalised - recordProps
+
+        assertEquals(emptySet<String>(), missing, "PlayerRecord fields missing from PlayersTable")
+        assertEquals(emptySet<String>(), extra, "PlayersTable columns with no PlayerRecord field")
+    }
+
+    // -----------------------------------------------------------------------
+    // 2. PlayerDto ↔ PlayerRecord round-trip
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `PlayerDto from-toDomain round-trip preserves all fields`() {
+        val roundTripped = PlayerDto.from(FULLY_POPULATED).toDomain()
+        assertEquals(FULLY_POPULATED, roundTripped)
+    }
+
+    // -----------------------------------------------------------------------
+    // 3. PostgreSQL save-then-load round-trip
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `Postgres save and findById round-trip preserves all fields`() =
+        runTest {
+            val repo = PostgresPlayerRepository(database)
+            // Create a seed record so the autoincrement id column is populated,
+            // then save the fully-populated record over it.
+            val seed =
+                repo.create(
+                    PlayerCreationRequest(
+                        name = FULLY_POPULATED.name,
+                        startRoomId = FULLY_POPULATED.roomId,
+                        nowEpochMs = FULLY_POPULATED.createdAtEpochMs,
+                        passwordHash = FULLY_POPULATED.passwordHash,
+                        ansiEnabled = FULLY_POPULATED.ansiEnabled,
+                        race = FULLY_POPULATED.race,
+                        playerClass = FULLY_POPULATED.playerClass,
+                        strength = FULLY_POPULATED.strength,
+                        dexterity = FULLY_POPULATED.dexterity,
+                        constitution = FULLY_POPULATED.constitution,
+                        intelligence = FULLY_POPULATED.intelligence,
+                        wisdom = FULLY_POPULATED.wisdom,
+                        charisma = FULLY_POPULATED.charisma,
+                    ),
+                )
+            val expected = FULLY_POPULATED.copy(id = seed.id)
+            repo.save(expected)
+
+            val loaded = repo.findById(seed.id)
+            assertEquals(expected, loaded)
+        }
+
+    // -----------------------------------------------------------------------
+    // 4. Redis JSON round-trip (via InMemoryStringCache)
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `Redis JSON round-trip preserves all fields`() {
+        // Match the production redisObjectMapper config (ignores computed properties
+        // like Progress.isComplete that Jackson serializes but cannot deserialize).
+        val mapper =
+            ObjectMapper()
+                .registerModule(KotlinModule.Builder().build())
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
+        val json = mapper.writeValueAsString(PlayerDto.from(FULLY_POPULATED))
+        val restored = mapper.readValue<PlayerDto>(json).toDomain()
+
+        assertEquals(FULLY_POPULATED, restored)
+    }
+
+    // -----------------------------------------------------------------------
+    // helpers
+    // -----------------------------------------------------------------------
+
+    /** Converts a `snake_case` SQL column name to `camelCase` Kotlin property name. */
+    private fun String.snakeToCamel(): String =
+        split('_')
+            .mapIndexed { i, part -> if (i == 0) part else part.replaceFirstChar { it.uppercase() } }
+            .joinToString("")
+}


### PR DESCRIPTION
## Summary\n\n- Add `PersistenceFieldCoverageTest` with a fully-populated `PlayerRecord` (all 30 fields set to non-default values) that validates field coverage across the entire persistence stack:\n  - **Reflective property-count guards**: `PlayerRecord` and `PlayerDto` property names must match; `PlayersTable` columns must cover all `PlayerRecord` fields (with known mapping exceptions like `nameLower` and `mailInbox` documented)\n  - **PlayerDto round-trip**: `PlayerDto.from(record).toDomain() == record`\n  - **Postgres round-trip**: `save` + `findById` preserves all fields including complex JSON types (quests, achievements, mail)\n  - **Redis JSON round-trip**: serialize + deserialize through the cache path preserves all fields\n- Fix latent bug: `PostgresPlayerRepository`'s `questMapper` was missing `FAIL_ON_UNKNOWN_PROPERTIES=false`, causing silent data loss for `activeQuests` and `achievementProgress` when `Progress.isComplete` (a computed `val`) was serialized then rejected on deserialization\n\nCloses #395\n\n## Test plan\n\n- [x] 5 new tests all pass (`integrationTest --tests *PersistenceFieldCoverageTest*`)\n- [x] Full `test` suite passes (non-integration tests unaffected)\n- [x] ktlintCheck passes"