### PR TITLE
refactor: extract shared GMCP full-state sync method (#413)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -10,8 +10,11 @@ import dev.ambon.domain.mob.MobState
 import dev.ambon.domain.world.Room
 import dev.ambon.engine.abilities.AbilityDefinition
 import dev.ambon.engine.abilities.AbilityId
+import dev.ambon.engine.abilities.AbilitySystem
 import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.engine.status.ActiveEffectSnapshot
+import dev.ambon.engine.status.StatusEffectSystem
 
 class GmcpEmitter(
     private val outbound: OutboundBus,
@@ -247,6 +250,52 @@ class GmcpEmitter(
 
     suspend fun sendCorePing(sessionId: SessionId) {
         emitRaw(sessionId, "Core.Ping", CORE_PING_JSON)
+    }
+
+    /**
+     * Sends the full character GMCP state: status vars, vitals, name, items,
+     * skills, status effects, achievements, and group info. Called on login
+     * and when a client negotiates GMCP support.
+     */
+    suspend fun sendFullCharacterSync(
+        sessionId: SessionId,
+        player: PlayerState,
+        items: ItemRegistry,
+        abilitySystem: AbilitySystem,
+        statusEffectSystem: StatusEffectSystem,
+        achievementRegistry: AchievementRegistry,
+        groupSystem: GroupSystem,
+        players: PlayerRegistry,
+    ) {
+        sendCharStatusVars(sessionId)
+        sendCharVitals(sessionId, player)
+        sendCharName(sessionId, player)
+        sendCharItemsList(sessionId, items.inventory(sessionId), items.equipment(sessionId))
+        sendCharSkills(sessionId, abilitySystem.knownAbilities(sessionId)) { abilityId ->
+            abilitySystem.cooldownRemainingMs(sessionId, abilityId)
+        }
+        sendCharStatusEffects(sessionId, statusEffectSystem.activePlayerEffects(sessionId))
+        sendCharAchievements(sessionId, player, achievementRegistry)
+        sendGroupSync(sessionId, groupSystem, players)
+    }
+
+    /**
+     * Resolves and sends the current group state for [sessionId].
+     * If the player is not in a group, sends an empty group payload.
+     */
+    suspend fun sendGroupSync(
+        sessionId: SessionId,
+        groupSystem: GroupSystem,
+        players: PlayerRegistry,
+    ) {
+        val group = groupSystem.getGroup(sessionId)
+        if (group != null) {
+            val leader = players.get(group.leader)?.name
+            val members = group.members.mapNotNull { players.get(it) }
+            sendGroupInfo(sessionId, leader, members)
+        } else {
+            sendGroupInfo(sessionId, null, emptyList())
+        }
     }
 
     suspend fun sendCharAchievements(

--- a/src/main/kotlin/dev/ambon/engine/events/GmcpEventHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/GmcpEventHandler.kt
@@ -43,25 +43,20 @@ class GmcpEventHandler(
 
                 val player = players.get(sid) ?: return
                 val room = world.rooms[player.roomId] ?: return
-                gmcpEmitter.sendCharStatusVars(sid)
-                gmcpEmitter.sendCharVitals(sid, player)
+                gmcpEmitter.sendFullCharacterSync(
+                    sid,
+                    player,
+                    items,
+                    abilitySystem,
+                    statusEffectSystem,
+                    achievementRegistry,
+                    groupSystem,
+                    players,
+                )
                 gmcpEmitter.sendRoomInfo(sid, room)
-                gmcpEmitter.sendCharName(sid, player)
-                gmcpEmitter.sendCharItemsList(sid, items.inventory(sid), items.equipment(sid))
                 gmcpEmitter.sendRoomPlayers(sid, players.playersInRoom(player.roomId).toList())
                 gmcpEmitter.sendRoomMobs(sid, mobs.mobsInRoom(player.roomId))
                 gmcpEmitter.sendRoomItems(sid, items.itemsInRoom(player.roomId))
-                gmcpEmitter.sendCharSkills(sid, abilitySystem.knownAbilities(sid)) { abilityId ->
-                    abilitySystem.cooldownRemainingMs(sid, abilityId)
-                }
-                gmcpEmitter.sendCharStatusEffects(sid, statusEffectSystem.activePlayerEffects(sid))
-                gmcpEmitter.sendCharAchievements(sid, player, achievementRegistry)
-                val group = groupSystem.getGroup(sid)
-                if (group != null) {
-                    val leader = players.get(group.leader)?.name
-                    val members = group.members.mapNotNull { players.get(it) }
-                    gmcpEmitter.sendGroupInfo(sid, leader, members)
-                }
             }
 
             "Core.Supports.Remove" -> {

--- a/src/main/kotlin/dev/ambon/engine/events/GmcpFlushHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/GmcpFlushHandler.kt
@@ -56,14 +56,7 @@ class GmcpFlushHandler(
 
     suspend fun flushDirtyGroup() {
         drainDirty(gmcpDirtyGroup) { sid ->
-            val group = groupSystem.getGroup(sid)
-            if (group != null) {
-                val leader = players.get(group.leader)?.name
-                val members = group.members.mapNotNull { players.get(it) }
-                gmcpEmitter.sendGroupInfo(sid, leader, members)
-            } else {
-                gmcpEmitter.sendGroupInfo(sid, null, emptyList())
-            }
+            gmcpEmitter.sendGroupSync(sid, groupSystem, players)
         }
     }
 

--- a/src/main/kotlin/dev/ambon/engine/events/LoginFlowHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/LoginFlowHandler.kt
@@ -498,21 +498,16 @@ internal class LoginFlowHandler(
         if (!suppressEnterBroadcast) {
             broadcastToRoom(players, outbound, me.roomId, "${me.name} enters.", sessionId)
         }
-        gmcpEmitter.sendCharStatusVars(sessionId)
-        gmcpEmitter.sendCharVitals(sessionId, me)
-        gmcpEmitter.sendCharName(sessionId, me)
-        gmcpEmitter.sendCharItemsList(sessionId, items.inventory(sessionId), items.equipment(sessionId))
-        gmcpEmitter.sendCharSkills(sessionId, abilitySystem.knownAbilities(sessionId)) { abilityId ->
-            abilitySystem.cooldownRemainingMs(sessionId, abilityId)
-        }
-        gmcpEmitter.sendCharStatusEffects(sessionId, statusEffectSystem.activePlayerEffects(sessionId))
-        gmcpEmitter.sendCharAchievements(sessionId, me, achievementRegistry)
-        val group = groupSystem.getGroup(sessionId)
-        if (group != null) {
-            val leader = players.get(group.leader)?.name
-            val members = group.members.mapNotNull { players.get(it) }
-            gmcpEmitter.sendGroupInfo(sessionId, leader, members)
-        }
+        gmcpEmitter.sendFullCharacterSync(
+            sessionId,
+            me,
+            items,
+            abilitySystem,
+            statusEffectSystem,
+            achievementRegistry,
+            groupSystem,
+            players,
+        )
         router.handle(sessionId, Command.Look)
 
         val unread = me.inbox.count { !it.read }


### PR DESCRIPTION
## Summary

- **Extract `GmcpEmitter.sendFullCharacterSync()`** — consolidates the identical 13-call GMCP character-state sync sequence (StatusVars, Vitals, Name, Items, Skills, StatusEffects, Achievements, GroupInfo) that was duplicated between login and GMCP `Core.Supports.Set` handling
- **Extract `GmcpEmitter.sendGroupSync()`** — consolidates the 4-line group-info resolution block that appeared in 3 places (LoginFlowHandler, GmcpEventHandler, GmcpFlushHandler)
- `LoginFlowHandler`: 15 duplicated lines replaced with 1 call
- `GmcpEventHandler`: 19 duplicated lines replaced with 1 call + 4 room-state calls
- `GmcpFlushHandler`: 7 duplicated lines replaced with 1 call

The two blocks can no longer drift apart when new GMCP packages are added.

## Test plan

- [x] `./gradlew ktlintCheck test` — all pass
- No new tests needed — existing `GmcpEmitterTest`, `GameEngineLoginFlowTest`, and `GameEngineIntegrationTest` cover these code paths

Closes #413