### PR TITLE
refactor: extract shared atomicWriteText utility (#415)

### DIFF
--- a/src/main/kotlin/dev/ambon/persistence/FileUtil.kt
+++ b/src/main/kotlin/dev/ambon/persistence/FileUtil.kt
@@ -1,0 +1,34 @@
+package dev.ambon.persistence
+
+import java.io.IOException
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.nio.file.StandardOpenOption
+import kotlin.io.path.createDirectories
+
+/**
+ * Writes [contents] to [path] atomically: writes to a temp file first,
+ * then renames it into place. Falls back to a non-atomic move if the
+ * file system does not support atomic rename.
+ *
+ * @throws PlayerPersistenceException if the write fails for any I/O reason.
+ */
+internal fun atomicWriteText(
+    path: Path,
+    contents: String,
+) {
+    try {
+        path.parent?.createDirectories()
+        val tmp = Files.createTempFile(path.parent, path.fileName.toString(), ".tmp")
+        Files.writeString(tmp, contents, StandardOpenOption.TRUNCATE_EXISTING)
+        try {
+            Files.move(tmp, path, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
+        } catch (_: AtomicMoveNotSupportedException) {
+            Files.move(tmp, path, StandardCopyOption.REPLACE_EXISTING)
+        }
+    } catch (e: IOException) {
+        throw PlayerPersistenceException("Failed to write file atomically: $path", e)
+    }
+}

--- a/src/main/kotlin/dev/ambon/persistence/YamlGuildRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/YamlGuildRepository.kt
@@ -8,12 +8,7 @@ import dev.ambon.domain.guild.GuildRank
 import dev.ambon.domain.guild.GuildRecord
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.io.IOException
-import java.nio.file.AtomicMoveNotSupportedException
-import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.StandardCopyOption
-import java.nio.file.StandardOpenOption
 import kotlin.io.path.createDirectories
 import kotlin.io.path.deleteIfExists
 import kotlin.io.path.exists
@@ -92,24 +87,6 @@ class YamlGuildRepository(
     private fun write(record: GuildRecord) {
         val path = pathFor(record.id)
         atomicWriteText(path, mapper.writeValueAsString(GuildDto.from(record)))
-    }
-
-    private fun atomicWriteText(
-        path: Path,
-        contents: String,
-    ) {
-        try {
-            path.parent?.createDirectories()
-            val tmp = Files.createTempFile(path.parent, path.fileName.toString(), ".tmp")
-            Files.writeString(tmp, contents, StandardOpenOption.TRUNCATE_EXISTING)
-            try {
-                Files.move(tmp, path, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
-            } catch (_: AtomicMoveNotSupportedException) {
-                Files.move(tmp, path, StandardCopyOption.REPLACE_EXISTING)
-            }
-        } catch (e: IOException) {
-            throw PlayerPersistenceException("Failed to write guild file atomically: $path", e)
-        }
     }
 }
 

--- a/src/main/kotlin/dev/ambon/persistence/YamlPlayerRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/YamlPlayerRepository.kt
@@ -8,12 +8,7 @@ import dev.ambon.metrics.GameMetrics
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.io.IOException
-import java.nio.file.AtomicMoveNotSupportedException
-import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.StandardCopyOption
-import java.nio.file.StandardOpenOption
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
@@ -191,26 +186,5 @@ class YamlPlayerRepository(
     private fun writePlayer(record: PlayerRecord) {
         atomicWriteText(pathFor(record.id.value), mapper.writeValueAsString(PlayerDto.from(record)))
         nameIndex[record.name.lowercase()] = record.id.value
-    }
-
-    private fun atomicWriteText(
-        path: Path,
-        contents: String,
-    ) {
-        try {
-            path.parent?.createDirectories()
-
-            val tmp = Files.createTempFile(path.parent, path.fileName.toString(), ".tmp")
-            Files.writeString(tmp, contents, StandardOpenOption.TRUNCATE_EXISTING)
-
-            // Best-effort atomic move; on Windows this can fail if antivirus hooks, etc.
-            try {
-                Files.move(tmp, path, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
-            } catch (_: AtomicMoveNotSupportedException) {
-                Files.move(tmp, path, StandardCopyOption.REPLACE_EXISTING)
-            }
-        } catch (e: IOException) {
-            throw PlayerPersistenceException("Failed to write file atomically: $path", e)
-        }
     }
 }

--- a/src/main/kotlin/dev/ambon/persistence/YamlWorldStateRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/YamlWorldStateRepository.kt
@@ -7,12 +7,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.io.IOException
-import java.nio.file.AtomicMoveNotSupportedException
-import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.StandardCopyOption
-import java.nio.file.StandardOpenOption
 import kotlin.io.path.createDirectories
 import kotlin.io.path.exists
 import kotlin.io.path.readText
@@ -52,22 +47,4 @@ class YamlWorldStateRepository(
                 log.error(e) { "Failed to save world state to $stateFile" }
             }
         }
-
-    private fun atomicWriteText(
-        path: Path,
-        contents: String,
-    ) {
-        try {
-            path.parent?.createDirectories()
-            val tmp = Files.createTempFile(path.parent, path.fileName.toString(), ".tmp")
-            Files.writeString(tmp, contents, StandardOpenOption.TRUNCATE_EXISTING)
-            try {
-                Files.move(tmp, path, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
-            } catch (_: AtomicMoveNotSupportedException) {
-                Files.move(tmp, path, StandardCopyOption.REPLACE_EXISTING)
-            }
-        } catch (e: IOException) {
-            throw RuntimeException("Failed to write file atomically: $path", e)
-        }
-    }
 }


### PR DESCRIPTION
## Summary

- **Extract `atomicWriteText(path, contents)`** into a new `persistence/FileUtil.kt` — the identical write-to-temp-then-atomic-rename method was copy-pasted across all 3 YAML repositories
- Remove private `atomicWriteText` from `YamlPlayerRepository`, `YamlGuildRepository`, and `YamlWorldStateRepository`
- Clean up unused imports (`Files`, `IOException`, `AtomicMoveNotSupportedException`, `StandardCopyOption`, `StandardOpenOption`)
- **Net reduction: 38 lines** (34 added in FileUtil.kt, 72 removed from 3 repositories)

## Test plan

- [x] `./gradlew ktlintCheck test` — all pass
- Existing `YamlPlayerRepositoryTest`, `YamlGuildRepositoryTest`, and `YamlWorldStateRepositoryTest` cover atomic write behavior

Closes #415