### PR TITLE
refactor: consolidate test drain() helpers and enhance GameEngineHarness (#416)

### DIFF
--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -17,6 +17,7 @@ import dev.ambon.engine.abilities.AbilityEffect
 import dev.ambon.engine.abilities.AbilityId
 import dev.ambon.engine.abilities.TargetType
 import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.test.drainAll
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -39,16 +40,7 @@ class GmcpEmitterTest {
         )
     }
 
-    private fun drain(): List<OutboundEvent> {
-        val events = mutableListOf<OutboundEvent>()
-        while (true) {
-            val result = outbound.tryReceive()
-            if (result.isSuccess) events.add(result.getOrNull()!!) else break
-        }
-        return events
-    }
-
-    private fun drainGmcp(): List<OutboundEvent.GmcpData> = drain().filterIsInstance<OutboundEvent.GmcpData>()
+    private fun drainGmcp(): List<OutboundEvent.GmcpData> = outbound.drainAll().filterIsInstance<OutboundEvent.GmcpData>()
 
     private fun player(
         name: String = "Alice",

--- a/src/test/kotlin/dev/ambon/engine/InterEngineMessageHandlingTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/InterEngineMessageHandlingTest.kt
@@ -14,6 +14,7 @@ import dev.ambon.sharding.InterEngineMessage
 import dev.ambon.sharding.LocalInterEngineBus
 import dev.ambon.sharding.PlayerSummary
 import dev.ambon.test.MutableClock
+import dev.ambon.test.drainAll
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
@@ -110,15 +111,6 @@ class InterEngineMessageHandlingTest {
         val clock: MutableClock,
     )
 
-    private fun drain(ch: LocalOutboundBus): List<OutboundEvent> {
-        val out = mutableListOf<OutboundEvent>()
-        while (true) {
-            val ev = ch.tryReceive().getOrNull() ?: break
-            out += ev
-        }
-        return out
-    }
-
     private suspend fun loginViaEngine(
         harness: EngineTestHarness,
         sid: SessionId,
@@ -151,7 +143,7 @@ class InterEngineMessageHandlingTest {
 
             loginViaEngine(h, sid, "Alice")
             pumpEngine(h)
-            drain(h.outbound)
+            h.outbound.drainAll()
 
             // Inject a gossip broadcast from another engine
             (h.bus as LocalInterEngineBus).broadcast(
@@ -164,7 +156,7 @@ class InterEngineMessageHandlingTest {
             )
             pumpEngine(h)
 
-            val outs = drain(h.outbound)
+            val outs = h.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && "[GOSSIP] Bob: hello from engine-2" in (it as OutboundEvent.SendText).text },
                 "Local player should receive remote gossip. got=$outs",
@@ -183,7 +175,7 @@ class InterEngineMessageHandlingTest {
 
             loginViaEngine(h, sid, "Alice")
             pumpEngine(h)
-            drain(h.outbound)
+            h.outbound.drainAll()
 
             (h.bus as LocalInterEngineBus).broadcast(
                 InterEngineMessage.GlobalBroadcast(
@@ -195,7 +187,7 @@ class InterEngineMessageHandlingTest {
             )
             pumpEngine(h)
 
-            val outs = drain(h.outbound)
+            val outs = h.outbound.drainAll()
             assertTrue(
                 outs.none { it is OutboundEvent.SendText && "my own gossip" in (it as OutboundEvent.SendText).text },
                 "Self-broadcast should be ignored. got=$outs",
@@ -214,7 +206,7 @@ class InterEngineMessageHandlingTest {
 
             loginViaEngine(h, sid, "Alice")
             pumpEngine(h)
-            drain(h.outbound)
+            h.outbound.drainAll()
 
             (h.bus as LocalInterEngineBus).broadcast(
                 InterEngineMessage.TellMessage(
@@ -225,7 +217,7 @@ class InterEngineMessageHandlingTest {
             )
             pumpEngine(h)
 
-            val outs = drain(h.outbound)
+            val outs = h.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && "Bob tells you: hi alice" in (it as OutboundEvent.SendText).text },
                 "Local player should receive remote tell. got=$outs",
@@ -245,7 +237,7 @@ class InterEngineMessageHandlingTest {
 
             loginViaEngine(h, sid, "Alice")
             pumpEngine(h)
-            drain(h.outbound)
+            h.outbound.drainAll()
             capturingBus.sent.clear()
 
             // Inject a WhoRequest from another engine
@@ -283,7 +275,7 @@ class InterEngineMessageHandlingTest {
 
             loginViaEngine(h, sid, "Alice")
             pumpEngine(h)
-            drain(h.outbound)
+            h.outbound.drainAll()
             capturingBus.sent.clear()
 
             // Inject a WhoRequest from self (should be ignored)
@@ -311,7 +303,7 @@ class InterEngineMessageHandlingTest {
 
             loginViaEngine(h, sid, "Alice")
             pumpEngine(h)
-            drain(h.outbound)
+            h.outbound.drainAll()
 
             // Inject a WhoResponse with an unknown requestId
             (h.bus as LocalInterEngineBus).broadcast(
@@ -322,7 +314,7 @@ class InterEngineMessageHandlingTest {
             )
             pumpEngine(h)
 
-            val outs = drain(h.outbound)
+            val outs = h.outbound.drainAll()
             assertTrue(
                 outs.none { it is OutboundEvent.SendInfo && "Bob" in (it as OutboundEvent.SendInfo).text },
                 "Unknown requestId WhoResponse should be dropped",
@@ -341,14 +333,14 @@ class InterEngineMessageHandlingTest {
 
             loginViaEngine(h, sid, "Alice")
             pumpEngine(h)
-            drain(h.outbound)
+            h.outbound.drainAll()
 
             (h.bus as LocalInterEngineBus).broadcast(
                 InterEngineMessage.KickRequest(targetPlayerName = "Alice"),
             )
             pumpEngine(h)
 
-            val outs = drain(h.outbound)
+            val outs = h.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.Close && it.sessionId == sid },
                 "KickRequest should close the local session. got=$outs",
@@ -368,14 +360,14 @@ class InterEngineMessageHandlingTest {
 
             loginViaEngine(h, sid, "Alice")
             pumpEngine(h)
-            drain(h.outbound)
+            h.outbound.drainAll()
 
             (h.bus as LocalInterEngineBus).broadcast(
                 InterEngineMessage.ShutdownRequest(initiatorName = "Admin"),
             )
             pumpEngine(h)
 
-            val outs = drain(h.outbound)
+            val outs = h.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && "shutdown" in (it as OutboundEvent.SendText).text.lowercase() },
                 "Local player should see shutdown message. got=$outs",

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterFeaturesTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterFeaturesTest.kt
@@ -17,6 +17,7 @@ import dev.ambon.engine.WorldStateRegistry
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.drainAll
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -60,14 +61,8 @@ class CommandRouterFeaturesTest {
         val sid = SessionId(1)
         val res = players.login(sid, "Tester", "password")
         require(res == LoginResult.Ok)
-        outbound.drain()
+        outbound.drainAll()
         return Harness(sid, players, items, router, outbound, worldState)
-    }
-
-    private fun LocalOutboundBus.drain(): List<OutboundEvent> {
-        val out = mutableListOf<OutboundEvent>()
-        while (true) out += tryReceive().getOrNull() ?: break
-        return out
     }
 
     private fun makeKey() =
@@ -89,7 +84,7 @@ class CommandRouterFeaturesTest {
         runTest {
             val h = harness()
             h.router.handle(h.sid, Command.Move(Direction.NORTH))
-            val outs = h.outbound.drain()
+            val outs = h.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && it.text.contains("locked", ignoreCase = true) },
                 "Expected blocked message, got: $outs",
@@ -104,7 +99,7 @@ class CommandRouterFeaturesTest {
             h.items.addToInventory(h.sid, makeKey())
 
             h.router.handle(h.sid, Command.UnlockFeature("n"))
-            val outs = h.outbound.drain()
+            val outs = h.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendInfo && it.text.contains("unlock", ignoreCase = true) },
                 "Expected unlock message, got: $outs",
@@ -116,7 +111,7 @@ class CommandRouterFeaturesTest {
         runTest {
             val h = harness()
             h.router.handle(h.sid, Command.UnlockFeature("n"))
-            val outs = h.outbound.drain()
+            val outs = h.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendError },
                 "Expected error, got: $outs",
@@ -130,10 +125,10 @@ class CommandRouterFeaturesTest {
             // Unlock first
             h.items.addToInventory(h.sid, makeKey())
             h.router.handle(h.sid, Command.UnlockFeature("n"))
-            h.outbound.drain()
+            h.outbound.drainAll()
 
             h.router.handle(h.sid, Command.OpenFeature("n"))
-            val outs = h.outbound.drain()
+            val outs = h.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendInfo && it.text.contains("open", ignoreCase = true) },
                 "Expected open message, got: $outs",
@@ -145,7 +140,7 @@ class CommandRouterFeaturesTest {
         runTest {
             val h = harness()
             h.router.handle(h.sid, Command.OpenFeature("n"))
-            val outs = h.outbound.drain()
+            val outs = h.outbound.drainAll()
             assertTrue(outs.any { it is OutboundEvent.SendError }, "Expected error, got: $outs")
         }
 
@@ -156,10 +151,10 @@ class CommandRouterFeaturesTest {
             h.items.addToInventory(h.sid, makeKey())
             h.router.handle(h.sid, Command.UnlockFeature("n"))
             h.router.handle(h.sid, Command.OpenFeature("n"))
-            h.outbound.drain()
+            h.outbound.drainAll()
 
             h.router.handle(h.sid, Command.CloseFeature("n"))
-            val outs = h.outbound.drain()
+            val outs = h.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendInfo && it.text.contains("close", ignoreCase = true) },
                 "Expected close message, got: $outs",
@@ -173,10 +168,10 @@ class CommandRouterFeaturesTest {
         runTest {
             val h = harness()
             h.players.moveTo(h.sid, RoomId("ok_features:storeroom"))
-            h.outbound.drain()
+            h.outbound.drainAll()
 
             h.router.handle(h.sid, Command.SearchContainer("chest"))
-            val outs = h.outbound.drain()
+            val outs = h.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendError },
                 "Expected error for closed container, got: $outs",
@@ -193,10 +188,10 @@ class CommandRouterFeaturesTest {
             h.worldState.clearDirty()
 
             h.players.moveTo(h.sid, RoomId("ok_features:storeroom"))
-            h.outbound.drain()
+            h.outbound.drainAll()
 
             h.router.handle(h.sid, Command.SearchContainer("chest"))
-            val outs = h.outbound.drain()
+            val outs = h.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendInfo && it.text.contains("coin", ignoreCase = true) },
                 "Expected coin in search results, got: $outs",
@@ -213,10 +208,10 @@ class CommandRouterFeaturesTest {
             h.worldState.clearDirty()
 
             h.players.moveTo(h.sid, RoomId("ok_features:storeroom"))
-            h.outbound.drain()
+            h.outbound.drainAll()
 
             h.router.handle(h.sid, Command.GetFrom("coin", "chest"))
-            val outs = h.outbound.drain()
+            val outs = h.outbound.drainAll()
             assertTrue(outs.any { it is OutboundEvent.SendInfo }, "Expected success, got: $outs")
             assertTrue(h.items.inventory(h.sid).any { it.item.keyword == "coin" })
             assertTrue(h.worldState.getContainerContents(containerId).isEmpty())
@@ -232,10 +227,10 @@ class CommandRouterFeaturesTest {
             h.items.addToInventory(h.sid, makeCoin())
 
             h.players.moveTo(h.sid, RoomId("ok_features:storeroom"))
-            h.outbound.drain()
+            h.outbound.drainAll()
 
             h.router.handle(h.sid, Command.PutIn("coin", "chest"))
-            val outs = h.outbound.drain()
+            val outs = h.outbound.drainAll()
             assertTrue(outs.any { it is OutboundEvent.SendInfo }, "Expected success, got: $outs")
             assertTrue(h.items.inventory(h.sid).isEmpty())
             assertFalse(h.worldState.getContainerContents(containerId).isEmpty())
@@ -248,10 +243,10 @@ class CommandRouterFeaturesTest {
         runTest {
             val h = harness()
             h.players.moveTo(h.sid, RoomId("ok_features:vault"))
-            h.outbound.drain()
+            h.outbound.drainAll()
 
             h.router.handle(h.sid, Command.Pull("lever"))
-            val outs = h.outbound.drain()
+            val outs = h.outbound.drainAll()
             assertTrue(outs.any { it is OutboundEvent.SendInfo }, "Expected success, got: $outs")
             assertEquals(LeverState.DOWN, h.worldState.getLeverState("ok_features:vault/iron_lever"))
         }
@@ -263,7 +258,7 @@ class CommandRouterFeaturesTest {
         runTest {
             val h = harness()
             h.router.handle(h.sid, Command.ReadSign("board"))
-            val outs = h.outbound.drain()
+            val outs = h.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendInfo && it.text.contains("Welcome", ignoreCase = true) },
                 "Expected sign text, got: $outs",
@@ -275,7 +270,7 @@ class CommandRouterFeaturesTest {
         runTest {
             val h = harness()
             h.router.handle(h.sid, Command.ReadSign("xyzzy"))
-            val outs = h.outbound.drain()
+            val outs = h.outbound.drainAll()
             assertTrue(outs.any { it is OutboundEvent.SendError }, "Expected error, got: $outs")
         }
 }

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterShopTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterShopTest.kt
@@ -16,6 +16,7 @@ import dev.ambon.engine.ShopRegistry
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.drainAll
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -32,7 +33,7 @@ class CommandRouterShopTest {
 
             env.router.handle(env.sid, Command.Balance)
 
-            val outs = env.drain()
+            val outs = env.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendInfo && it.text.contains("42 gold") },
                 "Expected balance message containing '42 gold'. got=$outs",
@@ -46,7 +47,7 @@ class CommandRouterShopTest {
 
             env.router.handle(env.sid, Command.ShopList)
 
-            val outs = env.drain()
+            val outs = env.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendInfo && it.text.contains("Market Vendor") },
                 "Expected shop name in listing. got=$outs",
@@ -70,7 +71,7 @@ class CommandRouterShopTest {
 
             env.router.handle(env.sid, Command.ShopList)
 
-            val outs = env.drain()
+            val outs = env.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && it.text.contains("no shop") },
                 "Expected 'no shop' message. got=$outs",
@@ -90,7 +91,7 @@ class CommandRouterShopTest {
             assertEquals(1, inv.size)
             assertEquals("sword", inv[0].item.keyword)
 
-            val outs = env.drain()
+            val outs = env.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && it.text.contains("You buy") && it.text.contains("50 gold") },
                 "Expected buy confirmation. got=$outs",
@@ -108,7 +109,7 @@ class CommandRouterShopTest {
             assertEquals(10L, env.player.gold)
             assertTrue(env.items.inventory(env.sid).isEmpty())
 
-            val outs = env.drain()
+            val outs = env.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && it.text.contains("afford") },
                 "Expected 'cannot afford' message. got=$outs",
@@ -127,7 +128,7 @@ class CommandRouterShopTest {
             assertEquals(100L, env.player.gold)
             assertTrue(env.items.inventory(env.sid).isEmpty())
 
-            val outs = env.drain()
+            val outs = env.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && it.text.contains("no shop") },
                 "Expected 'no shop' message. got=$outs",
@@ -144,7 +145,7 @@ class CommandRouterShopTest {
 
             assertEquals(100L, env.player.gold)
 
-            val outs = env.drain()
+            val outs = env.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && it.text.contains("doesn't sell") },
                 "Expected 'doesn't sell' message. got=$outs",
@@ -166,7 +167,7 @@ class CommandRouterShopTest {
             assertEquals(25L, env.player.gold) // 50 * 0.5 = 25
             assertTrue(env.items.inventory(env.sid).isEmpty())
 
-            val outs = env.drain()
+            val outs = env.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && it.text.contains("You sell") && it.text.contains("25 gold") },
                 "Expected sell confirmation. got=$outs",
@@ -188,7 +189,7 @@ class CommandRouterShopTest {
             assertEquals(0L, env.player.gold)
             assertEquals(1, env.items.inventory(env.sid).size)
 
-            val outs = env.drain()
+            val outs = env.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && it.text.contains("worthless") },
                 "Expected 'worthless' message. got=$outs",
@@ -211,7 +212,7 @@ class CommandRouterShopTest {
             assertEquals(0L, env.player.gold)
             assertEquals(1, env.items.inventory(env.sid).size)
 
-            val outs = env.drain()
+            val outs = env.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && it.text.contains("no shop") },
                 "Expected 'no shop' message. got=$outs",
@@ -228,7 +229,7 @@ class CommandRouterShopTest {
 
             assertEquals(0L, env.player.gold)
 
-            val outs = env.drain()
+            val outs = env.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && it.text.contains("don't have") },
                 "Expected 'don't have' message. got=$outs",
@@ -255,7 +256,7 @@ class CommandRouterShopTest {
             assertEquals(0L, env.player.gold)
             assertEquals(1, env.items.inventory(env.sid).size)
 
-            val outs = env.drain()
+            val outs = env.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && it.text.contains("worthless") },
                 "Expected 'worthless' message for 0-value sell. got=$outs",
@@ -285,16 +286,7 @@ class CommandRouterShopTest {
         val router: CommandRouter,
         val sid: SessionId,
         val player: dev.ambon.engine.PlayerState,
-    ) {
-        fun drain(): List<OutboundEvent> {
-            val out = mutableListOf<OutboundEvent>()
-            while (true) {
-                val v = outbound.tryReceive().getOrNull() ?: break
-                out.add(v)
-            }
-            return out
-        }
-    }
+    )
 
     private suspend fun setup(
         economyConfig: EconomyConfig =
@@ -327,7 +319,7 @@ class CommandRouterShopTest {
         val res = players.login(sid, "Shopper", "password")
         require(res == LoginResult.Ok) { "Login failed: $res" }
         // Drain login-related output
-        while (outbound.tryReceive().getOrNull() != null) { /* drain */ }
+        outbound.drainAll()
 
         val player = players.get(sid)!!
         return TestEnv(world, items, players, mobs, outbound, router, sid, player)

--- a/src/test/kotlin/dev/ambon/engine/dialogue/DialogueSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/dialogue/DialogueSystemTest.kt
@@ -11,6 +11,7 @@ import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.drainAll
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -96,16 +97,7 @@ class DialogueSystemTest {
         val outbound: LocalOutboundBus,
         val system: DialogueSystem,
         val items: ItemRegistry,
-    ) {
-        fun drain(): List<OutboundEvent> {
-            val out = mutableListOf<OutboundEvent>()
-            while (true) {
-                val v = outbound.tryReceive().getOrNull() ?: break
-                out.add(v)
-            }
-            return out
-        }
-    }
+    )
 
     private suspend fun TestEnv.loginPlayer(
         name: String = "Tester",
@@ -118,7 +110,7 @@ class DialogueSystemTest {
         val player = players.get(sid)!!
         player.playerClass = playerClass
         player.level = level
-        drain()
+        outbound.drainAll()
         return sid
     }
 
@@ -160,7 +152,7 @@ class DialogueSystemTest {
             val err = env.system.startConversation(sid, "sage")
             assertNull(err)
 
-            val outs = env.drain()
+            val outs = env.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && it.text.contains("Hello there!") },
                 "Expected root text. got=$outs",
@@ -199,12 +191,12 @@ class DialogueSystemTest {
             val sid = env.loginPlayer()
             env.addDialogueMob()
             env.system.startConversation(sid, "sage")
-            env.drain()
+            env.outbound.drainAll()
 
             val outcome = env.system.selectChoice(sid, 1) // "Tell me more."
             assertTrue(outcome is DialogueOutcome.Ok, "Expected Ok outcome. got=$outcome")
 
-            val outs = env.drain()
+            val outs = env.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && it.text.contains("more info") },
                 "Expected next node text. got=$outs",
@@ -218,7 +210,7 @@ class DialogueSystemTest {
             val sid = env.loginPlayer()
             env.addDialogueMob()
             env.system.startConversation(sid, "sage")
-            env.drain()
+            env.outbound.drainAll()
 
             val outcome = env.system.selectChoice(sid, 2) // "Goodbye." (null next)
             assertTrue(outcome is DialogueOutcome.Ok, "Expected Ok outcome. got=$outcome")
@@ -232,7 +224,7 @@ class DialogueSystemTest {
             val sid = env.loginPlayer()
             env.addDialogueMob()
             env.system.startConversation(sid, "sage")
-            env.drain()
+            env.outbound.drainAll()
 
             val outcome = env.system.selectChoice(sid, 5)
             assertTrue(
@@ -249,7 +241,7 @@ class DialogueSystemTest {
             env.addDialogueMob(dialogue = conditionalDialogue)
             env.system.startConversation(sid, "sage")
 
-            val outs = env.drain()
+            val outs = env.outbound.drainAll()
             val infoTexts =
                 outs
                     .filterIsInstance<OutboundEvent.SendInfo>()
@@ -272,7 +264,7 @@ class DialogueSystemTest {
             env.addDialogueMob(dialogue = conditionalDialogue)
             env.system.startConversation(sid, "sage")
 
-            val outs = env.drain()
+            val outs = env.outbound.drainAll()
             val infoTexts =
                 outs
                     .filterIsInstance<OutboundEvent.SendInfo>()
@@ -291,7 +283,7 @@ class DialogueSystemTest {
             env.addDialogueMob(dialogue = conditionalDialogue)
             env.system.startConversation(sid, "sage")
 
-            val outs = env.drain()
+            val outs = env.outbound.drainAll()
             val infoTexts =
                 outs
                     .filterIsInstance<OutboundEvent.SendInfo>()
@@ -310,7 +302,7 @@ class DialogueSystemTest {
             env.addDialogueMob(dialogue = conditionalDialogue)
             env.system.startConversation(sid, "sage")
 
-            val outs = env.drain()
+            val outs = env.outbound.drainAll()
             val infoTexts =
                 outs
                     .filterIsInstance<OutboundEvent.SendInfo>()
@@ -328,13 +320,13 @@ class DialogueSystemTest {
             val sid = env.loginPlayer()
             env.addDialogueMob()
             env.system.startConversation(sid, "sage")
-            env.drain()
+            env.outbound.drainAll()
 
             assertTrue(env.system.isInConversation(sid))
             env.system.onPlayerMoved(sid)
             assertFalse(env.system.isInConversation(sid))
 
-            val outs = env.drain()
+            val outs = env.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && it.text.contains("walk away") },
                 "Expected walk-away notification. got=$outs",
@@ -348,7 +340,7 @@ class DialogueSystemTest {
             val sid = env.loginPlayer()
             env.addDialogueMob()
             env.system.startConversation(sid, "sage")
-            env.drain()
+            env.outbound.drainAll()
 
             assertTrue(env.system.isInConversation(sid))
             env.system.onPlayerDisconnected(sid)
@@ -364,13 +356,13 @@ class DialogueSystemTest {
 
             env.system.startConversation(sid, "sage")
             assertTrue(env.system.isInConversation(sid))
-            env.drain()
+            env.outbound.drainAll()
 
             // Start again — should reset to root
             env.system.startConversation(sid, "sage")
             assertTrue(env.system.isInConversation(sid))
 
-            val outs = env.drain()
+            val outs = env.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && it.text.contains("Hello there!") },
                 "Expected root text on re-start. got=$outs",
@@ -384,13 +376,13 @@ class DialogueSystemTest {
             val sid = env.loginPlayer()
             val mobId = env.addDialogueMob()
             env.system.startConversation(sid, "sage")
-            env.drain()
+            env.outbound.drainAll()
 
             assertTrue(env.system.isInConversation(sid))
             env.system.onMobRemoved(mobId)
             assertFalse(env.system.isInConversation(sid))
 
-            val outs = env.drain()
+            val outs = env.outbound.drainAll()
             assertTrue(
                 outs.any { it is OutboundEvent.SendText && it.text.contains("no longer available") },
                 "Expected mob-removed notification. got=$outs",

--- a/src/test/kotlin/dev/ambon/test/TestFixtures.kt
+++ b/src/test/kotlin/dev/ambon/test/TestFixtures.kt
@@ -19,6 +19,8 @@ import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.commands.CommandRouter
 import dev.ambon.engine.commands.PhaseResult
 import dev.ambon.engine.commands.buildTestRouter
+import dev.ambon.engine.events.InboundEvent
+import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.engine.scheduler.Scheduler
 import dev.ambon.metrics.GameMetrics
@@ -181,6 +183,23 @@ class GameEngineHarness private constructor(
     val engine: GameEngine,
     val engineJob: Job,
 ) {
+    fun drain(): List<OutboundEvent> = outbound.drainAll()
+
+    /**
+     * Drives a fresh player through the engine's full login sequence
+     * (Connected → name → "yes" → password) and drains the resulting output.
+     */
+    suspend fun loginNewPlayer(
+        sid: SessionId,
+        name: String,
+        password: String = "password",
+    ) {
+        inbound.send(InboundEvent.Connected(sid))
+        inbound.send(InboundEvent.LineReceived(sid, name))
+        inbound.send(InboundEvent.LineReceived(sid, "yes"))
+        inbound.send(InboundEvent.LineReceived(sid, password))
+    }
+
     fun close() {
         engineJob.cancel()
         inbound.close()


### PR DESCRIPTION
## Summary
- Replace 5 local `drain()` re-implementations with the canonical `drainAll()` from `EngineTestHelpers` in `CommandRouterFeaturesTest`, `CommandRouterShopTest`, `DialogueSystemTest`, `GmcpEmitterTest`, and `InterEngineMessageHandlingTest`
- Add `drain()` convenience method to `GameEngineHarness` (delegates to `outbound.drainAll()`)
- Add `loginNewPlayer()` helper to `GameEngineHarness` for the standard 4-event engine login sequence

Net: -18 lines (92 added, 110 removed). All tests pass.

Closes #416

## Test plan
- [x] `ktlintCheck` passes
- [x] Full test suite passes — all 5 modified test files exercise the shared `drainAll()` path