### PR TITLE
refactor: reduce sendLook 8-argument call repetition

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
@@ -27,6 +27,7 @@ class AdminHandler(
     private val engineId: String = "",
     private val metrics: GameMetrics = GameMetrics.noop(),
 ) : CommandHandler {
+    private val ctx = ctx
     private val world = ctx.world
     private val players = ctx.players
     private val mobs = ctx.mobs
@@ -34,7 +35,6 @@ class AdminHandler(
     private val combat = ctx.combat
     private val outbound = ctx.outbound
     private val gmcpEmitter = ctx.gmcpEmitter
-    private val worldState = ctx.worldState
     private lateinit var router: CommandRouter
 
     private var adminSpawnSeq = 0
@@ -72,7 +72,7 @@ class AdminHandler(
                 return
             }
             players.moveTo(sessionId, targetRoomId)
-            sendLook(sessionId, world, players, mobs, items, worldState, outbound, gmcpEmitter)
+            ctx.sendLook(sessionId)
         }
     }
 
@@ -106,7 +106,7 @@ class AdminHandler(
                 }
                 players.moveTo(targetSid, targetRoomId)
                 outbound.send(OutboundEvent.SendText(targetSid, "You are transported by a divine hand."))
-                sendLook(targetSid, world, players, mobs, items, worldState, outbound, gmcpEmitter)
+                ctx.sendLook(targetSid)
                 outbound.send(OutboundEvent.SendPrompt(targetSid))
                 outbound.send(OutboundEvent.SendInfo(sessionId, "Transferred ${targetPlayer.name} to ${targetRoomId.value}."))
             }
@@ -180,7 +180,7 @@ class AdminHandler(
                     outbound.send(
                         OutboundEvent.SendText(targetSid, "A divine hand strikes you down. You awaken at the start, bruised and humbled."),
                     )
-                    sendLook(targetSid, world, players, mobs, items, worldState, outbound, gmcpEmitter)
+                    ctx.sendLook(targetSid)
                     outbound.send(OutboundEvent.SendPrompt(targetSid))
                     outbound.send(OutboundEvent.SendInfo(sessionId, "Smote ${targetPlayer.name}."))
                 }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -85,6 +85,10 @@ internal suspend fun requireSameRoom(
     return true
 }
 
+/** Convenience extension that delegates to the 8-argument [sendLook], pulling all dependencies from this context. */
+internal suspend fun EngineContext.sendLook(sessionId: SessionId) =
+    sendLook(sessionId, world, players, mobs, items, worldState, outbound, gmcpEmitter)
+
 /** Sends a full room description (title, description, exits, items, players, mobs) to [sessionId]. */
 internal suspend fun sendLook(
     sessionId: SessionId,

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
@@ -25,10 +25,9 @@ class NavigationHandler(
         const val RECALL_COOLDOWN_MS = 300_000L
     }
 
+    private val ctx = ctx
     private val world = ctx.world
     private val players = ctx.players
-    private val mobs = ctx.mobs
-    private val items = ctx.items
     private val combat = ctx.combat
     private val outbound = ctx.outbound
     private val worldState = ctx.worldState
@@ -45,7 +44,7 @@ class NavigationHandler(
     }
 
     private suspend fun handleLook(sessionId: SessionId) {
-        sendLook(sessionId, world, players, mobs, items, worldState, outbound, gmcpEmitter)
+        ctx.sendLook(sessionId)
     }
 
     private suspend fun handleMove(
@@ -104,7 +103,7 @@ class NavigationHandler(
                 gmcpEmitter,
                 dialogueSystem,
             )
-            sendLook(sessionId, world, players, mobs, items, worldState, outbound, gmcpEmitter)
+            ctx.sendLook(sessionId)
         }
     }
 
@@ -145,7 +144,7 @@ class NavigationHandler(
             dialogueSystem,
         )
         outbound.send(OutboundEvent.SendText(sessionId, "You feel a familiar warmth and find yourself back at your recall point."))
-        sendLook(sessionId, world, players, mobs, items, worldState, outbound, gmcpEmitter)
+        ctx.sendLook(sessionId)
     }
 
     private suspend fun handleExits(sessionId: SessionId) {


### PR DESCRIPTION
## Summary
- Adds an `EngineContext.sendLook(sessionId)` extension in `HandlerHelpers.kt` that delegates to the existing 8-argument `sendLook`, pulling all dependencies from context
- Replaces all 6 verbose call sites (3 in `NavigationHandler`, 3 in `AdminHandler`) with `ctx.sendLook(sessionId)`
- Removes field extractions that were only needed for `sendLook`: `mobs`/`items` from `NavigationHandler`, `worldState` from `AdminHandler`

Closes #417

## Test plan
- [x] `ktlintCheck` passes
- [x] All `CommandRouter*` and `GameEngineIntegration*` tests pass