### PR TITLE
Fix Kotlin compiler warnings in engine and test sources

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -561,7 +561,7 @@ class GameEngine(
     )
 
     private val router = CommandRouter(outbound = outbound, players = players)
-    private lateinit var mailHandler: MailHandler
+    private val mailHandler: MailHandler
 
     init {
         val crossZoneMove: (suspend (SessionId, RoomId) -> Unit)? = if (handoffManager != null) ::handleCrossZoneMove else null

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -111,7 +111,7 @@ internal suspend fun sendLook(
             room.exits.keys.joinToString(", ") { dir ->
                 val label = dir.name.lowercase()
                 val door = ws?.doorOnExit(roomId, dir)
-                if (door != null && ws != null) {
+                if (door != null) {
                     val state = ws.getDoorState(door.id)
                     if (state == LockableState.OPEN) label else "$label [${state.name.lowercase()}]"
                 } else {

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldFeaturesHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldFeaturesHandler.kt
@@ -34,7 +34,7 @@ class WorldFeaturesHandler(
     private suspend fun handleOpenFeature(
         sessionId: SessionId,
         keyword: String,
-    ) = withPlayerAndRoom(sessionId, players, world) { me, room ->
+    ): Unit = withPlayerAndRoom(sessionId, players, world) { me, room ->
         val feature = requireFeature(sessionId, room, keyword, "open", outbound) ?: return
         val lockable = requireLockable(sessionId, feature, worldState, "open", outbound) ?: return
         when (lockable.state) {
@@ -51,7 +51,7 @@ class WorldFeaturesHandler(
     private suspend fun handleCloseFeature(
         sessionId: SessionId,
         keyword: String,
-    ) = withPlayerAndRoom(sessionId, players, world) { me, room ->
+    ): Unit = withPlayerAndRoom(sessionId, players, world) { me, room ->
         val feature = requireFeature(sessionId, room, keyword, "close", outbound) ?: return
         val lockable = requireLockable(sessionId, feature, worldState, "close", outbound) ?: return
         when (lockable.state) {
@@ -72,7 +72,7 @@ class WorldFeaturesHandler(
     private suspend fun handleUnlockFeature(
         sessionId: SessionId,
         keyword: String,
-    ) = withPlayerAndRoom(sessionId, players, world) { me, room ->
+    ): Unit = withPlayerAndRoom(sessionId, players, world) { me, room ->
         val feature = requireFeature(sessionId, room, keyword, "unlock", outbound) ?: return
         val lockable = requireLockable(sessionId, feature, worldState, "unlock", outbound) ?: return
         when {
@@ -103,7 +103,7 @@ class WorldFeaturesHandler(
     private suspend fun handleLockFeature(
         sessionId: SessionId,
         keyword: String,
-    ) = withPlayerAndRoom(sessionId, players, world) { me, room ->
+    ): Unit = withPlayerAndRoom(sessionId, players, world) { me, room ->
         val feature = requireFeature(sessionId, room, keyword, "lock", outbound) ?: return
         val lockable = requireLockable(sessionId, feature, worldState, "lock", outbound) ?: return
         when {
@@ -136,7 +136,7 @@ class WorldFeaturesHandler(
     private suspend fun handleSearchContainer(
         sessionId: SessionId,
         keyword: String,
-    ) = withPlayerAndRoom(sessionId, players, world) { _, room ->
+    ): Unit = withPlayerAndRoom(sessionId, players, world) { _, room ->
         val feature = findFeatureByKeyword(room, keyword)
         if (feature == null || feature !is RoomFeature.Container) {
             outbound.send(OutboundEvent.SendError(sessionId, "You don't see any container called '$keyword' here."))
@@ -156,7 +156,7 @@ class WorldFeaturesHandler(
         sessionId: SessionId,
         itemKeyword: String,
         containerKeyword: String,
-    ) = withPlayerAndRoom(sessionId, players, world) { me, room ->
+    ): Unit = withPlayerAndRoom(sessionId, players, world) { me, room ->
         val feature = findFeatureByKeyword(room, containerKeyword)
         if (feature == null || feature !is RoomFeature.Container) {
             outbound.send(OutboundEvent.SendError(sessionId, "You don't see any container called '$containerKeyword' here."))
@@ -183,7 +183,7 @@ class WorldFeaturesHandler(
         sessionId: SessionId,
         itemKeyword: String,
         containerKeyword: String,
-    ) = withPlayerAndRoom(sessionId, players, world) { me, room ->
+    ): Unit = withPlayerAndRoom(sessionId, players, world) { me, room ->
         val feature = findFeatureByKeyword(room, containerKeyword)
         if (feature == null || feature !is RoomFeature.Container) {
             outbound.send(OutboundEvent.SendError(sessionId, "You don't see any container called '$containerKeyword' here."))
@@ -209,7 +209,7 @@ class WorldFeaturesHandler(
     private suspend fun handlePull(
         sessionId: SessionId,
         keyword: String,
-    ) = withPlayerAndRoom(sessionId, players, world) { me, room ->
+    ): Unit = withPlayerAndRoom(sessionId, players, world) { me, room ->
         val feature = findFeatureByKeyword(room, keyword)
         if (feature == null || feature !is RoomFeature.Lever) {
             outbound.send(OutboundEvent.SendError(sessionId, "You don't see any lever called '$keyword' here."))
@@ -225,7 +225,7 @@ class WorldFeaturesHandler(
     private suspend fun handleReadSign(
         sessionId: SessionId,
         keyword: String,
-    ) = withPlayerAndRoom(sessionId, players, world) { _, room ->
+    ): Unit = withPlayerAndRoom(sessionId, players, world) { _, room ->
         val feature = findFeatureByKeyword(room, keyword)
         if (feature == null || feature !is RoomFeature.Sign) {
             outbound.send(OutboundEvent.SendError(sessionId, "You don't see anything called '$keyword' to read here."))

--- a/src/test/kotlin/dev/ambon/engine/InterEngineMessageHandlingTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/InterEngineMessageHandlingTest.kt
@@ -158,7 +158,7 @@ class InterEngineMessageHandlingTest {
 
             val outs = h.outbound.drainAll()
             assertTrue(
-                outs.any { it is OutboundEvent.SendText && "[GOSSIP] Bob: hello from engine-2" in (it as OutboundEvent.SendText).text },
+                outs.any { it is OutboundEvent.SendText && "[GOSSIP] Bob: hello from engine-2" in it.text },
                 "Local player should receive remote gossip. got=$outs",
             )
 
@@ -189,7 +189,7 @@ class InterEngineMessageHandlingTest {
 
             val outs = h.outbound.drainAll()
             assertTrue(
-                outs.none { it is OutboundEvent.SendText && "my own gossip" in (it as OutboundEvent.SendText).text },
+                outs.none { it is OutboundEvent.SendText && "my own gossip" in it.text },
                 "Self-broadcast should be ignored. got=$outs",
             )
 
@@ -219,7 +219,7 @@ class InterEngineMessageHandlingTest {
 
             val outs = h.outbound.drainAll()
             assertTrue(
-                outs.any { it is OutboundEvent.SendText && "Bob tells you: hi alice" in (it as OutboundEvent.SendText).text },
+                outs.any { it is OutboundEvent.SendText && "Bob tells you: hi alice" in it.text },
                 "Local player should receive remote tell. got=$outs",
             )
 
@@ -316,7 +316,7 @@ class InterEngineMessageHandlingTest {
 
             val outs = h.outbound.drainAll()
             assertTrue(
-                outs.none { it is OutboundEvent.SendInfo && "Bob" in (it as OutboundEvent.SendInfo).text },
+                outs.none { it is OutboundEvent.SendInfo && "Bob" in it.text },
                 "Unknown requestId WhoResponse should be dropped",
             )
 
@@ -369,7 +369,7 @@ class InterEngineMessageHandlingTest {
 
             val outs = h.outbound.drainAll()
             assertTrue(
-                outs.any { it is OutboundEvent.SendText && "shutdown" in (it as OutboundEvent.SendText).text.lowercase() },
+                outs.any { it is OutboundEvent.SendText && "shutdown" in it.text.lowercase() },
                 "Local player should see shutdown message. got=$outs",
             )
             assertTrue(shutdownCalled, "onShutdown callback should be called")

--- a/src/test/kotlin/dev/ambon/engine/behavior/BehaviorTreeSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/behavior/BehaviorTreeSystemTest.kt
@@ -213,7 +213,7 @@ class BehaviorTreeSystemTest {
             assertTrue(e.combat.isInCombat(sid))
 
             val messages = e.outbound.drainAll()
-            assertTrue(messages.any { it is OutboundEvent.SendText && (it as OutboundEvent.SendText).text.contains("attacks you") })
+            assertTrue(messages.any { it is OutboundEvent.SendText && it.text.contains("attacks you") })
         }
 
     @Test
@@ -328,7 +328,7 @@ class BehaviorTreeSystemTest {
             assertTrue(newRoom != roomA.id, "Mob should have fled to a different room")
 
             val messages = e.outbound.drainAll()
-            assertTrue(messages.any { it is OutboundEvent.SendText && (it as OutboundEvent.SendText).text.contains("flees") })
+            assertTrue(messages.any { it is OutboundEvent.SendText && it.text.contains("flees") })
         }
 
     @Test

--- a/src/test/kotlin/dev/ambon/engine/commands/CrossEngineCommandsTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CrossEngineCommandsTest.kt
@@ -53,7 +53,7 @@ class CrossEngineCommandsTest {
             // Local delivery still works
             val outs = outbound.drainAll()
             assertTrue(
-                outs.any { it is OutboundEvent.SendText && it.sessionId == sid && "You gossip" in (it as OutboundEvent.SendText).text },
+                outs.any { it is OutboundEvent.SendText && it.sessionId == sid && "You gossip" in it.text },
             )
 
             // Bus should have a GlobalBroadcast
@@ -78,7 +78,7 @@ class CrossEngineCommandsTest {
             // Sender should see confirmation (not error)
             val outs = outbound.drainAll()
             assertTrue(
-                outs.any { it is OutboundEvent.SendText && "You tell Bob" in (it as OutboundEvent.SendText).text },
+                outs.any { it is OutboundEvent.SendText && "You tell Bob" in it.text },
             )
             assertTrue(
                 outs.none { it is OutboundEvent.SendError },
@@ -116,7 +116,7 @@ class CrossEngineCommandsTest {
             val outs = outbound.drainAll()
 
             assertTrue(
-                outs.any { it is OutboundEvent.SendError && "No such player" in (it as OutboundEvent.SendError).text },
+                outs.any { it is OutboundEvent.SendError && "No such player" in it.text },
             )
         }
 
@@ -132,7 +132,7 @@ class CrossEngineCommandsTest {
 
             val outs = outbound.drainAll()
             assertTrue(
-                outs.any { it is OutboundEvent.SendInfo && "Kick request sent" in (it as OutboundEvent.SendInfo).text },
+                outs.any { it is OutboundEvent.SendInfo && "Kick request sent" in it.text },
             )
 
             val msg = bus.incoming().tryReceive().getOrNull()
@@ -185,7 +185,7 @@ class CrossEngineCommandsTest {
 
             val outs = outbound.drainAll()
             assertTrue(
-                outs.any { it is OutboundEvent.SendInfo && "Transfer request sent" in (it as OutboundEvent.SendInfo).text },
+                outs.any { it is OutboundEvent.SendInfo && "Transfer request sent" in it.text },
             )
 
             val msg = bus.incoming().tryReceive().getOrNull()
@@ -222,7 +222,7 @@ class CrossEngineCommandsTest {
 
             val outs = outbound.drainAll()
             assertTrue(
-                outs.any { it is OutboundEvent.SendText && "You tell Bob" in (it as OutboundEvent.SendText).text },
+                outs.any { it is OutboundEvent.SendText && "You tell Bob" in it.text },
             )
             assertTrue(outs.none { it is OutboundEvent.SendError })
 

--- a/src/test/kotlin/dev/ambon/gateway/SessionRouterTest.kt
+++ b/src/test/kotlin/dev/ambon/gateway/SessionRouterTest.kt
@@ -6,6 +6,7 @@ import dev.ambon.grpc.proto.InboundEventProto
 import dev.ambon.sharding.EngineAddress
 import dev.ambon.sharding.LoadBalancedInstanceSelector
 import dev.ambon.sharding.StaticZoneRegistry
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -144,6 +145,7 @@ class SessionRouterTest {
         assertTrue(result.isFailure)
     }
 
+    @OptIn(DelicateCoroutinesApi::class)
     @Test
     fun `close closes all engine channels`() {
         val (router, channels) = makeRouter("e1", "e2")


### PR DESCRIPTION
### Motivation
- Remove current Kotlin compiler warnings and ktlint failures to keep the codebase clean and future-compatible with upcoming Kotlin language changes. 
- Prevent runtime surprises by ensuring API usage and expression-body signatures are explicit where the compiler warns. 

### Description
- Replace an unnecessary `lateinit var mailHandler` with an initialized `private val mailHandler` assigned in the engine `init` block to eliminate the "definitely initialized" warning (`GameEngine.kt`).
- Simplify a redundant null-check in the room look helper by using the known non-null `WorldStateRegistry` when a door exists (`HandlerHelpers.kt`).
- Add explicit `: Unit` return types to world-feature handler methods that use expression bodies with non-local `return` to avoid future language-version errors (`WorldFeaturesHandler.kt`).
- Remove unnecessary casts in multiple tests and opt into the delicate coroutines API for a test that checks channel close semantics, and fix import ordering to satisfy `ktlint` (`InterEngineMessageHandlingTest.kt`, `BehaviorTreeSystemTest.kt`, `CrossEngineCommandsTest.kt`, `SessionRouterTest.kt`).

### Testing
- Ran `./gradlew compileKotlin compileTestKotlin --warning-mode all` and the compile step completed successfully with the previous project-source compiler warnings resolved. (Succeeded)
- Ran `./gradlew ktlintCheck test` to validate style and unit tests, and both `ktlint` and the test suite completed successfully. (Succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a67af082508323bc5945b67cad0ded)