### PR TITLE
refactor: add room-level GMCP broadcast helpers

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -914,9 +914,7 @@ class GameEngine(
         roomId: RoomId,
     ) {
         mobRemovalCoordinator.onCombatKillCleanup(mobId)
-        for (p in players.playersInRoom(roomId)) {
-            gmcpEmitter.sendRoomRemoveMob(p.sessionId, mobId.value)
-        }
+        gmcpEmitter.broadcastRoomRemoveMob(roomId, mobId.value, players)
         val spawn = world.mobSpawns.find { it.id == mobId }
         val respawnMs = spawn?.respawnSeconds?.let { it * 1_000L }
         if (spawn != null && respawnMs != null) {
@@ -956,10 +954,7 @@ class GameEngine(
     }
 
     private suspend fun syncRoomItemsForRoom(roomId: RoomId) {
-        val roomItems = items.itemsInRoom(roomId)
-        for (player in players.playersInRoom(roomId)) {
-            gmcpEmitter.sendRoomItems(player.sessionId, roomItems)
-        }
+        gmcpEmitter.broadcastRoomItems(roomId, items.itemsInRoom(roomId), players)
     }
 
     private suspend fun onCombatMobKilledByPlayer(

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -3,6 +3,7 @@ package dev.ambon.engine
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import dev.ambon.bus.OutboundBus
+import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.items.ItemSlot
@@ -154,6 +155,24 @@ class GmcpEmitter(
         mobId: String,
     ) {
         emit(sessionId, "Room.RemoveMob", RoomRemoveMobPayload(id = mobId), supportCheck = "Room.Mobs")
+    }
+
+    // ── Room-level broadcast helpers ─────────────────────────────────────
+
+    suspend fun broadcastRoomAddMob(roomId: RoomId, mob: MobState, players: PlayerRegistry) {
+        for (p in players.playersInRoom(roomId)) sendRoomAddMob(p.sessionId, mob)
+    }
+
+    suspend fun broadcastRoomUpdateMob(roomId: RoomId, mob: MobState, players: PlayerRegistry) {
+        for (p in players.playersInRoom(roomId)) sendRoomUpdateMob(p.sessionId, mob)
+    }
+
+    suspend fun broadcastRoomRemoveMob(roomId: RoomId, mobId: String, players: PlayerRegistry) {
+        for (p in players.playersInRoom(roomId)) sendRoomRemoveMob(p.sessionId, mobId)
+    }
+
+    suspend fun broadcastRoomItems(roomId: RoomId, items: List<ItemInstance>, players: PlayerRegistry) {
+        for (p in players.playersInRoom(roomId)) sendRoomItems(p.sessionId, items)
     }
 
     suspend fun sendCharSkills(

--- a/src/main/kotlin/dev/ambon/engine/behavior/BtContext.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/BtContext.kt
@@ -40,11 +40,11 @@ suspend fun BtContext.moveMobWithNotify(
     val from = mob.roomId
     for (p in players.playersInRoom(from)) {
         outbound.send(OutboundEvent.SendText(p.sessionId, departMsg))
-        gmcpEmitter?.sendRoomRemoveMob(p.sessionId, mob.id.value)
     }
+    gmcpEmitter?.broadcastRoomRemoveMob(from, mob.id.value, players)
     mobs.moveTo(mob.id, destination)
     for (p in players.playersInRoom(destination)) {
         outbound.send(OutboundEvent.SendText(p.sessionId, arriveMsg))
-        gmcpEmitter?.sendRoomAddMob(p.sessionId, mob)
     }
+    gmcpEmitter?.broadcastRoomAddMob(destination, mob, players)
 }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
@@ -195,9 +195,7 @@ class AdminHandler(
             items.removeMobItems(targetMob.id)
             mobRemovalCoordinator?.removeMobExternally(targetMob.id)
             broadcastToRoom(players, outbound, me.roomId, "${targetMob.name} is struck down by divine wrath.")
-            for (p in players.playersInRoom(me.roomId)) {
-                gmcpEmitter?.sendRoomRemoveMob(p.sessionId, targetMob.id.value)
-            }
+            gmcpEmitter?.broadcastRoomRemoveMob(me.roomId, targetMob.id.value, players)
         }
     }
 

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ItemHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ItemHandler.kt
@@ -277,10 +277,6 @@ class ItemHandler(
     }
 
     private suspend fun syncRoomItemsGmcp(roomId: RoomId) {
-        val emitter = gmcpEmitter ?: return
-        val roomItems = items.itemsInRoom(roomId)
-        for (player in players.playersInRoom(roomId)) {
-            emitter.sendRoomItems(player.sessionId, roomItems)
-        }
+        gmcpEmitter?.broadcastRoomItems(roomId, items.itemsInRoom(roomId), players)
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/events/GmcpFlushHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/GmcpFlushHandler.kt
@@ -46,10 +46,8 @@ class GmcpFlushHandler(
             mobsByRoom.getOrPut(mob.roomId) { mutableListOf() }.add(mob)
         }
         for ((roomId, roomMobs) in mobsByRoom) {
-            for (p in players.playersInRoom(roomId)) {
-                for (mob in roomMobs) {
-                    gmcpEmitter.sendRoomUpdateMob(p.sessionId, mob)
-                }
+            for (mob in roomMobs) {
+                gmcpEmitter.broadcastRoomUpdateMob(roomId, mob, players)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Adds `broadcastRoomAddMob`, `broadcastRoomUpdateMob`, `broadcastRoomRemoveMob`, and `broadcastRoomItems` methods to `GmcpEmitter` that encapsulate the `playersInRoom` iteration
- Replaces 7 inline `for (p in players.playersInRoom(...)) { gmcpEmitter.sendXxx(p.sessionId, ...) }` loops across `GameEngine`, `GmcpFlushHandler`, `AdminHandler`, `ItemHandler`, and `BtContext`

Closes #418

## Test plan
- [x] `ktlintCheck` passes
- [x] Full test suite passes