### PR TITLE
refactor: share YAML and JSON ObjectMapper instances

### DIFF
--- a/src/main/kotlin/dev/ambon/MudServer.kt
+++ b/src/main/kotlin/dev/ambon/MudServer.kt
@@ -147,7 +147,6 @@ class MudServer(
             PersistenceBackend.POSTGRES ->
                 PostgresGuildRepository(
                     database = databaseManager!!.database,
-                    mapper = redisObjectMapper,
                 )
         }
 

--- a/src/main/kotlin/dev/ambon/persistence/MapperSupport.kt
+++ b/src/main/kotlin/dev/ambon/persistence/MapperSupport.kt
@@ -1,0 +1,18 @@
+package dev.ambon.persistence
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+
+/** Shared YAML ObjectMapper for persistence layer. Lenient on unknown properties for schema evolution. */
+val yamlMapper: ObjectMapper =
+    ObjectMapper(YAMLFactory())
+        .registerModule(KotlinModule.Builder().build())
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
+/** Shared JSON ObjectMapper for persistence layer. Lenient on unknown properties for schema evolution. */
+val jsonMapper: ObjectMapper =
+    ObjectMapper()
+        .registerModule(KotlinModule.Builder().build())
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)

--- a/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
@@ -1,9 +1,6 @@
 package dev.ambon.persistence
 
 import com.fasterxml.jackson.core.type.TypeReference
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.KotlinModule
 import dev.ambon.domain.achievement.AchievementState
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.mail.MailMessage
@@ -11,11 +8,6 @@ import dev.ambon.domain.quest.QuestState
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.statements.UpdateBuilder
-
-private val jsonMapper: ObjectMapper =
-    ObjectMapper()
-        .registerModule(KotlinModule.Builder().build())
-        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
 private val activeQuestsType = object : TypeReference<Map<String, QuestState>>() {}
 private val completedQuestIdsType = object : TypeReference<Set<String>>() {}

--- a/src/main/kotlin/dev/ambon/persistence/PostgresGuildRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PostgresGuildRepository.kt
@@ -1,7 +1,6 @@
 package dev.ambon.persistence
 
 import com.fasterxml.jackson.core.type.TypeReference
-import com.fasterxml.jackson.databind.ObjectMapper
 import dev.ambon.domain.guild.GuildRank
 import dev.ambon.domain.guild.GuildRecord
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -19,8 +18,9 @@ private val membersType = object : TypeReference<Map<Long, String>>() {}
 
 class PostgresGuildRepository(
     private val database: Database,
-    private val mapper: ObjectMapper,
 ) : GuildRepository {
+    private val mapper = jsonMapper
+
     override suspend fun findById(id: String): GuildRecord? =
         newSuspendedTransaction(Dispatchers.IO, database) {
             GuildsTable

--- a/src/main/kotlin/dev/ambon/persistence/PostgresWorldStateRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PostgresWorldStateRepository.kt
@@ -1,16 +1,13 @@
 package dev.ambon.persistence
 
 import com.fasterxml.jackson.core.type.TypeReference
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.KotlinModule
 import kotlinx.coroutines.Dispatchers
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
 import org.jetbrains.exposed.sql.upsert
 
-private val wsMapper: ObjectMapper =
-    ObjectMapper().registerModule(KotlinModule.Builder().build())
+private val wsMapper = jsonMapper
 
 private val strStrMapType = object : TypeReference<Map<String, String>>() {}
 private val strListStrMapType = object : TypeReference<Map<String, List<String>>>() {}

--- a/src/main/kotlin/dev/ambon/persistence/YamlGuildRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/YamlGuildRepository.kt
@@ -1,8 +1,5 @@
 package dev.ambon.persistence
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import dev.ambon.domain.guild.GuildRank
 import dev.ambon.domain.guild.GuildRecord
@@ -18,9 +15,7 @@ import kotlin.io.path.readText
 class YamlGuildRepository(
     private val rootDir: Path,
 ) : GuildRepository {
-    private val mapper: ObjectMapper =
-        ObjectMapper(YAMLFactory())
-            .registerModule(KotlinModule.Builder().build())
+    private val mapper = yamlMapper
     private val guildsDir: Path = rootDir.resolve("guilds")
 
     init {

--- a/src/main/kotlin/dev/ambon/persistence/YamlPlayerRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/YamlPlayerRepository.kt
@@ -1,9 +1,5 @@
 package dev.ambon.persistence
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import dev.ambon.metrics.GameMetrics
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -32,10 +28,7 @@ class YamlPlayerRepository(
     private val rootDir: Path,
     private val metrics: GameMetrics = GameMetrics.noop(),
 ) : PlayerRepository {
-    private val mapper: ObjectMapper =
-        ObjectMapper(YAMLFactory())
-            .registerModule(KotlinModule.Builder().build())
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    private val mapper = yamlMapper
 
     private val playersDir: Path = rootDir.resolve("players")
     private val nextIdFile: Path = rootDir.resolve("next_player_id.txt")

--- a/src/main/kotlin/dev/ambon/persistence/YamlWorldStateRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/YamlWorldStateRepository.kt
@@ -1,8 +1,5 @@
 package dev.ambon.persistence
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Dispatchers
@@ -17,9 +14,7 @@ private val log = KotlinLogging.logger {}
 class YamlWorldStateRepository(
     private val rootDir: Path,
 ) : WorldStateRepository {
-    private val mapper: ObjectMapper =
-        ObjectMapper(YAMLFactory())
-            .registerModule(KotlinModule.Builder().build())
+    private val mapper = yamlMapper
 
     private val stateFile: Path = rootDir.resolve("world_state.yml")
 

--- a/src/test/kotlin/dev/ambon/persistence/PostgresGuildRepositoryTest.kt
+++ b/src/test/kotlin/dev/ambon/persistence/PostgresGuildRepositoryTest.kt
@@ -1,6 +1,5 @@
 package dev.ambon.persistence
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import dev.ambon.domain.guild.GuildRank
@@ -25,7 +24,6 @@ class PostgresGuildRepositoryTest {
     companion object {
         private lateinit var hikari: HikariDataSource
         private lateinit var database: Database
-        private val mapper = ObjectMapper()
 
         @BeforeAll
         @JvmStatic
@@ -76,7 +74,7 @@ class PostgresGuildRepositoryTest {
     @Test
     fun `create then findById round-trips guild`() =
         runTest {
-            val repo = PostgresGuildRepository(database, mapper)
+            val repo = PostgresGuildRepository(database)
             val returned = repo.create(makeRecord())
 
             assertEquals("shadowblade", returned.id)
@@ -93,7 +91,7 @@ class PostgresGuildRepositoryTest {
     @Test
     fun `save persists member and motd changes`() =
         runTest {
-            val repo = PostgresGuildRepository(database, mapper)
+            val repo = PostgresGuildRepository(database)
             val member = PlayerId(2L)
             val record = repo.create(makeRecord())
             val updated =
@@ -114,7 +112,7 @@ class PostgresGuildRepositoryTest {
     @Test
     fun `delete removes guild`() =
         runTest {
-            val repo = PostgresGuildRepository(database, mapper)
+            val repo = PostgresGuildRepository(database)
             repo.create(makeRecord())
             assertNotNull(repo.findById("shadowblade"))
 
@@ -125,7 +123,7 @@ class PostgresGuildRepositoryTest {
     @Test
     fun `findByName is case-insensitive`() =
         runTest {
-            val repo = PostgresGuildRepository(database, mapper)
+            val repo = PostgresGuildRepository(database)
             repo.create(makeRecord())
 
             assertNotNull(repo.findByName("Shadowblade"))
@@ -137,7 +135,7 @@ class PostgresGuildRepositoryTest {
     @Test
     fun `findAll returns all guilds`() =
         runTest {
-            val repo = PostgresGuildRepository(database, mapper)
+            val repo = PostgresGuildRepository(database)
             repo.create(makeRecord("guild1", "GuildOne", "G1"))
             repo.create(makeRecord("guild2", "GuildTwo", "G2"))
 
@@ -150,14 +148,14 @@ class PostgresGuildRepositoryTest {
     @Test
     fun `findById returns null for unknown`() =
         runTest {
-            val repo = PostgresGuildRepository(database, mapper)
+            val repo = PostgresGuildRepository(database)
             assertNull(repo.findById("unknown"))
         }
 
     @Test
     fun `findByName returns null for unknown`() =
         runTest {
-            val repo = PostgresGuildRepository(database, mapper)
+            val repo = PostgresGuildRepository(database)
             assertNull(repo.findByName("nobody"))
         }
 }


### PR DESCRIPTION
## Summary
- Adds `MapperSupport.kt` with shared `yamlMapper` and `jsonMapper` singletons (both configured with `FAIL_ON_UNKNOWN_PROPERTIES = false`)
- Replaces 3 independent YAML `ObjectMapper` constructions in `YamlPlayerRepository`, `YamlGuildRepository`, `YamlWorldStateRepository`
- Replaces 2 independent JSON `ObjectMapper` constructions in `PlayersTable` and `PostgresWorldStateRepository`
- Removes `mapper` constructor parameter from `PostgresGuildRepository` (now uses shared `jsonMapper` internally)

Closes #419

## Test plan
- [x] `ktlintCheck` passes
- [x] Full test suite passes