### PR TITLE
refactor: extract requireOpenContainer helper

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -85,6 +85,10 @@ internal suspend fun requireSameRoom(
     return true
 }
 
+/** Convenience extension that delegates to the 8-argument [sendLook], pulling all dependencies from this context. */
+internal suspend fun EngineContext.sendLook(sessionId: SessionId) =
+    sendLook(sessionId, world, players, mobs, items, worldState, outbound, gmcpEmitter)
+
 /** Sends a full room description (title, description, exits, items, players, mobs) to [sessionId]. */
 internal suspend fun sendLook(
     sessionId: SessionId,
@@ -111,7 +115,7 @@ internal suspend fun sendLook(
             room.exits.keys.joinToString(", ") { dir ->
                 val label = dir.name.lowercase()
                 val door = ws?.doorOnExit(roomId, dir)
-                if (door != null && ws != null) {
+                if (door != null) {
                     val state = ws.getDoorState(door.id)
                     if (state == LockableState.OPEN) label else "$label [${state.name.lowercase()}]"
                 } else {

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldFeaturesHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldFeaturesHandler.kt
@@ -34,7 +34,7 @@ class WorldFeaturesHandler(
     private suspend fun handleOpenFeature(
         sessionId: SessionId,
         keyword: String,
-    ) = withPlayerAndRoom(sessionId, players, world) { me, room ->
+    ): Unit = withPlayerAndRoom(sessionId, players, world) { me, room ->
         val feature = requireFeature(sessionId, room, keyword, "open", outbound) ?: return
         val lockable = requireLockable(sessionId, feature, worldState, "open", outbound) ?: return
         when (lockable.state) {
@@ -51,7 +51,7 @@ class WorldFeaturesHandler(
     private suspend fun handleCloseFeature(
         sessionId: SessionId,
         keyword: String,
-    ) = withPlayerAndRoom(sessionId, players, world) { me, room ->
+    ): Unit = withPlayerAndRoom(sessionId, players, world) { me, room ->
         val feature = requireFeature(sessionId, room, keyword, "close", outbound) ?: return
         val lockable = requireLockable(sessionId, feature, worldState, "close", outbound) ?: return
         when (lockable.state) {
@@ -72,7 +72,7 @@ class WorldFeaturesHandler(
     private suspend fun handleUnlockFeature(
         sessionId: SessionId,
         keyword: String,
-    ) = withPlayerAndRoom(sessionId, players, world) { me, room ->
+    ): Unit = withPlayerAndRoom(sessionId, players, world) { me, room ->
         val feature = requireFeature(sessionId, room, keyword, "unlock", outbound) ?: return
         val lockable = requireLockable(sessionId, feature, worldState, "unlock", outbound) ?: return
         when {
@@ -103,7 +103,7 @@ class WorldFeaturesHandler(
     private suspend fun handleLockFeature(
         sessionId: SessionId,
         keyword: String,
-    ) = withPlayerAndRoom(sessionId, players, world) { me, room ->
+    ): Unit = withPlayerAndRoom(sessionId, players, world) { me, room ->
         val feature = requireFeature(sessionId, room, keyword, "lock", outbound) ?: return
         val lockable = requireLockable(sessionId, feature, worldState, "lock", outbound) ?: return
         when {
@@ -136,7 +136,7 @@ class WorldFeaturesHandler(
     private suspend fun handleSearchContainer(
         sessionId: SessionId,
         keyword: String,
-    ) = withPlayerAndRoom(sessionId, players, world) { _, room ->
+    ): Unit = withPlayerAndRoom(sessionId, players, world) { _, room ->
         val feature = requireOpenContainer(sessionId, room, keyword, worldState, outbound) ?: return
         val contents = worldState?.getContainerContents(feature.id) ?: emptyList()
         if (contents.isEmpty()) {
@@ -151,7 +151,7 @@ class WorldFeaturesHandler(
         sessionId: SessionId,
         itemKeyword: String,
         containerKeyword: String,
-    ) = withPlayerAndRoom(sessionId, players, world) { me, room ->
+    ): Unit = withPlayerAndRoom(sessionId, players, world) { me, room ->
         val feature = requireOpenContainer(sessionId, room, containerKeyword, worldState, outbound) ?: return
         val item = worldState?.removeFromContainer(feature.id, itemKeyword)
         if (item == null) {
@@ -173,7 +173,7 @@ class WorldFeaturesHandler(
         sessionId: SessionId,
         itemKeyword: String,
         containerKeyword: String,
-    ) = withPlayerAndRoom(sessionId, players, world) { me, room ->
+    ): Unit = withPlayerAndRoom(sessionId, players, world) { me, room ->
         val feature = requireOpenContainer(sessionId, room, containerKeyword, worldState, outbound) ?: return
         val item = items.removeFromInventory(sessionId, itemKeyword)
         if (item == null) {
@@ -194,7 +194,7 @@ class WorldFeaturesHandler(
     private suspend fun handlePull(
         sessionId: SessionId,
         keyword: String,
-    ) = withPlayerAndRoom(sessionId, players, world) { me, room ->
+    ): Unit = withPlayerAndRoom(sessionId, players, world) { me, room ->
         val feature = findFeatureByKeyword(room, keyword)
         if (feature == null || feature !is RoomFeature.Lever) {
             outbound.send(OutboundEvent.SendError(sessionId, "You don't see any lever called '$keyword' here."))
@@ -210,7 +210,7 @@ class WorldFeaturesHandler(
     private suspend fun handleReadSign(
         sessionId: SessionId,
         keyword: String,
-    ) = withPlayerAndRoom(sessionId, players, world) { _, room ->
+    ): Unit = withPlayerAndRoom(sessionId, players, world) { _, room ->
         val feature = findFeatureByKeyword(room, keyword)
         if (feature == null || feature !is RoomFeature.Sign) {
             outbound.send(OutboundEvent.SendError(sessionId, "You don't see anything called '$keyword' to read here."))


### PR DESCRIPTION
## Summary
- Adds `requireOpenContainer(sessionId, room, keyword, worldState, outbound)` to `HandlerHelpers.kt` that combines feature lookup, Container type check, and open-state check into a single guard
- Replaces the repeated 5-line preamble in `handleSearchContainer`, `handleGetFrom`, and `handlePutIn` with a single-line call

Closes #421

## Test plan
- [x] `ktlintCheck` passes
- [x] `CommandRouterFeaturesTest` passes