### PR TITLE
refactor: extract shared Redis deserialize helper for zone registries

### DIFF
--- a/src/main/kotlin/dev/ambon/sharding/ClassicRedisZoneRegistry.kt
+++ b/src/main/kotlin/dev/ambon/sharding/ClassicRedisZoneRegistry.kt
@@ -52,12 +52,7 @@ class ClassicRedisZoneRegistry(
             )
         for (key in cursor.keys) {
             val json = commands.get(key) ?: continue
-            val addr =
-                try {
-                    mapper.readValue<EngineAddress>(json)
-                } catch (_: Exception) {
-                    continue
-                }
+            val addr = mapper.readValueOrNull<EngineAddress>(json) ?: continue
             if (addr.engineId == engineId) {
                 commands.expire(key, leaseTtlSeconds)
             }
@@ -76,12 +71,7 @@ class ClassicRedisZoneRegistry(
         for (key in cursor.keys) {
             val zone = key.removePrefix(keyPrefix)
             val json = commands.get(key) ?: continue
-            val addr =
-                try {
-                    mapper.readValue<EngineAddress>(json)
-                } catch (_: Exception) {
-                    continue
-                }
+            val addr = mapper.readValueOrNull<EngineAddress>(json) ?: continue
             result[zone] = addr
         }
         return result

--- a/src/main/kotlin/dev/ambon/sharding/InstancedRedisZoneRegistry.kt
+++ b/src/main/kotlin/dev/ambon/sharding/InstancedRedisZoneRegistry.kt
@@ -1,7 +1,6 @@
 package dev.ambon.sharding
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import dev.ambon.redis.RedisConnectionManager
 import io.github.oshai.kotlinlogging.KotlinLogging
 
@@ -77,12 +76,7 @@ class InstancedRedisZoneRegistry(
             for ((engineId, json) in entries.toSortedMap()) {
                 val leaseKey = "$leasePrefix$zone:$engineId"
                 if (commands.exists(leaseKey) > 0) {
-                    val instance =
-                        try {
-                            mapper.readValue<ZoneInstance>(json)
-                        } catch (_: Exception) {
-                            continue
-                        }
+                    val instance = mapper.readValueOrNull<ZoneInstance>(json) ?: continue
                     result.putIfAbsent(zone, instance.address)
                 }
             }
@@ -97,11 +91,7 @@ class InstancedRedisZoneRegistry(
             .mapNotNull { (engineId, json) ->
                 val leaseKey = "$leasePrefix$zone:$engineId"
                 if (commands.exists(leaseKey) <= 0) return@mapNotNull null
-                try {
-                    mapper.readValue<ZoneInstance>(json)
-                } catch (_: Exception) {
-                    null
-                }
+                mapper.readValueOrNull<ZoneInstance>(json)
             }.sortedBy { it.engineId }
     }
 
@@ -113,12 +103,7 @@ class InstancedRedisZoneRegistry(
         for ((zone, count) in zoneCounts) {
             val hashKey = "$instanceHashPrefix$zone"
             val existingJson = commands.hget(hashKey, engineId) ?: continue
-            val instance =
-                try {
-                    mapper.readValue<ZoneInstance>(existingJson)
-                } catch (_: Exception) {
-                    continue
-                }
+            val instance = mapper.readValueOrNull<ZoneInstance>(existingJson) ?: continue
             val updated = instance.copy(playerCount = count)
             commands.hset(hashKey, engineId, mapper.writeValueAsString(updated))
         }

--- a/src/main/kotlin/dev/ambon/sharding/RedisRegistrySupport.kt
+++ b/src/main/kotlin/dev/ambon/sharding/RedisRegistrySupport.kt
@@ -1,0 +1,12 @@
+package dev.ambon.sharding
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+
+/** Deserializes [json] to [T], returning null on any parse/mapping failure. */
+internal inline fun <reified T> ObjectMapper.readValueOrNull(json: String): T? =
+    try {
+        readValue<T>(json)
+    } catch (_: Exception) {
+        null
+    }


### PR DESCRIPTION
## Summary
- Add `ObjectMapper.readValueOrNull<T>()` reified inline extension in new `RedisRegistrySupport.kt`
- Replace 5 identical `try { readValue } catch (_) { continue/null }` guards across `ClassicRedisZoneRegistry` and `InstancedRedisZoneRegistry`
- Leave the logging variant in `ClassicRedisZoneRegistry.ownerOf` unchanged (intentionally logs at WARN)

## Test plan
- [x] Existing tests pass (`./gradlew ktlintCheck test`)

Closes #423