### PR TITLE
refactor: standardize "player not found" error messages

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -97,7 +97,7 @@ class CombatSystem(
         sessionId: SessionId,
         keywordRaw: String,
     ): String? {
-        val player = players.get(sessionId) ?: return "You are not connected."
+        val player = players.get(sessionId) ?: return ERR_NOT_CONNECTED
         val keyword = keywordRaw.trim()
         if (keyword.isEmpty()) return "Kill what?"
 

--- a/src/main/kotlin/dev/ambon/engine/EngineUtil.kt
+++ b/src/main/kotlin/dev/ambon/engine/EngineUtil.kt
@@ -7,6 +7,9 @@ import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.events.OutboundEvent
 import java.util.Random
 
+/** Standard error when `players.get(sessionId)` returns null in a system method returning `String?`. */
+internal const val ERR_NOT_CONNECTED = "You are not connected."
+
 /**
  * Sends [text] as a [OutboundEvent.SendText] to every player in [roomId],
  * optionally excluding [exclude].

--- a/src/main/kotlin/dev/ambon/engine/GroupSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/GroupSystem.kt
@@ -62,7 +62,7 @@ class GroupSystem(
         inviterSid: SessionId,
         targetName: String,
     ): String? {
-        val inviter = players.get(inviterSid) ?: return "You are not connected."
+        val inviter = players.get(inviterSid) ?: return ERR_NOT_CONNECTED
 
         val targetSid =
             players.findSessionByName(targetName)
@@ -128,7 +128,7 @@ class GroupSystem(
             return "You are already in a group."
         }
 
-        val invitee = players.get(inviteeSid) ?: return "You are not connected."
+        val invitee = players.get(inviteeSid) ?: return ERR_NOT_CONNECTED
 
         // Get or create inviter's group
         val group =
@@ -270,7 +270,7 @@ class GroupSystem(
             groupBySession[sessionId]
                 ?: return "You are not in a group."
 
-        val player = players.get(sessionId) ?: return "You are not connected."
+        val player = players.get(sessionId) ?: return ERR_NOT_CONNECTED
 
         for (sid in group.members) {
             outbound.send(

--- a/src/main/kotlin/dev/ambon/engine/GuildSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/GuildSystem.kt
@@ -62,8 +62,8 @@ class GuildSystem(
         name: String,
         tag: String,
     ): String? {
-        val ps = players.get(sessionId) ?: return "You are not logged in."
-        val pid = ps.playerId ?: return "You are not logged in."
+        val ps = players.get(sessionId) ?: return ERR_NOT_CONNECTED
+        val pid = ps.playerId ?: return ERR_NOT_CONNECTED
 
         if (ps.guildId != null) return "You are already in a guild."
 
@@ -110,7 +110,7 @@ class GuildSystem(
     }
 
     suspend fun disband(sessionId: SessionId): String? {
-        val ps = players.get(sessionId) ?: return "You are not logged in."
+        val ps = players.get(sessionId) ?: return ERR_NOT_CONNECTED
         val gid = ps.guildId ?: return "You are not in a guild."
         if (ps.guildRank != GuildRank.LEADER) return "Only the guild leader can disband the guild."
 
@@ -145,7 +145,7 @@ class GuildSystem(
         targetName: String,
     ): String? {
         pruneExpiredInvites()
-        val ps = players.get(sessionId) ?: return "You are not logged in."
+        val ps = players.get(sessionId) ?: return ERR_NOT_CONNECTED
         val gid = ps.guildId ?: return "You are not in a guild."
         val rank = ps.guildRank ?: return "You are not in a guild."
         if (rank == GuildRank.MEMBER) return "Only officers and the leader can send guild invites."
@@ -174,8 +174,8 @@ class GuildSystem(
     }
 
     suspend fun accept(sessionId: SessionId): String? {
-        val ps = players.get(sessionId) ?: return "You are not logged in."
-        val pid = ps.playerId ?: return "You are not logged in."
+        val ps = players.get(sessionId) ?: return ERR_NOT_CONNECTED
+        val pid = ps.playerId ?: return ERR_NOT_CONNECTED
 
         if (ps.guildId != null) return "You are already in a guild."
 
@@ -202,8 +202,8 @@ class GuildSystem(
     }
 
     suspend fun leave(sessionId: SessionId): String? {
-        val ps = players.get(sessionId) ?: return "You are not logged in."
-        val pid = ps.playerId ?: return "You are not logged in."
+        val ps = players.get(sessionId) ?: return ERR_NOT_CONNECTED
+        val pid = ps.playerId ?: return ERR_NOT_CONNECTED
         val gid = ps.guildId ?: return "You are not in a guild."
         if (ps.guildRank == GuildRank.LEADER) {
             return "You are the guild leader. Disband the guild with 'guild disband', or promote another member to leader first."
@@ -227,7 +227,7 @@ class GuildSystem(
         sessionId: SessionId,
         targetName: String,
     ): String? {
-        val ps = players.get(sessionId) ?: return "You are not logged in."
+        val ps = players.get(sessionId) ?: return ERR_NOT_CONNECTED
         val gid = ps.guildId ?: return "You are not in a guild."
         val rank = ps.guildRank ?: return "You are not in a guild."
         if (rank == GuildRank.MEMBER) return "Only officers and the leader can kick guild members."
@@ -271,7 +271,7 @@ class GuildSystem(
         sessionId: SessionId,
         targetName: String,
     ): String? {
-        val ps = players.get(sessionId) ?: return "You are not logged in."
+        val ps = players.get(sessionId) ?: return ERR_NOT_CONNECTED
         val gid = ps.guildId ?: return "You are not in a guild."
         if (ps.guildRank != GuildRank.LEADER) return "Only the guild leader can promote members."
 
@@ -306,7 +306,7 @@ class GuildSystem(
         sessionId: SessionId,
         targetName: String,
     ): String? {
-        val ps = players.get(sessionId) ?: return "You are not logged in."
+        val ps = players.get(sessionId) ?: return ERR_NOT_CONNECTED
         val gid = ps.guildId ?: return "You are not in a guild."
         if (ps.guildRank != GuildRank.LEADER) return "Only the guild leader can demote members."
 
@@ -341,7 +341,7 @@ class GuildSystem(
         sessionId: SessionId,
         motd: String,
     ): String? {
-        val ps = players.get(sessionId) ?: return "You are not logged in."
+        val ps = players.get(sessionId) ?: return ERR_NOT_CONNECTED
         val gid = ps.guildId ?: return "You are not in a guild."
         val rank = ps.guildRank ?: return "You are not in a guild."
         if (rank == GuildRank.MEMBER) return "Only officers and the leader can set the guild MOTD."
@@ -356,7 +356,7 @@ class GuildSystem(
     }
 
     suspend fun roster(sessionId: SessionId): String? {
-        val ps = players.get(sessionId) ?: return "You are not logged in."
+        val ps = players.get(sessionId) ?: return ERR_NOT_CONNECTED
         val gid = ps.guildId ?: return "You are not in a guild."
         val guild = guildsById[gid] ?: return "Guild not found."
 
@@ -382,7 +382,7 @@ class GuildSystem(
     }
 
     suspend fun info(sessionId: SessionId): String? {
-        val ps = players.get(sessionId) ?: return "You are not logged in."
+        val ps = players.get(sessionId) ?: return ERR_NOT_CONNECTED
         val gid = ps.guildId ?: return "You are not in a guild."
         val guild = guildsById[gid] ?: return "Guild not found."
 
@@ -406,7 +406,7 @@ class GuildSystem(
         sessionId: SessionId,
         message: String,
     ): String? {
-        val ps = players.get(sessionId) ?: return "You are not logged in."
+        val ps = players.get(sessionId) ?: return ERR_NOT_CONNECTED
         val gid = ps.guildId ?: return "You are not in a guild."
         val guild = guildsById[gid] ?: return "Guild not found."
 

--- a/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
@@ -45,7 +45,7 @@ class QuestSystem(
         sessionId: SessionId,
         questId: String,
     ): String? {
-        val ps = players.get(sessionId) ?: return "Unknown player."
+        val ps = players.get(sessionId) ?: return ERR_NOT_CONNECTED
         val quest = registry.get(questId) ?: return "Unknown quest '$questId'."
         if (ps.activeQuests.containsKey(questId)) return "You are already on that quest."
         if (ps.completedQuestIds.contains(questId)) return "You have already completed that quest."
@@ -73,7 +73,7 @@ class QuestSystem(
         sessionId: SessionId,
         nameHint: String,
     ): String? {
-        val ps = players.get(sessionId) ?: return "Unknown player."
+        val ps = players.get(sessionId) ?: return ERR_NOT_CONNECTED
         val questId = findActiveQuestId(ps.activeQuests, nameHint) ?: return "No active quest matching '$nameHint'."
         val quest = registry.get(questId)
         ps.activeQuests = ps.activeQuests - questId

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
@@ -6,6 +6,7 @@ import dev.ambon.domain.StatBlock
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.DirtyNotifier
+import dev.ambon.engine.ERR_NOT_CONNECTED
 import dev.ambon.engine.GameSystem
 import dev.ambon.engine.GroupSystem
 import dev.ambon.engine.MobRegistry
@@ -64,7 +65,7 @@ class AbilitySystem(
         spellName: String,
         targetKeyword: String?,
     ): String? {
-        val player = players.get(sessionId) ?: return "You are not connected."
+        val player = players.get(sessionId) ?: return ERR_NOT_CONNECTED
 
         // 1. Resolve ability
         val ability = registry.findByKeyword(spellName)

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
@@ -94,7 +94,7 @@ class AdminHandler(
                     )
                     outbound.send(OutboundEvent.SendInfo(sessionId, "Transfer request sent to other engines."))
                 } else {
-                    outbound.send(OutboundEvent.SendError(sessionId, "Player not found: ${cmd.playerName}"))
+                    outbound.send(OutboundEvent.SendError(sessionId, "No such player: ${cmd.playerName}"))
                 }
                 return
             }
@@ -210,7 +210,7 @@ class AdminHandler(
                 interEngineBus.broadcast(InterEngineMessage.KickRequest(targetPlayerName = cmd.playerName))
                 outbound.send(OutboundEvent.SendInfo(sessionId, "Kick request sent to other engines."))
             } else {
-                outbound.send(OutboundEvent.SendError(sessionId, "Player not found: ${cmd.playerName}"))
+                outbound.send(OutboundEvent.SendError(sessionId, "No such player: ${cmd.playerName}"))
             }
             return
         }
@@ -227,11 +227,7 @@ class AdminHandler(
         cmd: Command.SetLevel,
     ) {
         if (!requireStaff(sessionId, players, outbound)) return
-        val targetSid = players.findSessionByName(cmd.playerName)
-        if (targetSid == null) {
-            outbound.send(OutboundEvent.SendError(sessionId, "Player '${cmd.playerName}' is not online."))
-            return
-        }
+        val targetSid = requirePlayerOnline(sessionId, cmd.playerName, players, outbound) ?: return
         val maxLevel = players.maxLevel
         if (cmd.level !in 1..maxLevel) {
             outbound.send(OutboundEvent.SendError(sessionId, "Level must be between 1 and $maxLevel."))


### PR DESCRIPTION
## Summary
- Add `ERR_NOT_CONNECTED` constant in `EngineUtil.kt` for the system-layer "player not in registry" message
- Unify GuildSystem ("You are not logged in."), QuestSystem ("Unknown player."), CombatSystem, GroupSystem, and AbilitySystem ("You are not connected.") to all use the shared constant
- Standardize AdminHandler transfer/kick error from "Player not found:" to "No such player:" (matching `requirePlayerOnline`)
- Refactor AdminHandler `handleSetLevel` to use the existing `requirePlayerOnline` helper instead of inline `findSessionByName` + custom error

## Test plan
- [x] Existing tests pass (`./gradlew ktlintCheck test`)

Closes #425