### PR TITLE
refactor: deduplicate idZone into a single shared function

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/ids/RoomId.kt
+++ b/src/main/kotlin/dev/ambon/domain/ids/RoomId.kt
@@ -4,6 +4,9 @@ package dev.ambon.domain.ids
 fun qualifyId(zone: String, localId: String): String =
     if (':' in localId) localId else "$zone:$localId"
 
+/** Extracts the zone prefix from a namespaced id (before the first `:`), or the full string if unqualified. */
+fun idZone(rawId: String): String = rawId.substringBefore(':', rawId)
+
 @JvmInline
 value class RoomId(
     val value: String,

--- a/src/main/kotlin/dev/ambon/engine/ZoneResetHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/ZoneResetHandler.kt
@@ -1,12 +1,12 @@
 package dev.ambon.engine
 
 import dev.ambon.bus.OutboundBus
+import dev.ambon.domain.ids.idZone
 import dev.ambon.domain.mob.MobState
 import dev.ambon.domain.world.MobSpawn
 import dev.ambon.domain.world.RoomFeature
 import dev.ambon.domain.world.World
 import dev.ambon.engine.behavior.BehaviorTreeSystem
-import dev.ambon.engine.commands.handlers.idZone
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
 import java.time.Clock

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -342,9 +342,6 @@ internal fun exitsLine(r: Room): String =
         "Exits: $names"
     }
 
-/** Returns the zone portion of a namespaced id (before the first ':'). */
-internal fun idZone(rawId: String): String = rawId.substringBefore(':', rawId)
-
 /**
  * Resolves [sessionId] to a [PlayerState] and its current [Room], then executes [block].
  * Returns early from the enclosing function if the player is not found or the room is missing.

--- a/src/main/kotlin/dev/ambon/engine/items/ItemRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/items/ItemRegistry.kt
@@ -5,6 +5,7 @@ import dev.ambon.domain.ids.ItemId
 import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.ids.idZone
 import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.items.ItemSlot
 import dev.ambon.domain.world.ItemSpawn
@@ -547,6 +548,4 @@ class ItemRegistry {
             }
         }
     }
-
-    private fun idZone(rawId: String): String = rawId.substringBefore(':', rawId)
 }


### PR DESCRIPTION
## Summary
- Move `idZone(rawId)` to `domain/ids/RoomId.kt` alongside the existing `qualifyId` utility
- Remove duplicate copies from `HandlerHelpers.kt` and `ItemRegistry.kt`
- Update `ZoneResetHandler` and `ItemRegistry` imports to use the shared version

## Test plan
- [x] Existing tests pass (`./gradlew ktlintCheck test`)

Closes #426