### PR TITLE
refactor: hoist intBonus calculation above when branches in AbilitySystem

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
@@ -132,11 +132,12 @@ class AbilitySystem(
         val playerMods = statusEffects?.getPlayerStatMods(sessionId) ?: StatBlock.ZERO
         val playerStats = resolveEffectiveStats(player, playerEquip, playerMods)
 
+        val intBonus = PlayerState.statBonus(playerStats.int, intSpellDivisor)
+
         when (val effect = ability.effect) {
             is AbilityEffect.DirectDamage -> {
                 deductManaAndCooldown(sessionId, player, ability, now)
                 val baseDamage = rollRange(rng, effect.damage.min, effect.damage.max)
-                val intBonus = PlayerState.statBonus(playerStats.int, intSpellDivisor)
                 val damage = (baseDamage + intBonus).coerceAtLeast(1)
                 mob.takeDamage(damage)
                 dirtyNotifier.mobHpDirty(mob.id)
@@ -169,7 +170,6 @@ class AbilitySystem(
                 }
 
                 deductManaAndCooldown(sessionId, player, ability, now)
-                val intBonus = PlayerState.statBonus(playerStats.int, intSpellDivisor)
                 for (m in targetMobs) {
                     val baseDamage = rollRange(rng, effect.damage.min, effect.damage.max)
                     val damage = (baseDamage + intBonus).coerceAtLeast(1)


### PR DESCRIPTION
## Summary
- Hoist `intBonus` calculation above the `when` expression in `handleEnemyCast()`
- Eliminates identical `PlayerState.statBonus(playerStats.int, intSpellDivisor)` calls in both `DirectDamage` and `AreaDamage` branches
- `playerStats` is already computed before the `when`, so `intBonus` can safely be computed once

Closes #428