### PR TITLE
refactor: extract AbstractPeriodicWorker from persistence workers

### DIFF
--- a/src/main/kotlin/dev/ambon/persistence/AbstractPeriodicWorker.kt
+++ b/src/main/kotlin/dev/ambon/persistence/AbstractPeriodicWorker.kt
@@ -1,0 +1,59 @@
+package dev.ambon.persistence
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Base class for background workers that periodically flush state.
+ * Subclasses implement [flush] (called each tick) and [shutdownFlush] (called once on shutdown).
+ */
+abstract class AbstractPeriodicWorker(
+    private val flushIntervalMs: Long,
+    private val scope: CoroutineScope,
+    private val dispatcher: CoroutineDispatcher,
+) {
+    private var job: Job? = null
+
+    protected abstract val workerName: String
+
+    protected abstract suspend fun flush()
+
+    protected abstract suspend fun shutdownFlush()
+
+    fun start(): Job {
+        val j =
+            scope.launch(dispatcher) {
+                log.info { "$workerName started (flushIntervalMs=$flushIntervalMs)" }
+                while (isActive) {
+                    delay(flushIntervalMs)
+                    try {
+                        flush()
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
+                        log.error(e) { "$workerName flush error" }
+                    }
+                }
+            }
+        job = j
+        return j
+    }
+
+    suspend fun shutdown() {
+        job?.cancelAndJoin()
+        job = null
+        try {
+            shutdownFlush()
+        } catch (e: Exception) {
+            log.error(e) { "$workerName shutdown flush failed" }
+        }
+    }
+}

--- a/src/main/kotlin/dev/ambon/persistence/PersistenceWorker.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PersistenceWorker.kt
@@ -4,51 +4,26 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
 
 private val log = KotlinLogging.logger {}
 
 class PersistenceWorker(
     private val repo: WriteCoalescingPlayerRepository,
-    private val flushIntervalMs: Long = 5_000L,
-    private val scope: CoroutineScope,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
-) {
-    private var job: Job? = null
+    flushIntervalMs: Long = 5_000L,
+    scope: CoroutineScope,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : AbstractPeriodicWorker(flushIntervalMs, scope, dispatcher) {
+    override val workerName = "PersistenceWorker"
 
-    fun start(): Job {
-        val j =
-            scope.launch(dispatcher) {
-                log.info { "PersistenceWorker started (flushIntervalMs=$flushIntervalMs)" }
-                while (isActive) {
-                    delay(flushIntervalMs)
-                    try {
-                        val flushed = repo.flushDirty()
-                        if (flushed > 0) {
-                            log.debug { "PersistenceWorker flushed $flushed dirty record(s)" }
-                        }
-                    } catch (e: Exception) {
-                        if (e is kotlinx.coroutines.CancellationException) throw e
-                        log.error(e) { "PersistenceWorker flush error" }
-                    }
-                }
-            }
-        job = j
-        return j
+    override suspend fun flush() {
+        val flushed = repo.flushDirty()
+        if (flushed > 0) {
+            log.debug { "PersistenceWorker flushed $flushed dirty record(s)" }
+        }
     }
 
-    suspend fun shutdown() {
-        job?.cancelAndJoin()
-        job = null
-        try {
-            val flushed = repo.flushAll()
-            log.info { "PersistenceWorker shutdown: flushed $flushed record(s)" }
-        } catch (e: Exception) {
-            log.error(e) { "PersistenceWorker shutdown flush failed" }
-        }
+    override suspend fun shutdownFlush() {
+        val flushed = repo.flushAll()
+        log.info { "PersistenceWorker shutdown: flushed $flushed record(s)" }
     }
 }

--- a/src/main/kotlin/dev/ambon/persistence/WorldStatePersistenceWorker.kt
+++ b/src/main/kotlin/dev/ambon/persistence/WorldStatePersistenceWorker.kt
@@ -2,15 +2,9 @@ package dev.ambon.persistence
 
 import dev.ambon.engine.WorldStateRegistry
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 private val log = KotlinLogging.logger {}
@@ -25,56 +19,25 @@ private val log = KotlinLogging.logger {}
 class WorldStatePersistenceWorker(
     private val registry: WorldStateRegistry,
     private val repo: WorldStateRepository,
-    private val flushIntervalMs: Long = 5_000L,
-    private val scope: CoroutineScope,
-    /** Must be the single-threaded engine dispatcher so snapshot building is thread-safe. */
-    private val engineDispatcher: CoroutineDispatcher,
-) {
-    private var job: Job? = null
+    flushIntervalMs: Long = 5_000L,
+    scope: CoroutineScope,
+    engineDispatcher: CoroutineDispatcher,
+) : AbstractPeriodicWorker(flushIntervalMs, scope, engineDispatcher) {
+    override val workerName = "WorldStatePersistenceWorker"
 
-    fun start(): Job {
-        val j =
-            scope.launch(engineDispatcher) {
-                log.info { "WorldStatePersistenceWorker started (flushIntervalMs=$flushIntervalMs)" }
-                while (isActive) {
-                    delay(flushIntervalMs)
-                    flush()
-                }
-            }
-        job = j
-        return j
-    }
-
-    /**
-     * Cancels the periodic job then performs a final flush.
-     * Safe to call after the engine coroutine has stopped (no concurrent modifications).
-     */
-    suspend fun shutdown() {
-        job?.cancelAndJoin()
-        job = null
-        try {
-            if (registry.isDirty) {
-                val snapshot = registry.buildSnapshot()
-                registry.clearDirty()
-                withContext(Dispatchers.IO) { repo.save(snapshot) }
-                log.info { "WorldStatePersistenceWorker shutdown: saved final world state" }
-            }
-        } catch (e: Exception) {
-            log.error(e) { "WorldStatePersistenceWorker shutdown flush failed" }
-        }
-    }
-
-    // Called on the engine dispatcher — safe to read/write registry here.
-    private suspend fun flush() {
+    override suspend fun flush() {
         if (!registry.isDirty) return
-        try {
-            val snapshot = registry.buildSnapshot()
-            registry.clearDirty()
-            withContext(Dispatchers.IO) { repo.save(snapshot) }
-            log.debug { "WorldStatePersistenceWorker flushed world state" }
-        } catch (e: Exception) {
-            if (e is CancellationException) throw e
-            log.error(e) { "WorldStatePersistenceWorker flush error" }
-        }
+        val snapshot = registry.buildSnapshot()
+        registry.clearDirty()
+        withContext(Dispatchers.IO) { repo.save(snapshot) }
+        log.debug { "WorldStatePersistenceWorker flushed world state" }
+    }
+
+    override suspend fun shutdownFlush() {
+        if (!registry.isDirty) return
+        val snapshot = registry.buildSnapshot()
+        registry.clearDirty()
+        withContext(Dispatchers.IO) { repo.save(snapshot) }
+        log.info { "WorldStatePersistenceWorker shutdown: saved final world state" }
     }
 }


### PR DESCRIPTION
## Summary
- Extract `AbstractPeriodicWorker` base class with shared `start()`/`shutdown()` lifecycle
- `PersistenceWorker` and `WorldStatePersistenceWorker` now extend the base class, implementing only `flush()` and `shutdownFlush()`
- Eliminates ~20 lines of duplicated coroutine lifecycle boilerplate

Closes #430