### PR TITLE
refactor: extract read-only ZoneInstanceReader interface

### DIFF
--- a/src/main/kotlin/dev/ambon/sharding/LoadBalancedInstanceSelector.kt
+++ b/src/main/kotlin/dev/ambon/sharding/LoadBalancedInstanceSelector.kt
@@ -9,7 +9,7 @@ package dev.ambon.sharding
  * 4. **Fallback** — if all instances are at or over capacity, pick the least loaded one.
  */
 class LoadBalancedInstanceSelector(
-    private val registry: ZoneRegistry,
+    private val registry: ZoneInstanceReader,
 ) : InstanceSelector {
     override fun select(
         zone: String,

--- a/src/main/kotlin/dev/ambon/sharding/ZoneRegistry.kt
+++ b/src/main/kotlin/dev/ambon/sharding/ZoneRegistry.kt
@@ -10,6 +10,14 @@ data class EngineAddress(
 )
 
 /**
+ * Read-only subset of [ZoneRegistry] for consumers that only need to query zone instances.
+ */
+interface ZoneInstanceReader {
+    /** All instances of a given zone. Empty list if nobody claims it. */
+    fun instancesOf(zone: String): List<ZoneInstance>
+}
+
+/**
  * Shared registry mapping zone names to the engine instance(s) that own them.
  *
  * In classic (non-instanced) mode each zone maps to exactly one engine.
@@ -19,7 +27,7 @@ data class EngineAddress(
  * Implementations can be backed by static config ([StaticZoneRegistry]) for
  * development or by Redis ([RedisZoneRegistry]) for dynamic deployments.
  */
-interface ZoneRegistry {
+interface ZoneRegistry : ZoneInstanceReader {
     /** Which engine owns this zone right now? Null if unclaimed. */
     fun ownerOf(zone: String): EngineAddress?
 
@@ -44,8 +52,7 @@ interface ZoneRegistry {
 
     // ---- Instancing-aware methods (default impls for backward compat) ----
 
-    /** All instances of a given zone. Empty list if nobody claims it. */
-    fun instancesOf(zone: String): List<ZoneInstance> =
+    override fun instancesOf(zone: String): List<ZoneInstance> =
         listOfNotNull(
             ownerOf(zone)?.let {
                 ZoneInstance(engineId = it.engineId, address = it, zone = zone)


### PR DESCRIPTION
## Summary
- Extract `ZoneInstanceReader` interface with the read-only `instancesOf(zone)` method
- `ZoneRegistry` now extends `ZoneInstanceReader`, keeping backward compatibility
- `LoadBalancedInstanceSelector` now depends on `ZoneInstanceReader` instead of the full `ZoneRegistry`, making the gateway's read-only intent explicit

Closes #434