### PR TITLE
refactor: add sealed subclass coverage tests for Redis bus and ProtoMapper

### DIFF
--- a/src/test/kotlin/dev/ambon/bus/RedisInboundBusTest.kt
+++ b/src/test/kotlin/dev/ambon/bus/RedisInboundBusTest.kt
@@ -155,6 +155,33 @@ class RedisInboundBusTest {
     }
 
     @Test
+    fun `all InboundEvent variants have a toEnvelope mapping`() =
+        runTest {
+            val sid = SessionId(100)
+            val variantNames =
+                InboundEvent::class.sealedSubclasses.map { it.simpleName!! }.toSet()
+            val sampleEvents: List<InboundEvent> =
+                listOf(
+                    InboundEvent.Connected(sid),
+                    InboundEvent.Disconnected(sid, "quit"),
+                    InboundEvent.LineReceived(sid, "test"),
+                    InboundEvent.GmcpReceived(sid, "Core.Hello", "{}"),
+                )
+            val coveredNames = sampleEvents.map { it::class.simpleName!! }.toSet()
+            assertEquals(
+                variantNames,
+                coveredNames,
+                "Missing InboundEvent round-trip coverage for: ${variantNames - coveredNames}",
+            )
+            // Verify every sample actually produces an envelope (toEnvelope returns non-null)
+            for (event in sampleEvents) {
+                bus.send(event)
+                assertTrue(fakePublisher.messages.isNotEmpty(), "${event::class.simpleName} should produce a Redis envelope")
+                fakePublisher.messages.clear()
+            }
+        }
+
+    @Test
     fun `trySend does not publish when delegate channel is full`() {
         val fullDelegate = LocalInboundBus(capacity = 1)
         fullDelegate.trySend(InboundEvent.Connected(SessionId(99)))

--- a/src/test/kotlin/dev/ambon/bus/RedisOutboundBusTest.kt
+++ b/src/test/kotlin/dev/ambon/bus/RedisOutboundBusTest.kt
@@ -192,6 +192,54 @@ class RedisOutboundBusTest {
             assertTrue(fakePublisher.messages.isEmpty())
         }
 
+    @Test
+    fun `all OutboundEvent variants have a toEnvelope mapping or are explicitly excluded`() =
+        runTest {
+            val sid = SessionId(100)
+            val variantNames =
+                OutboundEvent::class.sealedSubclasses.map { it.simpleName!! }.toSet()
+
+            // Every variant must appear here — either as a published event or as an excluded control-plane event.
+            val publishedEvents: List<OutboundEvent> =
+                listOf(
+                    OutboundEvent.SendText(sid, "t"),
+                    OutboundEvent.SendInfo(sid, "i"),
+                    OutboundEvent.SendError(sid, "e"),
+                    OutboundEvent.SendPrompt(sid),
+                    OutboundEvent.ShowLoginScreen(sid),
+                    OutboundEvent.SetAnsi(sid, true),
+                    OutboundEvent.Close(sid, "r"),
+                    OutboundEvent.ClearScreen(sid),
+                    OutboundEvent.ShowAnsiDemo(sid),
+                    OutboundEvent.GmcpData(sid, "p", "{}"),
+                )
+            val excludedEvents: List<OutboundEvent> =
+                listOf(
+                    OutboundEvent.SessionRedirect(sid, "e2", "h", 9092),
+                )
+
+            val coveredNames =
+                (publishedEvents + excludedEvents).map { it::class.simpleName!! }.toSet()
+            assertEquals(
+                variantNames,
+                coveredNames,
+                "Missing OutboundEvent round-trip coverage for: ${variantNames - coveredNames}",
+            )
+
+            // Verify published events produce envelopes
+            for (event in publishedEvents) {
+                bus.send(event)
+                assertTrue(fakePublisher.messages.isNotEmpty(), "${event::class.simpleName} should produce a Redis envelope")
+                fakePublisher.messages.clear()
+            }
+
+            // Verify excluded events do NOT produce envelopes
+            for (event in excludedEvents) {
+                bus.send(event)
+                assertTrue(fakePublisher.messages.isEmpty(), "${event::class.simpleName} should NOT produce a Redis envelope")
+            }
+        }
+
     private fun roundTrip(
         expected: OutboundEvent,
         sessionId: Long,

--- a/src/test/kotlin/dev/ambon/grpc/ProtoMapperTest.kt
+++ b/src/test/kotlin/dev/ambon/grpc/ProtoMapperTest.kt
@@ -148,6 +148,61 @@ class ProtoMapperTest {
         assertNull(proto.toDomain())
     }
 
+    // ── Sealed subclass coverage ────────────────────────────────────────────
+
+    @Test
+    fun `all InboundEvent variants have a proto round-trip`() {
+        val variantNames =
+            InboundEvent::class.sealedSubclasses.map { it.simpleName!! }.toSet()
+        val sampleEvents: List<InboundEvent> =
+            listOf(
+                InboundEvent.Connected(sid),
+                InboundEvent.Disconnected(sid, "quit"),
+                InboundEvent.LineReceived(sid, "test"),
+                InboundEvent.GmcpReceived(sid, "Core.Hello", "{}"),
+            )
+        val coveredNames = sampleEvents.map { it::class.simpleName!! }.toSet()
+        assertEquals(
+            variantNames,
+            coveredNames,
+            "Missing InboundEvent proto round-trip coverage for: ${variantNames - coveredNames}",
+        )
+        for (event in sampleEvents) {
+            val roundTripped = event.toProto().toDomain()
+            assertEquals(event, roundTripped, "${event::class.simpleName} should round-trip through proto")
+        }
+    }
+
+    @Test
+    fun `all OutboundEvent variants have a proto round-trip`() {
+        val variantNames =
+            OutboundEvent::class.sealedSubclasses.map { it.simpleName!! }.toSet()
+        val sampleEvents: List<OutboundEvent> =
+            listOf(
+                OutboundEvent.SendText(sid, "t"),
+                OutboundEvent.SendInfo(sid, "i"),
+                OutboundEvent.SendError(sid, "e"),
+                OutboundEvent.SendPrompt(sid),
+                OutboundEvent.ShowLoginScreen(sid),
+                OutboundEvent.SetAnsi(sid, true),
+                OutboundEvent.Close(sid, "r"),
+                OutboundEvent.ClearScreen(sid),
+                OutboundEvent.ShowAnsiDemo(sid),
+                OutboundEvent.SessionRedirect(sid, "e2", "h", 9092),
+                OutboundEvent.GmcpData(sid, "p", "{}"),
+            )
+        val coveredNames = sampleEvents.map { it::class.simpleName!! }.toSet()
+        assertEquals(
+            variantNames,
+            coveredNames,
+            "Missing OutboundEvent proto round-trip coverage for: ${variantNames - coveredNames}",
+        )
+        for (event in sampleEvents) {
+            val roundTripped = event.toProto().toDomain()
+            assertEquals(event, roundTripped, "${event::class.simpleName} should round-trip through proto")
+        }
+    }
+
     // ── sessionId preservation ─────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary
- Add `sealedSubclasses`-based coverage tests to `RedisInboundBusTest`, `RedisOutboundBusTest`, and `ProtoMapperTest`
- Tests assert that every `InboundEvent` and `OutboundEvent` sealed variant has a corresponding mapping in both the Redis bus and gRPC ProtoMapper layers
- Adding a new event variant without updating the mapping tests will now cause a test failure listing the missing variant(s)
- `SessionRedirect` is explicitly listed as excluded from Redis publishing (control-plane only)

Closes #435