### PR TITLE
refactor: extract requireOpenContainer helper in WorldFeaturesHandler

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -409,6 +409,26 @@ internal suspend fun requireContainerOpen(
     return true
 }
 
+/**
+ * Finds a [RoomFeature.Container] by keyword, verifies it's open, and returns it.
+ * Sends an appropriate error and returns null if not found, not a container, or not open.
+ */
+internal suspend fun requireOpenContainer(
+    sessionId: SessionId,
+    room: Room,
+    keyword: String,
+    worldState: WorldStateRegistry?,
+    outbound: OutboundBus,
+): RoomFeature.Container? {
+    val feature = findFeatureByKeyword(room, keyword)
+    if (feature == null || feature !is RoomFeature.Container) {
+        outbound.send(OutboundEvent.SendError(sessionId, "You don't see any container called '$keyword' here."))
+        return null
+    }
+    if (!requireContainerOpen(sessionId, feature, worldState, outbound)) return null
+    return feature
+}
+
 /** Adapter providing uniform access to a Door or Container's lockable state. */
 internal class Lockable(
     val displayName: String,

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldFeaturesHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldFeaturesHandler.kt
@@ -106,12 +106,7 @@ class WorldFeaturesHandler(
         sessionId: SessionId,
         keyword: String,
     ): Unit = withPlayerAndRoom(sessionId, players, world) { _, room ->
-        val feature = findFeatureByKeyword(room, keyword)
-        if (feature == null || feature !is RoomFeature.Container) {
-            outbound.send(OutboundEvent.SendError(sessionId, "You don't see any container called '$keyword' here."))
-            return
-        }
-        if (!requireContainerOpen(sessionId, feature, worldState, outbound)) return
+        val feature = requireOpenContainer(sessionId, room, keyword, worldState, outbound) ?: return
         val contents = worldState?.getContainerContents(feature.id) ?: emptyList()
         if (contents.isEmpty()) {
             outbound.send(OutboundEvent.SendInfo(sessionId, "The ${feature.displayName} is empty."))
@@ -126,12 +121,7 @@ class WorldFeaturesHandler(
         itemKeyword: String,
         containerKeyword: String,
     ): Unit = withPlayerAndRoom(sessionId, players, world) { me, room ->
-        val feature = findFeatureByKeyword(room, containerKeyword)
-        if (feature == null || feature !is RoomFeature.Container) {
-            outbound.send(OutboundEvent.SendError(sessionId, "You don't see any container called '$containerKeyword' here."))
-            return
-        }
-        if (!requireContainerOpen(sessionId, feature, worldState, outbound)) return
+        val feature = requireOpenContainer(sessionId, room, containerKeyword, worldState, outbound) ?: return
         val item = worldState?.removeFromContainer(feature.id, itemKeyword)
         if (item == null) {
             outbound.send(OutboundEvent.SendError(sessionId, "There is no '$itemKeyword' in the ${feature.displayName}."))
@@ -153,12 +143,7 @@ class WorldFeaturesHandler(
         itemKeyword: String,
         containerKeyword: String,
     ): Unit = withPlayerAndRoom(sessionId, players, world) { me, room ->
-        val feature = findFeatureByKeyword(room, containerKeyword)
-        if (feature == null || feature !is RoomFeature.Container) {
-            outbound.send(OutboundEvent.SendError(sessionId, "You don't see any container called '$containerKeyword' here."))
-            return
-        }
-        if (!requireContainerOpen(sessionId, feature, worldState, outbound)) return
+        val feature = requireOpenContainer(sessionId, room, containerKeyword, worldState, outbound) ?: return
         val item = items.removeFromInventory(sessionId, itemKeyword)
         if (item == null) {
             outbound.send(OutboundEvent.SendError(sessionId, "You don't have any '$itemKeyword'."))


### PR DESCRIPTION
## Summary
- Extract `requireOpenContainer()` helper in `HandlerHelpers.kt` that combines finding a container feature by keyword, verifying it's a `Container` type, and checking it's open
- Replace the duplicated 5-line preamble in `handleSearchContainer`, `handleGetFrom`, and `handlePutIn` with a single call

Closes #421