### PR TITLE
Add friends system with online status tracking

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -381,6 +381,7 @@ data class EngineConfig(
     val economy: EconomyConfig = EconomyConfig(),
     val group: GroupConfig = GroupConfig(),
     val guild: GuildConfig = GuildConfig(),
+    val friends: FriendsConfig = FriendsConfig(),
     val debug: EngineDebugConfig = EngineDebugConfig(),
     /** Maps class name (e.g. "WARRIOR") to a fully-qualified RoomId string for new-character placement. */
     val classStartRooms: Map<String, String> = emptyMap(),
@@ -545,6 +546,10 @@ data class GroupConfig(
 data class GuildConfig(
     val maxSize: Int = 50,
     val inviteTimeoutMs: Long = 60_000L,
+)
+
+data class FriendsConfig(
+    val maxFriends: Int = 50,
 )
 
 data class AbilityEngineConfig(

--- a/src/main/kotlin/dev/ambon/engine/FriendsSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/FriendsSystem.kt
@@ -1,0 +1,159 @@
+package dev.ambon.engine
+
+import dev.ambon.bus.OutboundBus
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.engine.events.OutboundEvent
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val log = KotlinLogging.logger {}
+
+class FriendsSystem(
+    private val players: PlayerRegistry,
+    private val outbound: OutboundBus,
+    private val gmcpEmitter: GmcpEmitter? = null,
+    private val maxFriends: Int = 50,
+    private val markPlayerDirty: suspend (SessionId) -> Unit = {},
+) {
+    /**
+     * Adds [targetName] to the player's friends list.
+     * Returns an error message or null on success.
+     */
+    suspend fun addFriend(sessionId: SessionId, targetName: String): String? {
+        val ps = players.get(sessionId) ?: return "You are not connected."
+        val normalizedTarget = targetName.trim()
+        if (normalizedTarget.isEmpty()) return "friend add <player>"
+
+        if (normalizedTarget.equals(ps.name, ignoreCase = true)) {
+            return "You cannot add yourself as a friend."
+        }
+
+        val key = normalizedTarget.lowercase()
+        if (ps.friendsList.contains(key)) {
+            return "$normalizedTarget is already on your friends list."
+        }
+
+        if (ps.friendsList.size >= maxFriends) {
+            return "Your friends list is full ($maxFriends maximum)."
+        }
+
+        // Verify the player name exists (online or offline)
+        val onlineTarget = players.getByName(normalizedTarget)
+        if (onlineTarget == null && !players.hasRegisteredName(normalizedTarget)) {
+            return "No player named '$normalizedTarget' exists."
+        }
+
+        val displayName = onlineTarget?.name ?: normalizedTarget
+        ps.friendsList.add(key)
+        markPlayerDirty(sessionId)
+
+        outbound.send(OutboundEvent.SendInfo(sessionId, "$displayName has been added to your friends list."))
+        gmcpEmitter?.sendFriendsList(sessionId, buildFriendsInfo(ps))
+        return null
+    }
+
+    /**
+     * Removes [targetName] from the player's friends list.
+     * Returns an error message or null on success.
+     */
+    suspend fun removeFriend(sessionId: SessionId, targetName: String): String? {
+        val ps = players.get(sessionId) ?: return "You are not connected."
+        val key = targetName.trim().lowercase()
+        if (key.isEmpty()) return "friend remove <player>"
+
+        if (!ps.friendsList.remove(key)) {
+            return "$targetName is not on your friends list."
+        }
+
+        markPlayerDirty(sessionId)
+
+        outbound.send(OutboundEvent.SendInfo(sessionId, "$targetName has been removed from your friends list."))
+        gmcpEmitter?.sendFriendsList(sessionId, buildFriendsInfo(ps))
+        return null
+    }
+
+    /**
+     * Lists all friends with online status and zone.
+     * Returns an error message or null on success.
+     */
+    suspend fun listFriends(sessionId: SessionId): String? {
+        val ps = players.get(sessionId) ?: return "You are not connected."
+
+        if (ps.friendsList.isEmpty()) {
+            outbound.send(OutboundEvent.SendInfo(sessionId, "Your friends list is empty."))
+            return null
+        }
+
+        val lines = buildString {
+            appendLine("=== Friends List (${ps.friendsList.size}/$maxFriends) ===")
+            for (friendKey in ps.friendsList.sorted()) {
+                val online = players.getByName(friendKey)
+                if (online != null) {
+                    val zone = online.roomId.zone
+                    append("  ${online.name} - Online ($zone)")
+                } else {
+                    append("  $friendKey - Offline")
+                }
+                appendLine()
+            }
+        }.trimEnd()
+
+        outbound.send(OutboundEvent.SendInfo(sessionId, lines))
+        gmcpEmitter?.sendFriendsList(sessionId, buildFriendsInfo(ps))
+        return null
+    }
+
+    /**
+     * Called when a player logs in. Notifies all online players who have this
+     * player on their friends list.
+     */
+    suspend fun onPlayerLogin(sessionId: SessionId) {
+        val ps = players.get(sessionId) ?: return
+        val lowerName = ps.name.lowercase()
+
+        for (other in players.allPlayers()) {
+            if (other.sessionId == sessionId) continue
+            if (other.friendsList.contains(lowerName)) {
+                outbound.send(
+                    OutboundEvent.SendInfo(other.sessionId, "Your friend ${ps.name} has logged in."),
+                )
+                gmcpEmitter?.sendFriendOnline(other.sessionId, ps.name, ps.level)
+            }
+        }
+    }
+
+    /**
+     * Called when a player logs out. Notifies all online players who have this
+     * player on their friends list.
+     */
+    suspend fun onPlayerLogout(playerName: String) {
+        val lowerName = playerName.lowercase()
+
+        for (other in players.allPlayers()) {
+            if (other.name.equals(playerName, ignoreCase = true)) continue
+            if (other.friendsList.contains(lowerName)) {
+                outbound.send(
+                    OutboundEvent.SendInfo(other.sessionId, "Your friend $playerName has logged out."),
+                )
+                gmcpEmitter?.sendFriendOffline(other.sessionId, playerName)
+            }
+        }
+    }
+
+    private fun buildFriendsInfo(ps: PlayerState): List<FriendInfo> =
+        ps.friendsList.sorted().map { friendKey ->
+            val online = players.getByName(friendKey)
+            FriendInfo(
+                name = online?.name ?: friendKey,
+                online = online != null,
+                level = online?.level,
+                zone = online?.roomId?.zone,
+            )
+        }
+}
+
+data class FriendInfo(
+    val name: String,
+    val online: Boolean,
+    val level: Int?,
+    val zone: String?,
+)

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -24,6 +24,7 @@ import dev.ambon.engine.commands.handlers.CombatHandler
 import dev.ambon.engine.commands.handlers.CommunicationHandler
 import dev.ambon.engine.commands.handlers.DialogueQuestHandler
 import dev.ambon.engine.commands.handlers.EngineContext
+import dev.ambon.engine.commands.handlers.FriendsHandler
 import dev.ambon.engine.commands.handlers.GroupHandler
 import dev.ambon.engine.commands.handlers.GuildHandler
 import dev.ambon.engine.commands.handlers.ItemHandler
@@ -156,7 +157,10 @@ class GameEngine(
             maxWrongPasswordRetries = loginConfig.maxWrongPasswordRetries,
             maxFailedLoginAttemptsBeforeDisconnect = loginConfig.maxFailedAttemptsBeforeDisconnect,
             maxConcurrentLogins = loginConfig.maxConcurrentLogins,
-            onAfterLogin = { sid -> guildSystem?.onPlayerLogin(sid) },
+            onAfterLogin = { sid ->
+                guildSystem?.onPlayerLogin(sid)
+                friendsSystem.onPlayerLogin(sid)
+            },
         )
     }
 
@@ -183,6 +187,7 @@ class GameEngine(
                 log.info { "Player logged out: name=${player.name} sessionId=$sid" }
                 playerLocationIndex?.unregister(player.name)
                 broadcastToRoom(players, outbound, player.roomId, "${player.name} leaves.", sid)
+                friendsSystem.onPlayerLogout(player.name)
             },
             metrics = metrics,
         )
@@ -419,6 +424,14 @@ class GameEngine(
         } else {
             null
         }
+    private val friendsSystem =
+        FriendsSystem(
+            players = players,
+            outbound = outbound,
+            gmcpEmitter = gmcpEmitter,
+            maxFriends = engineConfig.friends.maxFriends,
+            markPlayerDirty = { sid -> players.persistPlayer(sid) },
+        )
     private val combatSystem =
         CombatSystem(
             players = players,
@@ -640,6 +653,10 @@ class GameEngine(
             GuildHandler(
                 ctx = ctx,
                 guildSystem = guildSystem,
+            ),
+            FriendsHandler(
+                ctx = ctx,
+                friendsSystem = friendsSystem,
             ),
             WorldFeaturesHandler(ctx = ctx),
             AdminHandler(

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -346,6 +346,26 @@ class GmcpEmitter(
         emit(sessionId, "Char.Achievements", CharAchievementsPayload(completed = completed, inProgress = inProgress))
     }
 
+    // ---------- friends ----------
+
+    suspend fun sendFriendsList(sessionId: SessionId, friends: List<FriendInfo>) {
+        emit(
+            sessionId,
+            "Friends.List",
+            friends.map { f ->
+                FriendPayload(name = f.name, online = f.online, level = f.level, zone = f.zone)
+            },
+        )
+    }
+
+    suspend fun sendFriendOnline(sessionId: SessionId, friendName: String, level: Int) {
+        emit(sessionId, "Friends.Online", FriendEventPayload(name = friendName, level = level))
+    }
+
+    suspend fun sendFriendOffline(sessionId: SessionId, friendName: String) {
+        emit(sessionId, "Friends.Offline", FriendOfflinePayload(name = friendName))
+    }
+
     // ---------- emit helpers ----------
 
     private suspend fun <T : Any> emit(
@@ -515,6 +535,22 @@ class GmcpEmitter(
     private data class CharAchievementsPayload(
         val completed: List<CompletedAchievementPayload>,
         val inProgress: List<InProgressAchievementPayload>,
+    )
+
+    private data class FriendPayload(
+        val name: String,
+        val online: Boolean,
+        val level: Int?,
+        val zone: String?,
+    )
+
+    private data class FriendEventPayload(
+        val name: String,
+        val level: Int,
+    )
+
+    private data class FriendOfflinePayload(
+        val name: String,
     )
 
     private companion object {

--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -51,6 +51,7 @@ data class PlayerState(
     var guildRank: GuildRank? = null,
     var guildTag: String? = null,
     var recallRoomId: RoomId? = null,
+    var friendsList: MutableSet<String> = mutableSetOf(),
     /** Epoch-ms timestamp after which recall is available again. Runtime-only; not persisted. */
     var recallCooldownUntilMs: Long = 0L,
 ) {
@@ -146,6 +147,7 @@ fun PlayerRecord.toPlayerState(sessionId: SessionId): PlayerState =
         inbox = inbox.toMutableList(),
         guildId = guildId,
         recallRoomId = recallRoomId,
+        friendsList = friendsList.toMutableSet(),
     )
 
 /** Converts this runtime state to a [PlayerRecord] for persistence. */
@@ -182,6 +184,7 @@ fun PlayerState.toPlayerRecord(lastSeenEpochMs: Long): PlayerRecord {
         inbox = inbox.toList(),
         guildId = guildId,
         recallRoomId = recallRoomId,
+        friendsList = friendsList.toSet(),
     )
 }
 

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -310,6 +310,21 @@ sealed interface Command {
 
     data object Noop : Command
 
+    sealed interface Friend : Command {
+        /** `friend list` or `friend` or `friends` — show friends list. */
+        data object List : Friend
+
+        /** `friend add <name>` — add a player to friends list. */
+        data class Add(
+            val target: String,
+        ) : Friend
+
+        /** `friend remove <name>` — remove a player from friends list. */
+        data class Remove(
+            val target: String,
+        ) : Friend
+    }
+
     sealed interface Mail : Command {
         /** `mail` or `mail list` — show inbox. */
         data object List : Mail
@@ -675,6 +690,25 @@ object CommandParser {
                 }
                 "abort" -> Command.Mail.Abort
                 else -> Command.Invalid(line, "mail list | mail read <n> | mail delete <n> | mail send <player>")
+            }
+        }?.let { return it }
+
+        // friend subcommands: "friend", "friend list", "friend add <name>", "friend remove <name>"
+        // also "friends" as alias for "friend list"
+        matchPrefix(line, listOf("friend", "friends")) { rest ->
+            if (rest.isEmpty()) return@matchPrefix Command.Friend.List
+            val parts = rest.split(Regex("\\s+"), limit = 2)
+            when (parts[0].lowercase()) {
+                "list" -> Command.Friend.List
+                "add" -> {
+                    val name = parts.getOrNull(1)?.trim() ?: ""
+                    if (name.isEmpty()) Command.Invalid(line, "friend add <player>") else Command.Friend.Add(name)
+                }
+                "remove", "rem", "del", "delete" -> {
+                    val name = parts.getOrNull(1)?.trim() ?: ""
+                    if (name.isEmpty()) Command.Invalid(line, "friend remove <player>") else Command.Friend.Remove(name)
+                }
+                else -> Command.Invalid(line, "friend list | friend add <player> | friend remove <player>")
             }
         }?.let { return it }
 

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/FriendsHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/FriendsHandler.kt
@@ -1,0 +1,34 @@
+package dev.ambon.engine.commands.handlers
+
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.engine.FriendsSystem
+import dev.ambon.engine.commands.Command
+import dev.ambon.engine.commands.CommandHandler
+import dev.ambon.engine.commands.CommandRouter
+import dev.ambon.engine.commands.on
+
+class FriendsHandler(
+    ctx: EngineContext,
+    private val friendsSystem: FriendsSystem? = null,
+) : CommandHandler {
+    private val outbound = ctx.outbound
+
+    override fun register(router: CommandRouter) {
+        router.on<Command.Friend.List> { sid, _ -> handleFriendCmd(sid, Command.Friend.List) }
+        router.on<Command.Friend.Add> { sid, cmd -> handleFriendCmd(sid, cmd) }
+        router.on<Command.Friend.Remove> { sid, cmd -> handleFriendCmd(sid, cmd) }
+    }
+
+    private suspend fun handleFriendCmd(
+        sessionId: SessionId,
+        cmd: Command.Friend,
+    ) {
+        val fs = requireSystemOrNull(sessionId, friendsSystem, "Friends", outbound) ?: return
+        val err = when (cmd) {
+            Command.Friend.List -> fs.listFriends(sessionId)
+            is Command.Friend.Add -> fs.addFriend(sessionId, cmd.target)
+            is Command.Friend.Remove -> fs.removeFriend(sessionId, cmd.target)
+        }
+        outbound.sendIfError(sessionId, err)
+    }
+}

--- a/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
@@ -41,6 +41,7 @@ data class PlayerRecord(
     val inbox: List<MailMessage> = emptyList(),
     val guildId: String? = null,
     val recallRoomId: RoomId? = null,
+    val friendsList: Set<String> = emptySet(),
 ) {
     /**
      * Applies legacy migration fixes after deserialization.

--- a/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
@@ -14,6 +14,7 @@ private val completedQuestIdsType = object : TypeReference<Set<String>>() {}
 private val unlockedAchievementIdsType = object : TypeReference<Set<String>>() {}
 private val achievementProgressType = object : TypeReference<Map<String, AchievementState>>() {}
 private val mailInboxType = object : TypeReference<List<MailMessage>>() {}
+private val friendsListType = object : TypeReference<Set<String>>() {}
 
 /** Deserialises JSON with a fallback to [default] on any parse failure. */
 private fun <T> safeReadJson(json: String, type: TypeReference<T>, default: T): T =
@@ -51,6 +52,7 @@ object PlayersTable : Table("players") {
     val mailInbox = text("mail_inbox").default("[]")
     val guildId = varchar("guild_id", 64).nullable()
     val recallRoomId = varchar("recall_room_id", 128).nullable()
+    val friendsList = text("friends_list").default("[]")
 
     override val primaryKey = PrimaryKey(id)
 
@@ -87,6 +89,7 @@ object PlayersTable : Table("players") {
             inbox = safeReadJson(row[mailInbox], mailInboxType, emptyList()),
             guildId = row[guildId],
             recallRoomId = row[recallRoomId]?.let { RoomId(it) },
+            friendsList = safeReadJson(row[friendsList], friendsListType, emptySet()),
         ).migrateDefaults()
 
     /** Writes all [PlayerRecord] fields into an insert or upsert [statement]. */
@@ -122,5 +125,6 @@ object PlayersTable : Table("players") {
         statement[mailInbox] = jsonMapper.writeValueAsString(record.inbox)
         statement[guildId] = record.guildId
         statement[recallRoomId] = record.recallRoomId?.value
+        statement[friendsList] = jsonMapper.writeValueAsString(record.friendsList)
     }
 }

--- a/src/main/resources/db/migration/V13__add_player_friends.sql
+++ b/src/main/resources/db/migration/V13__add_player_friends.sql
@@ -1,0 +1,2 @@
+ALTER TABLE players
+    ADD COLUMN friends_list TEXT NOT NULL DEFAULT '[]';

--- a/src/test/kotlin/dev/ambon/engine/FriendsSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/FriendsSystemTest.kt
@@ -1,0 +1,340 @@
+package dev.ambon.engine
+
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.buildTestPlayerRegistry
+import dev.ambon.test.drainAll
+import dev.ambon.test.loginOrFail
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class FriendsSystemTest {
+    private val roomId = RoomId("zone:room")
+
+    private fun setup(maxFriends: Int = 50): TestHarness {
+        val items = ItemRegistry()
+        val playerRepo = InMemoryPlayerRepository()
+        val players = buildTestPlayerRegistry(roomId, playerRepo, items)
+        val outbound = LocalOutboundBus()
+        val friends = FriendsSystem(
+            players = players,
+            outbound = outbound,
+            maxFriends = maxFriends,
+        )
+        return TestHarness(players, playerRepo, outbound, friends, items)
+    }
+
+    private data class TestHarness(
+        val players: PlayerRegistry,
+        val playerRepo: InMemoryPlayerRepository,
+        val outbound: LocalOutboundBus,
+        val friends: FriendsSystem,
+        val items: ItemRegistry,
+    )
+
+    @Test
+    fun `add friend success`() = runTest {
+        val h = setup()
+        val sid1 = SessionId(1L)
+        val sid2 = SessionId(2L)
+        h.players.loginOrFail(sid1, "Alice")
+        h.players.loginOrFail(sid2, "Bob")
+        h.outbound.drainAll()
+
+        val err = h.friends.addFriend(sid1, "Bob")
+        assertNull(err)
+
+        val ps = h.players.get(sid1)!!
+        assertTrue(ps.friendsList.contains("bob"))
+
+        val events = h.outbound.drainAll()
+        assertTrue(events.any { it is OutboundEvent.SendInfo && it.text.contains("Bob") && it.text.contains("added") })
+    }
+
+    @Test
+    fun `add friend with offline player`() = runTest {
+        val h = setup()
+        val sid1 = SessionId(1L)
+        val sid2 = SessionId(2L)
+        // Create Bob's account then log out
+        h.players.loginOrFail(sid2, "Bob")
+        h.players.disconnect(sid2)
+        // Now Alice logs in
+        h.players.loginOrFail(sid1, "Alice")
+        h.outbound.drainAll()
+
+        val err = h.friends.addFriend(sid1, "Bob")
+        assertNull(err)
+
+        val ps = h.players.get(sid1)!!
+        assertTrue(ps.friendsList.contains("bob"))
+    }
+
+    @Test
+    fun `cannot add self as friend`() = runTest {
+        val h = setup()
+        val sid = SessionId(1L)
+        h.players.loginOrFail(sid, "Alice")
+        h.outbound.drainAll()
+
+        val err = h.friends.addFriend(sid, "Alice")
+        assertNotNull(err)
+        assertTrue(err!!.contains("yourself"))
+    }
+
+    @Test
+    fun `cannot add duplicate friend`() = runTest {
+        val h = setup()
+        val sid1 = SessionId(1L)
+        val sid2 = SessionId(2L)
+        h.players.loginOrFail(sid1, "Alice")
+        h.players.loginOrFail(sid2, "Bob")
+        h.outbound.drainAll()
+
+        assertNull(h.friends.addFriend(sid1, "Bob"))
+        val err = h.friends.addFriend(sid1, "Bob")
+        assertNotNull(err)
+        assertTrue(err!!.contains("already"))
+    }
+
+    @Test
+    fun `cannot add nonexistent player`() = runTest {
+        val h = setup()
+        val sid = SessionId(1L)
+        h.players.loginOrFail(sid, "Alice")
+        h.outbound.drainAll()
+
+        val err = h.friends.addFriend(sid, "Nobody")
+        assertNotNull(err)
+        assertTrue(err!!.contains("No player"))
+    }
+
+    @Test
+    fun `friends list full returns error`() = runTest {
+        val h = setup(maxFriends = 2)
+        val sid1 = SessionId(1L)
+        val sid2 = SessionId(2L)
+        val sid3 = SessionId(3L)
+        val sid4 = SessionId(4L)
+        h.players.loginOrFail(sid1, "Alice")
+        h.players.loginOrFail(sid2, "Bob")
+        h.players.loginOrFail(sid3, "Carol")
+        h.players.loginOrFail(sid4, "Dave")
+        h.outbound.drainAll()
+
+        assertNull(h.friends.addFriend(sid1, "Bob"))
+        assertNull(h.friends.addFriend(sid1, "Carol"))
+        val err = h.friends.addFriend(sid1, "Dave")
+        assertNotNull(err)
+        assertTrue(err!!.contains("full"))
+    }
+
+    @Test
+    fun `remove friend success`() = runTest {
+        val h = setup()
+        val sid1 = SessionId(1L)
+        val sid2 = SessionId(2L)
+        h.players.loginOrFail(sid1, "Alice")
+        h.players.loginOrFail(sid2, "Bob")
+        h.outbound.drainAll()
+
+        assertNull(h.friends.addFriend(sid1, "Bob"))
+        h.outbound.drainAll()
+
+        val err = h.friends.removeFriend(sid1, "Bob")
+        assertNull(err)
+
+        val ps = h.players.get(sid1)!!
+        assertTrue(ps.friendsList.isEmpty())
+
+        val events = h.outbound.drainAll()
+        assertTrue(events.any { it is OutboundEvent.SendInfo && it.text.contains("removed") })
+    }
+
+    @Test
+    fun `remove friend not on list returns error`() = runTest {
+        val h = setup()
+        val sid = SessionId(1L)
+        h.players.loginOrFail(sid, "Alice")
+        h.outbound.drainAll()
+
+        val err = h.friends.removeFriend(sid, "Bob")
+        assertNotNull(err)
+        assertTrue(err!!.contains("not on your friends list"))
+    }
+
+    @Test
+    fun `list friends when empty`() = runTest {
+        val h = setup()
+        val sid = SessionId(1L)
+        h.players.loginOrFail(sid, "Alice")
+        h.outbound.drainAll()
+
+        val err = h.friends.listFriends(sid)
+        assertNull(err)
+
+        val events = h.outbound.drainAll()
+        assertTrue(events.any { it is OutboundEvent.SendInfo && it.text.contains("empty") })
+    }
+
+    @Test
+    fun `list friends shows online status and zone`() = runTest {
+        val h = setup()
+        val sid1 = SessionId(1L)
+        val sid2 = SessionId(2L)
+        h.players.loginOrFail(sid1, "Alice")
+        h.players.loginOrFail(sid2, "Bob")
+        h.outbound.drainAll()
+
+        assertNull(h.friends.addFriend(sid1, "Bob"))
+        h.outbound.drainAll()
+
+        val err = h.friends.listFriends(sid1)
+        assertNull(err)
+
+        val events = h.outbound.drainAll()
+        val infoEvent = events.filterIsInstance<OutboundEvent.SendInfo>().first()
+        assertTrue(infoEvent.text.contains("Online"))
+        assertTrue(infoEvent.text.contains("zone"))
+    }
+
+    @Test
+    fun `list friends shows offline friend`() = runTest {
+        val h = setup()
+        val sid1 = SessionId(1L)
+        val sid2 = SessionId(2L)
+        h.players.loginOrFail(sid1, "Alice")
+        h.players.loginOrFail(sid2, "Bob")
+        assertNull(h.friends.addFriend(sid1, "Bob"))
+
+        // Bob logs out
+        h.players.disconnect(sid2)
+        h.outbound.drainAll()
+
+        val err = h.friends.listFriends(sid1)
+        assertNull(err)
+
+        val events = h.outbound.drainAll()
+        val infoEvent = events.filterIsInstance<OutboundEvent.SendInfo>().first()
+        assertTrue(infoEvent.text.contains("Offline"))
+    }
+
+    @Test
+    fun `friend login notifies online friends`() = runTest {
+        val h = setup()
+        val sid1 = SessionId(1L)
+        val sid2 = SessionId(2L)
+
+        // Alice logs in and adds Bob as friend
+        h.players.loginOrFail(sid1, "Alice")
+        h.players.loginOrFail(sid2, "Bob")
+        assertNull(h.friends.addFriend(sid1, "Bob"))
+        h.outbound.drainAll()
+
+        // Simulate Bob logging out and back in
+        h.players.disconnect(sid2)
+        h.outbound.drainAll()
+
+        val sid2b = SessionId(3L)
+        h.players.loginOrFail(sid2b, "Bob")
+        h.outbound.drainAll()
+
+        h.friends.onPlayerLogin(sid2b)
+
+        val events = h.outbound.drainAll()
+        // Alice should get a notification
+        val notification = events.filterIsInstance<OutboundEvent.SendInfo>()
+            .filter { it.sessionId == sid1 }
+        assertTrue(notification.any { it.text.contains("Bob") && it.text.contains("logged in") })
+    }
+
+    @Test
+    fun `friend logout notifies online friends`() = runTest {
+        val h = setup()
+        val sid1 = SessionId(1L)
+        val sid2 = SessionId(2L)
+
+        h.players.loginOrFail(sid1, "Alice")
+        h.players.loginOrFail(sid2, "Bob")
+        assertNull(h.friends.addFriend(sid1, "Bob"))
+        h.outbound.drainAll()
+
+        h.friends.onPlayerLogout("Bob")
+
+        val events = h.outbound.drainAll()
+        val notification = events.filterIsInstance<OutboundEvent.SendInfo>()
+            .filter { it.sessionId == sid1 }
+        assertTrue(notification.any { it.text.contains("Bob") && it.text.contains("logged out") })
+    }
+
+    @Test
+    fun `login notification is one-sided`() = runTest {
+        val h = setup()
+        val sid1 = SessionId(1L)
+        val sid2 = SessionId(2L)
+
+        // Alice adds Bob as friend, but Bob does NOT add Alice
+        h.players.loginOrFail(sid1, "Alice")
+        h.players.loginOrFail(sid2, "Bob")
+        assertNull(h.friends.addFriend(sid1, "Bob"))
+        h.outbound.drainAll()
+
+        // Simulate Alice logging out and back in
+        h.players.disconnect(sid1)
+        h.outbound.drainAll()
+
+        val sid1b = SessionId(3L)
+        h.players.loginOrFail(sid1b, "Alice")
+        h.outbound.drainAll()
+
+        h.friends.onPlayerLogin(sid1b)
+
+        val events = h.outbound.drainAll()
+        // Bob should NOT get a notification (he didn't add Alice)
+        val bobNotifications = events.filterIsInstance<OutboundEvent.SendInfo>()
+            .filter { it.sessionId == sid2 }
+        assertTrue(bobNotifications.isEmpty())
+    }
+
+    @Test
+    fun `add friend is case-insensitive`() = runTest {
+        val h = setup()
+        val sid1 = SessionId(1L)
+        val sid2 = SessionId(2L)
+        h.players.loginOrFail(sid1, "Alice")
+        h.players.loginOrFail(sid2, "Bob")
+        h.outbound.drainAll()
+
+        assertNull(h.friends.addFriend(sid1, "BOB"))
+        val ps = h.players.get(sid1)!!
+        assertTrue(ps.friendsList.contains("bob"))
+
+        // Adding again with different case should fail as duplicate
+        val err = h.friends.addFriend(sid1, "bob")
+        assertNotNull(err)
+        assertTrue(err!!.contains("already"))
+    }
+
+    @Test
+    fun `remove friend is case-insensitive`() = runTest {
+        val h = setup()
+        val sid1 = SessionId(1L)
+        val sid2 = SessionId(2L)
+        h.players.loginOrFail(sid1, "Alice")
+        h.players.loginOrFail(sid2, "Bob")
+        h.outbound.drainAll()
+
+        assertNull(h.friends.addFriend(sid1, "Bob"))
+        assertNull(h.friends.removeFriend(sid1, "BOB"))
+
+        val ps = h.players.get(sid1)!!
+        assertTrue(ps.friendsList.isEmpty())
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
@@ -450,4 +450,41 @@ class CommandParserTest {
     fun `guild invite without target is Invalid`() {
         assertTrue(CommandParser.parse("guild invite") is Command.Invalid)
     }
+
+    // -------- friend commands --------
+
+    @Test
+    fun `parses friend list`() {
+        assertEquals(Command.Friend.List, CommandParser.parse("friend"))
+        assertEquals(Command.Friend.List, CommandParser.parse("friend list"))
+        assertEquals(Command.Friend.List, CommandParser.parse("friends"))
+    }
+
+    @Test
+    fun `parses friend add`() {
+        assertEquals(Command.Friend.Add("Bob"), CommandParser.parse("friend add Bob"))
+    }
+
+    @Test
+    fun `friend add without target is Invalid`() {
+        assertTrue(CommandParser.parse("friend add") is Command.Invalid)
+    }
+
+    @Test
+    fun `parses friend remove`() {
+        assertEquals(Command.Friend.Remove("Bob"), CommandParser.parse("friend remove Bob"))
+        assertEquals(Command.Friend.Remove("Bob"), CommandParser.parse("friend rem Bob"))
+        assertEquals(Command.Friend.Remove("Bob"), CommandParser.parse("friend del Bob"))
+        assertEquals(Command.Friend.Remove("Bob"), CommandParser.parse("friend delete Bob"))
+    }
+
+    @Test
+    fun `friend remove without target is Invalid`() {
+        assertTrue(CommandParser.parse("friend remove") is Command.Invalid)
+    }
+
+    @Test
+    fun `friend unknown subcommand is Invalid`() {
+        assertTrue(CommandParser.parse("friend xyz") is Command.Invalid)
+    }
 }


### PR DESCRIPTION
## Summary
Implements a complete friends system allowing players to manage a friends list with online/offline status tracking and login/logout notifications.

## Key Changes
- **FriendsSystem class**: Core system managing friend list operations (add, remove, list) with validation for duplicates, self-adds, and list capacity limits
- **Friend commands**: Added `friend list`, `friend add <name>`, and `friend remove <name>` commands with case-insensitive name handling
- **Online status tracking**: Displays friend online/offline status and zone information in the friends list
- **Login/logout notifications**: Automatically notifies players when their friends log in or out (one-way notifications based on who added whom)
- **GMCP integration**: Sends friend list updates and online/offline events via GMCP protocol
- **Persistence**: Added `friends_list` column to players table and integrated with player record serialization
- **Configuration**: Added `FriendsConfig` to engine configuration with configurable max friends limit (default 50)
- **Comprehensive tests**: 16 test cases covering add/remove operations, validation, online status, notifications, and case-insensitivity

## Implementation Details
- Friend names are stored normalized (lowercase) internally but display with original casing
- Friends list capacity is enforced with configurable maximum
- Login/logout notifications are one-sided: only players who added the logging-in player receive notifications
- Integration with GameEngine's login/logout hooks for automatic notification dispatch
- Case-insensitive friend name matching for all operations

https://claude.ai/code/session_01RwFZ7LEvRhECnxC3d6ruDc