### PR TITLE
refactor: reuse shared jsonMapper for Redis serialization

### DIFF
--- a/src/main/kotlin/dev/ambon/redis/JsonSupport.kt
+++ b/src/main/kotlin/dev/ambon/redis/JsonSupport.kt
@@ -1,10 +1,7 @@
 package dev.ambon.redis
 
-import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.KotlinModule
+import dev.ambon.persistence.jsonMapper
 
-val redisObjectMapper: ObjectMapper =
-    ObjectMapper()
-        .registerModule(KotlinModule.Builder().build())
-        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+/** Shared JSON ObjectMapper for Redis serialization. Delegates to [jsonMapper] to avoid duplicate configuration. */
+val redisObjectMapper: ObjectMapper = jsonMapper


### PR DESCRIPTION
## Summary

- Eliminate duplicate `ObjectMapper` construction between `persistence/MapperSupport.kt` (`jsonMapper`) and `redis/JsonSupport.kt` (`redisObjectMapper`). Both were byte-for-byte identical Jackson configurations (KotlinModule + FAIL_ON_UNKNOWN_PROPERTIES=false).
- `redisObjectMapper` now delegates to `jsonMapper`, removing the redundant setup while preserving the public val name so all existing call sites remain unchanged.

## Test plan

- [x] `ktlintCheck` passes
- [x] Full test suite passes (all Redis bus, persistence, gRPC, and sharding tests)