### PR TITLE
refactor: use PlayerRepositoryFactory in EngineServer

### DIFF
--- a/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
+++ b/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
@@ -21,11 +21,7 @@ import dev.ambon.metrics.GameMetrics
 import dev.ambon.metrics.MetricsHttpServer
 import dev.ambon.persistence.DatabaseManager
 import dev.ambon.persistence.PersistenceWorker
-import dev.ambon.persistence.PlayerRepository
-import dev.ambon.persistence.PostgresPlayerRepository
-import dev.ambon.persistence.RedisCachingPlayerRepository
-import dev.ambon.persistence.WriteCoalescingPlayerRepository
-import dev.ambon.persistence.YamlPlayerRepository
+import dev.ambon.persistence.PlayerRepositoryFactory
 import dev.ambon.redis.RedisConnectionManager
 import dev.ambon.redis.redisObjectMapper
 import dev.ambon.sharding.ClassicRedisZoneRegistry
@@ -59,7 +55,6 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import java.nio.file.Paths
 import java.time.Clock
 import java.util.concurrent.Executors
 
@@ -106,40 +101,20 @@ class EngineServer(
             null
         }
 
-    private val baseRepo: PlayerRepository =
-        when (config.persistence.backend) {
-            PersistenceBackend.YAML ->
-                YamlPlayerRepository(
-                    rootDir = Paths.get(config.persistence.rootDir),
-                    metrics = gameMetrics,
-                )
-            PersistenceBackend.POSTGRES ->
-                PostgresPlayerRepository(
-                    database = databaseManager!!.database,
-                    metrics = gameMetrics,
-                )
-        }
-
     private val redisManager: RedisConnectionManager? =
         if (config.redis.enabled) RedisConnectionManager(config.redis) else null
 
-    private val redisRepo: RedisCachingPlayerRepository? =
-        if (redisManager != null) {
-            RedisCachingPlayerRepository(
-                delegate = baseRepo,
-                cache = redisManager,
-                cacheTtlSeconds = config.redis.cacheTtlSeconds,
-            )
-        } else {
-            null
-        }
+    private val playerRepoChain =
+        PlayerRepositoryFactory.buildChain(
+            persistence = config.persistence,
+            redis = config.redis,
+            redisManager = redisManager,
+            database = databaseManager?.database,
+            metrics = gameMetrics,
+        )
 
-    private val l2Repo: PlayerRepository = redisRepo ?: baseRepo
-
-    private val coalescingRepo: WriteCoalescingPlayerRepository? =
-        if (config.persistence.worker.enabled) WriteCoalescingPlayerRepository(l2Repo) else null
-
-    private val playerRepo = coalescingRepo ?: l2Repo
+    private val coalescingRepo = playerRepoChain.coalescingRepository
+    private val playerRepo = playerRepoChain.repository
 
     private val inbound: InboundBus = LocalInboundBus(capacity = config.server.inboundChannelCapacity)
     private val outbound: OutboundBus = LocalOutboundBus(capacity = config.server.outboundChannelCapacity)


### PR DESCRIPTION
## Summary

- Replace the inline player repository chain construction in `EngineServer` (~33 lines building `baseRepo` / `redisRepo` / `l2Repo` / `coalescingRepo` / `playerRepo`) with a single call to the existing `PlayerRepositoryFactory.buildChain()`, matching how `MudServer` already builds its chain.
- Remove five now-unused imports (`PlayerRepository`, `PostgresPlayerRepository`, `RedisCachingPlayerRepository`, `WriteCoalescingPlayerRepository`, `YamlPlayerRepository`, `Paths`) and add `PlayerRepositoryFactory`.
- Preserves access to `coalescingRepo` (for `PersistenceWorker`) and `playerRepo` (for `createPlayerRegistry`) via the returned `PlayerRepositoryChain`.

## Test plan

- [x] `ktlintCheck` passes
- [x] `EngineGrpcServerTest` passes
- [x] `GatewayEngineIntegrationTest` passes
- [x] `PlayerRepositoryFactoryTest` passes