### PR TITLE
refactor: extract persistence backend factory pattern for guild and world-state repos

### DIFF
--- a/src/main/kotlin/dev/ambon/MudServer.kt
+++ b/src/main/kotlin/dev/ambon/MudServer.kt
@@ -25,15 +25,11 @@ import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.engine.scheduler.Scheduler
 import dev.ambon.metrics.GameMetrics
 import dev.ambon.persistence.DatabaseManager
-import dev.ambon.persistence.GuildRepository
+import dev.ambon.persistence.GuildRepositoryFactory
 import dev.ambon.persistence.PersistenceWorker
 import dev.ambon.persistence.PlayerRepositoryFactory
-import dev.ambon.persistence.PostgresGuildRepository
-import dev.ambon.persistence.PostgresWorldStateRepository
 import dev.ambon.persistence.WorldStatePersistenceWorker
-import dev.ambon.persistence.WorldStateRepository
-import dev.ambon.persistence.YamlGuildRepository
-import dev.ambon.persistence.YamlWorldStateRepository
+import dev.ambon.persistence.WorldStateRepositoryFactory
 import dev.ambon.redis.RedisConnectionManager
 import dev.ambon.redis.redisObjectMapper
 import dev.ambon.session.AtomicSessionIdFactory
@@ -68,7 +64,6 @@ import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
-import java.nio.file.Paths
 import java.time.Clock
 import java.util.concurrent.Executors
 
@@ -124,31 +119,19 @@ class MudServer(
     private val coalescingRepo = playerRepoChain.coalescingRepository
     private val playerRepo = playerRepoChain.repository
 
-    private val worldStateRepo: WorldStateRepository =
-        when (config.persistence.backend) {
-            PersistenceBackend.YAML ->
-                YamlWorldStateRepository(
-                    rootDir = Paths.get(config.persistence.rootDir),
-                )
-            PersistenceBackend.POSTGRES ->
-                PostgresWorldStateRepository(
-                    database = databaseManager!!.database,
-                )
-        }
+    private val worldStateRepo =
+        WorldStateRepositoryFactory.create(
+            persistence = config.persistence,
+            database = databaseManager?.database,
+        )
 
     private var worldStatePersistenceWorker: WorldStatePersistenceWorker? = null
 
-    private val guildRepo: GuildRepository =
-        when (config.persistence.backend) {
-            PersistenceBackend.YAML ->
-                YamlGuildRepository(
-                    rootDir = Paths.get(config.persistence.rootDir),
-                )
-            PersistenceBackend.POSTGRES ->
-                PostgresGuildRepository(
-                    database = databaseManager!!.database,
-                )
-        }
+    private val guildRepo =
+        GuildRepositoryFactory.create(
+            persistence = config.persistence,
+            database = databaseManager?.database,
+        )
 
     private val instanceId: String =
         ServerInfrastructure.generateInstanceId(config)

--- a/src/main/kotlin/dev/ambon/persistence/GuildRepositoryFactory.kt
+++ b/src/main/kotlin/dev/ambon/persistence/GuildRepositoryFactory.kt
@@ -1,0 +1,25 @@
+package dev.ambon.persistence
+
+import dev.ambon.config.PersistenceBackend
+import dev.ambon.config.PersistenceConfig
+import org.jetbrains.exposed.sql.Database
+import java.nio.file.Paths
+
+object GuildRepositoryFactory {
+    fun create(
+        persistence: PersistenceConfig,
+        database: Database?,
+    ): GuildRepository =
+        when (persistence.backend) {
+            PersistenceBackend.YAML ->
+                YamlGuildRepository(
+                    rootDir = Paths.get(persistence.rootDir),
+                )
+            PersistenceBackend.POSTGRES ->
+                PostgresGuildRepository(
+                    database = requireNotNull(database) {
+                        "Database must be configured when persistence.backend=POSTGRES"
+                    },
+                )
+        }
+}

--- a/src/main/kotlin/dev/ambon/persistence/WorldStateRepositoryFactory.kt
+++ b/src/main/kotlin/dev/ambon/persistence/WorldStateRepositoryFactory.kt
@@ -1,0 +1,25 @@
+package dev.ambon.persistence
+
+import dev.ambon.config.PersistenceBackend
+import dev.ambon.config.PersistenceConfig
+import org.jetbrains.exposed.sql.Database
+import java.nio.file.Paths
+
+object WorldStateRepositoryFactory {
+    fun create(
+        persistence: PersistenceConfig,
+        database: Database?,
+    ): WorldStateRepository =
+        when (persistence.backend) {
+            PersistenceBackend.YAML ->
+                YamlWorldStateRepository(
+                    rootDir = Paths.get(persistence.rootDir),
+                )
+            PersistenceBackend.POSTGRES ->
+                PostgresWorldStateRepository(
+                    database = requireNotNull(database) {
+                        "Database must be configured when persistence.backend=POSTGRES"
+                    },
+                )
+        }
+}


### PR DESCRIPTION
## Summary
- Extracts `WorldStateRepositoryFactory` and `GuildRepositoryFactory` as dedicated factory objects in the persistence package, following the existing `PlayerRepositoryFactory` pattern.
- Replaces inline `when (config.persistence.backend)` switches in `MudServer.kt` with calls to the new factories.
- Replaces unsafe `databaseManager!!.database` with `requireNotNull` inside the factories, providing clear error messages on misconfiguration.
- Removes six now-unused imports from `MudServer.kt` (`YamlGuildRepository`, `PostgresGuildRepository`, `YamlWorldStateRepository`, `PostgresWorldStateRepository`, `WorldStateRepository`, `GuildRepository`, `Paths`).

## Test plan
- [x] `ktlintCheck` passes
- [x] Full test suite passes (no behavioral changes -- pure refactor)