### PR TITLE
refactor: reuse DefinitionRegistry base for quest and achievement registries

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/AchievementRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/AchievementRegistry.kt
@@ -2,14 +2,4 @@ package dev.ambon.engine
 
 import dev.ambon.domain.achievement.AchievementDef
 
-class AchievementRegistry {
-    private val achievements = mutableMapOf<String, AchievementDef>()
-
-    fun register(def: AchievementDef) {
-        achievements[def.id] = def
-    }
-
-    fun get(id: String): AchievementDef? = achievements[id]
-
-    fun all(): Collection<AchievementDef> = achievements.values
-}
+class AchievementRegistry : DefinitionRegistry<String, AchievementDef>({ it.id })

--- a/src/main/kotlin/dev/ambon/engine/QuestRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/QuestRegistry.kt
@@ -2,16 +2,6 @@ package dev.ambon.engine
 
 import dev.ambon.domain.quest.QuestDef
 
-class QuestRegistry {
-    private val quests = mutableMapOf<String, QuestDef>()
-
-    fun register(quest: QuestDef) {
-        quests[quest.id] = quest
-    }
-
-    fun get(questId: String): QuestDef? = quests[questId]
-
-    fun questsForMob(mobId: String): List<QuestDef> = quests.values.filter { it.giverMobId == mobId }
-
-    fun all(): Collection<QuestDef> = quests.values
+class QuestRegistry : DefinitionRegistry<String, QuestDef>({ it.id }) {
+    fun questsForMob(mobId: String): List<QuestDef> = all().filter { it.giverMobId == mobId }
 }


### PR DESCRIPTION
## Summary

- `QuestRegistry` and `AchievementRegistry` each duplicated the same `register`/`get`/`all` pattern (private mutable map + three accessor methods) that the existing `DefinitionRegistry<Id, Def>` open class already provides.
- Both now extend `DefinitionRegistry<String, *>({ it.id })`, eliminating ~20 lines of boilerplate.
- `QuestRegistry.questsForMob` is preserved as the only quest-specific method; it now delegates to the inherited `all()`.

## Test plan

- [x] `./gradlew.bat ktlintCheck` passes
- [x] Full test suite passes (`QuestSystemTest`, `AchievementSystemTest`, and all other tests)
- No behavioral change -- all call sites (`register`, `get`, `all`) have identical signatures in the base class