### PR TITLE
refactor: extract shared gRPC timeout constants into GrpcTimeouts

### DIFF
--- a/src/main/kotlin/dev/ambon/bus/GrpcInboundBus.kt
+++ b/src/main/kotlin/dev/ambon/bus/GrpcInboundBus.kt
@@ -1,6 +1,7 @@
 package dev.ambon.bus
 
 import dev.ambon.engine.events.InboundEvent
+import dev.ambon.grpc.GrpcTimeouts
 import dev.ambon.grpc.proto.InboundEventProto
 import dev.ambon.grpc.toProto
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -11,9 +12,6 @@ import kotlinx.coroutines.withTimeout
 
 private val log = KotlinLogging.logger {}
 
-/** Bounded wait for [send] before treating the gRPC channel as overloaded. */
-private const val FORWARD_SEND_TIMEOUT_MS = 5_000L
-
 /**
  * Gateway-side [InboundBus] that forwards every event to the engine via a gRPC stream.
  *
@@ -22,7 +20,7 @@ private const val FORWARD_SEND_TIMEOUT_MS = 5_000L
  * **Forwarding semantics:**
  * - [trySend] — non-blocking. Returns failure if the gRPC writer channel is full or closed.
  *   The existing "N backpressure failures → disconnect" policy in the transport applies.
- * - [send] — suspends up to [FORWARD_SEND_TIMEOUT_MS] waiting for space in the gRPC channel.
+ * - [send] — suspends up to [GrpcTimeouts.FORWARD_SEND_TIMEOUT_MS] waiting for space in the gRPC channel.
  *   Throws [IllegalStateException] if the channel stays full past the deadline, propagating
  *   backpressure to the caller so the session is torn down.
  *
@@ -46,13 +44,13 @@ class GrpcInboundBus(
         delegate.trySend(event) // best-effort tap; never suspends
         val proto = event.toProto()
         try {
-            withTimeout(FORWARD_SEND_TIMEOUT_MS) {
+            withTimeout(GrpcTimeouts.FORWARD_SEND_TIMEOUT_MS) {
                 grpcSendChannel.send(proto)
             }
         } catch (e: TimeoutCancellationException) {
-            log.warn { "Engine gRPC channel unresponsive for ${FORWARD_SEND_TIMEOUT_MS}ms; backpressure limit reached" }
+            log.warn { "Engine gRPC channel unresponsive for ${GrpcTimeouts.FORWARD_SEND_TIMEOUT_MS}ms; backpressure limit reached" }
             throw IllegalStateException(
-                "Engine gRPC channel did not accept event within ${FORWARD_SEND_TIMEOUT_MS}ms",
+                "Engine gRPC channel did not accept event within ${GrpcTimeouts.FORWARD_SEND_TIMEOUT_MS}ms",
                 e,
             )
         }

--- a/src/main/kotlin/dev/ambon/bus/GrpcOutboundBus.kt
+++ b/src/main/kotlin/dev/ambon/bus/GrpcOutboundBus.kt
@@ -3,6 +3,7 @@ package dev.ambon.bus
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.grpc.DeliveryOutcome
+import dev.ambon.grpc.GrpcTimeouts
 import dev.ambon.grpc.cancelJobWithTimeout
 import dev.ambon.grpc.deliverWithBackpressure
 import dev.ambon.grpc.isControlPlane
@@ -48,7 +49,7 @@ class GrpcOutboundBus(
     grpcReceiveFlow: Flow<dev.ambon.grpc.proto.OutboundEventProto>,
     private val scope: CoroutineScope,
     private val metrics: GameMetrics = GameMetrics.noop(),
-    private val controlPlaneSendTimeoutMs: Long = DEFAULT_CONTROL_PLANE_SEND_TIMEOUT_MS,
+    private val controlPlaneSendTimeoutMs: Long = GrpcTimeouts.DEFAULT_CONTROL_PLANE_SEND_TIMEOUT_MS,
     private val onFailure: (GrpcOutboundFailure) -> Unit = {},
 ) : OutboundBus,
     DepthAware {
@@ -152,7 +153,7 @@ class GrpcOutboundBus(
     fun isReceiverActive(): Boolean = receiverJob?.isActive == true
 
     fun stopReceiving() {
-        cancelJobWithTimeout(receiverJob, STOP_TIMEOUT_MS, "GrpcOutboundBus receiver")
+        cancelJobWithTimeout(receiverJob, GrpcTimeouts.STOP_TIMEOUT_MS, "GrpcOutboundBus receiver")
     }
 
     override suspend fun send(event: OutboundEvent) = delegate.send(event)
@@ -169,6 +170,3 @@ class GrpcOutboundBus(
 
     override val capacity: Int get() = delegate.capacity
 }
-
-private const val DEFAULT_CONTROL_PLANE_SEND_TIMEOUT_MS = 250L
-private const val STOP_TIMEOUT_MS = 5_000L

--- a/src/main/kotlin/dev/ambon/gateway/SessionRouter.kt
+++ b/src/main/kotlin/dev/ambon/gateway/SessionRouter.kt
@@ -3,6 +3,7 @@ package dev.ambon.gateway
 import dev.ambon.bus.InboundBus
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.events.InboundEvent
+import dev.ambon.grpc.GrpcTimeouts
 import dev.ambon.grpc.proto.InboundEventProto
 import dev.ambon.grpc.toProto
 import dev.ambon.sharding.InstanceSelector
@@ -146,13 +147,13 @@ class SessionRouter(
 
         val proto = event.toProto()
         try {
-            withTimeout(FORWARD_SEND_TIMEOUT_MS) {
+            withTimeout(GrpcTimeouts.FORWARD_SEND_TIMEOUT_MS) {
                 channel.send(proto)
             }
         } catch (e: TimeoutCancellationException) {
-            log.warn { "Engine $engineId gRPC channel unresponsive for ${FORWARD_SEND_TIMEOUT_MS}ms" }
+            log.warn { "Engine $engineId gRPC channel unresponsive for ${GrpcTimeouts.FORWARD_SEND_TIMEOUT_MS}ms" }
             throw IllegalStateException(
-                "Engine $engineId gRPC channel did not accept event within ${FORWARD_SEND_TIMEOUT_MS}ms",
+                "Engine $engineId gRPC channel did not accept event within ${GrpcTimeouts.FORWARD_SEND_TIMEOUT_MS}ms",
                 e,
             )
         }
@@ -211,5 +212,3 @@ private fun InboundEvent.sessionId(): SessionId =
         is InboundEvent.GmcpReceived -> sessionId
         is InboundEvent.LineReceived -> sessionId
     }
-
-private const val FORWARD_SEND_TIMEOUT_MS = 5_000L

--- a/src/main/kotlin/dev/ambon/grpc/GrpcOutboundDispatcher.kt
+++ b/src/main/kotlin/dev/ambon/grpc/GrpcOutboundDispatcher.kt
@@ -22,7 +22,7 @@ class GrpcOutboundDispatcher(
     private val serviceImpl: EngineServiceImpl,
     private val scope: CoroutineScope,
     private val metrics: GameMetrics = GameMetrics.noop(),
-    private val controlPlaneSendTimeoutMs: Long = DEFAULT_CONTROL_PLANE_SEND_TIMEOUT_MS,
+    private val controlPlaneSendTimeoutMs: Long = GrpcTimeouts.DEFAULT_CONTROL_PLANE_SEND_TIMEOUT_MS,
 ) {
     init {
         require(controlPlaneSendTimeoutMs > 0L) {
@@ -43,7 +43,7 @@ class GrpcOutboundDispatcher(
     }
 
     fun stop() {
-        cancelJobWithTimeout(job, STOP_TIMEOUT_MS, "GrpcOutboundDispatcher job")
+        cancelJobWithTimeout(job, GrpcTimeouts.STOP_TIMEOUT_MS, "GrpcOutboundDispatcher job")
         log.info { "GrpcOutboundDispatcher stopped" }
     }
 
@@ -101,6 +101,3 @@ class GrpcOutboundDispatcher(
         }
     }
 }
-
-private const val DEFAULT_CONTROL_PLANE_SEND_TIMEOUT_MS = 250L
-private const val STOP_TIMEOUT_MS = 5_000L

--- a/src/main/kotlin/dev/ambon/grpc/GrpcTimeouts.kt
+++ b/src/main/kotlin/dev/ambon/grpc/GrpcTimeouts.kt
@@ -1,0 +1,34 @@
+package dev.ambon.grpc
+
+/**
+ * Shared timeout constants for gRPC infrastructure.
+ *
+ * These values are used across both engine-side and gateway-side gRPC components
+ * (buses, dispatchers, routers) to keep timeout behaviour consistent.
+ */
+object GrpcTimeouts {
+    /**
+     * Maximum time (ms) to wait for a gRPC send channel to accept an inbound event before
+     * treating the remote engine as overloaded.
+     *
+     * Used by [dev.ambon.bus.GrpcInboundBus] and [dev.ambon.gateway.SessionRouter].
+     */
+    const val FORWARD_SEND_TIMEOUT_MS: Long = 5_000L
+
+    /**
+     * Maximum time (ms) to wait for a background coroutine to stop gracefully before
+     * forcing cancellation.
+     *
+     * Used by [GrpcOutboundDispatcher] and `GrpcOutboundBus` via [cancelJobWithTimeout].
+     */
+    const val STOP_TIMEOUT_MS: Long = 5_000L
+
+    /**
+     * Maximum time (ms) to wait for a control-plane event to be delivered through a
+     * backpressured channel before declaring delivery failure.
+     *
+     * Used as the default for the `controlPlaneSendTimeoutMs` parameter in both
+     * [GrpcOutboundDispatcher] and `GrpcOutboundBus`.
+     */
+    const val DEFAULT_CONTROL_PLANE_SEND_TIMEOUT_MS: Long = 250L
+}


### PR DESCRIPTION
## Summary
- Three timeout constants (`FORWARD_SEND_TIMEOUT_MS`, `STOP_TIMEOUT_MS`, `DEFAULT_CONTROL_PLANE_SEND_TIMEOUT_MS`) were independently declared as `private const` in four files across the `bus`, `grpc`, and `gateway` packages with identical names and values.
- Extracted them into a single `GrpcTimeouts` object in `dev.ambon.grpc` so future timeout tuning only requires one update site.
- Updated all four consumer files (`GrpcInboundBus`, `GrpcOutboundBus`, `GrpcOutboundDispatcher`, `SessionRouter`) to reference the shared constants.

## Test plan
- [x] `ktlintCheck` passes
- [x] Full test suite passes (no behavioral change -- purely mechanical extraction)