### PR TITLE
refactor: extract shared test constants for SessionId and RoomId

### DIFF
--- a/src/test/kotlin/dev/ambon/engine/AchievementSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/AchievementSystemTest.kt
@@ -6,11 +6,11 @@ import dev.ambon.domain.achievement.AchievementCriterion
 import dev.ambon.domain.achievement.AchievementDef
 import dev.ambon.domain.achievement.AchievementRewards
 import dev.ambon.domain.achievement.CriterionType
-import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.TEST_ROOM_ID
 import dev.ambon.test.drainAll
 import dev.ambon.test.loginOrFail
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AchievementSystemTest {
-    private val roomId = RoomId("zone:room")
+    private val roomId = TEST_ROOM_ID
 
     private fun setup(vararg achievements: AchievementDef): Triple<AchievementSystem, PlayerRegistry, LocalOutboundBus> {
         val items = ItemRegistry()

--- a/src/test/kotlin/dev/ambon/engine/FriendsSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/FriendsSystemTest.kt
@@ -1,11 +1,11 @@
 package dev.ambon.engine
 
 import dev.ambon.bus.LocalOutboundBus
-import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.TEST_ROOM_ID
 import dev.ambon.test.buildTestPlayerRegistry
 import dev.ambon.test.drainAll
 import dev.ambon.test.loginOrFail
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class FriendsSystemTest {
-    private val roomId = RoomId("zone:room")
+    private val roomId = TEST_ROOM_ID
 
     private fun setup(maxFriends: Int = 50): TestHarness {
         val items = ItemRegistry()

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -17,6 +17,7 @@ import dev.ambon.engine.abilities.AbilityEffect
 import dev.ambon.engine.abilities.AbilityId
 import dev.ambon.engine.abilities.TargetType
 import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.test.TEST_SESSION_ID
 import dev.ambon.test.drainAll
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -24,7 +25,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class GmcpEmitterTest {
-    private val sid = SessionId(1L)
+    private val sid = TEST_SESSION_ID
     private val outbound = LocalOutboundBus()
 
     private val progression = PlayerProgression()

--- a/src/test/kotlin/dev/ambon/engine/GroupSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GroupSystemTest.kt
@@ -7,6 +7,7 @@ import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.persistence.InMemoryPlayerRepository
 import dev.ambon.test.MutableClock
+import dev.ambon.test.TEST_ROOM_ID
 import dev.ambon.test.buildTestPlayerRegistry
 import dev.ambon.test.drainAll
 import dev.ambon.test.loginOrFail
@@ -19,7 +20,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class GroupSystemTest {
-    private val roomId = RoomId("zone:room")
+    private val roomId = TEST_ROOM_ID
     private val room2 = RoomId("zone:room2")
 
     private fun setup(): TestHarness {

--- a/src/test/kotlin/dev/ambon/engine/GuildSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GuildSystemTest.kt
@@ -2,13 +2,13 @@ package dev.ambon.engine
 
 import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.domain.guild.GuildRank
-import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.persistence.InMemoryGuildRepository
 import dev.ambon.persistence.InMemoryPlayerRepository
 import dev.ambon.test.MutableClock
+import dev.ambon.test.TEST_ROOM_ID
 import dev.ambon.test.buildTestPlayerRegistry
 import dev.ambon.test.drainAll
 import dev.ambon.test.loginOrFail
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class GuildSystemTest {
-    private val roomId = RoomId("zone:room")
+    private val roomId = TEST_ROOM_ID
 
     private fun setup(): TestHarness {
         val items = ItemRegistry()

--- a/src/test/kotlin/dev/ambon/engine/MobRespawnTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/MobRespawnTest.kt
@@ -13,6 +13,7 @@ import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.engine.scheduler.Scheduler
 import dev.ambon.persistence.InMemoryPlayerRepository
 import dev.ambon.test.MutableClock
+import dev.ambon.test.TEST_ROOM_ID
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -22,7 +23,7 @@ import org.junit.jupiter.api.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MobRespawnTest {
-    private val roomId = RoomId("zone:room")
+    private val roomId = TEST_ROOM_ID
     private val mobId = MobId("zone:rat")
 
     /**

--- a/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
@@ -2,7 +2,6 @@ package dev.ambon.engine
 
 import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.domain.ids.ItemId
-import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.items.Item
 import dev.ambon.domain.items.ItemInstance
@@ -15,6 +14,7 @@ import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.persistence.InMemoryPlayerRepository
 import dev.ambon.test.MutableClock
+import dev.ambon.test.TEST_ROOM_ID
 import dev.ambon.test.drainAll
 import dev.ambon.test.loginOrFail
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class QuestSystemTest {
-    private val roomId = RoomId("zone:room")
+    private val roomId = TEST_ROOM_ID
     private val questId = "zone:kill_quest"
     private val mobTemplateKey = "zone:target_mob"
     private val killQuest =

--- a/src/test/kotlin/dev/ambon/engine/RegenSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/RegenSystemTest.kt
@@ -1,10 +1,10 @@
 package dev.ambon.engine
 
-import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.persistence.InMemoryPlayerRepository
 import dev.ambon.test.MutableClock
+import dev.ambon.test.TEST_ROOM_ID
 import dev.ambon.test.loginOrFail
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -15,7 +15,7 @@ import java.util.Random
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class RegenSystemTest {
-    private val roomId = RoomId("zone:room")
+    private val roomId = TEST_ROOM_ID
 
     private fun makeRegen(
         players: PlayerRegistry,

--- a/src/test/kotlin/dev/ambon/engine/abilities/AbilitySystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/abilities/AbilitySystemTest.kt
@@ -3,8 +3,6 @@ package dev.ambon.engine.abilities
 import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.domain.DamageRange
 import dev.ambon.domain.ids.MobId
-import dev.ambon.domain.ids.RoomId
-import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.mob.MobState
 import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.DirtyNotifier
@@ -20,6 +18,8 @@ import dev.ambon.engine.status.StatusEffectRegistry
 import dev.ambon.engine.status.StatusEffectSystem
 import dev.ambon.test.AbilityTestFixture
 import dev.ambon.test.MutableClock
+import dev.ambon.test.TEST_ROOM_ID
+import dev.ambon.test.TEST_SESSION_ID
 import dev.ambon.test.drainAll
 import dev.ambon.test.loginOrFail
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -33,8 +33,8 @@ import java.util.Random
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AbilitySystemTest {
-    private val roomId = RoomId("zone:room")
-    private val sid = SessionId(1L)
+    private val roomId = TEST_ROOM_ID
+    private val sid = TEST_SESSION_ID
 
     private fun buildSystem(
         clock: MutableClock = MutableClock(0L),

--- a/src/test/kotlin/dev/ambon/engine/crafting/CraftingSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/crafting/CraftingSystemTest.kt
@@ -10,13 +10,13 @@ import dev.ambon.domain.crafting.MaterialRequirement
 import dev.ambon.domain.crafting.RecipeDef
 import dev.ambon.domain.ids.ItemId
 import dev.ambon.domain.ids.RoomId
-import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.items.Item
 import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.world.ItemSpawn
 import dev.ambon.engine.PlayerState
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.test.MutableClock
+import dev.ambon.test.TEST_SESSION_ID
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -44,7 +44,7 @@ class CraftingSystemTest {
         random = Random(42),
     )
     private val items = ItemRegistry()
-    private val sid = SessionId(1L)
+    private val sid = TEST_SESSION_ID
     private val roomId = RoomId("test:mine")
 
     private val copperOreId = ItemId("test:copper_ore")

--- a/src/test/kotlin/dev/ambon/engine/status/StatusEffectSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/status/StatusEffectSystemTest.kt
@@ -2,10 +2,11 @@ package dev.ambon.engine.status
 
 import dev.ambon.domain.StatBlock
 import dev.ambon.domain.ids.MobId
-import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.test.MutableClock
 import dev.ambon.test.StatusEffectTestFixture
+import dev.ambon.test.TEST_ROOM_ID
+import dev.ambon.test.TEST_SESSION_ID
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -16,8 +17,8 @@ import java.util.Random
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class StatusEffectSystemTest {
-    private val roomId = RoomId("zone:room")
-    private val sid = SessionId(1L)
+    private val roomId = TEST_ROOM_ID
+    private val sid = TEST_SESSION_ID
     private val mobId = MobId("zone:goblin")
 
     private fun buildSystem(

--- a/src/test/kotlin/dev/ambon/sharding/HandoffManagerTest.kt
+++ b/src/test/kotlin/dev/ambon/sharding/HandoffManagerTest.kt
@@ -16,6 +16,7 @@ import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.persistence.InMemoryPlayerRepository
 import dev.ambon.persistence.PlayerId
 import dev.ambon.test.MutableClock
+import dev.ambon.test.TEST_SESSION_ID
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -90,7 +91,7 @@ class HandoffManagerTest {
             ackTimeoutMs = 1_000L,
         )
 
-    private val sid = SessionId(1L)
+    private val sid = TEST_SESSION_ID
 
     @BeforeEach
     fun setup() =

--- a/src/test/kotlin/dev/ambon/test/AbilityTestFixture.kt
+++ b/src/test/kotlin/dev/ambon/test/AbilityTestFixture.kt
@@ -15,7 +15,7 @@ import dev.ambon.persistence.InMemoryPlayerRepository
 import java.util.Random
 
 class AbilityTestFixture(
-    override val roomId: RoomId = RoomId("zone:room"),
+    override val roomId: RoomId = TEST_ROOM_ID,
     val clock: MutableClock = MutableClock(0L),
     val rng: Random = Random(42),
     val items: ItemRegistry = ItemRegistry(),

--- a/src/test/kotlin/dev/ambon/test/CombatTestFixture.kt
+++ b/src/test/kotlin/dev/ambon/test/CombatTestFixture.kt
@@ -21,7 +21,7 @@ import java.time.Clock
 import java.util.Random
 
 class CombatTestFixture(
-    override val roomId: RoomId = RoomId("zone:room"),
+    override val roomId: RoomId = TEST_ROOM_ID,
     val clock: MutableClock = MutableClock(0L),
     val items: ItemRegistry = ItemRegistry(),
     val repo: InMemoryPlayerRepository = InMemoryPlayerRepository(),

--- a/src/test/kotlin/dev/ambon/test/StatusEffectTestFixture.kt
+++ b/src/test/kotlin/dev/ambon/test/StatusEffectTestFixture.kt
@@ -13,7 +13,7 @@ import dev.ambon.persistence.InMemoryPlayerRepository
 import java.util.Random
 
 class StatusEffectTestFixture(
-    override val roomId: RoomId = RoomId("zone:room"),
+    override val roomId: RoomId = TEST_ROOM_ID,
     val clock: MutableClock = MutableClock(0L),
     val rng: Random = Random(42),
     val items: ItemRegistry = ItemRegistry(),

--- a/src/test/kotlin/dev/ambon/test/TestFixtures.kt
+++ b/src/test/kotlin/dev/ambon/test/TestFixtures.kt
@@ -36,6 +36,12 @@ import java.time.Clock
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
+/** Common session ID for single-player tests. */
+val TEST_SESSION_ID = SessionId(1L)
+
+/** Common room ID for tests that need a generic `zone:room`. */
+val TEST_ROOM_ID = RoomId("zone:room")
+
 object TestWorlds {
     val testWorld: World by lazy { WorldLoader.loadFromResource("world/test_world.yaml") }
     val okSmall: World by lazy { WorldLoader.loadFromResource("world/ok_small.yaml") }


### PR DESCRIPTION
## Summary
- Add `TEST_SESSION_ID` (`SessionId(1L)`) and `TEST_ROOM_ID` (`RoomId("zone:room")`) constants to `TestFixtures.kt`
- Update 9 test classes that repeated `private val roomId = RoomId("zone:room")` at class level to use `TEST_ROOM_ID`
- Update 5 test classes that repeated `private val sid = SessionId(1L)` at class level to use `TEST_SESSION_ID`
- Update 3 test fixture classes (`CombatTestFixture`, `StatusEffectTestFixture`, `AbilityTestFixture`) to use `TEST_ROOM_ID` as the default parameter value
- Remove now-unused `RoomId`/`SessionId` imports where applicable

## Test plan
- [x] `ktlintCheck` passes
- [x] Full test suite passes (`gradlew ktlintCheck test`)
- [ ] Verify no behavioral changes -- all constants match the original literal values exactly