### PR TITLE
refactor: extract withCommands/withAsyncCommands helpers on RedisConnectionManager

### DIFF
--- a/src/main/kotlin/dev/ambon/MudServer.kt
+++ b/src/main/kotlin/dev/ambon/MudServer.kt
@@ -452,11 +452,8 @@ class MudServer(
                         clock = clock,
                     )
                 val publisher: ScaleDecisionPublisher =
-                    if (redisManager?.commands != null) {
-                        RedisScaleDecisionPublisher(redisManager.commands!!)
-                    } else {
-                        LoggingScaleDecisionPublisher()
-                    }
+                    redisManager?.withCommands { RedisScaleDecisionPublisher(it) }
+                        ?: LoggingScaleDecisionPublisher()
                 val evalIntervalMs = config.sharding.instancing.autoScale.evaluationIntervalMs
                 autoScaleJob =
                     scope.launchPeriodic(evalIntervalMs, "Auto-scale evaluation") {

--- a/src/main/kotlin/dev/ambon/bus/RedisBusInterfaces.kt
+++ b/src/main/kotlin/dev/ambon/bus/RedisBusInterfaces.kt
@@ -41,7 +41,7 @@ internal fun isValidHmac(
 /** Creates a [BusPublisher] that publishes to Redis via the given [manager]. */
 fun redisBusPublisher(manager: RedisConnectionManager): BusPublisher =
     BusPublisher { ch, msg ->
-        manager.asyncCommands?.publish(ch, msg)
+        manager.withAsyncCommands { it.publish(ch, msg) }
     }
 
 /** Creates a [BusSubscriberSetup] that subscribes to Redis pub/sub via the given [manager]. */

--- a/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
+++ b/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
@@ -379,11 +379,8 @@ class EngineServer(
                         clock = clock,
                     )
                 val publisher: ScaleDecisionPublisher =
-                    if (redisManager?.commands != null) {
-                        RedisScaleDecisionPublisher(redisManager.commands!!)
-                    } else {
-                        LoggingScaleDecisionPublisher()
-                    }
+                    redisManager?.withCommands { RedisScaleDecisionPublisher(it) }
+                        ?: LoggingScaleDecisionPublisher()
                 autoScaleJob = launchPeriodicJob(
                     intervalMs = config.sharding.instancing.autoScale.evaluationIntervalMs,
                     label = "Auto-scale evaluation",

--- a/src/main/kotlin/dev/ambon/redis/RedisConnectionManager.kt
+++ b/src/main/kotlin/dev/ambon/redis/RedisConnectionManager.kt
@@ -62,6 +62,25 @@ class RedisConnectionManager(
         commands?.setex(key, ttlSeconds, value)
     }
 
+    /**
+     * Executes [block] with the sync [RedisCommands] handle if Redis is connected,
+     * returning the block's result.  Returns `null` when the connection is absent.
+     *
+     * Callers that need a non-null default can chain the Elvis operator:
+     * ```
+     * redis.withCommands { it.hgetall(key) } ?: emptyMap()
+     * ```
+     */
+    inline fun <T> withCommands(block: (RedisCommands<String, String>) -> T): T? =
+        commands?.let(block)
+
+    /**
+     * Executes [block] with the async [RedisAsyncCommands] handle if Redis is
+     * connected, returning the block's result.  Returns `null` when absent.
+     */
+    inline fun <T> withAsyncCommands(block: (RedisAsyncCommands<String, String>) -> T): T? =
+        asyncCommands?.let(block)
+
     override fun close() {
         pubSubConnections.forEach { runCatching { it.close() } }
         pubSubConnections.clear()

--- a/src/main/kotlin/dev/ambon/sharding/ClassicRedisZoneRegistry.kt
+++ b/src/main/kotlin/dev/ambon/sharding/ClassicRedisZoneRegistry.kt
@@ -43,37 +43,38 @@ class ClassicRedisZoneRegistry(
     }
 
     override fun renewLease(engineId: String) {
-        val commands = redis.commands ?: return
-        val cursor =
-            commands.scan(
-                io.lettuce.core.ScanArgs.Builder
-                    .matches("$keyPrefix*")
-                    .limit(100),
-            )
-        for (key in cursor.keys) {
-            val json = commands.get(key) ?: continue
-            val addr = mapper.readValueOrNull<EngineAddress>(json) ?: continue
-            if (addr.engineId == engineId) {
-                commands.expire(key, leaseTtlSeconds)
+        redis.withCommands { commands ->
+            val cursor =
+                commands.scan(
+                    io.lettuce.core.ScanArgs.Builder
+                        .matches("$keyPrefix*")
+                        .limit(100),
+                )
+            for (key in cursor.keys) {
+                val json = commands.get(key) ?: continue
+                val addr = mapper.readValueOrNull<EngineAddress>(json) ?: continue
+                if (addr.engineId == engineId) {
+                    commands.expire(key, leaseTtlSeconds)
+                }
             }
         }
     }
 
-    override fun allAssignments(): Map<String, EngineAddress> {
-        val commands = redis.commands ?: return emptyMap()
-        val result = mutableMapOf<String, EngineAddress>()
-        val cursor =
-            commands.scan(
-                io.lettuce.core.ScanArgs.Builder
-                    .matches("$keyPrefix*")
-                    .limit(1000),
-            )
-        for (key in cursor.keys) {
-            val zone = key.removePrefix(keyPrefix)
-            val json = commands.get(key) ?: continue
-            val addr = mapper.readValueOrNull<EngineAddress>(json) ?: continue
-            result[zone] = addr
-        }
-        return result
-    }
+    override fun allAssignments(): Map<String, EngineAddress> =
+        redis.withCommands { commands ->
+            val result = mutableMapOf<String, EngineAddress>()
+            val cursor =
+                commands.scan(
+                    io.lettuce.core.ScanArgs.Builder
+                        .matches("$keyPrefix*")
+                        .limit(1000),
+                )
+            for (key in cursor.keys) {
+                val zone = key.removePrefix(keyPrefix)
+                val json = commands.get(key) ?: continue
+                val addr = mapper.readValueOrNull<EngineAddress>(json) ?: continue
+                result[zone] = addr
+            }
+            result
+        } ?: emptyMap()
 }

--- a/src/main/kotlin/dev/ambon/sharding/InstancedRedisZoneRegistry.kt
+++ b/src/main/kotlin/dev/ambon/sharding/InstancedRedisZoneRegistry.kt
@@ -32,80 +32,83 @@ class InstancedRedisZoneRegistry(
         address: EngineAddress,
         zones: Set<String>,
     ) {
-        val commands = redis.commands ?: return
-        for (zone in zones) {
-            val instance =
-                ZoneInstance(
-                    engineId = engineId,
-                    address = address,
-                    zone = zone,
-                    capacity = defaultCapacity,
-                )
-            val json = mapper.writeValueAsString(instance)
-            commands.hset("$instanceHashPrefix$zone", engineId, json)
-            commands.setex("$leasePrefix$zone:$engineId", leaseTtlSeconds, "1")
+        redis.withCommands { commands ->
+            for (zone in zones) {
+                val instance =
+                    ZoneInstance(
+                        engineId = engineId,
+                        address = address,
+                        zone = zone,
+                        capacity = defaultCapacity,
+                    )
+                val json = mapper.writeValueAsString(instance)
+                commands.hset("$instanceHashPrefix$zone", engineId, json)
+                commands.setex("$leasePrefix$zone:$engineId", leaseTtlSeconds, "1")
+            }
+            log.info { "Engine '$engineId' claimed instanced zones: $zones (TTL=${leaseTtlSeconds}s)" }
         }
-        log.info { "Engine '$engineId' claimed instanced zones: $zones (TTL=${leaseTtlSeconds}s)" }
     }
 
     override fun renewLease(engineId: String) {
-        val commands = redis.commands ?: return
-        val cursor =
-            commands.scan(
-                io.lettuce.core.ScanArgs.Builder
-                    .matches("$leasePrefix*:$engineId")
-                    .limit(100),
-            )
-        for (key in cursor.keys) {
-            commands.expire(key, leaseTtlSeconds)
-        }
-    }
-
-    override fun allAssignments(): Map<String, EngineAddress> {
-        val commands = redis.commands ?: return emptyMap()
-        val result = mutableMapOf<String, EngineAddress>()
-        val cursor =
-            commands.scan(
-                io.lettuce.core.ScanArgs.Builder
-                    .matches("$instanceHashPrefix*")
-                    .limit(1000),
-            )
-        for (key in cursor.keys) {
-            val zone = key.removePrefix(instanceHashPrefix)
-            val entries = commands.hgetall(key) ?: continue
-            for ((engineId, json) in entries.toSortedMap()) {
-                val leaseKey = "$leasePrefix$zone:$engineId"
-                if (commands.exists(leaseKey) > 0) {
-                    val instance = mapper.readValueOrNull<ZoneInstance>(json) ?: continue
-                    result.putIfAbsent(zone, instance.address)
-                }
+        redis.withCommands { commands ->
+            val cursor =
+                commands.scan(
+                    io.lettuce.core.ScanArgs.Builder
+                        .matches("$leasePrefix*:$engineId")
+                        .limit(100),
+                )
+            for (key in cursor.keys) {
+                commands.expire(key, leaseTtlSeconds)
             }
         }
-        return result
     }
 
-    override fun instancesOf(zone: String): List<ZoneInstance> {
-        val commands = redis.commands ?: return emptyList()
-        val entries = commands.hgetall("$instanceHashPrefix$zone") ?: return emptyList()
-        return entries
-            .mapNotNull { (engineId, json) ->
-                val leaseKey = "$leasePrefix$zone:$engineId"
-                if (commands.exists(leaseKey) <= 0) return@mapNotNull null
-                mapper.readValueOrNull<ZoneInstance>(json)
-            }.sortedBy { it.engineId }
-    }
+    override fun allAssignments(): Map<String, EngineAddress> =
+        redis.withCommands { commands ->
+            val result = mutableMapOf<String, EngineAddress>()
+            val cursor =
+                commands.scan(
+                    io.lettuce.core.ScanArgs.Builder
+                        .matches("$instanceHashPrefix*")
+                        .limit(1000),
+                )
+            for (key in cursor.keys) {
+                val zone = key.removePrefix(instanceHashPrefix)
+                val entries = commands.hgetall(key) ?: continue
+                for ((engineId, json) in entries.toSortedMap()) {
+                    val leaseKey = "$leasePrefix$zone:$engineId"
+                    if (commands.exists(leaseKey) > 0) {
+                        val instance = mapper.readValueOrNull<ZoneInstance>(json) ?: continue
+                        result.putIfAbsent(zone, instance.address)
+                    }
+                }
+            }
+            result
+        } ?: emptyMap()
+
+    override fun instancesOf(zone: String): List<ZoneInstance> =
+        redis.withCommands { commands ->
+            val entries = commands.hgetall("$instanceHashPrefix$zone") ?: return@withCommands emptyList()
+            entries
+                .mapNotNull { (engineId, json) ->
+                    val leaseKey = "$leasePrefix$zone:$engineId"
+                    if (commands.exists(leaseKey) <= 0) return@mapNotNull null
+                    mapper.readValueOrNull<ZoneInstance>(json)
+                }.sortedBy { it.engineId }
+        } ?: emptyList()
 
     override fun reportLoad(
         engineId: String,
         zoneCounts: Map<String, Int>,
     ) {
-        val commands = redis.commands ?: return
-        for ((zone, count) in zoneCounts) {
-            val hashKey = "$instanceHashPrefix$zone"
-            val existingJson = commands.hget(hashKey, engineId) ?: continue
-            val instance = mapper.readValueOrNull<ZoneInstance>(existingJson) ?: continue
-            val updated = instance.copy(playerCount = count)
-            commands.hset(hashKey, engineId, mapper.writeValueAsString(updated))
+        redis.withCommands { commands ->
+            for ((zone, count) in zoneCounts) {
+                val hashKey = "$instanceHashPrefix$zone"
+                val existingJson = commands.hget(hashKey, engineId) ?: continue
+                val instance = mapper.readValueOrNull<ZoneInstance>(existingJson) ?: continue
+                val updated = instance.copy(playerCount = count)
+                commands.hset(hashKey, engineId, mapper.writeValueAsString(updated))
+            }
         }
     }
 

--- a/src/main/kotlin/dev/ambon/sharding/RedisPlayerLocationIndex.kt
+++ b/src/main/kotlin/dev/ambon/sharding/RedisPlayerLocationIndex.kt
@@ -44,7 +44,7 @@ class RedisPlayerLocationIndex(
         val lower = playerName.lowercase()
         try {
             // asyncCommands returns immediately without blocking.
-            redis.asyncCommands?.setex(key(playerName), keyTtlSeconds, engineId)
+            redis.withAsyncCommands { it.setex(key(playerName), keyTtlSeconds, engineId) }
             registeredNames.add(lower)
         } catch (e: Exception) {
             log.warn(e) { "PlayerLocationIndex.register failed for player=$playerName" }
@@ -56,12 +56,14 @@ class RedisPlayerLocationIndex(
         try {
             // Conditional delete: only removes the key when this engine is the current owner.
             // Prevents overwriting a registration written by the target engine during handoff.
-            redis.asyncCommands?.eval<Long>(
-                conditionalDeleteScript,
-                ScriptOutputType.INTEGER,
-                arrayOf(key(playerName)),
-                engineId,
-            )
+            redis.withAsyncCommands {
+                it.eval<Long>(
+                    conditionalDeleteScript,
+                    ScriptOutputType.INTEGER,
+                    arrayOf(key(playerName)),
+                    engineId,
+                )
+            }
             registeredNames.remove(lower)
         } catch (e: Exception) {
             log.warn(e) { "PlayerLocationIndex.unregister failed for player=$playerName" }
@@ -71,7 +73,7 @@ class RedisPlayerLocationIndex(
     override suspend fun lookupEngineId(playerName: String): String? =
         withContext(Dispatchers.IO) {
             try {
-                redis.commands?.get(key(playerName))
+                redis.withCommands { it.get(key(playerName)) }
             } catch (e: Exception) {
                 log.warn(e) { "PlayerLocationIndex.lookup failed for player=$playerName" }
                 null
@@ -81,9 +83,10 @@ class RedisPlayerLocationIndex(
     override fun refreshTtls() {
         if (registeredNames.isEmpty()) return
         try {
-            val cmds = redis.asyncCommands ?: return
-            for (name in registeredNames) {
-                cmds.expire(key(name), keyTtlSeconds)
+            redis.withAsyncCommands { cmds ->
+                for (name in registeredNames) {
+                    cmds.expire(key(name), keyTtlSeconds)
+                }
             }
         } catch (e: Exception) {
             log.warn(e) { "PlayerLocationIndex.refreshTtls failed" }


### PR DESCRIPTION
## Summary
- Adds `inline fun <T> withCommands(block)` and `inline fun <T> withAsyncCommands(block)` to `RedisConnectionManager`, encapsulating the repeated null-guard pattern (`redis.commands ?: return`) into a single reusable helper.
- Replaces 7 occurrences of `val commands = redis.commands ?: return [default]` in `ClassicRedisZoneRegistry` and `InstancedRedisZoneRegistry`, 4 safe-call usages in `RedisPlayerLocationIndex`, 1 in `RedisBusInterfaces`, and eliminates the `!!` operator in both `MudServer` and `EngineServer` ScaleDecisionPublisher wiring.

## Test plan
- [x] `ktlintCheck` passes
- [x] Full test suite passes (`./gradlew test`)
- No new tests needed -- this is a pure mechanical refactor with no behavioral change