### PR TITLE
fix: add concurrency control and disk cleanup to deploy workflows

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -17,6 +17,10 @@ on:
     types: [completed]
     branches: [main]
 
+concurrency:
+  group: deploy-demo
+  cancel-in-progress: true    # only the latest image matters for demo
+
 permissions:
   contents: read
   id-token: write   # required for OIDC AWS credential federation
@@ -45,7 +49,7 @@ jobs:
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids "$INSTANCE_ID" \
             --document-name "AWS-RunShellScript" \
-            --parameters "commands=[\"update-ambonmud $IMAGE_TAG\"]" \
+            --parameters "commands=[\"docker image prune -af --filter 'until=1h' && update-ambonmud $IMAGE_TAG\"]" \
             --comment "Auto-deploy $IMAGE_TAG from GitHub Actions" \
             --query "Command.CommandId" \
             --output text)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,10 @@ on:
     types: [completed]
     branches: [main]
 
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false   # let the running deploy finish; queue the next one
+
 permissions:
   contents: read
   id-token: write


### PR DESCRIPTION
## Summary
- **Deploy (CDK)**: Was failing with `Stack is in UPDATE_IN_PROGRESS state` because rapid merges triggered concurrent CDK deploys that collided on the same CloudFormation stack. Added `concurrency: group: deploy-staging` with `cancel-in-progress: false` so deploys queue sequentially.
- **Deploy Demo**: Was failing with `no space left on device` because old Docker images accumulated on the EC2 instance. Added `docker image prune -af --filter 'until=1h'` before pulling the new image to free disk space. Also added `concurrency: group: deploy-demo` with `cancel-in-progress: true` so only the latest image gets deployed when multiple CI runs complete.

## Test plan
- [x] Workflow YAML is syntactically valid
- [ ] Next merge to main should trigger a successful deploy