### PR TITLE
feat: show gathering nodes and crafting stations in room look

### DIFF
--- a/docs/WORLD_YAML_SPEC.md
+++ b/docs/WORLD_YAML_SPEC.md
@@ -8,12 +8,14 @@ It is written for code generators that need to emit valid zone files.
 - One YAML document describes one zone file.
 - Multiple zone files can be merged into one world.
 - YAML files are deserialized into:
-  - `WorldFile` (`zone`, `lifespan`, `startRoom`, `rooms`, `mobs`, `items`, `shops`)
+  - `WorldFile` (`zone`, `lifespan`, `startRoom`, `rooms`, `mobs`, `items`, `shops`, `gatheringNodes`, `recipes`)
   - `RoomFile`
   - `MobFile`
   - `MobDropFile`
   - `ItemFile`
   - `ShopFile`
+  - `GatheringNodeFile`
+  - `RecipeFile`
 
 ## Top-Level Schema
 
@@ -25,6 +27,8 @@ rooms: <map<string, Room>, required, must be non-empty>
 mobs: <map<string, Mob>, optional, default {}>
 items: <map<string, Item>, optional, default {}>
 shops: <map<string, Shop>, optional, default {}>
+gatheringNodes: <map<string, GatheringNode>, optional, default {}>
+recipes: <map<string, Recipe>, optional, default {}>
 ```
 
 `lifespan` notes:
@@ -34,7 +38,7 @@ shops: <map<string, Shop>, optional, default {}>
 ### Required vs optional
 
 - Required top-level fields: `zone`, `startRoom`, `rooms`
-- Optional top-level fields: `lifespan`, `mobs`, `items`, `shops`
+- Optional top-level fields: `lifespan`, `mobs`, `items`, `shops`, `gatheringNodes`, `recipes`
 
 ## Nested Schemas
 
@@ -47,7 +51,13 @@ Each value:
 title: <string, required>
 description: <string, required>
 exits: <map<string direction, string target-room-id>, optional, default {}>
+station: <string, optional - one of FORGE|ALCHEMY_TABLE|WORKBENCH (case-insensitive)>
 ```
+
+`station` notes:
+- Designates the room as a crafting station of the given type.
+- Recipes that specify a matching `station` type receive a bonus when crafted in this room.
+- Visible in room descriptions as "Crafting station: Forge" (etc.).
 
 Valid direction keys (case-insensitive):
 
@@ -223,6 +233,78 @@ Shop ID normalization:
 - `room` follows the same normalization rules as other room references (prefixed with `<zone>:` when unqualified).
 - `items` entries follow the same normalization rules as item references.
 
+### `gatheringNodes` map
+
+Each key is a gathering node ID (local or fully qualified).
+Each value:
+
+```yaml
+displayName:    <string, required, non-blank after trim>
+keyword:        <string, required, non-blank after trim>
+skill:          <string, required - one of MINING|HERBALISM (case-insensitive); must be a gathering skill>
+skillRequired:  <integer >= 1, optional, default 1>
+yields:         <list<Yield>, required, must be non-empty>
+respawnSeconds: <integer > 0, optional, default 60>
+xpReward:       <integer >= 0, optional, default 10>
+room:           <room-id string, required>
+```
+
+`Yield` entry:
+
+```yaml
+itemId:      <item-id string, required - must resolve to an existing item>
+minQuantity: <integer >= 1, optional, default 1>
+maxQuantity: <integer >= minQuantity, optional, default 1>
+```
+
+Gathering node notes:
+- `skill` must be a **gathering** skill (`MINING` or `HERBALISM`). Crafting skills (`SMITHING`, `ALCHEMY`) are rejected.
+- Nodes are visible in the room when players use the `look` command ("Resources: a copper ore vein, ...").
+- After a player gathers from a node, it becomes depleted for `respawnSeconds` before becoming available again.
+- Players must have a skill level >= `skillRequired` to gather from the node.
+- There is a configurable cooldown between gather attempts (`crafting.gatherCooldownMs`, default 3000ms).
+
+Commands:
+- `gather <keyword>` / `harvest <keyword>` / `mine <keyword>` — gather from a node in the current room.
+- `craftskills` / `professions` / `prof` — view your gathering and crafting skill levels.
+
+### `recipes` map
+
+Each key is a recipe ID (local or fully qualified).
+Each value:
+
+```yaml
+displayName:   <string, required, non-blank after trim>
+skill:         <string, required - one of SMITHING|ALCHEMY (case-insensitive); must be a crafting skill>
+skillRequired: <integer >= 1, optional, default 1>
+levelRequired: <integer >= 1, optional, default 1>
+materials:     <list<Material>, required, must be non-empty>
+outputItemId:  <item-id string, required - must resolve to an existing item>
+outputQuantity: <integer >= 1, optional, default 1>
+station:       <string, optional - one of FORGE|ALCHEMY_TABLE|WORKBENCH (case-insensitive)>
+stationBonus:  <integer >= 0, optional, default 0 - extra output quantity when crafted at a matching station>
+xpReward:      <integer >= 0, optional, default 10>
+```
+
+`Material` entry:
+
+```yaml
+itemId:   <item-id string, required - must resolve to an existing item>
+quantity: <integer >= 1, required>
+```
+
+Recipe notes:
+- `skill` must be a **crafting** skill (`SMITHING` or `ALCHEMY`). Gathering skills are rejected.
+- `materials` are consumed from the player's inventory when crafting.
+- If `station` is set and the player is in a room with a matching `station` type, the `stationBonus` extra output is produced. If `stationBonus` is 0, the global `crafting.stationBonusQuantity` (default 1) is used instead.
+- `levelRequired` is the player's character level (not skill level).
+- Crafting stations are visible in the room description ("Crafting station: Forge").
+
+Commands:
+- `craft <keyword>` / `make <keyword>` / `create <keyword>` — craft a recipe.
+- `recipes [filter]` — list all recipes, optionally filtered by skill name or recipe name.
+- `craftskills` / `professions` / `prof` — view your gathering and crafting skill levels.
+
 ## ID Normalization Rules
 
 The loader normalizes IDs with this logic:
@@ -242,6 +324,11 @@ This applies to:
 - `items` keys and `items.*.room`
 - `shops.*.room`
 - `shops.*.items` entries
+- `gatheringNodes` keys and `gatheringNodes.*.room`
+- `gatheringNodes.*.yields.*.itemId`
+- `recipes` keys
+- `recipes.*.materials.*.itemId`
+- `recipes.*.outputItemId`
 
 Examples with `zone: swamp`:
 
@@ -276,7 +363,11 @@ When loading multiple files:
 7. Every mob drop `itemId` must resolve to an existing merged item.
 8. Every shop `room` must resolve to an existing merged room.
 9. Every shop `items` entry must resolve to an existing merged item.
-10. For repeated `zone` names across files, `lifespan` merge rule is:
+10. Every gathering node `room` must resolve to an existing merged room.
+11. Every gathering node `yields.*.itemId` must resolve to an existing merged item.
+12. Every recipe `materials.*.itemId` must resolve to an existing merged item.
+13. Every recipe `outputItemId` must resolve to an existing merged item.
+14. For repeated `zone` names across files, `lifespan` merge rule is:
    - if only one file sets `lifespan`, that value is used
    - if multiple files set it, all non-null values must match
    - conflicting non-null values are rejected
@@ -314,6 +405,14 @@ For each file your tool emits:
 17. If `behavior` is present, `template` must be one of the known templates.
 18. Do not combine `behavior` with `stationary: true` — they are mutually exclusive.
 19. If using `patrol` or `patrol_aggro` templates, `patrolRoute` must be non-empty and all room IDs must resolve.
+20. If `gatheringNodes` is present, each node's `skill` must be a gathering skill (`MINING` or `HERBALISM`).
+21. Each gathering node must have a non-empty `yields` list; all `itemId` references must resolve to existing items.
+22. Each gathering node's `room` must resolve to an existing room.
+23. If `recipes` is present, each recipe's `skill` must be a crafting skill (`SMITHING` or `ALCHEMY`).
+24. Each recipe must have a non-empty `materials` list; all `itemId` references must resolve to existing items.
+25. Each recipe's `outputItemId` must resolve to an existing item.
+26. If a recipe specifies `station`, it must be one of `FORGE`, `ALCHEMY_TABLE`, or `WORKBENCH`.
+27. If a room specifies `station`, it must be one of `FORGE`, `ALCHEMY_TABLE`, or `WORKBENCH`.
 
 ## Minimal Valid Example
 
@@ -365,6 +464,9 @@ items:
   fang:
     displayName: "a rat fang"
     basePrice: 2
+  iron_ore:
+    displayName: "a chunk of iron ore"
+    basePrice: 12
   sigil:
     displayName: "a chalk sigil"
     # basePrice 0 (default) — cannot be bought or sold
@@ -390,12 +492,46 @@ rooms:
     description: "A cracked stair descends."
     exits:
       n: hall
+      w: forge
   hall:
     title: "Hall"
     description: "Pillars vanish into shadow."
     exits:
       south: entry
       east: overworld:graveyard
+  forge:
+    title: "The Forge"
+    description: "A sweltering room with a roaring forge."
+    station: FORGE
+    exits:
+      e: entry
+
+gatheringNodes:
+  iron_vein:
+    displayName: "an iron ore vein"
+    keyword: iron
+    skill: MINING
+    skillRequired: 1
+    yields:
+      - itemId: iron_ore
+        minQuantity: 1
+        maxQuantity: 2
+    respawnSeconds: 30
+    xpReward: 15
+    room: hall
+
+recipes:
+  iron_blade:
+    displayName: "Iron Blade"
+    skill: SMITHING
+    skillRequired: 5
+    materials:
+      - itemId: iron_ore
+        quantity: 3
+    outputItemId: helm
+    station: FORGE
+    stationBonus: 0
+    xpReward: 25
 ```
 
 ## Notes For Robust Generators

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -607,6 +607,7 @@ class GameEngine(
             combat = combatSystem,
             gmcpEmitter = gmcpEmitter,
             worldState = worldState,
+            gatheringRegistry = gatheringRegistry,
         )
 
         listOf(

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/EngineContext.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/EngineContext.kt
@@ -7,6 +7,7 @@ import dev.ambon.engine.GmcpEmitter
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.WorldStateRegistry
+import dev.ambon.engine.crafting.GatheringRegistry
 import dev.ambon.engine.items.ItemRegistry
 
 /**
@@ -27,4 +28,5 @@ data class EngineContext(
     val combat: CombatSystem,
     val gmcpEmitter: GmcpEmitter?,
     val worldState: WorldStateRegistry?,
+    val gatheringRegistry: GatheringRegistry? = null,
 )

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -1,6 +1,7 @@
 package dev.ambon.engine.commands.handlers
 
 import dev.ambon.bus.OutboundBus
+import dev.ambon.domain.crafting.CraftingStationType
 import dev.ambon.domain.ids.ItemId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
@@ -16,6 +17,7 @@ import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.PlayerState
 import dev.ambon.engine.WorldStateRegistry
+import dev.ambon.engine.crafting.GatheringRegistry
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
 
@@ -85,11 +87,11 @@ internal suspend fun requireSameRoom(
     return true
 }
 
-/** Convenience extension that delegates to the 8-argument [sendLook], pulling all dependencies from this context. */
+/** Convenience extension that delegates to the full [sendLook], pulling all dependencies from this context. */
 internal suspend fun EngineContext.sendLook(sessionId: SessionId) =
-    sendLook(sessionId, world, players, mobs, items, worldState, outbound, gmcpEmitter)
+    sendLook(sessionId, world, players, mobs, items, worldState, outbound, gmcpEmitter, gatheringRegistry)
 
-/** Sends a full room description (title, description, exits, items, players, mobs) to [sessionId]. */
+/** Sends a full room description (title, description, exits, items, resources, players, mobs) to [sessionId]. */
 internal suspend fun sendLook(
     sessionId: SessionId,
     world: World,
@@ -99,6 +101,7 @@ internal suspend fun sendLook(
     worldState: WorldStateRegistry?,
     outbound: OutboundBus,
     gmcpEmitter: GmcpEmitter?,
+    gatheringRegistry: GatheringRegistry? = null,
 ) {
     val me = players.get(sessionId) ?: return
     val roomId = me.roomId
@@ -146,6 +149,18 @@ internal suspend fun sendLook(
         outbound.send(OutboundEvent.SendInfo(sessionId, "You notice: $featureDesc"))
     }
 
+    // Crafting station
+    if (room.station != null) {
+        outbound.send(OutboundEvent.SendInfo(sessionId, "Crafting station: ${stationDisplayName(room.station)}"))
+    }
+
+    // Gathering resources
+    val nodes = gatheringRegistry?.nodesInRoom(roomId) ?: emptyList()
+    if (nodes.isNotEmpty()) {
+        val nodeList = nodes.map { it.displayName }.sorted().joinToString(", ")
+        outbound.send(OutboundEvent.SendInfo(sessionId, "Resources: $nodeList"))
+    }
+
     // Items
     val here = items.itemsInRoom(roomId)
     if (here.isEmpty()) {
@@ -188,6 +203,14 @@ internal suspend fun sendLook(
     gmcpEmitter?.sendRoomMobs(sessionId, rawRoomMobs)
     gmcpEmitter?.sendRoomItems(sessionId, here)
 }
+
+/** Returns a human-readable display name for a [CraftingStationType]. */
+private fun stationDisplayName(station: CraftingStationType): String =
+    when (station) {
+        CraftingStationType.FORGE -> "Forge"
+        CraftingStationType.ALCHEMY_TABLE -> "Alchemy Table"
+        CraftingStationType.WORKBENCH -> "Workbench"
+    }
 
 /** Broadcasts [message] to every player in [roomId] except [excludeSessionId]. Delegates to [dev.ambon.engine.broadcastToRoom]. */
 internal suspend fun broadcastToRoomExcept(

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterTest.kt
@@ -1,8 +1,17 @@
 package dev.ambon.engine.commands
 
+import dev.ambon.domain.crafting.CraftingSkill
+import dev.ambon.domain.crafting.CraftingStationType
+import dev.ambon.domain.crafting.GatheringNodeDef
+import dev.ambon.domain.crafting.GatheringYield
+import dev.ambon.domain.ids.ItemId
+import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.world.Direction
+import dev.ambon.domain.world.Room
+import dev.ambon.domain.world.World
 import dev.ambon.engine.LoginResult
+import dev.ambon.engine.crafting.GatheringRegistry
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.test.CommandRouterHarness
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -373,5 +382,139 @@ class CommandRouterTest {
                 "Expected 'nothing that way' message. got=$outs",
             )
             assertTrue(outs.any { it is OutboundEvent.SendPrompt }, "Missing prompt. got=$outs")
+        }
+
+    @Test
+    fun `look shows gathering nodes in room`() =
+        runTest {
+            val startRoom = RoomId("zone:hub")
+            val world = World(
+                rooms = mapOf(
+                    startRoom to Room(
+                        id = startRoom,
+                        title = "Mine Tunnel",
+                        description = "A rough tunnel.",
+                        exits = emptyMap(),
+                    ),
+                ),
+                startRoom = startRoom,
+            )
+            val registry = GatheringRegistry()
+            registry.register(
+                listOf(
+                    GatheringNodeDef(
+                        id = "zone:copper_vein",
+                        displayName = "a copper ore vein",
+                        keyword = "copper",
+                        skill = CraftingSkill.MINING,
+                        yields = listOf(GatheringYield(ItemId("zone:copper_ore"))),
+                        roomId = startRoom,
+                    ),
+                    GatheringNodeDef(
+                        id = "zone:iron_vein",
+                        displayName = "an iron ore vein",
+                        keyword = "iron",
+                        skill = CraftingSkill.MINING,
+                        skillRequired = 15,
+                        yields = listOf(GatheringYield(ItemId("zone:iron_ore"))),
+                        roomId = startRoom,
+                    ),
+                ),
+            )
+            val h = CommandRouterHarness.create(world = world, gatheringRegistry = registry)
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Player1")
+            h.drain()
+
+            h.router.handle(sid, Command.Look)
+            val outs = h.drain()
+
+            val resourceLine = outs.filterIsInstance<OutboundEvent.SendInfo>()
+                .firstOrNull { it.text.startsWith("Resources:") }
+            assertTrue(resourceLine != null, "Expected Resources line in look output. got=$outs")
+            assertTrue(
+                resourceLine!!.text.contains("a copper ore vein"),
+                "Expected copper vein in resources. got=${resourceLine.text}",
+            )
+            assertTrue(
+                resourceLine.text.contains("an iron ore vein"),
+                "Expected iron vein in resources. got=${resourceLine.text}",
+            )
+        }
+
+    @Test
+    fun `look shows crafting station when room has one`() =
+        runTest {
+            val startRoom = RoomId("zone:forge")
+            val world = World(
+                rooms = mapOf(
+                    startRoom to Room(
+                        id = startRoom,
+                        title = "The Forge",
+                        description = "A sweltering room.",
+                        exits = emptyMap(),
+                        station = CraftingStationType.FORGE,
+                    ),
+                ),
+                startRoom = startRoom,
+            )
+            val h = CommandRouterHarness.create(world = world)
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Player1")
+            h.drain()
+
+            h.router.handle(sid, Command.Look)
+            val outs = h.drain()
+
+            val stationLine = outs.filterIsInstance<OutboundEvent.SendInfo>()
+                .firstOrNull { it.text.startsWith("Crafting station:") }
+            assertTrue(stationLine != null, "Expected Crafting station line. got=$outs")
+            assertEquals("Crafting station: Forge", stationLine!!.text)
+        }
+
+    @Test
+    fun `look omits resources line when no nodes in room`() =
+        runTest {
+            val h = CommandRouterHarness.create()
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Player1")
+            h.drain()
+
+            h.router.handle(sid, Command.Look)
+            val outs = h.drain()
+
+            val hasResources = outs.filterIsInstance<OutboundEvent.SendInfo>()
+                .any { it.text.startsWith("Resources:") }
+            assertFalse(hasResources, "Should not have Resources line when no nodes exist. got=$outs")
+        }
+
+    @Test
+    fun `look shows alchemy table station display name`() =
+        runTest {
+            val startRoom = RoomId("zone:lab")
+            val world = World(
+                rooms = mapOf(
+                    startRoom to Room(
+                        id = startRoom,
+                        title = "Alchemy Lab",
+                        description = "Glass vials everywhere.",
+                        exits = emptyMap(),
+                        station = CraftingStationType.ALCHEMY_TABLE,
+                    ),
+                ),
+                startRoom = startRoom,
+            )
+            val h = CommandRouterHarness.create(world = world)
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Player1")
+            h.drain()
+
+            h.router.handle(sid, Command.Look)
+            val outs = h.drain()
+
+            val stationLine = outs.filterIsInstance<OutboundEvent.SendInfo>()
+                .firstOrNull { it.text.startsWith("Crafting station:") }
+            assertTrue(stationLine != null, "Expected Crafting station line. got=$outs")
+            assertEquals("Crafting station: Alchemy Table", stationLine!!.text)
         }
 }

--- a/src/test/kotlin/dev/ambon/engine/commands/RouterTestHelper.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/RouterTestHelper.kt
@@ -28,6 +28,7 @@ import dev.ambon.engine.commands.handlers.ProgressionHandler
 import dev.ambon.engine.commands.handlers.ShopHandler
 import dev.ambon.engine.commands.handlers.UiHandler
 import dev.ambon.engine.commands.handlers.WorldFeaturesHandler
+import dev.ambon.engine.crafting.GatheringRegistry
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.sharding.InterEngineBus
 import dev.ambon.sharding.PlayerLocationIndex
@@ -61,6 +62,7 @@ internal fun buildTestRouter(
     clock: Clock = Clock.systemUTC(),
     shopRegistry: ShopRegistry? = null,
     economyConfig: EconomyConfig = EconomyConfig(),
+    gatheringRegistry: GatheringRegistry? = null,
 ): CommandRouter {
     val router = CommandRouter(outbound = outbound, players = players)
     val ctx = EngineContext(
@@ -72,6 +74,7 @@ internal fun buildTestRouter(
         combat = combat,
         gmcpEmitter = null,
         worldState = worldState,
+        gatheringRegistry = gatheringRegistry,
     )
     listOf(
         UiHandler(ctx = ctx, onPhase = onPhase),

--- a/src/test/kotlin/dev/ambon/test/TestFixtures.kt
+++ b/src/test/kotlin/dev/ambon/test/TestFixtures.kt
@@ -19,6 +19,7 @@ import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.commands.CommandRouter
 import dev.ambon.engine.commands.PhaseResult
 import dev.ambon.engine.commands.buildTestRouter
+import dev.ambon.engine.crafting.GatheringRegistry
 import dev.ambon.engine.events.InboundEvent
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
@@ -147,6 +148,7 @@ class CommandRouterHarness private constructor(
             onCrossZoneMove: (suspend (SessionId, RoomId) -> Unit)? = null,
             economyConfig: EconomyConfig = EconomyConfig(),
             clock: Clock = Clock.systemUTC(),
+            gatheringRegistry: GatheringRegistry? = null,
         ): CommandRouterHarness {
             val combat = CombatSystem(players, mobs, items, outbound)
             val router =
@@ -169,6 +171,7 @@ class CommandRouterHarness private constructor(
                     onCrossZoneMove = onCrossZoneMove,
                     economyConfig = economyConfig,
                     clock = clock,
+                    gatheringRegistry = gatheringRegistry,
                 )
             return CommandRouterHarness(world, repo, items, players, mobs, outbound, progression, groupSystem, combat, router)
         }


### PR DESCRIPTION
## Summary
- Display gathering resource nodes in room look output ("Resources: a copper ore vein, an iron ore vein") so players can discover what's available
- Display crafting stations in room look output ("Crafting station: Forge" / "Alchemy Table" / "Workbench")
- Add `GatheringRegistry` to `EngineContext` so `sendLook` can access node data
- Update `WORLD_YAML_SPEC.md` with full documentation for `gatheringNodes`, `recipes`, and room `station` field

## Test plan
- [x] `look shows gathering nodes in room` — verifies "Resources:" line with node display names
- [x] `look shows crafting station when room has one` — verifies "Crafting station: Forge"
- [x] `look omits resources line when no nodes in room` — no spurious output
- [x] `look shows alchemy table station display name` — ALCHEMY_TABLE renders as "Alchemy Table"
- [x] Full test suite passes
- [x] ktlintCheck passes