### PR TITLE
refactor: extract shared sharding infrastructure from MudServer/EngineServer

### DIFF
--- a/src/main/kotlin/dev/ambon/CoroutineExtensions.kt
+++ b/src/main/kotlin/dev/ambon/CoroutineExtensions.kt
@@ -14,7 +14,7 @@ private val log = KotlinLogging.logger {}
  * The first execution happens after the first delay.
  * Failures are logged as warnings under [name] and the loop continues.
  */
-internal fun CoroutineScope.launchPeriodic(
+fun CoroutineScope.launchPeriodic(
     intervalMs: Long,
     name: String,
     block: suspend () -> Unit,

--- a/src/main/kotlin/dev/ambon/MudServer.kt
+++ b/src/main/kotlin/dev/ambon/MudServer.kt
@@ -10,21 +10,17 @@ import dev.ambon.bus.RedisOutboundBus
 import dev.ambon.bus.redisBusPublisher
 import dev.ambon.bus.redisBusSubscriberSetup
 import dev.ambon.config.AppConfig
-import dev.ambon.config.PersistenceBackend
-import dev.ambon.config.ShardingRegistryType
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.world.WorldFactory
 import dev.ambon.engine.GameEngine
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PersistenceContext
 import dev.ambon.engine.PlayerProgression
-import dev.ambon.engine.ShardingContext
 import dev.ambon.engine.WorldStateRegistry
 import dev.ambon.engine.createPlayerRegistry
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.engine.scheduler.Scheduler
 import dev.ambon.metrics.GameMetrics
-import dev.ambon.persistence.DatabaseManager
 import dev.ambon.persistence.GuildRepositoryFactory
 import dev.ambon.persistence.PersistenceWorker
 import dev.ambon.persistence.PlayerRepositoryFactory
@@ -33,23 +29,7 @@ import dev.ambon.persistence.WorldStateRepositoryFactory
 import dev.ambon.redis.RedisConnectionManager
 import dev.ambon.redis.redisObjectMapper
 import dev.ambon.session.AtomicSessionIdFactory
-import dev.ambon.sharding.ClassicRedisZoneRegistry
 import dev.ambon.sharding.EngineAddress
-import dev.ambon.sharding.HandoffManager
-import dev.ambon.sharding.InstanceSelector
-import dev.ambon.sharding.InstancedRedisZoneRegistry
-import dev.ambon.sharding.InterEngineBus
-import dev.ambon.sharding.LoadBalancedInstanceSelector
-import dev.ambon.sharding.LocalInterEngineBus
-import dev.ambon.sharding.LoggingScaleDecisionPublisher
-import dev.ambon.sharding.PlayerLocationIndex
-import dev.ambon.sharding.RedisInterEngineBus
-import dev.ambon.sharding.RedisPlayerLocationIndex
-import dev.ambon.sharding.RedisScaleDecisionPublisher
-import dev.ambon.sharding.ScaleDecisionPublisher
-import dev.ambon.sharding.StaticZoneRegistry
-import dev.ambon.sharding.ThresholdInstanceScaler
-import dev.ambon.sharding.ZoneRegistry
 import dev.ambon.transport.BlockingSocketTransport
 import dev.ambon.transport.KtorWebSocketTransport
 import dev.ambon.transport.OutboundRouter
@@ -97,12 +77,8 @@ class MudServer(
     private val gameMetrics: GameMetrics =
         ServerInfrastructure.createGameMetrics(prometheusRegistry)
 
-    private val databaseManager: DatabaseManager? =
-        if (config.persistence.backend == PersistenceBackend.POSTGRES) {
-            DatabaseManager(config.database).also { it.migrate() }
-        } else {
-            null
-        }
+    private val databaseManager =
+        ServerInfrastructure.createDatabaseManager(config)
 
     private val redisManager: RedisConnectionManager? =
         ServerInfrastructure.createRedisManager(config)
@@ -173,17 +149,8 @@ class MudServer(
     private val progression = PlayerProgression(config.progression)
     private val shardingEnabled = config.sharding.enabled
     private val engineId = config.sharding.engineId
-    private val configuredShardedZones =
-        config.sharding.zones
-            .map(String::trim)
-            .filter { it.isNotEmpty() }
-            .toSet()
-    private val zoneFilter =
-        if (shardingEnabled && configuredShardedZones.isNotEmpty()) {
-            configuredShardedZones
-        } else {
-            emptySet()
-        }
+    private val configuredShardedZones = ServerInfrastructure.resolveConfiguredZones(config)
+    private val zoneFilter = ServerInfrastructure.resolveZoneFilter(config, configuredShardedZones)
 
     private val world =
         WorldFactory.demoWorld(
@@ -195,18 +162,9 @@ class MudServer(
     private val worldState = WorldStateRegistry(world)
     private val tickMillis: Long = config.server.tickMillis
     private val scheduler: Scheduler = Scheduler(clock)
-    private val localZones: Set<String> =
-        if (shardingEnabled && configuredShardedZones.isNotEmpty()) {
-            configuredShardedZones
-        } else {
-            world.rooms.keys.mapTo(linkedSetOf()) { it.zone }
-        }
+    private val localZones = ServerInfrastructure.resolveLocalZones(config, configuredShardedZones, world)
     private val advertisedEngineAddress: EngineAddress =
-        EngineAddress(
-            engineId = engineId,
-            host = config.sharding.advertiseHost,
-            port = config.sharding.advertisePort ?: config.server.telnetPort,
-        )
+        ServerInfrastructure.resolveEngineAddress(config, config.server.telnetPort)
 
     private val players =
         createPlayerRegistry(
@@ -220,107 +178,30 @@ class MudServer(
         )
 
     // --- Sharding infrastructure (null when sharding is disabled) ---
-    private val zoneRegistry: ZoneRegistry? =
-        if (shardingEnabled) {
-            when (config.sharding.registry.type) {
-                ShardingRegistryType.REDIS -> {
-                    val manager =
-                        requireNotNull(redisManager) {
-                            "Sharding registry type REDIS requires ambonMUD.redis.enabled=true"
-                        }
-                    if (config.sharding.instancing.enabled) {
-                        InstancedRedisZoneRegistry(
-                            redis = manager,
-                            mapper = redisObjectMapper,
-                            leaseTtlSeconds = config.sharding.registry.leaseTtlSeconds,
-                            defaultCapacity = config.sharding.instancing.defaultCapacity,
-                        )
-                    } else {
-                        ClassicRedisZoneRegistry(
-                            redis = manager,
-                            mapper = redisObjectMapper,
-                            leaseTtlSeconds = config.sharding.registry.leaseTtlSeconds,
-                        )
-                    }
-                }
+    private val zoneRegistry =
+        ServerInfrastructure.createZoneRegistry(config, redisManager, engineId, advertisedEngineAddress, localZones)
 
-                ShardingRegistryType.STATIC -> {
-                    val configuredAssignments = config.sharding.registry.assignments
-                    val assignmentMap =
-                        if (configuredAssignments.isEmpty()) {
-                            mapOf(engineId to Pair(advertisedEngineAddress, localZones))
-                        } else {
-                            configuredAssignments.associate { assignment ->
-                                assignment.engineId to
-                                    Pair(
-                                        EngineAddress(assignment.engineId, assignment.host, assignment.port),
-                                        assignment.zones
-                                            .map(String::trim)
-                                            .filter { it.isNotEmpty() }
-                                            .toSet(),
-                                    )
-                            }
-                        }
-                    StaticZoneRegistry(
-                        assignments = assignmentMap,
-                        instancing = config.sharding.instancing.enabled,
-                    )
-                }
-            }
-        } else {
-            null
-        }
+    private val interEngineBus =
+        ServerInfrastructure.createInterEngineBus(config, redisManager)
 
-    private val interEngineBus: InterEngineBus? =
-        if (shardingEnabled && redisManager != null) {
-            RedisInterEngineBus(
-                engineId = engineId,
-                publisher = redisBusPublisher(redisManager),
-                subscriberSetup = redisBusSubscriberSetup(redisManager),
-                mapper = redisObjectMapper,
-            )
-        } else if (shardingEnabled) {
-            LocalInterEngineBus()
-        } else {
-            null
-        }
+    private val instanceSelector =
+        ServerInfrastructure.createInstanceSelector(config, zoneRegistry)
 
-    private val instanceSelector: InstanceSelector? =
-        if (shardingEnabled && config.sharding.instancing.enabled && zoneRegistry != null) {
-            LoadBalancedInstanceSelector(zoneRegistry)
-        } else {
-            null
-        }
+    private val playerLocationIndex =
+        ServerInfrastructure.createPlayerLocationIndex(config, redisManager)
 
-    private val handoffManager: HandoffManager? =
-        if (shardingEnabled && interEngineBus != null && zoneRegistry != null) {
-            HandoffManager(
-                engineId = engineId,
-                players = players,
-                items = items,
-                outbound = outbound,
-                bus = interEngineBus,
-                zoneRegistry = zoneRegistry,
-                isTargetRoomLocal = world.rooms::containsKey,
-                clock = clock,
-                ackTimeoutMs = config.sharding.handoff.ackTimeoutMs,
-                instanceSelector = instanceSelector,
-            )
-        } else {
-            null
-        }
-
-    private val playerLocationIndex: PlayerLocationIndex? =
-        if (shardingEnabled && config.sharding.playerIndex.enabled && redisManager != null) {
-            val keyTtlSeconds = (config.sharding.playerIndex.heartbeatMs * 3L / 1_000L).coerceAtLeast(1L)
-            RedisPlayerLocationIndex(
-                engineId = engineId,
-                redis = redisManager,
-                keyTtlSeconds = keyTtlSeconds,
-            )
-        } else {
-            null
-        }
+    private val handoffManager =
+        ServerInfrastructure.createHandoffManager(
+            config = config,
+            players = players,
+            items = items,
+            outbound = outbound,
+            interEngineBus = interEngineBus,
+            zoneRegistry = zoneRegistry,
+            world = world,
+            clock = clock,
+            instanceSelector = instanceSelector,
+        )
 
     private val adminServer: AdminHttpServer? =
         if (config.admin.enabled) {
@@ -341,10 +222,7 @@ class MudServer(
             null
         }
 
-    private var zoneHeartbeatJob: Job? = null
-    private var playerIndexHeartbeatJob: Job? = null
-    private var zoneLoadReportJob: Job? = null
-    private var autoScaleJob: Job? = null
+    private var shardingJobs = ServerInfrastructure.ShardingJobs()
 
     init {
         bindQueueMetrics()
@@ -396,74 +274,19 @@ class MudServer(
         outboundRouter = OutboundRouter(outbound, scope, metrics = gameMetrics)
         routerJob = outboundRouter.start()
 
-        // Start inter-engine bus and register zones
-        if (interEngineBus != null) {
-            interEngineBus.start()
-        }
-
-        // Start player-location index heartbeat
-        if (playerLocationIndex != null) {
-            val heartbeatMs = config.sharding.playerIndex.heartbeatMs
-            // refreshTtls uses the index's own internal name tracking —
-            // no access to PlayerRegistry needed, avoiding a cross-thread read.
-            playerIndexHeartbeatJob =
-                scope.launchPeriodic(heartbeatMs, "Player location index heartbeat") {
-                    playerLocationIndex.refreshTtls()
-                }
-        }
-        if (zoneRegistry != null) {
-            zoneRegistry.claimZones(engineId, advertisedEngineAddress, localZones)
-            val heartbeatIntervalMs =
-                ((config.sharding.registry.leaseTtlSeconds * 1_000L) / 3L)
-                    .coerceAtLeast(1_000L)
-            zoneHeartbeatJob =
-                scope.launchPeriodic(heartbeatIntervalMs, "Zone lease heartbeat (engine=$engineId)") {
-                    zoneRegistry.renewLease(engineId)
-                    zoneRegistry.claimZones(engineId, advertisedEngineAddress, localZones)
-                }
-            // Zone load reporting for instance-aware routing
-            if (config.sharding.instancing.enabled) {
-                val loadReportIntervalMs = config.sharding.instancing.loadReportIntervalMs
-                zoneLoadReportJob =
-                    scope.launchPeriodic(loadReportIntervalMs, "Zone load report (engine=$engineId)") {
-                        val zoneCounts =
-                            players
-                                .allPlayers()
-                                .groupBy { it.roomId.zone }
-                                .mapValues { (_, ps) -> ps.size }
-                        zoneRegistry.reportLoad(engineId, zoneCounts)
-                    }
-            }
-            // Auto-scaling signal evaluation
-            if (config.sharding.instancing.autoScale.enabled) {
-                val scaler =
-                    ThresholdInstanceScaler(
-                        registry = zoneRegistry,
-                        scaleUpThreshold = config.sharding.instancing.autoScale.scaleUpThreshold,
-                        scaleDownThreshold = config.sharding.instancing.autoScale.scaleDownThreshold,
-                        cooldownMs = config.sharding.instancing.autoScale.cooldownMs,
-                        minInstances =
-                            if (world.startRoom.value.contains(":")) {
-                                val startZone = world.startRoom.value.substringBefore(":")
-                                mapOf(startZone to config.sharding.instancing.startZoneMinInstances)
-                            } else {
-                                emptyMap()
-                            },
-                        clock = clock,
-                    )
-                val publisher: ScaleDecisionPublisher =
-                    redisManager?.withCommands { RedisScaleDecisionPublisher(it) }
-                        ?: LoggingScaleDecisionPublisher()
-                val evalIntervalMs = config.sharding.instancing.autoScale.evaluationIntervalMs
-                autoScaleJob =
-                    scope.launchPeriodic(evalIntervalMs, "Auto-scale evaluation") {
-                        val decisions = scaler.evaluate()
-                        if (decisions.isNotEmpty()) {
-                            publisher.publish(decisions)
-                        }
-                    }
-            }
-        }
+        shardingJobs = ServerInfrastructure.startShardingJobs(
+            config = config,
+            scope = scope,
+            zoneRegistry = zoneRegistry,
+            playerLocationIndex = playerLocationIndex,
+            interEngineBus = interEngineBus,
+            redisManager = redisManager,
+            players = players,
+            engineAddress = advertisedEngineAddress,
+            localZones = localZones,
+            world = world,
+            clock = clock,
+        )
 
         engineJob =
             scope.launch(engineDispatcher) {
@@ -485,22 +308,12 @@ class MudServer(
                     metrics = gameMetrics,
                     onShutdown = { shutdownSignal.complete(Unit) },
                     worldState = worldState,
-                    sharding = ShardingContext(
-                        engineId = engineId,
+                    sharding = ServerInfrastructure.buildShardingContext(
+                        config = config,
                         handoffManager = handoffManager,
                         interEngineBus = interEngineBus,
-                        peerEngineCount = {
-                            zoneRegistry
-                                ?.allAssignments()
-                                ?.values
-                                ?.map { it.engineId }
-                                ?.filter { it != engineId }
-                                ?.toSet()
-                                ?.size
-                                ?: 0
-                        },
-                        playerLocationIndex = playerLocationIndex,
                         zoneRegistry = zoneRegistry,
+                        playerLocationIndex = playerLocationIndex,
                     ),
                     persistence = PersistenceContext(
                         worldStateRepository = worldStateRepo,
@@ -556,10 +369,7 @@ class MudServer(
         runCatching { adminServer?.stop() }
         runCatching { telnetTransport.stop() }
         runCatching { webTransport.stop() }
-        runCatching { zoneHeartbeatJob?.cancelAndJoin() }
-        runCatching { zoneLoadReportJob?.cancelAndJoin() }
-        runCatching { autoScaleJob?.cancelAndJoin() }
-        runCatching { playerIndexHeartbeatJob?.cancelAndJoin() }
+        shardingJobs.stopAll()
         runCatching { engineJob?.cancelAndJoin() }
         runCatching { interEngineBus?.close() }
         runCatching { persistenceWorker?.shutdown() }

--- a/src/main/kotlin/dev/ambon/ServerInfrastructure.kt
+++ b/src/main/kotlin/dev/ambon/ServerInfrastructure.kt
@@ -3,21 +3,52 @@ package dev.ambon
 import dev.ambon.bus.DepthAware
 import dev.ambon.bus.InboundBus
 import dev.ambon.bus.OutboundBus
+import dev.ambon.bus.redisBusPublisher
+import dev.ambon.bus.redisBusSubscriberSetup
 import dev.ambon.config.AppConfig
+import dev.ambon.config.PersistenceBackend
+import dev.ambon.config.ShardingRegistryType
+import dev.ambon.domain.world.World
+import dev.ambon.engine.PlayerRegistry
+import dev.ambon.engine.ShardingContext
+import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.metrics.GameMetrics
+import dev.ambon.persistence.DatabaseManager
 import dev.ambon.redis.RedisConnectionManager
+import dev.ambon.redis.redisObjectMapper
+import dev.ambon.sharding.ClassicRedisZoneRegistry
+import dev.ambon.sharding.EngineAddress
+import dev.ambon.sharding.HandoffManager
+import dev.ambon.sharding.InstanceSelector
+import dev.ambon.sharding.InstancedRedisZoneRegistry
+import dev.ambon.sharding.InterEngineBus
+import dev.ambon.sharding.LoadBalancedInstanceSelector
+import dev.ambon.sharding.LocalInterEngineBus
+import dev.ambon.sharding.LoggingScaleDecisionPublisher
+import dev.ambon.sharding.PlayerLocationIndex
+import dev.ambon.sharding.RedisInterEngineBus
+import dev.ambon.sharding.RedisPlayerLocationIndex
+import dev.ambon.sharding.RedisScaleDecisionPublisher
+import dev.ambon.sharding.ScaleDecisionPublisher
+import dev.ambon.sharding.StaticZoneRegistry
+import dev.ambon.sharding.ThresholdInstanceScaler
+import dev.ambon.sharding.ZoneRegistry
 import dev.ambon.transport.BlockingSocketTransport
 import dev.ambon.transport.KtorWebSocketTransport
 import dev.ambon.transport.OutboundRouter
 import io.micrometer.prometheusmetrics.PrometheusConfig
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import java.time.Clock
 import java.util.UUID
 import kotlin.coroutines.CoroutineContext
 
 /**
- * Shared factory functions for infrastructure that both [MudServer] and
- * [dev.ambon.gateway.GatewayServer] construct identically.
+ * Shared factory functions for infrastructure that [MudServer],
+ * [dev.ambon.grpc.EngineServer], and [dev.ambon.gateway.GatewayServer]
+ * construct identically.
  */
 object ServerInfrastructure {
     fun createPrometheusRegistry(
@@ -99,5 +130,328 @@ object ServerInfrastructure {
     ) {
         (inbound as? DepthAware)?.let { metrics.bindInboundBusQueue(it::depth) { it.capacity } }
         (outbound as? DepthAware)?.let { metrics.bindOutboundBusQueue(it::depth) { it.capacity } }
+    }
+
+    fun createDatabaseManager(config: AppConfig): DatabaseManager? =
+        if (config.persistence.backend == PersistenceBackend.POSTGRES) {
+            DatabaseManager(config.database).also { it.migrate() }
+        } else {
+            null
+        }
+
+    /**
+     * Computes the set of zone names this engine owns, trimmed and filtered.
+     */
+    fun resolveConfiguredZones(config: AppConfig): Set<String> =
+        config.sharding.zones
+            .map(String::trim)
+            .filter { it.isNotEmpty() }
+            .toSet()
+
+    /**
+     * Computes the zone filter to pass to [dev.ambon.domain.world.WorldFactory].
+     * Returns the configured zone set when sharding is enabled; empty otherwise.
+     */
+    fun resolveZoneFilter(config: AppConfig, configuredZones: Set<String>): Set<String> =
+        if (config.sharding.enabled && configuredZones.isNotEmpty()) configuredZones else emptySet()
+
+    /**
+     * Resolves which zones this engine owns at runtime.
+     * When sharding is enabled with explicit zones, uses the configured set;
+     * otherwise falls back to all zones present in the loaded world.
+     */
+    fun resolveLocalZones(config: AppConfig, configuredZones: Set<String>, world: World): Set<String> =
+        if (config.sharding.enabled && configuredZones.isNotEmpty()) {
+            configuredZones
+        } else {
+            world.rooms.keys.mapTo(linkedSetOf()) { it.zone }
+        }
+
+    /**
+     * Builds the [EngineAddress] this engine advertises in zone ownership records.
+     * [defaultPort] is the mode-specific port fallback (telnet for STANDALONE, gRPC for ENGINE).
+     */
+    fun resolveEngineAddress(config: AppConfig, defaultPort: Int): EngineAddress =
+        EngineAddress(
+            engineId = config.sharding.engineId,
+            host = config.sharding.advertiseHost,
+            port = config.sharding.advertisePort ?: defaultPort,
+        )
+
+    fun createZoneRegistry(
+        config: AppConfig,
+        redisManager: RedisConnectionManager?,
+        engineId: String,
+        engineAddress: EngineAddress,
+        localZones: Set<String>,
+    ): ZoneRegistry? =
+        if (!config.sharding.enabled) {
+            null
+        } else {
+            when (config.sharding.registry.type) {
+                ShardingRegistryType.REDIS -> {
+                    val manager = requireNotNull(redisManager) {
+                        "Sharding registry type REDIS requires ambonMUD.redis.enabled=true"
+                    }
+                    if (config.sharding.instancing.enabled) {
+                        InstancedRedisZoneRegistry(
+                            redis = manager,
+                            mapper = redisObjectMapper,
+                            leaseTtlSeconds = config.sharding.registry.leaseTtlSeconds,
+                            defaultCapacity = config.sharding.instancing.defaultCapacity,
+                        )
+                    } else {
+                        ClassicRedisZoneRegistry(
+                            redis = manager,
+                            mapper = redisObjectMapper,
+                            leaseTtlSeconds = config.sharding.registry.leaseTtlSeconds,
+                        )
+                    }
+                }
+
+                ShardingRegistryType.STATIC -> {
+                    val configuredAssignments = config.sharding.registry.assignments
+                    val assignmentMap =
+                        if (configuredAssignments.isEmpty()) {
+                            mapOf(engineId to Pair(engineAddress, localZones))
+                        } else {
+                            configuredAssignments.associate { assignment ->
+                                assignment.engineId to
+                                    Pair(
+                                        EngineAddress(assignment.engineId, assignment.host, assignment.port),
+                                        assignment.zones
+                                            .map(String::trim)
+                                            .filter { it.isNotEmpty() }
+                                            .toSet(),
+                                    )
+                            }
+                        }
+                    StaticZoneRegistry(
+                        assignments = assignmentMap,
+                        instancing = config.sharding.instancing.enabled,
+                    )
+                }
+            }
+        }
+
+    fun createInterEngineBus(
+        config: AppConfig,
+        redisManager: RedisConnectionManager?,
+    ): InterEngineBus? =
+        if (!config.sharding.enabled) {
+            null
+        } else if (redisManager != null) {
+            RedisInterEngineBus(
+                engineId = config.sharding.engineId,
+                publisher = redisBusPublisher(redisManager),
+                subscriberSetup = redisBusSubscriberSetup(redisManager),
+                mapper = redisObjectMapper,
+            )
+        } else {
+            LocalInterEngineBus()
+        }
+
+    fun createInstanceSelector(
+        config: AppConfig,
+        zoneRegistry: ZoneRegistry?,
+    ): InstanceSelector? =
+        if (config.sharding.enabled && config.sharding.instancing.enabled && zoneRegistry != null) {
+            LoadBalancedInstanceSelector(zoneRegistry)
+        } else {
+            null
+        }
+
+    fun createPlayerLocationIndex(
+        config: AppConfig,
+        redisManager: RedisConnectionManager?,
+    ): PlayerLocationIndex? =
+        if (config.sharding.enabled && config.sharding.playerIndex.enabled && redisManager != null) {
+            val keyTtlSeconds = (config.sharding.playerIndex.heartbeatMs * 3L / 1_000L).coerceAtLeast(1L)
+            RedisPlayerLocationIndex(
+                engineId = config.sharding.engineId,
+                redis = redisManager,
+                keyTtlSeconds = keyTtlSeconds,
+            )
+        } else {
+            null
+        }
+
+    fun createHandoffManager(
+        config: AppConfig,
+        players: PlayerRegistry,
+        items: ItemRegistry,
+        outbound: OutboundBus,
+        interEngineBus: InterEngineBus?,
+        zoneRegistry: ZoneRegistry?,
+        world: World,
+        clock: Clock,
+        instanceSelector: InstanceSelector?,
+    ): HandoffManager? =
+        if (config.sharding.enabled && interEngineBus != null && zoneRegistry != null) {
+            HandoffManager(
+                engineId = config.sharding.engineId,
+                players = players,
+                items = items,
+                outbound = outbound,
+                bus = interEngineBus,
+                zoneRegistry = zoneRegistry,
+                isTargetRoomLocal = world.rooms::containsKey,
+                clock = clock,
+                ackTimeoutMs = config.sharding.handoff.ackTimeoutMs,
+                instanceSelector = instanceSelector,
+            )
+        } else {
+            null
+        }
+
+    fun buildShardingContext(
+        config: AppConfig,
+        handoffManager: HandoffManager?,
+        interEngineBus: InterEngineBus?,
+        zoneRegistry: ZoneRegistry?,
+        playerLocationIndex: PlayerLocationIndex?,
+    ): ShardingContext {
+        val engineId = config.sharding.engineId
+        return ShardingContext(
+            engineId = engineId,
+            handoffManager = handoffManager,
+            interEngineBus = interEngineBus,
+            peerEngineCount = {
+                zoneRegistry
+                    ?.allAssignments()
+                    ?.values
+                    ?.map { it.engineId }
+                    ?.filter { it != engineId }
+                    ?.toSet()
+                    ?.size
+                    ?: 0
+            },
+            playerLocationIndex = playerLocationIndex,
+            zoneRegistry = zoneRegistry,
+        )
+    }
+
+    /**
+     * Holder for the background jobs started by [startShardingJobs].
+     * The caller is responsible for cancelling these on shutdown.
+     */
+    data class ShardingJobs(
+        val zoneHeartbeat: Job? = null,
+        val playerIndexHeartbeat: Job? = null,
+        val zoneLoadReport: Job? = null,
+        val autoScale: Job? = null,
+    ) {
+        /** Cancels all jobs, ignoring individual failures. */
+        suspend fun stopAll() {
+            runCatching { zoneHeartbeat?.cancelAndJoin() }
+            runCatching { playerIndexHeartbeat?.cancelAndJoin() }
+            runCatching { zoneLoadReport?.cancelAndJoin() }
+            runCatching { autoScale?.cancelAndJoin() }
+        }
+    }
+
+    /**
+     * Starts the periodic background jobs for sharding: zone lease heartbeat,
+     * player-location index heartbeat, zone load reporting, and auto-scale evaluation.
+     */
+    suspend fun startShardingJobs(
+        config: AppConfig,
+        scope: CoroutineScope,
+        zoneRegistry: ZoneRegistry?,
+        playerLocationIndex: PlayerLocationIndex?,
+        interEngineBus: InterEngineBus?,
+        redisManager: RedisConnectionManager?,
+        players: PlayerRegistry,
+        engineAddress: EngineAddress,
+        localZones: Set<String>,
+        world: World,
+        clock: Clock,
+    ): ShardingJobs {
+        val engineId = config.sharding.engineId
+
+        interEngineBus?.start()
+
+        val playerIndexHeartbeatJob =
+            if (playerLocationIndex != null) {
+                scope.launchPeriodic(
+                    config.sharding.playerIndex.heartbeatMs,
+                    "Player location index heartbeat",
+                ) {
+                    playerLocationIndex.refreshTtls()
+                }
+            } else {
+                null
+            }
+
+        if (zoneRegistry == null) {
+            return ShardingJobs(playerIndexHeartbeat = playerIndexHeartbeatJob)
+        }
+
+        zoneRegistry.claimZones(engineId, engineAddress, localZones)
+        val heartbeatIntervalMs =
+            ((config.sharding.registry.leaseTtlSeconds * 1_000L) / 3L)
+                .coerceAtLeast(1_000L)
+        val zoneHeartbeatJob =
+            scope.launchPeriodic(heartbeatIntervalMs, "Zone lease heartbeat (engine=$engineId)") {
+                zoneRegistry.renewLease(engineId)
+                zoneRegistry.claimZones(engineId, engineAddress, localZones)
+            }
+
+        val zoneLoadReportJob =
+            if (config.sharding.instancing.enabled) {
+                scope.launchPeriodic(
+                    config.sharding.instancing.loadReportIntervalMs,
+                    "Zone load report (engine=$engineId)",
+                ) {
+                    val zoneCounts =
+                        players
+                            .allPlayers()
+                            .groupBy { it.roomId.zone }
+                            .mapValues { (_, ps) -> ps.size }
+                    zoneRegistry.reportLoad(engineId, zoneCounts)
+                }
+            } else {
+                null
+            }
+
+        val autoScaleJob =
+            if (config.sharding.instancing.autoScale.enabled) {
+                val scaler =
+                    ThresholdInstanceScaler(
+                        registry = zoneRegistry,
+                        scaleUpThreshold = config.sharding.instancing.autoScale.scaleUpThreshold,
+                        scaleDownThreshold = config.sharding.instancing.autoScale.scaleDownThreshold,
+                        cooldownMs = config.sharding.instancing.autoScale.cooldownMs,
+                        minInstances =
+                            if (world.startRoom.value.contains(":")) {
+                                val startZone = world.startRoom.value.substringBefore(":")
+                                mapOf(startZone to config.sharding.instancing.startZoneMinInstances)
+                            } else {
+                                emptyMap()
+                            },
+                        clock = clock,
+                    )
+                val publisher: ScaleDecisionPublisher =
+                    redisManager?.withCommands { RedisScaleDecisionPublisher(it) }
+                        ?: LoggingScaleDecisionPublisher()
+                scope.launchPeriodic(
+                    config.sharding.instancing.autoScale.evaluationIntervalMs,
+                    "Auto-scale evaluation",
+                ) {
+                    val decisions = scaler.evaluate()
+                    if (decisions.isNotEmpty()) {
+                        publisher.publish(decisions)
+                    }
+                }
+            } else {
+                null
+            }
+
+        return ShardingJobs(
+            zoneHeartbeat = zoneHeartbeatJob,
+            playerIndexHeartbeat = playerIndexHeartbeatJob,
+            zoneLoadReport = zoneLoadReportJob,
+            autoScale = autoScaleJob,
+        )
     }
 }

--- a/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
+++ b/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
@@ -1,48 +1,23 @@
 package dev.ambon.grpc
 
+import dev.ambon.ServerInfrastructure
 import dev.ambon.bus.InboundBus
 import dev.ambon.bus.LocalInboundBus
 import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.bus.OutboundBus
-import dev.ambon.bus.redisBusPublisher
-import dev.ambon.bus.redisBusSubscriberSetup
 import dev.ambon.config.AppConfig
-import dev.ambon.config.PersistenceBackend
-import dev.ambon.config.ShardingRegistryType
 import dev.ambon.domain.world.WorldFactory
 import dev.ambon.engine.GameEngine
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PlayerProgression
-import dev.ambon.engine.ShardingContext
 import dev.ambon.engine.createPlayerRegistry
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.engine.scheduler.Scheduler
 import dev.ambon.metrics.GameMetrics
 import dev.ambon.metrics.MetricsHttpServer
-import dev.ambon.persistence.DatabaseManager
 import dev.ambon.persistence.PersistenceWorker
 import dev.ambon.persistence.PlayerRepositoryFactory
-import dev.ambon.redis.RedisConnectionManager
-import dev.ambon.redis.redisObjectMapper
-import dev.ambon.sharding.ClassicRedisZoneRegistry
-import dev.ambon.sharding.EngineAddress
-import dev.ambon.sharding.HandoffManager
-import dev.ambon.sharding.InstanceSelector
-import dev.ambon.sharding.InstancedRedisZoneRegistry
-import dev.ambon.sharding.InterEngineBus
-import dev.ambon.sharding.LoadBalancedInstanceSelector
-import dev.ambon.sharding.LocalInterEngineBus
-import dev.ambon.sharding.LoggingScaleDecisionPublisher
-import dev.ambon.sharding.PlayerLocationIndex
-import dev.ambon.sharding.RedisInterEngineBus
-import dev.ambon.sharding.RedisPlayerLocationIndex
-import dev.ambon.sharding.RedisScaleDecisionPublisher
-import dev.ambon.sharding.ScaleDecisionPublisher
-import dev.ambon.sharding.StaticZoneRegistry
-import dev.ambon.sharding.ThresholdInstanceScaler
-import dev.ambon.sharding.ZoneRegistry
 import io.github.oshai.kotlinlogging.KotlinLogging
-import io.micrometer.prometheusmetrics.PrometheusConfig
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -52,8 +27,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import java.time.Clock
 import java.util.concurrent.Executors
@@ -82,27 +55,16 @@ class EngineServer(
     private val shutdownSignal = CompletableDeferred<Unit>()
 
     private val prometheusRegistry: PrometheusMeterRegistry? =
-        if (config.observability.metricsEnabled) {
-            PrometheusMeterRegistry(PrometheusConfig.DEFAULT).also { reg ->
-                reg.config().commonTags("service", "ambonmud-engine")
-                config.observability.staticTags.forEach { (k, v) -> reg.config().commonTags(k, v) }
-            }
-        } else {
-            null
-        }
+        ServerInfrastructure.createPrometheusRegistry(config, "ambonmud-engine")
 
     private val gameMetrics: GameMetrics =
-        if (prometheusRegistry != null) GameMetrics(prometheusRegistry) else GameMetrics.noop()
+        ServerInfrastructure.createGameMetrics(prometheusRegistry)
 
-    private val databaseManager: DatabaseManager? =
-        if (config.persistence.backend == PersistenceBackend.POSTGRES) {
-            DatabaseManager(config.database).also { it.migrate() }
-        } else {
-            null
-        }
+    private val databaseManager =
+        ServerInfrastructure.createDatabaseManager(config)
 
-    private val redisManager: RedisConnectionManager? =
-        if (config.redis.enabled) RedisConnectionManager(config.redis) else null
+    private val redisManager =
+        ServerInfrastructure.createRedisManager(config)
 
     private val playerRepoChain =
         PlayerRepositoryFactory.buildChain(
@@ -133,17 +95,8 @@ class EngineServer(
     private val progression = PlayerProgression(config.progression)
     private val shardingEnabled = config.sharding.enabled
     private val engineId = config.sharding.engineId
-    private val configuredShardedZones =
-        config.sharding.zones
-            .map(String::trim)
-            .filter { it.isNotEmpty() }
-            .toSet()
-    private val zoneFilter =
-        if (shardingEnabled && configuredShardedZones.isNotEmpty()) {
-            configuredShardedZones
-        } else {
-            emptySet()
-        }
+    private val configuredShardedZones = ServerInfrastructure.resolveConfiguredZones(config)
+    private val zoneFilter = ServerInfrastructure.resolveZoneFilter(config, configuredShardedZones)
 
     private val world =
         WorldFactory.demoWorld(
@@ -152,18 +105,9 @@ class EngineServer(
             zoneFilter = zoneFilter,
         )
     private val scheduler: Scheduler = Scheduler(clock)
-    private val localZones: Set<String> =
-        if (shardingEnabled && configuredShardedZones.isNotEmpty()) {
-            configuredShardedZones
-        } else {
-            world.rooms.keys.mapTo(linkedSetOf()) { it.zone }
-        }
-    private val advertisedEngineAddress: EngineAddress =
-        EngineAddress(
-            engineId = engineId,
-            host = config.sharding.advertiseHost,
-            port = config.sharding.advertisePort ?: config.grpc.server.port,
-        )
+    private val localZones = ServerInfrastructure.resolveLocalZones(config, configuredShardedZones, world)
+    private val advertisedEngineAddress =
+        ServerInfrastructure.resolveEngineAddress(config, config.grpc.server.port)
 
     private val players =
         createPlayerRegistry(
@@ -177,132 +121,35 @@ class EngineServer(
         )
 
     // --- Sharding infrastructure (null when sharding is disabled) ---
-    private val zoneRegistry: ZoneRegistry? =
-        if (shardingEnabled) {
-            when (config.sharding.registry.type) {
-                ShardingRegistryType.REDIS -> {
-                    val manager =
-                        requireNotNull(redisManager) {
-                            "Sharding registry type REDIS requires ambonMUD.redis.enabled=true"
-                        }
-                    if (config.sharding.instancing.enabled) {
-                        InstancedRedisZoneRegistry(
-                            redis = manager,
-                            mapper = redisObjectMapper,
-                            leaseTtlSeconds = config.sharding.registry.leaseTtlSeconds,
-                            defaultCapacity = config.sharding.instancing.defaultCapacity,
-                        )
-                    } else {
-                        ClassicRedisZoneRegistry(
-                            redis = manager,
-                            mapper = redisObjectMapper,
-                            leaseTtlSeconds = config.sharding.registry.leaseTtlSeconds,
-                        )
-                    }
-                }
+    private val zoneRegistry =
+        ServerInfrastructure.createZoneRegistry(config, redisManager, engineId, advertisedEngineAddress, localZones)
 
-                ShardingRegistryType.STATIC -> {
-                    val configuredAssignments = config.sharding.registry.assignments
-                    val assignmentMap =
-                        if (configuredAssignments.isEmpty()) {
-                            mapOf(engineId to Pair(advertisedEngineAddress, localZones))
-                        } else {
-                            configuredAssignments.associate { assignment ->
-                                assignment.engineId to
-                                    Pair(
-                                        EngineAddress(assignment.engineId, assignment.host, assignment.port),
-                                        assignment.zones
-                                            .map(String::trim)
-                                            .filter { it.isNotEmpty() }
-                                            .toSet(),
-                                    )
-                            }
-                        }
-                    StaticZoneRegistry(
-                        assignments = assignmentMap,
-                        instancing = config.sharding.instancing.enabled,
-                    )
-                }
-            }
-        } else {
-            null
-        }
+    private val interEngineBus =
+        ServerInfrastructure.createInterEngineBus(config, redisManager)
 
-    private val interEngineBus: InterEngineBus? =
-        if (shardingEnabled && redisManager != null) {
-            RedisInterEngineBus(
-                engineId = engineId,
-                publisher = redisBusPublisher(redisManager),
-                subscriberSetup = redisBusSubscriberSetup(redisManager),
-                mapper = redisObjectMapper,
-            )
-        } else if (shardingEnabled) {
-            LocalInterEngineBus()
-        } else {
-            null
-        }
+    private val instanceSelector =
+        ServerInfrastructure.createInstanceSelector(config, zoneRegistry)
 
-    private val instanceSelector: InstanceSelector? =
-        if (shardingEnabled && config.sharding.instancing.enabled && zoneRegistry != null) {
-            LoadBalancedInstanceSelector(zoneRegistry)
-        } else {
-            null
-        }
+    private val playerLocationIndex =
+        ServerInfrastructure.createPlayerLocationIndex(config, redisManager)
 
-    private val playerLocationIndex: PlayerLocationIndex? =
-        if (shardingEnabled && config.sharding.playerIndex.enabled && redisManager != null) {
-            val keyTtlSeconds = (config.sharding.playerIndex.heartbeatMs * 3L / 1_000L).coerceAtLeast(1L)
-            RedisPlayerLocationIndex(
-                engineId = engineId,
-                redis = redisManager,
-                keyTtlSeconds = keyTtlSeconds,
-            )
-        } else {
-            null
-        }
-
-    private val handoffManager: HandoffManager? =
-        if (shardingEnabled && interEngineBus != null && zoneRegistry != null) {
-            HandoffManager(
-                engineId = engineId,
-                players = players,
-                items = items,
-                outbound = outbound,
-                bus = interEngineBus,
-                zoneRegistry = zoneRegistry,
-                isTargetRoomLocal = world.rooms::containsKey,
-                clock = clock,
-                ackTimeoutMs = config.sharding.handoff.ackTimeoutMs,
-                instanceSelector = instanceSelector,
-            )
-        } else {
-            null
-        }
+    private val handoffManager =
+        ServerInfrastructure.createHandoffManager(
+            config = config,
+            players = players,
+            items = items,
+            outbound = outbound,
+            interEngineBus = interEngineBus,
+            zoneRegistry = zoneRegistry,
+            world = world,
+            clock = clock,
+            instanceSelector = instanceSelector,
+        )
 
     private var persistenceWorker: PersistenceWorker? = null
     private var engineJob: Job? = null
     private var metricsHttpServer: MetricsHttpServer? = null
-    private var zoneHeartbeatJob: Job? = null
-    private var playerIndexHeartbeatJob: Job? = null
-    private var zoneLoadReportJob: Job? = null
-    private var autoScaleJob: Job? = null
-
-    /**
-     * Launches a coroutine that calls [action] every [intervalMs] milliseconds,
-     * logging a warning if the action throws.
-     */
-    private fun launchPeriodicJob(
-        intervalMs: Long,
-        label: String,
-        action: suspend () -> Unit,
-    ): Job = scope.launch {
-        while (isActive) {
-            delay(intervalMs)
-            runCatching { action() }.onFailure { err ->
-                log.warn(err) { "$label failed" }
-            }
-        }
-    }
+    private var shardingJobs = ServerInfrastructure.ShardingJobs()
 
     suspend fun start() {
         redisManager?.connect()
@@ -318,80 +165,19 @@ class EngineServer(
             persistenceWorker = worker
         }
 
-        // OutboundRouter isn't used in engine mode (GrpcOutboundDispatcher does the routing),
-        // but we still need to prevent the outbound bus channel from blocking.
-        // The GrpcOutboundDispatcher in EngineGrpcServer drains it.
-
-        // Start inter-engine bus and register zones
-        if (interEngineBus != null) {
-            interEngineBus.start()
-        }
-
-        // Start player-location index heartbeat
-        if (playerLocationIndex != null) {
-            playerIndexHeartbeatJob = launchPeriodicJob(
-                intervalMs = config.sharding.playerIndex.heartbeatMs,
-                label = "Player location index heartbeat",
-            ) {
-                playerLocationIndex.refreshTtls()
-            }
-        }
-        if (zoneRegistry != null) {
-            zoneRegistry.claimZones(engineId, advertisedEngineAddress, localZones)
-            val heartbeatIntervalMs =
-                ((config.sharding.registry.leaseTtlSeconds * 1_000L) / 3L)
-                    .coerceAtLeast(1_000L)
-            zoneHeartbeatJob = launchPeriodicJob(
-                intervalMs = heartbeatIntervalMs,
-                label = "Zone lease heartbeat for engine=$engineId",
-            ) {
-                zoneRegistry.renewLease(engineId)
-                zoneRegistry.claimZones(engineId, advertisedEngineAddress, localZones)
-            }
-            if (config.sharding.instancing.enabled) {
-                zoneLoadReportJob = launchPeriodicJob(
-                    intervalMs = config.sharding.instancing.loadReportIntervalMs,
-                    label = "Zone load report for engine=$engineId",
-                ) {
-                    val zoneCounts =
-                        players
-                            .allPlayers()
-                            .groupBy { it.roomId.zone }
-                            .mapValues { (_, ps) -> ps.size }
-                    zoneRegistry.reportLoad(engineId, zoneCounts)
-                }
-            }
-            // Auto-scaling signal evaluation
-            if (config.sharding.instancing.autoScale.enabled) {
-                val scaler =
-                    ThresholdInstanceScaler(
-                        registry = zoneRegistry,
-                        scaleUpThreshold = config.sharding.instancing.autoScale.scaleUpThreshold,
-                        scaleDownThreshold = config.sharding.instancing.autoScale.scaleDownThreshold,
-                        cooldownMs = config.sharding.instancing.autoScale.cooldownMs,
-                        minInstances =
-                            if (world.startRoom.value.contains(":")) {
-                                val startZone = world.startRoom.value.substringBefore(":")
-                                mapOf(startZone to config.sharding.instancing.startZoneMinInstances)
-                            } else {
-                                emptyMap()
-                            },
-                        clock = clock,
-                    )
-                val publisher: ScaleDecisionPublisher =
-                    redisManager?.withCommands { RedisScaleDecisionPublisher(it) }
-                        ?: LoggingScaleDecisionPublisher()
-                autoScaleJob = launchPeriodicJob(
-                    intervalMs = config.sharding.instancing.autoScale.evaluationIntervalMs,
-                    label = "Auto-scale evaluation",
-                ) {
-                    val decisions = scaler.evaluate()
-                    if (decisions.isNotEmpty()) {
-                        publisher.publish(decisions)
-                    }
-                }
-            }
-        }
+        shardingJobs = ServerInfrastructure.startShardingJobs(
+            config = config,
+            scope = scope,
+            zoneRegistry = zoneRegistry,
+            playerLocationIndex = playerLocationIndex,
+            interEngineBus = interEngineBus,
+            redisManager = redisManager,
+            players = players,
+            engineAddress = advertisedEngineAddress,
+            localZones = localZones,
+            world = world,
+            clock = clock,
+        )
 
         engineJob =
             scope.launch(engineDispatcher) {
@@ -412,22 +198,12 @@ class EngineServer(
                     progression = progression,
                     metrics = gameMetrics,
                     onShutdown = { shutdownSignal.complete(Unit) },
-                    sharding = ShardingContext(
-                        engineId = engineId,
+                    sharding = ServerInfrastructure.buildShardingContext(
+                        config = config,
                         handoffManager = handoffManager,
                         interEngineBus = interEngineBus,
-                        peerEngineCount = {
-                            zoneRegistry
-                                ?.allAssignments()
-                                ?.values
-                                ?.map { it.engineId }
-                                ?.filter { it != engineId }
-                                ?.toSet()
-                                ?.size
-                                ?: 0
-                        },
-                        playerLocationIndex = playerLocationIndex,
                         zoneRegistry = zoneRegistry,
+                        playerLocationIndex = playerLocationIndex,
                     ),
                 ).run()
             }
@@ -451,10 +227,7 @@ class EngineServer(
     suspend fun stop() {
         runCatching { metricsHttpServer?.stop() }
         runCatching { grpcServer.stop() }
-        runCatching { zoneHeartbeatJob?.cancelAndJoin() }
-        runCatching { playerIndexHeartbeatJob?.cancelAndJoin() }
-        runCatching { zoneLoadReportJob?.cancelAndJoin() }
-        runCatching { autoScaleJob?.cancelAndJoin() }
+        shardingJobs.stopAll()
         runCatching { engineJob?.cancelAndJoin() }
         runCatching { interEngineBus?.close() }
         runCatching { persistenceWorker?.shutdown() }


### PR DESCRIPTION
## Summary

- Extracts ~200 lines of duplicated sharding infrastructure setup from `MudServer` and `EngineServer` into shared factory methods on `ServerInfrastructure`
- New methods: `createDatabaseManager`, `resolveConfiguredZones`, `resolveZoneFilter`, `resolveLocalZones`, `resolveEngineAddress`, `createZoneRegistry`, `createInterEngineBus`, `createInstanceSelector`, `createPlayerLocationIndex`, `createHandoffManager`, `buildShardingContext`, `startShardingJobs`
- Introduces `ShardingJobs` data class with `stopAll()` to replace 4 individual job variables + cancellation
- Makes `launchPeriodic` public so `EngineServer` can use it instead of reimplementing its own `launchPeriodicJob`
- Net: 451 insertions, 514 deletions (both composition roots significantly simplified)

## Test plan
- [x] `ktlintCheck` passes
- [x] Full test suite passes
- [ ] Verify standalone mode starts correctly
- [ ] Verify engine mode starts correctly