### PR TITLE
refactor: extract mob keyword search into MobRegistry

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -556,13 +556,7 @@ class CombatSystem(
     private fun findMobsInRoom(
         roomId: RoomId,
         keyword: String,
-    ): List<MobState> {
-        val lower = keyword.lowercase()
-        return mobs
-            .mobsInRoom(roomId)
-            .filter { it.name.lowercase().contains(lower) }
-            .sortedBy { it.name }
-    }
+    ): List<MobState> = mobs.findInRoomByKeyword(roomId, keyword)
 
     private suspend fun handleMobDeath(
         killerSessionId: SessionId,

--- a/src/main/kotlin/dev/ambon/engine/MobRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/MobRegistry.kt
@@ -32,6 +32,20 @@ class MobRegistry {
 
     fun mobsInRoom(roomId: RoomId): List<MobState> = roomMembers[roomId]?.mapNotNull { mobs[it] } ?: emptyList()
 
+    /**
+     * Returns mobs in [roomId] whose name contains [keyword] (case-insensitive),
+     * sorted alphabetically by name.
+     */
+    fun findInRoomByKeyword(
+        roomId: RoomId,
+        keyword: String,
+    ): List<MobState> {
+        val lower = keyword.lowercase()
+        return mobsInRoom(roomId)
+            .filter { it.name.lowercase().contains(lower) }
+            .sortedBy { it.name }
+    }
+
     fun moveTo(
         mobId: MobId,
         newRoom: RoomId,

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestHandler.kt
@@ -48,8 +48,7 @@ class DialogueQuestHandler(
         }
         outbound.sendIfError(sessionId, dialogueSystem.startConversation(sessionId, cmd.target))
         if (questSystem != null && me != null) {
-            val targetLower = cmd.target.trim().lowercase()
-            val mob = mobs.mobsInRoom(me.roomId).firstOrNull { m -> m.name.lowercase().contains(targetLower) }
+            val mob = mobs.findInRoomByKeyword(me.roomId, cmd.target.trim()).firstOrNull()
             if (mob != null) {
                 val available = questSystem.availableQuests(sessionId, mob.id.value)
                 for (quest in available) {

--- a/src/main/kotlin/dev/ambon/engine/dialogue/DialogueSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/dialogue/DialogueSystem.kt
@@ -182,9 +182,5 @@ class DialogueSystem(
     private fun findMobInRoom(
         roomId: RoomId,
         keyword: String,
-    ) = mobs
-        .mobsInRoom(roomId)
-        .filter { it.name.lowercase().contains(keyword.lowercase()) }
-        .sortedBy { it.name }
-        .firstOrNull()
+    ) = mobs.findInRoomByKeyword(roomId, keyword).firstOrNull()
 }

--- a/src/test/kotlin/dev/ambon/engine/MobRegistryTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/MobRegistryTest.kt
@@ -38,6 +38,32 @@ class MobRegistryTest {
     }
 
     @Test
+    fun `findInRoomByKeyword filters and sorts by name`() {
+        val registry = MobRegistry()
+        val room = RoomId("zone:room1")
+        val rat = MobState(MobId("demo:rat"), "a rat", room)
+        val bat = MobState(MobId("demo:bat"), "a bat", room)
+        val wolf = MobState(MobId("demo:wolf"), "a wolf", room)
+
+        registry.upsert(rat)
+        registry.upsert(bat)
+        registry.upsert(wolf)
+
+        // keyword "at" matches "a rat" and "a bat", sorted alphabetically
+        val matches = registry.findInRoomByKeyword(room, "at")
+        assertEquals(listOf(bat, rat), matches)
+
+        // case-insensitive
+        assertEquals(listOf(wolf), registry.findInRoomByKeyword(room, "WOLF"))
+
+        // no match
+        assertTrue(registry.findInRoomByKeyword(room, "goblin").isEmpty())
+
+        // empty room
+        assertTrue(registry.findInRoomByKeyword(RoomId("zone:empty"), "rat").isEmpty())
+    }
+
+    @Test
     fun `moveTo updates room membership`() {
         val registry = MobRegistry()
         val roomA = RoomId("zone:roomA")


### PR DESCRIPTION
## Summary
- Extract duplicated "find mob in room by keyword" logic into `MobRegistry.findInRoomByKeyword(roomId, keyword)`
- Update `CombatSystem.findMobsInRoom`, `DialogueSystem.findMobInRoom`, and `DialogueQuestHandler` talk handler to delegate to the new method
- Add tests for the new method in `MobRegistryTest`

## Test plan
- [x] New `MobRegistryTest` test verifies keyword filtering, case-insensitivity, sorting, and empty results
- [x] Existing `CombatSystemTest`, `DialogueSystemTest`, and `CommandRouterTest` pass unchanged
- [x] Full test suite passes
- [x] ktlintCheck passes