### PR TITLE
refactor: extract resolvePlayerStats and ceilSeconds helpers

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -1,7 +1,6 @@
 package dev.ambon.engine
 
 import dev.ambon.bus.OutboundBus
-import dev.ambon.domain.StatBlock
 import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
@@ -312,8 +311,7 @@ class CombatSystem(
             // STUN check
             val stunned = statusEffects?.hasPlayerEffect(sessionId, EffectType.STUN) == true
             if (!stunned) {
-                val playerMods = statusEffects?.getPlayerStatMods(sessionId) ?: StatBlock.ZERO
-                val playerStats = resolveEffectiveStats(player, playerBonuses, playerMods)
+                val playerStats = resolvePlayerStats(player, items, statusEffects)
                 val playerAttack = playerBonuses.attack
                 val playerStrBonus = PlayerState.statBonus(playerStats.str, config.strDivisor)
                 val playerRoll = rollRange(rng, config.minDamage, config.maxDamage)
@@ -388,9 +386,7 @@ class CombatSystem(
 
             val target = players.get(targetSid) ?: continue
 
-            val targetBonuses = items.equipmentBonuses(targetSid)
-            val targetMods = statusEffects?.getPlayerStatMods(targetSid) ?: StatBlock.ZERO
-            val targetStats = resolveEffectiveStats(target, targetBonuses, targetMods)
+            val targetStats = resolvePlayerStats(target, items, statusEffects)
             val dodgePct = (PlayerState.statBonus(targetStats.dex, 1) * config.dexDodgePerPoint).coerceIn(0, config.maxDodgePercent)
             if (dodgePct > 0 && rng.nextInt(100) < dodgePct) {
                 outbound.send(OutboundEvent.SendText(targetSid, "You dodge ${mob.name}'s attack!"))

--- a/src/main/kotlin/dev/ambon/engine/EngineUtil.kt
+++ b/src/main/kotlin/dev/ambon/engine/EngineUtil.kt
@@ -10,6 +10,9 @@ import java.util.Random
 /** Standard error when `players.get(sessionId)` returns null in a system method returning `String?`. */
 internal const val ERR_NOT_CONNECTED = "You are not connected."
 
+/** Converts milliseconds to whole seconds, rounding up, with a minimum of 1. */
+internal fun Long.ceilSeconds(): Long = ((this + 999) / 1000).coerceAtLeast(1)
+
 /** Removes all entries whose expiry (extracted via [expiresAt]) is at or before [nowMs]. */
 internal fun <K, V> MutableMap<K, V>.removeExpired(nowMs: Long, expiresAt: (V) -> Long) {
     entries.removeIf { expiresAt(it.value) <= nowMs }

--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -227,3 +227,18 @@ fun resolveEffectiveStats(
         wis = player.wisdom + equip.stats.wis + mods.wis,
         cha = player.charisma + equip.stats.cha + mods.cha,
     )
+
+/**
+ * Convenience overload that gathers equipment bonuses and status-effect mods
+ * from the (possibly null) [items] and [statusEffects] systems, then resolves
+ * the player's effective stats in one call.
+ */
+fun resolvePlayerStats(
+    player: PlayerState,
+    items: ItemRegistry?,
+    statusEffects: dev.ambon.engine.status.StatusEffectSystem?,
+): StatBlock {
+    val equip = items?.equipmentBonuses(player.sessionId) ?: ItemRegistry.EquipmentBonuses()
+    val mods = statusEffects?.getPlayerStatMods(player.sessionId) ?: StatBlock.ZERO
+    return resolveEffectiveStats(player, equip, mods)
+}

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
@@ -2,7 +2,6 @@ package dev.ambon.engine.abilities
 
 import dev.ambon.bus.OutboundBus
 import dev.ambon.domain.PlayerClass
-import dev.ambon.domain.StatBlock
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.DirtyNotifier
@@ -13,11 +12,12 @@ import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.PlayerState
 import dev.ambon.engine.broadcastToRoom
+import dev.ambon.engine.ceilSeconds
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.healHp
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.engine.remapKey
-import dev.ambon.engine.resolveEffectiveStats
+import dev.ambon.engine.resolvePlayerStats
 import dev.ambon.engine.rollRange
 import dev.ambon.engine.spendMana
 import dev.ambon.engine.status.StatusEffectSystem
@@ -82,8 +82,7 @@ class AbilitySystem(
         val now = clock.millis()
         val expiresAt = cooldowns[sessionId]?.get(ability.id) ?: 0L
         if (now < expiresAt) {
-            val remainingMs = expiresAt - now
-            val remainingSec = ((remainingMs + 999) / 1000).coerceAtLeast(1)
+            val remainingSec = (expiresAt - now).ceilSeconds()
             return "${ability.displayName} is on cooldown (${remainingSec}s remaining)."
         }
 
@@ -128,9 +127,7 @@ class AbilitySystem(
                     ?: return "Cast ${ability.displayName} on whom?"
             }
 
-        val playerEquip = items?.equipmentBonuses(player.sessionId) ?: ItemRegistry.EquipmentBonuses()
-        val playerMods = statusEffects?.getPlayerStatMods(sessionId) ?: StatBlock.ZERO
-        val playerStats = resolveEffectiveStats(player, playerEquip, playerMods)
+        val playerStats = resolvePlayerStats(player, items, statusEffects)
 
         val intBonus = PlayerState.statBonus(playerStats.int, intSpellDivisor)
 

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
@@ -3,6 +3,7 @@ package dev.ambon.engine.commands.handlers
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.world.LockableState
+import dev.ambon.engine.ceilSeconds
 import dev.ambon.engine.commands.Command
 import dev.ambon.engine.commands.CommandHandler
 import dev.ambon.engine.commands.CommandRouter
@@ -115,7 +116,7 @@ class NavigationHandler(
         val me = players.get(sessionId) ?: return
         val now = clock.millis()
         if (now < me.recallCooldownUntilMs) {
-            val secondsLeft = (me.recallCooldownUntilMs - now + 999L) / 1000L
+            val secondsLeft = (me.recallCooldownUntilMs - now).ceilSeconds()
             outbound.send(OutboundEvent.SendText(sessionId, "You need to rest before recalling again. ($secondsLeft seconds remaining)"))
             return
         }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ProgressionHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ProgressionHandler.kt
@@ -7,6 +7,7 @@ import dev.ambon.domain.items.ItemSlot
 import dev.ambon.engine.GroupSystem
 import dev.ambon.engine.PlayerProgression
 import dev.ambon.engine.abilities.AbilitySystem
+import dev.ambon.engine.ceilSeconds
 import dev.ambon.engine.commands.Command
 import dev.ambon.engine.commands.CommandHandler
 import dev.ambon.engine.commands.CommandRouter
@@ -109,8 +110,7 @@ class ProgressionHandler(
                     val remainingMs = abilities.cooldownRemainingMs(sessionId, a.id)
                     val cdText =
                         if (remainingMs > 0) {
-                            val remainingSec = ((remainingMs + 999) / 1000).coerceAtLeast(1)
-                            "${remainingSec}s remaining"
+                            "${remainingMs.ceilSeconds()}s remaining"
                         } else if (a.cooldownMs > 0) {
                             "${a.cooldownMs / 1000}s cooldown"
                         } else {
@@ -141,7 +141,7 @@ class ProgressionHandler(
         } else {
             outbound.send(OutboundEvent.SendInfo(sessionId, "Active effects:"))
             for (e in effects) {
-                val remainingSec = ((e.remainingMs + 999) / 1000).coerceAtLeast(1)
+                val remainingSec = e.remainingMs.ceilSeconds()
                 val stacksText = if (e.stacks > 1) " (x${e.stacks})" else ""
                 outbound.send(
                     OutboundEvent.SendInfo(


### PR DESCRIPTION
## Summary
- Add `Long.ceilSeconds()` extension to `EngineUtil.kt` — replaces 4 instances of `((ms + 999) / 1000).coerceAtLeast(1)` across AbilitySystem, ProgressionHandler, and NavigationHandler
- Add `resolvePlayerStats()` convenience function to `PlayerState.kt` — chains the equipment bonuses + status effect mods + resolveEffectiveStats lookup into one call, used in CombatSystem (2 sites) and AbilitySystem (1 site)

## Test plan
- [x] Full test suite passes (CombatSystemTest, AbilitySystemTest, CommandRouterTest, etc.)
- [x] ktlintCheck passes
- [x] No behavioral changes — pure refactoring