### PR TITLE
refactor: consolidate persistence helpers and reuse shared yamlMapper

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/AchievementLoader.kt
+++ b/src/main/kotlin/dev/ambon/engine/AchievementLoader.kt
@@ -1,14 +1,12 @@
 package dev.ambon.engine
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import dev.ambon.domain.achievement.AchievementCategory
 import dev.ambon.domain.achievement.AchievementCriterion
 import dev.ambon.domain.achievement.AchievementDef
 import dev.ambon.domain.achievement.AchievementRewards
 import dev.ambon.domain.achievement.CriterionType
+import dev.ambon.persistence.yamlMapper
 
 /** Flat DTO for YAML deserialization of achievements.yaml. */
 internal data class AchievementsFile(
@@ -38,10 +36,6 @@ internal data class AchievementRewardsFile(
 )
 
 object AchievementLoader {
-    private val mapper: ObjectMapper =
-        ObjectMapper(YAMLFactory())
-            .registerModule(KotlinModule.Builder().build())
-
     /**
      * Loads achievements from a classpath resource and registers them in [registry].
      * Safe to call with a non-existent resource — will log a warning and skip.
@@ -54,7 +48,7 @@ object AchievementLoader {
             AchievementLoader::class.java.classLoader.getResourceAsStream(resourcePath)
                 ?: return
 
-        val file = mapper.readValue<AchievementsFile>(stream)
+        val file = yamlMapper.readValue<AchievementsFile>(stream)
         for ((rawId, entry) in file.achievements) {
             val id = rawId.trim()
             require(id.isNotEmpty()) { "Achievement id cannot be blank" }

--- a/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
@@ -5,9 +5,9 @@ import dev.ambon.domain.Race
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.persistence.PersistenceException
 import dev.ambon.persistence.PlayerCreationRequest
 import dev.ambon.persistence.PlayerId
-import dev.ambon.persistence.PlayerPersistenceException
 import dev.ambon.persistence.PlayerRecord
 import dev.ambon.persistence.PlayerRepository
 import kotlinx.coroutines.withContext
@@ -189,7 +189,7 @@ class PlayerRegistry(
                         charisma = baseStat + race.statMods.cha,
                     ),
                 )
-            } catch (_: PlayerPersistenceException) {
+            } catch (_: PersistenceException) {
                 return CreateAccountPrep.Taken
             }
         return CreateAccountPrep.Ready(record)

--- a/src/main/kotlin/dev/ambon/persistence/FileUtil.kt
+++ b/src/main/kotlin/dev/ambon/persistence/FileUtil.kt
@@ -13,7 +13,7 @@ import kotlin.io.path.createDirectories
  * then renames it into place. Falls back to a non-atomic move if the
  * file system does not support atomic rename.
  *
- * @throws PlayerPersistenceException if the write fails for any I/O reason.
+ * @throws PersistenceException if the write fails for any I/O reason.
  */
 internal fun atomicWriteText(
     path: Path,
@@ -29,6 +29,6 @@ internal fun atomicWriteText(
             Files.move(tmp, path, StandardCopyOption.REPLACE_EXISTING)
         }
     } catch (e: IOException) {
-        throw PlayerPersistenceException("Failed to write file atomically: $path", e)
+        throw PersistenceException("Failed to write file atomically: $path", e)
     }
 }

--- a/src/main/kotlin/dev/ambon/persistence/MapperSupport.kt
+++ b/src/main/kotlin/dev/ambon/persistence/MapperSupport.kt
@@ -16,3 +16,13 @@ val jsonMapper: ObjectMapper =
     ObjectMapper()
         .registerModule(KotlinModule.Builder().build())
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
+/**
+ * General persistence exception for I/O failures, uniqueness violations, and
+ * other repository-level errors. Originally named `PlayerPersistenceException`;
+ * renamed so guild and world-state repositories can use it too.
+ */
+class PersistenceException(
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/src/main/kotlin/dev/ambon/persistence/PostgresPlayerRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PostgresPlayerRepository.kt
@@ -62,7 +62,7 @@ class PostgresPlayerRepository(
         } catch (e: Exception) {
             // Unique-index violation on name_lower → treat as duplicate name
             if (e.message?.contains("idx_players_name_lower", ignoreCase = true) == true) {
-                throw PlayerPersistenceException("Name already taken: '$trimmed'", e)
+                throw PersistenceException("Name already taken: '$trimmed'", e)
             }
             throw e
         }

--- a/src/main/kotlin/dev/ambon/persistence/YamlGuildRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/YamlGuildRepository.kt
@@ -75,7 +75,7 @@ class YamlGuildRepository(
         return try {
             mapper.readValue<GuildDto>(path.readText())
         } catch (e: Exception) {
-            throw PlayerPersistenceException("Failed to read guild file: $path", e)
+            throw PersistenceException("Failed to read guild file: $path", e)
         }
     }
 

--- a/src/main/kotlin/dev/ambon/persistence/YamlPlayerRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/YamlPlayerRepository.kt
@@ -19,11 +19,6 @@ import kotlin.io.path.writeText
 
 private val log = KotlinLogging.logger {}
 
-class PlayerPersistenceException(
-    message: String,
-    cause: Throwable? = null,
-) : RuntimeException(message, cause)
-
 class YamlPlayerRepository(
     private val rootDir: Path,
     private val metrics: GameMetrics = GameMetrics.noop(),
@@ -81,7 +76,7 @@ class YamlPlayerRepository(
             createLock.withLock {
                 ensureNameIndexReady()
                 if (nameIndex.containsKey(nm.lowercase())) {
-                    throw PlayerPersistenceException("Name already taken: '$nm'")
+                    throw PersistenceException("Name already taken: '$nm'")
                 }
 
                 val id = nextId.getAndIncrement()
@@ -157,7 +152,7 @@ class YamlPlayerRepository(
         return try {
             mapper.readValue<PlayerRecord>(path.readText()).migrateDefaults()
         } catch (e: Exception) {
-            throw PlayerPersistenceException("Failed to read player file: $path", e)
+            throw PersistenceException("Failed to read player file: $path", e)
         }
     }
 
@@ -170,7 +165,7 @@ class YamlPlayerRepository(
                 .toLong()
                 .coerceAtLeast(1L)
         } catch (e: Exception) {
-            throw PlayerPersistenceException("Failed to read next_player_id.txt", e)
+            throw PersistenceException("Failed to read next_player_id.txt", e)
         }
     }
 

--- a/src/test/kotlin/dev/ambon/engine/PlayerRegistryFactoryTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/PlayerRegistryFactoryTest.kt
@@ -101,7 +101,7 @@ class PlayerRegistryFactoryTest {
             assertEquals(
                 CreateAccountPrep.Taken,
                 result,
-                "prepareCreateAccount should return Taken when repo.create throws PlayerPersistenceException",
+                "prepareCreateAccount should return Taken when repo.create throws PersistenceException",
             )
         }
 
@@ -149,7 +149,7 @@ class PlayerRegistryFactoryTest {
             assertEquals(
                 CreateResult.Taken,
                 result,
-                "create should return Taken when repo.create throws PlayerPersistenceException",
+                "create should return Taken when repo.create throws PersistenceException",
             )
         }
 }

--- a/src/test/kotlin/dev/ambon/persistence/InMemoryPlayerRepository.kt
+++ b/src/test/kotlin/dev/ambon/persistence/InMemoryPlayerRepository.kt
@@ -13,7 +13,7 @@ class InMemoryPlayerRepository : PlayerRepository {
     override suspend fun create(request: PlayerCreationRequest): PlayerRecord {
         val trimmed = request.name.trim()
         if (players.values.any { it.name.equals(trimmed, ignoreCase = true) }) {
-            throw PlayerPersistenceException("Name already taken: '$trimmed'")
+            throw PersistenceException("Name already taken: '$trimmed'")
         }
         val id = PlayerId(nextId.getAndIncrement())
         val record = request.toNewPlayerRecord(id)

--- a/src/test/kotlin/dev/ambon/persistence/PostgresPlayerRepositoryTest.kt
+++ b/src/test/kotlin/dev/ambon/persistence/PostgresPlayerRepositoryTest.kt
@@ -114,8 +114,8 @@ class PostgresPlayerRepositoryTest {
             val ex =
                 try {
                     repo.create(PlayerCreationRequest("carol", RoomId("test:a"), 1L, "hash789", ansiEnabled = false))
-                    fail("Expected PlayerPersistenceException")
-                } catch (e: PlayerPersistenceException) {
+                    fail("Expected PersistenceException")
+                } catch (e: PersistenceException) {
                     e
                 }
 

--- a/src/test/kotlin/dev/ambon/persistence/YamlPlayerRepositoryTest.kt
+++ b/src/test/kotlin/dev/ambon/persistence/YamlPlayerRepositoryTest.kt
@@ -93,8 +93,8 @@ class YamlPlayerRepositoryTest {
             val ex =
                 try {
                     repo.create(PlayerCreationRequest("carol", RoomId("test:a"), now, hash, ansiEnabled = false))
-                    fail("Expected PlayerPersistenceException")
-                } catch (e: PlayerPersistenceException) {
+                    fail("Expected PersistenceException")
+                } catch (e: PersistenceException) {
                     e
                 }
 
@@ -279,7 +279,7 @@ class YamlPlayerRepositoryTest {
             assertEquals(attempts - 1, results.count { it.isFailure })
             results.filter { it.isFailure }.forEach { result ->
                 val error = result.exceptionOrNull()
-                assertTrue(error is PlayerPersistenceException)
+                assertTrue(error is PersistenceException)
                 assertTrue(error!!.message!!.contains("taken", ignoreCase = true))
             }
         }


### PR DESCRIPTION
## Summary
- Rename `PlayerPersistenceException` to `PersistenceException` and move it from `YamlPlayerRepository.kt` to `MapperSupport.kt`, making it a shared exception for all persistence code (player, guild, etc.)
- Replace `AchievementLoader`'s private `ObjectMapper(YAMLFactory())` with the shared `yamlMapper` from `MapperSupport.kt`, eliminating a duplicated mapper instance

## Test plan
- [x] All existing tests pass (ktlintCheck + test)
- [x] `YamlPlayerRepositoryTest`, `PostgresPlayerRepositoryTest`, `PlayerRegistryFactoryTest` still catch `PersistenceException` correctly
- [x] `AchievementSystemTest` passes with the shared mapper