### PR TITLE
feat: persist inventory and equipment between logins

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
@@ -4,6 +4,7 @@ import dev.ambon.domain.PlayerClass
 import dev.ambon.domain.Race
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.items.ItemSlot
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.persistence.PersistenceException
 import dev.ambon.persistence.PlayerCreationRequest
@@ -273,6 +274,13 @@ class PlayerRegistry(
         roomMembers.getOrPut(ps.roomId) { mutableSetOf() }.add(sessionId)
         sessionByLowerName[ps.name.lowercase()] = sessionId
         items.ensurePlayer(sessionId)
+        for (item in boundRecord.inventoryItems) {
+            items.addToInventory(sessionId, item)
+        }
+        for ((slotName, item) in boundRecord.equippedItems) {
+            val slot = ItemSlot.parse(slotName) ?: continue
+            items.setEquippedItem(sessionId, slot, item)
+        }
 
         repo.save(
             boundRecord.copy(
@@ -517,7 +525,11 @@ class PlayerRegistry(
 
     private suspend fun persistIfClaimed(ps: PlayerState) {
         if (ps.playerId == null) return
-        repo.save(ps.toPlayerRecord(lastSeenEpochMs = clock.millis()))
+        val record = ps.toPlayerRecord(lastSeenEpochMs = clock.millis()).copy(
+            inventoryItems = items.inventory(ps.sessionId),
+            equippedItems = items.equipment(ps.sessionId).mapKeys { (slot, _) -> slot.name },
+        )
+        repo.save(record)
     }
 
     private fun isValidPassword(password: String): Boolean {

--- a/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
@@ -3,6 +3,7 @@ package dev.ambon.persistence
 import dev.ambon.domain.achievement.AchievementState
 import dev.ambon.domain.crafting.CraftingSkillState
 import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.mail.MailMessage
 import dev.ambon.domain.quest.QuestState
 
@@ -44,6 +45,8 @@ data class PlayerRecord(
     val recallRoomId: RoomId? = null,
     val craftingSkills: Map<String, CraftingSkillState> = emptyMap(),
     val friendsList: Set<String> = emptySet(),
+    val inventoryItems: List<ItemInstance> = emptyList(),
+    val equippedItems: Map<String, ItemInstance> = emptyMap(),
 ) {
     /**
      * Applies legacy migration fixes after deserialization.

--- a/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference
 import dev.ambon.domain.achievement.AchievementState
 import dev.ambon.domain.crafting.CraftingSkillState
 import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.mail.MailMessage
 import dev.ambon.domain.quest.QuestState
 import org.jetbrains.exposed.sql.ResultRow
@@ -17,6 +18,8 @@ private val achievementProgressType = object : TypeReference<Map<String, Achieve
 private val mailInboxType = object : TypeReference<List<MailMessage>>() {}
 private val craftingSkillsType = object : TypeReference<Map<String, CraftingSkillState>>() {}
 private val friendsListType = object : TypeReference<Set<String>>() {}
+private val inventoryItemsType = object : TypeReference<List<ItemInstance>>() {}
+private val equippedItemsType = object : TypeReference<Map<String, ItemInstance>>() {}
 
 /** Deserialises JSON with a fallback to [default] on any parse failure. */
 private fun <T> safeReadJson(json: String, type: TypeReference<T>, default: T): T =
@@ -56,6 +59,8 @@ object PlayersTable : Table("players") {
     val recallRoomId = varchar("recall_room_id", 128).nullable()
     val craftingSkills = text("crafting_skills").default("{}")
     val friendsList = text("friends_list").default("[]")
+    val inventoryItems = text("inventory_items").default("[]")
+    val equippedItems = text("equipped_items").default("{}")
 
     override val primaryKey = PrimaryKey(id)
 
@@ -94,6 +99,8 @@ object PlayersTable : Table("players") {
             recallRoomId = row[recallRoomId]?.let { RoomId(it) },
             craftingSkills = safeReadJson(row[craftingSkills], craftingSkillsType, emptyMap()),
             friendsList = safeReadJson(row[friendsList], friendsListType, emptySet()),
+            inventoryItems = safeReadJson(row[inventoryItems], inventoryItemsType, emptyList()),
+            equippedItems = safeReadJson(row[equippedItems], equippedItemsType, emptyMap()),
         ).migrateDefaults()
 
     /** Writes all [PlayerRecord] fields into an insert or upsert [statement]. */
@@ -131,5 +138,7 @@ object PlayersTable : Table("players") {
         statement[recallRoomId] = record.recallRoomId?.value
         statement[craftingSkills] = jsonMapper.writeValueAsString(record.craftingSkills)
         statement[friendsList] = jsonMapper.writeValueAsString(record.friendsList)
+        statement[inventoryItems] = jsonMapper.writeValueAsString(record.inventoryItems)
+        statement[equippedItems] = jsonMapper.writeValueAsString(record.equippedItems)
     }
 }

--- a/src/main/resources/db/migration/V14__add_player_items.sql
+++ b/src/main/resources/db/migration/V14__add_player_items.sql
@@ -1,0 +1,2 @@
+ALTER TABLE players ADD COLUMN inventory_items TEXT NOT NULL DEFAULT '[]';
+ALTER TABLE players ADD COLUMN equipped_items TEXT NOT NULL DEFAULT '{}';

--- a/src/test/kotlin/dev/ambon/persistence/PersistenceFieldCoverageTest.kt
+++ b/src/test/kotlin/dev/ambon/persistence/PersistenceFieldCoverageTest.kt
@@ -9,8 +9,12 @@ import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import dev.ambon.domain.Progress
 import dev.ambon.domain.achievement.AchievementState
+import dev.ambon.domain.ids.ItemId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.items.Item
+import dev.ambon.domain.items.ItemInstance
+import dev.ambon.domain.items.ItemSlot
 import dev.ambon.domain.mail.MailMessage
 import dev.ambon.domain.quest.QuestState
 import dev.ambon.engine.toPlayerRecord
@@ -99,6 +103,15 @@ class PersistenceFieldCoverageTest {
                 ),
                 guildId = "knights",
                 recallRoomId = RoomId("town:square"),
+                inventoryItems = listOf(
+                    ItemInstance(ItemId("test:potion"), Item(keyword = "potion", displayName = "a healing potion")),
+                ),
+                equippedItems = mapOf(
+                    "HAND" to ItemInstance(
+                        ItemId("test:sword"),
+                        Item(keyword = "sword", displayName = "a short sword", slot = ItemSlot.HAND),
+                    ),
+                ),
             )
 
         @BeforeAll
@@ -239,7 +252,10 @@ class PersistenceFieldCoverageTest {
         val ps = FULLY_POPULATED.toPlayerState(sid)
         val roundTripped = ps.toPlayerRecord(lastSeenEpochMs = FULLY_POPULATED.lastSeenEpochMs)
 
-        assertEquals(FULLY_POPULATED, roundTripped)
+        // Items are managed by ItemRegistry, not PlayerState, so they don't survive
+        // the PlayerState round-trip. All other fields must match.
+        val expected = FULLY_POPULATED.copy(inventoryItems = emptyList(), equippedItems = emptyMap())
+        assertEquals(expected, roundTripped)
     }
 
     // -----------------------------------------------------------------------

--- a/src/test/kotlin/dev/ambon/persistence/YamlPlayerRepositoryTest.kt
+++ b/src/test/kotlin/dev/ambon/persistence/YamlPlayerRepositoryTest.kt
@@ -1,7 +1,11 @@
 package dev.ambon.persistence
 
+import dev.ambon.domain.ids.ItemId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.items.Item
+import dev.ambon.domain.items.ItemInstance
+import dev.ambon.domain.items.ItemSlot
 import dev.ambon.engine.LoginResult
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.test.TestPasswordHasher
@@ -385,5 +389,32 @@ class YamlPlayerRepositoryTest {
             assertEquals("Bob", loaded.inbox[0].fromName)
             assertEquals("Hello Alice!", loaded.inbox[0].body)
             assertFalse(loaded.inbox[0].read)
+        }
+
+    @Test
+    fun `save and reload preserves inventory and equipped items`() =
+        runTest {
+            val repo = YamlPlayerRepository(tmp)
+            val r = repo.create(PlayerCreationRequest("ItemTest", RoomId("test:a"), 1000L, testHash, ansiEnabled = false))
+
+            val potion = ItemInstance(ItemId("test:potion"), Item(keyword = "potion", displayName = "a healing potion"))
+            val sword = ItemInstance(
+                ItemId("test:sword"),
+                Item(keyword = "sword", displayName = "a short sword", slot = ItemSlot.HAND),
+            )
+
+            val updated = r.copy(
+                inventoryItems = listOf(potion),
+                equippedItems = mapOf("HAND" to sword),
+            )
+            repo.save(updated)
+
+            val loaded = repo.findById(r.id)!!
+            assertEquals(1, loaded.inventoryItems.size)
+            assertEquals("potion", loaded.inventoryItems[0].item.keyword)
+            assertEquals(ItemId("test:potion"), loaded.inventoryItems[0].id)
+            assertEquals(1, loaded.equippedItems.size)
+            assertEquals("sword", loaded.equippedItems["HAND"]?.item?.keyword)
+            assertEquals(ItemId("test:sword"), loaded.equippedItems["HAND"]?.id)
         }
 }


### PR DESCRIPTION
## Summary
- Add `inventoryItems` and `equippedItems` fields to `PlayerRecord`, stored as JSON TEXT columns in Postgres (matching quests/achievements/mail pattern)
- Wire `PlayerRegistry.persistIfClaimed()` to snapshot items from `ItemRegistry` on every save, and `bindSession()` to restore them on login
- Add Flyway migration `V14__add_player_items.sql`

## Test plan
- [x] `PersistenceFieldCoverageTest` updated with non-default item values; catches any mapping omission across YAML, Redis JSON, Postgres, and PlayerState round-trips
- [x] PlayerState round-trip test adjusted to account for items bypassing PlayerState (managed by ItemRegistry)
- [x] New `YamlPlayerRepositoryTest` case: save inventory + equipment, reload, assert preserved
- [x] `ktlintCheck test` passes (full suite)