### PR TITLE
feat: add Guild GMCP packages (server-side)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -151,6 +151,7 @@ class GameEngine(
             statusEffectSystem = statusEffectSystem,
             achievementRegistry = achievementRegistry,
             groupSystem = groupSystem,
+            guildSystem = guildSystem,
             sessionLifecycle = sessionLifecycleCoordinator,
             router = router,
             playerLocationIndex = playerLocationIndex,
@@ -272,6 +273,7 @@ class GameEngine(
             statusEffectSystem = statusEffectSystem,
             achievementRegistry = achievementRegistry,
             groupSystem = groupSystem,
+            guildSystem = guildSystem,
             gmcpEmitter = gmcpEmitter,
             logger = log,
             metrics = metrics,
@@ -423,7 +425,8 @@ class GameEngine(
                 clock = clock,
                 maxSize = engineConfig.guild.maxSize,
                 inviteTimeoutMs = engineConfig.guild.inviteTimeoutMs,
-                markPlayerDirty = { sid -> players.persistPlayer(sid) }, // suspend lambda
+                markPlayerDirty = { sid -> players.persistPlayer(sid) },
+                gmcpEmitter = gmcpEmitter,
             )
         } else {
             null

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -285,6 +285,7 @@ class GmcpEmitter(
         achievementRegistry: AchievementRegistry,
         groupSystem: GroupSystem,
         players: PlayerRegistry,
+        guildSystem: GuildSystem? = null,
     ) {
         sendCharStatusVars(sessionId)
         sendCharVitals(sessionId, player)
@@ -296,6 +297,7 @@ class GmcpEmitter(
         sendCharStatusEffects(sessionId, statusEffectSystem.activePlayerEffects(sessionId))
         sendCharAchievements(sessionId, player, achievementRegistry)
         sendGroupSync(sessionId, groupSystem, players)
+        guildSystem?.sendGuildSync(sessionId)
     }
 
     /**
@@ -364,6 +366,53 @@ class GmcpEmitter(
 
     suspend fun sendFriendOffline(sessionId: SessionId, friendName: String) {
         emit(sessionId, "Friends.Offline", FriendOfflinePayload(name = friendName))
+    }
+
+    // ---------- guild ----------
+
+    suspend fun sendGuildInfo(
+        sessionId: SessionId,
+        name: String?,
+        tag: String?,
+        rank: String?,
+        motd: String?,
+        memberCount: Int,
+        maxSize: Int,
+    ) {
+        emit(
+            sessionId,
+            "Guild.Info",
+            GuildInfoGmcpPayload(
+                name = name,
+                tag = tag,
+                rank = rank,
+                motd = motd,
+                memberCount = memberCount,
+                maxSize = maxSize,
+            ),
+        )
+    }
+
+    suspend fun sendGuildMembers(
+        sessionId: SessionId,
+        members: List<GuildMemberInfo>,
+    ) {
+        emit(
+            sessionId,
+            "Guild.Members",
+            members.map { m ->
+                GuildMemberGmcpPayload(name = m.name, rank = m.rank, online = m.online, level = m.level)
+            },
+            supportCheck = "Guild.Info",
+        )
+    }
+
+    suspend fun sendGuildChat(
+        sessionId: SessionId,
+        sender: String,
+        message: String,
+    ) {
+        emit(sessionId, "Guild.Chat", GuildChatGmcpPayload(sender = sender, message = message), supportCheck = "Guild.Info")
     }
 
     // ---------- emit helpers ----------
@@ -551,6 +600,27 @@ class GmcpEmitter(
 
     private data class FriendOfflinePayload(
         val name: String,
+    )
+
+    private data class GuildInfoGmcpPayload(
+        val name: String?,
+        val tag: String?,
+        val rank: String?,
+        val motd: String?,
+        val memberCount: Int,
+        val maxSize: Int,
+    )
+
+    private data class GuildMemberGmcpPayload(
+        val name: String,
+        val rank: String,
+        val online: Boolean,
+        val level: Int?,
+    )
+
+    private data class GuildChatGmcpPayload(
+        val sender: String,
+        val message: String,
     )
 
     private companion object {

--- a/src/main/kotlin/dev/ambon/engine/GuildSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/GuildSystem.kt
@@ -27,6 +27,7 @@ class GuildSystem(
     private val maxSize: Int = 50,
     private val inviteTimeoutMs: Long = 60_000L,
     private val markPlayerDirty: suspend (SessionId) -> Unit = {},
+    private val gmcpEmitter: GmcpEmitter? = null,
 ) : GameSystem {
     private val guildsById = mutableMapOf<String, GuildRecord>()
     private val pendingInvites = mutableMapOf<SessionId, PendingGuildInvite>()
@@ -55,6 +56,7 @@ class GuildSystem(
         val playerId = ps.playerId ?: return
         ps.guildRank = guild.members[playerId]
         ps.guildTag = guild.tag
+        sendGuildSync(sessionId)
     }
 
     suspend fun create(
@@ -106,11 +108,15 @@ class GuildSystem(
         markPlayerDirty(sessionId)
 
         outbound.send(OutboundEvent.SendInfo(sessionId, "Guild '$trimName' [$trimTag] founded!"))
+        broadcastGuildGmcp(record)
         return null
     }
 
     suspend fun disband(sessionId: SessionId): String? = withMembership(sessionId) { ps, guild ->
         if (ps.guildRank != GuildRank.LEADER) return@withMembership "Only the guild leader can disband the guild."
+
+        // Collect online session IDs before clearing guild state
+        val onlineMemberSids = guild.members.keys.mapNotNull { players.findSessionByPlayerId(it) }
 
         // Notify and clear all online members
         for ((memberId, _) in guild.members) {
@@ -133,6 +139,11 @@ class GuildSystem(
         guildsById.remove(guild.id)
 
         outbound.send(OutboundEvent.SendInfo(sessionId, "Guild '${guild.name}' has been disbanded."))
+
+        // Send empty guild GMCP to all former online members
+        for (sid in onlineMemberSids) {
+            gmcpEmitter?.sendGuildInfo(sid, null, null, null, null, 0, maxSize)
+        }
         null
     }
 
@@ -194,6 +205,7 @@ class GuildSystem(
 
         outbound.send(OutboundEvent.SendInfo(sessionId, "You have joined guild '${guild.name}' [${guild.tag}]!"))
         broadcastToGuild(updated, "${ps.name} has joined the guild.", excludeSid = sessionId)
+        broadcastGuildGmcp(updated)
         return null
     }
 
@@ -213,6 +225,8 @@ class GuildSystem(
 
         outbound.send(OutboundEvent.SendInfo(sessionId, "You have left guild '$guildName'."))
         broadcastToGuild(updated, "${ps.name} has left the guild.", excludeSid = sessionId)
+        gmcpEmitter?.sendGuildInfo(sessionId, null, null, null, null, 0, maxSize)
+        broadcastGuildGmcp(updated)
         null
     }
 
@@ -248,6 +262,10 @@ class GuildSystem(
 
         outbound.send(OutboundEvent.SendInfo(sessionId, "$targetName has been kicked from the guild."))
         broadcastToGuild(updated, "$targetName has been kicked from the guild.", excludeSid = sessionId)
+        if (targetSid != null) {
+            gmcpEmitter?.sendGuildInfo(targetSid, null, null, null, null, 0, maxSize)
+        }
+        broadcastGuildGmcp(updated)
         null
     }
 
@@ -274,6 +292,7 @@ class GuildSystem(
         }
 
         outbound.send(OutboundEvent.SendInfo(sessionId, "$targetName has been promoted to Officer."))
+        broadcastGuildGmcp(updated)
         null
     }
 
@@ -300,6 +319,7 @@ class GuildSystem(
         }
 
         outbound.send(OutboundEvent.SendInfo(sessionId, "$targetName has been demoted to Member."))
+        broadcastGuildGmcp(updated)
         null
     }
 
@@ -314,6 +334,7 @@ class GuildSystem(
         persistGuild(updated)
 
         outbound.send(OutboundEvent.SendInfo(sessionId, "Guild MOTD updated."))
+        broadcastGuildGmcp(updated)
         null
     }
 
@@ -366,9 +387,60 @@ class GuildSystem(
         for ((memberId, _) in guild.members) {
             val sid = players.findSessionByPlayerId(memberId) ?: continue
             outbound.send(OutboundEvent.SendInfo(sid, formatted))
+            gmcpEmitter?.sendGuildChat(sid, ps.name, message)
         }
         null
     }
+
+    /** Sends Guild.Info and Guild.Members GMCP for the given session. */
+    suspend fun sendGuildSync(sessionId: SessionId) {
+        val emitter = gmcpEmitter ?: return
+        val ps = players.get(sessionId) ?: return
+        val gid = ps.guildId
+        if (gid == null) {
+            emitter.sendGuildInfo(sessionId, null, null, null, null, 0, maxSize)
+            return
+        }
+        val guild = guildsById[gid] ?: return
+        emitter.sendGuildInfo(
+            sessionId,
+            name = guild.name,
+            tag = guild.tag,
+            rank = ps.guildRank?.name,
+            motd = guild.motd,
+            memberCount = guild.members.size,
+            maxSize = maxSize,
+        )
+        emitter.sendGuildMembers(sessionId, buildMemberInfoList(guild))
+    }
+
+    /** Sends Guild.Info + Guild.Members to all online members of the guild. */
+    private suspend fun broadcastGuildGmcp(guild: GuildRecord) {
+        val emitter = gmcpEmitter ?: return
+        val memberInfos = buildMemberInfoList(guild)
+        for ((memberId, rank) in guild.members) {
+            val sid = players.findSessionByPlayerId(memberId) ?: continue
+            emitter.sendGuildInfo(
+                sid,
+                name = guild.name,
+                tag = guild.tag,
+                rank = rank.name,
+                motd = guild.motd,
+                memberCount = guild.members.size,
+                maxSize = maxSize,
+            )
+            emitter.sendGuildMembers(sid, memberInfos)
+        }
+    }
+
+    private suspend fun buildMemberInfoList(guild: GuildRecord): List<GuildMemberInfo> =
+        guild.members.entries.map { (memberId, rank) ->
+            val sid = players.findSessionByPlayerId(memberId)
+            val online = sid != null
+            val ps = if (sid != null) players.get(sid) else null
+            val name = ps?.name ?: players.findOfflinePlayerName(memberId) ?: "(unknown)"
+            GuildMemberInfo(name = name, rank = rank.name, online = online, level = ps?.level)
+        }
 
     // -------- helpers --------
 
@@ -416,3 +488,10 @@ class GuildSystem(
         pendingInvites.removeExpired(clock.millis()) { it.expiresAtMs }
     }
 }
+
+data class GuildMemberInfo(
+    val name: String,
+    val rank: String,
+    val online: Boolean,
+    val level: Int?,
+)

--- a/src/main/kotlin/dev/ambon/engine/events/GmcpEventHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/GmcpEventHandler.kt
@@ -5,6 +5,7 @@ import dev.ambon.domain.world.World
 import dev.ambon.engine.AchievementRegistry
 import dev.ambon.engine.GmcpEmitter
 import dev.ambon.engine.GroupSystem
+import dev.ambon.engine.GuildSystem
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.abilities.AbilitySystem
@@ -23,6 +24,7 @@ class GmcpEventHandler(
     private val statusEffectSystem: StatusEffectSystem,
     private val achievementRegistry: AchievementRegistry,
     private val groupSystem: GroupSystem,
+    private val guildSystem: GuildSystem? = null,
     private val gmcpEmitter: GmcpEmitter,
     private val logger: KLogger,
     private val metrics: GameMetrics = GameMetrics.noop(),
@@ -52,6 +54,7 @@ class GmcpEventHandler(
                     achievementRegistry,
                     groupSystem,
                     players,
+                    guildSystem,
                 )
                 gmcpEmitter.sendRoomInfo(sid, room)
                 gmcpEmitter.sendRoomPlayers(sid, players.playersInRoom(player.roomId).toList())

--- a/src/main/kotlin/dev/ambon/engine/events/LoginFlowHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/LoginFlowHandler.kt
@@ -8,6 +8,7 @@ import dev.ambon.domain.world.World
 import dev.ambon.engine.AchievementRegistry
 import dev.ambon.engine.GmcpEmitter
 import dev.ambon.engine.GroupSystem
+import dev.ambon.engine.GuildSystem
 import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.SessionLifecycleCoordinator
 import dev.ambon.engine.abilities.AbilitySystem
@@ -114,6 +115,7 @@ internal class LoginFlowHandler(
     private val statusEffectSystem: StatusEffectSystem,
     private val achievementRegistry: AchievementRegistry,
     private val groupSystem: GroupSystem,
+    private val guildSystem: GuildSystem? = null,
     private val sessionLifecycle: SessionLifecycleCoordinator,
     private val router: CommandRouter,
     private val playerLocationIndex: PlayerLocationIndex?,
@@ -507,6 +509,7 @@ internal class LoginFlowHandler(
             achievementRegistry,
             groupSystem,
             players,
+            guildSystem,
         )
         router.handle(sessionId, Command.Look)
 

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -616,4 +616,91 @@ class GmcpEmitterTest {
             e.sendGroupInfo(sid, "Alice", listOf(player()))
             assertTrue(drainGmcp().isEmpty())
         }
+
+    // ── Guild.Info ──
+
+    @Test
+    fun `sendGuildInfo emits guild name tag rank motd and counts`() =
+        runTest {
+            val e = emitter("Guild.Info")
+            e.sendGuildInfo(sid, "Knights", "KNT", "LEADER", "Welcome!", 5, 50)
+            val data = drainGmcp()[0]
+            assertEquals("Guild.Info", data.gmcpPackage)
+            assertTrue(data.jsonData.contains("\"name\":\"Knights\""))
+            assertTrue(data.jsonData.contains("\"tag\":\"KNT\""))
+            assertTrue(data.jsonData.contains("\"rank\":\"LEADER\""))
+            assertTrue(data.jsonData.contains("\"motd\":\"Welcome!\""))
+            assertTrue(data.jsonData.contains("\"memberCount\":5"))
+            assertTrue(data.jsonData.contains("\"maxSize\":50"))
+        }
+
+    @Test
+    fun `sendGuildInfo with null fields emits null values`() =
+        runTest {
+            val e = emitter("Guild.Info")
+            e.sendGuildInfo(sid, null, null, null, null, 0, 50)
+            val data = drainGmcp()[0]
+            assertTrue(data.jsonData.contains("\"name\":null"))
+            assertTrue(data.jsonData.contains("\"tag\":null"))
+            assertTrue(data.jsonData.contains("\"rank\":null"))
+            assertTrue(data.jsonData.contains("\"memberCount\":0"))
+        }
+
+    @Test
+    fun `sendGuildInfo skipped when not supported`() =
+        runTest {
+            val e = emitter()
+            e.sendGuildInfo(sid, "Knights", "KNT", "LEADER", null, 5, 50)
+            assertTrue(drainGmcp().isEmpty())
+        }
+
+    // ── Guild.Members ──
+
+    @Test
+    fun `sendGuildMembers emits member list with ranks and online status`() =
+        runTest {
+            val e = emitter("Guild.Info")
+            val members = listOf(
+                GuildMemberInfo(name = "Alice", rank = "LEADER", online = true, level = 10),
+                GuildMemberInfo(name = "Bob", rank = "MEMBER", online = false, level = 5),
+            )
+            e.sendGuildMembers(sid, members)
+            val data = drainGmcp()[0]
+            assertEquals("Guild.Members", data.gmcpPackage)
+            assertTrue(data.jsonData.contains("\"name\":\"Alice\""))
+            assertTrue(data.jsonData.contains("\"rank\":\"LEADER\""))
+            assertTrue(data.jsonData.contains("\"online\":true"))
+            assertTrue(data.jsonData.contains("\"name\":\"Bob\""))
+            assertTrue(data.jsonData.contains("\"online\":false"))
+            assertTrue(data.jsonData.contains("\"level\":5"))
+        }
+
+    @Test
+    fun `sendGuildMembers uses Guild Info as support check`() =
+        runTest {
+            val e = emitter()
+            e.sendGuildMembers(sid, listOf(GuildMemberInfo("Alice", "LEADER", true, 10)))
+            assertTrue(drainGmcp().isEmpty())
+        }
+
+    // ── Guild.Chat ──
+
+    @Test
+    fun `sendGuildChat emits sender and message`() =
+        runTest {
+            val e = emitter("Guild.Info")
+            e.sendGuildChat(sid, "Alice", "hello guild!")
+            val data = drainGmcp()[0]
+            assertEquals("Guild.Chat", data.gmcpPackage)
+            assertTrue(data.jsonData.contains("\"sender\":\"Alice\""))
+            assertTrue(data.jsonData.contains("\"message\":\"hello guild!\""))
+        }
+
+    @Test
+    fun `sendGuildChat skipped when not supported`() =
+        runTest {
+            val e = emitter()
+            e.sendGuildChat(sid, "Alice", "hello")
+            assertTrue(drainGmcp().isEmpty())
+        }
 }


### PR DESCRIPTION
## Summary
- Add `Guild.Info`, `Guild.Members`, and `Guild.Chat` GMCP packages to `GmcpEmitter`
- Wire `GuildSystem` to emit GMCP updates on every guild state change (create, join, leave, kick, promote, demote, disband, motd, gchat)
- Send guild sync on player login and GMCP `Core.Supports.Set` negotiation via `sendFullCharacterSync`
- Thread `guildSystem` through `LoginFlowHandler`, `GmcpEventHandler`, and `GameEngine` wiring

### GMCP Package Payloads

**`Guild.Info`** — sent to individual player on state change:
```json
{"name":"Knights","tag":"KNT","rank":"LEADER","motd":"Welcome!","memberCount":5,"maxSize":50}
```
Null name/tag/rank when player is not in a guild.

**`Guild.Members`** — member roster (support-checked via `Guild.Info`):
```json
[{"name":"Alice","rank":"LEADER","online":true,"level":10},{"name":"Bob","rank":"MEMBER","online":false,"level":5}]
```

**`Guild.Chat`** — guild chat messages (support-checked via `Guild.Info`):
```json
{"sender":"Alice","message":"hello guild!"}
```

Ref #503

## Test plan
- [x] 8 new tests in `GmcpEmitterTest` covering all three packages (emit, null fields, support gating)
- [x] Full `ktlintCheck test` passes