### PR TITLE
fix: advertise Guild, Friends, Group, and Achievements GMCP for WebSocket

### DIFF
--- a/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
+++ b/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
@@ -184,7 +184,7 @@ private suspend fun DefaultWebSocketServerSession.bridgeWebSocketSession(
         InboundEvent.GmcpReceived(
             sessionId,
             "Core.Supports.Set",
-            """["Char.Vitals 1","Room.Info 1","Char.StatusVars 1","Char.Items 1","Room.Players 1","Room.Mobs 1","Room.Items 1","Char.Skills 1","Char.Name 1","Char.StatusEffects 1","Comm.Channel 1","Core.Ping 1"]""",
+            """["Char.Vitals 1","Room.Info 1","Char.StatusVars 1","Char.Items 1","Room.Players 1","Room.Mobs 1","Room.Items 1","Char.Skills 1","Char.Name 1","Char.StatusEffects 1","Char.Achievements 1","Comm.Channel 1","Guild 1","Group.Info 1","Friends 1","Core.Ping 1"]""",
         ),
     )
     metrics.onWsConnected()


### PR DESCRIPTION
## Summary
- Adds `Char.Achievements 1`, `Guild 1`, `Group.Info 1`, and `Friends 1` to the WebSocket auto-opt GMCP support list in `KtorWebSocketTransport`
- Without these, the server's `supportsPackage()` check silently drops all emissions for guild info, friend list, group info, and achievements — the web client never receives the data even though the backend sends it

This fix was supposed to land with #517 but the PR was merged before the commit was pushed.

## Test plan
- [ ] Start server, connect via web client, verify guild/friends/group/achievements panels populate with data
- [ ] Existing backend tests pass (`KtorWebSocketTransportTest`, `GmcpEmitterTest`)