### PR TITLE
feat: add optional image field to rooms, mobs, and items

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/items/Item.kt
+++ b/src/main/kotlin/dev/ambon/domain/items/Item.kt
@@ -22,4 +22,5 @@ data class Item(
     val onUse: ItemUseEffect? = null,
     val matchByKey: Boolean = false,
     val basePrice: Int = 0,
+    val image: String? = null,
 )

--- a/src/main/kotlin/dev/ambon/domain/mob/MobState.kt
+++ b/src/main/kotlin/dev/ambon/domain/mob/MobState.kt
@@ -23,4 +23,5 @@ data class MobState(
     override val behaviorTree: BtNode? = null,
     val templateKey: String = "",
     override val questIds: List<String> = emptyList(),
+    override val image: String? = null,
 ) : MobTemplate

--- a/src/main/kotlin/dev/ambon/domain/mob/MobTemplate.kt
+++ b/src/main/kotlin/dev/ambon/domain/mob/MobTemplate.kt
@@ -22,4 +22,5 @@ interface MobTemplate {
     val dialogue: DialogueTree?
     val behaviorTree: BtNode?
     val questIds: List<String>
+    val image: String?
 }

--- a/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
@@ -22,4 +22,5 @@ data class MobSpawn(
     override val dialogue: DialogueTree? = null,
     override val behaviorTree: BtNode? = null,
     override val questIds: List<String> = emptyList(),
+    override val image: String? = null,
 ) : MobTemplate

--- a/src/main/kotlin/dev/ambon/domain/world/Room.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/Room.kt
@@ -14,4 +14,6 @@ data class Room(
     val features: List<RoomFeature> = emptyList(),
     /** Crafting station available in this room, if any. */
     val station: CraftingStationType? = null,
+    /** URL to an image representing this room. */
+    val image: String? = null,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/data/ItemFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/ItemFile.kt
@@ -22,4 +22,5 @@ data class ItemFile(
     val mob: String? = null,
     val matchByKey: Boolean = false,
     val basePrice: Int = 0,
+    val image: String? = null,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/data/MobFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/MobFile.kt
@@ -17,4 +17,5 @@ data class MobFile(
     val dialogue: Map<String, DialogueNodeFile> = emptyMap(),
     val behavior: BehaviorFile? = null,
     val quests: List<String> = emptyList(),
+    val image: String? = null,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/data/RoomFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/RoomFile.kt
@@ -15,4 +15,6 @@ data class RoomFile(
     val features: Map<String, FeatureFile> = emptyMap(),
     /** Crafting station type available in this room (e.g. "forge", "alchemy_table", "workbench"). */
     val station: String? = null,
+    /** URL to an image representing this room. */
+    val image: String? = null,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -135,6 +135,7 @@ object WorldLoader {
                         description = rf.description,
                         exits = emptyMap(),
                         station = station,
+                        image = rf.image,
                     )
             }
 
@@ -295,6 +296,7 @@ object WorldLoader {
                         dialogue = dialogue,
                         behaviorTree = behaviorTree,
                         questIds = questIds,
+                        image = mf.image,
                     )
             }
 
@@ -401,6 +403,7 @@ object WorldLoader {
                                         onUse = onUse,
                                         matchByKey = itemFile.matchByKey,
                                         basePrice = basePrice,
+                                        image = itemFile.image,
                                     ),
                             ),
                         roomId = roomId,

--- a/src/main/kotlin/dev/ambon/engine/ZoneResetHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/ZoneResetHandler.kt
@@ -29,6 +29,7 @@ internal fun spawnToMobState(spawn: MobSpawn): MobState =
         behaviorTree = spawn.behaviorTree,
         templateKey = spawn.id.value,
         questIds = spawn.questIds,
+        image = spawn.image,
     )
 
 /**

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
@@ -139,6 +139,7 @@ class AdminHandler(
                     armor = template.armor,
                     xpReward = template.xpReward,
                     drops = template.drops,
+                    image = template.image,
                 ),
             )
             outbound.send(OutboundEvent.SendInfo(sessionId, "${template.name} appears."))


### PR DESCRIPTION
## Summary
- Adds an optional `image: String?` field to rooms, mobs, and items across the full data pipeline (YAML DTOs → domain models → WorldLoader mappings)
- Propagates the image through mob spawn (`spawnToMobState`) and admin spawn paths
- No existing behavior changes — field defaults to `null` so all current world YAML continues to work

## Files changed (11)

**YAML DTOs:** `RoomFile`, `MobFile`, `ItemFile`
**Domain models:** `Room`, `Item`, `MobTemplate` (interface), `MobState`, `MobSpawn`
**Mappings:** `WorldLoader` (3 sites), `ZoneResetHandler`, `AdminHandler`

## Test plan
- [x] `ktlintCheck` passes
- [x] Full test suite passes (no behavioral changes — field is nullable with default)