### PR TITLE
Reduce mob wandering frequency and limit range from spawn

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -529,8 +529,8 @@ data class MobTiersConfig(
 }
 
 data class MobEngineConfig(
-    val minActionDelayMillis: Long = 2_000L,
-    val maxActionDelayMillis: Long = 5_000L,
+    val minActionDelayMillis: Long = 8_000L,
+    val maxActionDelayMillis: Long = 20_000L,
     val tiers: MobTiersConfig = MobTiersConfig(),
 )
 

--- a/src/main/kotlin/dev/ambon/domain/mob/MobState.kt
+++ b/src/main/kotlin/dev/ambon/domain/mob/MobState.kt
@@ -22,6 +22,8 @@ data class MobState(
     override val dialogue: DialogueTree? = null,
     override val behaviorTree: BtNode? = null,
     val templateKey: String = "",
+    val spawnRoomId: RoomId? = null,
+    val spawnDistanceMap: Map<RoomId, Int> = emptyMap(),
     override val questIds: List<String> = emptyList(),
     override val image: String? = null,
 ) : MobTemplate

--- a/src/main/kotlin/dev/ambon/domain/world/data/BehaviorFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/BehaviorFile.kt
@@ -10,4 +10,5 @@ data class BehaviorParamsFile(
     val fleeHpPercent: Int = 20,
     val aggroMessage: String? = null,
     val fleeMessage: String? = null,
+    val maxWanderDistance: Int = 3,
 )

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -710,7 +710,7 @@ class GameEngine(
 
     init {
         world.mobSpawns.forEach { spawn ->
-            mobs.upsert(spawnToMobState(spawn))
+            mobs.upsert(spawnToMobState(spawn, world))
         }
         items.loadSpawns(world.itemSpawns)
         shopRegistry.register(world.shopDefinitions)
@@ -967,7 +967,7 @@ class GameEngine(
             scheduler.scheduleIn(respawnMs) {
                 if (mobs.get(spawn.id) != null) return@scheduleIn
                 if (world.rooms[spawn.roomId] == null) return@scheduleIn
-                val respawned = spawnToMobState(spawn)
+                val respawned = spawnToMobState(spawn, world)
                 mobs.upsert(respawned)
                 mobSystem.onMobSpawned(spawn.id)
                 behaviorTreeSystem.onMobSpawned(spawn.id)

--- a/src/main/kotlin/dev/ambon/engine/ZoneResetHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/ZoneResetHandler.kt
@@ -1,6 +1,7 @@
 package dev.ambon.engine
 
 import dev.ambon.bus.OutboundBus
+import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.idZone
 import dev.ambon.domain.mob.MobState
 import dev.ambon.domain.world.MobSpawn
@@ -11,8 +12,28 @@ import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
 import java.time.Clock
 
+/** BFS from [start], staying within the same zone. Returns room → hop distance. */
+internal fun computeDistanceMap(start: RoomId, world: World): Map<RoomId, Int> {
+    val zone = start.zone
+    val distances = mutableMapOf(start to 0)
+    val queue = ArrayDeque<RoomId>()
+    queue.add(start)
+    while (queue.isNotEmpty()) {
+        val current = queue.removeFirst()
+        val dist = distances[current]!!
+        val room = world.rooms[current] ?: continue
+        for (exit in room.exits.values) {
+            if (exit.zone != zone) continue
+            if (exit in distances) continue
+            distances[exit] = dist + 1
+            queue.add(exit)
+        }
+    }
+    return distances
+}
+
 /** Converts a [MobSpawn] definition into a live [MobState] instance. */
-internal fun spawnToMobState(spawn: MobSpawn): MobState =
+internal fun spawnToMobState(spawn: MobSpawn, world: World): MobState =
     MobState(
         id = spawn.id,
         name = spawn.name,
@@ -28,6 +49,8 @@ internal fun spawnToMobState(spawn: MobSpawn): MobState =
         dialogue = spawn.dialogue,
         behaviorTree = spawn.behaviorTree,
         templateKey = spawn.id.value,
+        spawnRoomId = spawn.roomId,
+        spawnDistanceMap = computeDistanceMap(spawn.roomId, world),
         questIds = spawn.questIds,
         image = spawn.image,
     )
@@ -99,7 +122,7 @@ internal class ZoneResetHandler(
         }
 
         for (spawn in zoneMobSpawns) {
-            mobs.upsert(spawnToMobState(spawn))
+            mobs.upsert(spawnToMobState(spawn, world))
             mobSystem.onMobSpawned(spawn.id)
             behaviorTreeSystem.onMobSpawned(spawn.id)
         }

--- a/src/main/kotlin/dev/ambon/engine/behavior/BehaviorTemplates.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/BehaviorTemplates.kt
@@ -35,7 +35,7 @@ object BehaviorTemplates {
             "aggro_guard" -> aggroGuard(params)
             "patrol" -> patrol(params, zone)
             "patrol_aggro" -> patrolAggro(params, zone)
-            "wander" -> wander()
+            "wander" -> wander(params)
             "wander_aggro" -> wanderAggro(params)
             "coward" -> coward(params)
             else -> null
@@ -73,11 +73,11 @@ object BehaviorTemplates {
             ),
         )
 
-    private fun wander(): BtNode =
+    private fun wander(params: BehaviorParamsFile): BtNode =
         SelectorNode(
             listOf(
                 IsInCombat,
-                WanderAction,
+                WanderAction(params.maxWanderDistance),
             ),
         )
 
@@ -86,7 +86,7 @@ object BehaviorTemplates {
             listOf(
                 IsInCombat,
                 aggroSequence(params),
-                WanderAction,
+                WanderAction(params.maxWanderDistance),
             ),
         )
 
@@ -102,7 +102,7 @@ object BehaviorTemplates {
         return SelectorNode(
             listOf(
                 SequenceNode(fleeChildren),
-                WanderAction,
+                WanderAction(params.maxWanderDistance),
             ),
         )
     }

--- a/src/main/kotlin/dev/ambon/engine/behavior/actions/WanderAction.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/actions/WanderAction.kt
@@ -5,11 +5,18 @@ import dev.ambon.engine.behavior.BtNode
 import dev.ambon.engine.behavior.BtResult
 import dev.ambon.engine.behavior.moveMobWithNotify
 
-data object WanderAction : BtNode {
+data class WanderAction(
+    val maxDistance: Int = 3,
+) : BtNode {
     override suspend fun tick(ctx: BtContext): BtResult {
         val room = ctx.world.rooms[ctx.mob.roomId] ?: return BtResult.FAILURE
         val homeZone = ctx.mob.roomId.zone
-        val exits = room.exits.values.filter { it.zone == homeZone }
+        val distanceMap = ctx.mob.spawnDistanceMap
+
+        val exits = room.exits.values.filter { dest ->
+            dest.zone == homeZone &&
+                (distanceMap.isEmpty() || (distanceMap[dest] ?: Int.MAX_VALUE) <= maxDistance)
+        }
         if (exits.isEmpty()) return BtResult.FAILURE
 
         val destination = exits[ctx.rng.nextInt(exits.size)]

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
@@ -139,6 +139,7 @@ class AdminHandler(
                     armor = template.armor,
                     xpReward = template.xpReward,
                     drops = template.drops,
+                    spawnRoomId = me.roomId,
                     image = template.image,
                 ),
             )

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -118,8 +118,8 @@ ambonmud:
 
   engine:
     mob:
-      minActionDelayMillis: 2000
-      maxActionDelayMillis: 5000
+      minActionDelayMillis: 8000
+      maxActionDelayMillis: 20000
       tiers:
         weak:
           baseHp: 5

--- a/src/test/kotlin/dev/ambon/engine/behavior/BehaviorTreeSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/behavior/BehaviorTreeSystemTest.kt
@@ -363,7 +363,7 @@ class BehaviorTreeSystemTest {
     @Test
     fun `wander action moves mob to random adjacent room`() =
         runTest {
-            val tree = WanderAction
+            val tree = WanderAction()
             val e = env(behaviorTree = tree)
 
             e.system.tick() // schedule
@@ -406,10 +406,53 @@ class BehaviorTreeSystemTest {
                     mobMemory = MobBehaviorMemory(),
                 )
 
-            val result = WanderAction.tick(ctx)
+            val result = WanderAction().tick(ctx)
 
             assertEquals(BtResult.FAILURE, result, "Expected FAILURE — no same-zone exits")
             assertEquals(borderRoom.id, mobs.get(mob.id)!!.roomId, "Mob must not have crossed zone boundary")
+        }
+
+    @Test
+    fun `wander action respects maxDistance from spawn room`() =
+        runTest {
+            // roomA -> roomB -> roomC (linear). Mob spawns at roomA with maxDistance=1.
+            // It can reach roomB (distance 1) but not roomC (distance 2).
+            val distanceMap = mapOf(roomA.id to 0, roomB.id to 1, roomC.id to 2)
+            val mobs = MobRegistry()
+            val items = ItemRegistry()
+            val players = dev.ambon.test.buildTestPlayerRegistry(roomA.id, InMemoryPlayerRepository(), items)
+
+            // Place mob at roomB (distance 1 from spawn). Only exit toward roomC is distance 2 — blocked.
+            val mob = MobState(
+                MobId("zone:wanderer"),
+                "a wanderer",
+                roomB.id,
+                spawnRoomId = roomA.id,
+                spawnDistanceMap = distanceMap,
+            )
+            mobs.upsert(mob)
+
+            val ctx = BtContext(
+                mob = mob,
+                world = world,
+                mobs = mobs,
+                players = players,
+                outbound = LocalOutboundBus(),
+                clock = MutableClock(0L),
+                rng = Random(42),
+                isMobInCombat = { false },
+                startMobCombat = { _, _ -> false },
+                fleeMob = { false },
+                gmcpEmitter = null,
+                mobMemory = MobBehaviorMemory(),
+            )
+
+            val result = WanderAction(maxDistance = 1).tick(ctx)
+
+            // The only allowed exit is back to roomA (distance 0). roomC (distance 2) is blocked.
+            assertEquals(BtResult.SUCCESS, result)
+            val newRoom = mobs.get(mob.id)!!.roomId
+            assertTrue(newRoom == roomA.id, "Mob should only move to roomA (within maxDistance), got $newRoom")
         }
 
     // --- Say action tests ---


### PR DESCRIPTION
## Summary
- Increase default mob behavior action delay from 2-5s to **8-20s** so mobs stay in rooms longer
- Track `spawnRoomId` and a **precomputed BFS distance map** on `MobState` (computed once at spawn, O(1) lookup at tick time)
- `WanderAction` now enforces `maxDistance` (default **3 hops**) from spawn room — mobs can no longer drift across entire zones
- New `maxWanderDistance` YAML param on `BehaviorParamsFile` for per-mob tuning

## Test plan
- [x] Existing wander tests updated and passing
- [x] New test verifies mob at max distance can only move back toward spawn
- [x] `ktlintCheck test` passes