### PR TITLE
Grant staff immunity to aggro, damage, mana, and gold costs

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -98,8 +98,9 @@ fun PlayerState.healHp(amount: Int): Boolean {
     }
 }
 
-/** Decreases HP by [amount], clamped to 0. */
+/** Decreases HP by [amount], clamped to 0. Staff members are immune to damage. */
 fun PlayerState.takeDamage(amount: Int) {
+    if (isStaff) return
     hp = (hp - amount).coerceAtLeast(0)
 }
 
@@ -114,8 +115,9 @@ fun PlayerState.healMana(amount: Int): Boolean {
     }
 }
 
-/** Decreases mana by [amount], clamped to 0. */
+/** Decreases mana by [amount], clamped to 0. Staff members have infinite mana. */
 fun PlayerState.spendMana(amount: Int) {
+    if (isStaff) return
     mana = (mana - amount).coerceAtLeast(0)
 }
 

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
@@ -73,8 +73,8 @@ class AbilitySystem(
             return "You don't know a spell called '$spellName'."
         }
 
-        // 2. Check mana
-        if (player.mana < ability.manaCost) {
+        // 2. Check mana (staff have infinite mana)
+        if (!player.isStaff && player.mana < ability.manaCost) {
             return "Not enough mana. (${player.mana}/${ability.manaCost})"
         }
 

--- a/src/main/kotlin/dev/ambon/engine/behavior/actions/AggroAction.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/actions/AggroAction.kt
@@ -8,6 +8,7 @@ data object AggroAction : BtNode {
     override suspend fun tick(ctx: BtContext): BtResult {
         val playersInRoom = ctx.players.playersInRoom(ctx.mob.roomId)
         for (p in playersInRoom) {
+            if (p.isStaff) continue
             val started = ctx.startMobCombat(ctx.mob.id, p.sessionId)
             if (started) return BtResult.SUCCESS
         }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ShopHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ShopHandler.kt
@@ -80,7 +80,7 @@ class ShopHandler(
             }
             val (itemId, item) = match
             val buyPrice = (item.basePrice * economyConfig.buyMultiplier).roundToInt().toLong()
-            if (me.gold < buyPrice) {
+            if (!me.isStaff && me.gold < buyPrice) {
                 outbound.send(OutboundEvent.SendText(sessionId, "You can't afford ${item.displayName} ($buyPrice gold)."))
                 return
             }
@@ -89,7 +89,7 @@ class ShopHandler(
                 outbound.send(OutboundEvent.SendText(sessionId, "That item is out of stock."))
                 return
             }
-            me.gold -= buyPrice
+            if (!me.isStaff) me.gold -= buyPrice
             items.addToInventory(sessionId, newItem)
             markVitalsDirty(sessionId)
             outbound.send(OutboundEvent.SendText(sessionId, "You buy ${item.displayName} for $buyPrice gold."))

--- a/src/test/kotlin/dev/ambon/engine/StaffImmunityTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/StaffImmunityTest.kt
@@ -1,0 +1,62 @@
+package dev.ambon.engine
+
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class StaffImmunityTest {
+    private fun staffPlayer() =
+        PlayerState(
+            sessionId = SessionId(1L),
+            name = "Admin",
+            roomId = RoomId("zone:a"),
+            isStaff = true,
+            hp = 100,
+            maxHp = 100,
+            mana = 50,
+            maxMana = 50,
+            gold = 10L,
+        )
+
+    private fun normalPlayer() =
+        PlayerState(
+            sessionId = SessionId(2L),
+            name = "Normal",
+            roomId = RoomId("zone:a"),
+            isStaff = false,
+            hp = 100,
+            maxHp = 100,
+            mana = 50,
+            maxMana = 50,
+            gold = 10L,
+        )
+
+    @Test
+    fun `takeDamage is a no-op for staff`() {
+        val p = staffPlayer()
+        p.takeDamage(999)
+        assertEquals(100, p.hp)
+    }
+
+    @Test
+    fun `takeDamage reduces HP for normal player`() {
+        val p = normalPlayer()
+        p.takeDamage(30)
+        assertEquals(70, p.hp)
+    }
+
+    @Test
+    fun `spendMana is a no-op for staff`() {
+        val p = staffPlayer()
+        p.spendMana(999)
+        assertEquals(50, p.mana)
+    }
+
+    @Test
+    fun `spendMana reduces mana for normal player`() {
+        val p = normalPlayer()
+        p.spendMana(20)
+        assertEquals(30, p.mana)
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/behavior/BehaviorTreeSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/behavior/BehaviorTreeSystemTest.kt
@@ -265,6 +265,33 @@ class BehaviorTreeSystemTest {
             assertTrue(e.combat.isMobInCombat(e.mobId))
         }
 
+    @Test
+    fun `aggro guard ignores staff player in same room`() =
+        runTest {
+            val tree =
+                SelectorNode(
+                    listOf(
+                        IsInCombat,
+                        SequenceNode(listOf(IsPlayerInRoom, AggroAction)),
+                        StationaryAction,
+                    ),
+                )
+            val e = env(behaviorTree = tree)
+            val sid = SessionId(1L)
+            e.players.loginOrFail(sid, "StaffGuy")
+            e.players.get(sid)!!.isStaff = true
+
+            e.outbound.drainAll()
+
+            e.system.tick() // schedule
+            e.clock.advance(200)
+            e.system.tick() // execute
+
+            // Staff player should NOT be in combat — mob skips them
+            assertFalse(e.combat.isMobInCombat(e.mobId))
+            assertFalse(e.combat.isInCombat(sid))
+        }
+
     // --- Patrol tests ---
 
     @Test


### PR DESCRIPTION
## Summary

- Aggro mobs now skip staff players when scanning for targets in `AggroAction`
- `takeDamage()` is a no-op for staff, covering both mob melee hits and DOT status effects
- `spendMana()` is a no-op for staff, and the mana cost check in `AbilitySystem` is bypassed
- Shop purchases skip the affordability check and gold deduction for staff

## Test plan

- [x] New `StaffImmunityTest` with 4 unit tests for `takeDamage`/`spendMana` staff immunity
- [x] New aggro test in `BehaviorTreeSystemTest`: "aggro guard ignores staff player in same room"
- [x] Full test suite passes
- [x] ktlintCheck passes