### PR TITLE
Fix shop UI not appearing in web client

### DIFF
--- a/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
+++ b/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
@@ -189,7 +189,7 @@ private suspend fun DefaultWebSocketServerSession.bridgeWebSocketSession(
         InboundEvent.GmcpReceived(
             sessionId,
             "Core.Supports.Set",
-            """["Char.Vitals 1","Room.Info 1","Char.StatusVars 1","Char.Items 1","Room.Players 1","Room.Mobs 1","Room.Items 1","Char.Skills 1","Char.Name 1","Char.StatusEffects 1","Char.Achievements 1","Comm.Channel 1","Guild 1","Group.Info 1","Friends 1","Core.Ping 1","Dialogue 1","Char.Combat.Event 1","Char.Stats 1","Quest 1","Char.Cooldown 1","Char.Gain 1","Room.MobInfo 1"]""",
+            """["Char.Vitals 1","Room.Info 1","Char.StatusVars 1","Char.Items 1","Room.Players 1","Room.Mobs 1","Room.Items 1","Char.Skills 1","Char.Name 1","Char.StatusEffects 1","Char.Achievements 1","Comm.Channel 1","Guild 1","Group.Info 1","Friends 1","Core.Ping 1","Dialogue 1","Shop 1","Char.Combat.Event 1","Char.Stats 1","Quest 1","Char.Cooldown 1","Char.Gain 1","Room.MobInfo 1"]""",
         ),
     )
     metrics.onWsConnected()


### PR DESCRIPTION
## Summary

- Add `"Shop 1"` to the WebSocket auto-registered GMCP packages list in `KtorWebSocketTransport`
- The `Shop` package was missing from the hardcoded `Core.Supports.Set` sent on WebSocket connect, causing `GmcpEmitter` to silently drop all `Shop.List` and `Shop.Close` events for web clients

## Test plan

- [x] Existing tests pass (`KtorWebSocketTransportTest`, `GmcpEmitterTest`, `CommandRouterShopTest`)
- [ ] Connect via web client, navigate to a shop room, and verify the shop panel appears
- [ ] Buy/sell items and confirm the shop UI refreshes correctly