### PR TITLE
Increase EC2 demo EBS to 16 GB, aggressively prune Docker

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -68,7 +68,7 @@ jobs:
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids "$INSTANCE_ID" \
             --document-name "AWS-RunShellScript" \
-            --parameters "commands=[\"docker image prune -af --filter 'until=1h' && update-ambonmud $IMAGE_TAG\"]" \
+            --parameters "commands=[\"docker system prune -af && update-ambonmud $IMAGE_TAG\"]" \
             --comment "Auto-deploy $IMAGE_TAG from GitHub Actions" \
             --query "Command.CommandId" \
             --output text)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -367,10 +367,10 @@ CDK `cdk diff` shows exactly what will change before deploying. In-place tier up
 | Component | ~Monthly |
 |-----------|---------|
 | EC2 t4g.nano (2 vCPU burst / 512 MB) | ~$3.07 |
-| EBS gp3 8 GB (encrypted) | ~$0.64 |
+| EBS gp3 16 GB (encrypted) | ~$1.28 |
 | Elastic IP (free while attached) | $0 |
 | Route 53 hosted zone (optional) | ~$0.50 |
-| **Total** | **~$4–5/mo** |
+| **Total** | **~$5–6/mo** |
 
 No RDS, no Redis, no NAT gateway, no load balancer. YAML persistence stores player data at `/app/data` on the root EBS volume.
 

--- a/infra/lib/ec2-stack.ts
+++ b/infra/lib/ec2-stack.ts
@@ -242,7 +242,7 @@ export class Ec2Stack extends Stack {
       blockDevices: [
         {
           deviceName: '/dev/xvda',
-          volume: ec2.BlockDeviceVolume.ebs(8, {
+          volume: ec2.BlockDeviceVolume.ebs(16, {
             volumeType: ec2.EbsDeviceVolumeType.GP3,
             encrypted: true,
           }),


### PR DESCRIPTION
## Summary
- Doubles the EC2 demo EBS root volume from 8 GB to 16 GB to prevent disk-full failures during Docker image pulls
- Switches deploy-demo workflow from `docker image prune -af --filter 'until=1h'` to `docker system prune -af` so every deploy cleans all unused Docker artifacts
- Updates DEPLOYMENT.md cost table to reflect the new volume size

## Test plan
- [ ] `cdk diff --context topology=ec2` shows only the EBS size change
- [ ] After CDK redeploy, `df -h /` on the instance shows ~16 GB
- [ ] Next deploy-demo workflow run succeeds without disk space errors