### PR TITLE
Wire up staff player sprites using level 60 tier

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -894,7 +894,7 @@ class GmcpEmitter(
         val race: String,
         @get:JsonProperty("class") val playerClass: String,
         val level: Int,
-        val sprite: String?,
+        val sprite: String,
         val isStaff: Boolean,
     )
 
@@ -1135,13 +1135,13 @@ class GmcpEmitter(
         }
 
         private val SPRITE_LEVEL_TIERS = intArrayOf(50, 40, 30, 20, 10, 1)
+        private const val STAFF_SPRITE_TIER = 60
 
-        fun resolveSprite(player: PlayerState): String? {
-            if (player.isStaff) return null
+        fun resolveSprite(player: PlayerState): String {
             val gender = Gender.fromString(player.gender) ?: Gender.ENBY
             val race = player.race.lowercase()
             val cls = player.playerClass.lowercase()
-            val tier = SPRITE_LEVEL_TIERS.firstOrNull { player.level >= it } ?: 1
+            val tier = if (player.isStaff) STAFF_SPRITE_TIER else SPRITE_LEVEL_TIERS.firstOrNull { player.level >= it } ?: 1
             return "/images/player_sprites/${race}_${gender.spriteCode}_${cls}_l$tier.png"
         }
     }


### PR DESCRIPTION
## Summary
- Staff players now receive their avatar sprite via GMCP `Char.Name` instead of `null`
- Uses the L60 sprite tier from `player_sprites.yaml`, resolved by race/gender/class
- `resolveSprite()` return type changed from `String?` to `String` — all players always get a sprite
- No web client changes needed — it already displays the sprite when non-null

## Changes
- `GmcpEmitter.kt`: Added `STAFF_SPRITE_TIER = 60`, removed `if (player.isStaff) return null` guard, updated `CharNamePayload.sprite` from `String?` to `String`

## Test plan
- [ ] Staff player logs in → `Char.Name` GMCP includes `sprite: "/images/player_sprites/{race}_{gender}_{class}_l60.png"`
- [ ] Non-staff player sprite resolution unchanged (L1–L50 tiers)
- [ ] Web client displays staff avatar in character panel and canvas scenes