### PR TITLE
Refactor: extract notifyMembers, applyHeal, and applySpellDamage helpers

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/EngineUtil.kt
+++ b/src/main/kotlin/dev/ambon/engine/EngineUtil.kt
@@ -7,6 +7,22 @@ import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.events.OutboundEvent
 import java.util.Random
 
+/**
+ * Applies healing to [target], marks vitals dirty if HP changed, and returns the actual amount healed.
+ */
+internal fun applyHeal(
+    sessionId: SessionId,
+    target: PlayerState,
+    amount: Int,
+    dirtyNotifier: DirtyNotifier,
+): Int {
+    val before = target.hp
+    target.healHp(amount)
+    val healed = target.hp - before
+    if (healed > 0) dirtyNotifier.playerVitalsDirty(sessionId)
+    return healed
+}
+
 /** Standard error when `players.get(sessionId)` returns null in a system method returning `String?`. */
 internal const val ERR_NOT_CONNECTED = "You are not connected."
 

--- a/src/main/kotlin/dev/ambon/engine/GroupSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/GroupSystem.kt
@@ -152,13 +152,8 @@ class GroupSystem(
         groupBySession[inviteeSid] = group
 
         // Notify all group members
-        for (sid in group.members) {
-            markGroupDirty(sid)
-            if (sid == inviteeSid) {
-                outbound.send(OutboundEvent.SendText(sid, "You join ${inviter.name}'s group."))
-            } else {
-                outbound.send(OutboundEvent.SendText(sid, "${invitee.name} joins the group."))
-            }
+        notifyMembers(group) { sid ->
+            if (sid == inviteeSid) "You join ${inviter.name}'s group." else "${invitee.name} joins the group."
         }
 
         return null
@@ -186,15 +181,9 @@ class GroupSystem(
         if (group.leader == sessionId) {
             group.leader = group.members.first()
             val newLeaderName = players.get(group.leader)?.name ?: "Someone"
-            for (sid in group.members) {
-                markGroupDirty(sid)
-                outbound.send(OutboundEvent.SendText(sid, "$playerName leaves the group. $newLeaderName is now the leader."))
-            }
+            notifyMembers(group, "$playerName leaves the group. $newLeaderName is now the leader.")
         } else {
-            for (sid in group.members) {
-                markGroupDirty(sid)
-                outbound.send(OutboundEvent.SendText(sid, "$playerName leaves the group."))
-            }
+            notifyMembers(group, "$playerName leaves the group.")
         }
 
         return null
@@ -231,10 +220,7 @@ class GroupSystem(
             return null
         }
 
-        for (sid in group.members) {
-            markGroupDirty(sid)
-            outbound.send(OutboundEvent.SendText(sid, "$kickedName has been kicked from the group."))
-        }
+        notifyMembers(group, "$kickedName has been kicked from the group.")
 
         return null
     }
@@ -323,6 +309,20 @@ class GroupSystem(
         }
         if (group.leader == oldSid) {
             group.leader = newSid
+        }
+    }
+
+    private suspend fun notifyMembers(group: Group, message: String) {
+        for (sid in group.members) {
+            markGroupDirty(sid)
+            outbound.send(OutboundEvent.SendText(sid, message))
+        }
+    }
+
+    private suspend fun notifyMembers(group: Group, messageFor: (SessionId) -> String) {
+        for (sid in group.members) {
+            markGroupDirty(sid)
+            outbound.send(OutboundEvent.SendText(sid, messageFor(sid)))
         }
     }
 

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
@@ -3,6 +3,7 @@ package dev.ambon.engine.abilities
 import dev.ambon.bus.OutboundBus
 import dev.ambon.domain.PlayerClass
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.mob.MobState
 import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.DirtyNotifier
 import dev.ambon.engine.ERR_NOT_CONNECTED
@@ -11,11 +12,11 @@ import dev.ambon.engine.GroupSystem
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.PlayerState
+import dev.ambon.engine.applyHeal
 import dev.ambon.engine.broadcastToRoom
 import dev.ambon.engine.ceilSeconds
 import dev.ambon.engine.events.CombatEvent
 import dev.ambon.engine.events.OutboundEvent
-import dev.ambon.engine.healHp
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.engine.remapKey
 import dev.ambon.engine.resolvePlayerStats
@@ -137,30 +138,7 @@ class AbilitySystem(
             is AbilityEffect.DirectDamage -> {
                 deductManaAndCooldown(sessionId, player, ability, now)
                 val baseDamage = rollRange(rng, effect.damage.min, effect.damage.max)
-                val damage = (baseDamage + intBonus).coerceAtLeast(1)
-                mob.takeDamage(damage)
-                dirtyNotifier.mobHpDirty(mob.id)
-                combat.addThreat(mob.id, sessionId, damage.toDouble())
-                outbound.send(
-                    OutboundEvent.SendText(
-                        sessionId,
-                        "Your ${ability.displayName} hits ${mob.name} for $damage damage.",
-                    ),
-                )
-                onCombatEvent(
-                    sessionId,
-                    CombatEvent.AbilityHit(
-                        abilityId = ability.id.value,
-                        abilityName = ability.displayName,
-                        targetName = mob.name,
-                        targetId = mob.id.value,
-                        damage = damage,
-                        sourceIsPlayer = true,
-                    ),
-                )
-                if (mob.hp <= 0) {
-                    combat.handleSpellKill(sessionId, mob)
-                }
+                applySpellDamage(sessionId, mob, ability, baseDamage, intBonus)
             }
             is AbilityEffect.AreaDamage -> {
                 val mobRegistry = mobs ?: return "Area damage is not available."
@@ -182,30 +160,7 @@ class AbilitySystem(
                 deductManaAndCooldown(sessionId, player, ability, now)
                 for (m in targetMobs) {
                     val baseDamage = rollRange(rng, effect.damage.min, effect.damage.max)
-                    val damage = (baseDamage + intBonus).coerceAtLeast(1)
-                    m.takeDamage(damage)
-                    dirtyNotifier.mobHpDirty(m.id)
-                    combat.addThreat(m.id, sessionId, damage.toDouble())
-                    outbound.send(
-                        OutboundEvent.SendText(
-                            sessionId,
-                            "Your ${ability.displayName} hits ${m.name} for $damage damage.",
-                        ),
-                    )
-                    onCombatEvent(
-                        sessionId,
-                        CombatEvent.AbilityHit(
-                            abilityId = ability.id.value,
-                            abilityName = ability.displayName,
-                            targetName = m.name,
-                            targetId = m.id.value,
-                            damage = damage,
-                            sourceIsPlayer = true,
-                        ),
-                    )
-                    if (m.hp <= 0) {
-                        combat.handleSpellKill(sessionId, m)
-                    }
+                    applySpellDamage(sessionId, m, ability, baseDamage, intBonus)
                 }
             }
             is AbilityEffect.Taunt -> {
@@ -257,11 +212,8 @@ class AbilitySystem(
             is AbilityEffect.DirectHeal -> {
                 deductManaAndCooldown(sessionId, player, ability, now)
                 val healAmount = rollRange(rng, effect.minHeal, effect.maxHeal)
-                val before = player.hp
-                player.healHp(healAmount)
-                val healed = player.hp - before
+                val healed = applyHeal(sessionId, player, healAmount, dirtyNotifier)
                 if (healed > 0) {
-                    dirtyNotifier.playerVitalsDirty(sessionId)
                     combat.addHealingThreat(sessionId, healed)
                     onCombatEvent(
                         sessionId,
@@ -342,11 +294,8 @@ class AbilitySystem(
             is AbilityEffect.DirectHeal -> {
                 deductManaAndCooldown(sessionId, player, ability, now)
                 val healAmount = rollRange(rng, effect.minHeal, effect.maxHeal)
-                val before = target.hp
-                target.healHp(healAmount)
-                val healed = target.hp - before
+                val healed = applyHeal(targetSid, target, healAmount, dirtyNotifier)
                 if (healed > 0) {
-                    dirtyNotifier.playerVitalsDirty(targetSid)
                     combat.addHealingThreat(sessionId, healed)
                     onCombatEvent(
                         sessionId,
@@ -419,6 +368,39 @@ class AbilitySystem(
             exclude = sessionId,
         )
         return null
+    }
+
+    private suspend fun applySpellDamage(
+        sessionId: SessionId,
+        mob: MobState,
+        ability: AbilityDefinition,
+        baseDamage: Int,
+        intBonus: Int,
+    ) {
+        val damage = (baseDamage + intBonus).coerceAtLeast(1)
+        mob.takeDamage(damage)
+        dirtyNotifier.mobHpDirty(mob.id)
+        combat.addThreat(mob.id, sessionId, damage.toDouble())
+        outbound.send(
+            OutboundEvent.SendText(
+                sessionId,
+                "Your ${ability.displayName} hits ${mob.name} for $damage damage.",
+            ),
+        )
+        onCombatEvent(
+            sessionId,
+            CombatEvent.AbilityHit(
+                abilityId = ability.id.value,
+                abilityName = ability.displayName,
+                targetName = mob.name,
+                targetId = mob.id.value,
+                damage = damage,
+                sourceIsPlayer = true,
+            ),
+        )
+        if (mob.hp <= 0) {
+            combat.handleSpellKill(sessionId, mob)
+        }
     }
 
     private suspend fun deductManaAndCooldown(

--- a/src/main/kotlin/dev/ambon/engine/status/StatusEffectSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/status/StatusEffectSystem.kt
@@ -8,9 +8,9 @@ import dev.ambon.engine.DirtyNotifier
 import dev.ambon.engine.GameSystem
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PlayerRegistry
+import dev.ambon.engine.applyHeal
 import dev.ambon.engine.events.CombatEvent
 import dev.ambon.engine.events.OutboundEvent
-import dev.ambon.engine.healHp
 import dev.ambon.engine.remapKey
 import dev.ambon.engine.rollRange
 import dev.ambon.engine.takeDamage
@@ -185,11 +185,8 @@ class StatusEffectSystem(
                             )
                         }
                         EffectType.HOT -> {
-                            val before = player.hp
-                            player.healHp(value)
-                            val healed = player.hp - before
+                            val healed = applyHeal(sessionId, player, value, dirtyNotifier)
                             if (healed > 0) {
-                                dirtyNotifier.playerVitalsDirty(sessionId)
                                 outbound.send(
                                     OutboundEvent.SendText(
                                         sessionId,


### PR DESCRIPTION
## Summary

- **GroupSystem** (#494): Extract `notifyMembers(group, message)` and `notifyMembers(group, messageFor)` helpers to deduplicate 4 nearly identical mark-dirty-and-send loops in accept/leave/kick
- **EngineUtil + AbilitySystem + StatusEffectSystem** (#495): Add `applyHeal()` top-level function in `EngineUtil.kt` to consolidate the heal-then-mark-dirty pattern from 3 call sites across AbilitySystem (self-heal, ally-heal) and StatusEffectSystem (HOT tick)
- **AbilitySystem** (#496): Extract private `applySpellDamage()` method to deduplicate the identical 7-line damage-apply block in DirectDamage and AreaDamage handlers

Closes #494, closes #495, closes #496.

## Test plan

- [x] `ktlintCheck` passes
- [x] `GroupSystemTest`, `AbilitySystemTest`, `StatusEffectSystemTest` all pass
- [ ] CI confirms full suite green