### PR TITLE
Add mob descriptions and `look <target>` command

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/mob/MobState.kt
+++ b/src/main/kotlin/dev/ambon/domain/mob/MobState.kt
@@ -11,6 +11,7 @@ data class MobState(
     override val id: MobId,
     override var name: String,
     override var roomId: RoomId,
+    override val description: String = "",
     var hp: Int = 10,
     override var maxHp: Int = 10,
     override val damage: DamageRange = DamageRange(1, 4),

--- a/src/main/kotlin/dev/ambon/domain/mob/MobTemplate.kt
+++ b/src/main/kotlin/dev/ambon/domain/mob/MobTemplate.kt
@@ -12,6 +12,7 @@ interface MobTemplate {
     val id: MobId
     val name: String
     val roomId: RoomId
+    val description: String
     val maxHp: Int
     val damage: DamageRange
     val armor: Int

--- a/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
@@ -11,6 +11,7 @@ data class MobSpawn(
     override val id: MobId,
     override val name: String,
     override val roomId: RoomId,
+    override val description: String = "",
     override val maxHp: Int = 10,
     override val damage: DamageRange = DamageRange(1, 4),
     override val armor: Int = 0,

--- a/src/main/kotlin/dev/ambon/domain/world/data/MobFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/MobFile.kt
@@ -2,6 +2,7 @@ package dev.ambon.domain.world.data
 
 data class MobFile(
     val name: String,
+    val description: String = "",
     val room: String,
     val tier: String? = null,
     val level: Int? = null,

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -306,6 +306,7 @@ object WorldLoader {
                     MobSpawn(
                         id = mobId,
                         name = mf.name,
+                        description = mf.description,
                         roomId = roomId,
                         maxHp = resolvedHp,
                         damage = DamageRange(resolvedMinDamage, resolvedMaxDamage),

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -175,6 +175,7 @@ class GmcpEmitter(
                 RoomItemPayload(
                     id = it.id.value,
                     name = it.item.displayName,
+                    description = it.item.description,
                     image = it.item.image,
                     video = it.item.video,
                 )
@@ -819,6 +820,7 @@ class GmcpEmitter(
         RoomMobPayload(
             id = mob.id.value,
             name = mob.name,
+            description = mob.description,
             hp = mob.hp,
             maxHp = mob.maxHp,
             image = mob.image,
@@ -894,6 +896,7 @@ class GmcpEmitter(
     private data class RoomMobPayload(
         val id: String,
         val name: String,
+        val description: String = "",
         val hp: Int,
         val maxHp: Int,
         val image: String? = null,
@@ -907,6 +910,7 @@ class GmcpEmitter(
     private data class RoomItemPayload(
         val id: String,
         val name: String,
+        val description: String = "",
         val image: String? = null,
         val video: String? = null,
     )

--- a/src/main/kotlin/dev/ambon/engine/ZoneResetHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/ZoneResetHandler.kt
@@ -37,6 +37,7 @@ internal fun spawnToMobState(spawn: MobSpawn, world: World): MobState =
     MobState(
         id = spawn.id,
         name = spawn.name,
+        description = spawn.description,
         roomId = spawn.roomId,
         hp = spawn.maxHp,
         maxHp = spawn.maxHp,

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -26,6 +26,10 @@ sealed interface Command {
         val dir: Direction,
     ) : Command
 
+    data class LookAt(
+        val target: String,
+    ) : Command
+
     data object Exits : Command
 
     data class Say(
@@ -401,16 +405,15 @@ object CommandParser {
             if (msg.isEmpty()) Command.Unknown(line) else Command.Tell(target, msg)
         }?.let { return it }
 
-        // look <dir> / l <dir>
+        // look <dir> / look <target> / l <dir> / l <target>
         matchPrefix(
             line = line,
             aliases = listOf("look", "l"),
         ) { rest ->
             if (rest.isBlank()) return@matchPrefix null
-            val dir =
-                parseDirectionOrNull(rest.trim())
-                    ?: return@matchPrefix Command.Invalid(line, "Usage: look <direction> (e.g., look north)")
-            Command.LookDir(dir)
+            val trimmed = rest.trim()
+            val dir = parseDirectionOrNull(trimmed)
+            if (dir != null) Command.LookDir(dir) else Command.LookAt(trimmed)
         }?.let { return it }
 
         // inventory aliases

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
@@ -132,6 +132,7 @@ class AdminHandler(
                 MobState(
                     id = newMobId,
                     name = template.name,
+                    description = template.description,
                     roomId = me.roomId,
                     hp = template.maxHp,
                     maxHp = template.maxHp,

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
@@ -41,6 +41,7 @@ class NavigationHandler(
         router.on<Command.Move> { sid, cmd -> handleMove(sid, cmd) }
         router.on<Command.Exits> { sid, _ -> handleExits(sid) }
         router.on<Command.LookDir> { sid, cmd -> handleLookDir(sid, cmd) }
+        router.on<Command.LookAt> { sid, cmd -> handleLookAt(sid, cmd) }
         router.on<Command.Recall> { sid, _ -> handleRecall(sid) }
     }
 
@@ -152,6 +153,67 @@ class NavigationHandler(
         withPlayerAndRoom(sessionId, players, world) { _, r ->
             outbound.send(OutboundEvent.SendInfo(sessionId, exitsLine(r)))
         }
+    }
+
+    private suspend fun handleLookAt(
+        sessionId: SessionId,
+        cmd: Command.LookAt,
+    ) {
+        val me = players.get(sessionId) ?: return
+        val roomId = me.roomId
+
+        // Try mob first
+        val mob = ctx.mobs.findInRoomByKeyword(roomId, cmd.target).firstOrNull()
+        if (mob != null) {
+            val desc = mob.description.ifEmpty { "You see nothing special about ${mob.name}." }
+            outbound.send(OutboundEvent.SendText(sessionId, "${mob.name}: $desc"))
+            return
+        }
+
+        // Try room items
+        val roomItems = ctx.items.itemsInRoom(roomId)
+        val roomItem = roomItems.firstOrNull { matchesItemKeyword(it, cmd.target) }
+        if (roomItem != null) {
+            val desc = roomItem.item.description.ifEmpty { "You see nothing special about ${roomItem.item.displayName}." }
+            outbound.send(OutboundEvent.SendText(sessionId, "${roomItem.item.displayName}: $desc"))
+            return
+        }
+
+        // Try inventory items
+        val invItems = ctx.items.inventory(sessionId)
+        val invItem = invItems.firstOrNull { matchesItemKeyword(it, cmd.target) }
+        if (invItem != null) {
+            val desc = invItem.item.description.ifEmpty { "You see nothing special about ${invItem.item.displayName}." }
+            outbound.send(OutboundEvent.SendText(sessionId, "${invItem.item.displayName}: $desc"))
+            return
+        }
+
+        // Try equipment
+        val equipment = ctx.items.equipment(sessionId)
+        val eqItem = equipment.values.firstOrNull { matchesItemKeyword(it, cmd.target) }
+        if (eqItem != null) {
+            val desc = eqItem.item.description.ifEmpty { "You see nothing special about ${eqItem.item.displayName}." }
+            outbound.send(OutboundEvent.SendText(sessionId, "${eqItem.item.displayName}: $desc"))
+            return
+        }
+
+        // Try other players in the room
+        val otherPlayer = players.playersInRoom(roomId)
+            .firstOrNull { it.sessionId != sessionId && it.name.contains(cmd.target, ignoreCase = true) }
+        if (otherPlayer != null) {
+            val p = otherPlayer
+            val playerDesc = "You see ${p.name}, a level ${p.level} ${p.race} ${p.playerClass}."
+            outbound.send(OutboundEvent.SendText(sessionId, playerDesc))
+            return
+        }
+
+        outbound.send(OutboundEvent.SendError(sessionId, "You don't see '${cmd.target}' here."))
+    }
+
+    private fun matchesItemKeyword(item: dev.ambon.domain.items.ItemInstance, input: String): Boolean {
+        val lower = input.lowercase()
+        return item.item.keyword.equals(lower, ignoreCase = true) ||
+            item.item.displayName.contains(lower, ignoreCase = true)
     }
 
     private suspend fun handleLookDir(

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
@@ -133,9 +133,15 @@ class CommandParserTest {
     }
 
     @Test
-    fun `look direction invalid usage`() {
+    fun `look at target when not a direction`() {
         val c = CommandParser.parse("look sideways")
-        assertTrue(c is Command.Invalid)
+        assertEquals(Command.LookAt("sideways"), c)
+    }
+
+    @Test
+    fun `look at multi-word target`() {
+        val c = CommandParser.parse("look goblin warrior")
+        assertEquals(Command.LookAt("goblin warrior"), c)
     }
 
     @Test

--- a/web-v3/src/canvas/scenes/WorldScene.ts
+++ b/web-v3/src/canvas/scenes/WorldScene.ts
@@ -853,7 +853,7 @@ export class WorldScene {
     }
   }
 
-  private rebuildMobs(mobs: Array<{ id: string; name: string; hp: number; maxHp: number; image?: string | null; video?: string | null }>) {
+  private rebuildMobs(mobs: Array<{ id: string; name: string; description?: string; hp: number; maxHp: number; image?: string | null; video?: string | null }>) {
     for (const { sprite, label, hitArea } of this.mobSprites.values()) {
       this.container.removeChild(sprite);
       this.container.removeChild(label);
@@ -915,7 +915,7 @@ export class WorldScene {
           return;
         }
         const info = gameStateRef.current.mobInfo.find((m) => m.id === mobData.id) ?? null;
-        this.entityPopout.showMob(mobData.name, mobData.image, mobData.video, mobData.hp, mobData.maxHp, info);
+        this.entityPopout.showMob(mobData.name, mobData.description, mobData.image, mobData.video, mobData.hp, mobData.maxHp, info);
         this.showPopout();
       });
 
@@ -926,7 +926,7 @@ export class WorldScene {
     }
   }
 
-  private rebuildItems(items: Array<{ id: string; name: string; image?: string | null; video?: string | null }>) {
+  private rebuildItems(items: Array<{ id: string; name: string; description?: string; image?: string | null; video?: string | null }>) {
     for (const { sprite, label, hitArea } of this.itemSprites) {
       this.container.removeChild(sprite);
       this.container.removeChild(label);
@@ -962,7 +962,7 @@ export class WorldScene {
 
       const itemData = item;
       hitArea.on("pointerdown", () => {
-        this.entityPopout.showItem(itemData.name, itemData.image, itemData.video);
+        this.entityPopout.showItem(itemData.name, itemData.description, itemData.image, itemData.video);
         this.showPopout();
       });
 

--- a/web-v3/src/canvas/systems/EntityPopout.ts
+++ b/web-v3/src/canvas/systems/EntityPopout.ts
@@ -63,7 +63,7 @@ export class EntityPopout {
     this.height = height;
   }
 
-  showMob(name: string, image: string | null | undefined, video: string | null | undefined, hp: number, maxHp: number, info: { questGiver?: boolean; shopKeeper?: boolean; dialogue?: boolean } | null) {
+  showMob(name: string, description: string | null | undefined, image: string | null | undefined, video: string | null | undefined, hp: number, maxHp: number, info: { questGiver?: boolean; shopKeeper?: boolean; dialogue?: boolean } | null) {
     const actions: PopoutAction[] = [
       { label: "Look", command: `look ${name}`, color: 0x64b5f6 },
       { label: "Attack", command: `kill ${name}`, color: 0xef5350 },
@@ -72,7 +72,7 @@ export class EntityPopout {
     if (info?.shopKeeper) actions.push({ label: "Shop", command: `list`, color: 0x81a2be });
     if (video) actions.push({ label: "▶ Cinematic", command: `__video__:${video}`, color: 0xce93d8 });
 
-    const subtitle = maxHp > 0 ? `HP: ${hp}/${maxHp}` : "";
+    const subtitle = description || (maxHp > 0 ? `HP: ${hp}/${maxHp}` : "");
     this.show(name, subtitle, image ?? null, 0xf0c674, actions);
   }
 
@@ -84,13 +84,13 @@ export class EntityPopout {
     this.show(name, `Level ${level}`, null, 0x81a2be, actions);
   }
 
-  showItem(name: string, image: string | null | undefined, video: string | null | undefined) {
+  showItem(name: string, description: string | null | undefined, image: string | null | undefined, video: string | null | undefined) {
     const actions: PopoutAction[] = [
       { label: "Get", command: `get ${name}`, color: 0x8abeb7 },
       { label: "Look", command: `look ${name}`, color: 0x64b5f6 },
     ];
     if (video) actions.push({ label: "▶ Cinematic", command: `__video__:${video}`, color: 0xce93d8 });
-    this.show(name, "Item", image ?? null, 0x8abeb7, actions);
+    this.show(name, description || "Item", image ?? null, 0x8abeb7, actions);
   }
 
   hide() {

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -244,6 +244,7 @@ export function applyGmcpPackage(
           .map((entry, index) => ({
             id: typeof entry.id === "string" ? entry.id : `room-item-${index}-${Date.now()}`,
             name: typeof entry.name === "string" ? entry.name : "Unknown item",
+            description: typeof entry.description === "string" ? entry.description : undefined,
             image: typeof entry.image === "string" ? entry.image : null,
             video: typeof entry.video === "string" ? entry.video : null,
           })),
@@ -296,6 +297,7 @@ export function applyGmcpPackage(
           .map((entry) => ({
             id: typeof entry.id === "string" ? entry.id : `${Date.now()}-${Math.random()}`,
             name: typeof entry.name === "string" ? entry.name : "Unknown mob",
+            description: typeof entry.description === "string" ? entry.description : undefined,
             hp: safeNumber(entry.hp),
             maxHp: Math.max(1, safeNumber(entry.maxHp, 1)),
             image: typeof entry.image === "string" ? entry.image : null,
@@ -314,6 +316,7 @@ export function applyGmcpPackage(
         {
           id,
           name: typeof packet.name === "string" ? packet.name : "Unknown mob",
+          description: typeof packet.description === "string" ? packet.description : undefined,
           hp: safeNumber(packet.hp),
           maxHp: Math.max(1, safeNumber(packet.maxHp, 1)),
           image: typeof packet.image === "string" ? packet.image : null,
@@ -335,6 +338,7 @@ export function applyGmcpPackage(
             ...mob,
             hp: safeNumber(packet.hp, mob.hp),
             maxHp: Math.max(1, safeNumber(packet.maxHp, mob.maxHp)),
+            description: typeof packet.description === "string" ? packet.description : mob.description,
             image: typeof packet.image === "string" ? packet.image : mob.image,
             video: typeof packet.video === "string" ? packet.video : mob.video,
           };

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -126,6 +126,7 @@ export interface ShopState {
 export interface RoomItem {
   id: string;
   name: string;
+  description?: string;
   image?: string | null;
   video?: string | null;
 }
@@ -138,6 +139,7 @@ export interface RoomPlayer {
 export interface RoomMob {
   id: string;
   name: string;
+  description?: string;
   hp: number;
   maxHp: number;
   image?: string | null;


### PR DESCRIPTION
## Summary

- Add `description` field to mobs (`MobTemplate`, `MobState`, `MobSpawn`, `MobFile`) — items already had one
- Add `Command.LookAt` command variant: `look <target>` now searches mobs → room items → inventory → equipment → other players and displays the description
- Include `description` in `Room.Mobs` and `Room.Items` GMCP payloads so the web client receives it
- Update web-v3 `EntityPopout` to show description as the subtitle in mob/item pop-outs
- Thread description through `WorldLoader`, `ZoneResetHandler`, and `AdminHandler` spawn

## Usage

In world YAML, mobs can now specify a description:
```yaml
mobs:
  goblin:
    name: Goblin Scout
    description: A scrappy green-skinned creature with beady yellow eyes.
    room: forest_clearing
```

Players can then type `look goblin` to see the description in-game, or click the mob/item in the canvas client to see it in the pop-out.

## Test plan

- [x] `ktlintCheck` passes
- [x] `CommandParserTest` — updated existing test, added multi-word target test
- [x] `CommandRouterTest`, `CommandRouterItemsTest` pass
- [x] `GmcpEmitterTest`, `WorldLoaderTest` pass
- [ ] CI full suite
