### PR TITLE
Soften exit validation: warn on missing targets instead of crashing

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -41,12 +41,15 @@ import dev.ambon.engine.behavior.BtNode
 import dev.ambon.engine.dialogue.DialogueChoice
 import dev.ambon.engine.dialogue.DialogueNode
 import dev.ambon.engine.dialogue.DialogueTree
+import org.slf4j.LoggerFactory
 
 class WorldLoadException(
     message: String,
 ) : RuntimeException(message)
 
 object WorldLoader {
+    private val logger = LoggerFactory.getLogger(WorldLoader::class.java)
+
     private val mapper =
         ObjectMapper(YAMLFactory())
             .registerModule(KotlinModule.Builder().build())
@@ -602,31 +605,37 @@ object WorldLoader {
             }
         }
 
-        // Now validate that all exit targets exist in the merged room set.
-        // When a zone filter is active, exits pointing to rooms in non-loaded zones
-        // are kept but not validated (they are cross-zone stubs).
+        // Validate exit targets. Missing targets are logged as warnings and treated
+        // as remote/unreachable exits (players see "the way shimmers" instead of crashing).
         val loadedZones = mergedRooms.keys.mapTo(mutableSetOf()) { it.zone }
         val filteredLoad = zoneFilter.isNotEmpty()
+        val brokenExits = mutableSetOf<Pair<RoomId, Direction>>()
         for ((fromId, exits) in allExits) {
             for ((dir, targetId) in exits) {
                 if (filteredLoad && targetId.zone !in loadedZones) continue
                 if (!mergedRooms.containsKey(targetId)) {
-                    throw WorldLoadException(
-                        "Room '${fromId.value}' exit '$dir' points to missing room '${targetId.value}'",
+                    logger.warn(
+                        "Room '${fromId.value}' exit '$dir' points to missing room '${targetId.value}' — " +
+                            "exit will shimmer as unreachable",
                     )
+                    brokenExits.add(fromId to dir)
                 }
             }
         }
 
-        // Apply exits + features by copying rooms (immutable style)
+        // Apply exits + features by copying rooms (immutable style).
+        // Exits that point to unloaded zones or broken targets are marked as remote
+        // so navigation shows the shimmer message instead of crashing.
         for ((fromId, exits) in allExits) {
             val room = mergedRooms.getValue(fromId)
-            val remoteExits =
+            val remoteExits = buildSet {
                 if (filteredLoad) {
-                    exits.filterValues { it.zone !in loadedZones }.keys.toSet()
-                } else {
-                    emptySet()
+                    addAll(exits.filterValues { it.zone !in loadedZones }.keys)
                 }
+                for ((dir, _) in exits) {
+                    if ((fromId to dir) in brokenExits) add(dir)
+                }
+            }
             mergedRooms[fromId] = room.copy(
                 exits = exits,
                 remoteExits = remoteExits,

--- a/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
@@ -148,12 +148,11 @@ class WorldLoaderTest {
     }
 
     @Test
-    fun `fails when an exit points to a missing room`() {
-        val ex =
-            assertThrows(WorldLoadException::class.java) {
-                WorldLoader.loadFromResource("world/bad_exit_missing_room.yaml")
-            }
-        assertTrue(ex.message!!.contains("points to missing room", ignoreCase = true), "Got: ${ex.message}")
+    fun `exit to missing room loads but is marked remote`() {
+        val world = WorldLoader.loadFromResource("world/bad_exit_missing_room.yaml")
+        val roomA = world.rooms.getValue(RoomId("bad_exit_missing_room:a"))
+        assertTrue(roomA.exits.containsKey(Direction.NORTH), "Exit should still exist")
+        assertTrue(roomA.remoteExits.contains(Direction.NORTH), "Exit to missing room should be marked remote")
     }
 
     @Test
@@ -447,12 +446,11 @@ class WorldLoaderTest {
         }
 
         @Test
-        fun `fails if an exit targets a missing room across all zones`() {
-            val ex =
-                assertThrows(WorldLoadException::class.java) {
-                    WorldLoader.loadFromResources(listOf("world/mz_bad_missing_target.yaml"))
-                }
-            assertTrue(ex.message!!.contains("points to missing room"))
+        fun `exit to missing room across zones loads but is marked remote`() {
+            val world = WorldLoader.loadFromResources(listOf("world/mz_bad_missing_target.yaml"))
+            val mossyPath = world.rooms.getValue(RoomId("enchanted_forest:mossy_path"))
+            assertTrue(mossyPath.exits.containsKey(Direction.EAST), "Exit should still exist")
+            assertTrue(mossyPath.remoteExits.contains(Direction.EAST), "Exit to missing room should be marked remote")
         }
     }
 


### PR DESCRIPTION
## Summary
- Exits pointing to missing rooms no longer throw `WorldLoadException` on startup
- WorldLoader logs a warning and marks the exit as remote (unreachable)
- Players who try to use the exit see "The way shimmers but does not yield." and stay in place
- Enables partial world loading and WIP content without blocking server startup

## Test plan
- [x] Updated `WorldLoaderTest` — both single-zone and multi-zone missing-exit tests now assert the world loads with the exit marked remote
- [x] `CommandRouterTest` passes (navigation shimmer behavior already handled)
- [x] ktlintCheck passes