### PR TITLE
Add Server GMCP support + defer asset loads until GMCP arrives

### DIFF
--- a/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
+++ b/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
@@ -205,7 +205,7 @@ private suspend fun DefaultWebSocketServerSession.bridgeWebSocketSession(
         InboundEvent.GmcpReceived(
             sessionId,
             "Core.Supports.Set",
-            """["Char.Vitals 1","Room.Info 1","Char.StatusVars 1","Char.Items 1","Room.Players 1","Room.Mobs 1","Room.Items 1","Char.Skills 1","Char.Name 1","Char.StatusEffects 1","Char.Achievements 1","Comm.Channel 1","Guild 1","Group.Info 1","Friends 1","Core.Ping 1","Dialogue 1","Shop 1","Char.Combat 1","Char.Combat.Event 1","Char.Stats 1","Quest 1","Char.Cooldown 1","Char.Gain 1","Room.MobInfo 1","Login 1"]""",
+            """["Char.Vitals 1","Room.Info 1","Char.StatusVars 1","Char.Items 1","Room.Players 1","Room.Mobs 1","Room.Items 1","Char.Skills 1","Char.Name 1","Char.StatusEffects 1","Char.Achievements 1","Comm.Channel 1","Guild 1","Group.Info 1","Friends 1","Core.Ping 1","Dialogue 1","Shop 1","Char.Combat 1","Char.Combat.Event 1","Char.Stats 1","Quest 1","Char.Cooldown 1","Char.Gain 1","Room.MobInfo 1","Login 1","Server 1"]""",
         ),
     )
     metrics.onWsConnected()


### PR DESCRIPTION
## Summary
- **Root cause:** `Server.Assets` GMCP was silently dropped because the WebSocket client's `Core.Supports.Set` didn't include `"Server 1"`. The `supportsPackage()` check rejected `"Server.Assets"` and the assets never reached the client.
- Adds `"Server 1"` to the GMCP supported packages in `KtorWebSocketTransport.kt`
- Also defers all asset-dependent sprite loading (compass, shop, dialogue, aggro, quest icons, minimap fog) until `serverAssets` is populated, eliminating 404 fallback requests

## Test plan
- [ ] Deploy and verify `Server.Assets` GMCP is received by client (check browser console for GMCP traffic)
- [ ] Verify compass rose, direction markers, and all indicator sprites render correctly
- [ ] Verify no 404s for global asset paths in network tab
- [ ] Verify minimap fog/background textures load from CDN