### PR TITLE
Set video and audio base URLs to CDN

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1681,3 +1681,7 @@ ambonmud:
     quest_complete_indicator: 1c73d6a78405bb4e48456494bfaa87e6cefb505125c3c70eb890f89d6d31fd95.png
     minimap_unexplored: 97875d65ca8d97a0e84229b02f16ba06c23fca3a0a627fa6e5bffe9d6ccccef8.png
     map_background: 1dac3f33448349e9e4d69d02eff5c16b0bf9d17a480693aa61bd8f6351aea37c.jpg
+  videos:
+    baseUrl: https://assets.ambon.dev/
+  audio:
+    baseUrl: https://assets.ambon.dev/


### PR DESCRIPTION
## Summary
- Video and audio assets live at the root of the CDN bucket (`assets.ambon.dev/foo.mp4`), not under `/videos/` or `/audio/` subdirectories
- Sets `videos.baseUrl` and `audio.baseUrl` to `https://assets.ambon.dev/` to match `images.baseUrl`

## Test plan
- [ ] Verify room videos load from `assets.ambon.dev/` (no `/videos/` prefix)
- [ ] Verify room music/ambient audio loads from `assets.ambon.dev/` (no `/audio/` prefix)