### PR TITLE
Data-driven: move recall constants to config

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -695,10 +695,31 @@ data class EngineConfig(
     val targetTypes: TargetTypesConfig = TargetTypesConfig(),
     val stackBehaviors: StackBehaviorsConfig = StackBehaviorsConfig(),
     val achievementCriterionTypes: AchievementCriterionTypesConfig = AchievementCriterionTypesConfig(),
+    val navigation: NavigationConfig = NavigationConfig(),
     val guildRanks: GuildRanksConfig = GuildRanksConfig(),
     val characterCreation: CharacterCreationConfig = CharacterCreationConfig(),
     /** Maps class name (e.g. "WARRIOR") to a fully-qualified RoomId string for new-character placement. */
     val classStartRooms: Map<String, String> = emptyMap(),
+)
+
+data class NavigationConfig(
+    val recall: RecallConfig = RecallConfig(),
+)
+
+data class RecallConfig(
+    /** Cooldown between recall uses in milliseconds (default 5 minutes). */
+    val cooldownMs: Long = 300_000L,
+    val messages: RecallMessagesConfig = RecallMessagesConfig(),
+)
+
+data class RecallMessagesConfig(
+    val combatBlocked: String = "You are fighting for your life and cannot recall!",
+    val cooldownRemaining: String = "You need to rest before recalling again. ({seconds} seconds remaining)",
+    val castBegin: String = "You close your eyes and whisper a prayer...",
+    val unreachable: String = "Your recall point is unreachable.",
+    val departNotice: String = "vanishes in a flash of light.",
+    val arriveNotice: String = "appears in a flash of light.",
+    val arrival: String = "You feel a familiar warmth and find yourself back at your recall point.",
 )
 
 data class EngineDebugConfig(

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -716,6 +716,7 @@ class GameEngine(
                 statusEffects = statusEffectSystem,
                 dialogueSystem = dialogueSystem,
                 onCrossZoneMove = crossZoneMove,
+                recallConfig = engineConfig.navigation.recall,
             ),
             CommunicationHandler(
                 ctx = ctx,

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
@@ -1,5 +1,6 @@
 package dev.ambon.engine.commands.handlers
 
+import dev.ambon.config.RecallConfig
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.world.LockableState
@@ -19,12 +20,8 @@ class NavigationHandler(
     private val dialogueSystem: DialogueSystem? = null,
     private val onCrossZoneMove: (suspend (SessionId, RoomId) -> Unit)? = null,
     private val clock: Clock = Clock.systemUTC(),
+    private val recallConfig: RecallConfig = RecallConfig(),
 ) : CommandHandler {
-    companion object {
-        /** Cooldown between recall uses (5 minutes). */
-        const val RECALL_COOLDOWN_MS = 300_000L
-    }
-
     private val ctx = ctx
     private val world = ctx.world
     private val players = ctx.players
@@ -109,27 +106,28 @@ class NavigationHandler(
     }
 
     private suspend fun handleRecall(sessionId: SessionId) {
+        val msgs = recallConfig.messages
         if (combat.isInCombat(sessionId)) {
-            outbound.send(OutboundEvent.SendText(sessionId, "You are fighting for your life and cannot recall!"))
+            outbound.send(OutboundEvent.SendText(sessionId, msgs.combatBlocked))
             return
         }
         val me = players.get(sessionId) ?: return
         val now = clock.millis()
         if (now < me.recallCooldownUntilMs) {
             val secondsLeft = (me.recallCooldownUntilMs - now).ceilSeconds()
-            outbound.send(OutboundEvent.SendText(sessionId, "You need to rest before recalling again. ($secondsLeft seconds remaining)"))
+            outbound.send(OutboundEvent.SendText(sessionId, msgs.cooldownRemaining.replace("{seconds}", secondsLeft.toString())))
             return
         }
         val target = players.recallTarget(sessionId) ?: return
-        me.recallCooldownUntilMs = now + RECALL_COOLDOWN_MS
-        outbound.send(OutboundEvent.SendText(sessionId, "You close your eyes and whisper a prayer..."))
+        me.recallCooldownUntilMs = now + recallConfig.cooldownMs
+        outbound.send(OutboundEvent.SendText(sessionId, msgs.castBegin))
         if (!world.rooms.containsKey(target)) {
             if (onCrossZoneMove != null) {
                 router.suppressAutoPrompt()
                 onCrossZoneMove.invoke(sessionId, target)
                 return
             }
-            outbound.send(OutboundEvent.SendError(sessionId, "Your recall point is unreachable."))
+            outbound.send(OutboundEvent.SendError(sessionId, msgs.unreachable))
             return
         }
         val from = me.roomId
@@ -137,14 +135,14 @@ class NavigationHandler(
             sessionId,
             from,
             target,
-            "vanishes in a flash of light.",
-            "appears in a flash of light.",
+            msgs.departNotice,
+            msgs.arriveNotice,
             players,
             outbound,
             gmcpEmitter,
             dialogueSystem,
         )
-        outbound.send(OutboundEvent.SendText(sessionId, "You feel a familiar warmth and find yourself back at your recall point."))
+        outbound.send(OutboundEvent.SendText(sessionId, msgs.arrival))
         ctx.sendLook(sessionId)
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -126,6 +126,9 @@ ambonmud:
     authThreads: 8
 
   engine:
+    navigation:
+      recall:
+        cooldownMs: 300000
     mob:
       minActionDelayMillis: 8000
       maxActionDelayMillis: 20000

--- a/src/test/kotlin/dev/ambon/engine/commands/RecallCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/RecallCommandTest.kt
@@ -1,9 +1,9 @@
 package dev.ambon.engine.commands
 
+import dev.ambon.config.RecallConfig
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.mob.MobState
-import dev.ambon.engine.commands.handlers.NavigationHandler
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.test.CommandRouterHarness
 import dev.ambon.test.MutableClock
@@ -144,7 +144,7 @@ class RecallCommandTest {
             h.drain()
 
             // Advance past cooldown
-            clock.advance(NavigationHandler.RECALL_COOLDOWN_MS + 1L)
+            clock.advance(RecallConfig().cooldownMs + 1L)
 
             // Second recall — should succeed
             h.router.handle(sid, Command.Recall)


### PR DESCRIPTION
## Summary
- Extract `RECALL_COOLDOWN_MS` constant and 7 hardcoded recall message strings from `NavigationHandler` into data-driven config (`engine.navigation.recall` in `AppConfig`)
- Add `NavigationConfig` / `RecallConfig` / `RecallMessagesConfig` data classes with sensible defaults
- All existing behavior preserved — defaults match the previous hardcoded values
- Establishes the pattern for externalizing other handler constants in future PRs

Part 1 of the data-driven gap audit (see `docs/DATA_DRIVEN_GAP_AUDIT.md`).

## Test plan
- [x] `RecallCommandTest` passes (all 6 tests)
- [x] `ktlintCheck` clean