### PR TITLE
Data-driven: quest objective and completion handler registries

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
@@ -10,6 +10,8 @@ import dev.ambon.domain.quest.QuestRewards
 import dev.ambon.domain.quest.QuestState
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.engine.quest.CompletionHandlerRegistry
+import dev.ambon.engine.quest.ObjectiveHandlerRegistry
 import java.time.Clock
 
 class QuestSystem(
@@ -18,6 +20,8 @@ class QuestSystem(
     private val items: ItemRegistry,
     private val outbound: OutboundBus,
     private val clock: Clock = Clock.systemUTC(),
+    private val objectiveHandlers: ObjectiveHandlerRegistry = ObjectiveHandlerRegistry.withDefaults(),
+    private val completionHandlers: CompletionHandlerRegistry = CompletionHandlerRegistry.withDefaults(),
 ) {
     /** Invoked after a quest is successfully completed; used by AchievementSystem. */
     var onQuestCompleted: (suspend (SessionId, String) -> Unit)? = null
@@ -56,7 +60,8 @@ class QuestSystem(
         val ps = players.get(sessionId) ?: return emptySet()
         return mobIds.filterTo(mutableSetOf()) { mobId ->
             registry.questsForMob(mobId).any { quest ->
-                quest.completionType == "npc_turn_in" &&
+                val handler = completionHandlers.get(quest.completionType)
+                handler?.requiresNpcTurnIn == true &&
                     ps.activeQuests[quest.id]?.objectives?.all { it.isComplete } == true
             }
         }
@@ -116,9 +121,8 @@ class QuestSystem(
         templateKey: String,
     ) {
         advanceObjectives(sessionId) { objDef, prog ->
-            if (objDef.type != "kill") return@advanceObjectives null
-            if (objDef.targetId != templateKey) return@advanceObjectives null
-            prog.copy(current = prog.current + 1)
+            val handler = objectiveHandlers.killHandler(objDef.type) ?: return@advanceObjectives null
+            handler.advance(objDef, prog, templateKey)
         }
     }
 
@@ -130,14 +134,10 @@ class QuestSystem(
         item: ItemInstance,
     ) {
         advanceObjectives(sessionId) { objDef, prog ->
-            if (objDef.type != "collect") return@advanceObjectives null
-            val targetIdRaw = objDef.targetId
+            val handler = objectiveHandlers.collectHandler(objDef.type) ?: return@advanceObjectives null
             val itemId = item.id.value
-            if (itemId != targetIdRaw && !itemId.endsWith(":${targetIdRaw.substringAfterLast(':')}")) return@advanceObjectives null
             val currentCount = items.inventory(sessionId).count { inv -> inv.id.value == itemId }
-            val newCurrent = currentCount.coerceAtMost(prog.required)
-            if (newCurrent <= prog.current) return@advanceObjectives null
-            prog.copy(current = newCurrent)
+            handler.advance(objDef, prog, itemId, currentCount)
         }
     }
 
@@ -237,7 +237,8 @@ class QuestSystem(
     ) {
         for ((questId, state) in activeQuests) {
             val quest = registry.get(questId) ?: continue
-            if (quest.completionType != "auto") continue
+            val handler = completionHandlers.get(quest.completionType) ?: continue
+            if (!handler.autoCompletes) continue
             if (state.objectives.all { it.isComplete }) {
                 completeQuest(sessionId, questId, quest.rewards)
             }

--- a/src/main/kotlin/dev/ambon/engine/quest/BuiltInHandlers.kt
+++ b/src/main/kotlin/dev/ambon/engine/quest/BuiltInHandlers.kt
@@ -1,0 +1,49 @@
+package dev.ambon.engine.quest
+
+import dev.ambon.domain.quest.ObjectiveProgress
+import dev.ambon.domain.quest.QuestObjectiveDef
+
+/** Built-in kill objective handler: matches when the killed mob's template key equals targetId. */
+class KillObjectiveHandlerImpl : KillObjectiveHandler {
+    override val typeId: String = "kill"
+
+    override fun advance(
+        objDef: QuestObjectiveDef,
+        progress: ObjectiveProgress,
+        killedTemplateKey: String,
+    ): ObjectiveProgress? {
+        if (objDef.targetId != killedTemplateKey) return null
+        return progress.copy(current = progress.current + 1)
+    }
+}
+
+/** Built-in collect objective handler: checks inventory count against the objective target. */
+class CollectObjectiveHandlerImpl : CollectObjectiveHandler {
+    override val typeId: String = "collect"
+
+    override fun advance(
+        objDef: QuestObjectiveDef,
+        progress: ObjectiveProgress,
+        itemId: String,
+        currentInventoryCount: Int,
+    ): ObjectiveProgress? {
+        val targetIdRaw = objDef.targetId
+        if (itemId != targetIdRaw && !itemId.endsWith(":${targetIdRaw.substringAfterLast(':')}")) return null
+        val newCurrent = currentInventoryCount.coerceAtMost(progress.required)
+        if (newCurrent <= progress.current) return null
+        return progress.copy(current = newCurrent)
+    }
+}
+
+/** Auto-completion: quest completes as soon as all objectives are met. */
+class AutoCompletionHandler : CompletionHandler {
+    override val typeId: String = "auto"
+    override val autoCompletes: Boolean = true
+}
+
+/** NPC turn-in: player must talk to the quest-giver NPC to complete. */
+class NpcTurnInCompletionHandler : CompletionHandler {
+    override val typeId: String = "npc_turn_in"
+    override val autoCompletes: Boolean = false
+    override val requiresNpcTurnIn: Boolean = true
+}

--- a/src/main/kotlin/dev/ambon/engine/quest/CompletionHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/quest/CompletionHandler.kt
@@ -1,0 +1,18 @@
+package dev.ambon.engine.quest
+
+/**
+ * Determines how a quest is completed once all objectives are met.
+ *
+ * Implementations are registered by type ID in [CompletionHandlerRegistry]
+ * and dispatched by [QuestSystem].
+ */
+interface CompletionHandler {
+    /** The completion type ID this handler matches (e.g. "auto", "npc_turn_in"). */
+    val typeId: String
+
+    /** Whether this completion type triggers automatically when all objectives are complete. */
+    val autoCompletes: Boolean
+
+    /** Whether this completion type requires talking to the quest-giver NPC. */
+    val requiresNpcTurnIn: Boolean get() = false
+}

--- a/src/main/kotlin/dev/ambon/engine/quest/HandlerRegistries.kt
+++ b/src/main/kotlin/dev/ambon/engine/quest/HandlerRegistries.kt
@@ -1,0 +1,51 @@
+package dev.ambon.engine.quest
+
+/**
+ * Registry of objective handlers, keyed by type ID.
+ * Looked up by [QuestSystem] when processing game events.
+ */
+class ObjectiveHandlerRegistry {
+    private val killHandlers = mutableMapOf<String, KillObjectiveHandler>()
+    private val collectHandlers = mutableMapOf<String, CollectObjectiveHandler>()
+
+    fun registerKill(handler: KillObjectiveHandler) {
+        killHandlers[handler.typeId] = handler
+    }
+
+    fun registerCollect(handler: CollectObjectiveHandler) {
+        collectHandlers[handler.typeId] = handler
+    }
+
+    fun killHandler(typeId: String): KillObjectiveHandler? = killHandlers[typeId]
+
+    fun collectHandler(typeId: String): CollectObjectiveHandler? = collectHandlers[typeId]
+
+    companion object {
+        /** Creates a registry pre-loaded with the built-in kill and collect handlers. */
+        fun withDefaults(): ObjectiveHandlerRegistry = ObjectiveHandlerRegistry().apply {
+            registerKill(KillObjectiveHandlerImpl())
+            registerCollect(CollectObjectiveHandlerImpl())
+        }
+    }
+}
+
+/**
+ * Registry of completion handlers, keyed by type ID.
+ */
+class CompletionHandlerRegistry {
+    private val handlers = mutableMapOf<String, CompletionHandler>()
+
+    fun register(handler: CompletionHandler) {
+        handlers[handler.typeId] = handler
+    }
+
+    fun get(typeId: String): CompletionHandler? = handlers[typeId]
+
+    companion object {
+        /** Creates a registry pre-loaded with the built-in auto and npc_turn_in handlers. */
+        fun withDefaults(): CompletionHandlerRegistry = CompletionHandlerRegistry().apply {
+            register(AutoCompletionHandler())
+            register(NpcTurnInCompletionHandler())
+        }
+    }
+}

--- a/src/main/kotlin/dev/ambon/engine/quest/ObjectiveHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/quest/ObjectiveHandler.kt
@@ -1,0 +1,38 @@
+package dev.ambon.engine.quest
+
+import dev.ambon.domain.quest.ObjectiveProgress
+import dev.ambon.domain.quest.QuestObjectiveDef
+
+/**
+ * Handles advancement of a specific quest objective type (e.g. "kill", "collect").
+ *
+ * Implementations are registered by type ID in [ObjectiveHandlerRegistry] and
+ * dispatched by [QuestSystem] when relevant game events occur.
+ */
+interface ObjectiveHandler {
+    /** The objective type ID this handler matches (e.g. "kill", "collect"). */
+    val typeId: String
+}
+
+/**
+ * Handles kill-type objectives. Invoked when a mob is killed.
+ */
+interface KillObjectiveHandler : ObjectiveHandler {
+    fun advance(
+        objDef: QuestObjectiveDef,
+        progress: ObjectiveProgress,
+        killedTemplateKey: String,
+    ): ObjectiveProgress?
+}
+
+/**
+ * Handles collect-type objectives. Invoked when an item is picked up.
+ */
+interface CollectObjectiveHandler : ObjectiveHandler {
+    fun advance(
+        objDef: QuestObjectiveDef,
+        progress: ObjectiveProgress,
+        itemId: String,
+        currentInventoryCount: Int,
+    ): ObjectiveProgress?
+}


### PR DESCRIPTION
## Summary
- Replace hardcoded `"kill"`/`"collect"` objective type checks and `"auto"`/`"npc_turn_in"` completion type checks in `QuestSystem` with registry-dispatched handlers
- Add `ObjectiveHandler` / `CompletionHandler` interfaces with built-in implementations (`KillObjectiveHandlerImpl`, `CollectObjectiveHandlerImpl`, `AutoCompletionHandler`, `NpcTurnInCompletionHandler`)
- Add `ObjectiveHandlerRegistry` and `CompletionHandlerRegistry` with `withDefaults()` factory methods
- New objective/completion types can be added by registering additional handlers — no QuestSystem code changes needed
- All existing behavior preserved via default handler registrations

Part 3 of the data-driven gap audit (see `docs/DATA_DRIVEN_GAP_AUDIT.md`).

## Test plan
- [x] `QuestSystemTest` passes (all tests)
- [x] `ktlintCheck` clean