### PR TITLE
Data-driven: YAML DSL for composing behavior trees

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/world/data/BehaviorFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/BehaviorFile.kt
@@ -1,8 +1,10 @@
 package dev.ambon.domain.world.data
 
 data class BehaviorFile(
-    val template: String,
+    val template: String? = null,
     val params: BehaviorParamsFile = BehaviorParamsFile(),
+    /** Inline tree definition — alternative to using a named template. */
+    val tree: BehaviorNodeFile? = null,
 )
 
 data class BehaviorParamsFile(
@@ -11,4 +13,36 @@ data class BehaviorParamsFile(
     val aggroMessage: String? = null,
     val fleeMessage: String? = null,
     val maxWanderDistance: Int = 3,
+)
+
+/**
+ * YAML representation of a behavior tree node. Supports composing trees
+ * from existing node primitives without writing Kotlin code.
+ *
+ * Example YAML:
+ * ```yaml
+ * behavior:
+ *   tree:
+ *     type: selector
+ *     children:
+ *       - type: is_in_combat
+ *       - type: sequence
+ *         children:
+ *           - type: is_player_in_room
+ *           - type: say
+ *             message: "Halt!"
+ *           - type: aggro
+ *       - type: stationary
+ * ```
+ */
+data class BehaviorNodeFile(
+    val type: String = "",
+    val children: List<BehaviorNodeFile> = emptyList(),
+    // Action/condition parameters
+    val message: String? = null,
+    val route: List<String> = emptyList(),
+    val maxDistance: Int = 3,
+    val percent: Int = 20,
+    val cooldownMs: Long = 0L,
+    val key: String = "",
 )

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -37,6 +37,7 @@ import dev.ambon.domain.world.data.ExitValueDeserializer
 import dev.ambon.domain.world.data.FeatureFile
 import dev.ambon.domain.world.data.WorldFile
 import dev.ambon.engine.behavior.BehaviorTemplates
+import dev.ambon.engine.behavior.BehaviorTreeLoader
 import dev.ambon.engine.behavior.BtNode
 import dev.ambon.engine.dialogue.DialogueChoice
 import dev.ambon.engine.dialogue.DialogueNode
@@ -893,13 +894,29 @@ object WorldLoader {
     ): BtNode? {
         if (behaviorFile == null) return null
 
+        // Inline tree definition takes precedence over template
+        if (behaviorFile.tree != null) {
+            return try {
+                BehaviorTreeLoader.load(behaviorFile.tree, zone)
+            } catch (e: IllegalArgumentException) {
+                throw WorldLoadException(
+                    "Mob '${mobId.value}' has invalid inline behavior tree: ${e.message}",
+                )
+            }
+        }
+
+        val templateName = behaviorFile.template
+            ?: throw WorldLoadException(
+                "Mob '${mobId.value}' behavior must specify either 'template' or 'tree'.",
+            )
+
         val tree =
             BehaviorTemplates.resolve(
-                behaviorFile.template,
+                templateName,
                 behaviorFile.params,
                 zone,
             ) ?: throw WorldLoadException(
-                "Mob '${mobId.value}' references unknown behavior template '${behaviorFile.template}'. " +
+                "Mob '${mobId.value}' references unknown behavior template '$templateName'. " +
                     "Known templates: ${BehaviorTemplates.templateNames.sorted().joinToString(", ")}",
             )
 

--- a/src/main/kotlin/dev/ambon/engine/behavior/BehaviorTreeLoader.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/BehaviorTreeLoader.kt
@@ -1,0 +1,94 @@
+package dev.ambon.engine.behavior
+
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.qualifyId
+import dev.ambon.domain.world.data.BehaviorNodeFile
+import dev.ambon.engine.behavior.actions.AggroAction
+import dev.ambon.engine.behavior.actions.FleeAction
+import dev.ambon.engine.behavior.actions.PatrolAction
+import dev.ambon.engine.behavior.actions.SayAction
+import dev.ambon.engine.behavior.actions.StationaryAction
+import dev.ambon.engine.behavior.actions.WanderAction
+import dev.ambon.engine.behavior.conditions.IsHpBelow
+import dev.ambon.engine.behavior.conditions.IsInCombat
+import dev.ambon.engine.behavior.conditions.IsPlayerInRoom
+import dev.ambon.engine.behavior.nodes.CooldownNode
+import dev.ambon.engine.behavior.nodes.InverterNode
+import dev.ambon.engine.behavior.nodes.SelectorNode
+import dev.ambon.engine.behavior.nodes.SequenceNode
+
+/**
+ * Builds a [BtNode] tree from a YAML [BehaviorNodeFile] definition.
+ *
+ * Supports all built-in node types:
+ * - Control: `selector`, `sequence`, `inverter`, `cooldown`
+ * - Conditions: `is_in_combat`, `is_player_in_room`, `is_hp_below`
+ * - Actions: `stationary`, `say`, `aggro`, `flee`, `patrol`, `wander`
+ */
+object BehaviorTreeLoader {
+    val knownNodeTypes: Set<String> = setOf(
+        "selector",
+        "sequence",
+        "inverter",
+        "cooldown",
+        "is_in_combat",
+        "is_player_in_room",
+        "is_hp_below",
+        "stationary",
+        "say",
+        "aggro",
+        "flee",
+        "patrol",
+        "wander",
+    )
+
+    fun load(
+        nodeFile: BehaviorNodeFile,
+        zone: String,
+    ): BtNode {
+        val type = nodeFile.type.lowercase()
+        return when (type) {
+            // Control flow nodes
+            "selector" -> SelectorNode(nodeFile.children.map { load(it, zone) })
+            "sequence" -> SequenceNode(nodeFile.children.map { load(it, zone) })
+            "inverter" -> {
+                require(nodeFile.children.size == 1) {
+                    "Inverter node must have exactly 1 child, got ${nodeFile.children.size}"
+                }
+                InverterNode(load(nodeFile.children.first(), zone))
+            }
+            "cooldown" -> {
+                require(nodeFile.children.size == 1) {
+                    "Cooldown node must have exactly 1 child, got ${nodeFile.children.size}"
+                }
+                require(nodeFile.cooldownMs > 0) { "Cooldown node requires cooldownMs > 0" }
+                val key = nodeFile.key.ifEmpty { "cooldown_${nodeFile.hashCode()}" }
+                CooldownNode(nodeFile.cooldownMs, key, load(nodeFile.children.first(), zone))
+            }
+
+            // Condition nodes
+            "is_in_combat" -> IsInCombat
+            "is_player_in_room" -> IsPlayerInRoom
+            "is_hp_below" -> IsHpBelow(nodeFile.percent)
+
+            // Action nodes
+            "stationary" -> StationaryAction
+            "say" -> {
+                requireNotNull(nodeFile.message) { "Say node requires a 'message' parameter" }
+                SayAction(nodeFile.message)
+            }
+            "aggro" -> AggroAction
+            "flee" -> FleeAction
+            "patrol" -> {
+                require(nodeFile.route.isNotEmpty()) { "Patrol node requires a non-empty 'route'" }
+                PatrolAction(nodeFile.route.map { RoomId(qualifyId(zone, it)) })
+            }
+            "wander" -> WanderAction(nodeFile.maxDistance)
+
+            else -> throw IllegalArgumentException(
+                "Unknown behavior tree node type '$type'. " +
+                    "Known types: ${knownNodeTypes.sorted().joinToString(", ")}",
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `BehaviorNodeFile` YAML DTO for inline tree definitions as an alternative to named templates
- Add `BehaviorTreeLoader` that resolves YAML node types into `BtNode` objects
- Support all 14 built-in node types: `selector`, `sequence`, `inverter`, `cooldown`, `is_in_combat`, `is_player_in_room`, `is_hp_below`, `stationary`, `say`, `aggro`, `flee`, `patrol`, `wander`
- Update `WorldLoader.parseBehavior()` to support both `template` and `tree` definitions
- Inline trees are validated at world load time with clear error messages for unknown types
- Existing template-based behavior definitions continue to work unchanged

Example YAML usage:
```yaml
behavior:
  tree:
    type: selector
    children:
      - type: is_in_combat
      - type: sequence
        children:
          - type: is_player_in_room
          - type: say
            message: "Halt!"
          - type: aggro
      - type: wander
        maxDistance: 5
```

Part 5 of the data-driven gap audit (see `docs/DATA_DRIVEN_GAP_AUDIT.md`).

## Test plan
- [x] `BehaviorTreeSystemTest` passes (all tests)
- [x] `BehaviorYamlParsingTest` passes (all tests)
- [x] `WorldLoaderTest` passes (all tests)
- [x] `ktlintCheck` clean