### PR TITLE
Use class-independent base sprite for staff players

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -1196,8 +1196,9 @@ class GmcpEmitter(
 
     private fun resolveSprite(player: PlayerState): String {
         val race = player.race.lowercase()
+        if (player.isStaff) return "${imagesBase}player_sprites/${race}_base_tstaff.png"
         val cls = player.playerClass.lowercase()
-        val tierSuffix = if (player.isStaff) "tstaff" else "t${sortedTiers.firstOrNull { player.level >= it } ?: 1}"
+        val tierSuffix = "t${sortedTiers.firstOrNull { player.level >= it } ?: 1}"
         return "${imagesBase}player_sprites/${race}_${cls}_$tierSuffix.png"
     }
 }


### PR DESCRIPTION
## Summary
- Staff player sprites now resolve to `{race}_base_tstaff.png` instead of `{race}_{class}_tstaff.png`
- Staff don't depend on class for their sprite, reducing the number of required staff sprite assets

## Test plan
- [ ] Verify staff player sprite URL resolves to e.g. `mycorae_base_tstaff.png`
- [ ] Verify non-staff player sprites are unchanged (still include class)