### PR TITLE
Add admin log REST API with in-memory ring buffer

### DIFF
--- a/src/main/kotlin/dev/ambon/admin/AdminHttpServer.kt
+++ b/src/main/kotlin/dev/ambon/admin/AdminHttpServer.kt
@@ -745,6 +745,31 @@ internal fun Application.adminModule(
             )
         }
 
+        // ── Logs (ring buffer) ─────────────────────────────────────────────
+        get("/api/logs") {
+            val ringBuffer = LogRingBuffer.instance
+            if (ringBuffer == null) {
+                call.respondJsonError(HttpStatusCode.ServiceUnavailable, "Log ring buffer not available")
+                return@get
+            }
+            val minLevel = call.request.queryParameters["level"]?.let {
+                ch.qos.logback.classic.Level.toLevel(it, null)
+            }
+            val sinceMs = call.request.queryParameters["since"]?.toLongOrNull()
+            val loggerPrefix = call.request.queryParameters["logger"]?.takeIf { it.isNotBlank() }
+            val limit = call.request.queryParameters["limit"]?.toIntOrNull()?.coerceIn(1, 5000) ?: 500
+            val entries = ringBuffer.entries(
+                minLevel = minLevel,
+                sinceEpochMs = sinceMs,
+                loggerPrefix = loggerPrefix,
+                limit = limit,
+            )
+            call.respondText(
+                json.writeValueAsString(entries),
+                ContentType.Application.Json,
+            )
+        }
+
         // ── Staff toggle (JSON) ─────────────────────────────────────────────
         post("/api/players/{name}/staff") {
             val name = call.parameters["name"] ?: return@post call.respond(HttpStatusCode.BadRequest)

--- a/src/main/kotlin/dev/ambon/admin/LogRingBuffer.kt
+++ b/src/main/kotlin/dev/ambon/admin/LogRingBuffer.kt
@@ -1,0 +1,85 @@
+package dev.ambon.admin
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+/**
+ * A Logback appender that keeps the last [capacity] log entries in a ring buffer.
+ * Entries can be retrieved via [entries] for the admin REST API.
+ */
+class LogRingBuffer : AppenderBase<ILoggingEvent>() {
+    var capacity: Int = 2000
+
+    private val buffer = ArrayDeque<LogEntry>()
+    private val lock = Any()
+
+    override fun append(eventObject: ILoggingEvent) {
+        val entry = LogEntry(
+            timestamp = Instant.ofEpochMilli(eventObject.timeStamp)
+                .atOffset(ZoneOffset.UTC)
+                .format(TIMESTAMP_FORMAT),
+            epochMs = eventObject.timeStamp,
+            level = eventObject.level.toString(),
+            logger = eventObject.loggerName,
+            message = eventObject.formattedMessage,
+            thread = eventObject.threadName,
+        )
+        synchronized(lock) {
+            buffer.addLast(entry)
+            while (buffer.size > capacity) {
+                buffer.removeFirst()
+            }
+        }
+    }
+
+    /** Returns log entries, optionally filtered. Thread-safe snapshot. */
+    fun entries(
+        minLevel: Level? = null,
+        sinceEpochMs: Long? = null,
+        loggerPrefix: String? = null,
+        limit: Int = capacity,
+    ): List<LogEntry> {
+        val snapshot = synchronized(lock) { buffer.toList() }
+        var result: List<LogEntry> = snapshot
+        if (sinceEpochMs != null) {
+            result = result.filter { it.epochMs >= sinceEpochMs }
+        }
+        if (minLevel != null) {
+            result = result.filter { Level.toLevel(it.level).isGreaterOrEqual(minLevel) }
+        }
+        if (loggerPrefix != null) {
+            result = result.filter { it.logger.startsWith(loggerPrefix, ignoreCase = true) }
+        }
+        return result.takeLast(limit)
+    }
+
+    fun clear() {
+        synchronized(lock) { buffer.clear() }
+    }
+
+    companion object {
+        private val TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+
+        /** Global instance set by Logback during startup — used by the admin API. */
+        @Volatile
+        var instance: LogRingBuffer? = null
+    }
+
+    override fun start() {
+        super.start()
+        instance = this
+    }
+}
+
+data class LogEntry(
+    val timestamp: String,
+    val epochMs: Long,
+    val level: String,
+    val logger: String,
+    val message: String,
+    val thread: String,
+)

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -4,7 +4,11 @@
       <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{30} - %msg%n</pattern>
     </encoder>
   </appender>
+  <appender name="RING" class="dev.ambon.admin.LogRingBuffer">
+    <capacity>2000</capacity>
+  </appender>
   <root level="INFO">
     <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="RING"/>
   </root>
 </configuration>


### PR DESCRIPTION
## Summary

Adds a REST endpoint for viewing server logs without SSH/SSM access, backed by an in-memory ring buffer Logback appender.

- **LogRingBuffer** — custom Logback `AppenderBase<ILoggingEvent>` that keeps the last 2,000 log entries in a thread-safe `ArrayDeque`. Registered as the `RING` appender in `logback.xml` alongside the existing `CONSOLE` appender.
- **`GET /api/logs`** — returns log entries as a JSON array, with optional query parameters for filtering. Protected by the existing admin basic auth.

## API Reference (for Arcanum integration)

### `GET /api/logs`

**Auth:** HTTP Basic (same credentials as all admin endpoints)

**Query parameters** (all optional):

| Param | Type | Default | Description |
|-------|------|---------|-------------|
| `level` | string | all levels | Minimum log level: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR` |
| `since` | long | — | Only entries after this Unix epoch timestamp (milliseconds) |
| `logger` | string | — | Filter by logger name prefix (e.g. `dev.ambon.engine`) |
| `limit` | int | 500 | Max entries to return (1–5000) |

**Response:** JSON array of log entries, ordered chronologically (oldest first):

```json
[
  {
    "timestamp": "2026-03-26T22:15:03.142Z",
    "epochMs": 1743027303142,
    "level": "INFO",
    "logger": "dev.ambon.engine.GameEngine",
    "message": "Tick loop started on engine dispatcher",
    "thread": "engine-1"
  }
]
```

**Example requests:**

```bash
# Last 100 entries
curl -u admin:$TOKEN https://host:port/api/logs?limit=100

# Only warnings and errors
curl -u admin:$TOKEN https://host:port/api/logs?level=WARN

# Engine logs since a specific time
curl -u admin:$TOKEN https://host:port/api/logs?logger=dev.ambon.engine&since=1743027300000

# Polling pattern (get new entries since last seen)
curl -u admin:$TOKEN https://host:port/api/logs?since=$LAST_EPOCH_MS
```

**Arcanum integration notes:**
- Poll on a timer (e.g. every 2–5 seconds) using `since=<lastSeenEpochMs>` to get only new entries
- The `epochMs` field on each entry can be used as the `since` value for the next poll
- The ring buffer holds 2,000 entries; very fast poll rates aren't necessary
- Logger names follow the package structure: `dev.ambon.engine.*`, `dev.ambon.transport.*`, `dev.ambon.admin.*`, etc.

## Test plan

- [ ] Start server, verify `RING` appender initializes (no startup errors)
- [ ] `GET /api/logs` returns recent log entries as JSON array
- [ ] `?level=WARN` filters to WARN and ERROR only
- [ ] `?since=<epochMs>` returns only entries after that timestamp
- [ ] `?logger=dev.ambon.engine` filters by logger prefix
- [ ] `?limit=10` caps results at 10 entries
- [ ] Unauthenticated requests get 401
- [ ] Full test suite passes (1083 tests)