### PR TITLE
Fix GMCP protocol mismatches between server and web client

### DIFF
--- a/docs/WEB_CLIENT_PARITY_REPORT.md
+++ b/docs/WEB_CLIENT_PARITY_REPORT.md
@@ -1,0 +1,240 @@
+# Web Client Feature Parity Report (Consolidated)
+
+**Date:** 2026-03-27
+**Source:** Three independent parity studies merged and deduplicated.
+**Scope:** All MUD text commands/features vs web-v3 client UI and GMCP coverage.
+
+---
+
+## Executive Summary
+
+The web client covers the core gameplay loop well — navigation, combat, inventory/equipment, spells, quests, dialogue, shops, and chat. However, several full feature systems have **no web UI or GMCP support** (mail, crafting, world features), many others have **partial UI requiring text-command fallback** for management actions (guilds, groups, friends, titles), and a handful of **GMCP protocol issues** prevent data from reaching the client correctly.
+
+---
+
+## 1. GMCP Protocol Fixes
+
+These are server/client protocol bugs or mismatches — high impact, low risk.
+
+### 1.1 Zone.Map support-check handshake broken for WebSocket
+
+`GmcpEmitter.sendZoneMap()` uses `supportCheck = "Room"`, but WebSocket auto-support advertises `"Room.Info 1"` (not root `"Room 1"`). With prefix-match semantics, `"Room"` doesn't match `"Room.Info"` — so `Zone.Map` is silently dropped for web sessions.
+
+**Fix:** Either advertise `"Room 1"` in WebSocket `Core.Supports.Set`, or change the support check to `"Room.Info"`.
+
+### 1.2 Room.MobInfo missing fields
+
+`MobInfoEntry` has `questAvailable`, `questComplete`, `aggressive`, but `RoomMobInfoPayload` omits them — only sends `id`, `level`, `tier`, `questGiver`, `shopKeeper`, `dialogue`. Web client defaults these when missing.
+
+**Fix:** Include the three missing fields in the emitted payload.
+
+### 1.3 Char.Combat.Event field-name mismatch
+
+Server payload uses `amount` and `remaining`; web client reads `healing` and `shieldRemaining`. Healing/shield visuals and combat-log details can be incomplete.
+
+**Fix:** Standardize on one naming convention across server and web client.
+
+### 1.4 Core.Ping not handled by web client
+
+`GmcpEmitter` emits `Core.Ping` but `applyGmcpPackage.ts` has no case for it.
+
+**Fix:** Add `Core.Ping` handler; opportunity for connection-health/latency indicator.
+
+### 1.5 Char.Gain fields underutilized
+
+Server emits optional `newLevel`, `hpGained`, `manaGained` fields. Web client only reads `type`, `amount`, `source`.
+
+**Fix:** Consume the additional fields for richer level-up and resource-gain feedback.
+
+---
+
+## 2. Discoverability Gaps
+
+### 2.1 Command autocomplete incomplete
+
+`web-v3/src/constants.ts` command completion list is narrower than the full parser surface. Missing families: mail, crafting, world features, guild/group management, friends, phase, title, gender.
+
+### 2.2 In-app Help underrepresents command families
+
+`HelpContent` doesn't cover mail, crafting, world-feature/container verbs, and several other supported families.
+
+---
+
+## 3. Full Feature Gaps (No GMCP + No Web UI)
+
+These systems work via text commands but are invisible to the web client.
+
+### 3.1 Mail System
+
+**Commands:** `mail list/read/delete/send/abort`
+**GMCP needed:** `Mail.List`, `Mail.Message`, `Mail.Notification` (and compose-state feedback).
+**Web UI needed:** Mail panel with inbox, message viewer, compose form, delete action.
+**Note:** Multi-step compose (`mail send`, line capture, `.` to finish) is especially poor UX via generic command entry.
+
+### 3.2 Crafting & Gathering System
+
+**Commands:** `gather`, `craft`, `recipes`, `craftskills`/`professions`
+**GMCP needed:** `Crafting.Skills`, `Crafting.Recipes`, `Crafting.Nodes`, `Crafting.Result`.
+**Web UI needed:** Crafting panel with recipe browser, gather button on room nodes, skill progression display.
+
+### 3.3 World Features (Doors, Containers, Levers, Signs)
+
+**Commands:** `open`, `close`, `unlock`, `lock`, `pull`, `read`, `search`, `get <item> from <container>`, `put <item> in <container>`
+**GMCP needed:** `Room.Features` (interactive feature state, lock/key requirements, container contents, sign text).
+**Web UI needed:** Contextual action buttons on room features — click door to open/close, click sign to read, click container to search/open.
+
+### 3.4 Structured Who List
+
+**Commands:** `who`
+**GMCP needed:** `Server.Who` with structured player data (name, level, race, class, title, guild, idle).
+**Web UI needed:** Currently parses raw terminal text in Who tab — a GMCP package enables proper sorting, filtering, and click-to-tell.
+
+---
+
+## 4. UI-Only Gaps (GMCP Exists, Management UI Missing)
+
+### 4.1 Guild Management
+
+**GMCP available:** `Guild.Info`, `Guild.Members`, `Guild.Chat` — all handled.
+**Displayed:** Guild name/tag/rank/MOTD, member list with online status.
+**Missing actions:** Create, invite, accept invite, kick, promote, demote, set MOTD, leave, disband.
+
+### 4.2 Group Management
+
+**GMCP available:** `Group.Info` — shows member HP/Mana bars.
+**Displayed:** Group tab with leader + members + vitals.
+**Missing actions:** Invite, accept/decline invite, leave, kick, list.
+
+### 4.3 Friends Management
+
+**GMCP available:** `Friends.List`, `Friends.Online`, `Friends.Offline` — all handled.
+**Displayed:** Friends tab with online/offline status, level, zone.
+**Missing actions:** Add friend, remove friend, click-to-tell.
+
+### 4.4 Character Profile Controls (Title & Gender)
+
+**Title:** Achievement titles are sent via `Char.Achievements`, but no UI to set/clear active title.
+**Gender:** `gender <option>` command only — no selector in Character panel.
+
+### 4.5 Phase/Instance Selector
+
+**Commands:** `phase`/`layer` supported.
+**Missing:** No instance selector UI, no current-instance display, no occupancy information.
+**GMCP opportunity:** Instance list + current + occupancy + switch ack/error.
+
+### 4.6 Character Stats Tab
+
+**GMCP available:** `Char.Stats` sends full stat breakdown (STR/DEX/CON/INT/WIS/CHA base+effective, damage range, armor, dodge%).
+**State:** Stored in client (`charStats`) but no panel renders it.
+**Missing:** Stats tab in CharacterPanel showing attribute table with base vs effective values, derived combat stats.
+
+### 4.7 Score View
+
+**Commands:** `score`/`sc` shows comprehensive character summary.
+**Note:** All constituent data is already received via `Char.Vitals`, `Char.Name`, `Char.Stats` — can be composed from existing GMCP without new server changes.
+
+---
+
+## 5. UX Enhancement Gaps
+
+### 5.1 Flee Button
+
+Must type `flee` — needs an action bar button visible when `inCombat` is true.
+
+### 5.2 Recall Button
+
+Must type `recall` — needs a navigation button with cooldown indicator.
+
+### 5.3 Inventory Context Actions
+
+**Missing:** `Use` button for consumable items, `Put` for containers, `Search` for containers.
+
+### 5.4 Emote/Pose Picker
+
+Must type `emote <action>` or `pose <text>` — could have quick-access emote buttons in chat panel.
+
+### 5.5 Combat Target Selector
+
+When multiple mobs present, no tab-targeting or mob-list picker — only click-on-canvas targeting.
+
+### 5.6 Mob Status Effects
+
+`Char.StatusEffects` only shows player's own effects. No way to see enemy buffs/debuffs in battle scene.
+**GMCP opportunity:** `Room.MobEffects` or extend `Room.UpdateMob` with active effects.
+
+### 5.7 Contextual Entity Action Enrichment
+
+EntityPopout exists but could be richer based on `Room.MobInfo` flags — e.g., quest-giver shows "View Quests", shop-keeper shows "Browse Shop", hostile mob shows "Attack".
+
+---
+
+## 6. Infrastructure / Regression Prevention
+
+### 6.1 Command-Parity CI Check
+
+Script/test that diffs parser command families vs web command palette/autocomplete/action maps. Prevents future drift.
+
+### 6.2 GMCP Contract Tests
+
+Test that compares `GmcpEmitter` package strings and field schemas against `applyGmcpPackage.ts` cases. Catches field-name mismatches and missing handlers.
+
+### 6.3 Server.Commands Metadata Package
+
+A `Server.Commands` GMCP package providing command manifest (syntax, help, category, privilege) to power dynamic in-client command palette and context-aware UI.
+
+---
+
+## 7. Features with Full Coverage (No Gaps)
+
+| Feature | GMCP Packages | Web UI |
+|---------|--------------|--------|
+| Navigation & Movement | `Room.Info`, `Zone.Map` | Canvas world scene, minimap, exit buttons |
+| Room contents | `Room.Mobs`, `Room.Items`, `Room.Players`, `Room.MobInfo` | Canvas entities with labels, HP bars, role badges |
+| Combat | `Char.Combat`, `Char.Combat.Event`, `Char.Vitals` | Battle scene, combat log, HP/Mana bars, target card |
+| Spells & Abilities | `Char.Skills`, `Char.Cooldown` | Spellbook panel, quickbar with cooldown sweeps |
+| Status Effects | `Char.StatusEffects` | Character panel effects tab, battle scene indicators |
+| Inventory | `Char.Items.List/Add/Remove` | Inventory panel with wear/give/drop actions |
+| Equipment | `Char.Equipment.Slots` | Paperdoll equipment panel with remove action |
+| Quests | `Quest.List/Update/Complete/Available` | Quest panel with accept/abandon, progress tracking |
+| Dialogue | `Dialogue.Node/End` | Canvas dialogue overlay with clickable choices |
+| Shops | `Shop.List/Close` | Shop popout with buy/sell tabs |
+| Chat (all channels) | `Comm.Channel` | Chat panel with say/tell/gossip/shout/ooc/gtell/gchat |
+| Achievements | `Char.Achievements` | Character panel achievements tab with progress bars |
+| XP/Gold gains | `Char.Gain` | Floating gain notifications |
+| Login flow | `Login.Prompt/Error` | Login modal with race/class/gender selection |
+| Admin/Staff tools | `Staff.WorldInfo` | Admin panel with zone/room browser, teleport |
+
+---
+
+## 8. Summary Matrix
+
+| # | Feature | Has Text Cmd | Has GMCP | Has Web UI | Gap Type | Issue |
+|---|---------|:---:|:---:|:---:|----------|-------|
+| 1 | Zone.Map handshake | — | Broken | Ready | Protocol fix | #667 |
+| 2 | Room.MobInfo fields | — | Partial | Ready | Protocol fix | #668 |
+| 3 | Combat.Event names | — | Mismatched | Mismatched | Protocol fix | #669 |
+| 4 | Core.Ping | — | Emitted | Missing | Protocol fix | #670 |
+| 5 | Char.Gain fields | — | Emitted | Partial | Protocol fix | #671 |
+| 6 | Command autocomplete | Y | N/A | Partial | Discoverability | #672 |
+| 7 | Help coverage | Y | N/A | Partial | Discoverability | #673 |
+| 8 | Mail | Y | **N** | **N** | Full gap | #674 |
+| 9 | Crafting/Gathering | Y | **N** | **N** | Full gap | #675 |
+| 10 | World features | Y | **N** | **N** | Full gap | #676 |
+| 11 | Who (structured) | Y | **N** | Partial | Full gap | #677 |
+| 12 | Guild management | Y | Partial | **N** | UI gap | #678 |
+| 13 | Group management | Y | Y | **N** | UI gap | #679 |
+| 14 | Friends management | Y | Y | **N** | UI gap | #680 |
+| 15 | Title/gender controls | Y | Partial | **N** | UI gap | #681 |
+| 16 | Phase/instance selector | Y | **N** | **N** | UI gap | #682 |
+| 17 | Character stats tab | Y | Y | **N** | UI gap | #683 |
+| 18 | Score view | Y | Composable | **N** | UI gap | #684 |
+| 19 | Flee button | Y | N/A | **N** | UX gap | #685 |
+| 20 | Recall button | Y | N/A | **N** | UX gap | #686 |
+| 21 | Inventory use/put/search | Y | N/A | **N** | UX gap | #687 |
+| 22 | Emote picker | Y | N/A | **N** | UX gap | #688 |
+| 23 | Combat target selector | Y | N/A | **N** | UX gap | #689 |
+| 24 | Mob status effects | — | **N** | **N** | UX gap | #690 |
+| 25 | Entity action enrichment | — | Partial | Partial | UX gap | #691 |
+| 26 | Command-parity CI | — | — | — | Infra | #692 |
+| 27 | GMCP contract tests | — | — | — | Infra | #693 |
+| 28 | Server.Commands package | — | **N** | **N** | Infra | #694 |

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -152,7 +152,7 @@ class GmcpEmitter(
                     )
                 },
             ),
-            supportCheck = "Room",
+            supportCheck = "Zone.Map",
         )
     }
 
@@ -532,7 +532,7 @@ class GmcpEmitter(
                 type = "heal",
                 abilityName = event.abilityName,
                 targetName = event.targetName,
-                amount = event.amount,
+                healing = event.amount,
                 sourceIsPlayer = event.sourceIsPlayer,
             )
             is CombatEvent.Dodge -> CombatEventPayload(
@@ -552,7 +552,7 @@ class GmcpEmitter(
                 type = "hotTick",
                 effectName = event.effectName,
                 targetName = event.targetName,
-                amount = event.amount,
+                healing = event.amount,
             )
             is CombatEvent.Kill -> CombatEventPayload(
                 type = "kill",
@@ -570,7 +570,7 @@ class GmcpEmitter(
                 type = "shieldAbsorb",
                 attackerName = event.attackerName,
                 absorbed = event.absorbed,
-                remaining = event.remaining,
+                shieldRemaining = event.remaining,
             )
         }
         emit(sessionId, "Char.Combat.Event", payload, supportCheck = "Char.Combat.Event")
@@ -736,8 +736,11 @@ class GmcpEmitter(
                     level = m.level,
                     tier = m.tier,
                     questGiver = m.questGiver,
+                    questAvailable = m.questAvailable,
+                    questComplete = m.questComplete,
                     shopKeeper = m.shopKeeper,
                     dialogue = m.dialogue,
+                    aggressive = m.aggressive,
                 )
             },
         )
@@ -1217,7 +1220,7 @@ class GmcpEmitter(
         val targetName: String? = null,
         val targetId: String? = null,
         val damage: Int? = null,
-        val amount: Int? = null,
+        val healing: Int? = null,
         val sourceIsPlayer: Boolean? = null,
         val abilityId: String? = null,
         val abilityName: String? = null,
@@ -1228,7 +1231,7 @@ class GmcpEmitter(
         val killerIsPlayer: Boolean? = null,
         val attackerName: String? = null,
         val absorbed: Int? = null,
-        val remaining: Int? = null,
+        val shieldRemaining: Int? = null,
     )
 
     // ---------- stats payload ----------
@@ -1320,8 +1323,11 @@ class GmcpEmitter(
         val level: Int,
         val tier: String,
         val questGiver: Boolean,
+        val questAvailable: Boolean,
+        val questComplete: Boolean,
         val shopKeeper: Boolean,
         val dialogue: Boolean,
+        val aggressive: Boolean,
     )
 
     // ---------- shop payloads ----------

--- a/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
+++ b/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
@@ -205,7 +205,7 @@ private suspend fun DefaultWebSocketServerSession.bridgeWebSocketSession(
         InboundEvent.GmcpReceived(
             sessionId,
             "Core.Supports.Set",
-            """["Char.Vitals 1","Room.Info 1","Char.StatusVars 1","Char.Items 1","Char.Equipment 1","Room.Players 1","Room.Mobs 1","Room.Items 1","Char.Skills 1","Char.Name 1","Char.StatusEffects 1","Char.Achievements 1","Comm.Channel 1","Guild 1","Group.Info 1","Friends 1","Core.Ping 1","Dialogue 1","Shop 1","Char.Combat 1","Char.Combat.Event 1","Char.Stats 1","Quest 1","Char.Cooldown 1","Char.Gain 1","Room.MobInfo 1","Login 1","Server 1","UI.Feedback 1","Staff 1"]""",
+            """["Char.Vitals 1","Room.Info 1","Zone.Map 1","Char.StatusVars 1","Char.Items 1","Char.Equipment 1","Room.Players 1","Room.Mobs 1","Room.Items 1","Char.Skills 1","Char.Name 1","Char.StatusEffects 1","Char.Achievements 1","Comm.Channel 1","Guild 1","Group.Info 1","Friends 1","Core.Ping 1","Dialogue 1","Shop 1","Char.Combat 1","Char.Combat.Event 1","Char.Stats 1","Quest 1","Char.Cooldown 1","Char.Gain 1","Room.MobInfo 1","Login 1","Server 1","UI.Feedback 1","Staff 1"]""",
         ),
     )
     metrics.onWsConnected()

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -1307,7 +1307,7 @@ class GmcpEmitterTest {
     @Test
     fun `sendZoneMap emits rooms with horizontal exits only`() =
         runTest {
-            val e = emitter("Room")
+            val e = emitter("Zone.Map")
             val rooms = listOf(
                 zoneRoom(
                     "z:a",
@@ -1338,7 +1338,7 @@ class GmcpEmitterTest {
         }
 
     @Test
-    fun `sendZoneMap skipped when Room not supported`() =
+    fun `sendZoneMap skipped when Zone Map not supported`() =
         runTest {
             val e = emitter("Char")
             e.sendZoneMap(sid, "z", listOf(zoneRoom("z:a")))

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -333,6 +333,8 @@ function App() {
     resetMap();
   }, [resetMap]);
 
+  const sendGmcpRef = useRef<(pkg: string, payload: unknown) => void>(() => {});
+
   const handleGmcp = useCallback(
     (pkg: string, data: unknown) => {
       applyGmcpPackage(
@@ -381,13 +383,14 @@ function App() {
           setServerAssets,
           pushUiFeedback,
           setStaffWorldInfo,
+          sendGmcp: (pkg: string, payload: unknown) => sendGmcpRef.current(pkg, payload),
         },
       );
     },
     [pushFriendNotification, pushCombatEvent, pushGainEvent, pushQuestNotification, pushUiFeedback, updateMap, loadZoneMap],
   );
 
-  const { connected, liveMessage, connect, disconnect, reconnect, sendLine } = useMudSocket({
+  const { connected, liveMessage, connect, disconnect, reconnect, sendLine, sendGmcp } = useMudSocket({
     onOpen: () => {
       focusComposer();
     },
@@ -408,6 +411,8 @@ function App() {
       writeSystem("Connection error.");
     },
   });
+
+  sendGmcpRef.current = sendGmcp;
 
   const sendCommand = useCallback(
     (raw: string, echo: boolean) => {

--- a/web-v3/src/canvas/systems/GainPopup.ts
+++ b/web-v3/src/canvas/systems/GainPopup.ts
@@ -13,6 +13,7 @@ const GAIN_COLORS: Record<string, string> = {
   xp: "#b9aed8",
   gold: "#f0c674",
   level: "#81d4fa",
+  levelUp: "#81d4fa",
 };
 
 export class GainPopupSystem {
@@ -23,8 +24,12 @@ export class GainPopupSystem {
     const color = GAIN_COLORS[event.type] ?? "#d8dcef";
     let display: string;
 
-    if (event.type === "level") {
-      display = "Level Up!";
+    if (event.type === "level" || event.type === "levelUp") {
+      const parts = ["Level Up!"];
+      if (event.newLevel != null) parts[0] = `Level ${event.newLevel}!`;
+      if (event.hpGained) parts.push(`+${event.hpGained} HP`);
+      if (event.manaGained) parts.push(`+${event.manaGained} Mana`);
+      display = parts.join(" ");
     } else {
       const label = event.type === "xp" ? "XP" : event.type === "gold" ? "Gold" : event.type;
       display = `+${event.amount} ${label}`;

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -80,6 +80,7 @@ interface GmcpContext {
   setServerAssets: Dispatch<SetStateAction<Record<string, string>>>;
   pushUiFeedback: (feedback: UiFeedback) => void;
   setStaffWorldInfo: Dispatch<SetStateAction<StaffWorldZone[]>>;
+  sendGmcp: (pkg: string, payload: unknown) => void;
 }
 
 const CHAT_CHANNEL_SET = new Set<ChatChannel>(["say", "tell", "gossip", "shout", "ooc", "gtell", "gchat"]);
@@ -677,6 +678,10 @@ export function applyGmcpPackage(
         absorbed: safeNumber(packet.absorbed),
         shieldRemaining: safeNumber(packet.shieldRemaining),
         sourceIsPlayer: packet.sourceIsPlayer === true,
+        effectName: typeof packet.effectName === "string" ? packet.effectName : null,
+        killerName: typeof packet.killerName === "string" ? packet.killerName : null,
+        killerIsPlayer: packet.killerIsPlayer === true,
+        attackerName: typeof packet.attackerName === "string" ? packet.attackerName : null,
         xpGained: safeNumber(packet.xpGained),
         goldGained: safeNumber(packet.goldGained),
       });
@@ -825,10 +830,16 @@ export function applyGmcpPackage(
 
     case "Char.Gain": {
       const packet = data as Partial<Record<string, unknown>>;
+      const nl = typeof packet.newLevel === "number" ? packet.newLevel : null;
+      const hpG = typeof packet.hpGained === "number" ? packet.hpGained : null;
+      const manaG = typeof packet.manaGained === "number" ? packet.manaGained : null;
       ctx.pushGainEvent({
         type: typeof packet.type === "string" ? packet.type : "unknown",
         amount: safeNumber(packet.amount),
         source: typeof packet.source === "string" ? packet.source : null,
+        newLevel: nl,
+        hpGained: hpG,
+        manaGained: manaG,
       });
       break;
     }
@@ -909,6 +920,11 @@ export function applyGmcpPackage(
     case "UI.Feedback": {
       const packet = data as UiFeedback;
       ctx.pushUiFeedback(packet);
+      break;
+    }
+
+    case "Core.Ping": {
+      ctx.sendGmcp("Core.Ping", {});
       break;
     }
 

--- a/web-v3/src/hooks/useMudSocket.ts
+++ b/web-v3/src/hooks/useMudSocket.ts
@@ -80,6 +80,13 @@ export function useMudSocket(options: UseMudSocketOptions) {
     return true;
   }, []);
 
+  const sendGmcp = useCallback((pkg: string, payload: unknown): boolean => {
+    const ws = socketRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return false;
+    ws.send(JSON.stringify({ gmcp: pkg, data: payload }));
+    return true;
+  }, []);
+
   return {
     connected,
     liveMessage,
@@ -87,6 +94,7 @@ export function useMudSocket(options: UseMudSocketOptions) {
     disconnect,
     reconnect,
     sendLine,
+    sendGmcp,
   };
 }
 

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -247,6 +247,10 @@ export interface CombatEventData {
   absorbed: number;
   shieldRemaining: number;
   sourceIsPlayer: boolean;
+  effectName: string | null;
+  killerName: string | null;
+  killerIsPlayer: boolean;
+  attackerName: string | null;
   xpGained: number;
   goldGained: number;
 }
@@ -284,6 +288,9 @@ export interface GainEvent {
   type: string;
   amount: number;
   source: string | null;
+  newLevel: number | null;
+  hpGained: number | null;
+  manaGained: number | null;
 }
 
 export interface QuestNotification {


### PR DESCRIPTION
## Summary

Fixes 5 GMCP protocol issues identified in the web client feature parity audit (#667–#671):

- **#667 Zone.Map handshake**: Added `"Zone.Map 1"` to WebSocket auto-opt-in list and changed `sendZoneMap` support check from `"Room"` to `"Zone.Map"` — Zone.Map data was silently dropped for all web sessions
- **#668 Room.MobInfo fields**: Include `questAvailable`, `questComplete`, `aggressive` in emitted payload — web client already parsed these but they were always false
- **#669 Combat.Event field names**: Renamed `amount` → `healing` and `remaining` → `shieldRemaining` in `CombatEventPayload` to match web client expectations; added `effectName`/`killerName`/`killerIsPlayer`/`attackerName` to the web client type
- **#670 Core.Ping**: Added `Core.Ping` handler in web client that responds to server pings; added `sendGmcp` to `useMudSocket` for bidirectional GMCP
- **#671 Char.Gain fields**: Web client now consumes `newLevel`, `hpGained`, `manaGained` for richer level-up popups (e.g., "Level 5! +10 HP +5 Mana")

Also adds the consolidated `docs/WEB_CLIENT_PARITY_REPORT.md` covering all 28 identified parity gaps.

## Test plan

- [x] `ktlintCheck` passes
- [x] All 1083 tests pass (GmcpEmitterTest updated for new supportCheck)
- [x] TypeScript type check (`tsc --noEmit`) clean
- [x] ESLint clean
- [ ] Manual: verify Zone.Map renders on web client login
- [ ] Manual: verify mob quest/aggro badges appear in EntityPopout
- [ ] Manual: verify healing combat log entries show correct amounts
- [ ] Manual: verify level-up popup shows HP/Mana gains