### PR TITLE
Mail system: GMCP packages and web UI panel (#674)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -696,6 +696,62 @@ class GmcpEmitter(
         )
     }
 
+    // ---------- mail ----------
+
+    suspend fun sendMailList(
+        sessionId: SessionId,
+        inbox: List<dev.ambon.domain.mail.MailMessage>,
+    ) {
+        emit(
+            sessionId,
+            "Mail.List",
+            inbox.mapIndexed { index, msg ->
+                MailListEntry(
+                    index = index + 1,
+                    id = msg.id,
+                    from = msg.fromName,
+                    date = msg.sentAtEpochMs,
+                    read = msg.read,
+                    preview = msg.body.lineSequence().firstOrNull()?.take(80) ?: "",
+                )
+            },
+            supportCheck = "Mail",
+        )
+    }
+
+    suspend fun sendMailMessage(
+        sessionId: SessionId,
+        index: Int,
+        msg: dev.ambon.domain.mail.MailMessage,
+    ) {
+        emit(
+            sessionId,
+            "Mail.Message",
+            MailMessagePayload(
+                index = index,
+                id = msg.id,
+                from = msg.fromName,
+                body = msg.body,
+                date = msg.sentAtEpochMs,
+                read = msg.read,
+            ),
+            supportCheck = "Mail",
+        )
+    }
+
+    suspend fun sendMailNotification(
+        sessionId: SessionId,
+        from: String,
+        unreadCount: Int,
+    ) {
+        emit(
+            sessionId,
+            "Mail.Notification",
+            MailNotificationPayload(from = from, unreadCount = unreadCount),
+            supportCheck = "Mail",
+        )
+    }
+
     // ---------- gain events ----------
 
     suspend fun sendCharGain(
@@ -1303,6 +1359,31 @@ class GmcpEmitter(
     private data class CharCooldownPayload(
         val abilityId: String,
         val cooldownMs: Long,
+    )
+
+    // ---------- mail payloads ----------
+
+    private data class MailListEntry(
+        val index: Int,
+        val id: String,
+        val from: String,
+        val date: Long,
+        val read: Boolean,
+        val preview: String,
+    )
+
+    private data class MailMessagePayload(
+        val index: Int,
+        val id: String,
+        val from: String,
+        val body: String,
+        val date: Long,
+        val read: Boolean,
+    )
+
+    private data class MailNotificationPayload(
+        val from: String,
+        val unreadCount: Int,
     )
 
     // ---------- gain payload ----------

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/MailHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/MailHandler.kt
@@ -18,6 +18,7 @@ class MailHandler(
 ) : CommandHandler {
     private val players = ctx.players
     private val outbound = ctx.outbound
+    private val gmcpEmitter = ctx.gmcpEmitter
 
     override fun register(router: CommandRouter) {
         router.on<Command.Mail.List> { sid, _ -> handleList(sid) }
@@ -45,6 +46,7 @@ class MailHandler(
 
     private suspend fun handleList(sessionId: SessionId) {
         players.withPlayer(sessionId) { me ->
+            gmcpEmitter?.sendMailList(sessionId, me.inbox)
             if (me.inbox.isEmpty()) {
                 outbound.send(OutboundEvent.SendInfo(sessionId, "Your inbox is empty."))
                 return@withPlayer
@@ -82,7 +84,9 @@ class MailHandler(
             if (!msg.read) {
                 me.inbox[cmd.index - 1] = msg.copy(read = true)
                 players.persistPlayer(sessionId)
+                gmcpEmitter?.sendMailList(sessionId, me.inbox)
             }
+            gmcpEmitter?.sendMailMessage(sessionId, cmd.index, me.inbox[cmd.index - 1])
         }
     }
 
@@ -98,6 +102,7 @@ class MailHandler(
             me.inbox.removeAt(cmd.index - 1)
             outbound.send(OutboundEvent.SendInfo(sessionId, "Message ${cmd.index} deleted."))
             players.persistPlayer(sessionId)
+            gmcpEmitter?.sendMailList(sessionId, me.inbox)
         }
     }
 
@@ -167,6 +172,9 @@ class MailHandler(
                         "You have new mail from ${sender.name}. Type 'mail' to read it.",
                     ),
                 )
+                val unread = recipientOnline.inbox.count { !it.read }
+                gmcpEmitter?.sendMailNotification(recipientOnline.sessionId, sender.name, unread)
+                gmcpEmitter?.sendMailList(recipientOnline.sessionId, recipientOnline.inbox)
             }
         } else {
             val delivered = players.deliverMailOffline(compose.recipientName, message)

--- a/src/main/kotlin/dev/ambon/engine/events/LoginFlowHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/LoginFlowHandler.kt
@@ -538,6 +538,7 @@ internal class LoginFlowHandler(
         }
         router.handle(sessionId, Command.Look)
 
+        gmcpEmitter.sendMailList(sessionId, me.inbox)
         val unread = me.inbox.count { !it.read }
         if (unread > 0) {
             outbound.send(

--- a/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
+++ b/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
@@ -205,7 +205,7 @@ private suspend fun DefaultWebSocketServerSession.bridgeWebSocketSession(
         InboundEvent.GmcpReceived(
             sessionId,
             "Core.Supports.Set",
-            """["Char.Vitals 1","Room.Info 1","Zone.Map 1","Char.StatusVars 1","Char.Items 1","Char.Equipment 1","Room.Players 1","Room.Mobs 1","Room.Items 1","Char.Skills 1","Char.Name 1","Char.StatusEffects 1","Char.Achievements 1","Comm.Channel 1","Guild 1","Group.Info 1","Friends 1","Core.Ping 1","Dialogue 1","Shop 1","Char.Combat 1","Char.Combat.Event 1","Char.Stats 1","Quest 1","Char.Cooldown 1","Char.Gain 1","Room.MobInfo 1","Login 1","Server 1","UI.Feedback 1","Staff 1"]""",
+            """["Char.Vitals 1","Room.Info 1","Zone.Map 1","Char.StatusVars 1","Char.Items 1","Char.Equipment 1","Room.Players 1","Room.Mobs 1","Room.Items 1","Char.Skills 1","Char.Name 1","Char.StatusEffects 1","Char.Achievements 1","Comm.Channel 1","Guild 1","Group.Info 1","Friends 1","Core.Ping 1","Dialogue 1","Shop 1","Char.Combat 1","Char.Combat.Event 1","Char.Stats 1","Quest 1","Char.Cooldown 1","Char.Gain 1","Room.MobInfo 1","Mail 1","Login 1","Server 1","UI.Feedback 1","Staff 1"]""",
         ),
     )
     metrics.onWsConnected()

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -14,6 +14,7 @@ import { InventoryPanel } from "./components/panels/InventoryPanel";
 import { EquipmentPanel } from "./components/panels/EquipmentPanel";
 import { PlayPanel } from "./components/panels/PlayPanel";
 import { AdminPanel } from "./components/panels/AdminPanel";
+import { MailPanel } from "./components/panels/MailPanel";
 import { applyGmcpPackage } from "./gmcp/applyGmcpPackage";
 import { canvasCallbacks, gameStateRef, pendingCastRef } from "./canvas/GameStateBridge";
 import { canvasEvents } from "./canvas/CanvasEventBus";
@@ -50,6 +51,8 @@ import type {
   ItemSummary,
   LoginErrorState,
   LoginPromptState,
+  MailEntry,
+  MailMessage,
   MobInfo,
   PopoutPanel,
   QuestAvailable,
@@ -203,6 +206,8 @@ function App() {
   const [mobInfo, setMobInfo] = useState<MobInfo[]>([]);
   const [shop, setShop] = useState<ShopState | null>(null);
   const [questNotifications, setQuestNotifications] = useState<QuestNotification[]>([]);
+  const [mailInbox, setMailInbox] = useState<MailEntry[]>([]);
+  const [mailMessage, setMailMessage] = useState<MailMessage | null>(null);
   const [loginPrompt, setLoginPrompt] = useState<LoginPromptState | null>(null);
   const [loginError, setLoginError] = useState<LoginErrorState | null>(null);
   const [serverAssets, setServerAssets] = useState<Record<string, string>>({});
@@ -272,6 +277,10 @@ function App() {
     });
   }, []);
 
+  const pushMailNotification = useCallback(() => {
+    // Mail.List GMCP already updates the inbox; notification is informational.
+  }, []);
+
   const focusComposer = useCallback(() => {
     window.requestAnimationFrame(() => composerInputRef.current?.focus());
   }, []);
@@ -322,6 +331,8 @@ function App() {
     setMobInfo([]);
     setShop(null);
     setQuestNotifications([]);
+    setMailInbox([]);
+    setMailMessage(null);
     setLoginPrompt(null);
     setLoginError(null);
     combatEventsRef.current = [];
@@ -383,11 +394,14 @@ function App() {
           setServerAssets,
           pushUiFeedback,
           setStaffWorldInfo,
+          setMailInbox,
+          setMailMessage,
+          pushMailNotification,
           sendGmcp: (pkg: string, payload: unknown) => sendGmcpRef.current(pkg, payload),
         },
       );
     },
-    [pushFriendNotification, pushCombatEvent, pushGainEvent, pushQuestNotification, pushUiFeedback, updateMap, loadZoneMap],
+    [pushFriendNotification, pushCombatEvent, pushGainEvent, pushQuestNotification, pushUiFeedback, pushMailNotification, updateMap, loadZoneMap],
   );
 
   const { connected, liveMessage, connect, disconnect, reconnect, sendLine, sendGmcp } = useMudSocket({
@@ -861,6 +875,7 @@ function App() {
           quickbarSlots={quickbar.slots}
           shop={shop}
           questCount={quests.length}
+          mailUnreadCount={mailInbox.filter((m) => !m.read).length}
           activePopout={activePopout}
           onOpenPopout={setActivePopout}
           onCastSkill={handleCastSkill}
@@ -1013,6 +1028,25 @@ function App() {
               setToast(`${skill.name} — ${skill.manaCost} MP, ${cd}, ${skill.targetType.toLowerCase()} target`);
             }}
             onAssignSlot={quickbar.assign}
+          />
+        )}
+
+        {activePopout === "mail" && (
+          <MailPanel
+            connected={connected}
+            hasCharacterProfile={hasCharacterProfile}
+            inbox={mailInbox}
+            openMessage={mailMessage}
+            onReadMessage={(index) => {
+              sendCommand(`mail read ${index}`, true);
+            }}
+            onDeleteMessage={(index) => {
+              sendCommand(`mail delete ${index}`, true);
+            }}
+            onCompose={(recipient) => {
+              sendCommand(`mail send ${recipient}`, true);
+            }}
+            onClearMessage={() => setMailMessage(null)}
           />
         )}
 

--- a/web-v3/src/components/ActionBar.tsx
+++ b/web-v3/src/components/ActionBar.tsx
@@ -7,6 +7,7 @@ import {
   EquipmentIcon,
   WearingIcon,
   ChatBubbleIcon,
+  MailIcon,
   ShopIcon,
   HelpIcon,
   SpellbookIcon,
@@ -39,6 +40,7 @@ interface ActionBarProps {
   quickbarSlots: (SkillSummary | null)[];
   shop: ShopState | null;
   questCount: number;
+  mailUnreadCount: number;
   activePopout: PopoutPanel;
   onOpenPopout: (panel: PopoutPanel) => void;
   onCastSkill: (skillId: string, cooldownMs: number) => void;
@@ -160,6 +162,7 @@ export function ActionBar({
   quickbarSlots,
   shop,
   questCount,
+  mailUnreadCount,
   activePopout,
   onOpenPopout,
   onCastSkill,
@@ -183,6 +186,7 @@ export function ActionBar({
     { panel: "inventory", label: "Inventory", icon: <EquipmentIcon className="action-bar-btn-icon" />, requiresProfile: true },
     { panel: "spellbook", label: "Spellbook", icon: <SpellbookIcon className="action-bar-btn-icon" />, requiresProfile: true },
     { panel: "quests", label: "Quests", icon: <QuestsTabIcon className="action-bar-btn-icon" />, requiresProfile: true, badge: questCount > 0 ? questCount : undefined },
+    { panel: "mail", label: "Mail", icon: <MailIcon className="action-bar-btn-icon" />, requiresProfile: true, badge: mailUnreadCount > 0 ? mailUnreadCount : undefined },
     { panel: "chat", label: "Social", icon: <ChatBubbleIcon className="action-bar-btn-icon" />, requiresProfile: true },
     { panel: "help", label: "Help", icon: <HelpIcon className="action-bar-btn-icon" />, requiresProfile: false },
   ];

--- a/web-v3/src/components/Icons.tsx
+++ b/web-v3/src/components/Icons.tsx
@@ -433,6 +433,15 @@ export function ChatBubbleIcon({ className }: { className?: string }) {
   );
 }
 
+export function MailIcon({ className }: { className?: string }) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">
+      <rect x="3" y="5.5" width="18" height="13" rx="2" stroke="currentColor" strokeWidth="1.9" />
+      <path d="M3 7.5l9 5.5 9-5.5" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
 export function GlobeIcon({ className }: { className?: string }) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">

--- a/web-v3/src/components/panels/MailPanel.tsx
+++ b/web-v3/src/components/panels/MailPanel.tsx
@@ -1,0 +1,140 @@
+import { useState } from "react";
+import type { MailEntry, MailMessage } from "../../types";
+
+interface MailPanelProps {
+  connected: boolean;
+  hasCharacterProfile: boolean;
+  inbox: MailEntry[];
+  openMessage: MailMessage | null;
+  onReadMessage: (index: number) => void;
+  onDeleteMessage: (index: number) => void;
+  onCompose: (recipient: string) => void;
+  onClearMessage: () => void;
+}
+
+function formatDate(epochMs: number): string {
+  if (!epochMs) return "";
+  const d = new Date(epochMs);
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+}
+
+export function MailPanel({
+  connected,
+  hasCharacterProfile,
+  inbox,
+  openMessage,
+  onReadMessage,
+  onDeleteMessage,
+  onCompose,
+  onClearMessage,
+}: MailPanelProps) {
+  const [composeTarget, setComposeTarget] = useState("");
+  const [showCompose, setShowCompose] = useState(false);
+
+  if (!connected) {
+    return <p className="empty-note">Connect to view mail.</p>;
+  }
+  if (!hasCharacterProfile) {
+    return <p className="empty-note">Log in to view mail.</p>;
+  }
+
+  const unreadCount = inbox.filter((m) => !m.read).length;
+
+  // Reading a message
+  if (openMessage) {
+    return (
+      <div className="mail-panel">
+        <div className="mail-message-view">
+          <div className="mail-message-header">
+            <button className="mail-back-button" onClick={onClearMessage}>
+              &larr; Back
+            </button>
+            <span className="mail-message-title">Message {openMessage.index}</span>
+          </div>
+          <div className="mail-message-meta">
+            <span className="mail-message-from">From: <strong>{openMessage.from}</strong></span>
+            <span className="mail-message-date">{formatDate(openMessage.date)}</span>
+          </div>
+          <pre className="mail-message-body">{openMessage.body}</pre>
+        </div>
+      </div>
+    );
+  }
+
+  // Compose form
+  if (showCompose) {
+    return (
+      <div className="mail-panel">
+        <div className="mail-compose">
+          <div className="mail-message-header">
+            <button className="mail-back-button" onClick={() => { setShowCompose(false); setComposeTarget(""); }}>
+              &larr; Back
+            </button>
+            <span className="mail-message-title">New Message</span>
+          </div>
+          <div className="mail-compose-form">
+            <input
+              type="text"
+              className="mail-compose-input"
+              placeholder="Recipient name"
+              value={composeTarget}
+              onChange={(e) => setComposeTarget(e.target.value)}
+              autoFocus
+            />
+            <button
+              className="mail-compose-send"
+              disabled={composeTarget.trim().length === 0}
+              onClick={() => {
+                onCompose(composeTarget.trim());
+                setComposeTarget("");
+                setShowCompose(false);
+              }}
+            >
+              Begin Compose
+            </button>
+            <p className="mail-compose-hint">
+              This will start a compose session in the terminal. Type your message line by line, then type <code>.</code> alone to send.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Inbox list
+  return (
+    <div className="mail-panel">
+      <div className="mail-toolbar">
+        <span className="mail-inbox-label">
+          Inbox ({inbox.length}){unreadCount > 0 && <span className="mail-unread-badge">{unreadCount} new</span>}
+        </span>
+        <button className="mail-compose-button" onClick={() => setShowCompose(true)}>
+          Compose
+        </button>
+      </div>
+      {inbox.length === 0 ? (
+        <p className="empty-note">Your inbox is empty.</p>
+      ) : (
+        <ul className="mail-inbox-list">
+          {inbox.map((entry) => (
+            <li key={entry.id} className={`mail-inbox-item ${entry.read ? "" : "mail-unread"}`}>
+              <button className="mail-inbox-row" onClick={() => onReadMessage(entry.index)}>
+                <span className="mail-inbox-marker">{entry.read ? "" : "\u2022"}</span>
+                <span className="mail-inbox-from">{entry.from}</span>
+                <span className="mail-inbox-preview">{entry.preview}</span>
+                <span className="mail-inbox-date">{formatDate(entry.date)}</span>
+              </button>
+              <button
+                className="mail-delete-button"
+                title="Delete message"
+                onClick={() => onDeleteMessage(entry.index)}
+              >
+                &times;
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -23,6 +23,9 @@ import type {
   ItemSummary,
   LoginErrorState,
   LoginPromptState,
+  MailEntry,
+  MailMessage,
+  MailNotification,
   MobInfo,
   QuestAvailable,
   QuestEntry,
@@ -80,6 +83,9 @@ interface GmcpContext {
   setServerAssets: Dispatch<SetStateAction<Record<string, string>>>;
   pushUiFeedback: (feedback: UiFeedback) => void;
   setStaffWorldInfo: Dispatch<SetStateAction<StaffWorldZone[]>>;
+  setMailInbox: Dispatch<SetStateAction<MailEntry[]>>;
+  setMailMessage: Dispatch<SetStateAction<MailMessage | null>>;
+  pushMailNotification: (notification?: MailNotification) => void;
   sendGmcp: (pkg: string, payload: unknown) => void;
 }
 
@@ -920,6 +926,48 @@ export function applyGmcpPackage(
     case "UI.Feedback": {
       const packet = data as UiFeedback;
       ctx.pushUiFeedback(packet);
+      break;
+    }
+
+    case "Mail.List": {
+      if (!Array.isArray(data)) {
+        ctx.setMailInbox([]);
+        break;
+      }
+      ctx.setMailInbox(
+        data
+          .filter((e): e is Record<string, unknown> => typeof e === "object" && e !== null)
+          .map((e) => ({
+            index: safeNumber(e.index, 0),
+            id: typeof e.id === "string" ? e.id : "",
+            from: typeof e.from === "string" ? e.from : "",
+            date: safeNumber(e.date, 0),
+            read: e.read === true,
+            preview: typeof e.preview === "string" ? e.preview : "",
+          })),
+      );
+      break;
+    }
+
+    case "Mail.Message": {
+      const packet = data as Partial<Record<string, unknown>>;
+      ctx.setMailMessage({
+        index: safeNumber(packet.index, 0),
+        id: typeof packet.id === "string" ? packet.id : "",
+        from: typeof packet.from === "string" ? packet.from : "",
+        body: typeof packet.body === "string" ? packet.body : "",
+        date: safeNumber(packet.date, 0),
+        read: packet.read === true,
+      });
+      break;
+    }
+
+    case "Mail.Notification": {
+      const packet = data as Partial<Record<string, unknown>>;
+      ctx.pushMailNotification({
+        from: typeof packet.from === "string" ? packet.from : "",
+        unreadCount: safeNumber(packet.unreadCount, 0),
+      });
       break;
     }
 

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -2746,6 +2746,259 @@ body {
 
 /* ────────── Quest Panel (dedicated popout) ────────── */
 
+/* ── Mail panel ── */
+
+.mail-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-2) 0;
+}
+
+.mail-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 var(--space-2);
+}
+
+.mail-inbox-label {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.mail-unread-badge {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 7px;
+  border-radius: var(--radius-full);
+  background: linear-gradient(140deg, rgb(141 123 169 / 90%), rgb(110 90 148 / 85%));
+  color: var(--text-bright);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.mail-compose-button {
+  padding: 4px 12px;
+  border: 1px solid var(--line-faint);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  cursor: pointer;
+  transition: background 150ms var(--ease-out-soft), color 150ms var(--ease-out-soft);
+}
+
+.mail-compose-button:hover {
+  background: var(--bg-surface-hover);
+  color: var(--text-bright);
+}
+
+.mail-inbox-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.mail-inbox-item {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--line-faint);
+}
+
+.mail-inbox-item.mail-unread {
+  background: rgb(141 123 169 / 8%);
+}
+
+.mail-inbox-row {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px var(--space-2);
+  border: none;
+  background: none;
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+  font-size: 0.8rem;
+  cursor: pointer;
+  text-align: left;
+  transition: color 120ms;
+}
+
+.mail-inbox-row:hover {
+  color: var(--text-bright);
+}
+
+.mail-inbox-marker {
+  width: 10px;
+  color: var(--color-primary-lavender);
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.mail-inbox-from {
+  font-weight: 600;
+  color: var(--text-primary);
+  flex-shrink: 0;
+  min-width: 70px;
+}
+
+.mail-inbox-preview {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  opacity: 0.7;
+}
+
+.mail-inbox-date {
+  flex-shrink: 0;
+  font-size: 0.72rem;
+  opacity: 0.5;
+}
+
+.mail-delete-button {
+  padding: 4px 8px;
+  border: none;
+  background: none;
+  color: var(--text-secondary);
+  font-size: 1rem;
+  cursor: pointer;
+  opacity: 0.4;
+  transition: opacity 120ms, color 120ms;
+}
+
+.mail-delete-button:hover {
+  opacity: 1;
+  color: var(--color-error);
+}
+
+.mail-message-view {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: 0 var(--space-2);
+}
+
+.mail-message-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.mail-back-button {
+  padding: 4px 10px;
+  border: 1px solid var(--line-faint);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  cursor: pointer;
+  transition: background 150ms, color 150ms;
+}
+
+.mail-back-button:hover {
+  background: var(--bg-surface-hover);
+  color: var(--text-bright);
+}
+
+.mail-message-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.mail-message-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  padding-bottom: var(--space-1);
+  border-bottom: 1px solid var(--line-faint);
+}
+
+.mail-message-from strong {
+  color: var(--text-primary);
+}
+
+.mail-message-body {
+  font-family: var(--font-body);
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  margin: 0;
+}
+
+.mail-compose {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: 0 var(--space-2);
+}
+
+.mail-compose-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.mail-compose-input {
+  padding: 6px 10px;
+  border: 1px solid var(--line-faint);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 0.82rem;
+}
+
+.mail-compose-input:focus {
+  outline: none;
+  border-color: var(--color-primary-lavender);
+}
+
+.mail-compose-send {
+  align-self: flex-start;
+  padding: 6px 16px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: var(--color-primary-lavender);
+  color: var(--text-bright);
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 150ms;
+}
+
+.mail-compose-send:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.mail-compose-send:not(:disabled):hover {
+  opacity: 0.85;
+}
+
+.mail-compose-hint {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  opacity: 0.7;
+  margin: 0;
+}
+
+.mail-compose-hint code {
+  background: var(--bg-surface);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+/* ── Quest panel ── */
+
 .quest-panel {
   display: flex;
   flex-direction: column;

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -1,4 +1,4 @@
-export type PopoutPanel = "map" | "inventory" | "equipment" | "room" | "help" | "character" | "chat" | "shop" | "spellbook" | "quests" | null;
+export type PopoutPanel = "map" | "inventory" | "equipment" | "room" | "help" | "character" | "chat" | "shop" | "spellbook" | "quests" | "mail" | null;
 export type ChatChannel = "say" | "tell" | "gossip" | "shout" | "ooc" | "gtell" | "gchat";
 export type SocialTab = "chat" | "friends" | "guild" | "group" | "who";
 
@@ -291,6 +291,29 @@ export interface GainEvent {
   newLevel: number | null;
   hpGained: number | null;
   manaGained: number | null;
+}
+
+export interface MailEntry {
+  index: number;
+  id: string;
+  from: string;
+  date: number;
+  read: boolean;
+  preview: string;
+}
+
+export interface MailMessage {
+  index: number;
+  id: string;
+  from: string;
+  body: string;
+  date: number;
+  read: boolean;
+}
+
+export interface MailNotification {
+  from: string;
+  unreadCount: number;
 }
 
 export interface QuestNotification {


### PR DESCRIPTION
## Summary

Adds end-to-end mail support for the web client — previously mail was text-only.

### Server (GMCP)
- **`Mail.List`**: Emitted on login, and after list/read/delete operations. Array of `{index, id, from, date, read, preview}`
- **`Mail.Message`**: Emitted when reading a message. `{index, id, from, body, date, read}`
- **`Mail.Notification`**: Emitted to recipient when new mail is delivered. `{from, unreadCount}`
- Registered `"Mail 1"` in WebSocket auto-opt-in list

### Web client
- **MailPanel**: Inbox list with read/unread indicators, message viewer, compose form (initiates `mail send` compose session in terminal)
- **Action bar**: Mail button with unread badge count
- **GMCP handlers**: `Mail.List`, `Mail.Message`, `Mail.Notification`
- **MailIcon**: New SVG envelope icon

Closes #674

## Test plan

- [x] `ktlintCheck` passes
- [x] All 1083 tests pass
- [x] TypeScript type check clean
- [x] ESLint clean
- [ ] Manual: log in via web, verify Mail.List emits inbox on login
- [ ] Manual: open Mail panel, verify inbox displays with read/unread state
- [ ] Manual: click message to read, verify message view renders
- [ ] Manual: delete a message, verify list refreshes
- [ ] Manual: compose to another player, verify recipient gets notification
- [ ] Manual: verify unread badge on action bar