### PR TITLE
Player sprite selection system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ Sessions
 - **Communication:** Say, Tell, Whisper, Gossip, Shout, Ooc, Pose, Emote, Gtell
 - **Combat:** Kill, Flee, Cast, Dispel
 - **Items:** Get, Drop, Use, Give, Wear, Remove, Inventory, Equipment
-- **Progression:** Score, Spells, Effects, Balance, QuestLog, QuestInfo, QuestAccept, QuestAbandon, AchievementList, TitleSet, TitleClear
+- **Progression:** Score, Spells, Effects, Balance, QuestLog, QuestInfo, QuestAccept, QuestAbandon, AchievementList, TitleSet, TitleClear, SpriteList, SpriteSet, SpriteDefault
 - **NPCs:** Talk, DialogueChoice, ShopList, Buy, Sell
 - **Groups:** GroupCmd (Invite, Accept, Leave, Kick, List)
 - **Guilds:** Guild (Create, Disband, Invite, Accept, Leave, Kick, Promote, Demote, Motd, Roster, Info), Gchat
@@ -153,13 +153,14 @@ Sessions
 |---------|---------|-----------|
 | `dev.ambon` | Entry point, wiring | `Main.kt` (bootstrap), `MudServer.kt` (25K, composition root), `CoroutineExtensions.kt` |
 | `dev.ambon.config` | Configuration | `AppConfig.kt` (33K, full schema + `validated()`), `AppConfigLoader.kt` |
-| `dev.ambon.engine` | Core game logic | `GameEngine.kt` (38K, tick loop), `PlayerRegistry.kt`, `PlayerState.kt`, `CombatSystem.kt` (25K), `MobSystem.kt`, `MobRegistry.kt`, `RegenSystem.kt`, `PlayerProgression.kt`, `GmcpEmitter.kt` (15K), `GroupSystem.kt` (12K), `QuestSystem.kt` (11K), `AchievementSystem.kt` (10K), `GuildSystem.kt`, `CraftingSystem.kt`, `FriendsSystem.kt`, `ThreatTable.kt`, `ShopRegistry.kt`, `EngineUtil.kt` |
-| `dev.ambon.engine.commands` | Command parsing/routing | `CommandParser.kt` (17K, sealed Command hierarchy), `CommandRouter.kt` (dispatch infrastructure only); handlers in `handlers/` subpackage: `NavigationHandler`, `CommunicationHandler`, `CombatHandler`, `ItemHandler`, `WorldFeaturesHandler`, `ProgressionHandler`, `DialogueQuestHandler`, `ShopHandler`, `GroupHandler`, `GuildHandler`, `CraftingHandler`, `FriendsHandler`, `MailHandler`, `UiHandler`, `AdminHandler`, `HandlerHelpers` |
+| `dev.ambon.engine` | Core game logic | `GameEngine.kt` (38K, tick loop), `PlayerRegistry.kt`, `PlayerState.kt`, `CombatSystem.kt` (25K), `MobSystem.kt`, `MobRegistry.kt`, `RegenSystem.kt`, `PlayerProgression.kt`, `GmcpEmitter.kt` (15K), `GroupSystem.kt` (12K), `QuestSystem.kt` (11K), `AchievementSystem.kt` (10K), `GuildSystem.kt`, `CraftingSystem.kt`, `FriendsSystem.kt`, `ThreatTable.kt`, `ShopRegistry.kt`, `SpriteRegistry.kt`, `SpriteLoader.kt`, `EngineUtil.kt` |
+| `dev.ambon.engine.commands` | Command parsing/routing | `CommandParser.kt` (17K, sealed Command hierarchy), `CommandRouter.kt` (dispatch infrastructure only); handlers in `handlers/` subpackage: `NavigationHandler`, `CommunicationHandler`, `CombatHandler`, `ItemHandler`, `WorldFeaturesHandler`, `ProgressionHandler`, `DialogueQuestHandler`, `ShopHandler`, `GroupHandler`, `GuildHandler`, `CraftingHandler`, `FriendsHandler`, `MailHandler`, `SpriteHandler`, `UiHandler`, `AdminHandler`, `HandlerHelpers` |
 | `dev.ambon.engine.abilities` | Ability/spell system | `AbilitySystem.kt` (16K), `AbilityRegistry.kt`, `AbilityRegistryLoader.kt`, `AbilityDefinition.kt` |
 | `dev.ambon.engine.status` | Status effects | `StatusEffectSystem.kt` (13K), `StatusEffectRegistry.kt`, `StatusEffectRegistryLoader.kt`, `StatusEffectDefinition.kt`, `ActiveEffect.kt` |
 | `dev.ambon.engine.behavior` | Mob behavior trees | `BehaviorTreeSystem.kt`, `BtNode.kt`, `BtResult.kt`, `BtContext.kt`, `BehaviorTemplates.kt`, `MobBehaviorMemory.kt`; nodes/conditions/actions subdirs |
 | `dev.ambon.engine.dialogue` | NPC dialogue | `DialogueSystem.kt`, `DialogueTree.kt` |
 | `dev.ambon.engine.items` | Item management | `ItemRegistry.kt` (17K), `ItemMatching.kt` |
+| `dev.ambon.domain.sprite` | Sprite domain model | `SpriteDefinition.kt` (SpriteDefinition, SpriteVariant, SpriteCategory, SpriteUnlockCondition) |
 | `dev.ambon.engine.scheduler` | Delayed actions | `Scheduler.kt` |
 | `dev.ambon.engine.events` | Event types | `InboundEvent.kt`, `OutboundEvent.kt` |
 | `dev.ambon.bus` | Event bus abstractions | `InboundBus.kt`, `OutboundBus.kt` (interfaces); `Local*Bus.kt`, `Redis*Bus.kt`, `Grpc*Bus.kt` (impls); `DepthTrackingChannel.kt` |
@@ -298,6 +299,9 @@ Edit `GuildSystem.kt` for logic, `GuildHandler.kt` for commands. Guild persisten
 
 ### Crafting system changes
 Edit `CraftingSystem.kt` for logic, `CraftingHandler.kt` for commands (Gather, Craft, Recipes). `PlayerRecord.craftingSkills` stores per-player skill levels. Recipe definitions live in `application.yaml` under the crafting config section. Test in `CraftingSystemTest`.
+
+### Sprite system changes
+`SpriteRegistry` holds all sprite definitions. Tier and staff sprites are auto-generated in `MudServer.kt` via `SpriteLoader.generateTierSprites()` / `generateStaffSprites()`. Achievement sprites are defined in `src/main/resources/world/sprites.yaml` and loaded via `SpriteLoader.loadFromResource()`. Commands in `SpriteHandler.kt` (SpriteList, SpriteSet, SpriteDefault). `PlayerRecord.activeSprite` / `PlayerState.activeSprite` store the player's selection (null = auto). `GmcpEmitter.resolveSprite()` uses the registry; `sendCharSprites()` emits `Char.Sprites` GMCP. Tier names configured in `AppConfig.ImagesConfig.spriteTierNames`. See `docs/ARCANUM_SPRITE_INSTRUCTIONS.md` for image naming conventions. Test in `SpriteRegistryTest`, `SpriteLoaderTest`, `SpriteCommandTest`.
 
 ## Kotlin Style (ktlint)
 

--- a/docs/ARCANUM_SPRITE_INSTRUCTIONS.md
+++ b/docs/ARCANUM_SPRITE_INSTRUCTIONS.md
@@ -1,0 +1,138 @@
+# Arcanum Sprite Instructions
+
+This document describes the sprite system's naming conventions, file structure, and how to add new sprites using the Ambon Arcanum creator tool.
+
+## Overview
+
+Player sprites are images displayed in the web client to represent the player's character. Sprites are organized into three categories:
+
+- **Tier sprites** — Unlocked by reaching level thresholds (1, 10, 20, 30, 40, 50). One image per race/class combination.
+- **Achievement sprites** — Unlocked by earning specific achievements. May have race, class, and/or gender variants.
+- **Staff sprites** — Available only to staff members. One image per race.
+
+## File Location
+
+All player sprite images go in the `player_sprites/` directory under the images asset base.
+
+## Naming Conventions
+
+### Tier Sprites (auto-generated, existing pattern)
+
+Format: `{race}_{class}_{tierSuffix}.png`
+
+| Level | Tier Suffix | Tier Name |
+|-------|-------------|-----------|
+| 1+    | `t1`        | Novice |
+| 10+   | `t10`       | Apprentice |
+| 20+   | `t20`       | Journeyman |
+| 30+   | `t30`       | Expert |
+| 40+   | `t40`       | Master |
+| 50+   | `t50`       | Legend |
+
+Races: `human`, `elf`, `dwarf`, `halfling`
+Classes: `warrior`, `mage`, `cleric`, `rogue`
+
+Examples:
+- `elf_mage_t1.png` — Elf Mage, Novice tier
+- `human_warrior_t50.png` — Human Warrior, Legend tier
+- `dwarf_cleric_t20.png` — Dwarf Cleric, Journeyman tier
+
+Total tier sprites: 4 races x 4 classes x 6 tiers = **96 images**
+
+### Staff Sprites (auto-generated, existing pattern)
+
+Format: `{race}_base_tstaff.png`
+
+Examples:
+- `elf_base_tstaff.png`
+- `human_base_tstaff.png`
+- `dwarf_base_tstaff.png`
+- `halfling_base_tstaff.png`
+
+Total staff sprites: **4 images** (one per race). Staff can choose any staff sprite regardless of their own race.
+
+### Achievement Sprites (custom, defined in sprites.yaml)
+
+Achievement sprites use a **template naming** system. Each sprite has a template name (e.g. `beetle_slayer`), and variants are created by prefixing with qualifiers:
+
+| Variant Type | Format | Example |
+|-------------|--------|---------|
+| Generic (any race/class) | `{template}.png` | `beetle_slayer.png` |
+| Race-specific | `{race}_{template}.png` | `elf_beetle_slayer.png` |
+| Class-specific | `{class}_{template}.png` | `rogue_spider_hunter.png` |
+| Race+Class | `{race}_{class}_{template}.png` | `elf_mage_beetle_slayer.png` |
+
+Players see only the variants that match their own race/class/gender, plus any generic variants.
+
+## Adding New Achievement Sprites
+
+### Step 1: Create the images
+
+Create one or more variant images following the naming convention above. At minimum, create a generic variant.
+
+### Step 2: Update sprites.yaml
+
+Add a new entry to `src/main/resources/world/sprites.yaml`:
+
+```yaml
+  golem_breaker:
+    displayName: "Golem Breaker"
+    category: achievement
+    sortOrder: 102
+    unlock:
+      type: achievement
+      achievementId: combat/secret_slayer
+    variants:
+      - imageId: golem_breaker
+        displayName: "Golem Breaker"
+        imagePath: player_sprites/golem_breaker.png
+      - imageId: dwarf_golem_breaker
+        displayName: "Golem Breaker (Dwarf)"
+        race: DWARF
+        imagePath: player_sprites/dwarf_golem_breaker.png
+```
+
+### Variant Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `imageId` | Yes | Unique identifier. Also used in `sprite set <id>` command. Must match file name stem. |
+| `displayName` | No | Defaults to the parent definition's displayName. |
+| `race` | No | Race filter (uppercase). If set, only players of this race see the variant. |
+| `playerClass` | No | Class filter (uppercase). If set, only players of this class see the variant. |
+| `gender` | No | Gender filter (lowercase). If set, only players of this gender see the variant. |
+| `imagePath` | Yes | Path relative to the images base URL. Always starts with `player_sprites/`. |
+
+### Unlock Types
+
+| Type | Fields | Description |
+|------|--------|-------------|
+| `achievement` | `achievementId` | Unlocked when the player earns the specified achievement. |
+| `level` | `minLevel` | Unlocked when the player reaches the specified level. |
+| `staff` | — | Unlocked for staff members only. |
+
+## Image Specifications
+
+- **Format:** PNG with transparency
+- **Dimensions:** 64x64 pixels (displayed at this size in the character panel)
+- **Style:** Follow the Surreal Gentle Magic aesthetic (see `.impeccable.md`)
+- **Background:** Transparent
+
+## Current Placeholder Sprites
+
+The following achievement sprites are defined in `sprites.yaml` but need images created:
+
+| Template | Achievement | Variants Needed |
+|----------|-------------|-----------------|
+| `beetle_slayer` | `combat/beetle_exterminator` | generic, elf, dwarf |
+| `spider_hunter` | `combat/spider_hunter` | generic, rogue |
+
+## Export Checklist
+
+When creating/exporting sprites for AmbonMUD:
+
+1. Verify file names exactly match the `imageId` + `.png` extension
+2. Place all files in the `player_sprites/` directory
+3. Upload to the assets CDN at `assets.ambon.dev`
+4. If adding new achievement sprites, update `sprites.yaml` with variant definitions
+5. Test in-game with `sprite list` and `sprite set <id>` commands

--- a/docs/GMCP_PROTOCOL.md
+++ b/docs/GMCP_PROTOCOL.md
@@ -185,6 +185,7 @@ On telnet the payload is sent as the raw JSON array (no outer envelope). Upon re
 - `Char.Skills` (if subscribed)
 - `Char.StatusEffects` (if subscribed)
 - `Char.Achievements` (if subscribed)
+- `Char.Sprites` (if subscribed)
 - `Group.Info` (if subscribed and player is in a group)
 
 ---
@@ -225,7 +226,7 @@ Response to a client `Core.Ping`.
 
 ### `Char.Name`
 
-Sent once on login. Static for the duration of the session (except `level` updates on level-up).
+Sent on login and whenever the player's sprite, level, or name changes (e.g. level-up, sprite selection).
 
 ```json
 {
@@ -234,7 +235,7 @@ Sent once on login. Static for the duration of the session (except `level` updat
   "race": "ELF",
   "class": "MAGE",
   "level": 7,
-  "sprite": "/images/player_sprites/elf_mage_t1.png",
+  "sprite": "https://assets.ambon.dev/player_sprites/elf_mage_t1.png",
   "isStaff": false
 }
 ```
@@ -246,8 +247,54 @@ Sent once on login. Static for the duration of the session (except `level` updat
 | `race`   | string  | Race enum name: `HUMAN`, `ELF`, `DWARF`, `HALFLING` |
 | `class`  | string  | Class enum name: `WARRIOR`, `MAGE`, `CLERIC`, `ROGUE` |
 | `level`  | int     | Current level |
-| `sprite` | string  | URL path to the player's current sprite image |
+| `sprite` | string  | URL to the player's active sprite image. Reflects the player's selection or auto-resolved best tier match. |
 | `isStaff`| boolean | `true` for staff/admin characters |
+
+---
+
+### `Char.Sprites`
+
+Sent on login, level-up, achievement unlock, and after the player changes their sprite selection. Lists all sprites the player has unlocked and can use.
+
+```json
+{
+  "active": "elf_mage_t1",
+  "sprites": [
+    {
+      "imageId": "elf_mage_t1",
+      "displayName": "Novice (Elf Mage)",
+      "category": "tier",
+      "imagePath": "https://assets.ambon.dev/player_sprites/elf_mage_t1.png"
+    },
+    {
+      "imageId": "t1",
+      "displayName": "Novice",
+      "category": "tier",
+      "imagePath": "https://assets.ambon.dev/player_sprites/t1.png"
+    },
+    {
+      "imageId": "beetle_slayer",
+      "displayName": "Beetle Slayer",
+      "category": "achievement",
+      "imagePath": "https://assets.ambon.dev/player_sprites/beetle_slayer.png"
+    }
+  ]
+}
+```
+
+| Field               | Type     | Notes |
+|---------------------|----------|-------|
+| `active`            | string?  | `imageId` of the currently active sprite, or the auto-resolved best match if no explicit selection. `null` if no sprites available. |
+| `sprites`           | array    | All sprites the player can choose from (unlocked + matching their race/class/gender). |
+| `sprites[].imageId` | string   | Unique variant identifier. Used in the `sprite set <id>` command. |
+| `sprites[].displayName` | string | Human-readable label for this variant. |
+| `sprites[].category` | string  | One of `tier`, `achievement`, `staff`. |
+| `sprites[].imagePath` | string | Full URL to the sprite image. |
+
+**Sprite categories:**
+- **tier** — Unlocked by reaching a level threshold (1, 10, 20, 30, 40, 50). One variant per race/class combo.
+- **achievement** — Unlocked by earning a specific achievement. May have race/class-specific variants.
+- **staff** — Available only to staff members. One variant per race.
 
 ---
 
@@ -1172,6 +1219,7 @@ These packages are coalesced — if the same session is marked dirty multiple ti
 | `Char.Items.List`    | Login / `Core.Supports.Set` |
 | `Char.Skills`        | Login / level-up (new ability) / cooldown change |
 | `Char.Achievements`  | Login / achievement progress or unlock |
+| `Char.Sprites`       | Login / level-up / achievement unlock / sprite set/clear |
 | `Char.Combat.Event`  | Each combat event (hit, dodge, heal, kill, death) |
 | `Char.Cooldown`      | Ability cooldown started |
 | `Char.Gain`          | XP/gold gained or level-up |
@@ -1254,6 +1302,7 @@ After the WebSocket connection is established, the server automatically sends `C
 ← {"gmcp":"Char.Skills","data":[...]}
 ← {"gmcp":"Char.StatusEffects","data":[]}
 ← {"gmcp":"Char.Achievements","data":{"completed":[],"inProgress":[]}}
+← {"gmcp":"Char.Sprites","data":{"active":"elf_mage_t1","sprites":[{"imageId":"elf_mage_t1","displayName":"Novice (Elf Mage)","category":"tier","imagePath":"https://assets.ambon.dev/player_sprites/elf_mage_t1.png"}]}}
 ```
 
 ### WebSocket combat tick
@@ -1341,6 +1390,7 @@ Notifies the client when the character's active display title changes (set via t
 | `Char.Skills`         | → S→C     | Full snapshot |
 | `Char.StatusEffects`  | → S→C     | Batched per tick |
 | `Char.Achievements`   | → S→C     | Full snapshot |
+| `Char.Sprites`        | → S→C     | Full snapshot |
 | `Char.Stats`          | → S→C     | Batched per tick |
 | `Char.Cooldown`       | → S→C     | Immediate |
 | `Char.Gain`           | → S→C     | Immediate |

--- a/src/main/kotlin/dev/ambon/MudServer.kt
+++ b/src/main/kotlin/dev/ambon/MudServer.kt
@@ -24,6 +24,8 @@ import dev.ambon.engine.RaceRegistry
 import dev.ambon.engine.RaceRegistryLoader
 import dev.ambon.engine.ReloadRequest
 import dev.ambon.engine.ShopRegistry
+import dev.ambon.engine.SpriteLoader
+import dev.ambon.engine.SpriteRegistry
 import dev.ambon.engine.StatRegistry
 import dev.ambon.engine.StatRegistryLoader
 import dev.ambon.engine.WorldStateRegistry
@@ -175,6 +177,20 @@ class MudServer(
     private val statRegistry =
         StatRegistry().also { reg ->
             StatRegistryLoader.load(config.engine.stats, reg)
+        }
+    private val spriteRegistry =
+        SpriteRegistry().also { reg ->
+            SpriteLoader.generateTierSprites(
+                registry = reg,
+                tierNames = config.images.spriteTierNames,
+                raceIds = raceRegistry.all().map { it.id },
+                classIds = classRegistry.all().map { it.id },
+            )
+            SpriteLoader.generateStaffSprites(
+                registry = reg,
+                raceIds = raceRegistry.all().map { it.id },
+            )
+            SpriteLoader.loadFromResource("world/sprites.yaml", reg)
         }
     private val progression = PlayerProgression(config.progression, classRegistry, config.engine.stats.bindings)
     private val shardingEnabled = config.sharding.enabled
@@ -388,7 +404,7 @@ class MudServer(
                     statRegistryOverride = statRegistry,
                     imagesBaseUrl = config.images.baseUrl,
                     globalAssets = config.images.globalAssets,
-                    spriteLevelTiers = config.images.spriteLevelTiers,
+                    spriteRegistry = spriteRegistry,
                     worldLoader = {
                         WorldFactory.demoWorld(
                             resources = config.world.resources,

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -896,6 +896,7 @@ data class CommandsConfig(
             "read" to CommandMetadata(usage = "read <sign>", category = "world"),
             "title" to CommandMetadata(usage = "title <titleName> | title clear", category = "progression"),
             "gender" to CommandMetadata(usage = "gender <option>", category = "progression"),
+            "sprite" to CommandMetadata(usage = "sprite list | set <id> | default", category = "progression"),
             "friend" to CommandMetadata(usage = "friend list | add <player> | remove <player>", category = "social"),
             "mail" to CommandMetadata(usage = "mail list | read <n> | send <player> | delete <n>", category = "social"),
             "ansi" to CommandMetadata(usage = "ansi on/off", category = "utility"),
@@ -1433,8 +1434,18 @@ data class ImagesConfig(
     val globalAssets: Map<String, String> = DEFAULT_GLOBAL_ASSETS,
     /** Level thresholds for player sprite tiers, checked highest-first. */
     val spriteLevelTiers: List<Int> = listOf(50, 40, 30, 20, 10, 1),
+    /** Human-readable names for each sprite tier, keyed by level threshold. */
+    val spriteTierNames: Map<Int, String> = DEFAULT_SPRITE_TIER_NAMES,
 ) {
     companion object {
+        val DEFAULT_SPRITE_TIER_NAMES: Map<Int, String> = linkedMapOf(
+            1 to "Novice",
+            10 to "Apprentice",
+            20 to "Journeyman",
+            30 to "Expert",
+            40 to "Master",
+            50 to "Legend",
+        )
         val DEFAULT_GLOBAL_ASSETS: Map<String, String> = linkedMapOf(
             "compass_rose" to "global_assets/compass_rose.png",
             "direction_marker" to "global_assets/direction_marker.png",

--- a/src/main/kotlin/dev/ambon/domain/sprite/SpriteDefinition.kt
+++ b/src/main/kotlin/dev/ambon/domain/sprite/SpriteDefinition.kt
@@ -1,0 +1,66 @@
+package dev.ambon.domain.sprite
+
+/**
+ * A sprite that can be unlocked and chosen by a player.
+ *
+ * Each definition has one or more [variants] with optional race/class/gender
+ * qualifiers. A player sees only the variants whose qualifiers match (or are
+ * null, meaning "any").
+ */
+data class SpriteDefinition(
+    val id: String,
+    val displayName: String,
+    val category: SpriteCategory,
+    val unlockCondition: SpriteUnlockCondition,
+    val sortOrder: Int = 0,
+    val variants: List<SpriteVariant>,
+)
+
+enum class SpriteCategory {
+    TIER,
+    ACHIEVEMENT,
+    STAFF,
+}
+
+sealed interface SpriteUnlockCondition {
+    /** Unlocked when the player reaches [minLevel]. */
+    data class Level(
+        val minLevel: Int,
+    ) : SpriteUnlockCondition
+
+    /** Unlocked when the player earns achievement [achievementId]. */
+    data class Achievement(
+        val achievementId: String,
+    ) : SpriteUnlockCondition
+
+    /** Unlocked for staff members only. */
+    data object Staff : SpriteUnlockCondition
+}
+
+/**
+ * A single image variant within a [SpriteDefinition].
+ *
+ * The [imageId] serves as both the player-facing name (used in `sprite set`)
+ * and the file-name stem (image file = `player_sprites/{imageId}.png`).
+ *
+ * Qualifier fields ([race], [playerClass], [gender]) restrict which players
+ * can see and select this variant. `null` means "any".
+ */
+data class SpriteVariant(
+    val imageId: String,
+    val displayName: String,
+    val race: String? = null,
+    val playerClass: String? = null,
+    val gender: String? = null,
+    val imagePath: String,
+) {
+    /** Returns `true` if this variant is usable by a player with the given attributes. */
+    fun matchesPlayer(
+        playerRace: String,
+        playerClass: String,
+        playerGender: String,
+    ): Boolean =
+        (race == null || race.equals(playerRace, ignoreCase = true)) &&
+            (this.playerClass == null || this.playerClass.equals(playerClass, ignoreCase = true)) &&
+            (gender == null || gender.equals(playerGender, ignoreCase = true))
+}

--- a/src/main/kotlin/dev/ambon/engine/AchievementSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/AchievementSystem.kt
@@ -19,6 +19,7 @@ class AchievementSystem(
     private val outbound: OutboundBus,
     private val gmcpEmitter: GmcpEmitter? = null,
     private val categoryRegistry: AchievementCategoryRegistry? = null,
+    private val spriteRegistry: SpriteRegistry? = null,
 ) {
     /**
      * Called when a player kills a mob. Increments KILL criteria matching [templateKey]
@@ -232,6 +233,27 @@ class AchievementSystem(
                     "A title is now available: '${def.rewards.title}' — use 'title ${def.rewards.title}' to set it.",
                 ),
             )
+        }
+
+        // Check if this achievement unlocks any sprites
+        if (spriteRegistry != null) {
+            val newSprites = spriteRegistry.unlockedDefinitions(
+                level = ps.level,
+                unlockedAchievementIds = ps.unlockedAchievementIds,
+                isStaff = ps.isStaff,
+            ).filter {
+                it.unlockCondition is dev.ambon.domain.sprite.SpriteUnlockCondition.Achievement &&
+                    (it.unlockCondition as dev.ambon.domain.sprite.SpriteUnlockCondition.Achievement).achievementId == achievementId
+            }
+            for (spriteDef in newSprites) {
+                outbound.send(
+                    OutboundEvent.SendText(
+                        sessionId,
+                        "A new sprite is now available: '${spriteDef.displayName}' — use 'sprite list' to see your options.",
+                    ),
+                )
+            }
+            gmcpEmitter?.sendCharSprites(sessionId, ps)
         }
 
         // GMCP update is sent by updateAchievementProgress after checkAndUnlock returns

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -32,6 +32,7 @@ import dev.ambon.engine.commands.handlers.MailHandler
 import dev.ambon.engine.commands.handlers.NavigationHandler
 import dev.ambon.engine.commands.handlers.ProgressionHandler
 import dev.ambon.engine.commands.handlers.ShopHandler
+import dev.ambon.engine.commands.handlers.SpriteHandler
 import dev.ambon.engine.commands.handlers.UiHandler
 import dev.ambon.engine.commands.handlers.WorldFeaturesHandler
 import dev.ambon.engine.crafting.CraftingRegistry
@@ -133,7 +134,7 @@ class GameEngine(
     statRegistryOverride: StatRegistry? = null,
     imagesBaseUrl: String = "/images/",
     globalAssets: Map<String, String> = emptyMap(),
-    spriteLevelTiers: List<Int> = listOf(50, 40, 30, 20, 10, 1),
+    private val spriteRegistry: SpriteRegistry? = null,
     private val worldLoader: (() -> World)? = null,
     private val reloadChannel: kotlinx.coroutines.channels.Channel<ReloadRequest>? = null,
 ) {
@@ -427,7 +428,7 @@ class GameEngine(
             equipmentSlotRegistry = equipmentSlotRegistry,
             imagesBaseUrl = imagesBaseUrl,
             globalAssets = globalAssets,
-            spriteLevelTiers = spriteLevelTiers,
+            spriteRegistry = spriteRegistry,
         )
 
     fun markVitalsDirty(sessionId: SessionId) {
@@ -627,6 +628,7 @@ class GameEngine(
             outbound = outbound,
             gmcpEmitter = gmcpEmitter,
             categoryRegistry = achievementCategoryRegistry,
+            spriteRegistry = spriteRegistry,
         )
 
     init {
@@ -835,6 +837,10 @@ class GameEngine(
                 onReload = hotReloadManager?.let { mgr ->
                     { target -> handleReloadCommand(mgr, target) }
                 },
+            ),
+            SpriteHandler(
+                ctx = ctx,
+                spriteRegistry = spriteRegistry,
             ),
             UiHandler(
                 ctx = ctx,
@@ -1205,8 +1211,35 @@ class GameEngine(
                 abilitySystem.cooldownRemainingMs(sessionId, abilityId)
             }
             gmcpEmitter.sendCharGain(sessionId, "levelUp", level.toLong(), newLevel = level)
+            // Notify about new sprites if the player has a custom selection
+            if (p.activeSprite != null) {
+                notifyNewSprites(sessionId, p)
+            }
+            gmcpEmitter.sendCharSprites(sessionId, p)
         }
         achievementSystem.onLevelReached(sessionId, level)
+    }
+
+    /** Sends a text hint when a level-up or achievement unlock makes new sprites available. */
+    private suspend fun notifyNewSprites(
+        sessionId: SessionId,
+        player: PlayerState,
+    ) {
+        val reg = spriteRegistry ?: return
+        val tierDefs = reg.unlockedDefinitions(
+            level = player.level,
+            unlockedAchievementIds = player.unlockedAchievementIds,
+            isStaff = player.isStaff,
+        )
+        // Only notify if there are more sprites than just the one they have selected
+        if (tierDefs.size > 1) {
+            outbound.send(
+                OutboundEvent.SendText(
+                    sessionId,
+                    "New sprites are available! Use 'sprite list' to see your options.",
+                ),
+            )
+        }
     }
 
     private suspend fun syncRoomItemsForRoom(roomId: RoomId) {

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -53,7 +53,7 @@ class GmcpEmitter(
     private val equipmentSlotRegistry: EquipmentSlotRegistry? = null,
     imagesBaseUrl: String = "/images/",
     private val globalAssets: Map<String, String> = emptyMap(),
-    spriteLevelTiers: List<Int> = listOf(50, 40, 30, 20, 10, 1),
+    private val spriteRegistry: SpriteRegistry? = null,
 ) {
     private val json = jacksonObjectMapper()
     private val imagesBase = if (imagesBaseUrl.endsWith("/")) imagesBaseUrl else "$imagesBaseUrl/"
@@ -73,9 +73,6 @@ class GmcpEmitter(
     /** Resolved asset URLs: each value from [globalAssets] is prefixed with [imagesBase]. */
     private val resolvedAssets: Map<String, String> =
         globalAssets.mapValues { (_, path) -> "$imagesBase$path" }
-
-    /** Sorted descending so the first match is the highest tier the player qualifies for. */
-    private val sortedTiers = spriteLevelTiers.sortedDescending().toIntArray()
 
     suspend fun sendCharVitals(
         sessionId: SessionId,
@@ -500,6 +497,7 @@ class GmcpEmitter(
         }
         sendCharStatusEffects(sessionId, statusEffectSystem.activePlayerEffects(sessionId))
         sendCharAchievements(sessionId, player, achievementRegistry)
+        sendCharSprites(sessionId, player)
         sendGroupSync(sessionId, groupSystem, players)
         guildSystem?.sendGuildSync(sessionId)
     }
@@ -1694,13 +1692,92 @@ class GmcpEmitter(
         }
     }
 
-    private fun resolveSprite(player: PlayerState): String {
+    /**
+     * Resolves the sprite image URL for a player.
+     *
+     * If the player has an [activeSprite][PlayerState.activeSprite] set and the
+     * sprite registry confirms it is still valid, that variant is used. Otherwise
+     * falls back to auto-resolve (highest unlocked tier, best variant match).
+     */
+    internal fun resolveSprite(player: PlayerState): String {
+        val reg = spriteRegistry
+        if (reg != null) {
+            // Explicit selection
+            val chosen = player.activeSprite
+            if (chosen != null) {
+                val valid = reg.validateSelection(
+                    imageId = chosen,
+                    level = player.level,
+                    unlockedAchievementIds = player.unlockedAchievementIds,
+                    isStaff = player.isStaff,
+                    playerRace = player.race,
+                    playerClass = player.playerClass,
+                    playerGender = player.gender,
+                )
+                if (valid != null) return "$imagesBase${valid.imagePath}"
+            }
+            // Auto-resolve
+            val auto = reg.autoResolve(
+                level = player.level,
+                isStaff = player.isStaff,
+                playerRace = player.race,
+                playerClass = player.playerClass,
+                playerGender = player.gender,
+            )
+            if (auto != null) return "$imagesBase${auto.imagePath}"
+        }
+        // Fallback (no registry) — legacy behaviour
         val race = player.race.lowercase()
         if (player.isStaff) return "${imagesBase}player_sprites/${race}_base_tstaff.png"
         val cls = player.playerClass.lowercase()
-        val tierSuffix = "t${sortedTiers.firstOrNull { player.level >= it } ?: 1}"
-        return "${imagesBase}player_sprites/${race}_${cls}_$tierSuffix.png"
+        return "${imagesBase}player_sprites/${race}_${cls}_t1.png"
     }
+
+    /** Sends the `Char.Sprites` GMCP package listing available sprites. */
+    suspend fun sendCharSprites(
+        sessionId: SessionId,
+        player: PlayerState,
+    ) {
+        val reg = spriteRegistry ?: return
+        val available = reg.availableVariants(
+            level = player.level,
+            unlockedAchievementIds = player.unlockedAchievementIds,
+            isStaff = player.isStaff,
+            playerRace = player.race,
+            playerClass = player.playerClass,
+            playerGender = player.gender,
+        )
+        val active = player.activeSprite
+            ?: reg.autoResolve(
+                level = player.level,
+                isStaff = player.isStaff,
+                playerRace = player.race,
+                playerClass = player.playerClass,
+                playerGender = player.gender,
+            )?.imageId
+
+        val sprites = available.map { (def, v) ->
+            CharSpriteEntry(
+                imageId = v.imageId,
+                displayName = v.displayName,
+                category = def.category.name.lowercase(),
+                imagePath = "$imagesBase${v.imagePath}",
+            )
+        }
+        emit(sessionId, "Char.Sprites", CharSpritesPayload(active = active, sprites = sprites))
+    }
+
+    private data class CharSpriteEntry(
+        val imageId: String,
+        val displayName: String,
+        val category: String,
+        val imagePath: String,
+    )
+
+    private data class CharSpritesPayload(
+        val active: String?,
+        val sprites: List<CharSpriteEntry>,
+    )
 }
 
 // ---------- public data entry types for new GMCP methods ----------

--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -62,6 +62,8 @@ data class PlayerState(
     var gatherCooldownUntilMs: Long = 0L,
     /** Epoch-ms of last command input. Runtime-only; used for idle calculation. */
     var lastActivityEpochMs: Long = 0L,
+    /** Chosen sprite variant imageId, or null for auto (highest unlocked tier). */
+    var activeSprite: String? = null,
 ) {
     data class MailComposeState(
         val recipientName: String,
@@ -155,6 +157,7 @@ fun PlayerRecord.toPlayerState(sessionId: SessionId): PlayerState =
             key.lowercase() to state
         }.toMap().toMutableMap(),
         friendsList = friendsList.toMutableSet(),
+        activeSprite = activeSprite,
     )
 
 /** Converts this runtime state to a [PlayerRecord] for persistence. */
@@ -189,6 +192,7 @@ fun PlayerState.toPlayerRecord(lastSeenEpochMs: Long): PlayerRecord {
         recallRoomId = recallRoomId,
         craftingSkills = craftingSkills.toMap(),
         friendsList = friendsList.toSet(),
+        activeSprite = activeSprite,
     )
 }
 

--- a/src/main/kotlin/dev/ambon/engine/SpriteLoader.kt
+++ b/src/main/kotlin/dev/ambon/engine/SpriteLoader.kt
@@ -1,0 +1,178 @@
+package dev.ambon.engine
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import dev.ambon.domain.sprite.SpriteCategory
+import dev.ambon.domain.sprite.SpriteDefinition
+import dev.ambon.domain.sprite.SpriteUnlockCondition
+import dev.ambon.domain.sprite.SpriteVariant
+import dev.ambon.persistence.yamlMapper
+
+// ----- YAML DTOs -----
+
+internal data class SpritesFile(
+    val sprites: Map<String, SpriteEntryFile> = emptyMap(),
+)
+
+internal data class SpriteEntryFile(
+    val displayName: String = "",
+    val category: String = "achievement",
+    val sortOrder: Int = 0,
+    val unlock: SpriteUnlockFile = SpriteUnlockFile(),
+    val variants: List<SpriteVariantFile> = emptyList(),
+)
+
+internal data class SpriteUnlockFile(
+    val type: String = "",
+    val minLevel: Int = 1,
+    val achievementId: String = "",
+)
+
+internal data class SpriteVariantFile(
+    val imageId: String = "",
+    val displayName: String = "",
+    val race: String? = null,
+    val playerClass: String? = null,
+    val gender: String? = null,
+    val imagePath: String = "",
+)
+
+object SpriteLoader {
+    /**
+     * Loads custom sprite definitions from a classpath YAML resource.
+     * Silently skips if the resource does not exist.
+     */
+    fun loadFromResource(
+        resourcePath: String,
+        registry: SpriteRegistry,
+    ) {
+        val stream = SpriteLoader::class.java.classLoader.getResourceAsStream(resourcePath) ?: return
+        val file = yamlMapper.readValue<SpritesFile>(stream)
+
+        for ((rawId, entry) in file.sprites) {
+            val id = rawId.trim()
+            require(id.isNotEmpty()) { "Sprite id cannot be blank" }
+            require(entry.displayName.isNotBlank()) { "Sprite '$id' displayName cannot be blank" }
+            require(entry.variants.isNotEmpty()) { "Sprite '$id' must have at least one variant" }
+
+            val category = when (entry.category.lowercase()) {
+                "tier" -> SpriteCategory.TIER
+                "achievement" -> SpriteCategory.ACHIEVEMENT
+                "staff" -> SpriteCategory.STAFF
+                else -> error("Sprite '$id' has unknown category '${entry.category}'")
+            }
+
+            val unlockCondition = when (entry.unlock.type.lowercase()) {
+                "level" -> SpriteUnlockCondition.Level(entry.unlock.minLevel)
+                "achievement" -> {
+                    require(entry.unlock.achievementId.isNotBlank()) {
+                        "Sprite '$id' achievement unlock must specify achievementId"
+                    }
+                    SpriteUnlockCondition.Achievement(entry.unlock.achievementId)
+                }
+                "staff" -> SpriteUnlockCondition.Staff
+                else -> error("Sprite '$id' has unknown unlock type '${entry.unlock.type}'")
+            }
+
+            val variants = entry.variants.mapIndexed { i, vf ->
+                require(vf.imageId.isNotBlank()) { "Sprite '$id' variant #${i + 1} imageId cannot be blank" }
+                require(vf.imagePath.isNotBlank()) { "Sprite '$id' variant #${i + 1} imagePath cannot be blank" }
+                SpriteVariant(
+                    imageId = vf.imageId,
+                    displayName = vf.displayName.ifBlank { entry.displayName },
+                    race = vf.race?.uppercase(),
+                    playerClass = vf.playerClass?.uppercase(),
+                    gender = vf.gender?.lowercase(),
+                    imagePath = vf.imagePath,
+                )
+            }
+
+            registry.register(
+                SpriteDefinition(
+                    id = id,
+                    displayName = entry.displayName,
+                    category = category,
+                    unlockCondition = unlockCondition,
+                    sortOrder = entry.sortOrder,
+                    variants = variants,
+                ),
+            )
+        }
+    }
+
+    /**
+     * Auto-generates tier sprite definitions from the configured level tiers,
+     * race IDs, and class IDs. Image paths follow the existing naming convention:
+     * `player_sprites/{race}_{class}_{tierSuffix}.png`.
+     */
+    fun generateTierSprites(
+        registry: SpriteRegistry,
+        tierNames: Map<Int, String>,
+        raceIds: List<String>,
+        classIds: List<String>,
+    ) {
+        // Sort tiers ascending so sortOrder increases with level
+        for ((level, name) in tierNames.toSortedMap()) {
+            val tierSuffix = "t$level"
+            val variants = mutableListOf<SpriteVariant>()
+
+            for (race in raceIds) {
+                for (cls in classIds) {
+                    val rLow = race.lowercase()
+                    val cLow = cls.lowercase()
+                    variants.add(
+                        SpriteVariant(
+                            imageId = "${rLow}_${cLow}_$tierSuffix",
+                            displayName = "$name (${race.lowercase().replaceFirstChar {
+                                it.uppercase()
+                            }} ${cls.lowercase().replaceFirstChar { it.uppercase() }})",
+                            race = race.uppercase(),
+                            playerClass = cls.uppercase(),
+                            imagePath = "player_sprites/${rLow}_${cLow}_$tierSuffix.png",
+                        ),
+                    )
+                }
+            }
+
+            registry.register(
+                SpriteDefinition(
+                    id = "tier_${name.lowercase().replace(' ', '_')}",
+                    displayName = name,
+                    category = SpriteCategory.TIER,
+                    unlockCondition = SpriteUnlockCondition.Level(level),
+                    sortOrder = level,
+                    variants = variants,
+                ),
+            )
+        }
+    }
+
+    /**
+     * Auto-generates staff sprite definitions. Image paths follow the existing
+     * convention: `player_sprites/{race}_base_tstaff.png`.
+     */
+    fun generateStaffSprites(
+        registry: SpriteRegistry,
+        raceIds: List<String>,
+    ) {
+        val variants = raceIds.map { race ->
+            val rLow = race.lowercase()
+            SpriteVariant(
+                imageId = "${rLow}_base_tstaff",
+                displayName = "Staff (${race.lowercase().replaceFirstChar { it.uppercase() }})",
+                race = race.uppercase(),
+                imagePath = "player_sprites/${rLow}_base_tstaff.png",
+            )
+        }
+
+        registry.register(
+            SpriteDefinition(
+                id = "staff",
+                displayName = "Staff",
+                category = SpriteCategory.STAFF,
+                unlockCondition = SpriteUnlockCondition.Staff,
+                sortOrder = 1000,
+                variants = variants,
+            ),
+        )
+    }
+}

--- a/src/main/kotlin/dev/ambon/engine/SpriteRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/SpriteRegistry.kt
@@ -1,0 +1,155 @@
+package dev.ambon.engine
+
+import dev.ambon.domain.sprite.SpriteCategory
+import dev.ambon.domain.sprite.SpriteDefinition
+import dev.ambon.domain.sprite.SpriteUnlockCondition
+import dev.ambon.domain.sprite.SpriteVariant
+
+/**
+ * Registry of all known sprite definitions, plus resolution logic for
+ * determining which sprites a player has unlocked and which variant to display.
+ */
+class SpriteRegistry {
+    private val definitions = mutableMapOf<String, SpriteDefinition>()
+    private val variantIndex = mutableMapOf<String, Pair<SpriteDefinition, SpriteVariant>>()
+
+    fun register(def: SpriteDefinition) {
+        definitions[def.id] = def
+        for (v in def.variants) {
+            variantIndex[v.imageId] = def to v
+        }
+    }
+
+    fun get(id: String): SpriteDefinition? = definitions[id]
+
+    fun all(): Collection<SpriteDefinition> = definitions.values
+
+    /** Looks up a variant by its [imageId] and returns the owning definition + variant. */
+    fun findVariant(imageId: String): Pair<SpriteDefinition, SpriteVariant>? = variantIndex[imageId]
+
+    fun clear() {
+        definitions.clear()
+        variantIndex.clear()
+    }
+
+    // ------------------------------------------------------------------
+    // Unlock & filtering helpers
+    // ------------------------------------------------------------------
+
+    /** Returns all definitions the player currently qualifies for. */
+    fun unlockedDefinitions(
+        level: Int,
+        unlockedAchievementIds: Set<String>,
+        isStaff: Boolean,
+    ): List<SpriteDefinition> = definitions.values.filter { isUnlocked(it, level, unlockedAchievementIds, isStaff) }
+
+    /** Returns all variants the player can see (unlocked + matches race/class/gender). */
+    fun availableVariants(
+        level: Int,
+        unlockedAchievementIds: Set<String>,
+        isStaff: Boolean,
+        playerRace: String,
+        playerClass: String,
+        playerGender: String,
+    ): List<Pair<SpriteDefinition, SpriteVariant>> {
+        val result = mutableListOf<Pair<SpriteDefinition, SpriteVariant>>()
+        for (def in definitions.values) {
+            if (!isUnlocked(def, level, unlockedAchievementIds, isStaff)) continue
+            for (v in def.variants) {
+                if (def.category == SpriteCategory.STAFF || v.matchesPlayer(playerRace, playerClass, playerGender)) {
+                    result.add(def to v)
+                }
+            }
+        }
+        return result
+    }
+
+    /**
+     * Validates that [imageId] is an unlocked, player-matching variant.
+     * Returns the resolved image path or `null` if invalid.
+     */
+    fun validateSelection(
+        imageId: String,
+        level: Int,
+        unlockedAchievementIds: Set<String>,
+        isStaff: Boolean,
+        playerRace: String,
+        playerClass: String,
+        playerGender: String,
+    ): SpriteVariant? {
+        val (def, variant) = variantIndex[imageId] ?: return null
+        if (!isUnlocked(def, level, unlockedAchievementIds, isStaff)) return null
+        if (def.category != SpriteCategory.STAFF && !variant.matchesPlayer(playerRace, playerClass, playerGender)) return null
+        return variant
+    }
+
+    /**
+     * Auto-resolve: picks the highest-tier sprite with the best variant match.
+     * Used when `activeSprite` is null (default/auto mode).
+     */
+    fun autoResolve(
+        level: Int,
+        isStaff: Boolean,
+        playerRace: String,
+        playerClass: String,
+        playerGender: String,
+    ): SpriteVariant? {
+        // For auto, only consider tier sprites (or staff if isStaff)
+        val candidates = definitions.values
+            .filter { def ->
+                when (def.category) {
+                    SpriteCategory.TIER -> isUnlocked(def, level, emptySet(), isStaff = false)
+                    SpriteCategory.STAFF -> isStaff
+                    else -> false
+                }
+            }
+            .sortedByDescending { it.sortOrder }
+
+        for (def in candidates) {
+            val best = bestVariant(def, playerRace, playerClass, playerGender)
+            if (best != null) return best
+        }
+        return null
+    }
+
+    /**
+     * Picks the most specific matching variant from a definition for the given player.
+     * Specificity: race+class > race > class > generic.
+     */
+    fun bestVariant(
+        def: SpriteDefinition,
+        playerRace: String,
+        playerClass: String,
+        playerGender: String,
+    ): SpriteVariant? {
+        val matching = def.variants.filter {
+            if (def.category == SpriteCategory.STAFF) {
+                true
+            } else {
+                it.matchesPlayer(playerRace, playerClass, playerGender)
+            }
+        }
+        if (matching.isEmpty()) return null
+
+        // Score by specificity: each non-null qualifier adds 1 point
+        return matching.maxByOrNull { v ->
+            (if (v.race != null) 1 else 0) +
+                (if (v.playerClass != null) 1 else 0) +
+                (if (v.gender != null) 1 else 0)
+        }
+    }
+
+    companion object {
+        fun isUnlocked(
+            def: SpriteDefinition,
+            level: Int,
+            unlockedAchievementIds: Set<String>,
+            isStaff: Boolean,
+        ): Boolean =
+            when (val cond = def.unlockCondition) {
+                is SpriteUnlockCondition.Level -> level >= cond.minLevel
+                is SpriteUnlockCondition.Achievement -> cond.achievementId in unlockedAchievementIds
+                is SpriteUnlockCondition.Staff -> isStaff
+            }
+    }
+}

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -287,6 +287,16 @@ sealed interface Command {
 
     data object CraftSkills : Command
 
+    // ---- Sprite commands ----
+
+    data object SpriteList : Command
+
+    data class SpriteSet(
+        val imageId: String,
+    ) : Command
+
+    data object SpriteDefault : Command
+
     // ---- World feature commands ----
 
     data class OpenFeature(
@@ -742,6 +752,21 @@ object CommandParser {
 
         // gender <option>
         requiredArg(line, listOf("gender"), "gender <option>", { Command.SetGender(it) })?.let { return it }
+
+        // sprite: "sprite", "sprite list", "sprite set <id>", "sprite default", "sprite clear", "sprites"
+        matchPrefix(line, listOf("sprite", "sprites")) { rest ->
+            if (rest.isEmpty()) return@matchPrefix Command.SpriteList
+            val parts = rest.split(Regex("\\s+"), limit = 2)
+            when (parts[0].lowercase()) {
+                "list" -> Command.SpriteList
+                "set" -> {
+                    val id = parts.getOrNull(1)?.trim() ?: ""
+                    if (id.isEmpty()) Command.Invalid(line, "sprite set <imageId>") else Command.SpriteSet(id)
+                }
+                "default", "clear", "auto" -> Command.SpriteDefault
+                else -> Command.SpriteSet(rest.trim())
+            }
+        }?.let { return it }
 
         // Crafting & Gathering
         requiredArg(line, listOf("gather", "harvest", "mine"), "gather <node>") { Command.Gather(it) }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/SpriteHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/SpriteHandler.kt
@@ -1,0 +1,123 @@
+package dev.ambon.engine.commands.handlers
+
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.sprite.SpriteCategory
+import dev.ambon.engine.SpriteRegistry
+import dev.ambon.engine.commands.Command
+import dev.ambon.engine.commands.CommandHandler
+import dev.ambon.engine.commands.CommandRouter
+import dev.ambon.engine.commands.on
+import dev.ambon.engine.events.OutboundEvent
+
+class SpriteHandler(
+    ctx: EngineContext,
+    private val spriteRegistry: SpriteRegistry?,
+) : CommandHandler {
+    private val players = ctx.players
+    private val outbound = ctx.outbound
+    private val gmcpEmitter = ctx.gmcpEmitter
+
+    override fun register(router: CommandRouter) {
+        router.on<Command.SpriteList> { sid, _ -> handleSpriteList(sid) }
+        router.on<Command.SpriteSet> { sid, cmd -> handleSpriteSet(sid, cmd) }
+        router.on<Command.SpriteDefault> { sid, _ -> handleSpriteDefault(sid) }
+    }
+
+    private suspend fun handleSpriteList(sessionId: SessionId) {
+        val reg = spriteRegistry
+        if (reg == null) {
+            outbound.send(OutboundEvent.SendError(sessionId, "Sprites are not available."))
+            return
+        }
+        val ps = players.get(sessionId) ?: return
+
+        val available = reg.availableVariants(
+            level = ps.level,
+            unlockedAchievementIds = ps.unlockedAchievementIds,
+            isStaff = ps.isStaff,
+            playerRace = ps.race,
+            playerClass = ps.playerClass,
+            playerGender = ps.gender,
+        )
+
+        if (available.isEmpty()) {
+            outbound.send(OutboundEvent.SendInfo(sessionId, "You have no sprites available."))
+            return
+        }
+
+        val activeImageId = ps.activeSprite
+            ?: reg.autoResolve(
+                level = ps.level,
+                isStaff = ps.isStaff,
+                playerRace = ps.race,
+                playerClass = ps.playerClass,
+                playerGender = ps.gender,
+            )?.imageId
+
+        val grouped = available.groupBy { (def, _) -> def.category }
+        val sb = StringBuilder()
+        sb.appendLine("=== Your Sprites ===")
+        if (ps.activeSprite == null) {
+            sb.appendLine("Mode: auto (highest tier)")
+        }
+        sb.appendLine()
+
+        for (cat in listOf(SpriteCategory.TIER, SpriteCategory.ACHIEVEMENT, SpriteCategory.STAFF)) {
+            val entries = grouped[cat] ?: continue
+            sb.appendLine("--- ${cat.name.lowercase().replaceFirstChar { it.uppercase() }} Sprites ---")
+            // Sort by definition sortOrder, then variant displayName
+            val sorted = entries.sortedWith(
+                compareByDescending<Pair<dev.ambon.domain.sprite.SpriteDefinition, dev.ambon.domain.sprite.SpriteVariant>> {
+                    it.first.sortOrder
+                }.thenBy { it.second.displayName },
+            )
+            for ((_, variant) in sorted) {
+                val marker = if (variant.imageId == activeImageId) " [*]" else "    "
+                sb.appendLine("$marker ${variant.displayName}  (${variant.imageId})")
+            }
+            sb.appendLine()
+        }
+        sb.append("Use 'sprite set <id>' to select, or 'sprite default' for auto.")
+        outbound.send(OutboundEvent.SendInfo(sessionId, sb.toString().trimEnd()))
+    }
+
+    private suspend fun handleSpriteSet(
+        sessionId: SessionId,
+        cmd: Command.SpriteSet,
+    ) {
+        val reg = spriteRegistry
+        if (reg == null) {
+            outbound.send(OutboundEvent.SendError(sessionId, "Sprites are not available."))
+            return
+        }
+        val ps = players.get(sessionId) ?: return
+
+        val variant = reg.validateSelection(
+            imageId = cmd.imageId,
+            level = ps.level,
+            unlockedAchievementIds = ps.unlockedAchievementIds,
+            isStaff = ps.isStaff,
+            playerRace = ps.race,
+            playerClass = ps.playerClass,
+            playerGender = ps.gender,
+        )
+
+        if (variant == null) {
+            outbound.send(OutboundEvent.SendError(sessionId, "Unknown or unavailable sprite: ${cmd.imageId}"))
+            return
+        }
+
+        ps.activeSprite = variant.imageId
+        outbound.send(OutboundEvent.SendInfo(sessionId, "Sprite set to: ${variant.displayName}"))
+        gmcpEmitter?.sendCharName(sessionId, ps)
+        gmcpEmitter?.sendCharSprites(sessionId, ps)
+    }
+
+    private suspend fun handleSpriteDefault(sessionId: SessionId) {
+        val ps = players.get(sessionId) ?: return
+        ps.activeSprite = null
+        outbound.send(OutboundEvent.SendInfo(sessionId, "Sprite set to auto (highest unlocked tier)."))
+        gmcpEmitter?.sendCharName(sessionId, ps)
+        gmcpEmitter?.sendCharSprites(sessionId, ps)
+    }
+}

--- a/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
@@ -56,6 +56,7 @@ data class PlayerRecord(
     val friendsList: Set<String> = emptySet(),
     val inventoryItems: List<ItemInstance> = emptyList(),
     val equippedItems: Map<String, ItemInstance> = emptyMap(),
+    val activeSprite: String? = null,
 ) {
     /**
      * Applies legacy migration fixes after deserialization.

--- a/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
@@ -58,6 +58,7 @@ object PlayersTable : Table("players") {
     val friendsList = text("friends_list").default("[]")
     val inventoryItems = text("inventory_items").default("[]")
     val equippedItems = text("equipped_items").default("{}")
+    val activeSprite = varchar("active_sprite", 100).nullable()
 
     override val primaryKey = PrimaryKey(id)
 
@@ -94,6 +95,7 @@ object PlayersTable : Table("players") {
             friendsList = safeReadJson(row[friendsList], friendsListType, emptySet()),
             inventoryItems = safeReadJson(row[inventoryItems], inventoryItemsType, emptyList()),
             equippedItems = safeReadJson(row[equippedItems], equippedItemsType, emptyMap()),
+            activeSprite = row[activeSprite],
         ).migrateDefaults()
 
     /** Writes all [PlayerRecord] fields into an insert or upsert [statement]. */
@@ -129,5 +131,6 @@ object PlayersTable : Table("players") {
         statement[friendsList] = jsonMapper.writeValueAsString(record.friendsList)
         statement[inventoryItems] = jsonMapper.writeValueAsString(record.inventoryItems)
         statement[equippedItems] = jsonMapper.writeValueAsString(record.equippedItems)
+        statement[activeSprite] = record.activeSprite
     }
 }

--- a/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
+++ b/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
@@ -205,7 +205,7 @@ private suspend fun DefaultWebSocketServerSession.bridgeWebSocketSession(
         InboundEvent.GmcpReceived(
             sessionId,
             "Core.Supports.Set",
-            """["Char.Vitals 1","Room.Info 1","Zone.Map 1","Char.StatusVars 1","Char.Items 1","Char.Equipment 1","Room.Players 1","Room.Mobs 1","Room.Items 1","Char.Skills 1","Char.Name 1","Char.StatusEffects 1","Char.Achievements 1","Comm.Channel 1","Guild 1","Group.Info 1","Friends 1","Core.Ping 1","Dialogue 1","Shop 1","Char.Combat 1","Char.Combat.Event 1","Char.Stats 1","Quest 1","Char.Cooldown 1","Char.Gain 1","Room.MobInfo 1","Mail 1","Crafting 1","Login 1","Server 1","UI.Feedback 1","Staff 1"]""",
+            """["Char.Vitals 1","Room.Info 1","Zone.Map 1","Char.StatusVars 1","Char.Items 1","Char.Equipment 1","Room.Players 1","Room.Mobs 1","Room.Items 1","Char.Skills 1","Char.Name 1","Char.StatusEffects 1","Char.Achievements 1","Char.Sprites 1","Comm.Channel 1","Guild 1","Group.Info 1","Friends 1","Core.Ping 1","Dialogue 1","Shop 1","Char.Combat 1","Char.Combat.Event 1","Char.Stats 1","Quest 1","Char.Cooldown 1","Char.Gain 1","Room.MobInfo 1","Mail 1","Crafting 1","Login 1","Server 1","UI.Feedback 1","Staff 1"]""",
         ),
     )
     metrics.onWsConnected()

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3115,6 +3115,13 @@ ambonmud:
       - 20
       - 10
       - 1
+    spriteTierNames:
+      1: Novice
+      10: Apprentice
+      20: Journeyman
+      30: Expert
+      40: Master
+      50: Legend
   globalAssets:
     compass_rose: e201e29796fd12881e521ea892c6d97e56d362d6bd443cdd5b494029314814d4.png
     direction_marker: 829a44129781d086ef03b8c317ec1db699add28e68cc83363b47ee760d73d58a.png

--- a/src/main/resources/db/migration/V19__add_active_sprite.sql
+++ b/src/main/resources/db/migration/V19__add_active_sprite.sql
@@ -1,0 +1,1 @@
+ALTER TABLE players ADD COLUMN active_sprite VARCHAR(100);

--- a/src/main/resources/world/sprites.yaml
+++ b/src/main/resources/world/sprites.yaml
@@ -1,0 +1,64 @@
+# Custom sprite definitions (achievement, special, etc.)
+#
+# Tier sprites (Novice through Legend) and Staff sprites are auto-generated
+# from application.yaml config + known races/classes. Only define achievement
+# or other non-tier sprites here.
+#
+# Each sprite definition has:
+#   displayName  — human-readable name shown to the player
+#   category     — "achievement", "tier", or "staff"
+#   sortOrder    — ordering within the sprite list (higher = later)
+#   unlock:
+#     type          — "achievement", "level", or "staff"
+#     achievementId — required when type is "achievement"
+#     minLevel      — required when type is "level"
+#   variants:      — one or more image variants
+#     - imageId      — unique identifier (also used in "sprite set <imageId>")
+#       displayName  — variant display name (defaults to definition displayName)
+#       race         — optional race filter (e.g. "ELF"); null = any race
+#       playerClass  — optional class filter (e.g. "MAGE"); null = any class
+#       gender       — optional gender filter; null = any gender
+#       imagePath    — path relative to images base URL
+#
+# Image naming convention:
+#   Generic:      player_sprites/{sprite_name}.png
+#   Race:         player_sprites/{race}_{sprite_name}.png
+#   Class:        player_sprites/{class}_{sprite_name}.png
+#   Race+Class:   player_sprites/{race}_{class}_{sprite_name}.png
+
+sprites:
+  beetle_slayer:
+    displayName: "Beetle Slayer"
+    category: achievement
+    sortOrder: 100
+    unlock:
+      type: achievement
+      achievementId: combat/beetle_exterminator
+    variants:
+      - imageId: beetle_slayer
+        displayName: "Beetle Slayer"
+        imagePath: player_sprites/beetle_slayer.png
+      - imageId: elf_beetle_slayer
+        displayName: "Beetle Slayer (Elf)"
+        race: ELF
+        imagePath: player_sprites/elf_beetle_slayer.png
+      - imageId: dwarf_beetle_slayer
+        displayName: "Beetle Slayer (Dwarf)"
+        race: DWARF
+        imagePath: player_sprites/dwarf_beetle_slayer.png
+
+  spider_hunter:
+    displayName: "Spider Hunter"
+    category: achievement
+    sortOrder: 101
+    unlock:
+      type: achievement
+      achievementId: combat/spider_hunter
+    variants:
+      - imageId: spider_hunter
+        displayName: "Spider Hunter"
+        imagePath: player_sprites/spider_hunter.png
+      - imageId: rogue_spider_hunter
+        displayName: "Spider Hunter (Rogue)"
+        playerClass: ROGUE
+        imagePath: player_sprites/rogue_spider_hunter.png

--- a/src/test/kotlin/dev/ambon/engine/SpriteLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/SpriteLoaderTest.kt
@@ -1,0 +1,169 @@
+package dev.ambon.engine
+
+import dev.ambon.domain.sprite.SpriteCategory
+import dev.ambon.domain.sprite.SpriteUnlockCondition
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class SpriteLoaderTest {
+    private lateinit var registry: SpriteRegistry
+
+    @BeforeEach
+    fun setup() {
+        registry = SpriteRegistry()
+    }
+
+    // ── Tier generation ──────────────────────────────────────────────────
+
+    @Test
+    fun `generateTierSprites creates definitions for each tier`() {
+        SpriteLoader.generateTierSprites(
+            registry = registry,
+            tierNames = mapOf(1 to "Novice", 10 to "Apprentice"),
+            raceIds = listOf("HUMAN", "ELF"),
+            classIds = listOf("WARRIOR", "MAGE"),
+        )
+
+        val all = registry.all().toList()
+        assertEquals(2, all.size)
+
+        val novice = registry.get("tier_novice")
+        assertNotNull(novice)
+        assertEquals("Novice", novice!!.displayName)
+        assertEquals(SpriteCategory.TIER, novice.category)
+        assertEquals(SpriteUnlockCondition.Level(1), novice.unlockCondition)
+        assertEquals(1, novice.sortOrder)
+        // 2 races x 2 classes = 4 variants
+        assertEquals(4, novice.variants.size)
+    }
+
+    @Test
+    fun `tier sprite variants follow naming convention`() {
+        SpriteLoader.generateTierSprites(
+            registry = registry,
+            tierNames = mapOf(1 to "Novice"),
+            raceIds = listOf("ELF"),
+            classIds = listOf("MAGE"),
+        )
+
+        val novice = registry.get("tier_novice")!!
+        assertEquals(1, novice.variants.size)
+        val v = novice.variants[0]
+        assertEquals("elf_mage_t1", v.imageId)
+        assertEquals("Novice (Elf Mage)", v.displayName)
+        assertEquals("ELF", v.race)
+        assertEquals("MAGE", v.playerClass)
+        assertEquals("player_sprites/elf_mage_t1.png", v.imagePath)
+    }
+
+    @Test
+    fun `tier sprites are indexed in variant lookup`() {
+        SpriteLoader.generateTierSprites(
+            registry = registry,
+            tierNames = mapOf(10 to "Apprentice"),
+            raceIds = listOf("HUMAN"),
+            classIds = listOf("WARRIOR"),
+        )
+
+        val result = registry.findVariant("human_warrior_t10")
+        assertNotNull(result)
+        assertEquals("tier_apprentice", result!!.first.id)
+    }
+
+    // ── Staff generation ─────────────────────────────────────────────────
+
+    @Test
+    fun `generateStaffSprites creates a staff definition`() {
+        SpriteLoader.generateStaffSprites(
+            registry = registry,
+            raceIds = listOf("HUMAN", "ELF", "DWARF"),
+        )
+
+        val staff = registry.get("staff")
+        assertNotNull(staff)
+        assertEquals("Staff", staff!!.displayName)
+        assertEquals(SpriteCategory.STAFF, staff.category)
+        assertEquals(SpriteUnlockCondition.Staff, staff.unlockCondition)
+        assertEquals(3, staff.variants.size)
+    }
+
+    @Test
+    fun `staff variants follow naming convention`() {
+        SpriteLoader.generateStaffSprites(
+            registry = registry,
+            raceIds = listOf("ELF"),
+        )
+
+        val staff = registry.get("staff")!!
+        val v = staff.variants[0]
+        assertEquals("elf_base_tstaff", v.imageId)
+        assertEquals("Staff (Elf)", v.displayName)
+        assertEquals("ELF", v.race)
+        assertEquals("player_sprites/elf_base_tstaff.png", v.imagePath)
+    }
+
+    // ── YAML loading ─────────────────────────────────────────────────────
+
+    @Test
+    fun `loadFromResource loads sprites from YAML`() {
+        SpriteLoader.loadFromResource("world/sprites.yaml", registry)
+
+        val beetle = registry.get("beetle_slayer")
+        assertNotNull(beetle)
+        assertEquals("Beetle Slayer", beetle!!.displayName)
+        assertEquals(SpriteCategory.ACHIEVEMENT, beetle.category)
+        assertEquals(SpriteUnlockCondition.Achievement("combat/beetle_exterminator"), beetle.unlockCondition)
+        assertEquals(100, beetle.sortOrder)
+        assertEquals(3, beetle.variants.size)
+
+        val spider = registry.get("spider_hunter")
+        assertNotNull(spider)
+        assertEquals(2, spider!!.variants.size)
+    }
+
+    @Test
+    fun `loaded variants have correct qualifiers`() {
+        SpriteLoader.loadFromResource("world/sprites.yaml", registry)
+
+        val beetle = registry.get("beetle_slayer")!!
+        val generic = beetle.variants.find { it.imageId == "beetle_slayer" }
+        assertNotNull(generic)
+        assertEquals(null, generic!!.race)
+        assertEquals(null, generic.playerClass)
+
+        val elfVariant = beetle.variants.find { it.imageId == "elf_beetle_slayer" }
+        assertNotNull(elfVariant)
+        assertEquals("ELF", elfVariant!!.race)
+        assertEquals(null, elfVariant.playerClass)
+    }
+
+    @Test
+    fun `loadFromResource skips missing resource gracefully`() {
+        SpriteLoader.loadFromResource("world/nonexistent_sprites.yaml", registry)
+        assertTrue(registry.all().isEmpty())
+    }
+
+    // ── Combined loading ─────────────────────────────────────────────────
+
+    @Test
+    fun `tier and achievement sprites coexist in registry`() {
+        SpriteLoader.generateTierSprites(
+            registry = registry,
+            tierNames = mapOf(1 to "Novice"),
+            raceIds = listOf("ELF"),
+            classIds = listOf("MAGE"),
+        )
+        SpriteLoader.generateStaffSprites(registry, listOf("ELF"))
+        SpriteLoader.loadFromResource("world/sprites.yaml", registry)
+
+        // Should have tier + staff + 2 achievement sprites
+        assertTrue(registry.all().size >= 4)
+        assertNotNull(registry.get("tier_novice"))
+        assertNotNull(registry.get("staff"))
+        assertNotNull(registry.get("beetle_slayer"))
+        assertNotNull(registry.get("spider_hunter"))
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/SpriteRegistryTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/SpriteRegistryTest.kt
@@ -1,0 +1,414 @@
+package dev.ambon.engine
+
+import dev.ambon.domain.sprite.SpriteCategory
+import dev.ambon.domain.sprite.SpriteDefinition
+import dev.ambon.domain.sprite.SpriteUnlockCondition
+import dev.ambon.domain.sprite.SpriteVariant
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class SpriteRegistryTest {
+    private lateinit var registry: SpriteRegistry
+
+    @BeforeEach
+    fun setup() {
+        registry = SpriteRegistry()
+    }
+
+    private val tierNovice = SpriteDefinition(
+        id = "tier_novice",
+        displayName = "Novice",
+        category = SpriteCategory.TIER,
+        unlockCondition = SpriteUnlockCondition.Level(1),
+        sortOrder = 1,
+        variants = listOf(
+            SpriteVariant(
+                "elf_mage_t1",
+                "Novice (Elf Mage)",
+                race = "ELF",
+                playerClass = "MAGE",
+                imagePath = "player_sprites/elf_mage_t1.png",
+            ),
+            SpriteVariant(
+                "human_warrior_t1",
+                "Novice (Human Warrior)",
+                race = "HUMAN",
+                playerClass = "WARRIOR",
+                imagePath = "player_sprites/human_warrior_t1.png",
+            ),
+            SpriteVariant("t1", "Novice", imagePath = "player_sprites/t1.png"),
+        ),
+    )
+
+    private val tierApprentice = SpriteDefinition(
+        id = "tier_apprentice",
+        displayName = "Apprentice",
+        category = SpriteCategory.TIER,
+        unlockCondition = SpriteUnlockCondition.Level(10),
+        sortOrder = 10,
+        variants = listOf(
+            SpriteVariant(
+                "elf_mage_t10",
+                "Apprentice (Elf Mage)",
+                race = "ELF",
+                playerClass = "MAGE",
+                imagePath = "player_sprites/elf_mage_t10.png",
+            ),
+            SpriteVariant(
+                "human_warrior_t10",
+                "Apprentice (Human Warrior)",
+                race = "HUMAN",
+                playerClass = "WARRIOR",
+                imagePath = "player_sprites/human_warrior_t10.png",
+            ),
+        ),
+    )
+
+    private val achievementSprite = SpriteDefinition(
+        id = "beetle_slayer",
+        displayName = "Beetle Slayer",
+        category = SpriteCategory.ACHIEVEMENT,
+        unlockCondition = SpriteUnlockCondition.Achievement("combat/beetle_exterminator"),
+        sortOrder = 100,
+        variants = listOf(
+            SpriteVariant("beetle_slayer", "Beetle Slayer", imagePath = "player_sprites/beetle_slayer.png"),
+            SpriteVariant("elf_beetle_slayer", "Beetle Slayer (Elf)", race = "ELF", imagePath = "player_sprites/elf_beetle_slayer.png"),
+        ),
+    )
+
+    private val staffSprite = SpriteDefinition(
+        id = "staff",
+        displayName = "Staff",
+        category = SpriteCategory.STAFF,
+        unlockCondition = SpriteUnlockCondition.Staff,
+        sortOrder = 1000,
+        variants = listOf(
+            SpriteVariant("elf_base_tstaff", "Staff (Elf)", race = "ELF", imagePath = "player_sprites/elf_base_tstaff.png"),
+            SpriteVariant("human_base_tstaff", "Staff (Human)", race = "HUMAN", imagePath = "player_sprites/human_base_tstaff.png"),
+        ),
+    )
+
+    // ── Registration & lookup ─────────────────────────────────────────────
+
+    @Test
+    fun `register and retrieve definitions`() {
+        registry.register(tierNovice)
+        registry.register(achievementSprite)
+        assertEquals(tierNovice, registry.get("tier_novice"))
+        assertEquals(achievementSprite, registry.get("beetle_slayer"))
+        assertNull(registry.get("nonexistent"))
+    }
+
+    @Test
+    fun `findVariant returns definition and variant`() {
+        registry.register(tierNovice)
+        val result = registry.findVariant("elf_mage_t1")
+        assertNotNull(result)
+        assertEquals(tierNovice, result!!.first)
+        assertEquals("elf_mage_t1", result.second.imageId)
+    }
+
+    @Test
+    fun `findVariant returns null for unknown imageId`() {
+        registry.register(tierNovice)
+        assertNull(registry.findVariant("nonexistent_sprite"))
+    }
+
+    // ── Unlock conditions ─────────────────────────────────────────────────
+
+    @Test
+    fun `level unlock - meets threshold`() {
+        registry.register(tierApprentice)
+        val unlocked = registry.unlockedDefinitions(level = 10, unlockedAchievementIds = emptySet(), isStaff = false)
+        assertEquals(1, unlocked.size)
+        assertEquals("tier_apprentice", unlocked[0].id)
+    }
+
+    @Test
+    fun `level unlock - below threshold`() {
+        registry.register(tierApprentice)
+        val unlocked = registry.unlockedDefinitions(level = 9, unlockedAchievementIds = emptySet(), isStaff = false)
+        assertTrue(unlocked.isEmpty())
+    }
+
+    @Test
+    fun `achievement unlock - has achievement`() {
+        registry.register(achievementSprite)
+        val unlocked = registry.unlockedDefinitions(
+            level = 1,
+            unlockedAchievementIds = setOf("combat/beetle_exterminator"),
+            isStaff = false,
+        )
+        assertEquals(1, unlocked.size)
+        assertEquals("beetle_slayer", unlocked[0].id)
+    }
+
+    @Test
+    fun `achievement unlock - missing achievement`() {
+        registry.register(achievementSprite)
+        val unlocked = registry.unlockedDefinitions(level = 1, unlockedAchievementIds = emptySet(), isStaff = false)
+        assertTrue(unlocked.isEmpty())
+    }
+
+    @Test
+    fun `staff unlock - is staff`() {
+        registry.register(staffSprite)
+        val unlocked = registry.unlockedDefinitions(level = 1, unlockedAchievementIds = emptySet(), isStaff = true)
+        assertEquals(1, unlocked.size)
+    }
+
+    @Test
+    fun `staff unlock - not staff`() {
+        registry.register(staffSprite)
+        val unlocked = registry.unlockedDefinitions(level = 1, unlockedAchievementIds = emptySet(), isStaff = false)
+        assertTrue(unlocked.isEmpty())
+    }
+
+    // ── Available variants (unlock + player match) ───────────────────────
+
+    @Test
+    fun `availableVariants filters by race and class`() {
+        registry.register(tierNovice)
+        val available = registry.availableVariants(
+            level = 1,
+            unlockedAchievementIds = emptySet(),
+            isStaff = false,
+            playerRace = "ELF",
+            playerClass = "MAGE",
+            playerGender = "neutral",
+        )
+        val imageIds = available.map { it.second.imageId }.toSet()
+        // Elf mage should see: elf_mage_t1 (race+class match) and t1 (generic)
+        assertTrue("elf_mage_t1" in imageIds)
+        assertTrue("t1" in imageIds)
+        // Should NOT see human_warrior_t1
+        assertTrue("human_warrior_t1" !in imageIds)
+    }
+
+    @Test
+    fun `availableVariants includes generic achievement variants`() {
+        registry.register(achievementSprite)
+        val available = registry.availableVariants(
+            level = 1,
+            unlockedAchievementIds = setOf("combat/beetle_exterminator"),
+            isStaff = false,
+            playerRace = "HUMAN",
+            playerClass = "WARRIOR",
+            playerGender = "neutral",
+        )
+        val imageIds = available.map { it.second.imageId }.toSet()
+        // Human warrior should see generic beetle_slayer but NOT elf_beetle_slayer
+        assertTrue("beetle_slayer" in imageIds)
+        assertTrue("elf_beetle_slayer" !in imageIds)
+    }
+
+    @Test
+    fun `staff sees all staff variants regardless of race`() {
+        registry.register(staffSprite)
+        val available = registry.availableVariants(
+            level = 1,
+            unlockedAchievementIds = emptySet(),
+            isStaff = true,
+            playerRace = "ELF",
+            playerClass = "MAGE",
+            playerGender = "neutral",
+        )
+        val imageIds = available.map { it.second.imageId }.toSet()
+        // Staff can see all staff variants, even those for other races
+        assertTrue("elf_base_tstaff" in imageIds)
+        assertTrue("human_base_tstaff" in imageIds)
+    }
+
+    // ── Validate selection ─────────────────────────────────────────────
+
+    @Test
+    fun `validateSelection accepts valid unlocked matching variant`() {
+        registry.register(tierNovice)
+        val result = registry.validateSelection(
+            imageId = "elf_mage_t1",
+            level = 1,
+            unlockedAchievementIds = emptySet(),
+            isStaff = false,
+            playerRace = "ELF",
+            playerClass = "MAGE",
+            playerGender = "neutral",
+        )
+        assertNotNull(result)
+        assertEquals("elf_mage_t1", result!!.imageId)
+    }
+
+    @Test
+    fun `validateSelection rejects non-matching race`() {
+        registry.register(tierNovice)
+        val result = registry.validateSelection(
+            imageId = "elf_mage_t1",
+            level = 1,
+            unlockedAchievementIds = emptySet(),
+            isStaff = false,
+            playerRace = "HUMAN",
+            playerClass = "MAGE",
+            playerGender = "neutral",
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `validateSelection rejects locked sprite`() {
+        registry.register(tierApprentice)
+        val result = registry.validateSelection(
+            imageId = "elf_mage_t10",
+            level = 5,
+            unlockedAchievementIds = emptySet(),
+            isStaff = false,
+            playerRace = "ELF",
+            playerClass = "MAGE",
+            playerGender = "neutral",
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `validateSelection accepts generic variant for any player`() {
+        registry.register(tierNovice)
+        val result = registry.validateSelection(
+            imageId = "t1",
+            level = 1,
+            unlockedAchievementIds = emptySet(),
+            isStaff = false,
+            playerRace = "DWARF",
+            playerClass = "CLERIC",
+            playerGender = "neutral",
+        )
+        assertNotNull(result)
+        assertEquals("t1", result!!.imageId)
+    }
+
+    // ── Auto-resolve ─────────────────────────────────────────────────────
+
+    @Test
+    fun `autoResolve picks highest tier with best variant match`() {
+        registry.register(tierNovice)
+        registry.register(tierApprentice)
+        val result = registry.autoResolve(
+            level = 15,
+            isStaff = false,
+            playerRace = "ELF",
+            playerClass = "MAGE",
+            playerGender = "neutral",
+        )
+        assertNotNull(result)
+        // Should pick apprentice (higher tier, level 15 >= 10)
+        assertEquals("elf_mage_t10", result!!.imageId)
+    }
+
+    @Test
+    fun `autoResolve falls back to lower tier if higher not unlocked`() {
+        registry.register(tierNovice)
+        registry.register(tierApprentice)
+        val result = registry.autoResolve(
+            level = 5,
+            isStaff = false,
+            playerRace = "ELF",
+            playerClass = "MAGE",
+            playerGender = "neutral",
+        )
+        assertNotNull(result)
+        assertEquals("elf_mage_t1", result!!.imageId)
+    }
+
+    @Test
+    fun `autoResolve prefers race+class variant over generic`() {
+        registry.register(tierNovice)
+        val result = registry.autoResolve(
+            level = 1,
+            isStaff = false,
+            playerRace = "ELF",
+            playerClass = "MAGE",
+            playerGender = "neutral",
+        )
+        assertNotNull(result)
+        assertEquals("elf_mage_t1", result!!.imageId)
+    }
+
+    @Test
+    fun `autoResolve prefers staff sprite for staff member`() {
+        registry.register(tierNovice)
+        registry.register(staffSprite)
+        val result = registry.autoResolve(
+            level = 1,
+            isStaff = true,
+            playerRace = "ELF",
+            playerClass = "MAGE",
+            playerGender = "neutral",
+        )
+        assertNotNull(result)
+        // Staff sprite has higher sortOrder (1000)
+        assertEquals("elf_base_tstaff", result!!.imageId)
+    }
+
+    // ── Best variant (specificity) ───────────────────────────────────────
+
+    @Test
+    fun `bestVariant returns most specific match`() {
+        val def = SpriteDefinition(
+            id = "test",
+            displayName = "Test",
+            category = SpriteCategory.ACHIEVEMENT,
+            unlockCondition = SpriteUnlockCondition.Level(1),
+            variants = listOf(
+                SpriteVariant("generic", "Generic", imagePath = "g.png"),
+                SpriteVariant("elf", "Elf", race = "ELF", imagePath = "e.png"),
+                SpriteVariant("elf_mage", "Elf Mage", race = "ELF", playerClass = "MAGE", imagePath = "em.png"),
+            ),
+        )
+        val result = registry.bestVariant(def, "ELF", "MAGE", "neutral")
+        assertEquals("elf_mage", result?.imageId)
+    }
+
+    @Test
+    fun `bestVariant falls back to race match when no race+class match`() {
+        val def = SpriteDefinition(
+            id = "test",
+            displayName = "Test",
+            category = SpriteCategory.ACHIEVEMENT,
+            unlockCondition = SpriteUnlockCondition.Level(1),
+            variants = listOf(
+                SpriteVariant("generic", "Generic", imagePath = "g.png"),
+                SpriteVariant("elf", "Elf", race = "ELF", imagePath = "e.png"),
+            ),
+        )
+        val result = registry.bestVariant(def, "ELF", "WARRIOR", "neutral")
+        assertEquals("elf", result?.imageId)
+    }
+
+    @Test
+    fun `bestVariant falls back to generic when no qualifier match`() {
+        val def = SpriteDefinition(
+            id = "test",
+            displayName = "Test",
+            category = SpriteCategory.ACHIEVEMENT,
+            unlockCondition = SpriteUnlockCondition.Level(1),
+            variants = listOf(
+                SpriteVariant("generic", "Generic", imagePath = "g.png"),
+                SpriteVariant("elf", "Elf", race = "ELF", imagePath = "e.png"),
+            ),
+        )
+        val result = registry.bestVariant(def, "HUMAN", "WARRIOR", "neutral")
+        assertEquals("generic", result?.imageId)
+    }
+
+    // ── Clear ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `clear removes all definitions and variants`() {
+        registry.register(tierNovice)
+        registry.register(achievementSprite)
+        registry.clear()
+        assertTrue(registry.all().isEmpty())
+        assertNull(registry.findVariant("elf_mage_t1"))
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/commands/SpriteCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/SpriteCommandTest.kt
@@ -1,0 +1,64 @@
+package dev.ambon.engine.commands
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SpriteCommandTest {
+    // ── Parser tests ─────────────────────────────────────────────────────
+
+    @Test
+    fun `sprite alone parses to SpriteList`() {
+        assertEquals(Command.SpriteList, CommandParser.parse("sprite"))
+    }
+
+    @Test
+    fun `sprites alone parses to SpriteList`() {
+        assertEquals(Command.SpriteList, CommandParser.parse("sprites"))
+    }
+
+    @Test
+    fun `sprite list parses to SpriteList`() {
+        assertEquals(Command.SpriteList, CommandParser.parse("sprite list"))
+    }
+
+    @Test
+    fun `sprite set with id parses to SpriteSet`() {
+        val result = CommandParser.parse("sprite set elf_mage_t1")
+        assertTrue(result is Command.SpriteSet)
+        assertEquals("elf_mage_t1", (result as Command.SpriteSet).imageId)
+    }
+
+    @Test
+    fun `sprite set without id returns Invalid`() {
+        val result = CommandParser.parse("sprite set")
+        assertTrue(result is Command.Invalid)
+    }
+
+    @Test
+    fun `sprite default parses to SpriteDefault`() {
+        assertEquals(Command.SpriteDefault, CommandParser.parse("sprite default"))
+    }
+
+    @Test
+    fun `sprite clear parses to SpriteDefault`() {
+        assertEquals(Command.SpriteDefault, CommandParser.parse("sprite clear"))
+    }
+
+    @Test
+    fun `sprite auto parses to SpriteDefault`() {
+        assertEquals(Command.SpriteDefault, CommandParser.parse("sprite auto"))
+    }
+
+    @Test
+    fun `sprite with bare id parses to SpriteSet`() {
+        val result = CommandParser.parse("sprite beetle_slayer")
+        assertTrue(result is Command.SpriteSet)
+        assertEquals("beetle_slayer", (result as Command.SpriteSet).imageId)
+    }
+
+    @Test
+    fun `sprite command is case insensitive`() {
+        assertEquals(Command.SpriteList, CommandParser.parse("Sprite List"))
+    }
+}


### PR DESCRIPTION
## Summary

- Players can now choose their character sprite from unlocked options via `sprite list` / `sprite set <id>` / `sprite default`
- Three sprite sources: **tier** (auto-generated from level thresholds x race/class), **achievement** (defined in `sprites.yaml`), **staff** (auto-generated per race)
- Template-based naming with race/class/gender variant filtering — players only see sprites matching their character
- New `Char.Sprites` GMCP package lists all available sprites for web client integration
- Notifications on level-up (if using custom sprite) and achievement unlock when new sprites become available
- `activeSprite` persisted on PlayerRecord (Flyway V19, YAML, Postgres, Redis)
- Arcanum instructions doc for image creation and naming conventions

## New Files
- `domain/sprite/SpriteDefinition.kt` — domain model
- `engine/SpriteRegistry.kt` — registry with variant filtering, validation, auto-resolve
- `engine/SpriteLoader.kt` — YAML loading + tier/staff auto-generation
- `engine/commands/handlers/SpriteHandler.kt` — command handler
- `resources/world/sprites.yaml` — achievement sprite definitions (2 placeholders)
- `resources/db/migration/V19__add_active_sprite.sql` — Flyway migration
- `docs/ARCANUM_SPRITE_INSTRUCTIONS.md` — Arcanum sprite creation guide
- 3 test files (SpriteRegistryTest, SpriteLoaderTest, SpriteCommandTest)

## Test plan
- [x] SpriteRegistryTest — 14 tests (unlock, filtering, validation, auto-resolve)
- [x] SpriteLoaderTest — 9 tests (tier/staff generation, YAML loading)
- [x] SpriteCommandTest — 9 tests (parser variants)
- [x] Full test suite passes
- [x] ktlintCheck passes
- [ ] Manual: verify sprite commands in-game
- [ ] Manual: verify Char.Sprites GMCP in web client