### PR TITLE
Command and GMCP parity tests (#692, #693)

### DIFF
--- a/src/test/kotlin/dev/ambon/parity/CommandWebParityTest.kt
+++ b/src/test/kotlin/dev/ambon/parity/CommandWebParityTest.kt
@@ -1,0 +1,92 @@
+package dev.ambon.parity
+
+import dev.ambon.config.CommandsConfig
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Safety-net test that ensures the web client's command autocomplete list
+ * stays in sync with the server's command metadata.
+ *
+ * When a new non-staff command is added to [CommandsConfig.defaultCommandEntries]
+ * but not to the web client's `COMMANDS` array in `constants.ts`, this test
+ * fails with an actionable message.
+ *
+ * Closes #692.
+ */
+class CommandWebParityTest {
+    companion object {
+        /**
+         * Metadata keys whose web COMMANDS representation differs from the
+         * simple key / underscore-prefix derivation rule.
+         *
+         * - `null` means the command is intentionally absent from web autocomplete.
+         * - A string value is the expected COMMANDS entry for that metadata key.
+         */
+        private val SPECIAL_MAPPINGS: Map<String, String?> = mapOf(
+            "move" to null, // Represented by individual direction words (north, south, …)
+            "ansi" to null, // Web client always has ANSI; no autocomplete needed
+            "balance" to "gold", // Web uses the "gold" alias
+            "shop_list" to "list", // Web uses the "list" alias
+        )
+    }
+
+    /**
+     * For every non-staff command family in server metadata, assert there is a
+     * corresponding entry in the web client's COMMANDS autocomplete array.
+     */
+    @Test
+    fun `web COMMANDS list covers all non-staff command families`() {
+        val webCommands = extractWebCommands()
+        val metadata = CommandsConfig.defaultCommandEntries()
+
+        val expected = mutableSetOf<String>()
+        for ((key, meta) in metadata) {
+            if (meta.staff) continue
+
+            if (SPECIAL_MAPPINGS.containsKey(key)) {
+                SPECIAL_MAPPINGS[key]?.let { expected.add(it) }
+                continue
+            }
+
+            // Compound keys like "group_invite" → "group", "put_in" → "put"
+            expected.add(key.substringBefore("_"))
+        }
+
+        val missing = expected - webCommands
+        assertTrue(missing.isEmpty()) {
+            "Commands in server metadata but missing from web COMMANDS array " +
+                "(web-v3/src/constants.ts):\n  ${missing.sorted().joinToString(", ")}\n\n" +
+                "Add them to the COMMANDS array, or add an exclusion to " +
+                "SPECIAL_MAPPINGS in this test."
+        }
+    }
+
+    @Test
+    fun `web COMMANDS has no duplicate entries`() {
+        val commands = parseWebCommandsList()
+        val dupes = commands.groupBy { it }.filter { it.value.size > 1 }.keys
+        assertTrue(dupes.isEmpty()) {
+            "Duplicate entries in web COMMANDS array: ${dupes.sorted().joinToString(", ")}"
+        }
+    }
+
+    private fun extractWebCommands(): Set<String> = parseWebCommandsList().toSet()
+
+    private fun parseWebCommandsList(): List<String> {
+        val source = File("web-v3/src/constants.ts").also {
+            assertTrue(it.exists()) { "Cannot find web-v3/src/constants.ts — run tests from project root" }
+        }.readText()
+
+        val match = Regex(
+            """export\s+const\s+COMMANDS\s*=\s*\[(.*?)]""",
+            RegexOption.DOT_MATCHES_ALL,
+        ).find(source) ?: fail("Could not find COMMANDS array in constants.ts")
+
+        return Regex(""""([^"]+)"""").findAll(match.groupValues[1])
+            .map { it.groupValues[1] }
+            .toList()
+    }
+}

--- a/src/test/kotlin/dev/ambon/parity/GmcpWebContractTest.kt
+++ b/src/test/kotlin/dev/ambon/parity/GmcpWebContractTest.kt
@@ -1,0 +1,111 @@
+package dev.ambon.parity
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Safety-net test that ensures every GMCP package emitted by the server has
+ * a corresponding handler in the web client, and vice versa.
+ *
+ * When a new GMCP package is added to the server but not the web client
+ * (or vice versa), this test fails with an actionable message.
+ *
+ * Closes #693.
+ */
+class GmcpWebContractTest {
+    companion object {
+        /** Matches GMCP package name string literals: `"Word.Word"` or `"Word.Word.Word"`. */
+        private val GMCP_PACKAGE_RE = Regex(""""([A-Z][a-zA-Z]+(?:\.[A-Z][a-zA-Z]+)+)"""")
+
+        /**
+         * Server-side source files that originate GMCP packages.
+         * Infrastructure files (ProtoMapper, RedisOutboundBus) that merely relay
+         * events are excluded — only files that create [OutboundEvent.GmcpData]
+         * with new package strings belong here.
+         */
+        private val SERVER_GMCP_SOURCES = listOf(
+            "src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt",
+            "src/main/kotlin/dev/ambon/engine/events/LoginFlowHandler.kt",
+        )
+
+        private const val CLIENT_GMCP_HANDLER = "web-v3/src/gmcp/applyGmcpPackage.ts"
+
+        /**
+         * GMCP packages emitted by the server but intentionally not (yet) handled
+         * by the web client. Each entry must have a comment explaining why.
+         */
+        private val SERVER_ONLY_EXCLUSIONS: Set<String> = setOf(
+            // Char.Sprites: web client sprite-list UI not yet implemented.
+            // Server emits this for the sprite selection system (#706);
+            // web handler to be added when the sprite picker panel is built.
+            "Char.Sprites",
+        )
+
+        /**
+         * GMCP packages handled by the web client but not originating from the
+         * scanned server source files (e.g. emitted from a different module,
+         * or client-initiated). Each entry must have a comment.
+         */
+        private val CLIENT_ONLY_EXCLUSIONS: Set<String> = emptySet()
+    }
+
+    @Test
+    fun `every server-emitted GMCP package has a web client handler`() {
+        val serverPackages = extractServerPackages()
+        val clientPackages = extractClientPackages()
+
+        val unhandled = serverPackages - clientPackages - SERVER_ONLY_EXCLUSIONS
+        assertTrue(unhandled.isEmpty()) {
+            "GMCP packages emitted by server but not handled in web client " +
+                "($CLIENT_GMCP_HANDLER):\n  ${unhandled.sorted().joinToString("\n  ")}\n\n" +
+                "Add a case in applyGmcpPackage.ts, or add an exclusion to " +
+                "SERVER_ONLY_EXCLUSIONS in this test with a comment."
+        }
+    }
+
+    @Test
+    fun `every web client GMCP handler corresponds to a server emission`() {
+        val serverPackages = extractServerPackages()
+        val clientPackages = extractClientPackages()
+
+        val orphaned = clientPackages - serverPackages - CLIENT_ONLY_EXCLUSIONS
+        assertTrue(orphaned.isEmpty()) {
+            "GMCP packages handled by web client but never emitted by server:\n" +
+                "  ${orphaned.sorted().joinToString("\n  ")}\n\n" +
+                "Remove the dead handler, or add an exclusion to " +
+                "CLIENT_ONLY_EXCLUSIONS in this test with a comment."
+        }
+    }
+
+    @Test
+    fun `web client GMCP handler has no duplicate case entries`() {
+        val source = readFile(CLIENT_GMCP_HANDLER)
+        val cases = Regex("""case\s+"([^"]+)"""").findAll(source)
+            .map { it.groupValues[1] }
+            .toList()
+        val dupes = cases.groupBy { it }.filter { it.value.size > 1 }.keys
+        assertTrue(dupes.isEmpty()) {
+            "Duplicate case entries in $CLIENT_GMCP_HANDLER:\n  ${dupes.sorted().joinToString(", ")}"
+        }
+    }
+
+    private fun extractServerPackages(): Set<String> =
+        SERVER_GMCP_SOURCES.flatMap { path ->
+            val source = readFile(path)
+            GMCP_PACKAGE_RE.findAll(source).map { it.groupValues[1] }
+        }.toSet()
+
+    private fun extractClientPackages(): Set<String> {
+        val source = readFile(CLIENT_GMCP_HANDLER)
+        return Regex("""case\s+"([^"]+)"""").findAll(source)
+            .map { it.groupValues[1] }
+            .filter { '.' in it }
+            .toSet()
+    }
+
+    private fun readFile(relativePath: String): String =
+        File(relativePath).also {
+            assertTrue(it.exists()) { "Cannot find $relativePath — run tests from project root" }
+        }.readText()
+}

--- a/web-v3/src/constants.ts
+++ b/web-v3/src/constants.ts
@@ -86,6 +86,8 @@ export const COMMANDS = [
   "friend", "mail",
   // Crafting
   "gather", "craft", "recipes", "craftskills",
+  // Sprites
+  "sprite",
   // Utility
   "phase", "help", "quit", "clear", "colors",
 ];


### PR DESCRIPTION
## Summary

- **CommandWebParityTest** (#692): Verifies every non-staff command family in `CommandsConfig.defaultCommandEntries()` has a corresponding entry in the web client's `COMMANDS` autocomplete array (`constants.ts`). Uses an explicit mapping for special cases (`move` → directions, `balance` → `gold`, etc.) and fails with actionable guidance when a new command is missing.
- **GmcpWebContractTest** (#693): Verifies every GMCP package emitted by the server (`GmcpEmitter.kt`, `LoginFlowHandler.kt`) has a `case` handler in `applyGmcpPackage.ts`, and vice versa. Extracts package names via regex over source files. `Char.Sprites` is documented as a known exclusion (web sprite picker UI not yet built).
- Adds `"sprite"` to the web `COMMANDS` array — a gap the command parity test would have caught.

Both tests also check for duplicates in their respective lists.

Closes #692, closes #693.

## Test plan

- [x] `./gradlew test --tests "dev.ambon.parity.*"` — all 5 new tests pass
- [x] `./gradlew ktlintCheck` — clean
- [x] `./gradlew test` — full suite passes
- [x] CI passes