### PR TITLE
Broadcast room announcement for admin-spawned mobs

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
@@ -135,23 +135,23 @@ class AdminHandler(
             val zone = template.id.value.substringBefore(':', template.id.value)
             val local = template.id.value.substringAfter(':', template.id.value)
             val newMobId = MobId("$zone:${local}_adm_$seq")
-            mobs.upsert(
-                MobState(
-                    id = newMobId,
-                    name = template.name,
-                    description = template.description,
-                    roomId = me.roomId,
-                    hp = template.maxHp,
-                    maxHp = template.maxHp,
-                    damage = template.damage,
-                    armor = template.armor,
-                    xpReward = template.xpReward,
-                    drops = template.drops,
-                    spawnRoomId = me.roomId,
-                    image = template.image,
-                ),
+            val spawned = MobState(
+                id = newMobId,
+                name = template.name,
+                description = template.description,
+                roomId = me.roomId,
+                hp = template.maxHp,
+                maxHp = template.maxHp,
+                damage = template.damage,
+                armor = template.armor,
+                xpReward = template.xpReward,
+                drops = template.drops,
+                spawnRoomId = me.roomId,
+                image = template.image,
             )
-            outbound.send(OutboundEvent.SendInfo(sessionId, "${template.name} appears."))
+            mobs.upsert(spawned)
+            broadcastToRoom(players, outbound, me.roomId, "${template.name} appears.")
+            gmcpEmitter?.broadcastRoomAddMob(me.roomId, spawned, players)
         }
     }
 

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterAdminTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterAdminTest.kt
@@ -178,8 +178,8 @@ class CommandRouterAdminTest {
             val spawned = h.mobs.mobsInRoom(staffRoom)
             assertTrue(spawned.isNotEmpty(), "Expected a mob to be spawned in staff room")
             assertTrue(
-                outs.any { it is OutboundEvent.SendInfo && it.sessionId == staffSid },
-                "Expected spawn confirmation. got=$outs",
+                outs.any { it is OutboundEvent.SendText && it.sessionId == staffSid && it.text.contains("appears") },
+                "Expected spawn room announcement. got=$outs",
             )
         }
 


### PR DESCRIPTION
## Summary
Admin-spawned mobs were invisible to other players — the spawn only sent a confirmation to the staff member. Now:

- **Terminal**: All players in the room see `"<mob> appears."` via `broadcastToRoom`
- **Canvas**: All players receive `Room.AddMob` GMCP so the mob sprite appears immediately

This matches the natural respawn flow in `GameEngine.onCombatMobRemoved()`.

## Changes
- `AdminHandler.handleSpawn()`: Replace `SendInfo` (admin-only) with `broadcastToRoom` + `broadcastRoomAddMob`
- `CommandRouterAdminTest`: Update spawn test to expect `SendText` room broadcast instead of `SendInfo`

## Test plan
- [x] `ktlintCheck` passes
- [x] Full test suite passes (including updated spawn test)
- [ ] Staff spawns mob → all players in room see text + mob appears on canvas
- [ ] Staff spawns mob while alone → staff sees text + mob on canvas