### PR TITLE
Staff mob possession system: possess, pilot, and return

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -989,6 +989,14 @@ data class CommandsConfig(
             ),
             "shutdown" to CommandMetadata("shutdown", "Shut down the server", "admin", staff = true),
             "reload" to CommandMetadata("reload [scope]", "Reload world data", "admin", staff = true),
+            "possess" to CommandMetadata(
+                usage = "possess/switch <mob>",
+                description = "Take control of a mob",
+                category = "admin",
+                staff = true,
+                requiresTarget = true,
+            ),
+            "return" to CommandMetadata("return/unpossess", "Release a possessed mob", "admin", staff = true),
         )
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -247,6 +247,8 @@ class GameEngine(
             routeCommandLine = { sid, line ->
                 if (players.get(sid)?.mailCompose != null) {
                     mailHandler.handleComposeLine(sid, line)
+                } else if (players.get(sid)?.possessedMobId != null) {
+                    adminHandler.handlePossessedCommand(sid, line)
                 } else {
                     router.handle(sid, CommandParser.parse(line))
                 }
@@ -664,6 +666,7 @@ class GameEngine(
             clock = clock,
             isMobInCombat = { mobId -> combatSystem.isMobInCombat(mobId) },
             isMobRooted = { mobId -> statusEffectSystem.hasMobEffect(mobId, "root") },
+            isMobPossessed = { mobId -> players.allPlayers().any { it.possessedMobId == mobId } },
             startMobCombat = { mobId, sessionId -> combatSystem.startMobCombat(mobId, sessionId) },
             fleeMob = { mobId -> combatSystem.fleeMob(mobId) },
             gmcpEmitter = gmcpEmitter,
@@ -723,6 +726,7 @@ class GameEngine(
 
     private val router = CommandRouter(outbound = outbound, players = players)
     private val communicationHandler: CommunicationHandler
+    private val adminHandler: AdminHandler
     private val mailHandler: MailHandler
 
     init {
@@ -762,6 +766,20 @@ class GameEngine(
             engineId = engineId,
             onRemoteWho = if (interEngineBus != null) interEngineEventHandler::handleRemoteWho else null,
             clock = clock,
+        )
+
+        adminHandler = AdminHandler(
+            ctx = ctx,
+            onShutdown = onShutdown,
+            mobRemovalCoordinator = mobRemovalCoordinator,
+            onCrossZoneMove = crossZoneMove,
+            statusEffects = statusEffectSystem,
+            interEngineBus = interEngineBus,
+            engineId = engineId,
+            metrics = metrics,
+            onReload = hotReloadManager?.let { mgr ->
+                { target -> handleReloadCommand(mgr, target) }
+            },
         )
 
         listOf(
@@ -829,19 +847,7 @@ class GameEngine(
                 friendsSystem = friendsSystem,
             ),
             WorldFeaturesHandler(ctx = ctx),
-            AdminHandler(
-                ctx = ctx,
-                onShutdown = onShutdown,
-                mobRemovalCoordinator = mobRemovalCoordinator,
-                onCrossZoneMove = crossZoneMove,
-                statusEffects = statusEffectSystem,
-                interEngineBus = interEngineBus,
-                engineId = engineId,
-                metrics = metrics,
-                onReload = hotReloadManager?.let { mgr ->
-                    { target -> handleReloadCommand(mgr, target) }
-                },
-            ),
+            adminHandler,
             SpriteHandler(
                 ctx = ctx,
                 spriteRegistry = spriteRegistry,

--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -3,6 +3,7 @@ package dev.ambon.engine
 import dev.ambon.domain.StatMap
 import dev.ambon.domain.achievement.AchievementState
 import dev.ambon.domain.crafting.CraftingSkillState
+import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.mail.MailMessage
@@ -64,6 +65,10 @@ data class PlayerState(
     var lastActivityEpochMs: Long = 0L,
     /** Chosen sprite variant imageId, or null for auto (highest unlocked tier). */
     var activeSprite: String? = null,
+    /** Non-null while staff is possessing a mob. Runtime-only; not persisted. */
+    var possessedMobId: MobId? = null,
+    /** The player's real room before possession began. Runtime-only; not persisted. */
+    var prePossessRoomId: RoomId? = null,
 ) {
     data class MailComposeState(
         val recipientName: String,

--- a/src/main/kotlin/dev/ambon/engine/behavior/BehaviorTreeSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/BehaviorTreeSystem.kt
@@ -20,6 +20,7 @@ class BehaviorTreeSystem(
     private val rng: Random = Random(),
     private val isMobInCombat: (MobId) -> Boolean = { false },
     private val isMobRooted: (MobId) -> Boolean = { false },
+    private val isMobPossessed: (MobId) -> Boolean = { false },
     private val startMobCombat: suspend (MobId, SessionId) -> Boolean = { _, _ -> false },
     private val fleeMob: suspend (MobId) -> Boolean = { false },
     private val gmcpEmitter: GmcpEmitter? = null,
@@ -55,7 +56,7 @@ class BehaviorTreeSystem(
 
             if (now < dueAt) continue
 
-            if (isMobRooted(m.id)) {
+            if (isMobRooted(m.id) || isMobPossessed(m.id)) {
                 nextActAtMillis[m.id] = now + randomDelay()
                 continue
             }

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -121,6 +121,12 @@ sealed interface Command {
         val playerName: String,
     ) : Command
 
+    data class Possess(
+        val target: String,
+    ) : Command
+
+    data object Return : Command
+
     data class SetLevel(
         val playerName: String,
         val level: Int,
@@ -652,6 +658,12 @@ object CommandParser {
 
         // kick
         requiredArg(line, listOf("kick"), "kick <player>", { Command.Kick(it) })?.let { return it }
+
+        // possess
+        requiredArg(line, listOf("possess", "switch"), "possess <mob>", { Command.Possess(it) })?.let { return it }
+
+        // return (from possession)
+        matchPrefix(line, listOf("return", "unpossess")) { _ -> Command.Return }?.let { return it }
 
         // setlevel
         matchPrefix(line, listOf("setlevel")) { rest ->

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
@@ -5,9 +5,11 @@ import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.mob.MobState
 import dev.ambon.engine.MobRemovalCoordinator
+import dev.ambon.engine.PlayerState
 import dev.ambon.engine.broadcastToRoom
 import dev.ambon.engine.commands.Command
 import dev.ambon.engine.commands.CommandHandler
+import dev.ambon.engine.commands.CommandParser
 import dev.ambon.engine.commands.CommandRouter
 import dev.ambon.engine.commands.onStaff
 import dev.ambon.engine.events.OutboundEvent
@@ -51,6 +53,8 @@ class AdminHandler(
         router.onStaff<Command.SetLevel> { sid, cmd -> handleSetLevel(sid, cmd) }
         router.onStaff<Command.Dispel> { sid, cmd -> handleDispel(sid, cmd) }
         router.onStaff<Command.Reload> { sid, cmd -> handleReload(sid, cmd) }
+        router.onStaff<Command.Possess> { sid, cmd -> handlePossess(sid, cmd) }
+        router.onStaff<Command.Return> { sid, _ -> handleReturn(sid) }
     }
 
     private suspend fun handleGoto(
@@ -297,6 +301,195 @@ class AdminHandler(
         outbound.send(OutboundEvent.SendInfo(sessionId, "Reloading ${target ?: "all"}..."))
         val summary = onReload.invoke(target)
         outbound.send(OutboundEvent.SendInfo(sessionId, summary))
+    }
+
+    private suspend fun handlePossess(
+        sessionId: SessionId,
+        cmd: Command.Possess,
+    ) {
+        players.withPlayer(sessionId) { me ->
+            if (me.possessedMobId != null) {
+                outbound.send(OutboundEvent.SendError(sessionId, "You are already possessing a mob. Use 'return' first."))
+                return
+            }
+            if (combat.isInCombat(sessionId)) {
+                outbound.send(OutboundEvent.SendError(sessionId, "You cannot possess a mob while in combat."))
+                return
+            }
+            val mob = mobs.findInRoomByKeyword(me.roomId, cmd.target).firstOrNull()
+            if (mob == null) {
+                outbound.send(OutboundEvent.SendError(sessionId, "No mob '${cmd.target}' found in this room."))
+                return
+            }
+            me.possessedMobId = mob.id
+            me.prePossessRoomId = me.roomId
+            outbound.send(
+                OutboundEvent.SendInfo(sessionId, "You take control of ${mob.name}. Type 'return' to release."),
+            )
+            outbound.send(OutboundEvent.SendPrompt(sessionId))
+        }
+    }
+
+    private suspend fun handleReturn(sessionId: SessionId) {
+        players.withPlayer(sessionId) { me ->
+            val mobId = me.possessedMobId
+            if (mobId == null) {
+                outbound.send(OutboundEvent.SendError(sessionId, "You are not possessing a mob."))
+                return
+            }
+            val mobName = mobs.get(mobId)?.name ?: "the mob"
+            me.possessedMobId = null
+            val returnRoom = me.prePossessRoomId ?: me.roomId
+            me.prePossessRoomId = null
+            if (me.roomId != returnRoom) {
+                players.moveTo(sessionId, returnRoom)
+                ctx.sendLook(sessionId)
+            }
+            outbound.send(OutboundEvent.SendInfo(sessionId, "You release $mobName and return to your body."))
+            outbound.send(OutboundEvent.SendPrompt(sessionId))
+        }
+    }
+
+    /**
+     * Routes a command while the player is possessing a mob.
+     * Navigation moves the mob; say/emote speak as the mob; other staff commands pass through.
+     */
+    suspend fun handlePossessedCommand(sessionId: SessionId, line: String) {
+        val me = players.get(sessionId) ?: return
+        val mobId = me.possessedMobId ?: return
+        val mob = mobs.get(mobId)
+        if (mob == null) {
+            me.possessedMobId = null
+            me.prePossessRoomId = null
+            outbound.send(OutboundEvent.SendError(sessionId, "The mob you were possessing no longer exists."))
+            outbound.send(OutboundEvent.SendPrompt(sessionId))
+            return
+        }
+
+        val cmd = CommandParser.parse(line)
+        when (cmd) {
+            // Return always works
+            is Command.Return -> {
+                handleReturn(sessionId)
+                return
+            }
+            // Staff commands pass through normally
+            is Command.Goto, is Command.Transfer, is Command.Spawn, is Command.Shutdown,
+            is Command.Smite, is Command.Kick, is Command.SetLevel, is Command.Dispel,
+            is Command.Reload, is Command.Possess,
+            -> {
+                router.handle(sessionId, cmd)
+                return
+            }
+            // Navigation moves the mob
+            is Command.Move -> {
+                possessedMove(sessionId, me, mob, cmd)
+                return
+            }
+            // Look shows mob's room
+            is Command.Look -> {
+                // Ensure player's roomId is the mob's room for sendLook
+                val playerRoom = me.roomId
+                if (playerRoom != mob.roomId) {
+                    players.moveTo(sessionId, mob.roomId)
+                }
+                ctx.sendLook(sessionId)
+                outbound.send(OutboundEvent.SendPrompt(sessionId))
+                return
+            }
+            // Exits shows mob's room exits
+            is Command.Exits -> {
+                val room = world.rooms[mob.roomId]
+                if (room != null) {
+                    val exitList = if (room.exits.isEmpty()) "none" else room.exits.keys.joinToString(", ") { it.name.lowercase() }
+                    outbound.send(OutboundEvent.SendText(sessionId, "Exits: $exitList"))
+                }
+                outbound.send(OutboundEvent.SendPrompt(sessionId))
+                return
+            }
+            // Say speaks as the mob
+            is Command.Say -> {
+                broadcastToRoom(players, outbound, mob.roomId, "${mob.name} says: ${cmd.message}")
+                outbound.send(OutboundEvent.SendText(sessionId, "[${mob.name}] says: ${cmd.message}"))
+                for (p in players.playersInRoom(mob.roomId)) {
+                    gmcpEmitter?.sendCommChannel(p.sessionId, "say", mob.name, cmd.message)
+                }
+                outbound.send(OutboundEvent.SendPrompt(sessionId))
+                return
+            }
+            // Emote as the mob
+            is Command.Emote -> {
+                broadcastToRoom(players, outbound, mob.roomId, "${mob.name} ${cmd.message}")
+                outbound.send(OutboundEvent.SendText(sessionId, "[${mob.name}] ${cmd.message}"))
+                outbound.send(OutboundEvent.SendPrompt(sessionId))
+                return
+            }
+            // Score shows mob stats
+            is Command.Score -> {
+                outbound.send(
+                    OutboundEvent.SendText(
+                        sessionId,
+                        "Possessing: ${mob.name} | HP: ${mob.hp}/${mob.maxHp} | Room: ${mob.roomId.value}",
+                    ),
+                )
+                outbound.send(OutboundEvent.SendPrompt(sessionId))
+                return
+            }
+            else -> {
+                outbound.send(
+                    OutboundEvent.SendError(
+                        sessionId,
+                        "While possessing: move, look, say, emote, score, or 'return'. Staff commands also work.",
+                    ),
+                )
+                outbound.send(OutboundEvent.SendPrompt(sessionId))
+            }
+        }
+    }
+
+    private suspend fun possessedMove(
+        sessionId: SessionId,
+        me: PlayerState,
+        mob: dev.ambon.domain.mob.MobState,
+        cmd: Command.Move,
+    ) {
+        val from = mob.roomId
+        val room = world.rooms[from]
+        if (room == null) {
+            outbound.send(OutboundEvent.SendError(sessionId, "The mob's room doesn't exist."))
+            return
+        }
+        val to = room.exits[cmd.dir]
+        if (to == null) {
+            outbound.send(OutboundEvent.SendText(sessionId, "You can't go that way."))
+            outbound.send(OutboundEvent.SendPrompt(sessionId))
+            return
+        }
+        if (!world.rooms.containsKey(to)) {
+            outbound.send(OutboundEvent.SendText(sessionId, "That exit leads to an unloaded zone."))
+            outbound.send(OutboundEvent.SendPrompt(sessionId))
+            return
+        }
+
+        // Announce departure
+        for (p in players.playersInRoom(from)) {
+            outbound.send(OutboundEvent.SendText(p.sessionId, "${mob.name} leaves."))
+        }
+        gmcpEmitter?.broadcastRoomRemoveMob(from, mob.id.value, players)
+
+        // Move the mob
+        mobs.moveTo(mob.id, to)
+
+        // Announce arrival
+        for (p in players.playersInRoom(to)) {
+            outbound.send(OutboundEvent.SendText(p.sessionId, "${mob.name} arrives."))
+        }
+        gmcpEmitter?.broadcastRoomAddMob(to, mob, players)
+
+        // Move player's perspective to the mob's new room
+        players.moveTo(sessionId, to)
+        ctx.sendLook(sessionId)
+        outbound.send(OutboundEvent.SendPrompt(sessionId))
     }
 
     private fun findMobTemplate(arg: String): dev.ambon.domain.world.MobSpawn? {

--- a/src/main/kotlin/dev/ambon/engine/events/SessionEventHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/SessionEventHandler.kt
@@ -59,6 +59,15 @@ class SessionEventHandler(
         gmcpEmitter?.forgetSession(sessionId)
 
         if (me != null) {
+            // Release mob possession on disconnect
+            if (me.possessedMobId != null) {
+                val returnRoom = me.prePossessRoomId ?: me.roomId
+                me.possessedMobId = null
+                me.prePossessRoomId = null
+                if (me.roomId != returnRoom) {
+                    players.moveTo(sessionId, returnRoom)
+                }
+            }
             onPlayerLoggedOut(me, sessionId)
         }
 

--- a/src/test/kotlin/dev/ambon/engine/WebClientParityTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/WebClientParityTest.kt
@@ -52,7 +52,7 @@ class WebClientParityTest {
         "ansi" -> listOf() // ANSI toggle is not exposed in the web client (no terminal)
         // Staff commands — not in client autocomplete (gated server-side)
         "goto", "transfer", "spawn", "smite", "staff_kick", "dispel",
-        "setlevel", "shutdown", "reload",
+        "setlevel", "shutdown", "reload", "possess", "return",
         -> listOf()
         // Default: the key itself is the word the player types
         else -> listOf(key)


### PR DESCRIPTION
## Summary
Staff can now take control of mobs and pilot them around the world, speak as them, and then release control.

### New commands
- `possess <mob>` / `switch <mob>` — take control of a mob in the current room
- `return` / `unpossess` — release the mob and snap back to your body

### While possessing
- **Movement** (n/s/e/w/u/d) — moves the mob between rooms with arrival/departure text and `Room.AddMob`/`Room.RemoveMob` GMCP for all players in both rooms
- **Perspective** — player sees the mob's room (look, exits, GMCP room info all reflect the mob's location)
- **Communication** — `say` and `emote` use the mob's name (e.g., "the Innkeeper says: Welcome!")
- **Score** — shows possessed mob stats (HP, room ID)
- **Staff commands** — goto, spawn, transfer, etc. still work normally
- **Other commands** — show a help message listing available actions

### Safety
- Behavior tree ticks skip possessed mobs (`isMobPossessed` check in `BehaviorTreeSystem`)
- Disconnect auto-releases possession and returns player to original room
- Cannot possess while in combat
- If the possessed mob is removed, player is auto-released

### Files changed
- `PlayerState.kt` — add `possessedMobId` and `prePossessRoomId` runtime fields
- `CommandParser.kt` — add `Possess` and `Return` command variants
- `AdminHandler.kt` — possess/return handlers + `handlePossessedCommand` router
- `GameEngine.kt` — command routing intercept + `isMobPossessed` wiring + extract `adminHandler` field
- `BehaviorTreeSystem.kt` — skip possessed mobs during tick
- `SessionEventHandler.kt` — release possession on disconnect
- `AppConfig.kt` — register possess/return in command manifest

## Test plan
- [x] `ktlintCheck` passes
- [x] Full test suite passes (including parity test)
- [ ] `possess innkeeper` → "You take control of the Innkeeper"
- [ ] Move north → mob moves, player sees new room
- [ ] `say Hello!` → room sees "the Innkeeper says: Hello!"
- [ ] `return` → player snaps back to original room
- [ ] Disconnect while possessing → player returns to original room on reconnect
- [ ] Possessed mob's behavior tree is paused