### PR TITLE
Mob possession: combat and kill support (#756)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -1185,6 +1185,8 @@ class GameEngine(
         mobId: MobId,
         roomId: RoomId,
     ) {
+        // Release any staff player possessing this mob
+        adminHandler.releasePossessorOfPublic(mobId)
         mobRemovalCoordinator.onCombatKillCleanup(mobId)
         gmcpEmitter.broadcastRoomRemoveMob(roomId, mobId.value, players)
         val spawn = world.mobSpawns.find { it.id == mobId }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
@@ -229,6 +229,7 @@ class AdminHandler(
                 outbound.send(OutboundEvent.SendError(sessionId, "No player or mob named '${cmd.target}'."))
                 return
             }
+            releasePossessorOf(targetMob.id)
             items.removeMobItems(targetMob.id)
             mobRemovalCoordinator?.removeMobExternally(targetMob.id)
             broadcastToRoom(players, outbound, me.roomId, "${targetMob.name} is struck down by divine wrath.")
@@ -451,12 +452,24 @@ class AdminHandler(
                 outbound.send(OutboundEvent.SendPrompt(sessionId))
                 return
             }
+            // Combat: kill starts player combat from mob's room
+            is Command.Kill -> {
+                if (me.roomId != mob.roomId) players.moveTo(sessionId, mob.roomId)
+                router.handle(sessionId, cmd)
+                return
+            }
+            // Combat: flee ends player combat
+            is Command.Flee -> {
+                router.handle(sessionId, cmd)
+                return
+            }
             // Score shows mob stats
             is Command.Score -> {
+                val combatStatus = if (combat.isInCombat(sessionId)) " | IN COMBAT" else ""
                 outbound.send(
                     OutboundEvent.SendText(
                         sessionId,
-                        "Possessing: ${mob.name} | HP: ${mob.hp}/${mob.maxHp} | Room: ${mob.roomId.value}",
+                        "Possessing: ${mob.name} | HP: ${mob.hp}/${mob.maxHp} | Room: ${mob.roomId.value}$combatStatus",
                     ),
                 )
                 outbound.send(OutboundEvent.SendPrompt(sessionId))
@@ -466,7 +479,7 @@ class AdminHandler(
                 outbound.send(
                     OutboundEvent.SendError(
                         sessionId,
-                        "While possessing: move, look, say, emote, score, or 'return'. Staff commands also work.",
+                        "While possessing: move, look, say, emote, kill, flee, score, or 'return'. Staff commands also work.",
                     ),
                 )
                 outbound.send(OutboundEvent.SendPrompt(sessionId))
@@ -527,6 +540,26 @@ class AdminHandler(
             outbound.send(OutboundEvent.SendPrompt(sessionId))
         }
     }
+
+    /** Release any staff player possessing the given mob, returning them to their body. */
+    private suspend fun releasePossessorOf(mobId: MobId) {
+        for (p in players.allPlayers()) {
+            if (p.possessedMobId == mobId) {
+                p.possessedMobId = null
+                val returnRoom = p.prePossessRoomId ?: p.roomId
+                p.prePossessRoomId = null
+                setInvisible(p.sessionId, p, false)
+                if (p.roomId != returnRoom) players.moveTo(p.sessionId, returnRoom)
+                outbound.send(
+                    OutboundEvent.SendError(p.sessionId, "The mob you were possessing has been killed. Returning to your body."),
+                )
+                outbound.send(OutboundEvent.SendPrompt(p.sessionId))
+            }
+        }
+    }
+
+    /** Release possessor when a mob dies — called from GameEngine.onCombatMobRemoved. */
+    suspend fun releasePossessorOfPublic(mobId: MobId) = releasePossessorOf(mobId)
 
     private suspend fun setInvisible(sessionId: SessionId, me: PlayerState, invisible: Boolean) {
         if (me.invisible == invisible) return


### PR DESCRIPTION
## Summary
Staff can now fight while possessing a mob.

### Combat commands while possessing
- **`kill <target>`** — starts combat from the mob's room using the staff player's stats. The player is already positioned in the mob's room (via possession), so combat targeting works naturally.
- **`flee`** — ends combat normally via the standard flee handler.
- **`score`** — now shows combat status ("IN COMBAT") alongside mob HP.

### Possessed mob death handling
When a possessed mob is killed (by another player or by smite):
1. Possession auto-releases
2. Staff player returns to their original room
3. Invisibility clears (staff body reappears)
4. Error message: "The mob you were possessing has been killed. Returning to your body."

Both `onCombatMobRemoved` (combat kills) and `handleSmite` (admin smite) use `releasePossessorOf()` for clean unwinding.

### Staff body safety
Already handled by the invisibility system from #758 — invisible players cannot be targeted.

### Note on stats
Combat uses the **staff player's stats** (HP, damage, level), not the possessed mob's. This is intentional for the MVP — it lets staff test combat encounters and mob behavior. A future enhancement could override combat stats to match the possessed mob.

Closes #756

## Test plan
- [x] `ktlintCheck` passes
- [x] Full test suite passes
- [ ] `possess grunt` → `kill goblin` → combat starts, damage flows normally
- [ ] `flee` while possessing in combat → combat ends
- [ ] Another player kills the possessed mob → staff auto-released, returned to body
- [ ] `smite` the possessed mob → same auto-release
- [ ] `score` while in combat shows "IN COMBAT" flag