### PR TITLE
Sync achievements.yaml from R2 + hot-reload support

### DIFF
--- a/.github/workflows/refresh-demo-world.yml
+++ b/.github/workflows/refresh-demo-world.yml
@@ -1,7 +1,7 @@
 name: Refresh Demo World
 
-# Re-downloads lore config and world zone YAML files onto the demo
-# instance without restarting the server or dropping player connections.
+# Re-downloads lore config, achievements, and world zone YAML files onto
+# the demo instance without restarting the server or dropping player connections.
 # After this runs, a staff `reload all` or POST /api/reload?target=all
 # is needed to apply the new data to the running engine.
 #
@@ -67,10 +67,11 @@ jobs:
           INSTANCE_ID: ${{ secrets.DEMO_INSTANCE_ID }}
           LORE_URL: ${{ secrets.LORE_CONFIG_URL }}
         run: |
+          ACHIEVEMENTS_URL="${LORE_URL%/*}/achievements.yaml"
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids "$INSTANCE_ID" \
             --document-name "AWS-RunShellScript" \
-            --parameters "commands=[\"curl -fsSL -o /app/data/application-local.yaml $LORE_URL && /usr/local/bin/fetch-world-zones\"]" \
+            --parameters "commands=[\"curl -fsSL -o /app/data/application-local.yaml $LORE_URL && /usr/local/bin/fetch-world-zones && mkdir -p /app/data/world && curl -fsSL -o /app/data/world/achievements.yaml $ACHIEVEMENTS_URL\"]" \
             --comment "Refresh world files from Ambon lore repo" \
             --query "Command.CommandId" \
             --output text)

--- a/infra/lib/ec2-stack.ts
+++ b/infra/lib/ec2-stack.ts
@@ -378,6 +378,11 @@ export class Ec2Stack extends Stack {
       ...(worldZonesBaseUrl
         ? [`ExecStartPre=/usr/local/bin/fetch-world-zones`]
         : []),
+      // Fetch achievements.yaml from the same R2 config directory as the lore overlay.
+      // Must run AFTER fetch-world-zones (which rm -f's /app/data/world/*.yaml).
+      ...(loreConfigUrl
+        ? [`ExecStartPre=/bin/bash -c 'mkdir -p /app/data/world && curl -fsSL -o /app/data/world/achievements.yaml ${loreConfigUrl.replace(/[^/]+$/, '')}achievements.yaml'`]
+        : []),
       // Generate htpasswd for nginx basic auth on /grafana/, /prometheus/, /admin/.
       'ExecStartPre=/usr/local/bin/generate-htpasswd',
       // JAVA_TOOL_OPTIONS is read directly by the JVM (not Hoplite), making it

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -711,6 +711,8 @@ class GameEngine(
                 abilityRegistry = abilityRegistry,
                 statusEffectRegistry = statusEffectRegistry,
                 equipmentSlotRegistry = equipmentSlotRegistry,
+                achievementRegistry = achievementRegistry,
+                achievementCategoryRegistry = achievementCategoryRegistry,
                 mobSystem = mobSystem,
                 behaviorTreeSystem = behaviorTreeSystem,
                 gmcpEmitter = gmcpEmitter,

--- a/src/main/kotlin/dev/ambon/engine/HotReloadManager.kt
+++ b/src/main/kotlin/dev/ambon/engine/HotReloadManager.kt
@@ -85,6 +85,8 @@ class HotReloadManager(
     private val behaviorTreeSystem: BehaviorTreeSystem,
     private val gmcpEmitter: GmcpEmitter,
     private val worldState: WorldStateRegistry,
+    private val achievementRegistry: AchievementRegistry,
+    private val achievementCategoryRegistry: AchievementCategoryRegistry,
     private val engineConfig: EngineConfig,
     private val imagesBaseUrl: String,
     private val worldLoader: () -> World,
@@ -150,6 +152,10 @@ class HotReloadManager(
 
         questRegistry.clear()
         world.questDefinitions.forEach { questRegistry.register(it) }
+
+        // Reload achievement definitions from classpath (may be shadowed by /app/data overlay).
+        achievementRegistry.clear()
+        AchievementLoader.loadFromResource("world/achievements.yaml", achievementRegistry, achievementCategoryRegistry)
 
         // Update item templates (existing items keep old stats; new templates get placed).
         val newItemSpawns = items.updateTemplates(world.itemSpawns)

--- a/src/test/kotlin/dev/ambon/engine/HotReloadManagerTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/HotReloadManagerTest.kt
@@ -202,6 +202,8 @@ class HotReloadManagerTest {
             abilityRegistry = abilityRegistry,
             statusEffectRegistry = statusEffectRegistry,
             equipmentSlotRegistry = EquipmentSlotRegistry(EngineConfig().equipment),
+            achievementRegistry = AchievementRegistry(),
+            achievementCategoryRegistry = AchievementCategoryRegistry(EngineConfig().achievementCategories),
             mobSystem = mobSystem,
             behaviorTreeSystem = behaviorTreeSystem,
             gmcpEmitter = gmcpEmitter,


### PR DESCRIPTION
## Summary
- Fetch `config/achievements.yaml` from R2 during demo deploy (`ec2-stack.ts` ExecStartPre) and world refresh (GitHub Actions workflow), placing it at `/app/data/world/achievements.yaml` where the classpath overlay shadows the built-in resource
- Wire `AchievementRegistry` into `HotReloadManager.reloadWorld()` so achievements refresh alongside zones, quests, and other world data on `reload world` / `reload all`

## Test plan
- [x] `compileKotlin` passes
- [x] `compileTestKotlin` passes
- [x] `HotReloadManagerTest` passes
- [ ] CI green
- [ ] After merge: trigger Refresh Demo World workflow, then `reload world` on demo to verify achievements update live