### PR TITLE
Fix: implement group decline and guild decline commands

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GroupSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/GroupSystem.kt
@@ -161,6 +161,19 @@ class GroupSystem(
         return null
     }
 
+    suspend fun decline(inviteeSid: SessionId): String? {
+        cleanExpiredInvites()
+        val invite = pendingInvites.remove(inviteeSid)
+            ?: return "You have no pending group invite."
+        val inviter = players.get(invite.inviterSid)
+        outbound.send(OutboundEvent.SendText(inviteeSid, "You decline the group invite."))
+        if (inviter != null) {
+            val inviteeName = players.get(inviteeSid)?.name ?: "Someone"
+            outbound.send(OutboundEvent.SendText(invite.inviterSid, "$inviteeName declined your group invite."))
+        }
+        return null
+    }
+
     suspend fun leave(sessionId: SessionId): String? {
         val group =
             groupBySession[sessionId]

--- a/src/main/kotlin/dev/ambon/engine/GuildSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/GuildSystem.kt
@@ -217,6 +217,22 @@ class GuildSystem(
         return null
     }
 
+    suspend fun decline(sessionId: SessionId): String? {
+        pruneExpiredInvites()
+        val invite = pendingInvites.remove(sessionId)
+            ?: return "You have no pending guild invite."
+        outbound.send(OutboundEvent.SendInfo(sessionId, "You decline the guild invite."))
+        // Notify the inviter if online
+        val inviterSid = players.findSessionByName(invite.inviterName)
+        if (inviterSid != null) {
+            val declineName = players.get(sessionId)?.name ?: "Someone"
+            outbound.send(
+                OutboundEvent.SendInfo(inviterSid, "$declineName declined the guild invite."),
+            )
+        }
+        return null
+    }
+
     suspend fun leave(sessionId: SessionId): String? = withMembership(sessionId) { ps, guild ->
         val pid = ps.playerId ?: return@withMembership ERR_NOT_CONNECTED
         val rank = ps.guildRank ?: return@withMembership ERR_NOT_CONNECTED

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -229,6 +229,8 @@ sealed interface Command {
 
         data object Accept : GroupCmd
 
+        data object Decline : GroupCmd
+
         data object Leave : GroupCmd
 
         data class Kick(
@@ -259,6 +261,8 @@ sealed interface Command {
         ) : Guild
 
         data object Accept : Guild
+
+        data object Decline : Guild
 
         data object Leave : Guild
 
@@ -539,6 +543,7 @@ object CommandParser {
                     if (target.isEmpty()) Command.Invalid(line, "guild invite <player>") else Command.Guild.Invite(target)
                 }
                 "accept" -> Command.Guild.Accept
+                "decline", "reject" -> Command.Guild.Decline
                 "leave" -> Command.Guild.Leave
                 "kick" -> {
                     val target = parts.getOrNull(1)?.trim() ?: ""
@@ -572,6 +577,7 @@ object CommandParser {
                     if (target.isEmpty()) Command.Invalid(line, "group invite <player>") else Command.GroupCmd.Invite(target)
                 }
                 "accept", "acc" -> Command.GroupCmd.Accept
+                "decline", "reject" -> Command.GroupCmd.Decline
                 "leave" -> Command.GroupCmd.Leave
                 "kick" -> {
                     val target = parts.getOrNull(1)?.trim() ?: ""

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/GroupHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/GroupHandler.kt
@@ -16,6 +16,7 @@ class GroupHandler(
     override fun register(router: CommandRouter) {
         router.on<Command.GroupCmd.Invite> { sid, cmd -> handleGroupCmd(sid, cmd) }
         router.on<Command.GroupCmd.Accept> { sid, _ -> handleGroupCmd(sid, Command.GroupCmd.Accept) }
+        router.on<Command.GroupCmd.Decline> { sid, _ -> handleGroupCmd(sid, Command.GroupCmd.Decline) }
         router.on<Command.GroupCmd.Leave> { sid, _ -> handleGroupCmd(sid, Command.GroupCmd.Leave) }
         router.on<Command.GroupCmd.Kick> { sid, cmd -> handleGroupCmd(sid, cmd) }
         router.on<Command.GroupCmd.List> { sid, _ -> handleGroupCmd(sid, Command.GroupCmd.List) }
@@ -31,6 +32,7 @@ class GroupHandler(
             when (cmd) {
                 is Command.GroupCmd.Invite -> gs.invite(sessionId, cmd.target)
                 Command.GroupCmd.Accept -> gs.accept(sessionId)
+                Command.GroupCmd.Decline -> gs.decline(sessionId)
                 Command.GroupCmd.Leave -> gs.leave(sessionId)
                 is Command.GroupCmd.Kick -> gs.kick(sessionId, cmd.target)
                 Command.GroupCmd.List -> gs.list(sessionId)

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/GuildHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/GuildHandler.kt
@@ -18,6 +18,7 @@ class GuildHandler(
         router.on<Command.Guild.Disband> { sid, _ -> handleGuildCmd(sid, Command.Guild.Disband) }
         router.on<Command.Guild.Invite> { sid, cmd -> handleGuildCmd(sid, cmd) }
         router.on<Command.Guild.Accept> { sid, _ -> handleGuildCmd(sid, Command.Guild.Accept) }
+        router.on<Command.Guild.Decline> { sid, _ -> handleGuildCmd(sid, Command.Guild.Decline) }
         router.on<Command.Guild.Leave> { sid, _ -> handleGuildCmd(sid, Command.Guild.Leave) }
         router.on<Command.Guild.Kick> { sid, cmd -> handleGuildCmd(sid, cmd) }
         router.on<Command.Guild.Promote> { sid, cmd -> handleGuildCmd(sid, cmd) }
@@ -39,6 +40,7 @@ class GuildHandler(
                 Command.Guild.Disband -> gs.disband(sessionId)
                 is Command.Guild.Invite -> gs.invite(sessionId, cmd.target)
                 Command.Guild.Accept -> gs.accept(sessionId)
+                Command.Guild.Decline -> gs.decline(sessionId)
                 Command.Guild.Leave -> gs.leave(sessionId)
                 is Command.Guild.Kick -> gs.kick(sessionId, cmd.target)
                 is Command.Guild.Promote -> gs.promote(sessionId, cmd.target)

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
@@ -384,6 +384,12 @@ class CommandParserTest {
     }
 
     @Test
+    fun `parses group decline`() {
+        assertEquals(Command.GroupCmd.Decline, CommandParser.parse("group decline"))
+        assertEquals(Command.GroupCmd.Decline, CommandParser.parse("group reject"))
+    }
+
+    @Test
     fun `parses group leave`() {
         assertEquals(Command.GroupCmd.Leave, CommandParser.parse("group leave"))
     }
@@ -464,6 +470,13 @@ class CommandParserTest {
     @Test
     fun `guild invite without target is Invalid`() {
         assertTrue(CommandParser.parse("guild invite") is Command.Invalid)
+    }
+
+    @Test
+    fun `parses guild accept and decline`() {
+        assertEquals(Command.Guild.Accept, CommandParser.parse("guild accept"))
+        assertEquals(Command.Guild.Decline, CommandParser.parse("guild decline"))
+        assertEquals(Command.Guild.Decline, CommandParser.parse("guild reject"))
     }
 
     // ---- Crafting & Gathering ----


### PR DESCRIPTION
## Summary
The web client's group/guild invite cards expose Decline buttons that send `group decline` and `guild decline`, but CommandParser didn't recognize "decline" as a subcommand — the buttons silently failed (resolved to Unknown/Invalid).

### Parser
- Add `Command.GroupCmd.Decline` and `Command.Guild.Decline` variants
- Parse `decline` and `reject` as aliases for both

### Handlers
- `GroupSystem.decline()`: removes pending invite, notifies inviter ("X declined your invite") and invitee ("You decline the group invite")
- `GuildSystem.decline()`: same pattern for guilds
- Wired through `GroupHandler` and `GuildHandler`

### Tests
- Parser tests for `group decline`, `group reject`, `guild decline`, `guild reject`

## Test plan
- [x] `ktlintCheck` passes
- [x] Full test suite passes (including new parser tests)
- [ ] Receive group invite → click Decline → invite dismissed, inviter notified
- [ ] Receive guild invite → click Decline → invite dismissed, inviter notified
- [ ] `group decline` in terminal works
- [ ] `guild reject` in terminal works (alias)