### PR TITLE
Unify pose/emote into a single UI action (#780)

### DIFF
--- a/web-v3/src/components/panels/ChatPanel.tsx
+++ b/web-v3/src/components/panels/ChatPanel.tsx
@@ -319,7 +319,15 @@ export function ChatPanel({
                     </button>
                   ))}
                 </div>
-                <form className="emote-custom-form" onSubmit={(e) => { e.preventDefault(); const msg = customEmote.trim(); if (msg) { onCommand(`emote ${msg}`); setCustomEmote(""); } }}>
+                <form className="emote-custom-form" onSubmit={(e) => {
+                  e.preventDefault();
+                  const msg = customEmote.trim();
+                  if (!msg) return;
+                  // If text contains the player's name, send as pose (freeform); otherwise emote (third-person)
+                  const cmd = msg.toLowerCase().includes(playerName.toLowerCase()) ? "pose" : "emote";
+                  onCommand(`${cmd} ${msg}`);
+                  setCustomEmote("");
+                }}>
                   <input
                     type="text"
                     className="social-action-input"
@@ -328,6 +336,15 @@ export function ChatPanel({
                     onChange={(e) => setCustomEmote(e.target.value)}
                     aria-label="Custom emote"
                   />
+                  <button
+                    type="button"
+                    className="emote-name-btn"
+                    title="Insert your name for freeform pose"
+                    aria-label="Insert your character name"
+                    onClick={() => setCustomEmote((prev) => prev + playerName + " ")}
+                  >
+                    @me
+                  </button>
                   <button type="submit" className="social-action-btn" disabled={!customEmote.trim()}>Emote</button>
                 </form>
               </div>

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -2006,6 +2006,25 @@ body {
   align-items: center;
 }
 
+.emote-name-btn {
+  padding: 4px 8px;
+  min-height: 44px;
+  border: 1px solid var(--line-faint);
+  border-radius: var(--radius-sm);
+  background: rgb(120 100 160 / 12%);
+  color: var(--color-primary-lavender);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+
+.emote-name-btn:hover {
+  background: rgb(120 100 160 / 22%);
+  border-color: var(--color-primary-lavender);
+}
 
 .chat-input,
 .chat-target-input {


### PR DESCRIPTION
## Summary
Collapse the pose and emote commands into one intuitive interaction in the emote picker.

### How it works
- The custom emote text input now auto-detects the right command:
  - Text **contains your character name** → sent as \`pose\` (freeform, shown verbatim)
  - Text **doesn't contain your name** → sent as \`emote\` (third-person, server prepends name)
- New **\`@me\` button** next to the input inserts your character name, making freeform pose discoverable

### Examples
| Input | Command sent | Room sees |
|-------|-------------|-----------|
| \`waves hello\` | \`emote waves hello\` | Ambuoroko waves hello |
| \`Ambuoroko draws a magic circle\` | \`pose Ambuoroko draws a magic circle\` | Ambuoroko draws a magic circle |
| Click @me → \`Ambuoroko stretches\` | \`pose Ambuoroko stretches\` | Ambuoroko stretches |

### No server changes
Both \`emote\` and \`pose\` already exist in the parser. This is purely a UI convenience.

Closes #780

## Test plan
- [x] Web client lints and builds clean
- [ ] Type without name → sends as emote
- [ ] Type with name → sends as pose
- [ ] Click @me → inserts character name, cursor stays in input
- [ ] Preset emote buttons still work (unchanged)