### PR TITLE
Fix Docker build: make buildWeb task inputs optional

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -162,12 +162,12 @@ val buildWeb by tasks.registering {
     val webDir = layout.projectDirectory.dir("web-v3")
     val outputDir = layout.projectDirectory.dir("src/main/resources/web-v3")
     val isWindows = System.getProperty("os.name").lowercase().contains("win")
-    inputs.dir(webSrcDir)
-    inputs.file(webDir.file("package.json"))
-    inputs.file(webDir.file("bun.lock"))
-    inputs.file(webDir.file("vite.config.ts"))
-    inputs.file(webDir.file("tsconfig.json"))
-    inputs.file(webDir.file("index.html"))
+    inputs.dir(webSrcDir).optional()
+    inputs.file(webDir.file("package.json")).optional()
+    inputs.file(webDir.file("bun.lock")).optional()
+    inputs.file(webDir.file("vite.config.ts")).optional()
+    inputs.file(webDir.file("index.html")).optional()
+    inputs.file(webDir.file("tsconfig.json")).optional()
     outputs.dir(outputDir)
     doLast {
         val bun = if (isWindows) "bun.exe" else "bun"


### PR DESCRIPTION
## Summary
Docker image builds have been failing on every merge to main. The `shadowJar` step fails with "input file does not exist" errors for `web-v3/package.json`, `bun.lock`, `vite.config.ts`, and `tsconfig.json`.

### Root cause
The `buildWeb` Gradle task declares these files as required inputs for up-to-date checking. In the Docker multi-stage build, the builder stage copies `src/` and the pre-built web output from the frontend stage — but NOT the `web-v3/` source directory. Gradle 9 validates all declared task inputs at configuration time, even for tasks that won't run, causing the build to fail.

### Fix
Mark all `buildWeb` inputs as `.optional()`. This tells Gradle to skip validation when the files aren't present. The task already handles missing `bun` gracefully (warns and skips), so optional inputs are consistent with the design.

### Impact
Every merge to main since the `buildWeb` task was added has failed the Docker build step. Tests and frontend CI pass; only the Docker image push was broken.

## Test plan
- [x] `shadowJar` builds locally
- [x] `ktlintCheck` + full test suite passes
- [ ] Docker build succeeds in CI (the actual fix)