### PR TITLE
Minimap: highlighted path trail to nearest quest objective

### DIFF
--- a/web-v3/src/canvas/systems/Minimap.ts
+++ b/web-v3/src/canvas/systems/Minimap.ts
@@ -28,6 +28,8 @@ const FOG_COLOR = 0x2a3050;
 const QUEST_COLOR = 0xbea873;
 const HOUSING_COLOR = 0xc8a078;
 const QUEST_PULSE_PERIOD = 2500; // ms
+const PATH_COLOR = 0xd4b86a;
+const PATH_SHIMMER_PERIOD = 1800; // ms
 
 export class Minimap {
   readonly container = new Container();
@@ -335,6 +337,9 @@ export class Minimap {
       return { px: cx + lp.lx * CELL, py: cy + lp.ly * CELL };
     };
 
+    // Compute shortest path to nearest quest target (BFS)
+    const pathEdges = this.computeQuestPath(questTargets);
+
     // Draw connecting lines
     for (const [id] of localPos) {
       const node = this.visited.get(id);
@@ -352,6 +357,30 @@ export class Minimap {
           this.mapGraphics.lineTo(tp.px, tp.py);
           this.mapGraphics.stroke({ color: LINE_COLOR, width: 2, alpha: 0.65 });
         }
+      }
+    }
+
+    // Draw quest path trail — gold glow over the shortest path edges
+    if (pathEdges.length > 0) {
+      const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+      const shimmer = reducedMotion
+        ? 0.7
+        : 0.45 + 0.3 * (0.5 + 0.5 * Math.sin(Date.now() / PATH_SHIMMER_PERIOD * Math.PI * 2));
+
+      for (const [fromId, toId] of pathEdges) {
+        const sp = posOf(fromId);
+        const tp = posOf(toId);
+        if (!sp || !tp) continue;
+        if (!this.inBounds(sp.px, sp.py) && !this.inBounds(tp.px, tp.py)) continue;
+
+        // Outer glow
+        this.mapGraphics.moveTo(sp.px, sp.py);
+        this.mapGraphics.lineTo(tp.px, tp.py);
+        this.mapGraphics.stroke({ color: PATH_COLOR, width: 5, alpha: shimmer * 0.3 });
+        // Inner bright line
+        this.mapGraphics.moveTo(sp.px, sp.py);
+        this.mapGraphics.lineTo(tp.px, tp.py);
+        this.mapGraphics.stroke({ color: PATH_COLOR, width: 2, alpha: shimmer });
       }
     }
 
@@ -474,6 +503,60 @@ export class Minimap {
         this.clickAreas.push({ roomId: targetId, area });
       }
     }
+  }
+
+  /**
+   * BFS from the current room to the nearest quest target.
+   * Returns an array of [fromId, toId] edge pairs representing the shortest path,
+   * or an empty array if no path exists.
+   */
+  private computeQuestPath(questTargets: Set<string>): Array<[string, string]> {
+    if (questTargets.size === 0 || !this.currentRoomId) return [];
+
+    const start = this.currentRoomId;
+    if (questTargets.has(start)) return []; // already at a quest target
+
+    const visited = new Set<string>();
+    const parent = new Map<string, string>();
+    const queue: string[] = [start];
+    visited.add(start);
+
+    let target: string | null = null;
+
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      const node = this.visited.get(current);
+      if (!node) continue;
+
+      for (const [dir, neighborId] of Object.entries(node.exits)) {
+        if (!HORIZONTAL_DIRS.has(dir)) continue;
+        if (visited.has(neighborId)) continue;
+        if (!this.visited.has(neighborId)) continue; // only traverse explored rooms
+
+        visited.add(neighborId);
+        parent.set(neighborId, current);
+
+        if (questTargets.has(neighborId)) {
+          target = neighborId;
+          break;
+        }
+        queue.push(neighborId);
+      }
+      if (target) break;
+    }
+
+    if (!target) return [];
+
+    // Reconstruct path as edge pairs
+    const edges: Array<[string, string]> = [];
+    let current = target;
+    while (parent.has(current)) {
+      const prev = parent.get(current)!;
+      edges.push([prev, current]);
+      current = prev;
+    }
+    edges.reverse();
+    return edges;
   }
 
   private ensureThumb(roomId: string, imagePath: string | null, nx: number, ny: number, radius: number, alpha: number, preloaded: Texture | null) {

--- a/web-v3/src/hooks/useMiniMap.ts
+++ b/web-v3/src/hooks/useMiniMap.ts
@@ -13,8 +13,11 @@ const FOG_FILL = "rgba(42, 48, 80, 0.5)";
 const FOG_STROKE = "rgba(58, 64, 96, 0.35)";
 const NODE_STROKE = "rgba(90, 106, 144, 0.5)";
 const QUEST_MARKER = "#bea873";
+const PATH_GLOW = "rgba(212, 184, 106, 0.7)";
+const PATH_GLOW_OUTER = "rgba(212, 184, 106, 0.25)";
 const HOUSING_FILL = "#c8a078";
 const QUEST_PULSE_PERIOD = 2500; // ms for one full cycle
+const PATH_SHIMMER_PERIOD = 1800; // ms
 const CELL = 80;
 const NODE_RADIUS = 18;
 const CURRENT_RADIUS = 24;
@@ -136,6 +139,47 @@ function renderMap(
         ctx.lineTo(tx, ty);
         ctx.stroke();
       }
+    }
+  }
+
+  // Quest path trail — BFS from current room to nearest quest target
+  if (currentId && questTargetRoomIds.size > 0 && !questTargetRoomIds.has(currentId)) {
+    const pathEdges = bfsQuestPath(currentId, questTargetRoomIds, visited);
+    if (pathEdges.length > 0) {
+      const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+      const shimmer = reducedMotion
+        ? 0.7
+        : 0.45 + 0.3 * (0.5 + 0.5 * Math.sin(Date.now() / PATH_SHIMMER_PERIOD * Math.PI * 2));
+
+      for (const [fromId, toId] of pathEdges) {
+        const fromNode = visited.get(fromId);
+        const toNode = visited.get(toId);
+        if (!fromNode || !toNode) continue;
+        const sx = nodeX(fromNode);
+        const sy = nodeY(fromNode);
+        const tx = nodeX(toNode);
+        const ty = nodeY(toNode);
+        if (!inScrollBounds(sx, sy) && !inScrollBounds(tx, ty)) continue;
+
+        // Outer glow
+        ctx.globalAlpha = shimmer * 0.35;
+        ctx.strokeStyle = PATH_GLOW_OUTER;
+        ctx.lineWidth = 6;
+        ctx.beginPath();
+        ctx.moveTo(sx, sy);
+        ctx.lineTo(tx, ty);
+        ctx.stroke();
+
+        // Inner bright line
+        ctx.globalAlpha = shimmer;
+        ctx.strokeStyle = PATH_GLOW;
+        ctx.lineWidth = 2.5;
+        ctx.beginPath();
+        ctx.moveTo(sx, sy);
+        ctx.lineTo(tx, ty);
+        ctx.stroke();
+      }
+      ctx.globalAlpha = 1;
     }
   }
 
@@ -304,6 +348,45 @@ function renderMap(
 
   // Restore from scroll-bounds clip
   ctx.restore();
+}
+
+/** BFS from currentId to the nearest quest target. Returns edge pairs [from, to]. */
+function bfsQuestPath(
+  currentId: string,
+  targets: Set<string>,
+  visited: Map<string, MapRoom>,
+): Array<[string, string]> {
+  const seen = new Set<string>();
+  const parent = new Map<string, string>();
+  const queue: string[] = [currentId];
+  seen.add(currentId);
+  let found: string | null = null;
+
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    const node = visited.get(id);
+    if (!node) continue;
+    for (const [dir, neighborId] of Object.entries(node.exits)) {
+      if (dir === "up" || dir === "down") continue;
+      if (seen.has(neighborId) || !visited.has(neighborId)) continue;
+      seen.add(neighborId);
+      parent.set(neighborId, id);
+      if (targets.has(neighborId)) { found = neighborId; break; }
+      queue.push(neighborId);
+    }
+    if (found) break;
+  }
+
+  if (!found) return [];
+  const edges: Array<[string, string]> = [];
+  let cur = found;
+  while (parent.has(cur)) {
+    const prev = parent.get(cur)!;
+    edges.push([prev, cur]);
+    cur = prev;
+  }
+  edges.reverse();
+  return edges;
 }
 
 export function useMiniMap() {


### PR DESCRIPTION
## Summary

Adds a subtle gold path trail on the minimap showing the shortest route from the player's current room to the nearest active quest objective.

- **BFS pathfinding** from current room to nearest quest target room, traversing only explored rooms via horizontal exits (N/S/E/W)
- **Gold glow rendering**: outer 5px stroke at 25% alpha + inner 2px stroke at 70% alpha, layered over normal edge lines
- **Gentle shimmer animation** (1.8s period) flowing along the path
- **`prefers-reduced-motion` respected**: static 70% alpha with no animation
- Only shows path to the **nearest** objective to avoid visual clutter
- Path recomputed on every redraw cycle (room change or tick)
- Both minimap implementations updated (PixiJS canvas + HTML canvas fallback)

## Visual behavior

- When no quests are active or player is already at a quest target: no trail shown
- When quest target is within the 2-hop minimap neighborhood: gold trail connects rooms
- When quest target is beyond view: existing off-screen chevron indicators still point the way
- Path follows only explored rooms — unexplored shortcuts won't be revealed

## Test plan
- [ ] Accept a quest with a target room — gold path trail appears on minimap
- [ ] Walk along the path — trail updates each room, always pointing toward target
- [ ] Complete the quest objective — trail disappears
- [ ] Multiple active quests — trail shows path to the nearest one
- [ ] Already at a quest target room — no trail shown
- [ ] Quest target in unexplored area — no trail (can't path through fog)
- [ ] Enable `prefers-reduced-motion` in OS settings — trail is static, no shimmer
- [ ] Check HTML canvas minimap (scroll view) — same gold trail behavior

Closes #790