### PR TITLE
Day/night cycle, weather system, and seasonal events

### DIFF
--- a/docs/RECENT_YAML_CHANGES.md
+++ b/docs/RECENT_YAML_CHANGES.md
@@ -488,3 +488,129 @@ New `Char.Bank` package emitted after deposit/withdraw:
 | `gold` | Long | Banked gold balance |
 | `items` | Array | Items in vault (id, name, keyword, image) |
 | `maxItems` | Int | Maximum vault capacity |
+
+---
+
+## Day/Night Cycle (application.yaml)
+
+New config section under `ambonmud.engine.worldTime`:
+
+```yaml
+ambonmud:
+  engine:
+    worldTime:
+      cycleLengthMs: 3600000     # Real ms for one game day (default: 1 hour)
+      dawnHour: 5                # Game hour when dawn begins
+      dayHour: 8                 # Game hour when day begins
+      duskHour: 18               # Game hour when dusk begins
+      nightHour: 21              # Game hour when night begins
+```
+
+### Time Periods
+
+| Period | Default Hours | Description |
+|--------|--------------|-------------|
+| NIGHT | 21:00–04:59 | Stars glitter overhead in the dark sky. |
+| DAWN | 05:00–07:59 | The sky brightens with the first light of dawn. |
+| DAY | 08:00–17:59 | Sunlight fills the world. |
+| DUSK | 18:00–20:59 | Long shadows stretch as the sun sinks low. |
+
+### Command
+
+| Command | Description |
+|---------|-------------|
+| `time` | Show current game time, weather, and active events |
+
+### GMCP: `World.Time`
+
+Broadcast to all players when the time period changes:
+
+```json
+{ "period": "DAY", "hour": 8, "minute": 0 }
+```
+
+---
+
+## Weather System (application.yaml)
+
+New config section under `ambonmud.engine.weather`:
+
+```yaml
+ambonmud:
+  engine:
+    weather:
+      minTransitionMs: 300000    # Min real ms between weather changes (5 min)
+      maxTransitionMs: 900000    # Max real ms between weather changes (15 min)
+```
+
+### Weather Types
+
+| Type | Weight | Description |
+|------|--------|-------------|
+| CLEAR | 3.0 | The sky is clear. |
+| RAIN | 2.0 | A steady rain falls. |
+| STORM | 0.5 | Thunder rumbles and lightning splits the sky. |
+| FOG | 1.0 | A thick fog blankets the area. |
+| SNOW | 0.8 | Soft snow drifts down from above. |
+| WIND | 1.0 | A fierce wind howls through the area. |
+
+Weather transitions are per-zone and weighted random. Higher weight = more likely.
+
+### GMCP: `World.Weather`
+
+Sent to players in a zone when its weather changes:
+
+```json
+{ "zone": "ambon_hub", "weather": "RAIN", "description": "A steady rain falls." }
+```
+
+---
+
+## Seasonal Events Framework (application.yaml)
+
+New config section under `ambonmud.engine.worldEvents`:
+
+```yaml
+ambonmud:
+  engine:
+    worldEvents:
+      definitions:
+        spring_festival:
+          displayName: "Spring Festival"
+          description: "Flowers bloom across the realm."
+          startDate: "2026-03-20"    # ISO date (yyyy-MM-dd)
+          endDate: "2026-04-20"
+          flags:
+            - spring_festival        # Queryable by quests, mobs, items
+            - bonus_herbalism
+          startMessage: "The Spring Festival has begun!"
+          endMessage: "The Spring Festival has ended."
+```
+
+### Event Definition Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `displayName` | String | `""` | Display name shown to players |
+| `description` | String | `""` | Flavor text |
+| `startDate` | String | `""` | ISO date for event start (empty = always active) |
+| `endDate` | String | `""` | ISO date for event end (empty = no end) |
+| `flags` | List\<String\> | `[]` | Flags set when event is active |
+| `startMessage` | String | `""` | Broadcast when event activates |
+| `endMessage` | String | `""` | Broadcast when event deactivates |
+
+### Behavior
+- Events activate/deactivate based on real-world UTC date
+- `startMessage` and `endMessage` are broadcast to all online players
+- `flags` are queryable by other systems via `WorldEventSystem.hasFlag(flag)`
+- Empty `startDate`/`endDate` = always active (permanent event)
+
+### GMCP: `World.Events`
+
+Broadcast to all players when events change:
+
+```json
+[
+  { "id": "spring_festival", "name": "Spring Festival", "description": "Flowers bloom across the realm." }
+]
+```

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -390,6 +390,15 @@ data class AppConfig(
         }
 
         require(engine.bank.maxItems > 0) { "ambonMUD.engine.bank.maxItems must be > 0" }
+        require(engine.worldTime.cycleLengthMs > 0L) { "ambonMUD.engine.worldTime.cycleLengthMs must be > 0" }
+        require(engine.worldTime.dawnHour in 0..23) { "ambonMUD.engine.worldTime.dawnHour must be 0..23" }
+        require(engine.worldTime.dayHour in 0..23) { "ambonMUD.engine.worldTime.dayHour must be 0..23" }
+        require(engine.worldTime.duskHour in 0..23) { "ambonMUD.engine.worldTime.duskHour must be 0..23" }
+        require(engine.worldTime.nightHour in 0..23) { "ambonMUD.engine.worldTime.nightHour must be 0..23" }
+        require(engine.weather.minTransitionMs > 0L) { "ambonMUD.engine.weather.minTransitionMs must be > 0" }
+        require(engine.weather.maxTransitionMs >= engine.weather.minTransitionMs) {
+            "ambonMUD.engine.weather.maxTransitionMs must be >= minTransitionMs"
+        }
 
         // Validate enchantment definitions
         require(engine.enchanting.maxEnchantmentsPerItem > 0) {
@@ -497,6 +506,41 @@ data class PetConfig(
 
 data class BankConfig(
     val maxItems: Int = 50,
+)
+
+data class WorldTimeConfig(
+    /** Real-time milliseconds for one full game day (24 game hours). Default: 1 hour. */
+    val cycleLengthMs: Long = 3_600_000L,
+    val dawnHour: Int = 5,
+    val dayHour: Int = 8,
+    val duskHour: Int = 18,
+    val nightHour: Int = 21,
+)
+
+data class WeatherConfig(
+    /** Minimum real-time ms between weather transitions per zone. */
+    val minTransitionMs: Long = 300_000L,
+    /** Maximum real-time ms between weather transitions per zone. */
+    val maxTransitionMs: Long = 900_000L,
+)
+
+data class WorldEventDefinition(
+    val displayName: String = "",
+    val description: String = "",
+    /** ISO date string (yyyy-MM-dd) for event start, empty = always active. */
+    val startDate: String = "",
+    /** ISO date string (yyyy-MM-dd) for event end, empty = no end. */
+    val endDate: String = "",
+    /** Flags set on the world when event is active, queryable by quests/mobs. */
+    val flags: List<String> = emptyList(),
+    /** Announcement broadcast when event activates. */
+    val startMessage: String = "",
+    /** Announcement broadcast when event ends. */
+    val endMessage: String = "",
+)
+
+data class WorldEventsConfig(
+    val definitions: Map<String, WorldEventDefinition> = emptyMap(),
 )
 
 data class EnchantmentDefinition(
@@ -865,6 +909,9 @@ data class EngineConfig(
     val pets: PetConfig = PetConfig(),
     val enchanting: EnchantingConfig = EnchantingConfig(),
     val bank: BankConfig = BankConfig(),
+    val worldTime: WorldTimeConfig = WorldTimeConfig(),
+    val weather: WeatherConfig = WeatherConfig(),
+    val worldEvents: WorldEventsConfig = WorldEventsConfig(),
     val friends: FriendsConfig = FriendsConfig(),
     val debug: EngineDebugConfig = EngineDebugConfig(),
     val classes: ClassEngineConfig = ClassEngineConfig(),

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -45,6 +45,7 @@ import dev.ambon.engine.commands.handlers.SpriteHandler
 import dev.ambon.engine.commands.handlers.TradeHandler
 import dev.ambon.engine.commands.handlers.UiHandler
 import dev.ambon.engine.commands.handlers.WorldFeaturesHandler
+import dev.ambon.engine.commands.handlers.WorldInfoHandler
 import dev.ambon.engine.crafting.CraftingRegistry
 import dev.ambon.engine.crafting.CraftingSystem
 import dev.ambon.engine.crafting.EnchantSystem
@@ -651,6 +652,23 @@ class GameEngine(
         clock = clock,
     )
 
+    private val worldTimeSystem = WorldTimeSystem(
+        config = engineConfig.worldTime,
+        clock = clock,
+    )
+
+    private val weatherSystem = WeatherSystem(
+        config = engineConfig.weather,
+        clock = clock,
+    )
+
+    private val worldEventSystem = WorldEventSystem(
+        config = engineConfig.worldEvents,
+        clock = clock,
+    )
+
+    private var lastTimePeriod: TimePeriod = worldTimeSystem.period()
+
     private val abilitySystem: AbilitySystem =
         AbilitySystem(
             players = players,
@@ -977,6 +995,12 @@ class GameEngine(
                 bankConfig = engineConfig.bank,
                 markVitalsDirty = ::markVitalsDirty,
             ),
+            WorldInfoHandler(
+                ctx = ctx,
+                worldTimeSystem = worldTimeSystem,
+                weatherSystem = weatherSystem,
+                worldEventSystem = worldEventSystem,
+            ),
             DialogueQuestHandler(
                 ctx = ctx,
                 dialogueSystem = dialogueSystem,
@@ -1208,6 +1232,61 @@ class GameEngine(
                             ),
                         )
                         emitPetState(expired.ownerSessionId, null)
+                    }
+
+                    // Tick world time — broadcast on period change
+                    val newPeriod = worldTimeSystem.tick(lastTimePeriod)
+                    if (newPeriod != null) {
+                        lastTimePeriod = newPeriod
+                        gmcpEmitter.broadcastWorldTime(
+                            GmcpEmitter.WorldTimePayload(
+                                period = newPeriod.name,
+                                hour = worldTimeSystem.gameHour(),
+                                minute = worldTimeSystem.gameMinute(),
+                            ),
+                            players,
+                        )
+                    }
+
+                    // Tick weather — broadcast zone changes
+                    val activeZones = players.allPlayers().map { it.roomId.zone }.toSet()
+                    val weatherChanges = weatherSystem.tick(activeZones)
+                    for ((zone, weather) in weatherChanges) {
+                        for (p in players.playersInZone(zone)) {
+                            gmcpEmitter.sendWorldWeather(
+                                p.sessionId,
+                                GmcpEmitter.WorldWeatherPayload(
+                                    zone = zone,
+                                    weather = weather.name,
+                                    description = weather.description,
+                                ),
+                            )
+                        }
+                    }
+
+                    // Tick world events — broadcast activations/deactivations
+                    val eventResult = worldEventSystem.tick()
+                    if (eventResult.hasChanges()) {
+                        for (id in eventResult.activated) {
+                            val def = engineConfig.worldEvents.definitions[id] ?: continue
+                            if (def.startMessage.isNotEmpty()) {
+                                for (p in players.allPlayers()) {
+                                    outbound.send(OutboundEvent.SendInfo(p.sessionId, "[Event] ${def.startMessage}"))
+                                }
+                            }
+                        }
+                        for (id in eventResult.deactivated) {
+                            val def = engineConfig.worldEvents.definitions[id] ?: continue
+                            if (def.endMessage.isNotEmpty()) {
+                                for (p in players.allPlayers()) {
+                                    outbound.send(OutboundEvent.SendInfo(p.sessionId, "[Event] ${def.endMessage}"))
+                                }
+                            }
+                        }
+                        val activePayloads = worldEventSystem.activeEvents().map { (id, def) ->
+                            GmcpEmitter.WorldEventPayload(id, def.displayName, def.description)
+                        }
+                        gmcpEmitter.broadcastWorldEvents(activePayloads, players)
                     }
 
                     // Tick gathering node respawns

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -1032,6 +1032,50 @@ class GmcpEmitter(
         )
     }
 
+    // ---------- world atmosphere ----------
+
+    data class WorldTimePayload(
+        val period: String,
+        val hour: Int,
+        val minute: Int,
+    )
+
+    data class WorldWeatherPayload(
+        val zone: String,
+        val weather: String,
+        val description: String,
+    )
+
+    data class WorldEventPayload(
+        val id: String,
+        val name: String,
+        val description: String,
+    )
+
+    suspend fun sendWorldTime(sessionId: SessionId, payload: WorldTimePayload) {
+        emit(sessionId, "World.Time", payload)
+    }
+
+    suspend fun broadcastWorldTime(payload: WorldTimePayload, players: PlayerRegistry) {
+        for (p in players.allPlayers()) {
+            emit(p.sessionId, "World.Time", payload)
+        }
+    }
+
+    suspend fun sendWorldWeather(sessionId: SessionId, payload: WorldWeatherPayload) {
+        emit(sessionId, "World.Weather", payload)
+    }
+
+    suspend fun sendWorldEvents(sessionId: SessionId, events: List<WorldEventPayload>) {
+        emit(sessionId, "World.Events", events)
+    }
+
+    suspend fun broadcastWorldEvents(events: List<WorldEventPayload>, players: PlayerRegistry) {
+        for (p in players.allPlayers()) {
+            emit(p.sessionId, "World.Events", events)
+        }
+    }
+
     // ---------- reputation / factions ----------
 
     data class FactionStandingPayload(

--- a/src/main/kotlin/dev/ambon/engine/WeatherSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/WeatherSystem.kt
@@ -1,0 +1,86 @@
+package dev.ambon.engine
+
+import dev.ambon.config.WeatherConfig
+import java.time.Clock
+
+/**
+ * Manages per-zone weather state with random transitions.
+ *
+ * Each zone independently transitions between weather types on a random
+ * schedule within the configured interval range.
+ */
+class WeatherSystem(
+    private val config: WeatherConfig,
+    private val clock: Clock,
+    private val rng: java.util.Random = java.util.Random(),
+) {
+    private val zoneWeather = mutableMapOf<String, WeatherType>()
+    private val nextTransition = mutableMapOf<String, Long>()
+
+    fun weatherForZone(zone: String): WeatherType =
+        zoneWeather.getOrPut(zone) { WeatherType.CLEAR }
+
+    fun allZoneWeather(): Map<String, WeatherType> = zoneWeather.toMap()
+
+    /**
+     * Called each engine tick. Returns a map of zones whose weather changed this tick.
+     * Zones are lazily initialized on first [weatherForZone] call or when a player
+     * enters a zone.
+     */
+    fun tick(activeZones: Set<String>): Map<String, WeatherType> {
+        val now = clock.millis()
+        val changes = mutableMapOf<String, WeatherType>()
+        for (zone in activeZones) {
+            zoneWeather.getOrPut(zone) { WeatherType.CLEAR }
+            val deadline = nextTransition.getOrPut(zone) { scheduleNext(now) }
+            if (now >= deadline) {
+                val current = zoneWeather[zone] ?: WeatherType.CLEAR
+                val next = rollNextWeather(current)
+                zoneWeather[zone] = next
+                nextTransition[zone] = scheduleNext(now)
+                if (next != current) {
+                    changes[zone] = next
+                }
+            }
+        }
+        return changes
+    }
+
+    /** Force-sets weather for a zone (e.g., for events or staff commands). */
+    fun setWeather(zone: String, weather: WeatherType) {
+        zoneWeather[zone] = weather
+        nextTransition[zone] = scheduleNext(clock.millis())
+    }
+
+    private fun scheduleNext(now: Long): Long {
+        val range = config.maxTransitionMs - config.minTransitionMs
+        val delay = config.minTransitionMs + (rng.nextDouble() * range).toLong()
+        return now + delay
+    }
+
+    private fun rollNextWeather(current: WeatherType): WeatherType {
+        // Weighted transitions: favor clear/rain, less likely storm/snow
+        val candidates = WeatherType.entries.filter { it != current }
+        val weights = candidates.map { it.weight }
+        val total = weights.sum()
+        var roll = rng.nextDouble() * total
+        for ((i, w) in weights.withIndex()) {
+            roll -= w
+            if (roll <= 0) return candidates[i]
+        }
+        return WeatherType.CLEAR
+    }
+}
+
+enum class WeatherType(
+    val displayName: String,
+    val description: String,
+    val weight: Double,
+) {
+    CLEAR("Clear", "The sky is clear.", 3.0),
+    RAIN("Rain", "A steady rain falls.", 2.0),
+    STORM("Storm", "Thunder rumbles and lightning splits the sky.", 0.5),
+    FOG("Fog", "A thick fog blankets the area.", 1.0),
+    SNOW("Snow", "Soft snow drifts down from above.", 0.8),
+    WIND("Wind", "A fierce wind howls through the area.", 1.0),
+}

--- a/src/main/kotlin/dev/ambon/engine/WorldEventSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/WorldEventSystem.kt
@@ -1,0 +1,82 @@
+package dev.ambon.engine
+
+import dev.ambon.config.WorldEventDefinition
+import dev.ambon.config.WorldEventsConfig
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.time.Clock
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Manages config-driven world events with real-world date ranges.
+ *
+ * Events activate and deactivate based on the current date. Other systems
+ * can query [activeFlags] to check if event-specific content should be enabled.
+ */
+class WorldEventSystem(
+    private val config: WorldEventsConfig,
+    private val clock: Clock,
+) {
+    private val currentlyActive = mutableSetOf<String>()
+
+    /** Returns the set of event IDs that are currently active. */
+    fun activeEventIds(): Set<String> = currentlyActive.toSet()
+
+    /** Returns definitions for all currently active events. */
+    fun activeEvents(): Map<String, WorldEventDefinition> =
+        currentlyActive.associateWith { config.definitions.getValue(it) }
+
+    /** Returns all flags from all currently active events. */
+    fun activeFlags(): Set<String> =
+        currentlyActive.flatMap { config.definitions[it]?.flags ?: emptyList() }.toSet()
+
+    /** Returns true if any active event has the given flag. */
+    fun hasFlag(flag: String): Boolean = activeFlags().contains(flag)
+
+    /** Returns all defined events with their current active status. */
+    fun allEvents(): Map<String, Pair<WorldEventDefinition, Boolean>> =
+        config.definitions.mapValues { (id, def) -> def to (id in currentlyActive) }
+
+    /**
+     * Called each engine tick (or periodically). Returns lists of events
+     * that just activated or deactivated.
+     */
+    fun tick(): EventTickResult {
+        val today = LocalDate.ofInstant(clock.instant(), ZoneOffset.UTC)
+        val activated = mutableListOf<String>()
+        val deactivated = mutableListOf<String>()
+
+        for ((id, def) in config.definitions) {
+            val shouldBeActive = isActiveOn(def, today)
+            val wasActive = id in currentlyActive
+
+            if (shouldBeActive && !wasActive) {
+                currentlyActive.add(id)
+                activated.add(id)
+                log.info { "World event activated: $id (${def.displayName})" }
+            } else if (!shouldBeActive && wasActive) {
+                currentlyActive.remove(id)
+                deactivated.add(id)
+                log.info { "World event deactivated: $id (${def.displayName})" }
+            }
+        }
+
+        return EventTickResult(activated, deactivated)
+    }
+
+    private fun isActiveOn(def: WorldEventDefinition, date: LocalDate): Boolean {
+        if (def.startDate.isEmpty() && def.endDate.isEmpty()) return true
+        val start = if (def.startDate.isNotEmpty()) LocalDate.parse(def.startDate) else LocalDate.MIN
+        val end = if (def.endDate.isNotEmpty()) LocalDate.parse(def.endDate) else LocalDate.MAX
+        return !date.isBefore(start) && !date.isAfter(end)
+    }
+
+    data class EventTickResult(
+        val activated: List<String>,
+        val deactivated: List<String>,
+    ) {
+        fun hasChanges(): Boolean = activated.isNotEmpty() || deactivated.isNotEmpty()
+    }
+}

--- a/src/main/kotlin/dev/ambon/engine/WorldTimeSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/WorldTimeSystem.kt
@@ -1,0 +1,63 @@
+package dev.ambon.engine
+
+import dev.ambon.config.WorldTimeConfig
+import java.time.Clock
+
+/**
+ * Tracks an accelerated game-world day/night cycle.
+ *
+ * One full game day (24 game-hours) maps to [WorldTimeConfig.cycleLengthMs] of real time.
+ * The current time period (DAWN, DAY, DUSK, NIGHT) is derived from the game hour.
+ */
+class WorldTimeSystem(
+    private val config: WorldTimeConfig,
+    private val clock: Clock,
+) {
+    private val startMs: Long = clock.millis()
+
+    /** Returns the current game hour (0-23). */
+    fun gameHour(): Int {
+        val elapsed = clock.millis() - startMs
+        val dayProgress = (elapsed % config.cycleLengthMs).toDouble() / config.cycleLengthMs
+        return (dayProgress * 24).toInt().coerceIn(0, 23)
+    }
+
+    /** Returns the current game minute (0-59). */
+    fun gameMinute(): Int {
+        val elapsed = clock.millis() - startMs
+        val dayProgress = (elapsed % config.cycleLengthMs).toDouble() / config.cycleLengthMs
+        val totalMinutes = dayProgress * 24 * 60
+        return (totalMinutes.toInt() % 60).coerceIn(0, 59)
+    }
+
+    /** Returns the current time period based on game hour. */
+    fun period(): TimePeriod {
+        val hour = gameHour()
+        return when {
+            hour >= config.nightHour -> TimePeriod.NIGHT
+            hour >= config.duskHour -> TimePeriod.DUSK
+            hour >= config.dayHour -> TimePeriod.DAY
+            hour >= config.dawnHour -> TimePeriod.DAWN
+            else -> TimePeriod.NIGHT
+        }
+    }
+
+    /**
+     * Called each engine tick. Returns the new [TimePeriod] if it changed since [lastPeriod],
+     * or null if unchanged.
+     */
+    fun tick(lastPeriod: TimePeriod): TimePeriod? {
+        val current = period()
+        return if (current != lastPeriod) current else null
+    }
+}
+
+enum class TimePeriod(
+    val displayName: String,
+    val description: String,
+) {
+    DAWN("Dawn", "The sky brightens with the first light of dawn."),
+    DAY("Day", "Sunlight fills the world."),
+    DUSK("Dusk", "Long shadows stretch as the sun sinks low."),
+    NIGHT("Night", "Stars glitter overhead in the dark sky."),
+}

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -41,6 +41,8 @@ sealed interface Command {
 
     data object Who : Command
 
+    data object Time : Command
+
     data class Tell(
         val target: String,
         val message: String,
@@ -763,6 +765,10 @@ object CommandParser {
 
         matchPrefix(line, listOf("bank")) { _ ->
             Command.Bank.Balance
+        }?.let { return it }
+
+        matchPrefix(line, listOf("time")) { _ ->
+            Command.Time
         }?.let { return it }
 
         matchPrefix(line, listOf("whisper", "wh")) { rest ->

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldInfoHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldInfoHandler.kt
@@ -1,0 +1,50 @@
+package dev.ambon.engine.commands.handlers
+
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.engine.WeatherSystem
+import dev.ambon.engine.WorldEventSystem
+import dev.ambon.engine.WorldTimeSystem
+import dev.ambon.engine.commands.Command
+import dev.ambon.engine.commands.CommandHandler
+import dev.ambon.engine.commands.CommandRouter
+import dev.ambon.engine.commands.on
+import dev.ambon.engine.events.OutboundEvent
+
+class WorldInfoHandler(
+    ctx: EngineContext,
+    private val worldTimeSystem: WorldTimeSystem,
+    private val weatherSystem: WeatherSystem,
+    private val worldEventSystem: WorldEventSystem,
+) : CommandHandler {
+    private val players = ctx.players
+    private val outbound = ctx.outbound
+
+    override fun register(router: CommandRouter) {
+        router.on<Command.Time> { sid, _ -> handleTime(sid) }
+    }
+
+    private suspend fun handleTime(sessionId: SessionId) {
+        val period = worldTimeSystem.period()
+        val hour = worldTimeSystem.gameHour()
+        val minute = worldTimeSystem.gameMinute()
+        val timeStr = "%d:%02d".format(hour, minute)
+
+        outbound.send(OutboundEvent.SendInfo(sessionId, "[ World Status ]"))
+        outbound.send(OutboundEvent.SendInfo(sessionId, "  Time: $timeStr ($period — ${period.description})"))
+
+        val me = players.get(sessionId)
+        if (me != null) {
+            val zone = me.roomId.zone
+            val weather = weatherSystem.weatherForZone(zone)
+            outbound.send(OutboundEvent.SendInfo(sessionId, "  Weather: ${weather.displayName} — ${weather.description}"))
+        }
+
+        val activeEvents = worldEventSystem.activeEvents()
+        if (activeEvents.isNotEmpty()) {
+            outbound.send(OutboundEvent.SendInfo(sessionId, "  Active Events:"))
+            for ((_, def) in activeEvents) {
+                outbound.send(OutboundEvent.SendInfo(sessionId, "    ${def.displayName}: ${def.description}"))
+            }
+        }
+    }
+}

--- a/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
+++ b/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
@@ -205,7 +205,7 @@ private suspend fun DefaultWebSocketServerSession.bridgeWebSocketSession(
         InboundEvent.GmcpReceived(
             sessionId,
             "Core.Supports.Set",
-            """["Char.Vitals 1","Room.Info 1","Zone.Map 1","Char.StatusVars 1","Char.Items 1","Char.Equipment 1","Room.Players 1","Room.Mobs 1","Room.Items 1","Char.Skills 1","Char.Name 1","Char.StatusEffects 1","Char.Achievements 1","Char.Sprites 1","Comm.Channel 1","Guild 1","Group.Info 1","Friends 1","Core.Ping 1","Dialogue 1","Shop 1","Char.Combat 1","Char.Combat.Event 1","Char.Stats 1","Quest 1","Char.Cooldown 1","Char.Gain 1","Room.MobInfo 1","Mail 1","Crafting 1","Login 1","Server 1","UI.Feedback 1","Staff 1","Housing 1","Session 1","Trade 1","Auction 1","Char.Factions 1","Char.Pet 1","Char.Bank 1"]""",
+            """["Char.Vitals 1","Room.Info 1","Zone.Map 1","Char.StatusVars 1","Char.Items 1","Char.Equipment 1","Room.Players 1","Room.Mobs 1","Room.Items 1","Char.Skills 1","Char.Name 1","Char.StatusEffects 1","Char.Achievements 1","Char.Sprites 1","Comm.Channel 1","Guild 1","Group.Info 1","Friends 1","Core.Ping 1","Dialogue 1","Shop 1","Char.Combat 1","Char.Combat.Event 1","Char.Stats 1","Quest 1","Char.Cooldown 1","Char.Gain 1","Room.MobInfo 1","Mail 1","Crafting 1","Login 1","Server 1","UI.Feedback 1","Staff 1","Housing 1","Session 1","Trade 1","Auction 1","Char.Factions 1","Char.Pet 1","Char.Bank 1","World 1"]""",
         ),
     )
     metrics.onWsConnected()

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2476,6 +2476,39 @@ ambonmud:
           targetSlots: []
           xpReward: 80
 
+    worldTime:
+      cycleLengthMs: 3600000     # 1 real hour = 1 game day
+      dawnHour: 5
+      dayHour: 8
+      duskHour: 18
+      nightHour: 21
+
+    weather:
+      minTransitionMs: 300000    # 5 min minimum between transitions
+      maxTransitionMs: 900000    # 15 min maximum between transitions
+
+    worldEvents:
+      definitions:
+        spring_festival:
+          displayName: "Spring Festival"
+          description: "Flowers bloom across the realm and crafters find rare herbs more easily."
+          startDate: "2026-03-20"
+          endDate: "2026-04-20"
+          flags:
+            - spring_festival
+            - bonus_herbalism
+          startMessage: "The Spring Festival has begun! Flowers bloom across the realm."
+          endMessage: "The Spring Festival has ended. The flowers fade."
+        midsummer_night:
+          displayName: "Midsummer Night"
+          description: "The longest day brings warm breezes and wandering spirits."
+          startDate: "2026-06-20"
+          endDate: "2026-06-22"
+          flags:
+            - midsummer
+          startMessage: "Midsummer Night is here — the veil between worlds grows thin."
+          endMessage: "Midsummer Night has passed. The spirits retreat."
+
     debug:
       enableSwarmClass: false
 

--- a/src/test/kotlin/dev/ambon/engine/WeatherSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/WeatherSystemTest.kt
@@ -1,0 +1,85 @@
+package dev.ambon.engine
+
+import dev.ambon.config.WeatherConfig
+import dev.ambon.test.MutableClock
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class WeatherSystemTest {
+    private val config = WeatherConfig(
+        minTransitionMs = 1000L,
+        maxTransitionMs = 1000L, // Fixed interval for deterministic tests
+    )
+
+    @Test
+    fun `default weather is CLEAR`() {
+        val clock = MutableClock(0L)
+        val system = WeatherSystem(config, clock)
+        assertEquals(WeatherType.CLEAR, system.weatherForZone("test_zone"))
+    }
+
+    @Test
+    fun `tick with no active zones produces no changes`() {
+        val clock = MutableClock(0L)
+        val system = WeatherSystem(config, clock)
+        val changes = system.tick(emptySet())
+        assertTrue(changes.isEmpty())
+    }
+
+    @Test
+    fun `tick transitions weather after interval`() {
+        val clock = MutableClock(0L)
+        val system = WeatherSystem(config, clock)
+
+        // Initialize zone
+        system.weatherForZone("zone1")
+
+        // No change before interval
+        clock.advance(500L)
+        val noChanges = system.tick(setOf("zone1"))
+        assertTrue(noChanges.isEmpty())
+
+        // After interval, the system rolls a new weather type.
+        // It may or may not differ from CLEAR, so just verify the tick ran without error.
+        clock.advance(600L) // total 1100ms > 1000ms
+        system.tick(setOf("zone1"))
+        // Verify zone still has a valid weather type
+        assertTrue(WeatherType.entries.contains(system.weatherForZone("zone1")))
+    }
+
+    @Test
+    fun `different zones have independent weather`() {
+        val clock = MutableClock(0L)
+        val system = WeatherSystem(config, clock)
+
+        system.setWeather("zone1", WeatherType.RAIN)
+        system.setWeather("zone2", WeatherType.SNOW)
+
+        assertEquals(WeatherType.RAIN, system.weatherForZone("zone1"))
+        assertEquals(WeatherType.SNOW, system.weatherForZone("zone2"))
+    }
+
+    @Test
+    fun `setWeather overrides current weather`() {
+        val clock = MutableClock(0L)
+        val system = WeatherSystem(config, clock)
+
+        system.setWeather("zone1", WeatherType.STORM)
+        assertEquals(WeatherType.STORM, system.weatherForZone("zone1"))
+    }
+
+    @Test
+    fun `allZoneWeather returns all tracked zones`() {
+        val clock = MutableClock(0L)
+        val system = WeatherSystem(config, clock)
+
+        system.weatherForZone("a")
+        system.weatherForZone("b")
+
+        val all = system.allZoneWeather()
+        assertEquals(2, all.size)
+        assertTrue(all.containsKey("a"))
+        assertTrue(all.containsKey("b"))
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/WorldEventSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/WorldEventSystemTest.kt
@@ -1,0 +1,129 @@
+package dev.ambon.engine
+
+import dev.ambon.config.WorldEventDefinition
+import dev.ambon.config.WorldEventsConfig
+import dev.ambon.test.MutableClock
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+class WorldEventSystemTest {
+    private fun clockAtDate(date: String): MutableClock {
+        val instant = LocalDate.parse(date).atStartOfDay(ZoneOffset.UTC).toInstant()
+        return MutableClock(instant.toEpochMilli())
+    }
+
+    private val festivalDef = WorldEventDefinition(
+        displayName = "Spring Festival",
+        description = "Flowers bloom.",
+        startDate = "2026-03-20",
+        endDate = "2026-04-20",
+        flags = listOf("spring_festival", "bonus_herbalism"),
+        startMessage = "Festival begins!",
+        endMessage = "Festival ends.",
+    )
+
+    private val alwaysActiveDef = WorldEventDefinition(
+        displayName = "Permanent Event",
+        description = "Always on.",
+    )
+
+    @Test
+    fun `event activates within date range`() {
+        val clock = clockAtDate("2026-03-25")
+        val config = WorldEventsConfig(definitions = mapOf("spring" to festivalDef))
+        val system = WorldEventSystem(config, clock)
+
+        val result = system.tick()
+        assertTrue(result.activated.contains("spring"))
+        assertTrue(system.activeEventIds().contains("spring"))
+    }
+
+    @Test
+    fun `event not active before start date`() {
+        val clock = clockAtDate("2026-03-01")
+        val config = WorldEventsConfig(definitions = mapOf("spring" to festivalDef))
+        val system = WorldEventSystem(config, clock)
+
+        val result = system.tick()
+        assertTrue(result.activated.isEmpty())
+        assertFalse(system.activeEventIds().contains("spring"))
+    }
+
+    @Test
+    fun `event not active after end date`() {
+        val clock = clockAtDate("2026-05-01")
+        val config = WorldEventsConfig(definitions = mapOf("spring" to festivalDef))
+        val system = WorldEventSystem(config, clock)
+
+        val result = system.tick()
+        assertTrue(result.activated.isEmpty())
+    }
+
+    @Test
+    fun `event deactivates when date passes`() {
+        val clock = clockAtDate("2026-04-15")
+        val config = WorldEventsConfig(definitions = mapOf("spring" to festivalDef))
+        val system = WorldEventSystem(config, clock)
+
+        // Activate
+        system.tick()
+        assertTrue(system.activeEventIds().contains("spring"))
+
+        // Advance past end date (6 days = 518400000ms)
+        clock.advance(518_400_000L)
+
+        val result = system.tick()
+        assertTrue(result.deactivated.contains("spring"))
+        assertFalse(system.activeEventIds().contains("spring"))
+    }
+
+    @Test
+    fun `always-active event is always on`() {
+        val clock = clockAtDate("2026-01-01")
+        val config = WorldEventsConfig(definitions = mapOf("perm" to alwaysActiveDef))
+        val system = WorldEventSystem(config, clock)
+
+        val result = system.tick()
+        assertTrue(result.activated.contains("perm"))
+    }
+
+    @Test
+    fun `flags are queryable`() {
+        val clock = clockAtDate("2026-04-01")
+        val config = WorldEventsConfig(definitions = mapOf("spring" to festivalDef))
+        val system = WorldEventSystem(config, clock)
+        system.tick()
+
+        assertTrue(system.hasFlag("spring_festival"))
+        assertTrue(system.hasFlag("bonus_herbalism"))
+        assertFalse(system.hasFlag("nonexistent"))
+    }
+
+    @Test
+    fun `no duplicate activations on repeated ticks`() {
+        val clock = clockAtDate("2026-04-01")
+        val config = WorldEventsConfig(definitions = mapOf("spring" to festivalDef))
+        val system = WorldEventSystem(config, clock)
+
+        system.tick()
+        val result2 = system.tick()
+        assertTrue(result2.activated.isEmpty())
+        assertTrue(result2.deactivated.isEmpty())
+    }
+
+    @Test
+    fun `activeEvents returns definitions for active events`() {
+        val clock = clockAtDate("2026-04-01")
+        val config = WorldEventsConfig(definitions = mapOf("spring" to festivalDef))
+        val system = WorldEventSystem(config, clock)
+        system.tick()
+
+        val active = system.activeEvents()
+        assertEquals(1, active.size)
+        assertEquals("Spring Festival", active["spring"]?.displayName)
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/WorldTimeSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/WorldTimeSystemTest.kt
@@ -1,0 +1,103 @@
+package dev.ambon.engine
+
+import dev.ambon.config.WorldTimeConfig
+import dev.ambon.test.MutableClock
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class WorldTimeSystemTest {
+    private val config = WorldTimeConfig(
+        cycleLengthMs = 24_000L, // 24 seconds = 1 game day (1 second per game hour)
+        dawnHour = 5,
+        dayHour = 8,
+        duskHour = 18,
+        nightHour = 21,
+    )
+
+    @Test
+    fun `starts at hour 0 (night)`() {
+        val clock = MutableClock(0L)
+        val system = WorldTimeSystem(config, clock)
+        assertEquals(0, system.gameHour())
+        assertEquals(TimePeriod.NIGHT, system.period())
+    }
+
+    @Test
+    fun `dawn at hour 5`() {
+        val clock = MutableClock(0L)
+        val system = WorldTimeSystem(config, clock)
+        // 5 hours = 5000ms into a 24000ms cycle
+        clock.advance(5000L)
+        assertEquals(5, system.gameHour())
+        assertEquals(TimePeriod.DAWN, system.period())
+    }
+
+    @Test
+    fun `day at hour 8`() {
+        val clock = MutableClock(0L)
+        val system = WorldTimeSystem(config, clock)
+        clock.advance(8000L)
+        assertEquals(8, system.gameHour())
+        assertEquals(TimePeriod.DAY, system.period())
+    }
+
+    @Test
+    fun `dusk at hour 18`() {
+        val clock = MutableClock(0L)
+        val system = WorldTimeSystem(config, clock)
+        clock.advance(18000L)
+        assertEquals(18, system.gameHour())
+        assertEquals(TimePeriod.DUSK, system.period())
+    }
+
+    @Test
+    fun `night at hour 21`() {
+        val clock = MutableClock(0L)
+        val system = WorldTimeSystem(config, clock)
+        clock.advance(21000L)
+        assertEquals(21, system.gameHour())
+        assertEquals(TimePeriod.NIGHT, system.period())
+    }
+
+    @Test
+    fun `cycle wraps around after full day`() {
+        val clock = MutableClock(0L)
+        val system = WorldTimeSystem(config, clock)
+        clock.advance(24000L) // full cycle
+        assertEquals(0, system.gameHour())
+        assertEquals(TimePeriod.NIGHT, system.period())
+    }
+
+    @Test
+    fun `tick returns new period on change`() {
+        val clock = MutableClock(0L)
+        val system = WorldTimeSystem(config, clock)
+        // Start at night (hour 0)
+        assertNull(system.tick(TimePeriod.NIGHT))
+        // Advance to dawn
+        clock.advance(5000L)
+        val result = system.tick(TimePeriod.NIGHT)
+        assertNotNull(result)
+        assertEquals(TimePeriod.DAWN, result)
+    }
+
+    @Test
+    fun `tick returns null when period unchanged`() {
+        val clock = MutableClock(0L)
+        val system = WorldTimeSystem(config, clock)
+        clock.advance(6000L) // hour 6, still dawn
+        assertNull(system.tick(TimePeriod.DAWN))
+    }
+
+    @Test
+    fun `minute calculation`() {
+        val clock = MutableClock(0L)
+        val system = WorldTimeSystem(config, clock)
+        // 1 game hour = 1000ms, so 500ms = 30 game minutes
+        clock.advance(500L)
+        assertEquals(0, system.gameHour())
+        assertEquals(30, system.gameMinute())
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
@@ -316,6 +316,11 @@ class CommandParserTest {
     }
 
     @Test
+    fun `parses time command`() {
+        assertEquals(Command.Time, CommandParser.parse("time"))
+    }
+
+    @Test
     fun `parses shop list aliases`() {
         assertEquals(Command.ShopList, CommandParser.parse("list"))
         assertEquals(Command.ShopList, CommandParser.parse("shop"))

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -1359,6 +1359,21 @@ export function applyGmcpPackage(
       break;
     }
 
+    case "World.Time": {
+      // World time received via GMCP — available for day/night UI.
+      break;
+    }
+
+    case "World.Weather": {
+      // Zone weather received via GMCP — available for weather effects.
+      break;
+    }
+
+    case "World.Events": {
+      // Active world events received via GMCP — available for event panel.
+      break;
+    }
+
     case "Auction.List": {
       if (!Array.isArray(data)) {
         ctx.setAuctionListings([]);


### PR DESCRIPTION
## Summary
Closes #838, #845, #848.

Three engine-side atmosphere systems that add world depth, connect to the web client via GMCP, and provide hooks for gameplay effects.

### Day/Night Cycle (#838)
- `WorldTimeSystem`: accelerated game clock (configurable — default 1 real hour = 1 game day)
- Four time periods: DAWN (5am), DAY (8am), DUSK (6pm), NIGHT (9pm)
- `World.Time` GMCP broadcast to all players on period transitions
- `time` command shows game time, zone weather, and active events

### Weather System (#845)
- `WeatherSystem`: per-zone weather state with weighted random transitions
- Six types: CLEAR, RAIN, STORM, FOG, SNOW, WIND (weighted by rarity)
- Configurable transition interval (default 5–15 min between changes)
- `World.Weather` GMCP sent to zone players on change
- `setWeather()` API for staff commands and event-driven overrides

### Seasonal Events Framework (#848)
- `WorldEventSystem`: config-driven events with real-world date ranges
- Event flags queryable by other systems (`hasFlag("bonus_herbalism")`)
- Start/end broadcast messages to all online players
- `World.Events` GMCP broadcast on activation/deactivation
- Two sample events: Spring Festival (Mar 20–Apr 20), Midsummer Night (Jun 20–22)

## New files
| File | Purpose |
|------|---------|
| `WorldTimeSystem.kt` | Accelerated game clock with time periods |
| `WeatherSystem.kt` | Per-zone weather state machine |
| `WorldEventSystem.kt` | Date-driven event activation/deactivation |
| `WorldInfoHandler.kt` | `time` command handler |
| `WorldTimeSystemTest.kt` | 9 tests |
| `WeatherSystemTest.kt` | 6 tests |
| `WorldEventSystemTest.kt` | 8 tests |

## Test plan
- [ ] `time` command shows current game hour, period, zone weather, active events
- [ ] Time period transitions broadcast `World.Time` GMCP to all players
- [ ] Weather changes per-zone on configurable interval
- [ ] `World.Weather` GMCP sent to players in affected zone
- [ ] Events activate when current date is within startDate–endDate range
- [ ] Events deactivate when date passes endDate
- [ ] Start/end messages broadcast to all online players
- [ ] `hasFlag()` returns true for active event flags
- [ ] Always-active events (empty dates) are always on
- [ ] Config validation catches invalid hour ranges and transition intervals