### PR TITLE
Leaderboards and hall of fame (#847)

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -508,6 +508,13 @@ data class BankConfig(
     val maxItems: Int = 50,
 )
 
+data class LeaderboardConfig(
+    /** How often to refresh the leaderboard cache from player data (ms). Default: 5 minutes. */
+    val refreshIntervalMs: Long = 300_000L,
+    /** Maximum number of entries per leaderboard category. */
+    val topN: Int = 10,
+)
+
 data class WorldTimeConfig(
     /** Real-time milliseconds for one full game day (24 game hours). Default: 1 hour. */
     val cycleLengthMs: Long = 3_600_000L,
@@ -938,6 +945,7 @@ data class EngineConfig(
     val classStartRooms: Map<String, String> = emptyMap(),
     /** How long to hold a disconnected player's session before full logout (ms). 0 disables. */
     val sessionResumeGracePeriodMs: Long = 90_000,
+    val leaderboard: LeaderboardConfig = LeaderboardConfig(),
 )
 
 data class NavigationConfig(

--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -637,6 +637,9 @@ class CombatSystem(
             ),
         )
 
+        // Increment kill counter for the killing blow
+        players.get(killerSessionId)?.let { it.mobsKilledTotal += 1 }
+
         // Fire quest/achievement callbacks for all contributors
         if (mob.templateKey.isNotEmpty()) {
             for (sid in contributors) {

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -35,6 +35,7 @@ import dev.ambon.engine.commands.handlers.GroupHandler
 import dev.ambon.engine.commands.handlers.GuildHandler
 import dev.ambon.engine.commands.handlers.HousingHandler
 import dev.ambon.engine.commands.handlers.ItemHandler
+import dev.ambon.engine.commands.handlers.LeaderboardHandler
 import dev.ambon.engine.commands.handlers.MailHandler
 import dev.ambon.engine.commands.handlers.NavigationHandler
 import dev.ambon.engine.commands.handlers.PetHandler
@@ -667,6 +668,15 @@ class GameEngine(
         clock = clock,
     )
 
+    private val leaderboardSystem: LeaderboardSystem? =
+        persistence.playerRepo?.let { repo ->
+            LeaderboardSystem(
+                playerRepo = repo,
+                playerRegistry = players,
+                config = engineConfig.leaderboard,
+            )
+        }
+
     private var lastTimePeriod: TimePeriod = worldTimeSystem.period()
 
     private val abilitySystem: AbilitySystem =
@@ -911,6 +921,7 @@ class GameEngine(
             statRegistry = statRegistry,
             equipmentSlotRegistry = equipmentSlotRegistry,
             genderRegistry = genderRegistry,
+            leaderboardSystem = leaderboardSystem,
         )
 
         communicationHandler = CommunicationHandler(
@@ -1063,6 +1074,7 @@ class GameEngine(
                 ctx = ctx,
                 spriteRegistry = spriteRegistry,
             ),
+            LeaderboardHandler(ctx = ctx),
             UiHandler(
                 ctx = ctx,
                 onPhase = phaseCallback,
@@ -1118,6 +1130,11 @@ class GameEngine(
 
             // Load guild data into memory.
             guildSystem?.initialize()
+
+            // Schedule initial leaderboard population and recurring refresh.
+            leaderboardSystem?.let { sys ->
+                scheduleLeaderboardRefresh(sys)
+            }
 
             // Restore persisted world state, overriding in-memory defaults.
             worldStateRepository?.load()?.let { snapshot ->
@@ -1865,11 +1882,22 @@ class GameEngine(
         )
     }
 
+    /** Schedules a leaderboard refresh, then re-schedules itself for the next interval. */
+    private suspend fun scheduleLeaderboardRefresh(sys: LeaderboardSystem) {
+        scheduler.scheduleIn(sys.refreshIntervalMs) {
+            sys.refresh()
+            scheduleLeaderboardRefresh(sys)
+        }
+        // Run the first refresh immediately on the first tick so the cache is populated at startup.
+        sys.refresh()
+    }
+
     private suspend fun checkDungeonBossKilled(mobId: MobId) {
         val inst = dungeonManager.findInstanceByBossMob(mobId)
         if (inst == null || inst.completed) return
         dungeonManager.markComplete(inst)
         for (sid in inst.members) {
+            players.get(sid)?.let { it.dungeonsCompleted += 1 }
             outbound.send(
                 OutboundEvent.SendInfo(
                     sid,

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -2286,6 +2286,40 @@ class GmcpEmitter(
         val active: String?,
         val sprites: List<CharSpriteEntry>,
     )
+
+    // ---------- leaderboard ----------
+
+    /** Sends the `Leaderboard.Data` GMCP package for a specific category. */
+    suspend fun sendLeaderboard(
+        sessionId: SessionId,
+        category: LeaderboardSystem.Category,
+        entries: List<LeaderboardSystem.LeaderboardEntry>,
+    ) {
+        emit(
+            sessionId,
+            "Leaderboard.Data",
+            LeaderboardPayload(
+                category = category.key,
+                label = category.displayName,
+                scoreLabel = category.scoreLabel,
+                entries = entries.map { LeaderboardEntryPayload(rank = it.rank, name = it.playerName, score = it.score) },
+            ),
+            supportCheck = "Leaderboard",
+        )
+    }
+
+    private data class LeaderboardEntryPayload(
+        val rank: Int,
+        val name: String,
+        val score: Long,
+    )
+
+    private data class LeaderboardPayload(
+        val category: String,
+        val label: String,
+        val scoreLabel: String,
+        val entries: List<LeaderboardEntryPayload>,
+    )
 }
 
 // ---------- public data entry types for new GMCP methods ----------

--- a/src/main/kotlin/dev/ambon/engine/LeaderboardSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/LeaderboardSystem.kt
@@ -1,0 +1,105 @@
+package dev.ambon.engine
+
+import dev.ambon.config.LeaderboardConfig
+import dev.ambon.persistence.PlayerRecord
+import dev.ambon.persistence.PlayerRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Maintains in-memory leaderboard caches for each category.
+ * Refresh is triggered periodically (via the engine scheduler) and is safe to call from
+ * suspend contexts — it dispatches to Dispatchers.IO via the repository.
+ * Online players' live state is merged over their persisted records so that
+ * in-session progress (kills, dungeon completions) is reflected immediately.
+ */
+class LeaderboardSystem(
+    private val playerRepo: PlayerRepository,
+    private val playerRegistry: PlayerRegistry,
+    private val config: LeaderboardConfig = LeaderboardConfig(),
+) {
+    enum class Category(
+        val key: String,
+        val displayName: String,
+        val scoreLabel: String,
+    ) {
+        LEVEL("level", "Highest Level", "level"),
+        ACHIEVEMENTS("achievements", "Most Achievements", "achievements"),
+        CRAFTING("crafting", "Best Crafter", "craft lvl"),
+        DUNGEONS("dungeons", "Dungeon Champion", "dungeons"),
+        KILLS("kills", "Monster Slayer", "kills"),
+        ;
+
+        companion object {
+            fun fromKey(key: String): Category? =
+                entries.firstOrNull { it.key == key || it.key.startsWith(key) }
+        }
+    }
+
+    data class LeaderboardEntry(
+        val rank: Int,
+        val playerName: String,
+        val score: Long,
+    )
+
+    @Volatile
+    private var cache: Map<String, List<LeaderboardEntry>> = emptyMap()
+
+    val refreshIntervalMs: Long get() = config.refreshIntervalMs
+
+    /** Returns the top entries for [category], or an empty list if the cache is not yet populated. */
+    fun getEntries(category: Category): List<LeaderboardEntry> = cache[category.key] ?: emptyList()
+
+    /**
+     * Rebuilds the leaderboard cache from persistent storage, overlaying live player state
+     * for any currently-online players.
+     */
+    suspend fun refresh() {
+        try {
+            val allRecords = playerRepo.findAll().associateBy { it.id.value }.toMutableMap()
+
+            // Overlay live in-memory state — online players may have unsaved kills or dungeon runs.
+            for (live in playerRegistry.allPlayers()) {
+                val id = live.playerId?.value ?: continue
+                val base = allRecords[id] ?: continue
+                allRecords[id] = base.copy(
+                    level = live.level,
+                    unlockedAchievementIds = live.unlockedAchievementIds,
+                    craftingSkills = live.craftingSkills.toMap(),
+                    mobsKilledTotal = live.mobsKilledTotal,
+                    dungeonsCompleted = live.dungeonsCompleted,
+                )
+            }
+
+            val records = allRecords.values.toList()
+            val topN = config.topN
+
+            val newCache = mutableMapOf<String, List<LeaderboardEntry>>()
+            newCache[Category.LEVEL.key] = rank(records, topN) { it.level.toLong() }
+            newCache[Category.ACHIEVEMENTS.key] = rank(records, topN) { it.unlockedAchievementIds.size.toLong() }
+            newCache[Category.CRAFTING.key] = rank(records, topN) { maxCraftLevel(it) }
+            newCache[Category.DUNGEONS.key] = rank(records, topN) { it.dungeonsCompleted.toLong() }
+            newCache[Category.KILLS.key] = rank(records, topN) { it.mobsKilledTotal }
+            cache = newCache
+
+            log.debug { "Leaderboard refreshed — ${records.size} records, topN=$topN" }
+        } catch (e: Exception) {
+            log.warn(e) { "Leaderboard refresh failed" }
+        }
+    }
+
+    private fun rank(
+        records: List<PlayerRecord>,
+        topN: Int,
+        scoreOf: (PlayerRecord) -> Long,
+    ): List<LeaderboardEntry> =
+        records
+            .filter { !it.isStaff }
+            .sortedByDescending(scoreOf)
+            .take(topN)
+            .mapIndexed { i, r -> LeaderboardEntry(rank = i + 1, playerName = r.name, score = scoreOf(r)) }
+
+    private fun maxCraftLevel(record: PlayerRecord): Long =
+        record.craftingSkills.values.maxOfOrNull { it.level.toLong() } ?: 0L
+}

--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -78,6 +78,10 @@ data class PlayerState(
     var invisible: Boolean = false,
     /** Cached flag indicating whether this player owns a house. Runtime-only; set on login. */
     var hasHouse: Boolean = false,
+    /** Cumulative count of mobs killed by this player. */
+    var mobsKilledTotal: Long = 0L,
+    /** Number of dungeon instances completed by this player. */
+    var dungeonsCompleted: Int = 0,
 ) {
     data class MailComposeState(
         val recipientName: String,
@@ -177,6 +181,8 @@ fun PlayerRecord.toPlayerState(sessionId: SessionId): PlayerState =
         bankGold = bankGold,
         bankItems = bankItems.toMutableList(),
         activeSprite = activeSprite,
+        mobsKilledTotal = mobsKilledTotal,
+        dungeonsCompleted = dungeonsCompleted,
     )
 
 /** Converts this runtime state to a [PlayerRecord] for persistence. */
@@ -217,6 +223,8 @@ fun PlayerState.toPlayerRecord(lastSeenEpochMs: Long): PlayerRecord {
         bankGold = bankGold,
         bankItems = bankItems.toList(),
         activeSprite = activeSprite,
+        mobsKilledTotal = mobsKilledTotal,
+        dungeonsCompleted = dungeonsCompleted,
     )
 }
 

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -420,6 +420,13 @@ sealed interface Command {
 
     data object SpriteDefault : Command
 
+    // ---- Leaderboard commands ----
+
+    /** Show a leaderboard. [category] is one of: level, achievements, crafting, dungeons, kills. */
+    data class Leaderboard(
+        val category: String?,
+    ) : Command
+
     // ---- World feature commands ----
 
     data class OpenFeature(
@@ -1137,6 +1144,11 @@ object CommandParser {
                 "default", "clear", "auto" -> Command.SpriteDefault
                 else -> Command.SpriteSet(rest.trim())
             }
+        }?.let { return it }
+
+        // leaderboard [category]
+        matchPrefix(line, listOf("leaderboard", "leaders", "top")) { rest ->
+            Command.Leaderboard(rest.takeIf { it.isNotBlank() })
         }?.let { return it }
 
         // Crafting & Gathering

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/EngineContext.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/EngineContext.kt
@@ -7,6 +7,7 @@ import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.EquipmentSlotRegistry
 import dev.ambon.engine.GenderRegistry
 import dev.ambon.engine.GmcpEmitter
+import dev.ambon.engine.LeaderboardSystem
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PlayerClassRegistry
 import dev.ambon.engine.PlayerRegistry
@@ -45,4 +46,5 @@ data class EngineContext(
     val statRegistry: StatRegistry? = null,
     val equipmentSlotRegistry: EquipmentSlotRegistry? = null,
     val genderRegistry: GenderRegistry? = null,
+    val leaderboardSystem: LeaderboardSystem? = null,
 )

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/LeaderboardHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/LeaderboardHandler.kt
@@ -1,0 +1,67 @@
+package dev.ambon.engine.commands.handlers
+
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.engine.LeaderboardSystem
+import dev.ambon.engine.commands.Command
+import dev.ambon.engine.commands.CommandHandler
+import dev.ambon.engine.commands.CommandRouter
+import dev.ambon.engine.commands.on
+import dev.ambon.engine.events.OutboundEvent
+
+class LeaderboardHandler(
+    ctx: EngineContext,
+) : CommandHandler {
+    private val outbound = ctx.outbound
+    private val gmcpEmitter = ctx.gmcpEmitter
+    private val leaderboardSystem = ctx.leaderboardSystem
+
+    override fun register(router: CommandRouter) {
+        router.on<Command.Leaderboard> { sid, cmd -> handleLeaderboard(sid, cmd) }
+    }
+
+    private suspend fun handleLeaderboard(sessionId: SessionId, cmd: Command.Leaderboard) {
+        val sys = leaderboardSystem
+        if (sys == null) {
+            outbound.send(OutboundEvent.SendError(sessionId, "Leaderboards are not available."))
+            return
+        }
+
+        val category = resolveCategory(cmd.category)
+        if (category == null) {
+            val categories = LeaderboardSystem.Category.entries.joinToString(", ") { it.key }
+            outbound.send(
+                OutboundEvent.SendError(
+                    sessionId,
+                    "Unknown category '${ cmd.category }'. Available: $categories",
+                ),
+            )
+            return
+        }
+
+        val entries = sys.getEntries(category)
+
+        // Send via GMCP for web clients
+        gmcpEmitter?.sendLeaderboard(sessionId, category, entries)
+
+        val sb = StringBuilder()
+        sb.appendLine("=== ${category.displayName} ===")
+        if (entries.isEmpty()) {
+            sb.append("The leaderboard is empty. Be the first to make your mark!")
+        } else {
+            for (e in entries) {
+                val rankPad = e.rank.toString().padStart(2)
+                sb.appendLine("  $rankPad. ${e.playerName.padEnd(16)} ${e.score} ${category.scoreLabel}")
+            }
+            val allCategories = LeaderboardSystem.Category.entries.joinToString(", ") { it.key }
+            sb.append("Categories: $allCategories")
+        }
+        outbound.send(OutboundEvent.SendInfo(sessionId, sb.toString().trimEnd()))
+    }
+
+    private fun resolveCategory(input: String?): LeaderboardSystem.Category? =
+        if (input == null) {
+            LeaderboardSystem.Category.LEVEL
+        } else {
+            LeaderboardSystem.Category.fromKey(input.trim().lowercase())
+        }
+}

--- a/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
@@ -66,6 +66,10 @@ data class PlayerRecord(
     val authTokenHash: String = "",
     /** Epoch millis when the auth token was issued. 0 = no token. */
     val authTokenIssuedAt: Long = 0L,
+    /** Cumulative count of mobs killed by this player. */
+    val mobsKilledTotal: Long = 0L,
+    /** Number of dungeon instances completed by this player. */
+    val dungeonsCompleted: Int = 0,
 ) {
     /**
      * Applies legacy migration fixes after deserialization.

--- a/src/main/kotlin/dev/ambon/persistence/PlayerRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayerRepository.kt
@@ -52,6 +52,14 @@ interface PlayerRepository {
     suspend fun save(record: PlayerRecord)
 
     /**
+     * Returns all persisted player records. Intended for bulk reads (e.g., leaderboard
+     * generation). Implementations should be efficient but may be slow on large datasets;
+     * callers should avoid calling this on the hot tick path.
+     * Default implementation returns an empty list (no-op for wrappers like caching layers).
+     */
+    suspend fun findAll(): List<PlayerRecord> = emptyList()
+
+    /**
      * Hint that the given player is no longer active and any cached state
      * may be discarded.  Implementations should flush any pending writes
      * for [id] before evicting.  The next [findById]/[findByName] will

--- a/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
@@ -68,6 +68,8 @@ object PlayersTable : Table("players") {
     val activeSprite = varchar("active_sprite", 100).nullable()
     val authTokenHash = varchar("auth_token_hash", 64).default("")
     val authTokenIssuedAt = long("auth_token_issued_at").default(0L)
+    val mobsKilledTotal = long("mobs_killed_total").default(0L)
+    val dungeonsCompleted = integer("dungeons_completed").default(0)
 
     override val primaryKey = PrimaryKey(id)
 
@@ -112,6 +114,8 @@ object PlayersTable : Table("players") {
             activeSprite = row[activeSprite],
             authTokenHash = row[authTokenHash],
             authTokenIssuedAt = row[authTokenIssuedAt],
+            mobsKilledTotal = row[mobsKilledTotal],
+            dungeonsCompleted = row[dungeonsCompleted],
         ).migrateDefaults()
 
     /** Writes all [PlayerRecord] fields into an insert or upsert [statement]. */
@@ -155,5 +159,7 @@ object PlayersTable : Table("players") {
         statement[activeSprite] = record.activeSprite
         statement[authTokenHash] = record.authTokenHash
         statement[authTokenIssuedAt] = record.authTokenIssuedAt
+        statement[mobsKilledTotal] = record.mobsKilledTotal
+        statement[dungeonsCompleted] = record.dungeonsCompleted
     }
 }

--- a/src/main/kotlin/dev/ambon/persistence/PostgresPlayerRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PostgresPlayerRepository.kt
@@ -83,4 +83,9 @@ class PostgresPlayerRepository(
             }
         }
     }
+
+    override suspend fun findAll(): List<PlayerRecord> =
+        database.dbQuery {
+            PlayersTable.selectAll().map { PlayersTable.readRecord(it) }
+        }
 }

--- a/src/main/kotlin/dev/ambon/persistence/YamlPlayerRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/YamlPlayerRepository.kt
@@ -110,6 +110,14 @@ class YamlPlayerRepository(
             }
         }
 
+    override suspend fun findAll(): List<PlayerRecord> =
+        withContext(Dispatchers.IO) {
+            if (!playersDir.exists()) return@withContext emptyList()
+            playersDir.listDirectoryEntries("*.yaml").mapNotNull { path ->
+                runCatching { readRecord(path) }.getOrNull()
+            }
+        }
+
     // -------- internals --------
 
     /**

--- a/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
+++ b/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
@@ -205,7 +205,7 @@ private suspend fun DefaultWebSocketServerSession.bridgeWebSocketSession(
         InboundEvent.GmcpReceived(
             sessionId,
             "Core.Supports.Set",
-            """["Char.Vitals 1","Room.Info 1","Zone.Map 1","Char.StatusVars 1","Char.Items 1","Char.Equipment 1","Room.Players 1","Room.Mobs 1","Room.Items 1","Char.Skills 1","Char.Name 1","Char.StatusEffects 1","Char.Achievements 1","Char.Sprites 1","Comm.Channel 1","Guild 1","Group.Info 1","Friends 1","Core.Ping 1","Dialogue 1","Shop 1","Char.Combat 1","Char.Combat.Event 1","Char.Stats 1","Quest 1","Char.Cooldown 1","Char.Gain 1","Room.MobInfo 1","Mail 1","Crafting 1","Login 1","Server 1","UI.Feedback 1","Staff 1","Housing 1","Session 1","Trade 1","Auction 1","Char.Factions 1","Char.Pet 1","Char.Bank 1","World 1"]""",
+            """["Char.Vitals 1","Room.Info 1","Zone.Map 1","Char.StatusVars 1","Char.Items 1","Char.Equipment 1","Room.Players 1","Room.Mobs 1","Room.Items 1","Char.Skills 1","Char.Name 1","Char.StatusEffects 1","Char.Achievements 1","Char.Sprites 1","Comm.Channel 1","Guild 1","Group.Info 1","Friends 1","Core.Ping 1","Dialogue 1","Shop 1","Char.Combat 1","Char.Combat.Event 1","Char.Stats 1","Quest 1","Char.Cooldown 1","Char.Gain 1","Room.MobInfo 1","Mail 1","Crafting 1","Login 1","Server 1","UI.Feedback 1","Staff 1","Housing 1","Session 1","Trade 1","Auction 1","Char.Factions 1","Char.Pet 1","Char.Bank 1","World 1","Leaderboard 1"]""",
         ),
     )
     metrics.onWsConnected()

--- a/src/main/resources/db/migration/V25__add_leaderboard_tracking.sql
+++ b/src/main/resources/db/migration/V25__add_leaderboard_tracking.sql
@@ -1,0 +1,2 @@
+ALTER TABLE players ADD COLUMN mobs_killed_total BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE players ADD COLUMN dungeons_completed INT NOT NULL DEFAULT 0;

--- a/src/test/kotlin/dev/ambon/engine/LeaderboardSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/LeaderboardSystemTest.kt
@@ -1,0 +1,182 @@
+package dev.ambon.engine
+
+import dev.ambon.config.LeaderboardConfig
+import dev.ambon.domain.crafting.CraftingSkillState
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.persistence.PlayerId
+import dev.ambon.persistence.PlayerRecord
+import dev.ambon.test.MutableClock
+import dev.ambon.test.TEST_ROOM_ID
+import dev.ambon.test.buildTestPlayerRegistry
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class LeaderboardSystemTest {
+    private val repo = InMemoryPlayerRepository()
+    private val clock = MutableClock(0L)
+    private val registry = buildTestPlayerRegistry(TEST_ROOM_ID, repo, clock = clock)
+    private val system = LeaderboardSystem(
+        playerRepo = repo,
+        playerRegistry = registry,
+        config = LeaderboardConfig(topN = 3),
+    )
+
+    @BeforeEach
+    fun setUp() {
+        repo.clear()
+    }
+
+    private suspend fun savePlayer(
+        id: Long,
+        name: String,
+        level: Int = 1,
+        achievements: Int = 0,
+        craftLevel: Int = 0,
+        dungeons: Int = 0,
+        kills: Long = 0L,
+        isStaff: Boolean = false,
+    ) {
+        val record = PlayerRecord(
+            id = PlayerId(id),
+            name = name,
+            roomId = RoomId("test:room"),
+            createdAtEpochMs = 0L,
+            lastSeenEpochMs = 0L,
+            level = level,
+            unlockedAchievementIds = (1..achievements).map { "ach$it" }.toSet(),
+            craftingSkills = if (craftLevel > 0) mapOf("smithing" to CraftingSkillState(level = craftLevel)) else emptyMap(),
+            dungeonsCompleted = dungeons,
+            mobsKilledTotal = kills,
+            isStaff = isStaff,
+        )
+        repo.save(record)
+    }
+
+    @Test
+    fun `level leaderboard ranks by level descending`() =
+        runTest {
+            savePlayer(1, "Alpha", level = 5)
+            savePlayer(2, "Beta", level = 10)
+            savePlayer(3, "Gamma", level = 3)
+
+            system.refresh()
+
+            val entries = system.getEntries(LeaderboardSystem.Category.LEVEL)
+            assertEquals(3, entries.size)
+            assertEquals("Beta", entries[0].playerName)
+            assertEquals(10L, entries[0].score)
+            assertEquals(1, entries[0].rank)
+            assertEquals("Alpha", entries[1].playerName)
+            assertEquals("Gamma", entries[2].playerName)
+        }
+
+    @Test
+    fun `achievements leaderboard ranks by achievement count`() =
+        runTest {
+            savePlayer(1, "Alpha", achievements = 3)
+            savePlayer(2, "Beta", achievements = 7)
+            savePlayer(3, "Gamma", achievements = 1)
+
+            system.refresh()
+
+            val entries = system.getEntries(LeaderboardSystem.Category.ACHIEVEMENTS)
+            assertEquals("Beta", entries[0].playerName)
+            assertEquals(7L, entries[0].score)
+        }
+
+    @Test
+    fun `kills leaderboard ranks by mob kill total`() =
+        runTest {
+            savePlayer(1, "Hunter", kills = 150L)
+            savePlayer(2, "Slayer", kills = 500L)
+            savePlayer(3, "Novice", kills = 10L)
+
+            system.refresh()
+
+            val entries = system.getEntries(LeaderboardSystem.Category.KILLS)
+            assertEquals("Slayer", entries[0].playerName)
+            assertEquals(500L, entries[0].score)
+            assertEquals(3, entries.size)
+        }
+
+    @Test
+    fun `dungeons leaderboard ranks by dungeons completed`() =
+        runTest {
+            savePlayer(1, "Delver", dungeons = 8)
+            savePlayer(2, "Casual", dungeons = 2)
+
+            system.refresh()
+
+            val entries = system.getEntries(LeaderboardSystem.Category.DUNGEONS)
+            assertEquals("Delver", entries[0].playerName)
+            assertEquals(8L, entries[0].score)
+        }
+
+    @Test
+    fun `crafting leaderboard uses max skill level`() =
+        runTest {
+            savePlayer(1, "Smith", craftLevel = 10)
+            savePlayer(2, "Novice", craftLevel = 2)
+            savePlayer(3, "Master", craftLevel = 15)
+
+            system.refresh()
+
+            val entries = system.getEntries(LeaderboardSystem.Category.CRAFTING)
+            assertEquals("Master", entries[0].playerName)
+            assertEquals(15L, entries[0].score)
+        }
+
+    @Test
+    fun `topN limits results`() =
+        runTest {
+            for (i in 1..10) savePlayer(i.toLong(), "Player$i", level = i)
+
+            system.refresh()
+
+            val entries = system.getEntries(LeaderboardSystem.Category.LEVEL)
+            assertEquals(3, entries.size)
+        }
+
+    @Test
+    fun `empty leaderboard returns empty list before refresh`() {
+        val entries = system.getEntries(LeaderboardSystem.Category.LEVEL)
+        assertTrue(entries.isEmpty())
+    }
+
+    @Test
+    fun `staff players are excluded from leaderboards`() =
+        runTest {
+            savePlayer(1, "Admin", level = 99, isStaff = true)
+            savePlayer(2, "Player", level = 5)
+
+            system.refresh()
+
+            val entries = system.getEntries(LeaderboardSystem.Category.LEVEL)
+            assertEquals(1, entries.size)
+            assertEquals("Player", entries[0].playerName)
+        }
+
+    @Test
+    fun `Category fromKey resolves by exact and prefix match`() {
+        assertEquals(LeaderboardSystem.Category.LEVEL, LeaderboardSystem.Category.fromKey("level"))
+        assertEquals(LeaderboardSystem.Category.KILLS, LeaderboardSystem.Category.fromKey("kills"))
+        assertEquals(null, LeaderboardSystem.Category.fromKey("nonexistent"))
+    }
+
+    @Test
+    fun `rank indexes start at 1`() =
+        runTest {
+            savePlayer(1, "Alpha", level = 5)
+            savePlayer(2, "Beta", level = 3)
+
+            system.refresh()
+
+            val entries = system.getEntries(LeaderboardSystem.Category.LEVEL)
+            assertEquals(1, entries[0].rank)
+            assertEquals(2, entries[1].rank)
+        }
+}

--- a/src/test/kotlin/dev/ambon/persistence/InMemoryPlayerRepository.kt
+++ b/src/test/kotlin/dev/ambon/persistence/InMemoryPlayerRepository.kt
@@ -30,6 +30,8 @@ class InMemoryPlayerRepository : PlayerRepository {
         players[record.id] = record
     }
 
+    override suspend fun findAll(): List<PlayerRecord> = players.values.toList()
+
     fun clear() {
         players.clear()
     }

--- a/src/test/kotlin/dev/ambon/persistence/PersistenceFieldCoverageTest.kt
+++ b/src/test/kotlin/dev/ambon/persistence/PersistenceFieldCoverageTest.kt
@@ -122,6 +122,8 @@ class PersistenceFieldCoverageTest {
                         Item(keyword = "sword", displayName = "a short sword", slot = ItemSlot.HAND),
                     ),
                 ),
+                mobsKilledTotal = 99L,
+                dungeonsCompleted = 5,
             )
 
         @BeforeAll
@@ -263,6 +265,32 @@ class PersistenceFieldCoverageTest {
         val expected = FULLY_POPULATED.copy(inventoryItems = emptyList(), equippedItems = emptyMap())
         assertEquals(expected, roundTripped)
     }
+
+    // -----------------------------------------------------------------------
+    // 6. findAll round-trip
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `Postgres findAll returns all saved records`() =
+        runTest {
+            val repo = PostgresPlayerRepository(database)
+            val seed =
+                repo.create(
+                    PlayerCreationRequest(
+                        name = FULLY_POPULATED.name,
+                        startRoomId = FULLY_POPULATED.roomId,
+                        nowEpochMs = FULLY_POPULATED.createdAtEpochMs,
+                        passwordHash = FULLY_POPULATED.passwordHash,
+                        ansiEnabled = FULLY_POPULATED.ansiEnabled,
+                    ),
+                )
+            val expected = FULLY_POPULATED.copy(id = seed.id)
+            repo.save(expected)
+
+            val all = repo.findAll()
+            assertEquals(1, all.size)
+            assertEquals(expected, all.first())
+        }
 
     // -----------------------------------------------------------------------
     // helpers

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -18,6 +18,7 @@ import { AdminPanel } from "./components/panels/AdminPanel";
 import { MailPanel } from "./components/panels/MailPanel";
 import { CraftingPanel } from "./components/panels/CraftingPanel";
 import { HousingPanel } from "./components/panels/HousingPanel";
+import { LeaderboardPanel } from "./components/panels/LeaderboardPanel";
 import { CommandPalette } from "./components/CommandPalette";
 import { applyGmcpPackage } from "./gmcp/applyGmcpPackage";
 import { canvasCallbacks, gameStateRef, pendingCastRef } from "./canvas/GameStateBridge";
@@ -93,6 +94,7 @@ import type {
   Vitals,
   WhoPlayer,
   ZoneInstances,
+  LeaderboardData,
 } from "./types";
 import { sortExits, titleCaseWords } from "./utils";
 import "@xterm/xterm/css/xterm.css";
@@ -227,6 +229,7 @@ function App() {
   const [tradeState, setTradeState] = useState<TradeState | null>(null);
   const [auctionListings, setAuctionListings] = useState<AuctionListing[]>([]); // GMCP Auction.List data for future panel
   void auctionListings; // suppress unused-var lint until auction panel is built
+  const [leaderboard, setLeaderboard] = useState<Record<string, LeaderboardData>>({});
   const combatEventsRef = useRef<CombatEventData[]>([]);
   const gainEventsRef = useRef<GainEvent[]>([]);
 
@@ -471,6 +474,7 @@ function App() {
           setHousing,
           setTradeState,
           setAuctionListings,
+          setLeaderboard,
           sendGmcp: (pkg: string, payload: unknown) => { sendGmcpRef.current(pkg, payload); return true; },
         },
       );
@@ -1290,6 +1294,13 @@ function App() {
             housing={housing}
             room={room}
             onSendCommand={(cmd) => { sendCommand(cmd, true); focusComposer(); }}
+          />
+        )}
+
+        {activePopout === "leaderboard" && (
+          <LeaderboardPanel
+            leaderboard={leaderboard}
+            onCommand={(cmd) => { sendCommand(cmd, true); focusComposer(); }}
           />
         )}
       </PopoutLayer>

--- a/web-v3/src/components/panels/LeaderboardPanel.tsx
+++ b/web-v3/src/components/panels/LeaderboardPanel.tsx
@@ -1,0 +1,83 @@
+import type { LeaderboardData } from "../../types";
+
+const CATEGORIES = [
+  { key: "level", label: "Top Level" },
+  { key: "achievements", label: "Achievements" },
+  { key: "crafting", label: "Crafting" },
+  { key: "dungeons", label: "Dungeons" },
+  { key: "kills", label: "Kills" },
+];
+
+interface Props {
+  leaderboard: Record<string, LeaderboardData>;
+  onCommand: (cmd: string) => void;
+}
+
+export function LeaderboardPanel({ leaderboard, onCommand }: Props) {
+  const activeCats = CATEGORIES.filter((c) => {
+    const data = leaderboard[c.key];
+    return data && data.entries.length > 0;
+  });
+
+  return (
+    <div className="leaderboard-panel">
+      <div className="panel-header">
+        <span className="panel-title">Leaderboards</span>
+      </div>
+
+      {activeCats.length === 0 ? (
+        <div className="leaderboard-empty">
+          <p>No leaderboard data yet.</p>
+          <p>Use the leaderboard command to load rankings.</p>
+          <div className="leaderboard-cat-buttons">
+            {CATEGORIES.map((c) => (
+              <button
+                key={c.key}
+                className="leaderboard-cat-btn"
+                onClick={() => onCommand(`leaderboard ${c.key}`)}
+              >
+                {c.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : (
+        <div className="leaderboard-content">
+          <div className="leaderboard-cat-buttons">
+            {CATEGORIES.map((c) => (
+              <button
+                key={c.key}
+                className="leaderboard-cat-btn"
+                onClick={() => onCommand(`leaderboard ${c.key}`)}
+              >
+                {c.label}
+              </button>
+            ))}
+          </div>
+
+          {activeCats.map((c) => {
+            const data = leaderboard[c.key];
+            return (
+              <div key={c.key} className="leaderboard-category">
+                <div className="leaderboard-cat-header">{data.label}</div>
+                <table className="leaderboard-table">
+                  <tbody>
+                    {data.entries.map((e) => (
+                      <tr key={e.rank} className="leaderboard-row">
+                        <td className="leaderboard-rank">#{e.rank}</td>
+                        <td className="leaderboard-name">{e.name}</td>
+                        <td className="leaderboard-score">
+                          {e.score.toLocaleString()} {data.scoreLabel}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -63,6 +63,8 @@ import type {
   WhoPlayer,
   ZoneInstances,
   ZoneInstanceItem,
+  LeaderboardData,
+  LeaderboardEntry,
 } from "../types";
 import { MAX_CHAT_MESSAGES_PER_CHANNEL } from "../constants";
 import { safeNumber } from "../utils";
@@ -132,6 +134,7 @@ interface GmcpContext {
   setHousing: Dispatch<SetStateAction<HousingInfo | null>>;
   setTradeState: Dispatch<SetStateAction<TradeState | null>>;
   setAuctionListings: Dispatch<SetStateAction<AuctionListing[]>>;
+  setLeaderboard: Dispatch<SetStateAction<Record<string, LeaderboardData>>>;
 }
 
 const CHAT_CHANNEL_SET = new Set<ChatChannel>(["say", "tell", "gossip", "shout", "ooc", "gtell", "gchat"]);
@@ -1390,6 +1393,25 @@ export function applyGmcpPackage(
             seller: typeof e.seller === "string" ? e.seller : "",
           })),
       );
+      break;
+    }
+
+    case "Leaderboard.Data": {
+      const packet = data as Partial<Record<string, unknown>>;
+      const category = typeof packet.category === "string" ? packet.category : "";
+      const label = typeof packet.label === "string" ? packet.label : category;
+      const scoreLabel = typeof packet.scoreLabel === "string" ? packet.scoreLabel : "";
+      const entries: LeaderboardEntry[] = Array.isArray(packet.entries)
+        ? packet.entries
+            .filter((e): e is Record<string, unknown> => typeof e === "object" && e !== null)
+            .map((e) => ({
+              rank: safeNumber(e.rank, 0),
+              name: typeof e.name === "string" ? e.name : "",
+              score: safeNumber(e.score, 0),
+            }))
+        : [];
+      const leaderboardData: LeaderboardData = { category, label, scoreLabel, entries };
+      ctx.setLeaderboard((prev) => ({ ...prev, [category]: leaderboardData }));
       break;
     }
 

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -9819,3 +9819,102 @@ body {
   border-radius: 3px;
   font-size: 0.7rem;
 }
+
+/* ── Leaderboard Panel ──────────────────────────────────────────────────── */
+
+.leaderboard-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.leaderboard-empty {
+  padding: var(--space-4);
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+.leaderboard-empty p {
+  margin: 0 0 var(--space-2);
+}
+
+.leaderboard-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 var(--space-2) var(--space-2);
+}
+
+.leaderboard-cat-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  padding: var(--space-2) 0 var(--space-3);
+}
+
+.leaderboard-cat-btn {
+  padding: 4px 10px;
+  border: 1px solid var(--line-faint);
+  border-radius: var(--radius-sm);
+  background: rgb(255 255 255 / 5%);
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.leaderboard-cat-btn:hover {
+  background: var(--primary-glass);
+  color: var(--text-primary);
+  border-color: var(--primary-dim);
+}
+
+.leaderboard-category {
+  margin-bottom: var(--space-4);
+}
+
+.leaderboard-cat-header {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--accent-gold);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: var(--space-1) 0;
+  border-bottom: 1px solid var(--line-faint);
+  margin-bottom: var(--space-2);
+}
+
+.leaderboard-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.leaderboard-row {
+  transition: background 0.1s;
+}
+
+.leaderboard-row:hover {
+  background: rgb(255 255 255 / 3%);
+}
+
+.leaderboard-rank {
+  width: 2rem;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  padding: 3px 0;
+}
+
+.leaderboard-name {
+  color: var(--text-primary);
+  font-size: 0.85rem;
+  padding: 3px var(--space-2);
+}
+
+.leaderboard-score {
+  text-align: right;
+  color: var(--accent-gold);
+  font-size: 0.82rem;
+  font-variant-numeric: tabular-nums;
+  padding: 3px 0;
+}

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -1,4 +1,4 @@
-export type PopoutPanel = "map" | "inventory" | "equipment" | "room" | "help" | "character" | "chat" | "shop" | "spellbook" | "quests" | "mail" | "crafting" | "housing" | null;
+export type PopoutPanel = "map" | "inventory" | "equipment" | "room" | "help" | "character" | "chat" | "shop" | "spellbook" | "quests" | "mail" | "crafting" | "housing" | "leaderboard" | null;
 export type ChatChannel = "say" | "tell" | "gossip" | "shout" | "ooc" | "gtell" | "gchat";
 export type SocialTab = "chat" | "friends" | "guild" | "group" | "who";
 
@@ -8,6 +8,19 @@ export interface AuctionListing {
   itemId: string;
   price: number;
   seller: string;
+}
+
+export interface LeaderboardEntry {
+  rank: number;
+  name: string;
+  score: number;
+}
+
+export interface LeaderboardData {
+  category: string;
+  label: string;
+  scoreLabel: string;
+  entries: LeaderboardEntry[];
 }
 
 export interface TradeItem {


### PR DESCRIPTION
Closes #847

## Summary

- **`leaderboard [category]` command** — 5 categories: `level`, `achievements`, `crafting`, `dungeons`, `kills`. Defaults to `level` when no category given. Also aliased as `leaders` and `top`.
- **Kill and dungeon tracking** — new `mobsKilledTotal` (Long) and `dungeonsCompleted` (Int) fields on `PlayerRecord`/`PlayerState`; incremented on mob kill (`CombatSystem.handleMobDeath`) and dungeon boss defeat (`GameEngine.checkDungeonBossKilled`). V25 Flyway migration adds the columns.
- **`LeaderboardSystem`** — in-memory cache per category, refreshed on a configurable interval (default 5 min via `engine.leaderboard.refreshIntervalMs`). Merges live `PlayerState` over persisted records so in-session kills/dungeons are reflected immediately. Staff players are excluded.
- **`PlayerRepository.findAll()`** — new interface method (default no-op) for bulk reads; implemented in `YamlPlayerRepository` and `PostgresPlayerRepository`.
- **`Leaderboard.Data` GMCP** — emitted on every `leaderboard` command for web clients. `KtorWebSocketTransport` auto-opts in via `Leaderboard 1`.
- **Web client panel** — `LeaderboardPanel.tsx` with category quick-buttons and ranked table; `setLeaderboard` state wired through `App.tsx` and `applyGmcpPackage.ts`; `"leaderboard"` added to `PopoutPanel` type; CSS styles added.

## Test plan

- [ ] `LeaderboardSystemTest` — 10 unit tests: ranking by each category, topN cap, staff exclusion, rank index, empty cache
- [ ] `PersistenceFieldCoverageTest` — sentinel values for `mobsKilledTotal`/`dungeonsCompleted` added; `findAll` Postgres round-trip test added
- [ ] `./gradlew ktlintCheck test integrationTest` passes locally