### PR TITLE
Pause demo auto-deploy and world refresh during Eryndal rewrite

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -12,17 +12,20 @@ name: Deploy Demo
 #   GitHub variables:
 #     AWS_REGION              AWS region (default: us-east-1)
 
+# AUTO-DEPLOY PAUSED: automatic deployment is disabled while the Eryndal world
+# rewrite is in progress. Re-enable by restoring the workflow_run trigger below.
+# To re-enable, add back:
+#   workflow_run:
+#     workflows: [CI]
+#     types: [completed]
+#     branches: [main]
+
 on:
   workflow_dispatch:
     inputs:
       image-tag:
         description: "Docker image tag (git SHA) to deploy. Defaults to HEAD of main."
         required: false
-
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
-    branches: [main]
 
 concurrency:
   group: deploy-demo

--- a/.github/workflows/refresh-demo-world.yml
+++ b/.github/workflows/refresh-demo-world.yml
@@ -22,9 +22,13 @@ name: Refresh Demo World
 #   GitHub variables:
 #     AWS_REGION              AWS region (default: us-east-1)
 
+# AUTO-REFRESH PAUSED: automatic world refresh is disabled while the Eryndal world
+# rewrite is in progress. Re-enable by restoring the repository_dispatch trigger below.
+# To re-enable, add back:
+#   repository_dispatch:
+#     types: [refresh-world]
+
 on:
-  repository_dispatch:
-    types: [refresh-world]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

Temporarily disables automatic deployment while the Eryndal base world is being built. The current demo instance stays pinned at its current stable version until the new world is ready.

## Changes

- **`deploy-demo.yml`** — removes the `workflow_run` trigger that fired after every successful CI build on `main`. Workflow is still runnable manually via `workflow_dispatch`.
- **`refresh-demo-world.yml`** — removes the `repository_dispatch` trigger that fired when the Ambon lore repo sent a `refresh-world` event. Workflow is still runnable manually via `workflow_dispatch`.
- **`deploy.yml`** — no change (already manual-only).

Restoring instructions are left as comments in each file — just uncomment the trigger block to re-enable.

## Re-enabling

When the Eryndal world is ready to deploy (after Phase 8), revert this PR or manually restore the commented-out trigger blocks in both files.
