### PR TITLE
Fix engine concurrency and memory leak issues

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -445,7 +445,14 @@ class GameEngine(
         )
     }
 
-    /** GMCP packages each session has opted into (e.g. "Char.Vitals", "Room.Info"). */
+    /**
+     * GMCP packages each session has opted into (e.g. "Char.Vitals", "Room.Info").
+     *
+     * Thread safety: all reads and writes happen on the single-threaded engine
+     * dispatcher (via [GmcpEventHandler], [SessionEventHandler], and the
+     * [GmcpEmitter.supportsPackage] lambda), so a plain [MutableMap] is safe.
+     * If any access ever moves off the engine thread, switch to ConcurrentHashMap.
+     */
     private val gmcpSessions = mutableMapOf<SessionId, MutableSet<String>>()
 
     /** Sessions whose vitals changed this tick and need a Char.Vitals push. */
@@ -1403,7 +1410,12 @@ class GameEngine(
         phaseEventHandler.handlePhase(sessionId, targetHint)
 
     private suspend fun handleHandoffTimeout(sessionId: SessionId) {
-        if (players.get(sessionId) == null) return
+        val player = players.get(sessionId)
+        if (player == null) {
+            log.warn { "Handoff timeout for session=${sessionId.value} but player already disconnected; state cleaned up." }
+            return
+        }
+        log.warn { "Handoff timeout for session=${sessionId.value} player=${player.name}; notifying player." }
         outbound.send(
             OutboundEvent.SendError(
                 sessionId,

--- a/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
@@ -361,6 +361,8 @@ class PlayerRegistry(
     /**
      * Reattach a suspended PlayerState to a new session after reconnect.
      * Uses the same remap logic as session takeover.
+     * All map mutations are non-suspending to prevent interleaved coroutine
+     * access on the single-threaded engine dispatcher.
      */
     suspend fun resumeSession(
         oldSessionId: SessionId,
@@ -368,16 +370,17 @@ class PlayerRegistry(
         playerState: PlayerState,
     ) {
         val resumed = playerState.copy(sessionId = newSessionId)
+
+        // --- begin atomic map mutations (no suspend points) ---
         players[newSessionId] = resumed
 
-        // Remap room membership
-        roomMembers[resumed.roomId]?.let { members ->
-            members.remove(oldSessionId)
-            members.add(newSessionId)
-        }
+        // Remap room membership, cleaning up empty sets
+        roomMembers.removeFromSet(resumed.roomId, oldSessionId)
+        roomMembers.getOrPut(resumed.roomId) { mutableSetOf() }.add(newSessionId)
 
         sessionByLowerName[resumed.name.lowercase()] = newSessionId
         items.remapPlayer(oldSessionId, newSessionId)
+        // --- end atomic map mutations ---
     }
 
     /**
@@ -577,6 +580,12 @@ class PlayerRegistry(
         return true
     }
 
+    /**
+     * Remap a player from [oldSid] to [newSid] atomically.
+     * All map mutations are non-suspending to prevent interleaved coroutine
+     * access on the single-threaded engine dispatcher.
+     * The only suspend call ([persistIfClaimed]) happens after all maps are consistent.
+     */
     private suspend fun takeoverSession(
         oldSid: SessionId,
         newSid: SessionId,
@@ -586,17 +595,17 @@ class PlayerRegistry(
         val oldPs = players[oldSid] ?: return
         val newPs = oldPs.copy(sessionId = newSid, ansiEnabled = boundRecord.ansiEnabled)
 
+        // --- begin atomic map mutations (no suspend points) ---
         players.remove(oldSid)
         players[newSid] = newPs
 
-        roomMembers[oldPs.roomId]?.let { members ->
-            members.remove(oldSid)
-            members.add(newSid)
-        }
+        roomMembers.removeFromSet(oldPs.roomId, oldSid)
+        roomMembers.getOrPut(newPs.roomId) { mutableSetOf() }.add(newSid)
 
         sessionByLowerName[newPs.name.lowercase()] = newSid
 
         items.remapPlayer(oldSid, newSid)
+        // --- end atomic map mutations ---
 
         persistIfClaimed(newPs)
     }

--- a/src/main/kotlin/dev/ambon/engine/events/GmcpFlushHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/GmcpFlushHandler.kt
@@ -96,9 +96,12 @@ class GmcpFlushHandler(
 
     private inline fun <T> drainDirty(set: MutableSet<T>, action: (T) -> Unit) {
         if (set.isEmpty()) return
-        for (item in set) {
-            action(item)
+        try {
+            for (item in set) {
+                action(item)
+            }
+        } finally {
+            set.clear()
         }
-        set.clear()
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/scheduler/Scheduler.kt
+++ b/src/main/kotlin/dev/ambon/engine/scheduler/Scheduler.kt
@@ -86,7 +86,9 @@ class Scheduler(
 
         // O(1): remaining dueQueue entries are all overdue but unrun this tick.
         val dropped = dueQueue.size
-        if (dropped > 0) log.warn { "Scheduler dropped $dropped overdue actions (cap=$maxActions)" }
+        if (dropped > 0) {
+            log.warn { "Scheduler cap reached: $ran actions ran, $dropped due actions deferred to next tick (maxActions=$maxActions)" }
+        }
         return Pair(ran, dropped)
     }
 


### PR DESCRIPTION
## Summary

- **GMCP dirty set leak (CRITICAL):** `GmcpFlushHandler.drainDirty` now wraps iteration in try-finally to guarantee dirty sets are cleared even when an exception interrupts the GMCP flush phase. Previously, an exception would leave stale session/mob IDs in the dirty sets, growing unbounded across ticks.
- **PlayerRegistry takeoverSession/resumeSession atomicity:** Both methods now use `removeFromSet` + `getOrPut` for room member map operations, ensuring empty room sets are cleaned up and all map mutations happen in a non-suspending block with no interleaved coroutine access.
- **GMCP session map thread safety:** Added documentation confirming all `gmcpSessions` reads/writes occur on the single-threaded engine dispatcher, so a plain `MutableMap` is safe. Includes a note to switch to `ConcurrentHashMap` if any access ever moves off-thread.
- **Handoff timeout observability:** `handleHandoffTimeout` now logs at warn level regardless of whether the player is still online. Previously the early return for disconnected players was silent.
- **Scheduler log clarity:** Improved the cap-reached log message to say "deferred to next tick" instead of "dropped", since actions remain in the due queue and are retried.

## Test plan

- [x] `./gradlew.bat ktlintCheck` passes
- [x] Full test suite passes (`./gradlew.bat test -x buildWeb`)
- [x] Targeted tests pass: `HandoffManagerTest`, `SchedulerTest`, `SchedulerDropsTest`
- [ ] Verify CI passes