### PR TITLE
Fix player death cleanup across game systems

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -57,6 +57,9 @@ class CombatSystem(
     /** Callback for gold gain events; wired by GameEngine after construction. */
     var onGoldGained: suspend (SessionId, Long, String) -> Unit = { _, _, _ -> }
 
+    /** Callback for player death cleanup; wired by GameEngine after construction. */
+    var onPlayerDeath: suspend (SessionId) -> Unit = { _ -> }
+
     // Per-mob combat state (tracks tick timing)
     private data class MobCombatState(
         val mobId: MobId,
@@ -524,6 +527,10 @@ class CombatSystem(
         outbound.send(OutboundEvent.SendText(sessionId, deathMessage))
         outbound.send(OutboundEvent.SendText(sessionId, "You are safe now — rest and your wounds will mend."))
         broadcastToRoom(players, outbound, roomId, roomMessage, exclude = sessionId)
+
+        // Clean up cross-system state that should not persist through death
+        onPlayerDeath(sessionId)
+
         outbound.send(OutboundEvent.SendPrompt(sessionId))
     }
 

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -790,6 +790,7 @@ class GameEngine(
         combatSystem.onCombatEvent = { sid, event -> gmcpEmitter.sendCombatEvent(sid, event) }
         combatSystem.onXpGained = { sid, amount, source -> gmcpEmitter.sendCharGain(sid, "xp", amount, source) }
         combatSystem.onGoldGained = { sid, amount, source -> gmcpEmitter.sendCharGain(sid, "gold", amount, source) }
+        combatSystem.onPlayerDeath = { sid -> cleanupOnPlayerDeath(sid) }
         statusEffectSystem.onCombatEvent = { sid, event -> gmcpEmitter.sendCombatEvent(sid, event) }
 
         questSystem.onQuestCompleted = { sid, questId ->
@@ -1737,6 +1738,43 @@ class GameEngine(
             else -> mgr.reloadAll()
         }
         return result.summary()
+    }
+
+    /**
+     * Cleans up cross-system state when a player dies.
+     * Unlike disconnect, the player remains connected — only active game state
+     * that should not survive death is cleared.
+     */
+    private suspend fun cleanupOnPlayerDeath(sessionId: SessionId) {
+        // End active trades (return escrowed items/gold)
+        tradeSystem.cancelForPlayer(sessionId)
+
+        // End active duels
+        val endedDuel = duelSystem.endDuel(sessionId)
+        if (endedDuel != null) {
+            val other = if (endedDuel.player1 == sessionId) endedDuel.player2 else endedDuel.player1
+            outbound.send(
+                OutboundEvent.SendInfo(other, "Your duel opponent has died. Duel ended."),
+            )
+        }
+
+        // Dismiss active pets
+        petSystem.dismissAll(sessionId)
+
+        // Clear status effects (stop DOTs ticking on a corpse)
+        statusEffectSystem.removeAllFromPlayer(sessionId)
+
+        // Reset ability cooldowns
+        abilitySystem.clearCooldowns(sessionId)
+
+        // End active dialogue conversations
+        dialogueSystem.endConversation(sessionId)
+
+        // Leave group (dead players should not receive XP sharing)
+        groupSystem.leave(sessionId)
+
+        // Remove from dungeon instance
+        dungeonManager.removePlayer(sessionId)
     }
 
     private suspend fun onCombatMobRemoved(

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
@@ -679,6 +679,11 @@ class AbilitySystem(
         return (expiresAt - clock.millis()).coerceAtLeast(0L)
     }
 
+    /** Clears all ability cooldowns for a player (e.g. on death). Learned abilities are preserved. */
+    fun clearCooldowns(sessionId: SessionId) {
+        cooldowns.remove(sessionId)
+    }
+
     override suspend fun onPlayerDisconnected(sessionId: SessionId) {
         learnedAbilities.remove(sessionId)
         cooldowns.remove(sessionId)

--- a/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
@@ -861,4 +861,95 @@ class CombatSystemTest {
                     .map { it.text }
             assertTrue(messages.none { it.contains("gold") && it.contains("find") }, "Expected no gold message, got: $messages")
         }
+
+    @Test
+    fun `player death invokes onPlayerDeath callback`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            val mob =
+                MobState(
+                    MobId("demo:ogre"),
+                    "an ogre",
+                    fixture.roomId,
+                    hp = 100,
+                    maxHp = 100,
+                    damage = DamageRange(50, 50),
+                )
+            fixture.mobs.upsert(mob)
+
+            val combat = fixture.buildCombat(rng = Random(1), minDamage = 1, maxDamage = 1)
+
+            val deathCallbackSessions = mutableListOf<SessionId>()
+            combat.onPlayerDeath = { sid -> deathCallbackSessions.add(sid) }
+
+            val sid = SessionId(30L)
+            fixture.players.loginOrFail(sid, "Doomed")
+            combat.startCombat(sid, "ogre")
+            fixture.outbound.drainAll()
+
+            fixture.tickCombat(combat)
+
+            assertEquals(
+                listOf(sid),
+                deathCallbackSessions,
+                "Expected onPlayerDeath callback to fire exactly once for the dying player",
+            )
+        }
+
+    @Test
+    fun `player death clears status effects via onPlayerDeath`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            val poison =
+                StatusEffectDefinition(
+                    id = StatusEffectId("poison"),
+                    displayName = "Poison",
+                    effectType = "damage",
+                    durationMs = 60_000L,
+                    tickIntervalMs = 5_000L,
+                    tickMinValue = 5,
+                    tickMaxValue = 5,
+                )
+            val statusEffects = fixture.buildStatusEffects(poison)
+            val mob =
+                MobState(
+                    MobId("demo:ogre"),
+                    "an ogre",
+                    fixture.roomId,
+                    hp = 100,
+                    maxHp = 100,
+                    damage = DamageRange(50, 50),
+                )
+            fixture.mobs.upsert(mob)
+
+            val combat = fixture.buildCombat(
+                rng = Random(1),
+                minDamage = 1,
+                maxDamage = 1,
+                statusEffects = statusEffects,
+            )
+
+            val sid = SessionId(31L)
+            fixture.players.loginOrFail(sid, "Poisoned")
+
+            // Apply poison before combat
+            statusEffects.applyToPlayer(sid, StatusEffectId("poison"))
+            assertTrue(
+                statusEffects.hasPlayerEffect(sid, "damage"),
+                "Precondition: player should have damage effect",
+            )
+
+            // Wire onPlayerDeath to clear effects
+            combat.onPlayerDeath = { s -> statusEffects.removeAllFromPlayer(s) }
+
+            combat.startCombat(sid, "ogre")
+            fixture.outbound.drainAll()
+
+            fixture.tickCombat(combat)
+
+            assertTrue(
+                !statusEffects.hasPlayerEffect(sid, "damage"),
+                "Expected damage effect to be cleared on death",
+            )
+        }
 }


### PR DESCRIPTION
## Summary

- **Fixed:** `handlePlayerDeath()` in `CombatSystem` only handled combat state and messaging but did not clean up other game systems, causing multiple bugs when players died.
- **Added** `onPlayerDeath` callback to `CombatSystem` (following the existing `onCombatEvent` pattern), wired from `GameEngine.cleanupOnPlayerDeath()` to clear cross-system state.
- **Added** `AbilitySystem.clearCooldowns()` method to reset cooldowns without removing learned abilities (unlike `onPlayerDisconnected` which clears both).

### Systems cleaned up on death

| System | Method called | Bug fixed |
|--------|--------------|-----------|
| TradeSystem | `cancelForPlayer()` | Items/gold locked in escrow |
| DuelSystem | `endDuel()` | Opponent stuck fighting dead player |
| PetSystem | `dismissAll()` | Dead player's pets keep attacking |
| StatusEffectSystem | `removeAllFromPlayer()` | DOTs continue ticking on corpses |
| AbilitySystem | `clearCooldowns()` (new) | Cooldowns persist through death |
| DialogueSystem | `endConversation()` | NPC conversations stay open |
| GroupSystem | `leave()` | Dead players receive XP sharing |
| DungeonManager | `removePlayer()` | Instance persists with dead members |

## Test plan

- [x] New test: `player death invokes onPlayerDeath callback` -- verifies the callback fires exactly once on death
- [x] New test: `player death clears status effects via onPlayerDeath` -- verifies status effects are removed on death
- [x] All 1383 existing tests pass
- [x] ktlintCheck passes