### PR TITLE
Fix persistence layer and cache coherence bugs

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/AuctionSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/AuctionSystem.kt
@@ -8,6 +8,7 @@ import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.items.Item
 import dev.ambon.domain.items.ItemInstance
 import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.persistence.atomicWriteText
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.nio.file.Files
 import java.nio.file.Path
@@ -181,8 +182,7 @@ class AuctionSystem(
                     expiresAtMs = listing.expiresAtMs,
                 )
             }
-            Files.createDirectories(path.parent)
-            Files.writeString(path, mapper.writeValueAsString(persisted))
+            atomicWriteText(path, mapper.writeValueAsString(persisted))
         } catch (e: Exception) {
             log.warn(e) { "Failed to persist auction listings to $path" }
         }

--- a/src/main/kotlin/dev/ambon/persistence/DatabaseManager.kt
+++ b/src/main/kotlin/dev/ambon/persistence/DatabaseManager.kt
@@ -21,6 +21,9 @@ class DatabaseManager(
                 password = config.password
                 maximumPoolSize = config.maxPoolSize
                 minimumIdle = config.minimumIdle
+                maxLifetime = 1_800_000L // 30 min
+                connectionTimeout = 30_000L // 30 sec
+                idleTimeout = 600_000L // 10 min
             }
         hikariDataSource = HikariDataSource(hikariConfig)
         database = Database.connect(hikariDataSource)

--- a/src/main/kotlin/dev/ambon/persistence/FileUtil.kt
+++ b/src/main/kotlin/dev/ambon/persistence/FileUtil.kt
@@ -22,11 +22,21 @@ internal fun atomicWriteText(
     try {
         path.parent?.createDirectories()
         val tmp = Files.createTempFile(path.parent, path.fileName.toString(), ".tmp")
-        Files.writeString(tmp, contents, StandardOpenOption.TRUNCATE_EXISTING)
         try {
-            Files.move(tmp, path, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
-        } catch (_: AtomicMoveNotSupportedException) {
-            Files.move(tmp, path, StandardCopyOption.REPLACE_EXISTING)
+            Files.writeString(tmp, contents, StandardOpenOption.TRUNCATE_EXISTING)
+            try {
+                Files.move(tmp, path, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
+            } catch (_: AtomicMoveNotSupportedException) {
+                Files.move(tmp, path, StandardCopyOption.REPLACE_EXISTING)
+            }
+        } catch (e: Exception) {
+            // Clean up temp file on any failure (disk full, permission denied, etc.)
+            try {
+                Files.deleteIfExists(tmp)
+            } catch (_: IOException) {
+                // Best-effort cleanup
+            }
+            throw e
         }
     } catch (e: IOException) {
         throw PersistenceException("Failed to write file atomically: $path", e)

--- a/src/main/kotlin/dev/ambon/persistence/PostgresPlayerRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PostgresPlayerRepository.kt
@@ -1,6 +1,7 @@
 package dev.ambon.persistence
 
 import dev.ambon.metrics.GameMetrics
+import org.jetbrains.exposed.exceptions.ExposedSQLException
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.selectAll
@@ -65,9 +66,10 @@ class PostgresPlayerRepository(
 
                 request.toNewPlayerRecord(PlayerId(result[PlayersTable.id]))
             }
-        } catch (e: Exception) {
-            // Unique-index violation on name_lower → treat as duplicate name
-            if (e.message?.contains("idx_players_name_lower", ignoreCase = true) == true) {
+        } catch (e: ExposedSQLException) {
+            // SQL state 23505 = unique_violation (works across Postgres versions)
+            val sqlState = e.sqlState
+            if (sqlState == "23505") {
                 throw PersistenceException("Name already taken: '$trimmed'", e)
             }
             throw e

--- a/src/main/kotlin/dev/ambon/persistence/RedisCachingPlayerRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/RedisCachingPlayerRepository.kt
@@ -37,6 +37,10 @@ class RedisCachingPlayerRepository(
         cacheRecord(record)
     }
 
+    override suspend fun storeOnSave(record: PlayerRecord) {
+        cacheRecord(record)
+    }
+
     private suspend fun withCacheReadFallback(
         warningContext: String,
         lookup: suspend () -> PlayerRecord?,

--- a/src/main/kotlin/dev/ambon/persistence/WriteCoalescingPlayerRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/WriteCoalescingPlayerRepository.kt
@@ -128,6 +128,10 @@ class WriteCoalescingPlayerRepository(
      * in-memory cache so the next lookup reads fresh from the delegate
      * (e.g. YAML on disk).  This lets external edits to player files
      * take effect on the next login.
+     *
+     * Uses a single lock acquisition for the flush-check and eviction to
+     * prevent a TOCTOU race where another thread could mark the player
+     * dirty again between the version check and the cache removal.
      */
     override suspend fun evict(id: PlayerId) {
         val pending = lock.withLock {
@@ -137,13 +141,13 @@ class WriteCoalescingPlayerRepository(
         }
         if (pending != null) {
             delegate.save(pending.record)
-            lock.withLock {
-                if (dirtyVersions[id] == pending.version) {
-                    dirtyVersions.remove(id)
-                }
-            }
         }
         lock.withLock {
+            // Clear dirty flag only if the version hasn't changed since our flush
+            if (pending != null && dirtyVersions[id] == pending.version) {
+                dirtyVersions.remove(id)
+            }
+            // Only evict if no new dirty writes arrived
             if (dirtyVersions.containsKey(id)) return
             val removed = cache.remove(id) ?: return
             nameIndex.remove(removed.name.lowercase())

--- a/src/test/kotlin/dev/ambon/engine/AuctionSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/AuctionSystemTest.kt
@@ -10,9 +10,13 @@ import dev.ambon.test.MutableClock
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.exists
 
 class AuctionSystemTest {
     private val clock = MutableClock(1000L)
@@ -170,6 +174,65 @@ class AuctionSystemTest {
             val expired = auction.expireListings()
 
             assertEquals(0, expired.size)
+            assertEquals(1, auction.allListings().size)
+        }
+    }
+
+    @Nested
+    inner class Persistence {
+        @Test
+        fun `atomic write persists listings and survives reload`(
+            @TempDir tempDir: Path,
+        ) {
+            val persistPath = tempDir.resolve("auction_listings.json")
+            val persistedAuction = AuctionSystem(
+                items = items,
+                clock = clock,
+                listingDurationMs = 60_000L,
+                persistPath = persistPath,
+            )
+            giveSword(sid1)
+            persistedAuction.postListing(sid1, "Player1", "sword", 100)
+
+            assertTrue(persistPath.exists(), "Persist file should exist after posting")
+
+            // Reload into a fresh AuctionSystem to verify data survives
+            val reloaded = AuctionSystem(
+                items = items,
+                clock = clock,
+                listingDurationMs = 60_000L,
+                persistPath = persistPath,
+            )
+            reloaded.loadPersistedListings()
+            assertEquals(1, reloaded.allListings().size)
+            assertEquals("Player1", reloaded.allListings().first().sellerName)
+            assertEquals(100L, reloaded.allListings().first().price)
+        }
+
+        @Test
+        fun `no temp files left after successful persist`(
+            @TempDir tempDir: Path,
+        ) {
+            val persistPath = tempDir.resolve("auction_listings.json")
+            val persistedAuction = AuctionSystem(
+                items = items,
+                clock = clock,
+                listingDurationMs = 60_000L,
+                persistPath = persistPath,
+            )
+            giveSword(sid1)
+            persistedAuction.postListing(sid1, "Player1", "sword", 100)
+
+            // Verify no .tmp files remain in the directory
+            val tmpFiles = tempDir.toFile().listFiles { f -> f.name.endsWith(".tmp") }
+            assertTrue(tmpFiles.isNullOrEmpty(), "No .tmp files should remain after atomic write")
+        }
+
+        @Test
+        fun `persist file not created when no persist path configured`() {
+            // Default auction (no persistPath) should not throw
+            giveSword(sid1)
+            auction.postListing(sid1, "Player1", "sword", 100)
             assertEquals(1, auction.allListings().size)
         }
     }

--- a/src/test/kotlin/dev/ambon/persistence/RedisCachingPlayerRepositoryTest.kt
+++ b/src/test/kotlin/dev/ambon/persistence/RedisCachingPlayerRepositoryTest.kt
@@ -166,6 +166,38 @@ class RedisCachingPlayerRepositoryTest {
         }
 
     @Test
+    fun `save updates redis cache so stale reads do not occur`() =
+        runBlocking {
+            val record =
+                repo.create(
+                    PlayerCreationRequest(
+                        name = "Boromir",
+                        startRoomId = RoomId("demo:start"),
+                        nowEpochMs = 9000L,
+                        passwordHash = "hash9",
+                        ansiEnabled = false,
+                    ),
+                )
+            // Mutate and save — cache must reflect the updated record
+            val updated = record.copy(level = 10, gold = 250L, roomId = RoomId("demo:tavern"))
+            repo.save(updated)
+
+            // Clear delegate so lookups can only succeed from cache
+            delegate.clear()
+
+            val byId = repo.findById(record.id)
+            assertNotNull(byId)
+            assertEquals(10, byId!!.level)
+            assertEquals(250L, byId.gold)
+            assertEquals(RoomId("demo:tavern"), byId.roomId)
+
+            val byName = repo.findByName("Boromir")
+            assertNotNull(byName)
+            assertEquals(10, byName!!.level)
+            assertEquals(250L, byName.gold)
+        }
+
+    @Test
     fun `all fields survive round-trip including isStaff`() =
         runBlocking {
             val created =

--- a/src/test/kotlin/dev/ambon/persistence/WriteCoalescingPlayerRepositoryTest.kt
+++ b/src/test/kotlin/dev/ambon/persistence/WriteCoalescingPlayerRepositoryTest.kt
@@ -194,6 +194,57 @@ class WriteCoalescingPlayerRepositoryTest {
             assertEquals(1, flushed)
             assertEquals(0, repo.dirtyCount())
         }
+
+    @Test
+    fun `evict flushes dirty record and removes from cache`() =
+        runTest {
+            val delegate = InMemoryPlayerRepository()
+            val repo = WriteCoalescingPlayerRepository(delegate)
+
+            val record = delegate.create(PlayerCreationRequest("Frank", startRoom, 1000L, "hash", false))
+            repo.save(record.copy(roomId = RoomId("zone:updated")))
+            assertEquals(1, repo.dirtyCount())
+
+            repo.evict(record.id)
+
+            // Dirty record should have been flushed to delegate
+            val fromDelegate = delegate.findById(record.id)
+            assertNotNull(fromDelegate)
+            assertEquals(RoomId("zone:updated"), fromDelegate!!.roomId)
+
+            // Cache should be empty — next lookup goes to delegate
+            assertEquals(0, repo.dirtyCount())
+            assertEquals(0, repo.cachedCount())
+        }
+
+    @Test
+    fun `evict does not remove cache when new dirty write arrives during flush`() =
+        runTest {
+            val delegate = BlockingSaveRepository(InMemoryPlayerRepository())
+            val repo = WriteCoalescingPlayerRepository(delegate)
+            val record = delegate.create(PlayerCreationRequest("Grace", startRoom, 1000L, "hash", false))
+
+            repo.save(record.copy(roomId = RoomId("zone:v1")))
+
+            val saveStarted = CompletableDeferred<Unit>()
+            val allowSaveToFinish = CompletableDeferred<Unit>()
+            delegate.blockNextSave(started = saveStarted, proceed = allowSaveToFinish)
+
+            val evictJob = async { repo.evict(record.id) }
+            saveStarted.await()
+
+            // While evict is flushing, a new save arrives
+            repo.save(record.copy(roomId = RoomId("zone:v2")))
+
+            allowSaveToFinish.complete(Unit)
+            evictJob.await()
+
+            // The new dirty write should prevent eviction
+            assertEquals(1, repo.dirtyCount())
+            assertEquals(1, repo.cachedCount())
+            val cached = repo.findById(record.id)
+            assertEquals(RoomId("zone:v2"), cached!!.roomId)
+        }
 }
 
 private class SaveCountingRepository(


### PR DESCRIPTION
## Summary
- **Redis cache not updated on save**: `RedisCachingPlayerRepository` now explicitly overrides `storeOnSave()` to write updated records to Redis after each save, preventing stale cache reads
- **Auction file non-atomic writes**: Replaced raw `Files.writeString()` in `AuctionSystem.persist()` with `atomicWriteText()`, preventing file corruption on crash mid-write
- **HikariCP missing timeouts**: Added `maxLifetime` (30 min), `connectionTimeout` (30 sec), and `idleTimeout` (10 min) to `DatabaseManager` HikariCP configuration
- **Postgres fragile exception matching**: Changed `PostgresPlayerRepository.create()` to catch `ExposedSQLException` and check SQL state code `23505` (unique_violation) instead of brittle string matching on index name
- **Atomic write temp file leak**: Wrapped temp file write+move in `FileUtil.atomicWriteText()` with try-finally to delete the temp file on failure (e.g., disk full)
- **Write-coalescing eviction race**: Merged the dirty-flag version check and cache removal in `WriteCoalescingPlayerRepository.evict()` into a single lock acquisition, eliminating a TOCTOU race where a concurrent save could re-dirty the record between check and removal

## Test plan
- [x] New test: `save updates redis cache so stale reads do not occur` (RedisCachingPlayerRepositoryTest)
- [x] New test: `atomic write persists listings and survives reload` (AuctionSystemTest)
- [x] New test: `no temp files left after successful persist` (AuctionSystemTest)
- [x] New test: `persist file not created when no persist path configured` (AuctionSystemTest)
- [x] New test: `evict flushes dirty record and removes from cache` (WriteCoalescingPlayerRepositoryTest)
- [x] New test: `evict does not remove cache when new dirty write arrives during flush` (WriteCoalescingPlayerRepositoryTest)
- [x] All existing persistence tests pass unchanged
- [x] Full test suite passes