### PR TITLE
Fix metric cardinality explosion and config validation gaps

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -62,7 +62,8 @@ data class AppConfig(
         require(server.inboundBudgetMs < server.tickMillis) { "ambonMUD.server.inboundBudgetMs must be < tickMillis" }
 
         require(world.resources.all { it.isNotBlank() }) { "ambonMUD.world.resources entries must be non-blank" }
-        world.startRoom?.let { sr ->
+        require(world.startRoom != null) { "ambonMUD.world.startRoom must be configured" }
+        world.startRoom.let { sr ->
             require(sr.contains(':')) { "ambonMUD.world.startRoom must be in 'zone:room' format, got '$sr'" }
         }
 
@@ -108,9 +109,13 @@ data class AppConfig(
         require(engine.regen.regenAmount > 0) { "ambonMUD.engine.regen.regenAmount must be > 0" }
 
         require(engine.equipment.slots.isNotEmpty()) { "ambonMUD.engine.equipment.slots must not be empty" }
-        for ((id, _) in engine.equipment.slots) {
+        val slotOrders = mutableSetOf<Int>()
+        for ((id, slot) in engine.equipment.slots) {
             require(id == id.trim().lowercase()) {
                 "ambonMUD.engine.equipment.slots key '$id' must be lowercase with no surrounding whitespace"
+            }
+            require(slotOrders.add(slot.order)) {
+                "ambonMUD.engine.equipment.slots: duplicate order ${slot.order} for slot '$id'"
             }
         }
 
@@ -211,7 +216,9 @@ data class AppConfig(
 
         require(progression.maxLevel > 0) { "ambonMUD.progression.maxLevel must be > 0" }
         require(progression.xp.baseXp > 0L) { "ambonMUD.progression.xp.baseXp must be > 0" }
-        require(progression.xp.exponent > 0.0) { "ambonMUD.progression.xp.exponent must be > 0" }
+        require(progression.xp.exponent >= 1.0) {
+            "ambonMUD.progression.xp.exponent must be >= 1.0 to ensure XP requirements increase with level"
+        }
         require(progression.xp.linearXp >= 0L) { "ambonMUD.progression.xp.linearXp must be >= 0" }
         require(progression.xp.multiplier >= 0.0) { "ambonMUD.progression.xp.multiplier must be >= 0" }
         require(progression.xp.defaultKillXp >= 0L) { "ambonMUD.progression.xp.defaultKillXp must be >= 0" }
@@ -395,6 +402,15 @@ data class AppConfig(
         require(engine.worldTime.dayHour in 0..23) { "ambonMUD.engine.worldTime.dayHour must be 0..23" }
         require(engine.worldTime.duskHour in 0..23) { "ambonMUD.engine.worldTime.duskHour must be 0..23" }
         require(engine.worldTime.nightHour in 0..23) { "ambonMUD.engine.worldTime.nightHour must be 0..23" }
+        require(engine.worldTime.dawnHour < engine.worldTime.dayHour) {
+            "ambonMUD.engine.worldTime.dawnHour (${engine.worldTime.dawnHour}) must be < dayHour (${engine.worldTime.dayHour})"
+        }
+        require(engine.worldTime.dayHour < engine.worldTime.duskHour) {
+            "ambonMUD.engine.worldTime.dayHour (${engine.worldTime.dayHour}) must be < duskHour (${engine.worldTime.duskHour})"
+        }
+        require(engine.worldTime.duskHour < engine.worldTime.nightHour) {
+            "ambonMUD.engine.worldTime.duskHour (${engine.worldTime.duskHour}) must be < nightHour (${engine.worldTime.nightHour})"
+        }
         require(engine.weather.minTransitionMs > 0L) { "ambonMUD.engine.weather.minTransitionMs must be > 0" }
         require(engine.weather.maxTransitionMs >= engine.weather.minTransitionMs) {
             "ambonMUD.engine.weather.maxTransitionMs must be >= minTransitionMs"
@@ -414,9 +430,21 @@ data class AppConfig(
         val factionIds = engine.factions.definitions.keys
         for ((factionId, def) in engine.factions.definitions) {
             for (enemyId in def.enemies) {
-                if (enemyId !in factionIds) {
-                    warnConfig("faction '$factionId' references enemy '$enemyId' which is not defined in factions.definitions")
+                require(enemyId in factionIds) {
+                    "faction '$factionId' references enemy '$enemyId' which is not defined in factions.definitions"
                 }
+            }
+        }
+
+        // Sharding / instancing interdependency checks
+        if (sharding.enabled) {
+            require(redis.enabled) {
+                "ambonMUD.redis.enabled must be true when sharding.enabled=true (sharding requires Redis)"
+            }
+        }
+        if (sharding.instancing.enabled) {
+            require(sharding.enabled) {
+                "ambonMUD.sharding.enabled must be true when sharding.instancing.enabled=true"
             }
         }
 

--- a/src/main/kotlin/dev/ambon/metrics/GameMetrics.kt
+++ b/src/main/kotlin/dev/ambon/metrics/GameMetrics.kt
@@ -1,6 +1,7 @@
 package dev.ambon.metrics
 
 import dev.ambon.domain.ids.SessionId
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.Gauge
@@ -16,6 +17,78 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Normalised disconnect reason for bounded metric cardinality.
+ * Every raw reason string is mapped to one of these known values.
+ */
+enum class DisconnectReason(
+    val tag: String,
+) {
+    EOF("EOF"),
+    BACKPRESSURE("backpressure"),
+    TIMEOUT("timeout"),
+    KICKED("kicked"),
+    ERROR("error"),
+    CONNECTION_RESET("connection_reset"),
+    PROTOCOL_VIOLATION("protocol_violation"),
+    INBOUND_CLOSED("inbound_closed"),
+    UNKNOWN("unknown"),
+    ;
+
+    companion object {
+        /** Map an arbitrary reason string to the closest known enum value. */
+        fun fromString(reason: String): DisconnectReason {
+            val lower = reason.lowercase()
+            return when {
+                lower == "eof" -> EOF
+                lower.contains("backpressure") -> BACKPRESSURE
+                lower.contains("timeout") -> TIMEOUT
+                lower.contains("kicked") || lower.contains("kick") -> KICKED
+                lower.contains("connection reset") || lower.contains("connection_reset") -> CONNECTION_RESET
+                lower.contains("protocol violation") || lower.contains("protocol_violation") -> PROTOCOL_VIOLATION
+                lower.contains("inbound closed") || lower.contains("inbound_closed") -> INBOUND_CLOSED
+                lower.contains("error") -> ERROR
+                else -> UNKNOWN
+            }
+        }
+    }
+}
+
+/**
+ * Normalised gRPC drop reason for bounded metric cardinality.
+ * Every raw reason string is mapped to one of these known values.
+ */
+enum class GrpcDropReason(
+    val tag: String,
+) {
+    NO_STREAM("no_stream"),
+    STREAM_CLOSED("stream_closed"),
+    STREAM_FULL("stream_full"),
+    STREAM_FULL_TIMEOUT("stream_full_timeout"),
+    GATEWAY_LOCAL_QUEUE_FULL("gateway_local_queue_full"),
+    GATEWAY_LOCAL_QUEUE_FULL_TIMEOUT("gateway_local_queue_full_timeout"),
+    UNKNOWN("unknown"),
+    ;
+
+    companion object {
+        /** Map an arbitrary reason string to the closest known enum value. */
+        fun fromString(reason: String): GrpcDropReason {
+            val lower = reason.lowercase()
+            return when {
+                lower == "no_stream" -> NO_STREAM
+                lower == "stream_closed" -> STREAM_CLOSED
+                lower == "stream_full_timeout" -> STREAM_FULL_TIMEOUT
+                lower == "stream_full" -> STREAM_FULL
+                lower == "gateway_local_queue_full_timeout" -> GATEWAY_LOCAL_QUEUE_FULL_TIMEOUT
+                lower == "gateway_local_queue_full" -> GATEWAY_LOCAL_QUEUE_FULL
+                else -> UNKNOWN
+            }
+        }
+    }
+}
 
 class GameMetrics(
     private val registry: MeterRegistry,
@@ -124,6 +197,16 @@ class GameMetrics(
             .publishPercentileHistogram()
             .register(registry)
 
+    /** Pre-registered tick phase timers — bounded cardinality, one per known phase name. */
+    private val tickPhaseTimers: Map<String, Timer> =
+        KNOWN_TICK_PHASES.associateWith { phase ->
+            Timer
+                .builder("engine_tick_phase_duration_seconds")
+                .tag("phase", phase)
+                .publishPercentileHistogram()
+                .register(registry)
+        }
+
     val mobSystemTickTimer: Timer =
         Timer
             .builder("mob_system_tick_duration_seconds")
@@ -183,7 +266,8 @@ class GameMetrics(
     }
 
     fun onTelnetDisconnected(reason: String) {
-        registry.counter("sessions_disconnected_total", "transport", "telnet", "reason", reason).increment()
+        val normalized = DisconnectReason.fromString(reason).tag
+        registry.counter("sessions_disconnected_total", "transport", "telnet", "reason", normalized).increment()
         sessionsOnlineCount.decrementAndGet()
         telnetOnlineCount.decrementAndGet()
     }
@@ -195,7 +279,8 @@ class GameMetrics(
     }
 
     fun onWsDisconnected(reason: String) {
-        registry.counter("sessions_disconnected_total", "transport", "ws", "reason", reason).increment()
+        val normalized = DisconnectReason.fromString(reason).tag
+        registry.counter("sessions_disconnected_total", "transport", "ws", "reason", normalized).increment()
         sessionsOnlineCount.decrementAndGet()
         wsOnlineCount.decrementAndGet()
     }
@@ -213,17 +298,20 @@ class GameMetrics(
     fun onOutboundEnqueueFailed() = outboundEnqueueFailedCounter.increment()
 
     fun onGrpcControlPlaneDrop(reason: String) {
-        registry.counter("grpc_outbound_control_plane_dropped_total", "reason", reason).increment()
+        val normalized = GrpcDropReason.fromString(reason).tag
+        registry.counter("grpc_outbound_control_plane_dropped_total", "reason", normalized).increment()
     }
 
     fun onGrpcDataPlaneDrop(reason: String) {
-        registry.counter("grpc_outbound_data_plane_dropped_total", "reason", reason).increment()
+        val normalized = GrpcDropReason.fromString(reason).tag
+        registry.counter("grpc_outbound_data_plane_dropped_total", "reason", normalized).increment()
     }
 
     fun onGrpcControlPlaneFallbackSend() = grpcControlPlaneFallbackCounter.increment()
 
     fun onGrpcForcedDisconnectDueToControlDeliveryFailure(reason: String) {
-        registry.counter("grpc_forced_disconnect_control_plane_total", "reason", reason).increment()
+        val normalized = GrpcDropReason.fromString(reason).tag
+        registry.counter("grpc_forced_disconnect_control_plane_total", "reason", normalized).increment()
     }
 
     fun onEngineTick() = engineTicksCounter.increment()
@@ -334,18 +422,19 @@ class GameMetrics(
     /**
      * Records the duration of a named tick phase (inbound_drain, simulation, gmcp_flush, outbound_flush).
      * Emits a histogram under `engine_tick_phase_duration_seconds{phase=<phase>}`.
+     *
+     * Only known phase names are accepted to prevent metric cardinality explosion.
+     * Unknown phases are logged and dropped.
      */
     fun recordTickPhase(
         phase: String,
         sample: Timer.Sample,
     ) {
-        sample.stop(
-            Timer
-                .builder("engine_tick_phase_duration_seconds")
-                .tag("phase", phase)
-                .publishPercentileHistogram()
-                .register(registry),
-        )
+        if (phase !in KNOWN_TICK_PHASES) {
+            log.warn { "Unknown tick phase '$phase' — dropping metric sample to prevent cardinality explosion" }
+            return
+        }
+        sample.stop(tickPhaseTimers.getValue(phase))
     }
 
     fun bindPlayerRegistry(supplier: () -> Int) {
@@ -407,6 +496,14 @@ class GameMetrics(
     }
 
     companion object {
+        /** Pre-registered tick phase names. Only these values are accepted by [recordTickPhase]. */
+        val KNOWN_TICK_PHASES: Set<String> = setOf(
+            "inbound_drain",
+            "simulation",
+            "gmcp_flush",
+            "outbound_flush",
+        )
+
         fun noop(): GameMetrics = GameMetrics(SimpleMeterRegistry(), bindJvmMetrics = false)
     }
 }

--- a/src/test/kotlin/dev/ambon/config/AppConfigLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/config/AppConfigLoaderTest.kt
@@ -9,6 +9,9 @@ import org.junit.jupiter.api.Test
 class AppConfigLoaderTest {
     private val testResourcePath = "/test-application.yaml"
 
+    /** Minimal valid world config used when the test is exercising a non-world validation path. */
+    private val validWorld = WorldConfig(startRoom = "test:room")
+
     @Test
     fun `system property overrides default config`() {
         val key = "config.override.ambonmud.server.telnetPort"
@@ -39,13 +42,13 @@ class AppConfigLoaderTest {
 
     @Test
     fun `validation rejects invalid values`() {
-        val invalid = AppConfig(server = ServerConfig(telnetPort = 0))
+        val invalid = AppConfig(server = ServerConfig(telnetPort = 0), world = validWorld)
         assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
     }
 
     @Test
     fun `validation rejects invalid progression values`() {
-        val invalid = AppConfig(progression = ProgressionConfig(maxLevel = 0))
+        val invalid = AppConfig(progression = ProgressionConfig(maxLevel = 0), world = validWorld)
         assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
     }
 
@@ -55,6 +58,7 @@ class AppConfigLoaderTest {
         val invalid =
             AppConfig(
                 engine = EngineConfig(mob = MobEngineConfig(tiers = MobTiersConfig(standard = badTier))),
+                world = validWorld,
             )
         assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
     }
@@ -70,49 +74,62 @@ class AppConfigLoaderTest {
                                 feedback = CombatFeedbackConfig(enabled = false, roomBroadcastEnabled = true),
                             ),
                     ),
+                world = validWorld,
             )
         assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
     }
 
     @Test
     fun `validation rejects inboundBudgetMs of zero`() {
-        val invalid = AppConfig(server = ServerConfig(inboundBudgetMs = 0L))
+        val invalid = AppConfig(server = ServerConfig(inboundBudgetMs = 0L), world = validWorld)
         assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
     }
 
     @Test
     fun `validation rejects inboundBudgetMs equal to tickMillis`() {
-        val invalid = AppConfig(server = ServerConfig(tickMillis = 100L, inboundBudgetMs = 100L))
+        val invalid = AppConfig(
+            server = ServerConfig(tickMillis = 100L, inboundBudgetMs = 100L),
+            world = validWorld,
+        )
         assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
     }
 
     @Test
     fun `validation rejects inboundBudgetMs greater than tickMillis`() {
-        val invalid = AppConfig(server = ServerConfig(tickMillis = 100L, inboundBudgetMs = 101L))
+        val invalid = AppConfig(
+            server = ServerConfig(tickMillis = 100L, inboundBudgetMs = 101L),
+            world = validWorld,
+        )
         assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
     }
 
     @Test
     fun `validation accepts valid inboundBudgetMs`() {
-        val valid = AppConfig(server = ServerConfig(tickMillis = 100L, inboundBudgetMs = 30L))
+        val valid = AppConfig(
+            server = ServerConfig(tickMillis = 100L, inboundBudgetMs = 30L),
+            world = validWorld,
+        )
         valid.validated() // should not throw
     }
 
     @Test
     fun `redis validation skipped when disabled`() {
-        val config = AppConfig(redis = RedisConfig(enabled = false, uri = ""))
+        val config = AppConfig(redis = RedisConfig(enabled = false, uri = ""), world = validWorld)
         config.validated()
     }
 
     @Test
     fun `redis validation rejects blank uri when enabled`() {
-        val invalid = AppConfig(redis = RedisConfig(enabled = true, uri = ""))
+        val invalid = AppConfig(redis = RedisConfig(enabled = true, uri = ""), world = validWorld)
         assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
     }
 
     @Test
     fun `redis validation rejects non-positive cacheTtlSeconds`() {
-        val invalid = AppConfig(redis = RedisConfig(enabled = true, cacheTtlSeconds = 0L))
+        val invalid = AppConfig(
+            redis = RedisConfig(enabled = true, cacheTtlSeconds = 0L),
+            world = validWorld,
+        )
         assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
     }
 
@@ -125,6 +142,7 @@ class AppConfigLoaderTest {
                         enabled = true,
                         bus = RedisBusConfig(enabled = true, sharedSecret = ""),
                     ),
+                world = validWorld,
             )
         assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
     }
@@ -138,13 +156,14 @@ class AppConfigLoaderTest {
                         enabled = true,
                         bus = RedisBusConfig(enabled = true, sharedSecret = "secret"),
                     ),
+                world = validWorld,
             )
         config.validated()
     }
 
     @Test
     fun `validation accepts empty resources list for auto-discovery`() {
-        AppConfig(world = WorldConfig(resources = emptyList())).validated()
+        AppConfig(world = WorldConfig(resources = emptyList(), startRoom = "z:r")).validated()
     }
 
     @Test
@@ -159,6 +178,12 @@ class AppConfigLoaderTest {
     }
 
     @Test
+    fun `validation rejects null startRoom`() {
+        val invalid = AppConfig(world = WorldConfig(startRoom = null))
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
+
+    @Test
     fun `validated warns on stat binding referencing undefined stat`() {
         val config =
             AppConfig(
@@ -169,6 +194,7 @@ class AppConfigLoaderTest {
                                 bindings = StatBindingsConfig(meleeDamageStat = "UNKNOWN"),
                             ),
                     ),
+                world = validWorld,
             )
         // Should warn but not throw — degraded config is acceptable in production
         config.validated()
@@ -185,6 +211,7 @@ class AppConfigLoaderTest {
                                 bindings = StatBindingsConfig(meleeDamageDivisor = 0),
                             ),
                     ),
+                world = validWorld,
             )
         assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
     }
@@ -200,6 +227,7 @@ class AppConfigLoaderTest {
                                 bindings = StatBindingsConfig(maxDodgePercent = 101),
                             ),
                     ),
+                world = validWorld,
             )
         assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
     }
@@ -209,6 +237,7 @@ class AppConfigLoaderTest {
         val invalid =
             AppConfig(
                 progression = ProgressionConfig(rewards = LevelRewardsConfig(baseHp = 0)),
+                world = validWorld,
             )
         assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
     }
@@ -218,6 +247,7 @@ class AppConfigLoaderTest {
         val invalid =
             AppConfig(
                 progression = ProgressionConfig(rewards = LevelRewardsConfig(baseMana = -1)),
+                world = validWorld,
             )
         assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
     }
@@ -227,6 +257,7 @@ class AppConfigLoaderTest {
         val invalid =
             AppConfig(
                 engine = EngineConfig(characterCreation = CharacterCreationConfig(startingGold = -1L)),
+                world = validWorld,
             )
         assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
     }
@@ -245,9 +276,125 @@ class AppConfigLoaderTest {
                                     ),
                             ),
                     ),
+                world = validWorld,
             )
         // Should warn but not throw — degraded config is acceptable in production
         config.validated()
+    }
+
+    @Test
+    fun `validated rejects world time hours out of order`() {
+        val invalid = AppConfig(
+            engine = EngineConfig(
+                worldTime = WorldTimeConfig(dawnHour = 10, dayHour = 5, duskHour = 18, nightHour = 21),
+            ),
+            world = validWorld,
+        )
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
+
+    @Test
+    fun `validated rejects dusk before day hour`() {
+        val invalid = AppConfig(
+            engine = EngineConfig(
+                worldTime = WorldTimeConfig(dawnHour = 5, dayHour = 18, duskHour = 8, nightHour = 21),
+            ),
+            world = validWorld,
+        )
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
+
+    @Test
+    fun `validated rejects night before dusk hour`() {
+        val invalid = AppConfig(
+            engine = EngineConfig(
+                worldTime = WorldTimeConfig(dawnHour = 5, dayHour = 8, duskHour = 21, nightHour = 18),
+            ),
+            world = validWorld,
+        )
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
+
+    @Test
+    fun `validated rejects faction referencing undefined enemy`() {
+        val invalid = AppConfig(
+            engine = EngineConfig(
+                factions = FactionConfig(
+                    definitions = mapOf(
+                        "guild_a" to FactionDefinition(name = "Guild A", enemies = listOf("nonexistent")),
+                    ),
+                ),
+            ),
+            world = validWorld,
+        )
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
+
+    @Test
+    fun `validated accepts faction with valid enemy cross-reference`() {
+        val config = AppConfig(
+            engine = EngineConfig(
+                factions = FactionConfig(
+                    definitions = mapOf(
+                        "guild_a" to FactionDefinition(name = "Guild A", enemies = listOf("guild_b")),
+                        "guild_b" to FactionDefinition(name = "Guild B", enemies = listOf("guild_a")),
+                    ),
+                ),
+            ),
+            world = validWorld,
+        )
+        config.validated()
+    }
+
+    @Test
+    fun `validated rejects duplicate equipment slot orders`() {
+        val invalid = AppConfig(
+            engine = EngineConfig(
+                equipment = EquipmentConfig(
+                    slots = linkedMapOf(
+                        "head" to EquipmentSlotConfig(displayName = "Head", order = 0),
+                        "body" to EquipmentSlotConfig(displayName = "Body", order = 0),
+                    ),
+                ),
+            ),
+            world = validWorld,
+        )
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
+
+    @Test
+    fun `validated rejects xp exponent below 1`() {
+        val invalid = AppConfig(
+            progression = ProgressionConfig(xp = XpCurveConfig(exponent = 0.5)),
+            world = validWorld,
+        )
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
+
+    @Test
+    fun `validated rejects sharding without redis`() {
+        val invalid = AppConfig(
+            sharding = ShardingConfig(
+                enabled = true,
+                engineId = "e1",
+                advertiseHost = "localhost",
+            ),
+            redis = RedisConfig(enabled = false),
+            world = validWorld,
+        )
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
+
+    @Test
+    fun `validated rejects instancing without sharding`() {
+        val invalid = AppConfig(
+            sharding = ShardingConfig(
+                enabled = false,
+                instancing = InstanceConfig(enabled = true),
+            ),
+            world = validWorld,
+        )
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
     }
 
     @Test

--- a/src/test/resources/test-application.yaml
+++ b/src/test/resources/test-application.yaml
@@ -2,3 +2,4 @@ ambonmud:
   world:
     resources:
       - world/test_world.yaml
+    startRoom: "test_zone:hub"


### PR DESCRIPTION
## Summary
- **Metric cardinality (CRITICAL):** Disconnect reasons, gRPC drop reasons, and tick phase names were passed as arbitrary strings to Prometheus counters/timers, creating unbounded metric series. Added `DisconnectReason` and `GrpcDropReason` enums with `fromString()` normalization, and pre-registered tick phase timers that reject unknown phases.
- **Config validation:** Added six missing validation checks in `AppConfig.validated()`: non-null `startRoom`, world time hour ordering (`dawn < day < dusk < night`), faction enemy cross-reference hard failure, sharding-requires-redis interdependency, instancing-requires-sharding interdependency, unique equipment slot display orders, and XP exponent minimum of 1.0 for monotonicity.

## Test plan
- [x] All existing tests pass with updated configs (`validWorld` helper for tests not exercising world config)
- [x] New tests for: null startRoom rejection, hour ordering (3 cases), undefined faction enemy, valid faction cross-ref, duplicate slot orders, XP exponent < 1, sharding without redis, instancing without sharding
- [x] ktlintCheck passes
- [x] Full test suite passes