### PR TITLE
Fix transport layer security and reliability issues

### DIFF
--- a/src/main/kotlin/dev/ambon/ServerInfrastructure.kt
+++ b/src/main/kotlin/dev/ambon/ServerInfrastructure.kt
@@ -94,6 +94,7 @@ object ServerInfrastructure {
             maxNonPrintablePerLine = config.transport.telnet.maxNonPrintablePerLine,
             maxInboundBackpressureFailures = config.transport.maxInboundBackpressureFailures,
             socketBacklog = config.transport.telnet.socketBacklog,
+            maxConnections = config.transport.telnet.maxConnections,
             metrics = metrics,
             sessionDispatcher = sessionDispatcher,
         )

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -225,6 +225,7 @@ data class AppConfig(
             "ambonMUD.transport.telnet.maxNonPrintablePerLine must be >= 0"
         }
         require(transport.telnet.socketBacklog > 0) { "ambonMUD.transport.telnet.socketBacklog must be > 0" }
+        require(transport.telnet.maxConnections > 0) { "ambonMUD.transport.telnet.maxConnections must be > 0" }
         require(transport.maxInboundBackpressureFailures > 0) {
             "ambonMUD.transport.maxInboundBackpressureFailures must be > 0"
         }
@@ -1574,6 +1575,8 @@ data class TelnetTransportConfig(
     val maxNonPrintablePerLine: Int = 32,
     /** OS-level TCP accept backlog for the telnet ServerSocket (default 256 vs JVM default of 50). */
     val socketBacklog: Int = 256,
+    /** Maximum number of concurrent telnet connections before new connections are rejected. */
+    val maxConnections: Int = 5000,
 )
 
 data class WebSocketTransportConfig(

--- a/src/main/kotlin/dev/ambon/session/SnowflakeSessionIdFactory.kt
+++ b/src/main/kotlin/dev/ambon/session/SnowflakeSessionIdFactory.kt
@@ -66,20 +66,22 @@ class SnowflakeSessionIdFactory(
                 // now == lastSecond: same second, normal increment — no action needed
             }
 
-            // Sequence overflow: release the lock, sleep briefly, then re-check.
+            // Sequence overflow: wait until the clock advances to the next second.
+            // Multiple threads may enter this branch concurrently (via wait releasing
+            // the monitor). Only the first thread to wake after the clock advances
+            // resets seq; subsequent threads see lastSecond already updated and skip
+            // the reset, picking up the current seq value instead.
             if (seq > 0xFFFF) {
                 log.warn { "Sequence overflow at second=$lastSecond — waiting for clock to advance" }
                 onSequenceOverflow()
                 val overflowSecond = lastSecond
-                while (true) {
-                    // Release the lock while sleeping so other callers are not blocked.
+                while (lastSecond == overflowSecond) {
                     @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
                     (this as java.lang.Object).wait(1)
                     val nowAfterWait = clockSeconds()
-                    if (nowAfterWait > overflowSecond) {
+                    if (nowAfterWait > lastSecond) {
                         lastSecond = nowAfterWait
                         seq = 0
-                        break
                     }
                 }
             }

--- a/src/main/kotlin/dev/ambon/transport/BlockingSocketTransport.kt
+++ b/src/main/kotlin/dev/ambon/transport/BlockingSocketTransport.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import java.net.ServerSocket
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.coroutines.CoroutineContext
 
 private val log = KotlinLogging.logger {}
@@ -26,11 +27,13 @@ class BlockingSocketTransport(
     private val maxNonPrintablePerLine: Int = 32,
     private val maxInboundBackpressureFailures: Int = 3,
     private val socketBacklog: Int = 256,
+    private val maxConnections: Int = 5000,
     private val metrics: GameMetrics = GameMetrics.noop(),
     private val sessionDispatcher: CoroutineContext = Dispatchers.IO,
 ) : Transport {
     private var serverSocket: ServerSocket? = null
     private var acceptJob: Job? = null
+    private val activeConnections = AtomicInteger(0)
 
     override suspend fun start() {
         serverSocket = ServerSocket(port, socketBacklog)
@@ -39,35 +42,52 @@ class BlockingSocketTransport(
             scope.launch(Dispatchers.IO) {
                 while (isActive) {
                     val sock = serverSocket!!.accept()
-                    sock.tcpNoDelay = true
-                    val sessionId = sessionIdFactory()
-                    log.debug { "New telnet connection: remoteAddress=${sock.remoteSocketAddress} sessionId=$sessionId" }
-                    val outboundQueue = Channel<OutboundFrame>(capacity = sessionOutboundQueueCapacity)
-                    val session =
-                        NetworkSession(
-                            sessionId = sessionId,
-                            socket = sock,
-                            inbound = inbound,
-                            outboundQueue = outboundQueue,
-                            onDisconnected = { outboundRouter.unregister(sessionId) },
-                            scope = scope,
-                            onOutboundFrameWritten = { enqueuedAt -> outboundRouter.onSessionQueueFrameConsumed(sessionId, enqueuedAt) },
-                            maxLineLen = maxLineLen,
-                            maxNonPrintablePerLine = maxNonPrintablePerLine,
-                            maxInboundBackpressureFailures = maxInboundBackpressureFailures,
-                            metrics = metrics,
-                            dispatcher = sessionDispatcher,
-                        )
-                    outboundRouter.register(
-                        sessionId = sessionId,
-                        queue = outboundQueue,
-                        queueCapacity = sessionOutboundQueueCapacity,
-                        transport = "telnet",
-                        defaultAnsiEnabled = false,
-                    ) { reason ->
-                        session.closeNow(reason)
+                    if (activeConnections.get() >= maxConnections) {
+                        log.warn { "Connection limit reached ($maxConnections), rejecting: ${sock.remoteSocketAddress}" }
+                        runCatching { sock.close() }
+                        continue
                     }
-                    session.start()
+                    activeConnections.incrementAndGet()
+                    try {
+                        sock.tcpNoDelay = true
+                        val sessionId = sessionIdFactory()
+                        log.debug { "New telnet connection: remoteAddress=${sock.remoteSocketAddress} sessionId=$sessionId" }
+                        val outboundQueue = Channel<OutboundFrame>(capacity = sessionOutboundQueueCapacity)
+                        val session =
+                            NetworkSession(
+                                sessionId = sessionId,
+                                socket = sock,
+                                inbound = inbound,
+                                outboundQueue = outboundQueue,
+                                onDisconnected = {
+                                    activeConnections.decrementAndGet()
+                                    outboundRouter.unregister(sessionId)
+                                },
+                                scope = scope,
+                                onOutboundFrameWritten = { enqueuedAt ->
+                                    outboundRouter.onSessionQueueFrameConsumed(sessionId, enqueuedAt)
+                                },
+                                maxLineLen = maxLineLen,
+                                maxNonPrintablePerLine = maxNonPrintablePerLine,
+                                maxInboundBackpressureFailures = maxInboundBackpressureFailures,
+                                metrics = metrics,
+                                dispatcher = sessionDispatcher,
+                            )
+                        outboundRouter.register(
+                            sessionId = sessionId,
+                            queue = outboundQueue,
+                            queueCapacity = sessionOutboundQueueCapacity,
+                            transport = "telnet",
+                            defaultAnsiEnabled = false,
+                        ) { reason ->
+                            session.closeNow(reason)
+                        }
+                        session.start()
+                    } catch (e: Exception) {
+                        activeConnections.decrementAndGet()
+                        log.warn(e) { "Failed to set up telnet session, closing socket: ${sock.remoteSocketAddress}" }
+                        runCatching { sock.close() }
+                    }
                 }
             }
     }

--- a/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
+++ b/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
@@ -234,6 +234,10 @@ private suspend fun DefaultWebSocketServerSession.bridgeWebSocketSession(
         for (frame in incoming) {
             when (frame) {
                 is Frame.Text -> {
+                    if (frame.data.size > MAX_WS_FRAME_SIZE) {
+                        log.warn { "WebSocket frame too large (${frame.data.size} bytes), disconnecting: sessionId=$sessionId" }
+                        throw ProtocolViolation("Frame too large (${frame.data.size} > $MAX_WS_FRAME_SIZE)")
+                    }
                     val text = frame.readText()
                     // Detect GMCP JSON envelope: {"gmcp":"Package","data":<anything>}
                     val gmcpPair = tryParseGmcpEnvelope(text)
@@ -353,11 +357,7 @@ internal fun sanitizeIncomingLines(
 }
 
 private fun sanitizeCloseReason(reason: String): String {
-    val cleaned =
-        reason
-            .replace('\r', ' ')
-            .replace('\n', ' ')
-            .trim()
+    val cleaned = reason.filter { it.code in 0x20..0x7E }.trim()
     return when {
         cleaned.isEmpty() -> "closed"
         cleaned.length <= MAX_CLOSE_REASON_LENGTH -> cleaned
@@ -384,3 +384,4 @@ internal fun tryParseGmcpEnvelope(text: String): Pair<String, String>? {
 }
 
 private const val MAX_CLOSE_REASON_LENGTH = 123
+private const val MAX_WS_FRAME_SIZE = 65_536


### PR DESCRIPTION
## Summary

- **Socket leak on accept failure (BlockingSocketTransport):** Post-accept session setup is now wrapped in try-catch. If `sessionIdFactory()` or `NetworkSession` construction fails, the accepted socket is closed immediately instead of leaking.
- **Connection limit (BlockingSocketTransport):** Added configurable `maxConnections` (default 5000) with `AtomicInteger` tracking. New connections beyond the limit are rejected by closing the socket, mitigating resource-exhaustion DoS.
- **Close reason sanitization (KtorWebSocketTransport):** `sanitizeCloseReason()` now filters to printable ASCII only (`0x20..0x7E`) instead of just stripping CR/LF, preventing control character injection in WebSocket close frames.
- **WebSocket frame size validation (KtorWebSocketTransport):** Incoming frames larger than 64KB are rejected with a `ProtocolViolation`, disconnecting the client before processing.
- **Snowflake ID sequence overflow race (SnowflakeSessionIdFactory):** Fixed a race condition where multiple threads waiting on sequence overflow could each reset `seq` to 0 after the clock advanced, producing duplicate session IDs. Now only the first thread to observe the clock advance performs the reset; subsequent threads pick up the incremented counter.

### Not changed (verified as false positives)

- **Telnet partial write (#1):** Java's `OutputStream.write(byte[])` guarantees all bytes are written or an exception is thrown. The existing `flush()` calls in `NetworkSession.writeLoop()` are correct.

## Test plan

- [x] `./gradlew ktlintCheck` passes
- [x] `./gradlew test` passes (all ~137 test files)
- [x] `SnowflakeSessionIdFactoryTest` passes
- [ ] Manual telnet connection limit test: connect >5000 sessions and verify rejection
- [ ] Manual WebSocket oversized frame test: send >64KB text frame and verify disconnect