### PR TITLE
Harden command system: input limits, state validation, rate limiting

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -983,6 +983,8 @@ class GameEngine(
                 ctx = ctx,
                 questSystem = questSystem,
                 abilitySystem = abilitySystem,
+                dialogueSystem = dialogueSystem,
+                tradeSystem = tradeSystem,
                 markVitalsDirty = ::markVitalsDirty,
                 markStatsDirty = ::markStatsDirty,
                 metrics = metrics,

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -574,7 +574,15 @@ sealed interface Command {
 }
 
 object CommandParser {
+    /** Maximum allowed input length — protects against oversized payloads. */
+    const val MAX_INPUT_LENGTH = 2000
+
+    /** Maximum price that can be set on an auction listing. */
+    const val MAX_AUCTION_PRICE = 1_000_000_000L
+
     fun parse(input: String): Command {
+        if (input.length > MAX_INPUT_LENGTH) return Command.Invalid("input", "Input too long (max $MAX_INPUT_LENGTH characters).")
+
         val line = input.trim()
         if (line.isEmpty()) return Command.Noop
 
@@ -703,6 +711,10 @@ object CommandParser {
                 val price = priceStr.toLongOrNull()
                 if (price == null || keyword.isEmpty()) {
                     Command.Invalid(line, "auction sell <item> <price>")
+                } else if (price <= 0) {
+                    Command.Invalid(line, "Price must be greater than zero.")
+                } else if (price > MAX_AUCTION_PRICE) {
+                    Command.Invalid(line, "Price cannot exceed $MAX_AUCTION_PRICE gold.")
                 } else {
                     Command.AuctionSell(keyword, price)
                 }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/CombatHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/CombatHandler.kt
@@ -61,6 +61,8 @@ class CombatHandler(
     }
 
     private suspend fun handleFlee(sessionId: SessionId) {
+        dialogueSystem?.endConversation(sessionId)
+
         // Check if player is in a duel first
         if (duelSystem?.isInDuel(sessionId) == true) {
             val duel = duelSystem.endDuel(sessionId)

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/CommunicationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/CommunicationHandler.kt
@@ -27,6 +27,9 @@ class CommunicationHandler(
     private val outbound = ctx.outbound
     private val gmcpEmitter = ctx.gmcpEmitter
 
+    /** Tracks the last time each session sent a global broadcast (gossip/ooc/shout). */
+    private val lastBroadcastTime = mutableMapOf<SessionId, Long>()
+
     override fun register(router: CommandRouter) {
         router.on<Command.Say> { sid, cmd -> handleSay(sid, cmd) }
         router.on<Command.Emote> { sid, cmd -> handleEmote(sid, cmd) }
@@ -124,10 +127,28 @@ class CommunicationHandler(
         }
     }
 
+    /**
+     * Returns true and sends an error if the session is broadcasting too quickly.
+     * Staff players are exempt from rate limiting.
+     */
+    private suspend fun isBroadcastRateLimited(sessionId: SessionId): Boolean {
+        val me = players.get(sessionId) ?: return false
+        if (me.isStaff) return false
+        val now = clock.millis()
+        val last = lastBroadcastTime[sessionId]
+        if (last != null && (now - last) < BROADCAST_COOLDOWN_MS) {
+            outbound.send(OutboundEvent.SendError(sessionId, "You are sending messages too quickly. Please wait a moment."))
+            return true
+        }
+        lastBroadcastTime[sessionId] = now
+        return false
+    }
+
     private suspend fun handleGossip(
         sessionId: SessionId,
         cmd: Command.Gossip,
     ) {
+        if (isBroadcastRateLimited(sessionId)) return
         broadcastGlobalChannel(
             sessionId = sessionId,
             channelName = "gossip",
@@ -142,6 +163,7 @@ class CommunicationHandler(
         sessionId: SessionId,
         cmd: Command.Shout,
     ) {
+        if (isBroadcastRateLimited(sessionId)) return
         players.withPlayer(sessionId) { me ->
             val zone = me.roomId.zone
             outbound.send(OutboundEvent.SendText(sessionId, "You shout: ${cmd.message}"))
@@ -158,6 +180,7 @@ class CommunicationHandler(
         sessionId: SessionId,
         cmd: Command.Ooc,
     ) {
+        if (isBroadcastRateLimited(sessionId)) return
         broadcastGlobalChannel(
             sessionId = sessionId,
             channelName = "ooc",
@@ -251,5 +274,10 @@ class CommunicationHandler(
             groupSize = group?.members?.size ?: 0,
             idleSeconds = if (p.lastActivityEpochMs > 0) (nowMs - p.lastActivityEpochMs) / 1000 else 0,
         )
+    }
+
+    companion object {
+        /** Minimum interval between global broadcast commands, in milliseconds. */
+        const val BROADCAST_COOLDOWN_MS = 2_000L
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -599,8 +599,11 @@ internal fun resolveLockable(
 
 /**
  * Attempts a cross-zone move to [targetRoomId]. If [onCrossZoneMove] is available,
- * suppresses auto-prompt, invokes the callback, and returns true.
+ * invokes the callback and then suppresses auto-prompt, returning true.
  * Otherwise returns false (caller should send a fallback error).
+ *
+ * Auto-prompt is suppressed *after* the callback completes so that if the
+ * callback throws, the router's default prompt delivery still fires.
  */
 internal suspend fun attemptCrossZoneMove(
     sessionId: SessionId,
@@ -609,8 +612,8 @@ internal suspend fun attemptCrossZoneMove(
     suppressAutoPrompt: () -> Unit,
 ): Boolean {
     if (onCrossZoneMove != null) {
-        suppressAutoPrompt()
         onCrossZoneMove.invoke(sessionId, targetRoomId)
+        suppressAutoPrompt()
         return true
     }
     return false

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ItemHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ItemHandler.kt
@@ -8,11 +8,13 @@ import dev.ambon.engine.EquipmentSlotRegistry
 import dev.ambon.engine.HousingSystem
 import dev.ambon.engine.PlayerProgression
 import dev.ambon.engine.QuestSystem
+import dev.ambon.engine.TradeSystem
 import dev.ambon.engine.abilities.AbilitySystem
 import dev.ambon.engine.commands.Command
 import dev.ambon.engine.commands.CommandHandler
 import dev.ambon.engine.commands.CommandRouter
 import dev.ambon.engine.commands.on
+import dev.ambon.engine.dialogue.DialogueSystem
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.healHp
 import dev.ambon.engine.items.ItemRegistry
@@ -22,6 +24,8 @@ class ItemHandler(
     ctx: EngineContext,
     private val questSystem: QuestSystem? = null,
     private val abilitySystem: AbilitySystem? = null,
+    private val dialogueSystem: DialogueSystem? = null,
+    private val tradeSystem: TradeSystem? = null,
     private val markVitalsDirty: (SessionId) -> Unit = {},
     private val markStatsDirty: (SessionId) -> Unit = {},
     private val metrics: GameMetrics = GameMetrics.noop(),
@@ -45,6 +49,29 @@ class ItemHandler(
         router.on<Command.Drop> { sid, cmd -> handleDrop(sid, cmd) }
         router.on<Command.Use> { sid, cmd -> handleUse(sid, cmd) }
         router.on<Command.Give> { sid, cmd -> handleGive(sid, cmd) }
+    }
+
+    /**
+     * Returns true (and sends an error) if the player is in a state that blocks the item command.
+     * Dialogue and trade always block. Combat blocks unless [allowInCombat] is true (e.g. potions).
+     */
+    private suspend fun isBlocked(
+        sessionId: SessionId,
+        allowInCombat: Boolean = false,
+    ): Boolean {
+        if (!allowInCombat && combat.isInCombat(sessionId)) {
+            outbound.send(OutboundEvent.SendError(sessionId, "You can't do that while in combat."))
+            return true
+        }
+        if (dialogueSystem?.isInConversation(sessionId) == true) {
+            outbound.send(OutboundEvent.SendError(sessionId, "You can't do that while in conversation."))
+            return true
+        }
+        if (tradeSystem?.isInTrade(sessionId) == true) {
+            outbound.send(OutboundEvent.SendError(sessionId, "You can't do that while trading."))
+            return true
+        }
+        return false
     }
 
     private suspend fun handleInventory(sessionId: SessionId) {
@@ -80,6 +107,7 @@ class ItemHandler(
         sessionId: SessionId,
         cmd: Command.Wear,
     ) {
+        if (isBlocked(sessionId)) return
         players.withPlayer(sessionId) { me ->
             when (val result = items.equipFromInventory(me.sessionId, cmd.keyword)) {
                 is ItemRegistry.EquipResult.Equipped -> {
@@ -110,6 +138,7 @@ class ItemHandler(
         sessionId: SessionId,
         cmd: Command.Remove,
     ) {
+        if (isBlocked(sessionId)) return
         val slot = ItemSlot.parse(cmd.slot)
         if (slot == null || (equipSlots != null && !equipSlots.isValid(slot))) {
             val validSlots = equipSlots?.slotNames()?.joinToString("|") ?: "head|body|hand"
@@ -142,6 +171,7 @@ class ItemHandler(
         sessionId: SessionId,
         cmd: Command.Get,
     ) {
+        if (isBlocked(sessionId)) return
         players.withPlayer(sessionId) { me ->
             if (housingSystem != null && housingSystem.isHouseRoom(me.roomId) && !housingSystem.isInOwnHouse(sessionId)) {
                 outbound.send(OutboundEvent.SendError(sessionId, "You can't take items from someone else's house."))
@@ -164,6 +194,7 @@ class ItemHandler(
         sessionId: SessionId,
         cmd: Command.Drop,
     ) {
+        if (isBlocked(sessionId)) return
         players.withPlayer(sessionId) { me ->
             val roomId = me.roomId
             // Check vault capacity in house rooms
@@ -193,6 +224,7 @@ class ItemHandler(
         sessionId: SessionId,
         cmd: Command.Use,
     ) {
+        if (isBlocked(sessionId, allowInCombat = true)) return
         players.withPlayer(sessionId) { me ->
             when (val result = items.useItem(me.sessionId, cmd.keyword)) {
                 is ItemRegistry.UseResult.Used -> {
@@ -247,6 +279,7 @@ class ItemHandler(
         sessionId: SessionId,
         cmd: Command.Give,
     ) {
+        if (isBlocked(sessionId)) return
         players.withPlayer(sessionId) { me ->
             val targetSid = requirePlayerOnline(sessionId, cmd.playerName, players, outbound) ?: return
             if (targetSid == sessionId) {

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
@@ -652,4 +652,61 @@ class CommandParserTest {
     fun `home alias parses as house status`() {
         assertEquals(Command.House.Status, CommandParser.parse("home"))
     }
+
+    // ---- Input length limit ----
+
+    @Test
+    fun `rejects input exceeding max length`() {
+        val longInput = "a".repeat(CommandParser.MAX_INPUT_LENGTH + 1)
+        val result = CommandParser.parse(longInput)
+        assertTrue(result is Command.Invalid, "Expected Invalid for oversized input, got=$result")
+        val invalid = result as Command.Invalid
+        assertTrue(invalid.usage!!.contains("too long"), "Expected 'too long' in usage, got=${invalid.usage}")
+    }
+
+    @Test
+    fun `accepts input at max length`() {
+        val maxInput = "a".repeat(CommandParser.MAX_INPUT_LENGTH)
+        val result = CommandParser.parse(maxInput)
+        assertTrue(
+            result !is Command.Invalid || !(result as Command.Invalid).usage!!.contains("too long"),
+            "Input at exactly max length should not be rejected for length",
+        )
+    }
+
+    // ---- Auction sell price validation ----
+
+    @Test
+    fun `auction sell rejects zero price`() {
+        val result = CommandParser.parse("auction sell sword 0")
+        assertTrue(result is Command.Invalid, "Expected Invalid for zero price, got=$result")
+        assertTrue((result as Command.Invalid).usage!!.contains("greater than zero"))
+    }
+
+    @Test
+    fun `auction sell rejects negative price`() {
+        val result = CommandParser.parse("auction sell sword -5")
+        // Negative numbers won't parse via toLongOrNull when preceded by space, but just in case:
+        assertTrue(result is Command.Invalid, "Expected Invalid for negative price, got=$result")
+    }
+
+    @Test
+    fun `auction sell rejects price exceeding cap`() {
+        val overMax = CommandParser.MAX_AUCTION_PRICE + 1
+        val result = CommandParser.parse("auction sell sword $overMax")
+        assertTrue(result is Command.Invalid, "Expected Invalid for price exceeding cap, got=$result")
+        assertTrue((result as Command.Invalid).usage!!.contains("cannot exceed"))
+    }
+
+    @Test
+    fun `auction sell accepts valid price`() {
+        val result = CommandParser.parse("auction sell sword 100")
+        assertEquals(Command.AuctionSell("sword", 100), result)
+    }
+
+    @Test
+    fun `auction sell accepts price at cap`() {
+        val result = CommandParser.parse("auction sell sword ${CommandParser.MAX_AUCTION_PRICE}")
+        assertEquals(Command.AuctionSell("sword", CommandParser.MAX_AUCTION_PRICE), result)
+    }
 }

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterItemsTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterItemsTest.kt
@@ -408,4 +408,109 @@ class CommandRouterItemsTest {
             val outs = h.drain()
             assertTrue(outs.any { it is OutboundEvent.SendError && it.text.contains("not here") })
         }
+
+    // ---- State-blocking tests (combat) ----
+
+    @Test
+    fun `wear blocked during combat`() =
+        runTest {
+            val h = CommandRouterHarness.create()
+            val sid = SessionId(30L)
+            h.loginPlayer(sid, "Fighter1")
+
+            // Spawn a mob in the start room and start combat
+            val mob = dev.ambon.domain.mob.MobState(
+                id = dev.ambon.domain.ids.MobId("test:rat"),
+                name = "rat",
+                roomId = h.world.startRoom,
+            )
+            h.mobs.upsert(mob)
+            h.combat.startCombat(sid, "rat")
+            h.drain()
+
+            h.router.handle(sid, Command.Wear("sword"))
+
+            val outs = h.drain()
+            assertTrue(
+                outs.any { it is OutboundEvent.SendError && it.text.contains("combat") },
+                "Expected combat block error. got=$outs",
+            )
+        }
+
+    @Test
+    fun `drop blocked during combat`() =
+        runTest {
+            val h = CommandRouterHarness.create()
+            val sid = SessionId(31L)
+            h.loginPlayer(sid, "Fighter2")
+
+            val mob = dev.ambon.domain.mob.MobState(
+                id = dev.ambon.domain.ids.MobId("test:rat"),
+                name = "rat",
+                roomId = h.world.startRoom,
+            )
+            h.mobs.upsert(mob)
+            h.combat.startCombat(sid, "rat")
+            h.drain()
+
+            h.router.handle(sid, Command.Drop("sword"))
+
+            val outs = h.drain()
+            assertTrue(
+                outs.any { it is OutboundEvent.SendError && it.text.contains("combat") },
+                "Expected combat block error. got=$outs",
+            )
+        }
+
+    @Test
+    fun `give blocked during combat`() =
+        runTest {
+            val h = CommandRouterHarness.create()
+            val sid = SessionId(32L)
+            h.loginPlayer(sid, "Fighter3")
+
+            val mob = dev.ambon.domain.mob.MobState(
+                id = dev.ambon.domain.ids.MobId("test:rat"),
+                name = "rat",
+                roomId = h.world.startRoom,
+            )
+            h.mobs.upsert(mob)
+            h.combat.startCombat(sid, "rat")
+            h.drain()
+
+            h.router.handle(sid, Command.Give("sword", "Someone"))
+
+            val outs = h.drain()
+            assertTrue(
+                outs.any { it is OutboundEvent.SendError && it.text.contains("combat") },
+                "Expected combat block error. got=$outs",
+            )
+        }
+
+    @Test
+    fun `use allowed during combat`() =
+        runTest {
+            val h = CommandRouterHarness.create()
+            val sid = SessionId(33L)
+            h.loginPlayer(sid, "Fighter4")
+
+            val mob = dev.ambon.domain.mob.MobState(
+                id = dev.ambon.domain.ids.MobId("test:rat"),
+                name = "rat",
+                roomId = h.world.startRoom,
+            )
+            h.mobs.upsert(mob)
+            h.combat.startCombat(sid, "rat")
+            h.drain()
+
+            // Use should NOT be blocked by combat (potions)
+            h.router.handle(sid, Command.Use("potion"))
+
+            val outs = h.drain()
+            // Should get "not carrying" error, NOT a combat block error
+            assertTrue(
+                outs.none { it is OutboundEvent.SendError && it.text.contains("combat") },
+                "Use should not be blocked by combat. got=$outs",
+            )
+        }
 }


### PR DESCRIPTION
## Summary
- **Input length limit**: Reject commands exceeding 2000 characters at the parser level to prevent oversized payloads
- **Auction price validation**: Block zero/negative prices and cap at 1 billion gold in `CommandParser`
- **Item handler state checks**: Block `get`, `drop`, `wear`, `remove`, `give` during combat/dialogue/trade; allow `use` (potions) during combat but block during dialogue/trade
- **Cross-zone move prompt fix**: Defer `suppressAutoPrompt()` until after the callback completes so failed cross-zone moves still receive the router's auto-prompt
- **Flee dialogue cleanup**: End active NPC dialogue when fleeing combat
- **Broadcast rate limiting**: Gossip, OOC, and shout commands enforce a 2-second cooldown per session (staff exempt), using the injected `Clock`

## Test plan
- [x] `CommandParserTest` -- input length rejection (over limit, at limit)
- [x] `CommandParserTest` -- auction sell price validation (zero, negative, over cap, valid, at cap)
- [x] `CommandRouterItemsTest` -- wear/drop/give blocked during combat
- [x] `CommandRouterItemsTest` -- use NOT blocked during combat (potion use case)
- [x] Full test suite passes (`./gradlew ktlintCheck test`)