### PR TITLE
Add critical test coverage for release readiness

### DIFF
--- a/src/test/kotlin/dev/ambon/engine/MobSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/MobSystemTest.kt
@@ -1,12 +1,24 @@
 package dev.ambon.engine
 
+import dev.ambon.domain.DamageRange
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.mob.MobState
+import dev.ambon.engine.scheduler.Scheduler
+import dev.ambon.test.MutableClock
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MobSystemTest {
+    private val roomA = RoomId("zone:roomA")
+    private val roomB = RoomId("zone:roomB")
+
     @Test
     fun `tick always returns 0 - movement is driven by BehaviorTreeSystem`() =
         runTest {
@@ -14,4 +26,167 @@ class MobSystemTest {
             assertEquals(0, system.tick())
             assertEquals(0, system.tick())
         }
+
+    @Test
+    fun `mob spawn populates room with correct stats`() {
+        val mobs = MobRegistry()
+        val mob = MobState(
+            id = MobId("zone:goblin"),
+            name = "a goblin",
+            roomId = roomA,
+            hp = 30,
+            maxHp = 30,
+            damage = DamageRange(3, 6),
+            armor = 2,
+            xpReward = 50L,
+        )
+        mobs.upsert(mob)
+
+        val found = mobs.mobsInRoom(roomA)
+        assertEquals(1, found.size)
+        assertEquals("a goblin", found[0].name)
+        assertEquals(30, found[0].hp)
+        assertEquals(30, found[0].maxHp)
+        assertEquals(50L, found[0].xpReward)
+    }
+
+    @Test
+    fun `mob death removes from room`() {
+        val mobs = MobRegistry()
+        val mobId = MobId("zone:rat")
+        mobs.upsert(MobState(mobId, "a rat", roomA, hp = 10, maxHp = 10))
+
+        assertEquals(1, mobs.mobsInRoom(roomA).size)
+
+        // Simulate death: remove from registry
+        mobs.remove(mobId)
+
+        assertTrue(mobs.mobsInRoom(roomA).isEmpty(), "Room should be empty after mob death")
+        assertNull(mobs.get(mobId), "Mob should not exist in registry")
+    }
+
+    @Test
+    fun `mob respawn via scheduler restores mob after delay`() = runTest {
+        val clock = MutableClock(0L)
+        val scheduler = Scheduler(clock)
+        val mobs = MobRegistry()
+        val mobSystem = MobSystem()
+        val mobId = MobId("zone:rat")
+
+        // Spawn initial mob
+        mobs.upsert(MobState(mobId, "a rat", roomA, hp = 10, maxHp = 10))
+        mobSystem.onMobSpawned(mobId)
+
+        // Kill the mob
+        mobs.remove(mobId)
+        mobSystem.onMobRemoved(mobId)
+        assertNull(mobs.get(mobId))
+
+        // Schedule respawn (60 seconds)
+        val respawnMs = 60_000L
+        scheduler.scheduleIn(respawnMs) {
+            if (mobs.get(mobId) == null) {
+                mobs.upsert(MobState(mobId, "a rat", roomA, hp = 10, maxHp = 10))
+                mobSystem.onMobSpawned(mobId)
+            }
+        }
+
+        // Advance time less than respawn — still dead
+        clock.advance(30_000L)
+        scheduler.runDue()
+        assertNull(mobs.get(mobId), "Mob should still be dead before respawn time")
+
+        // Advance past respawn time
+        clock.advance(31_000L)
+        scheduler.runDue()
+        assertNotNull(mobs.get(mobId), "Mob should have respawned")
+        assertEquals("a rat", mobs.get(mobId)!!.name)
+        assertEquals(10, mobs.get(mobId)!!.hp, "Respawned mob should have full HP")
+    }
+
+    @Test
+    fun `multiple mobs can exist in same room`() {
+        val mobs = MobRegistry()
+        mobs.upsert(MobState(MobId("zone:rat_1"), "a rat", roomA, hp = 10, maxHp = 10))
+        mobs.upsert(MobState(MobId("zone:rat_2"), "a rat", roomA, hp = 10, maxHp = 10))
+        mobs.upsert(MobState(MobId("zone:spider"), "a spider", roomA, hp = 15, maxHp = 15))
+
+        assertEquals(3, mobs.mobsInRoom(roomA).size)
+
+        // Remove one mob
+        mobs.remove(MobId("zone:rat_1"))
+        assertEquals(2, mobs.mobsInRoom(roomA).size)
+    }
+
+    @Test
+    fun `mob movement between rooms updates room membership`() {
+        val mobs = MobRegistry()
+        val mobId = MobId("zone:wolf")
+        mobs.upsert(MobState(mobId, "a wolf", roomA, hp = 20, maxHp = 20))
+
+        assertEquals(1, mobs.mobsInRoom(roomA).size)
+        assertTrue(mobs.mobsInRoom(roomB).isEmpty())
+
+        mobs.moveTo(mobId, roomB)
+
+        assertTrue(mobs.mobsInRoom(roomA).isEmpty(), "Wolf should no longer be in room A")
+        assertEquals(1, mobs.mobsInRoom(roomB).size, "Wolf should be in room B")
+        assertEquals(roomB, mobs.get(mobId)!!.roomId)
+    }
+
+    @Test
+    fun `aggressive mob flag is tracked`() {
+        val mobs = MobRegistry()
+        val passiveMob = MobState(
+            id = MobId("zone:deer"),
+            name = "a deer",
+            roomId = roomA,
+            hp = 10,
+            maxHp = 10,
+            aggressive = false,
+        )
+        val aggroMob = MobState(
+            id = MobId("zone:wolf"),
+            name = "a wolf",
+            roomId = roomA,
+            hp = 20,
+            maxHp = 20,
+            aggressive = true,
+        )
+        mobs.upsert(passiveMob)
+        mobs.upsert(aggroMob)
+
+        val roomMobs = mobs.mobsInRoom(roomA)
+        val aggressiveMobs = roomMobs.filter { it.aggressive }
+        val passiveMobs = roomMobs.filter { !it.aggressive }
+
+        assertEquals(1, aggressiveMobs.size, "Should be 1 aggressive mob")
+        assertEquals("a wolf", aggressiveMobs[0].name)
+        assertEquals(1, passiveMobs.size, "Should be 1 passive mob")
+        assertEquals("a deer", passiveMobs[0].name)
+    }
+
+    @Test
+    fun `mob not respawned if already present in registry`() = runTest {
+        val clock = MutableClock(0L)
+        val scheduler = Scheduler(clock)
+        val mobs = MobRegistry()
+        val mobId = MobId("zone:rat")
+
+        // Mob is alive
+        mobs.upsert(MobState(mobId, "a rat", roomA, hp = 10, maxHp = 10))
+
+        // Schedule a respawn that checks if mob already exists
+        scheduler.scheduleIn(1_000L) {
+            if (mobs.get(mobId) == null) {
+                mobs.upsert(MobState(mobId, "a rat", roomA, hp = 10, maxHp = 10))
+            }
+        }
+
+        clock.advance(1_500L)
+        scheduler.runDue()
+
+        // Should still be just 1 mob — the scheduler skip should have prevented duplicate
+        assertEquals(1, mobs.all().size, "Should not duplicate mob")
+    }
 }

--- a/src/test/kotlin/dev/ambon/engine/MultiSystemIntegrationTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/MultiSystemIntegrationTest.kt
@@ -1,0 +1,389 @@
+package dev.ambon.engine
+
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.domain.achievement.AchievementCriterion
+import dev.ambon.domain.achievement.AchievementDef
+import dev.ambon.domain.ids.ItemId
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.items.Item
+import dev.ambon.domain.items.ItemInstance
+import dev.ambon.domain.items.ItemSlot
+import dev.ambon.domain.quest.QuestDef
+import dev.ambon.domain.quest.QuestObjectiveDef
+import dev.ambon.domain.quest.QuestRewards
+import dev.ambon.domain.world.Room
+import dev.ambon.domain.world.World
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.engine.status.StatusEffectDefinition
+import dev.ambon.engine.status.StatusEffectId
+import dev.ambon.engine.status.StatusEffectRegistry
+import dev.ambon.engine.status.StatusEffectSystem
+import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.MutableClock
+import dev.ambon.test.buildTestPlayerRegistry
+import dev.ambon.test.drainAll
+import dev.ambon.test.loginOrFail
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests cross-system interactions that span multiple game systems.
+ * These tests verify that side-effects propagate correctly when
+ * events trigger chains across DuelSystem, TradeSystem, GroupSystem,
+ * StatusEffectSystem, and the ability cooldown system.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class MultiSystemIntegrationTest {
+    private val startRoom = RoomId("test:start")
+
+    private fun testWorld(): World {
+        val rooms = mapOf(
+            startRoom to Room(
+                id = startRoom,
+                title = "Test Room",
+                description = "A test room.",
+                exits = emptyMap(),
+            ),
+        )
+        return World(rooms = rooms, startRoom = startRoom)
+    }
+
+    private fun sword() = ItemInstance(
+        id = ItemId("sword_1"),
+        item = Item(keyword = "sword", displayName = "a copper sword", slot = ItemSlot.HAND, damage = 4),
+    )
+
+    private fun shield() = ItemInstance(
+        id = ItemId("shield_1"),
+        item = Item(keyword = "shield", displayName = "a wooden shield", slot = ItemSlot.HAND, armor = 2),
+    )
+
+    // ── Death cleanup chain ──────────────────────────────────────────────
+
+    @Test
+    fun `player death cancels active trade and returns escrowed items`() = runTest {
+        val items = ItemRegistry()
+        val tradeSystem = TradeSystem(items)
+        val repo = InMemoryPlayerRepository()
+        val players = buildTestPlayerRegistry(startRoom, repo, items)
+
+        val alice = SessionId(1)
+        val bob = SessionId(2)
+        players.loginOrFail(alice, "Alice")
+        players.loginOrFail(bob, "Bob")
+
+        // Give items and start trade
+        items.addToInventory(alice, sword())
+        items.addToInventory(bob, shield())
+
+        tradeSystem.createSession(alice, bob)
+        tradeSystem.offerItem(alice, "sword")
+        tradeSystem.offerItem(bob, "shield")
+
+        // Verify items are in escrow
+        assertTrue(items.inventory(alice).isEmpty(), "Alice's sword should be in escrow")
+        assertTrue(items.inventory(bob).isEmpty(), "Bob's shield should be in escrow")
+
+        // Simulate death cleanup: cancel trade
+        tradeSystem.cancelForPlayer(alice)
+
+        // Verify items returned
+        assertTrue(items.inventory(alice).any { it.item.keyword == "sword" }, "Sword should return to Alice")
+        assertTrue(items.inventory(bob).any { it.item.keyword == "shield" }, "Shield should return to Bob")
+        assertFalse(tradeSystem.isInTrade(alice))
+        assertFalse(tradeSystem.isInTrade(bob))
+    }
+
+    @Test
+    fun `player death ends active duel`() = runTest {
+        val clock = MutableClock(0L)
+        val duelSystem = DuelSystem(clock)
+
+        val alice = SessionId(1)
+        val bob = SessionId(2)
+
+        // Set up and accept a duel
+        duelSystem.challenge(alice, bob)
+        duelSystem.accept(bob)
+        assertTrue(duelSystem.isInDuel(alice))
+        assertTrue(duelSystem.isInDuel(bob))
+
+        // Alice dies — end the duel
+        val endedDuel = duelSystem.endDuel(alice)
+        assertFalse(duelSystem.isInDuel(alice))
+        assertFalse(duelSystem.isInDuel(bob))
+        assertEquals(alice, endedDuel!!.player1)
+    }
+
+    @Test
+    fun `player death removes from group`() = runTest {
+        val outbound = LocalOutboundBus()
+        val repo = InMemoryPlayerRepository()
+        val items = ItemRegistry()
+        val players = buildTestPlayerRegistry(startRoom, repo, items)
+        val groupSystem = GroupSystem(players, outbound)
+
+        val alice = SessionId(1)
+        val bob = SessionId(2)
+        players.loginOrFail(alice, "Alice")
+        players.loginOrFail(bob, "Bob")
+
+        // Form a group
+        groupSystem.invite(alice, "Bob")
+        groupSystem.accept(bob)
+        assertTrue(groupSystem.getGroup(alice) != null, "Group should exist")
+        assertTrue(groupSystem.getGroup(bob) != null, "Bob should be in group")
+
+        outbound.drainAll()
+
+        // Alice dies — leave group
+        groupSystem.leave(alice)
+
+        // Bob should still have a group (as leader); Alice should not
+        assertNull(groupSystem.getGroup(alice), "Alice should not be in a group after death")
+    }
+
+    @Test
+    fun `player death clears status effects`() = runTest {
+        val clock = MutableClock(0L)
+        val outbound = LocalOutboundBus()
+        val repo = InMemoryPlayerRepository()
+        val items = ItemRegistry()
+        val players = buildTestPlayerRegistry(startRoom, repo, items, clock = clock)
+        val mobs = MobRegistry()
+        val effectRegistry = StatusEffectRegistry()
+        effectRegistry.register(
+            StatusEffectDefinition(
+                id = StatusEffectId("poison"),
+                displayName = "Poison",
+                durationMs = 10_000L,
+                tickIntervalMs = 2_000L,
+                effectType = "dot",
+                tickMinValue = 5,
+                tickMaxValue = 5,
+            ),
+        )
+
+        val statusEffects = StatusEffectSystem(
+            registry = effectRegistry,
+            players = players,
+            mobs = mobs,
+            outbound = outbound,
+            clock = clock,
+        )
+
+        val alice = SessionId(1)
+        players.loginOrFail(alice, "Alice")
+
+        // Apply a DOT
+        statusEffects.applyToPlayer(alice, StatusEffectId("poison"))
+        assertTrue(statusEffects.activePlayerEffects(alice).isNotEmpty(), "Alice should have poison effect")
+
+        // Death: remove all effects
+        statusEffects.removeAllFromPlayer(alice)
+
+        assertTrue(statusEffects.activePlayerEffects(alice).isEmpty(), "Effects should be cleared after death")
+    }
+
+    // ── Combined chain: death triggers multi-system cleanup ──────────────
+
+    @Test
+    fun `death cleanup chain clears trade duel group and effects together`() = runTest {
+        val clock = MutableClock(0L)
+        val items = ItemRegistry()
+        val repo = InMemoryPlayerRepository()
+        val outbound = LocalOutboundBus()
+        val players = buildTestPlayerRegistry(startRoom, repo, items, clock = clock)
+        val mobs = MobRegistry()
+        val tradeSystem = TradeSystem(items)
+        val duelSystem = DuelSystem(clock)
+        val groupSystem = GroupSystem(players, outbound)
+        val effectRegistry = StatusEffectRegistry()
+        effectRegistry.register(
+            StatusEffectDefinition(
+                id = StatusEffectId("regen"),
+                displayName = "Regeneration",
+                durationMs = 60_000L,
+                tickIntervalMs = 5_000L,
+                effectType = "hot",
+                tickMinValue = 10,
+                tickMaxValue = 10,
+            ),
+        )
+        val statusEffects = StatusEffectSystem(
+            registry = effectRegistry,
+            players = players,
+            mobs = mobs,
+            outbound = outbound,
+            clock = clock,
+        )
+
+        val alice = SessionId(1)
+        val bob = SessionId(2)
+        val charlie = SessionId(3)
+        players.loginOrFail(alice, "Alice")
+        players.loginOrFail(bob, "Bob")
+        players.loginOrFail(charlie, "Charlie")
+        outbound.drainAll()
+
+        // Set up trade between Alice and Bob
+        items.addToInventory(alice, sword())
+        tradeSystem.createSession(alice, bob)
+        tradeSystem.offerItem(alice, "sword")
+
+        // Set up group: Alice + Charlie
+        groupSystem.invite(alice, "Charlie")
+        groupSystem.accept(charlie)
+        outbound.drainAll()
+
+        // Apply a status effect to Alice
+        statusEffects.applyToPlayer(alice, StatusEffectId("regen"))
+
+        // Verify pre-conditions
+        assertTrue(tradeSystem.isInTrade(alice), "Alice should be in trade")
+        assertTrue(groupSystem.getGroup(alice) != null, "Alice should be in group")
+        assertTrue(statusEffects.activePlayerEffects(alice).isNotEmpty(), "Alice should have regen")
+
+        // ── Simulate the death cleanup chain (same as GameEngine.cleanupOnPlayerDeath) ──
+        tradeSystem.cancelForPlayer(alice)
+        statusEffects.removeAllFromPlayer(alice)
+        groupSystem.leave(alice)
+
+        // Verify everything is cleaned up
+        assertFalse(tradeSystem.isInTrade(alice), "Trade should be cancelled")
+        assertFalse(tradeSystem.isInTrade(bob), "Bob's trade should be cancelled too")
+        assertTrue(items.inventory(alice).any { it.item.keyword == "sword" }, "Sword should return from escrow")
+        assertTrue(statusEffects.activePlayerEffects(alice).isEmpty(), "Effects should be cleared")
+        assertNull(groupSystem.getGroup(alice), "Alice should not be in group")
+    }
+
+    // ── Quest completion → achievement unlock chain ──────────────────────
+
+    @Test
+    fun `quest completion triggers achievement check`() = runTest {
+        val clock = MutableClock(0L)
+        val outbound = LocalOutboundBus()
+        val repo = InMemoryPlayerRepository()
+        val items = ItemRegistry()
+        val players = buildTestPlayerRegistry(startRoom, repo, items, clock = clock)
+
+        val achievementRegistry = AchievementRegistry()
+        val categoryRegistry = AchievementCategoryRegistry(dev.ambon.config.AchievementCategoriesConfig())
+        achievementRegistry.register(
+            AchievementDef(
+                id = "quests/first_quest",
+                displayName = "Quest Master",
+                description = "Complete your first quest.",
+                category = "quests",
+                criteria = listOf(
+                    AchievementCriterion(
+                        type = "quest_complete",
+                        targetId = "test_quest",
+                        count = 1,
+                    ),
+                ),
+            ),
+        )
+        val achievementSystem = AchievementSystem(
+            registry = achievementRegistry,
+            players = players,
+            outbound = outbound,
+            categoryRegistry = categoryRegistry,
+        )
+
+        val alice = SessionId(1)
+        players.loginOrFail(alice, "Alice")
+        outbound.drainAll()
+
+        // Simulate quest completion triggering achievement
+        achievementSystem.onQuestCompleted(alice, "test_quest")
+
+        // Check that the achievement was unlocked
+        val ps = players.get(alice)!!
+        assertTrue(
+            "quests/first_quest" in ps.unlockedAchievementIds,
+            "Achievement should be unlocked. Unlocked=${ps.unlockedAchievementIds}",
+        )
+
+        // Check for the achievement notification
+        val events = outbound.drainAll()
+        val infos = events.filterIsInstance<OutboundEvent.SendInfo>()
+            .filter { it.sessionId == alice }
+            .map { it.text }
+        assertTrue(infos.any { it.contains("Quest Master") || it.contains("Achievement") }, "got=$infos")
+    }
+
+    // ── Mob kill → quest progress → quest completion chain ──────────────
+
+    @Test
+    fun `mob kill advances quest objective and completes quest when target met`() = runTest {
+        val clock = MutableClock(0L)
+        val outbound = LocalOutboundBus()
+        val repo = InMemoryPlayerRepository()
+        val items = ItemRegistry()
+        val players = buildTestPlayerRegistry(startRoom, repo, items, clock = clock)
+
+        val questDef = QuestDef(
+            id = "slay_goblins",
+            name = "Goblin Slayer",
+            giverMobId = "guard",
+            description = "Kill 2 goblins.",
+            objectives = listOf(
+                QuestObjectiveDef(
+                    description = "Kill goblins",
+                    type = "kill",
+                    targetId = "goblin",
+                    count = 2,
+                ),
+            ),
+            rewards = QuestRewards(xp = 100, gold = 50),
+        )
+        val questRegistry = QuestRegistry()
+        questRegistry.register(questDef)
+
+        val questSystem = QuestSystem(
+            registry = questRegistry,
+            players = players,
+            items = items,
+            outbound = outbound,
+            clock = clock,
+        )
+
+        var completedQuestId: String? = null
+        questSystem.onQuestCompleted = { _, questId -> completedQuestId = questId }
+
+        val alice = SessionId(1)
+        players.loginOrFail(alice, "Alice")
+        outbound.drainAll()
+
+        // Accept the quest
+        questSystem.acceptQuest(alice, "slay_goblins")
+        outbound.drainAll()
+
+        // Kill first goblin
+        questSystem.onMobKilled(alice, "goblin")
+        val ps1 = players.get(alice)!!
+        val questState = ps1.activeQuests["slay_goblins"]!!
+        assertEquals(1, questState.objectives[0].current, "First kill should register")
+
+        outbound.drainAll()
+
+        // Kill second goblin — should complete the quest
+        questSystem.onMobKilled(alice, "goblin")
+
+        assertEquals("slay_goblins", completedQuestId, "Quest should be marked complete")
+
+        val events = outbound.drainAll()
+        val infos = events.filterIsInstance<OutboundEvent.SendInfo>()
+            .filter { it.sessionId == alice }
+            .map { it.text }
+        assertTrue(infos.any { it.contains("complete") || it.contains("Goblin Slayer") }, "got=$infos")
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/ShutdownCleanupTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/ShutdownCleanupTest.kt
@@ -1,0 +1,258 @@
+package dev.ambon.engine
+
+import dev.ambon.domain.ids.ItemId
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.items.Item
+import dev.ambon.domain.items.ItemInstance
+import dev.ambon.domain.items.ItemSlot
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.persistence.PersistenceWorker
+import dev.ambon.persistence.PlayerCreationRequest
+import dev.ambon.persistence.WriteCoalescingPlayerRepository
+import dev.ambon.test.MutableClock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests shutdown-related cleanup: persistence flush, trade cleanup,
+ * and auction listing persistence.
+ *
+ * These tests ensure that server shutdown procedures properly persist
+ * all dirty state and clean up active game sessions.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ShutdownCleanupTest {
+    private val startRoom = RoomId("zone:start")
+
+    // ── Persistence flush on shutdown ─────────────────────────────────────
+
+    @Test
+    fun `shutdown flushes all dirty player records`() = runTest {
+        val delegate = InMemoryPlayerRepository()
+        val repo = WriteCoalescingPlayerRepository(delegate)
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val testScope = TestScope(testScheduler)
+        val worker = PersistenceWorker(
+            repo,
+            flushIntervalMs = 60_000L, // Very long so it won't auto-flush
+            scope = testScope,
+            dispatcher = testDispatcher,
+        )
+
+        // Create multiple players with dirty records
+        val record1 = delegate.create(PlayerCreationRequest("Alice", startRoom, 1000L, "hash", false))
+        val record2 = delegate.create(PlayerCreationRequest("Bob", startRoom, 1000L, "hash", false))
+        val record3 = delegate.create(PlayerCreationRequest("Charlie", startRoom, 1000L, "hash", false))
+
+        repo.save(record1.copy(roomId = RoomId("zone:room1")))
+        repo.save(record2.copy(roomId = RoomId("zone:room2")))
+        repo.save(record3.copy(roomId = RoomId("zone:room3")))
+
+        assertEquals(3, repo.dirtyCount(), "All 3 records should be dirty")
+
+        worker.start()
+        runCurrent()
+
+        // No time advanced — records should still be dirty
+        assertEquals(3, repo.dirtyCount(), "Records should still be dirty before shutdown")
+
+        // Trigger shutdown
+        worker.shutdown()
+
+        // All records should have been flushed
+        assertEquals(0, repo.dirtyCount(), "All records should be flushed after shutdown")
+        assertEquals(RoomId("zone:room1"), delegate.findById(record1.id)!!.roomId)
+        assertEquals(RoomId("zone:room2"), delegate.findById(record2.id)!!.roomId)
+        assertEquals(RoomId("zone:room3"), delegate.findById(record3.id)!!.roomId)
+    }
+
+    @Test
+    fun `shutdown flushes records that were modified just before shutdown`() = runTest {
+        val delegate = InMemoryPlayerRepository()
+        val repo = WriteCoalescingPlayerRepository(delegate)
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val testScope = TestScope(testScheduler)
+        val worker = PersistenceWorker(
+            repo,
+            flushIntervalMs = 60_000L,
+            scope = testScope,
+            dispatcher = testDispatcher,
+        )
+
+        val record = delegate.create(PlayerCreationRequest("Alice", startRoom, 1000L, "hash", false))
+
+        worker.start()
+        runCurrent()
+
+        // Simulate rapid state changes right before shutdown
+        repo.save(record.copy(roomId = RoomId("zone:r1"), gold = 100))
+        repo.save(record.copy(roomId = RoomId("zone:r2"), gold = 200))
+        repo.save(record.copy(roomId = RoomId("zone:final"), gold = 500))
+
+        // The coalescing should mean only 1 dirty entry
+        assertEquals(1, repo.dirtyCount())
+
+        worker.shutdown()
+
+        // The final state should be persisted
+        val persisted = delegate.findById(record.id)!!
+        assertEquals(RoomId("zone:final"), persisted.roomId)
+        assertEquals(500, persisted.gold)
+    }
+
+    // ── Trade cleanup on shutdown ─────────────────────────────────────────
+
+    @Test
+    fun `active trades are canceled on shutdown returning escrowed items`() = runTest {
+        val items = ItemRegistry()
+        val tradeSystem = TradeSystem(items)
+
+        val alice = SessionId(1)
+        val bob = SessionId(2)
+
+        val sword = ItemInstance(
+            id = ItemId("sword_1"),
+            item = Item(keyword = "sword", displayName = "a copper sword", slot = ItemSlot.HAND, damage = 4),
+        )
+        val shield = ItemInstance(
+            id = ItemId("shield_1"),
+            item = Item(keyword = "shield", displayName = "a wooden shield", slot = ItemSlot.HAND, armor = 2),
+        )
+
+        items.addToInventory(alice, sword)
+        items.addToInventory(bob, shield)
+
+        // Start a trade and offer items
+        tradeSystem.createSession(alice, bob)
+        tradeSystem.offerItem(alice, "sword")
+        tradeSystem.offerItem(bob, "shield")
+
+        // Verify items are in escrow
+        assertTrue(items.inventory(alice).isEmpty(), "Sword in escrow")
+        assertTrue(items.inventory(bob).isEmpty(), "Shield in escrow")
+
+        // Simulate shutdown: cancel all active trades
+        tradeSystem.cancelForPlayer(alice)
+
+        // Items should be returned
+        assertTrue(items.inventory(alice).any { it.item.keyword == "sword" }, "Sword returned to Alice")
+        assertTrue(items.inventory(bob).any { it.item.keyword == "shield" }, "Shield returned to Bob")
+        assertFalse(tradeSystem.isInTrade(alice))
+        assertFalse(tradeSystem.isInTrade(bob))
+    }
+
+    @Test
+    fun `multiple concurrent trades are all cleaned up on shutdown`() = runTest {
+        val items = ItemRegistry()
+        val tradeSystem = TradeSystem(items)
+
+        val alice = SessionId(1)
+        val bob = SessionId(2)
+        val charlie = SessionId(3)
+        val dave = SessionId(4)
+
+        val sword = ItemInstance(
+            id = ItemId("sword_1"),
+            item = Item(keyword = "sword", displayName = "sword", slot = ItemSlot.HAND, damage = 4),
+        )
+        val shield = ItemInstance(
+            id = ItemId("shield_1"),
+            item = Item(keyword = "shield", displayName = "shield", slot = ItemSlot.HAND, armor = 2),
+        )
+
+        items.addToInventory(alice, sword)
+        items.addToInventory(charlie, shield)
+
+        // Two separate trades
+        tradeSystem.createSession(alice, bob)
+        tradeSystem.offerItem(alice, "sword")
+
+        tradeSystem.createSession(charlie, dave)
+        tradeSystem.offerItem(charlie, "shield")
+
+        // Shutdown: cancel all
+        tradeSystem.cancelForPlayer(alice)
+        tradeSystem.cancelForPlayer(charlie)
+
+        assertTrue(items.inventory(alice).any { it.item.keyword == "sword" })
+        assertTrue(items.inventory(charlie).any { it.item.keyword == "shield" })
+        assertFalse(tradeSystem.isInTrade(alice))
+        assertFalse(tradeSystem.isInTrade(bob))
+        assertFalse(tradeSystem.isInTrade(charlie))
+        assertFalse(tradeSystem.isInTrade(dave))
+    }
+
+    // ── Duel cleanup on shutdown ──────────────────────────────────────────
+
+    @Test
+    fun `active duels are ended on shutdown`() = runTest {
+        val clock = MutableClock(0L)
+        val duelSystem = DuelSystem(clock)
+
+        val alice = SessionId(1)
+        val bob = SessionId(2)
+        val charlie = SessionId(3)
+        val dave = SessionId(4)
+
+        // Two active duels
+        duelSystem.challenge(alice, bob)
+        duelSystem.accept(bob)
+        duelSystem.challenge(charlie, dave)
+        duelSystem.accept(dave)
+
+        assertTrue(duelSystem.isInDuel(alice))
+        assertTrue(duelSystem.isInDuel(charlie))
+
+        // Shutdown: end all
+        duelSystem.onPlayerDisconnect(alice)
+        duelSystem.onPlayerDisconnect(charlie)
+
+        assertFalse(duelSystem.isInDuel(alice))
+        assertFalse(duelSystem.isInDuel(bob))
+        assertFalse(duelSystem.isInDuel(charlie))
+        assertFalse(duelSystem.isInDuel(dave))
+    }
+
+    // ── Write coalescing preserves most recent state ──────────────────────
+
+    @Test
+    fun `coalescing repository preserves last written state through shutdown`() = runTest {
+        val delegate = InMemoryPlayerRepository()
+        val repo = WriteCoalescingPlayerRepository(delegate)
+
+        val record = delegate.create(PlayerCreationRequest("Alice", startRoom, 1000L, "hash", false))
+
+        // Simulate a player gaining XP and gold across many ticks
+        for (i in 1..50) {
+            repo.save(
+                record.copy(
+                    xpTotal = i.toLong() * 100,
+                    gold = i.toLong() * 10,
+                    roomId = RoomId("zone:room_$i"),
+                ),
+            )
+        }
+
+        // Should only be 1 dirty entry despite 50 saves
+        assertEquals(1, repo.dirtyCount())
+
+        // Flush all (as shutdown does)
+        val flushed = repo.flushAll()
+        assertEquals(1, flushed)
+
+        // The final state should be the one persisted
+        val persisted = delegate.findById(record.id)!!
+        assertEquals(5000L, persisted.xpTotal)
+        assertEquals(500L, persisted.gold)
+        assertEquals(RoomId("zone:room_50"), persisted.roomId)
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/commands/DuelCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/DuelCommandTest.kt
@@ -1,0 +1,296 @@
+package dev.ambon.engine.commands
+
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.world.Direction
+import dev.ambon.domain.world.Room
+import dev.ambon.domain.world.World
+import dev.ambon.engine.DuelSystem
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.test.CommandRouterHarness
+import dev.ambon.test.MutableClock
+import dev.ambon.test.buildTestPlayerRegistry
+import dev.ambon.test.errorMessages
+import dev.ambon.test.infoMessages
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DuelCommandTest {
+    private val roomA = RoomId("test:arena")
+    private val roomB = RoomId("test:hall")
+
+    private fun duelWorld(): World {
+        val rooms = mapOf(
+            roomA to Room(
+                id = roomA,
+                title = "Arena",
+                description = "A fighting arena.",
+                exits = mapOf(Direction.NORTH to roomB),
+            ),
+            roomB to Room(
+                id = roomB,
+                title = "Hall",
+                description = "A hall.",
+                exits = mapOf(Direction.SOUTH to roomA),
+            ),
+        )
+        return World(rooms = rooms, startRoom = roomA)
+    }
+
+    private fun harness(clock: MutableClock = MutableClock(0L)): Pair<CommandRouterHarness, DuelSystem> {
+        val world = duelWorld()
+        val duelSystem = DuelSystem(clock)
+        val players = buildTestPlayerRegistry(world.startRoom, clock = clock)
+        val h = CommandRouterHarness.create(
+            world = world,
+            players = players,
+            duelSystem = duelSystem,
+            clock = clock,
+        )
+        return h to duelSystem
+    }
+
+    @Test
+    fun `challenge sends notifications to both players and bystanders`() = runTest {
+        val (h, _) = harness()
+        val alice = SessionId(1)
+        val bob = SessionId(2)
+        val charlie = SessionId(3)
+        h.loginPlayer(alice, "Alice")
+        h.loginPlayer(bob, "Bob")
+        h.loginPlayer(charlie, "Charlie")
+        h.drain()
+
+        h.router.handle(alice, Command.Duel("Bob"))
+
+        val events = h.drain()
+        val aliceInfos = events.infoMessages(alice)
+        val bobInfos = events.infoMessages(bob)
+        val charlieTexts = events.filterIsInstance<OutboundEvent.SendText>()
+            .filter { it.sessionId == charlie }
+            .map { it.text }
+
+        assertTrue(aliceInfos.any { it.contains("challenge") && it.contains("Bob") }, "Alice sees challenge. got=$aliceInfos")
+        assertTrue(bobInfos.any { it.contains("Alice") && it.contains("duel") }, "Bob sees challenge. got=$bobInfos")
+        assertTrue(charlieTexts.any { it.contains("Alice") && it.contains("Bob") }, "Bystander sees broadcast. got=$charlieTexts")
+    }
+
+    @Test
+    fun `accept starts duel and notifies both players`() = runTest {
+        val (h, ds) = harness()
+        val alice = SessionId(1)
+        val bob = SessionId(2)
+        h.loginPlayer(alice, "Alice")
+        h.loginPlayer(bob, "Bob")
+        h.drain()
+
+        h.router.handle(alice, Command.Duel("Bob"))
+        h.drain()
+
+        h.router.handle(bob, Command.DuelAccept)
+
+        val events = h.drain()
+        val aliceInfos = events.infoMessages(alice)
+        val bobInfos = events.infoMessages(bob)
+
+        assertTrue(aliceInfos.any { it.contains("Fight") }, "Alice sees fight start. got=$aliceInfos")
+        assertTrue(bobInfos.any { it.contains("Fight") || it.contains("accept") }, "Bob sees fight start. got=$bobInfos")
+        assertTrue(ds.isInDuel(alice), "Alice should be in duel")
+        assertTrue(ds.isInDuel(bob), "Bob should be in duel")
+    }
+
+    @Test
+    fun `decline ends challenge and notifies both players`() = runTest {
+        val (h, ds) = harness()
+        val alice = SessionId(1)
+        val bob = SessionId(2)
+        h.loginPlayer(alice, "Alice")
+        h.loginPlayer(bob, "Bob")
+        h.drain()
+
+        h.router.handle(alice, Command.Duel("Bob"))
+        h.drain()
+
+        h.router.handle(bob, Command.DuelDecline)
+
+        val events = h.drain()
+        val bobInfos = events.infoMessages(bob)
+        val aliceInfos = events.infoMessages(alice)
+
+        assertTrue(bobInfos.any { it.contains("decline") }, "Bob sees decline. got=$bobInfos")
+        assertTrue(aliceInfos.any { it.contains("declined") }, "Alice is notified. got=$aliceInfos")
+        assertNull(ds.getPendingChallenge(bob), "Challenge should be removed")
+    }
+
+    @Test
+    fun `cannot duel yourself`() = runTest {
+        val (h, _) = harness()
+        val alice = SessionId(1)
+        h.loginPlayer(alice, "Alice")
+        h.drain()
+
+        h.router.handle(alice, Command.Duel("Alice"))
+
+        val errors = h.drain().errorMessages(alice)
+        assertTrue(errors.any { it.contains("yourself") }, "got=$errors")
+    }
+
+    @Test
+    fun `cannot challenge while already in duel`() = runTest {
+        val (h, ds) = harness()
+        val alice = SessionId(1)
+        val bob = SessionId(2)
+        val charlie = SessionId(3)
+        h.loginPlayer(alice, "Alice")
+        h.loginPlayer(bob, "Bob")
+        h.loginPlayer(charlie, "Charlie")
+        h.drain()
+
+        // Start a duel
+        h.router.handle(alice, Command.Duel("Bob"))
+        h.drain()
+        h.router.handle(bob, Command.DuelAccept)
+        h.drain()
+        assertTrue(ds.isInDuel(alice))
+
+        // Try to challenge another player
+        h.router.handle(alice, Command.Duel("Charlie"))
+
+        val errors = h.drain().errorMessages(alice)
+        assertTrue(errors.any { it.contains("already") }, "got=$errors")
+    }
+
+    @Test
+    fun `accept with no pending challenge sends error`() = runTest {
+        val (h, _) = harness()
+        val alice = SessionId(1)
+        h.loginPlayer(alice, "Alice")
+        h.drain()
+
+        h.router.handle(alice, Command.DuelAccept)
+
+        val errors = h.drain().errorMessages(alice)
+        assertTrue(errors.any { it.contains("No pending") }, "got=$errors")
+    }
+
+    @Test
+    fun `decline with no pending challenge sends error`() = runTest {
+        val (h, _) = harness()
+        val alice = SessionId(1)
+        h.loginPlayer(alice, "Alice")
+        h.drain()
+
+        h.router.handle(alice, Command.DuelDecline)
+
+        val errors = h.drain().errorMessages(alice)
+        assertTrue(errors.any { it.contains("No pending") }, "got=$errors")
+    }
+
+    @Test
+    fun `challenge expires after timeout`() = runTest {
+        val clock = MutableClock(0L)
+        val (h, ds) = harness(clock)
+        val alice = SessionId(1)
+        val bob = SessionId(2)
+        h.loginPlayer(alice, "Alice")
+        h.loginPlayer(bob, "Bob")
+        h.drain()
+
+        h.router.handle(alice, Command.Duel("Bob"))
+        h.drain()
+
+        assertNotNull(ds.getPendingChallenge(bob))
+
+        // Advance past the 30-second timeout
+        clock.advance(31_000L)
+
+        // Try to accept — should fail because the challenge expired
+        h.router.handle(bob, Command.DuelAccept)
+
+        val errors = h.drain().errorMessages(bob)
+        assertTrue(errors.any { it.contains("No pending") }, "got=$errors")
+        assertFalse(ds.isInDuel(bob))
+    }
+
+    @Test
+    fun `disconnect cleans up challenge and active duel`() = runTest {
+        val (h, ds) = harness()
+        val alice = SessionId(1)
+        val bob = SessionId(2)
+        h.loginPlayer(alice, "Alice")
+        h.loginPlayer(bob, "Bob")
+        h.drain()
+
+        // Create a pending challenge
+        h.router.handle(alice, Command.Duel("Bob"))
+        h.drain()
+        assertNotNull(ds.getPendingChallenge(bob))
+
+        // Simulate disconnect
+        val endedDuel = ds.onPlayerDisconnect(alice)
+        assertNull(endedDuel, "No active duel to end")
+        assertNull(ds.getPendingChallenge(bob), "Challenge should be cleaned up")
+    }
+
+    @Test
+    fun `disconnect during active duel ends duel`() = runTest {
+        val (h, ds) = harness()
+        val alice = SessionId(1)
+        val bob = SessionId(2)
+        h.loginPlayer(alice, "Alice")
+        h.loginPlayer(bob, "Bob")
+        h.drain()
+
+        h.router.handle(alice, Command.Duel("Bob"))
+        h.drain()
+        h.router.handle(bob, Command.DuelAccept)
+        h.drain()
+        assertTrue(ds.isInDuel(alice))
+        assertTrue(ds.isInDuel(bob))
+
+        // Disconnect alice
+        val endedDuel = ds.onPlayerDisconnect(alice)
+        assertNotNull(endedDuel, "Active duel should be returned")
+        assertFalse(ds.isInDuel(alice), "Alice should no longer be in duel")
+        assertFalse(ds.isInDuel(bob), "Bob should no longer be in duel")
+    }
+
+    @Test
+    fun `cannot challenge player in different room`() = runTest {
+        val (h, _) = harness()
+        val alice = SessionId(1)
+        val bob = SessionId(2)
+        h.loginPlayer(alice, "Alice")
+        h.loginPlayer(bob, "Bob")
+        h.drain()
+
+        // Move bob to a different room
+        h.router.handle(bob, Command.Move(Direction.NORTH))
+        h.drain()
+
+        h.router.handle(alice, Command.Duel("Bob"))
+
+        val errors = h.drain().errorMessages(alice)
+        assertTrue(errors.any { it.contains("not here") }, "got=$errors")
+    }
+
+    @Test
+    fun `duel unavailable sends error when system is null`() = runTest {
+        val world = duelWorld()
+        val h = CommandRouterHarness.create(world = world)
+        val sid = SessionId(1)
+        h.loginPlayer(sid, "Alice")
+        h.drain()
+
+        h.router.handle(sid, Command.Duel("Bob"))
+
+        val errors = h.drain().errorMessages(sid)
+        assertTrue(errors.any { it.contains("not available") }, "got=$errors")
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/commands/DungeonCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/DungeonCommandTest.kt
@@ -1,0 +1,284 @@
+package dev.ambon.engine.commands
+
+import dev.ambon.domain.DamageRange
+import dev.ambon.domain.dungeon.DungeonMobPoolDef
+import dev.ambon.domain.dungeon.DungeonRoomTemplateDef
+import dev.ambon.domain.dungeon.DungeonRoomType
+import dev.ambon.domain.dungeon.DungeonTemplateDef
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.world.MobSpawn
+import dev.ambon.domain.world.Room
+import dev.ambon.domain.world.World
+import dev.ambon.engine.MobRegistry
+import dev.ambon.engine.dungeon.DungeonGenerator
+import dev.ambon.engine.dungeon.DungeonManager
+import dev.ambon.engine.dungeon.DungeonRegistry
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.test.CommandRouterHarness
+import dev.ambon.test.buildTestPlayerRegistry
+import dev.ambon.test.infoMessages
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DungeonCommandTest {
+    private val portalRoom = RoomId("test:portal")
+
+    private val template = DungeonTemplateDef(
+        id = "test:crypt",
+        name = "Test Crypt",
+        minLevel = 3,
+        roomCountMin = 5,
+        roomCountMax = 5,
+        roomTemplates = mapOf(
+            DungeonRoomType.ENTRANCE to listOf(DungeonRoomTemplateDef("Crypt Entrance", "Enter the crypt.")),
+            DungeonRoomType.CORRIDOR to listOf(DungeonRoomTemplateDef("Dark Passage", "A dark passage.")),
+            DungeonRoomType.BOSS to listOf(DungeonRoomTemplateDef("Boss Chamber", "The boss lurks here.")),
+        ),
+        mobPools = DungeonMobPoolDef(
+            common = listOf("test_skeleton"),
+            boss = listOf("test_boss"),
+        ),
+    )
+
+    private val skeletonSpawn = MobSpawn(
+        id = MobId("test:test_skeleton"),
+        name = "a skeleton",
+        roomId = portalRoom,
+        maxHp = 20,
+        damage = DamageRange(2, 4),
+        xpReward = 30L,
+    )
+
+    private val bossSpawn = MobSpawn(
+        id = MobId("test:test_boss"),
+        name = "the Boss",
+        roomId = portalRoom,
+        maxHp = 100,
+        damage = DamageRange(8, 15),
+        xpReward = 200L,
+    )
+
+    private lateinit var world: World
+    private lateinit var mobs: MobRegistry
+    private lateinit var registry: DungeonRegistry
+    private lateinit var manager: DungeonManager
+
+    @BeforeEach
+    fun setUp() {
+        world = World(
+            rooms = mapOf(portalRoom to Room(portalRoom, "Portal Room", "A room with a dungeon portal.", emptyMap())),
+            startRoom = portalRoom,
+            mobSpawns = listOf(skeletonSpawn, bossSpawn),
+        )
+        mobs = MobRegistry()
+        registry = DungeonRegistry()
+        registry.register(template)
+        manager = DungeonManager(
+            world = world,
+            mobs = mobs,
+            generator = DungeonGenerator(Random(42)),
+            dungeonRegistry = registry,
+        )
+    }
+
+    private fun harness(): CommandRouterHarness {
+        val players = buildTestPlayerRegistry(world.startRoom)
+        return CommandRouterHarness.create(
+            world = world,
+            players = players,
+            mobs = mobs,
+            dungeonManager = manager,
+            dungeonRegistry = registry,
+        )
+    }
+
+    @Test
+    fun `enter dungeon teleports player and shows dungeon message`() = runTest {
+        val h = harness()
+        val sid = SessionId(1)
+        h.loginPlayer(sid, "Alice")
+        h.players.get(sid)!!.level = 5
+        h.drain()
+
+        h.router.handle(sid, Command.DungeonEnter("crypt", null))
+
+        val events = h.drain()
+        val infos = events.infoMessages(sid)
+
+        assertTrue(infos.any { it.contains("Test Crypt") }, "Should see dungeon name. got=$infos")
+        assertTrue(manager.isInDungeon(sid), "Player should be in dungeon")
+
+        // Player should have been moved to a dungeon room
+        val ps = h.players.get(sid)!!
+        assertTrue(ps.roomId.value.startsWith("dg_"), "Room should be a dungeon room. got=${ps.roomId}")
+    }
+
+    @Test
+    fun `enter dungeon with insufficient level sends error`() = runTest {
+        val h = harness()
+        val sid = SessionId(1)
+        h.loginPlayer(sid, "Alice")
+        h.players.get(sid)!!.level = 1 // Below minLevel 3
+        h.drain()
+
+        h.router.handle(sid, Command.DungeonEnter("crypt", null))
+
+        val events = h.drain()
+        val texts = events.filterIsInstance<OutboundEvent.SendText>()
+            .filter { it.sessionId == sid }
+            .map { it.text }
+
+        assertTrue(texts.any { it.contains("level") }, "Should mention level requirement. got=$texts")
+        assertFalse(manager.isInDungeon(sid), "Player should NOT be in dungeon")
+    }
+
+    @Test
+    fun `enter with unknown template sends error`() = runTest {
+        val h = harness()
+        val sid = SessionId(1)
+        h.loginPlayer(sid, "Alice")
+        h.players.get(sid)!!.level = 5
+        h.drain()
+
+        h.router.handle(sid, Command.DungeonEnter("nonexistent", null))
+
+        val events = h.drain()
+        val texts = events.filterIsInstance<OutboundEvent.SendText>()
+            .filter { it.sessionId == sid }
+            .map { it.text }
+
+        assertTrue(texts.any { it.contains("Unknown") }, "Should say unknown dungeon. got=$texts")
+    }
+
+    @Test
+    fun `leave dungeon returns player to original room`() = runTest {
+        val h = harness()
+        val sid = SessionId(1)
+        h.loginPlayer(sid, "Alice")
+        h.players.get(sid)!!.level = 5
+        h.drain()
+
+        // Enter dungeon
+        h.router.handle(sid, Command.DungeonEnter("crypt", null))
+        h.drain()
+        assertTrue(manager.isInDungeon(sid))
+
+        // Leave dungeon
+        h.router.handle(sid, Command.DungeonLeave)
+
+        val events = h.drain()
+        val infos = events.infoMessages(sid)
+
+        assertTrue(infos.any { it.contains("leave") }, "Should see leave message. got=$infos")
+        assertFalse(manager.isInDungeon(sid), "Player should not be in dungeon")
+
+        val ps = h.players.get(sid)!!
+        assertTrue(ps.roomId == portalRoom, "Player should be back in portal room. got=${ps.roomId}")
+    }
+
+    @Test
+    fun `leave when not in dungeon sends error`() = runTest {
+        val h = harness()
+        val sid = SessionId(1)
+        h.loginPlayer(sid, "Alice")
+        h.drain()
+
+        h.router.handle(sid, Command.DungeonLeave)
+
+        val events = h.drain()
+        val texts = events.filterIsInstance<OutboundEvent.SendText>()
+            .filter { it.sessionId == sid }
+            .map { it.text }
+
+        assertTrue(texts.any { it.contains("not in a dungeon") }, "Should say not in dungeon. got=$texts")
+    }
+
+    @Test
+    fun `re-enter dungeon teleports back to existing instance`() = runTest {
+        val h = harness()
+        val sid = SessionId(1)
+        h.loginPlayer(sid, "Alice")
+        h.players.get(sid)!!.level = 5
+        h.drain()
+
+        // Enter dungeon
+        h.router.handle(sid, Command.DungeonEnter("crypt", null))
+        h.drain()
+        val instanceRoom = h.players.get(sid)!!.roomId
+
+        // Manually move player out (simulating something like death teleport)
+        h.players.moveTo(sid, portalRoom)
+
+        // Re-enter should go back to the existing instance
+        h.router.handle(sid, Command.DungeonEnter("crypt", null))
+
+        val events = h.drain()
+        val infos = events.infoMessages(sid)
+
+        assertTrue(infos.any { it.contains("re-enter") }, "Should see re-entry message. got=$infos")
+        assertTrue(manager.isInDungeon(sid), "Player should be in dungeon again")
+    }
+
+    @Test
+    fun `enter with difficulty creates instance at that difficulty`() = runTest {
+        val h = harness()
+        val sid = SessionId(1)
+        h.loginPlayer(sid, "Alice")
+        h.players.get(sid)!!.level = 5
+        h.drain()
+
+        h.router.handle(sid, Command.DungeonEnter("crypt", "hard"))
+
+        val events = h.drain()
+        val infos = events.infoMessages(sid)
+
+        assertTrue(infos.any { it.contains("Hard") }, "Should see difficulty name. got=$infos")
+    }
+
+    @Test
+    fun `enter with invalid difficulty sends error`() = runTest {
+        val h = harness()
+        val sid = SessionId(1)
+        h.loginPlayer(sid, "Alice")
+        h.players.get(sid)!!.level = 5
+        h.drain()
+
+        h.router.handle(sid, Command.DungeonEnter("crypt", "impossible"))
+
+        val events = h.drain()
+        val texts = events.filterIsInstance<OutboundEvent.SendText>()
+            .filter { it.sessionId == sid }
+            .map { it.text }
+
+        assertTrue(texts.any { it.contains("Unknown difficulty") }, "Should reject invalid difficulty. got=$texts")
+    }
+
+    @Test
+    fun `dungeon unavailable when manager is null`() = runTest {
+        val players = buildTestPlayerRegistry(portalRoom)
+        val h = CommandRouterHarness.create(
+            world = world,
+            players = players,
+        )
+        val sid = SessionId(1)
+        h.loginPlayer(sid, "Alice")
+        h.drain()
+
+        h.router.handle(sid, Command.DungeonEnter("crypt", null))
+
+        val events = h.drain()
+        val texts = events.filterIsInstance<OutboundEvent.SendText>()
+            .filter { it.sessionId == sid }
+            .map { it.text }
+
+        assertTrue(texts.any { it.contains("not available") }, "got=$texts")
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/commands/HousingCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/HousingCommandTest.kt
@@ -1,0 +1,227 @@
+package dev.ambon.engine.commands
+
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.config.HousingConfig
+import dev.ambon.config.RoomTemplateConfig
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.world.Direction
+import dev.ambon.domain.world.Room
+import dev.ambon.domain.world.World
+import dev.ambon.engine.HousingSystem
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.persistence.InMemoryHouseRepository
+import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.CommandRouterHarness
+import dev.ambon.test.MutableClock
+import dev.ambon.test.buildTestPlayerRegistry
+import dev.ambon.test.errorMessages
+import dev.ambon.test.infoMessages
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HousingCommandTest {
+    private val startRoom = RoomId("zone:start")
+
+    private val housingConfig = HousingConfig(
+        enabled = true,
+        entryExitDirection = Direction.SOUTH,
+        templates = mapOf(
+            "cottage_entry" to RoomTemplateConfig(
+                title = "Cottage Entryway",
+                description = "A cozy entryway.",
+                cost = 100,
+                isEntry = true,
+                safe = true,
+            ),
+            "vault" to RoomTemplateConfig(
+                title = "Storage Vault",
+                description = "A reinforced room.",
+                cost = 200,
+                maxDroppedItems = 50,
+                safe = true,
+            ),
+        ),
+    )
+
+    private fun makeWorld(): World {
+        val rooms = mapOf(
+            startRoom to Room(
+                id = startRoom,
+                title = "Town Square",
+                description = "The town square.",
+                exits = emptyMap(),
+            ),
+        )
+        return World(rooms = rooms, startRoom = startRoom)
+    }
+
+    private fun harness(): Triple<CommandRouterHarness, HousingSystem, InMemoryHouseRepository> {
+        val world = makeWorld()
+        val items = ItemRegistry()
+        val playerRepo = InMemoryPlayerRepository()
+        val outbound = LocalOutboundBus()
+        val clock = MutableClock(0L)
+        val houseRepo = InMemoryHouseRepository()
+        val players = buildTestPlayerRegistry(startRoom, playerRepo, items, clock = clock, startingGold = 1000)
+
+        val housing = HousingSystem(
+            players = players,
+            houseRepo = houseRepo,
+            world = world,
+            outbound = outbound,
+            items = items,
+            config = housingConfig,
+            clock = clock,
+        )
+
+        val h = CommandRouterHarness.create(
+            world = world,
+            repo = playerRepo,
+            items = items,
+            players = players,
+            outbound = outbound,
+            clock = clock,
+            housingSystem = housing,
+        )
+        return Triple(h, housing, houseRepo)
+    }
+
+    @Test
+    fun `house status without a house shows no-house message`() = runTest {
+        val (h, _, _) = harness()
+        val sid = SessionId(1)
+        h.loginPlayer(sid, "Alice")
+        h.drain()
+
+        h.router.handle(sid, Command.House.Status)
+
+        val infos = h.drain().infoMessages(sid)
+        assertTrue(infos.any { it.contains("don't own") }, "got=$infos")
+    }
+
+    @Test
+    fun `house buy creates a house and confirms`() = runTest {
+        val (h, _, _) = harness()
+        val sid = SessionId(1)
+        h.loginPlayer(sid, "Alice")
+        h.drain()
+
+        h.router.handle(sid, Command.House.Buy)
+
+        val infos = h.drain().infoMessages(sid)
+        assertTrue(infos.any { it.contains("homeowner") }, "got=$infos")
+        assertTrue(h.players.get(sid)!!.hasHouse, "Player should own a house")
+    }
+
+    @Test
+    fun `house buy fails with insufficient gold`() = runTest {
+        val (h, _, _) = harness()
+        val sid = SessionId(1)
+        h.loginPlayer(sid, "Alice")
+        h.players.get(sid)!!.gold = 10 // Entry costs 100
+        h.drain()
+
+        h.router.handle(sid, Command.House.Buy)
+
+        val errors = h.drain().errorMessages(sid)
+        assertTrue(errors.any { it.contains("gold") }, "got=$errors")
+    }
+
+    @Test
+    fun `house buy fails if already own a house`() = runTest {
+        val (h, _, _) = harness()
+        val sid = SessionId(1)
+        h.loginPlayer(sid, "Alice")
+        h.drain()
+
+        // Buy first house
+        h.router.handle(sid, Command.House.Buy)
+        h.drain()
+
+        // Try to buy again
+        h.router.handle(sid, Command.House.Buy)
+
+        val errors = h.drain().errorMessages(sid)
+        assertTrue(errors.any { it.contains("already") }, "got=$errors")
+    }
+
+    @Test
+    fun `house status after buying shows rooms`() = runTest {
+        val (h, _, _) = harness()
+        val sid = SessionId(1)
+        h.loginPlayer(sid, "Alice")
+        h.drain()
+
+        h.router.handle(sid, Command.House.Buy)
+        h.drain()
+
+        h.router.handle(sid, Command.House.Status)
+
+        val events = h.drain()
+        val texts = events.filterIsInstance<OutboundEvent.SendText>()
+            .filter { it.sessionId == sid }
+            .map { it.text }
+        val infos = events.infoMessages(sid)
+
+        assertTrue(texts.any { it.contains("Alice") && it.contains("House") }, "got texts=$texts infos=$infos")
+        assertTrue(infos.any { it.contains("Rooms") }, "got=$infos")
+    }
+
+    @Test
+    fun `house list templates shows available templates`() = runTest {
+        val (h, _, _) = harness()
+        val sid = SessionId(1)
+        h.loginPlayer(sid, "Alice")
+        h.drain()
+
+        h.router.handle(sid, Command.House.ListTemplates)
+
+        val events = h.drain()
+        val infos = events.infoMessages(sid)
+
+        assertTrue(infos.any { it.contains("Cottage Entryway") }, "got=$infos")
+        assertTrue(infos.any { it.contains("Storage Vault") }, "got=$infos")
+    }
+
+    @Test
+    fun `house guests shows no visitors initially`() = runTest {
+        val (h, housing, _) = harness()
+        val sid = SessionId(1)
+        h.loginPlayer(sid, "Alice")
+        h.drain()
+
+        h.router.handle(sid, Command.House.Buy)
+        h.drain()
+
+        // Need to be in the house to check guests
+        val entryRoom = housing.entryRoomId("Alice")
+        h.players.moveTo(sid, entryRoom)
+
+        h.router.handle(sid, Command.House.Guests)
+
+        val infos = h.drain().infoMessages(sid)
+        assertTrue(infos.any { it.contains("no visitors") }, "got=$infos")
+    }
+
+    @Test
+    fun `housing not registered when system is null produces no handler output`() = runTest {
+        val world = makeWorld()
+        val h = CommandRouterHarness.create(world = world)
+        val sid = SessionId(1)
+        h.loginPlayer(sid, "Alice")
+        h.drain()
+
+        h.router.handle(sid, Command.House.Status)
+
+        val events = h.drain()
+        // With no HousingHandler registered, the command is silently ignored (only a prompt is sent)
+        val errors = events.errorMessages(sid)
+        val infos = events.infoMessages(sid)
+        assertTrue(errors.isEmpty() && infos.isEmpty(), "No handler output expected. errors=$errors infos=$infos")
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/commands/RouterTestHelper.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/RouterTestHelper.kt
@@ -7,34 +7,43 @@ import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.world.World
 import dev.ambon.engine.CombatSystem
+import dev.ambon.engine.DuelSystem
 import dev.ambon.engine.GroupSystem
 import dev.ambon.engine.GuildSystem
+import dev.ambon.engine.HousingSystem
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.MobRemovalCoordinator
 import dev.ambon.engine.PetSystem
 import dev.ambon.engine.PlayerProgression
 import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.ShopRegistry
+import dev.ambon.engine.TradeSystem
 import dev.ambon.engine.WorldStateRegistry
 import dev.ambon.engine.commands.handlers.AdminHandler
 import dev.ambon.engine.commands.handlers.BankHandler
 import dev.ambon.engine.commands.handlers.CombatHandler
 import dev.ambon.engine.commands.handlers.CommunicationHandler
 import dev.ambon.engine.commands.handlers.DialogueQuestHandler
+import dev.ambon.engine.commands.handlers.DuelHandler
+import dev.ambon.engine.commands.handlers.DungeonHandler
 import dev.ambon.engine.commands.handlers.EnchantHandler
 import dev.ambon.engine.commands.handlers.EngineContext
 import dev.ambon.engine.commands.handlers.GroupHandler
 import dev.ambon.engine.commands.handlers.GuildHandler
+import dev.ambon.engine.commands.handlers.HousingHandler
 import dev.ambon.engine.commands.handlers.ItemHandler
 import dev.ambon.engine.commands.handlers.MailHandler
 import dev.ambon.engine.commands.handlers.NavigationHandler
 import dev.ambon.engine.commands.handlers.PetHandler
 import dev.ambon.engine.commands.handlers.ProgressionHandler
 import dev.ambon.engine.commands.handlers.ShopHandler
+import dev.ambon.engine.commands.handlers.TradeHandler
 import dev.ambon.engine.commands.handlers.UiHandler
 import dev.ambon.engine.commands.handlers.WorldFeaturesHandler
 import dev.ambon.engine.crafting.EnchantSystem
 import dev.ambon.engine.crafting.GatheringRegistry
+import dev.ambon.engine.dungeon.DungeonManager
+import dev.ambon.engine.dungeon.DungeonRegistry
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.sharding.InterEngineBus
 import dev.ambon.sharding.PlayerLocationIndex
@@ -72,6 +81,11 @@ internal fun buildTestRouter(
     petSystem: PetSystem? = null,
     enchantSystem: EnchantSystem? = null,
     bankConfig: BankConfig? = null,
+    duelSystem: DuelSystem? = null,
+    tradeSystem: TradeSystem? = null,
+    dungeonManager: DungeonManager? = null,
+    dungeonRegistry: DungeonRegistry? = null,
+    housingSystem: HousingSystem? = null,
 ): CommandRouter {
     val router = CommandRouter(outbound = outbound, players = players)
     val ctx = EngineContext(
@@ -110,6 +124,10 @@ internal fun buildTestRouter(
         petSystem?.let { PetHandler(ctx = ctx, petSystem = it) },
         enchantSystem?.let { EnchantHandler(ctx = ctx, enchantSystem = it) },
         bankConfig?.let { BankHandler(ctx = ctx, bankConfig = it) },
+        DuelHandler(ctx = ctx, duelSystem = duelSystem, combatSystem = combat),
+        tradeSystem?.let { TradeHandler(ctx = ctx, tradeSystem = it) },
+        DungeonHandler(ctx = ctx, dungeonManager = dungeonManager, dungeonRegistry = dungeonRegistry, groupSystem = groupSystem),
+        housingSystem?.let { HousingHandler(ctx = ctx, housingSystem = it) },
         AdminHandler(
             ctx = ctx,
             onShutdown = onShutdown,

--- a/src/test/kotlin/dev/ambon/engine/commands/TradeCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/TradeCommandTest.kt
@@ -1,0 +1,329 @@
+package dev.ambon.engine.commands
+
+import dev.ambon.domain.ids.ItemId
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.items.Item
+import dev.ambon.domain.items.ItemInstance
+import dev.ambon.domain.items.ItemSlot
+import dev.ambon.domain.world.Direction
+import dev.ambon.domain.world.Room
+import dev.ambon.domain.world.World
+import dev.ambon.engine.TradeSystem
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.test.CommandRouterHarness
+import dev.ambon.test.buildTestPlayerRegistry
+import dev.ambon.test.errorMessages
+import dev.ambon.test.infoMessages
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TradeCommandTest {
+    private val roomA = RoomId("test:market")
+    private val roomB = RoomId("test:alley")
+
+    private fun tradeWorld(): World {
+        val rooms = mapOf(
+            roomA to Room(
+                id = roomA,
+                title = "Market",
+                description = "A bustling market.",
+                exits = mapOf(Direction.NORTH to roomB),
+            ),
+            roomB to Room(
+                id = roomB,
+                title = "Alley",
+                description = "A dark alley.",
+                exits = mapOf(Direction.SOUTH to roomA),
+            ),
+        )
+        return World(rooms = rooms, startRoom = roomA)
+    }
+
+    private fun sword(suffix: String = "1") = ItemInstance(
+        id = ItemId("sword_$suffix"),
+        item = Item(keyword = "sword", displayName = "a copper sword", slot = ItemSlot.HAND, damage = 4),
+    )
+
+    private fun shield() = ItemInstance(
+        id = ItemId("shield_1"),
+        item = Item(keyword = "shield", displayName = "a wooden shield", slot = ItemSlot.HAND, armor = 2),
+    )
+
+    private fun harness(): Triple<CommandRouterHarness, ItemRegistry, TradeSystem> {
+        val world = tradeWorld()
+        val items = ItemRegistry()
+        val tradeSystem = TradeSystem(items)
+        val players = buildTestPlayerRegistry(world.startRoom, items = items)
+        val h = CommandRouterHarness.create(
+            world = world,
+            items = items,
+            players = players,
+            tradeSystem = tradeSystem,
+        )
+        return Triple(h, items, tradeSystem)
+    }
+
+    @Test
+    fun `initiate trade sends notifications to both players`() = runTest {
+        val (h, _, _) = harness()
+        val alice = SessionId(1)
+        val bob = SessionId(2)
+        h.loginPlayer(alice, "Alice")
+        h.loginPlayer(bob, "Bob")
+        h.drain()
+
+        h.router.handle(alice, Command.TradeRequest("Bob"))
+
+        val events = h.drain()
+        val aliceInfos = events.infoMessages(alice)
+        val bobInfos = events.infoMessages(bob)
+
+        assertTrue(aliceInfos.any { it.contains("initiate") && it.contains("Bob") }, "got=$aliceInfos")
+        assertTrue(bobInfos.any { it.contains("Alice") && it.contains("trade") }, "got=$bobInfos")
+    }
+
+    @Test
+    fun `cannot trade with yourself`() = runTest {
+        val (h, _, _) = harness()
+        val alice = SessionId(1)
+        h.loginPlayer(alice, "Alice")
+        h.drain()
+
+        h.router.handle(alice, Command.TradeRequest("Alice"))
+
+        val errors = h.drain().errorMessages(alice)
+        assertTrue(errors.any { it.contains("yourself") }, "got=$errors")
+    }
+
+    @Test
+    fun `offer item removes from inventory and adds to trade`() = runTest {
+        val (h, items, ts) = harness()
+        val alice = SessionId(1)
+        val bob = SessionId(2)
+        h.loginPlayer(alice, "Alice")
+        h.loginPlayer(bob, "Bob")
+        items.addToInventory(alice, sword())
+        h.drain()
+
+        h.router.handle(alice, Command.TradeRequest("Bob"))
+        h.drain()
+
+        h.router.handle(alice, Command.TradeOffer("sword"))
+
+        val events = h.drain()
+        val aliceInfos = events.infoMessages(alice)
+        val bobInfos = events.infoMessages(bob)
+
+        assertTrue(aliceInfos.any { it.contains("offer") && it.contains("copper sword") }, "got=$aliceInfos")
+        assertTrue(bobInfos.any { it.contains("Alice") && it.contains("copper sword") }, "got=$bobInfos")
+        assertTrue(items.inventory(alice).isEmpty(), "Item should be removed from inventory (held in escrow)")
+
+        val session = ts.getSession(alice)!!
+        assertEquals(1, session.initiatorItems.size, "Item should be in trade session")
+    }
+
+    @Test
+    fun `both accept completes trade and transfers items`() = runTest {
+        val (h, items, _) = harness()
+        val alice = SessionId(1)
+        val bob = SessionId(2)
+        h.loginPlayer(alice, "Alice")
+        h.loginPlayer(bob, "Bob")
+        items.addToInventory(alice, sword())
+        items.addToInventory(bob, shield())
+        h.drain()
+
+        // Initiate trade
+        h.router.handle(alice, Command.TradeRequest("Bob"))
+        h.drain()
+
+        // Offer items
+        h.router.handle(alice, Command.TradeOffer("sword"))
+        h.drain()
+        h.router.handle(bob, Command.TradeOffer("shield"))
+        h.drain()
+
+        // Both accept
+        h.router.handle(alice, Command.TradeAccept)
+        h.drain()
+        h.router.handle(bob, Command.TradeAccept)
+
+        val events = h.drain()
+        val aliceInfos = events.infoMessages(alice)
+        val bobInfos = events.infoMessages(bob)
+
+        assertTrue(aliceInfos.any { it.contains("Trade complete") }, "got=$aliceInfos")
+        assertTrue(bobInfos.any { it.contains("Trade complete") }, "got=$bobInfos")
+
+        // Verify items transferred
+        val aliceInv = items.inventory(alice).map { it.item.keyword }
+        val bobInv = items.inventory(bob).map { it.item.keyword }
+        assertTrue("shield" in aliceInv, "Alice should have the shield. got=$aliceInv")
+        assertTrue("sword" in bobInv, "Bob should have the sword. got=$bobInv")
+    }
+
+    @Test
+    fun `one-sided accept waits for other player`() = runTest {
+        val (h, _, ts) = harness()
+        val alice = SessionId(1)
+        val bob = SessionId(2)
+        h.loginPlayer(alice, "Alice")
+        h.loginPlayer(bob, "Bob")
+        h.drain()
+
+        h.router.handle(alice, Command.TradeRequest("Bob"))
+        h.drain()
+
+        h.router.handle(alice, Command.TradeAccept)
+
+        val events = h.drain()
+        val aliceInfos = events.infoMessages(alice)
+        assertTrue(aliceInfos.any { it.contains("Waiting") }, "got=$aliceInfos")
+
+        val session = ts.getSession(alice)!!
+        assertTrue(session.initiatorAccepted)
+        assertFalse(session.targetAccepted)
+    }
+
+    @Test
+    fun `cancel returns escrowed items to original owners`() = runTest {
+        val (h, items, ts) = harness()
+        val alice = SessionId(1)
+        val bob = SessionId(2)
+        h.loginPlayer(alice, "Alice")
+        h.loginPlayer(bob, "Bob")
+        items.addToInventory(alice, sword())
+        h.drain()
+
+        h.router.handle(alice, Command.TradeRequest("Bob"))
+        h.drain()
+
+        h.router.handle(alice, Command.TradeOffer("sword"))
+        h.drain()
+        assertTrue(items.inventory(alice).isEmpty(), "Sword should be in escrow")
+
+        h.router.handle(bob, Command.TradeCancel)
+
+        val events = h.drain()
+        val bobInfos = events.infoMessages(bob)
+        assertTrue(bobInfos.any { it.contains("cancel") }, "got=$bobInfos")
+
+        // Verify item returned
+        val aliceInv = items.inventory(alice).map { it.item.keyword }
+        assertTrue("sword" in aliceInv, "Sword should be returned to Alice. got=$aliceInv")
+        assertFalse(ts.isInTrade(alice), "Alice should no longer be in trade")
+        assertFalse(ts.isInTrade(bob), "Bob should no longer be in trade")
+    }
+
+    @Test
+    fun `cannot start trade while already in one`() = runTest {
+        val (h, _, _) = harness()
+        val alice = SessionId(1)
+        val bob = SessionId(2)
+        val charlie = SessionId(3)
+        h.loginPlayer(alice, "Alice")
+        h.loginPlayer(bob, "Bob")
+        h.loginPlayer(charlie, "Charlie")
+        h.drain()
+
+        h.router.handle(alice, Command.TradeRequest("Bob"))
+        h.drain()
+
+        h.router.handle(alice, Command.TradeRequest("Charlie"))
+
+        val errors = h.drain().errorMessages(alice)
+        assertTrue(errors.any { it.contains("already") }, "got=$errors")
+    }
+
+    @Test
+    fun `offer gold works and shows in status`() = runTest {
+        val (h, _, _) = harness()
+        val alice = SessionId(1)
+        val bob = SessionId(2)
+        h.loginPlayer(alice, "Alice")
+        h.loginPlayer(bob, "Bob")
+        h.players.get(alice)!!.gold = 500L
+        h.drain()
+
+        h.router.handle(alice, Command.TradeRequest("Bob"))
+        h.drain()
+        h.router.handle(alice, Command.TradeOfferGold(100))
+        h.drain()
+
+        h.router.handle(alice, Command.TradeStatus)
+
+        val events = h.drain()
+        val infos = events.infoMessages(alice)
+        assertTrue(infos.any { it.contains("100 gold") }, "Status should show gold offered. got=$infos")
+    }
+
+    @Test
+    fun `offer more gold than available fails`() = runTest {
+        val (h, _, _) = harness()
+        val alice = SessionId(1)
+        val bob = SessionId(2)
+        h.loginPlayer(alice, "Alice")
+        h.loginPlayer(bob, "Bob")
+        h.players.get(alice)!!.gold = 10L
+        h.drain()
+
+        h.router.handle(alice, Command.TradeRequest("Bob"))
+        h.drain()
+
+        h.router.handle(alice, Command.TradeOfferGold(100))
+
+        val errors = h.drain().errorMessages(alice)
+        assertTrue(errors.any { it.contains("only have") }, "got=$errors")
+    }
+
+    @Test
+    fun `disconnect during trade returns escrowed items`() = runTest {
+        val (h, items, ts) = harness()
+        val alice = SessionId(1)
+        val bob = SessionId(2)
+        h.loginPlayer(alice, "Alice")
+        h.loginPlayer(bob, "Bob")
+        items.addToInventory(alice, sword())
+        items.addToInventory(bob, shield())
+        h.drain()
+
+        h.router.handle(alice, Command.TradeRequest("Bob"))
+        h.drain()
+        h.router.handle(alice, Command.TradeOffer("sword"))
+        h.drain()
+        h.router.handle(bob, Command.TradeOffer("shield"))
+        h.drain()
+
+        // Simulate disconnect
+        ts.cancelForPlayer(alice)
+
+        // Verify items returned
+        assertTrue(items.inventory(alice).any { it.item.keyword == "sword" }, "Sword should return to Alice")
+        assertTrue(items.inventory(bob).any { it.item.keyword == "shield" }, "Shield should return to Bob")
+        assertFalse(ts.isInTrade(alice))
+        assertFalse(ts.isInTrade(bob))
+    }
+
+    @Test
+    fun `trade not registered when system is null produces no handler output`() = runTest {
+        val world = tradeWorld()
+        val h = CommandRouterHarness.create(world = world)
+        val sid = SessionId(1)
+        h.loginPlayer(sid, "Alice")
+        h.drain()
+
+        h.router.handle(sid, Command.TradeRequest("Bob"))
+
+        val events = h.drain()
+        // With no TradeHandler registered, the command is silently ignored (only a prompt is sent)
+        val errors = events.errorMessages(sid)
+        val infos = events.infoMessages(sid)
+        assertTrue(errors.isEmpty() && infos.isEmpty(), "No handler output expected. errors=$errors infos=$infos")
+    }
+}

--- a/src/test/kotlin/dev/ambon/test/TestFixtures.kt
+++ b/src/test/kotlin/dev/ambon/test/TestFixtures.kt
@@ -13,8 +13,10 @@ import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.world.World
 import dev.ambon.domain.world.load.WorldLoader
 import dev.ambon.engine.CombatSystem
+import dev.ambon.engine.DuelSystem
 import dev.ambon.engine.GameEngine
 import dev.ambon.engine.GroupSystem
+import dev.ambon.engine.HousingSystem
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.MobRemovalCoordinator
 import dev.ambon.engine.PasswordHasher
@@ -26,11 +28,14 @@ import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.RaceRegistry
 import dev.ambon.engine.RaceRegistryLoader
 import dev.ambon.engine.StatRegistry
+import dev.ambon.engine.TradeSystem
 import dev.ambon.engine.commands.CommandRouter
 import dev.ambon.engine.commands.PhaseResult
 import dev.ambon.engine.commands.buildTestRouter
 import dev.ambon.engine.crafting.EnchantSystem
 import dev.ambon.engine.crafting.GatheringRegistry
+import dev.ambon.engine.dungeon.DungeonManager
+import dev.ambon.engine.dungeon.DungeonRegistry
 import dev.ambon.engine.events.InboundEvent
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
@@ -188,6 +193,8 @@ class CommandRouterHarness private constructor(
     val groupSystem: GroupSystem?,
     val combat: CombatSystem,
     val router: CommandRouter,
+    val duelSystem: DuelSystem? = null,
+    val tradeSystem: TradeSystem? = null,
 ) {
     suspend fun loginPlayer(
         sessionId: SessionId,
@@ -232,6 +239,11 @@ class CommandRouterHarness private constructor(
             petSystem: PetSystem? = null,
             enchantSystem: EnchantSystem? = null,
             bankConfig: BankConfig? = null,
+            duelSystem: DuelSystem? = null,
+            tradeSystem: TradeSystem? = null,
+            dungeonManager: DungeonManager? = null,
+            dungeonRegistry: DungeonRegistry? = null,
+            housingSystem: HousingSystem? = null,
         ): CommandRouterHarness {
             val combat = CombatSystem(players, mobs, items, outbound)
             val router =
@@ -258,8 +270,26 @@ class CommandRouterHarness private constructor(
                     petSystem = petSystem,
                     enchantSystem = enchantSystem,
                     bankConfig = bankConfig,
+                    duelSystem = duelSystem,
+                    tradeSystem = tradeSystem,
+                    dungeonManager = dungeonManager,
+                    dungeonRegistry = dungeonRegistry,
+                    housingSystem = housingSystem,
                 )
-            return CommandRouterHarness(world, repo, items, players, mobs, outbound, progression, groupSystem, combat, router)
+            return CommandRouterHarness(
+                world = world,
+                repo = repo,
+                items = items,
+                players = players,
+                mobs = mobs,
+                outbound = outbound,
+                progression = progression,
+                groupSystem = groupSystem,
+                combat = combat,
+                router = router,
+                duelSystem = duelSystem,
+                tradeSystem = tradeSystem,
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add **6 new test files** and expand 1 existing test file, adding ~61 new test cases across critical system gaps
- Wire 4 previously untested command handlers (Duel, Trade, Dungeon, Housing) into the test harness infrastructure
- Cover cross-system interaction chains that were previously untested

## New Test Files

### Cross-System Integration (`MultiSystemIntegrationTest.kt`)
- Death cleanup chain: verifies trade cancellation, duel termination, group removal, and status effect clearing all propagate correctly on player death
- Quest completion -> achievement unlock chain
- Mob kill -> quest objective progress -> quest completion chain

### Shutdown Cleanup (`ShutdownCleanupTest.kt`)
- Persistence flush: all dirty player records flushed on shutdown
- Late-modified records preserved through shutdown
- Trade cleanup: escrowed items returned on shutdown
- Multiple concurrent trades cleaned up
- Active duels ended on shutdown
- Write coalescing preserves final state through flush

### Handler Command Tests
- **DuelCommandTest**: challenge, accept, decline, self-duel prevention, timeout expiry, disconnect cleanup, same-room validation, system-unavailable
- **TradeCommandTest**: initiate, offer items/gold, mutual accept with item transfer, cancel with escrow return, gold validation, disconnect cleanup
- **DungeonCommandTest**: enter, leave, level requirement enforcement, re-entry to existing instance, difficulty selection, unknown template/difficulty handling
- **HousingCommandTest**: status, buy, insufficient gold, duplicate purchase prevention, templates listing, guests

### Expanded MobSystemTest
- Grew from 1 test to 8 tests covering spawn, death/removal, respawn via scheduler, multiple mobs per room, movement, aggressive flag tracking, and duplicate prevention

## Infrastructure Changes
- `RouterTestHelper.kt`: wired `DuelHandler`, `TradeHandler`, `DungeonHandler`, `HousingHandler`
- `TestFixtures.kt`: extended `CommandRouterHarness` to pass through new handler parameters

## Test plan
- [x] All 61 new tests pass
- [x] Full existing test suite passes (no regressions)
- [x] ktlintCheck passes