### PR TITLE
Fix persistence layer polish: index, normalization, flush reporting

### DIFF
--- a/src/main/kotlin/dev/ambon/persistence/PersistenceWorker.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PersistenceWorker.kt
@@ -16,14 +16,20 @@ class PersistenceWorker(
     override val workerName = "PersistenceWorker"
 
     override suspend fun flush() {
-        val flushed = repo.flushDirty()
-        if (flushed > 0) {
-            log.debug { "PersistenceWorker flushed $flushed dirty record(s)" }
+        val result = repo.flushDirty()
+        if (result.flushed > 0 || result.failed > 0) {
+            log.debug { "PersistenceWorker flushed ${result.flushed} dirty record(s)" }
+        }
+        if (result.failed > 0) {
+            log.warn { "PersistenceWorker flush: ${result.failed} record(s) failed to persist" }
         }
     }
 
     override suspend fun shutdownFlush() {
-        val flushed = repo.flushAll()
-        log.info { "PersistenceWorker shutdown: flushed $flushed record(s)" }
+        val result = repo.flushAll()
+        log.info { "PersistenceWorker shutdown: flushed ${result.flushed} record(s)" }
+        if (result.failed > 0) {
+            log.error { "PersistenceWorker shutdown: ${result.failed} record(s) failed to persist!" }
+        }
     }
 }

--- a/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
@@ -84,11 +84,25 @@ data class PlayerRecord(
      */
     fun migrateDefaults(): PlayerRecord {
         var record = this
-        // Fix any zero-valued stats from legacy saves
-        val fixedStats = record.stats.mapValues { (_, v) -> if (v == 0) DEFAULT_STAT else v }
-        if (fixedStats != record.stats) record = record.copy(stats = fixedStats)
-        val normalized = record.equippedItems.mapKeys { (k, _) -> k.trim().lowercase() }
-        if (normalized != record.equippedItems) record = record.copy(equippedItems = normalized)
+
+        // Normalize stat keys to uppercase (canonical format) and ensure all values are at least 1.
+        // Legacy saves may have lowercase keys ("str") or zero values from old migration bugs.
+        val mergedStats = DEFAULT_STATS + record.stats.mapKeys { (k, _) -> k.trim().uppercase() }
+        val coercedStats = mergedStats.mapValues { (_, v) -> v.coerceAtLeast(1) }
+        if (coercedStats != record.stats) record = record.copy(stats = coercedStats)
+
+        // Normalize factionStandings keys to lowercase
+        val normalizedFactions = record.factionStandings.mapKeys { (k, _) -> k.trim().lowercase() }
+        if (normalizedFactions != record.factionStandings) record = record.copy(factionStandings = normalizedFactions)
+
+        // Normalize craftingSkills keys to lowercase
+        val normalizedCrafting = record.craftingSkills.mapKeys { (k, _) -> k.trim().lowercase() }
+        if (normalizedCrafting != record.craftingSkills) record = record.copy(craftingSkills = normalizedCrafting)
+
+        // Normalize equippedItems keys to lowercase
+        val normalizedEquipped = record.equippedItems.mapKeys { (k, _) -> k.trim().lowercase() }
+        if (normalizedEquipped != record.equippedItems) record = record.copy(equippedItems = normalizedEquipped)
+
         return record
     }
 }

--- a/src/main/kotlin/dev/ambon/persistence/WriteCoalescingPlayerRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/WriteCoalescingPlayerRepository.kt
@@ -7,6 +7,12 @@ import kotlin.concurrent.withLock
 
 private val log = KotlinLogging.logger {}
 
+/** Result of a [WriteCoalescingPlayerRepository.flushDirty] or [WriteCoalescingPlayerRepository.flushAll] call. */
+data class FlushResult(
+    val flushed: Int,
+    val failed: Int,
+)
+
 /**
  * Wraps a [PlayerRepository] delegate, intercepting [save] to mark records dirty
  * in an in-memory cache instead of writing immediately.
@@ -89,10 +95,11 @@ class WriteCoalescingPlayerRepository(
         nameIndex[record.name.lowercase()] = record.id
     }
 
-    suspend fun flushDirty(): Int {
+    suspend fun flushDirty(): FlushResult {
         val toFlush = snapshotDirty()
-        if (toFlush.isEmpty()) return 0
+        if (toFlush.isEmpty()) return FlushResult(flushed = 0, failed = 0)
         var flushed = 0
+        var failed = 0
         for (pending in toFlush) {
             try {
                 delegate.save(pending.record)
@@ -103,19 +110,27 @@ class WriteCoalescingPlayerRepository(
                 }
                 flushed++
             } catch (e: Exception) {
+                failed++
                 log.error(e) { "Failed to flush player record: id=${pending.id} name=${pending.record.name}" }
             }
         }
-        return flushed
+        if (failed > 0) {
+            log.warn { "Flush completed with $failed failure(s) out of ${toFlush.size} record(s)" }
+        }
+        return FlushResult(flushed = flushed, failed = failed)
     }
 
-    suspend fun flushAll(): Int {
-        var total = 0
+    suspend fun flushAll(): FlushResult {
+        var totalFlushed = 0
+        var totalFailed = 0
         while (true) {
-            val flushed = flushDirty()
-            total += flushed
+            val result = flushDirty()
+            totalFlushed += result.flushed
+            totalFailed += result.failed
             val hasDirty = lock.withLock { dirtyVersions.isNotEmpty() }
-            if (!hasDirty || flushed == 0) return total
+            if (!hasDirty || result.flushed == 0) {
+                return FlushResult(flushed = totalFlushed, failed = totalFailed)
+            }
         }
     }
 

--- a/src/main/kotlin/dev/ambon/persistence/YamlGuildRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/YamlGuildRepository.kt
@@ -2,6 +2,7 @@ package dev.ambon.persistence
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import dev.ambon.domain.guild.GuildRecord
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.nio.file.Path
@@ -10,6 +11,8 @@ import kotlin.io.path.deleteIfExists
 import kotlin.io.path.exists
 import kotlin.io.path.listDirectoryEntries
 import kotlin.io.path.readText
+
+private val log = KotlinLogging.logger {}
 
 class YamlGuildRepository(
     private val rootDir: Path,
@@ -67,7 +70,14 @@ class YamlGuildRepository(
 
     private fun pathFor(id: String): Path = guildsDir.resolve("${sanitizeId(id)}.yaml")
 
-    private fun sanitizeId(id: String): String = id.replace(Regex("[^a-zA-Z0-9_\\-]"), "_")
+    private val safeIdPattern = Regex("^[a-zA-Z0-9_\\-]+$")
+
+    private fun sanitizeId(id: String): String {
+        if (safeIdPattern.matches(id)) return id
+        val sanitized = id.replace(Regex("[^a-zA-Z0-9_\\-]"), "_")
+        log.warn { "Guild ID '$id' contains unsafe characters; sanitized to '$sanitized'. Potential file-path collision risk." }
+        return sanitized
+    }
 
     private fun readDto(path: Path): GuildDto? {
         if (!path.exists()) return null

--- a/src/main/resources/db/migration/V27__add_auth_token_hash_index.sql
+++ b/src/main/resources/db/migration/V27__add_auth_token_hash_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_players_auth_token_hash ON players (auth_token_hash);

--- a/src/test/kotlin/dev/ambon/engine/ShutdownCleanupTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/ShutdownCleanupTest.kt
@@ -246,8 +246,9 @@ class ShutdownCleanupTest {
         assertEquals(1, repo.dirtyCount())
 
         // Flush all (as shutdown does)
-        val flushed = repo.flushAll()
-        assertEquals(1, flushed)
+        val result = repo.flushAll()
+        assertEquals(1, result.flushed)
+        assertEquals(0, result.failed)
 
         // The final state should be the one persisted
         val persisted = delegate.findById(record.id)!!

--- a/src/test/kotlin/dev/ambon/persistence/WriteCoalescingPlayerRepositoryTest.kt
+++ b/src/test/kotlin/dev/ambon/persistence/WriteCoalescingPlayerRepositoryTest.kt
@@ -48,8 +48,9 @@ class WriteCoalescingPlayerRepositoryTest {
             val updated = record.copy(roomId = RoomId("zone:room2"))
             repo.save(updated)
 
-            val flushed = repo.flushDirty()
-            assertEquals(1, flushed)
+            val result = repo.flushDirty()
+            assertEquals(1, result.flushed)
+            assertEquals(0, result.failed)
             assertEquals(0, repo.dirtyCount())
 
             val fromDelegate = delegate.findById(record.id)
@@ -178,7 +179,7 @@ class WriteCoalescingPlayerRepositoryTest {
             val delegate = InMemoryPlayerRepository()
             val repo = WriteCoalescingPlayerRepository(delegate)
 
-            assertEquals(0, repo.flushDirty())
+            assertEquals(FlushResult(flushed = 0, failed = 0), repo.flushDirty())
         }
 
     @Test
@@ -190,8 +191,9 @@ class WriteCoalescingPlayerRepositoryTest {
             val record = delegate.create(PlayerCreationRequest("Eve", startRoom, 1000L, "hash", false))
             repo.save(record.copy(roomId = RoomId("zone:new")))
 
-            val flushed = repo.flushAll()
-            assertEquals(1, flushed)
+            val result = repo.flushAll()
+            assertEquals(1, result.flushed)
+            assertEquals(0, result.failed)
             assertEquals(0, repo.dirtyCount())
         }
 


### PR DESCRIPTION
## Summary
- **Flyway V27 migration:** Adds index on `auth_token_hash` column to eliminate full table scans during token-based login
- **Stat key normalization:** `migrateDefaults()` now normalizes `stats` keys to uppercase (canonical format), `factionStandings`/`craftingSkills`/`equippedItems` keys to lowercase, and coerces all stat values to at least 1 to prevent division-by-zero
- **FlushResult data class:** `flushDirty()`/`flushAll()` now return `FlushResult(flushed, failed)` instead of bare `Int`, with WARN/ERROR-level logging in `PersistenceWorker` when failures occur
- **Guild ID safety:** `YamlGuildRepository.sanitizeId()` now logs a warning when an ID requires character replacement, flagging potential file-path collision risk

## Test plan
- [x] All existing persistence tests pass (`WriteCoalescingPlayerRepositoryTest`, `PersistenceWorkerTest`, `ShutdownCleanupTest`, `PersistenceFieldCoverageTest`)
- [x] `ktlintCheck` passes
- [x] Full test suite passes
- [ ] Verify V27 migration runs cleanly on a fresh Postgres database
- [ ] Verify legacy saves with mixed-case stat keys load correctly