### PR TITLE
Fix protocol and engine performance issues

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -1301,8 +1301,12 @@ class GameEngine(
                         )
                     }
 
+                    // Snapshot all players once for the remainder of this tick to avoid
+                    // repeated list copies in weather / event / broadcast phases.
+                    val allPlayersSnapshot = players.allPlayers()
+
                     // Tick weather — broadcast zone changes
-                    val activeZones = players.allPlayers().map { it.roomId.zone }.toSet()
+                    val activeZones = allPlayersSnapshot.map { it.roomId.zone }.toSet()
                     val weatherChanges = weatherSystem.tick(activeZones)
                     for ((zone, weather) in weatherChanges) {
                         for (p in players.playersInZone(zone)) {
@@ -1323,7 +1327,7 @@ class GameEngine(
                         for (id in eventResult.activated) {
                             val def = engineConfig.worldEvents.definitions[id] ?: continue
                             if (def.startMessage.isNotEmpty()) {
-                                for (p in players.allPlayers()) {
+                                for (p in allPlayersSnapshot) {
                                     outbound.send(OutboundEvent.SendInfo(p.sessionId, "[Event] ${def.startMessage}"))
                                 }
                             }
@@ -1331,7 +1335,7 @@ class GameEngine(
                         for (id in eventResult.deactivated) {
                             val def = engineConfig.worldEvents.definitions[id] ?: continue
                             if (def.endMessage.isNotEmpty()) {
-                                for (p in players.allPlayers()) {
+                                for (p in allPlayersSnapshot) {
                                     outbound.send(OutboundEvent.SendInfo(p.sessionId, "[Event] ${def.endMessage}"))
                                 }
                             }

--- a/src/main/kotlin/dev/ambon/gateway/SessionRouter.kt
+++ b/src/main/kotlin/dev/ambon/gateway/SessionRouter.kt
@@ -94,7 +94,7 @@ class SessionRouter(
             }
         }
         // Fallback: round-robin
-        val idx = roundRobinIndex.getAndIncrement() % orderedEngineIds.size
+        val idx = Math.floorMod(roundRobinIndex.getAndIncrement(), orderedEngineIds.size)
         val engineId = orderedEngineIds[idx]
         sessionToEngine[sessionId] = engineId
         log.debug { "Assigned session $sessionId to engine $engineId (round-robin)" }
@@ -151,9 +151,13 @@ class SessionRouter(
                 channel.send(proto)
             }
         } catch (e: TimeoutCancellationException) {
-            log.warn { "Engine $engineId gRPC channel unresponsive for ${GrpcTimeouts.FORWARD_SEND_TIMEOUT_MS}ms" }
+            log.warn {
+                "Engine $engineId gRPC channel unresponsive for ${GrpcTimeouts.FORWARD_SEND_TIMEOUT_MS}ms; " +
+                    "dropping ${event::class.simpleName} for session $sessionId"
+            }
             throw IllegalStateException(
-                "Engine $engineId gRPC channel did not accept event within ${GrpcTimeouts.FORWARD_SEND_TIMEOUT_MS}ms",
+                "Engine $engineId gRPC channel did not accept ${event::class.simpleName} " +
+                    "for session $sessionId within ${GrpcTimeouts.FORWARD_SEND_TIMEOUT_MS}ms",
                 e,
             )
         }
@@ -184,7 +188,11 @@ class SessionRouter(
 
         val result = channel.trySend(event.toProto())
         if (result.isFailure) {
-            log.warn { "Engine $engineId gRPC channel full or closed; dropping ${event::class.simpleName}" }
+            val reason = if (result.isClosed) "closed" else "full"
+            log.warn {
+                "Engine $engineId gRPC channel $reason; dropping ${event::class.simpleName} " +
+                    "for session $sessionId"
+            }
         }
 
         if (result.isSuccess && event is InboundEvent.Disconnected) {

--- a/src/main/kotlin/dev/ambon/grpc/GrpcOutboundDispatcher.kt
+++ b/src/main/kotlin/dev/ambon/grpc/GrpcOutboundDispatcher.kt
@@ -7,6 +7,8 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 
 private val log = KotlinLogging.logger {}
 
@@ -43,8 +45,25 @@ class GrpcOutboundDispatcher(
     }
 
     fun stop() {
+        // Drain remaining events before cancelling, so goodbye messages reach players.
+        runBlocking {
+            var drained = 0
+            withTimeoutOrNull(DRAIN_TIMEOUT_MS) {
+                while (true) {
+                    val event = outbound.asReceiveChannel().tryReceive().getOrNull() ?: break
+                    dispatch(event)
+                    drained++
+                }
+            }
+            if (drained > 0) log.info { "Drained $drained remaining outbound events before shutdown" }
+        }
         cancelJobWithTimeout(job, GrpcTimeouts.STOP_TIMEOUT_MS, "GrpcOutboundDispatcher job")
         log.info { "GrpcOutboundDispatcher stopped" }
+    }
+
+    companion object {
+        /** Maximum time to spend draining remaining events during shutdown. */
+        const val DRAIN_TIMEOUT_MS = 2_000L
     }
 
     private suspend fun dispatch(event: OutboundEvent) {

--- a/src/main/kotlin/dev/ambon/grpc/ProtoMapper.kt
+++ b/src/main/kotlin/dev/ambon/grpc/ProtoMapper.kt
@@ -20,6 +20,9 @@ import dev.ambon.grpc.proto.SessionRedirectProto
 import dev.ambon.grpc.proto.SetAnsiProto
 import dev.ambon.grpc.proto.ShowAnsiDemoProto
 import dev.ambon.grpc.proto.ShowLoginScreenProto
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val log = KotlinLogging.logger {}
 
 /** Converts domain [InboundEvent] to [InboundEventProto]. */
 fun InboundEvent.toProto(): InboundEventProto =
@@ -55,7 +58,10 @@ fun InboundEventProto.toDomain(): InboundEvent? {
                 gmcpPackage = gmcpReceived.gmcpPackage,
                 jsonData = gmcpReceived.jsonData,
             )
-        else -> null
+        else -> {
+            log.warn { "Unknown inbound event case: $eventCase (sessionId=$sessionId)" }
+            null
+        }
     }
 }
 
@@ -111,7 +117,10 @@ fun OutboundEventProto.toDomain(): OutboundEvent? {
                 gmcpPackage = gmcpData.gmcpPackage,
                 jsonData = gmcpData.jsonData,
             )
-        else -> null
+        else -> {
+            log.warn { "Unknown outbound event case: $eventCase (sessionId=$sessionId)" }
+            null
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- **ProtoMapper**: Add WARN-level logging for unknown inbound/outbound proto event cases instead of silently returning null, improving debuggability of version mismatches between engine and gateway
- **GrpcOutboundDispatcher**: Drain pending outbound events (2s timeout) before cancelling the dispatch job on shutdown, so goodbye/close messages reach players instead of being lost
- **GameEngine**: Cache `allPlayers()` snapshot once per tick and reuse it across weather, world event, and broadcast phases to eliminate repeated list copies (3 calls per tick reduced to 1)
- **SessionRouter**: Use `Math.floorMod()` for round-robin index to prevent negative array index after `AtomicInteger` overflow at 2^31 sessions
- **SessionRouter**: Improve failure logging to distinguish channel-full from channel-closed, and include event type and session ID in timeout/failure messages

## Test plan

- [x] `./gradlew.bat ktlintCheck` passes
- [x] `./gradlew.bat test` passes (all existing tests)
- [ ] Verify ProtoMapper logging by inspecting logs during gateway-engine version mismatch scenarios
- [ ] Verify GrpcOutboundDispatcher drain by checking that shutdown messages are delivered before disconnect
- [ ] Verify no behavioral regression in weather/event broadcasts under normal gameplay