### PR TITLE
Add JaCoCo coverage, CI artifact uploads, and security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,20 @@ jobs:
       - run: chmod +x ./gradlew
       - run: ./gradlew ktlintCheck test integrationTest
 
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: build/test-results/
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: build/reports/jacoco/
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,8 +29,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: java-kotlin
-          # Queries: use the default set; add extras below if desired.
-          # queries: security-extended
+          queries: security-and-quality
 
       - name: Build (custom — required for JVM languages)
         run: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import java.time.Duration
 plugins {
     kotlin("jvm") version "2.3.10"
     application
+    jacoco
     id("org.jlleitschuh.gradle.ktlint") version "14.2.0"
     id("com.google.protobuf") version "0.9.6"
     id("com.gradleup.shadow") version "9.4.1"
@@ -99,6 +100,15 @@ tasks.test {
     // leaks or gRPC streams that never close). Individual test timeouts are configured
     // in junit-platform.properties; this is a backstop for the Gradle process itself.
     timeout = Duration.ofMinutes(5)
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
 }
 
 val integrationTest by tasks.registering(Test::class) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     environment:
       POSTGRES_DB: ambonmud
       POSTGRES_USER: ambon
-      POSTGRES_PASSWORD: ambon
+      POSTGRES_PASSWORD: changeme
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -454,6 +454,10 @@ data class AppConfig(
             }
         }
 
+        if ("*" in admin.corsOrigins) {
+            warnConfig("admin.corsOrigins contains wildcard '*' — this allows any origin and should not be used in production")
+        }
+
         return this
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -110,7 +110,7 @@ ambonmud:
   database:
     jdbcUrl: "jdbc:postgresql://localhost:5432/ambonmud"
     username: ambon
-    password: ambon
+    password: changeme  # Override via AMBONMUD_DATABASE_PASSWORD env var in production
     maxPoolSize: 5
     minimumIdle: 1
 


### PR DESCRIPTION
## Summary

- **JaCoCo code coverage**: Added the JaCoCo plugin to `build.gradle.kts`, configured to generate XML and HTML reports after the test task runs
- **CI artifact uploads**: Test results and JaCoCo coverage reports are now uploaded as GitHub Actions artifacts (available even when tests fail, via `if: always()`)
- **CodeQL security-and-quality**: Upgraded CodeQL analysis from default queries to the `security-and-quality` suite for broader vulnerability and code quality detection
- **Default database password**: Replaced the hardcoded `ambon` password in `application.yaml` and `docker-compose.yml` with `changeme` placeholder to avoid shipping a real credential in source control
- **CORS wildcard warning**: Added a startup config warning when `admin.corsOrigins` contains `"*"`, which would allow any origin in production

## Test plan

- [x] `ktlintCheck` passes
- [x] Full test suite passes (1485 tests, 0 failures)
- [x] JaCoCo report generates successfully after test run
- [ ] Verify CI workflow uploads artifacts after merge
- [ ] Verify CodeQL runs with extended queries on next main push