### PR TITLE
Fix game system edge cases found in pre-release review

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -216,7 +216,7 @@ data class AppConfig(
             if (def.effectType.isBlank()) warnConfig("statusEffect '$key' effectType is blank")
             if (def.durationMs <= 0L) warnConfig("statusEffect '$key' durationMs is ${def.durationMs}, expected > 0")
             if (def.tickIntervalMs < 0L) warnConfig("statusEffect '$key' tickIntervalMs is ${def.tickIntervalMs}, expected >= 0")
-            if (def.maxStacks < 1) warnConfig("statusEffect '$key' maxStacks is ${def.maxStacks}, expected >= 1")
+            require(def.maxStacks >= 1) { "statusEffect '$key' maxStacks is ${def.maxStacks}, must be >= 1" }
         }
 
         require(progression.maxLevel > 0) { "ambonMUD.progression.maxLevel must be > 0" }

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -1907,6 +1907,11 @@ class GameEngine(
         sessionId: SessionId,
         templateKey: String,
     ) {
+        // Skip quest/achievement callbacks for dead players (HP <= 0) — they may have
+        // died in the same tick from a different mob.  Rewards should not fire posthumously.
+        val player = players.get(sessionId)
+        if (player == null || player.hp <= 0) return
+
         questSystem.onMobKilled(sessionId, templateKey)
         achievementSystem.onMobKilled(sessionId, templateKey)
 

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
@@ -390,8 +390,15 @@ class AdminHandler(
         val mob = mobs.get(mobId)
         if (mob == null) {
             me.possessedMobId = null
+            val returnRoom = me.prePossessRoomId ?: me.roomId
             me.prePossessRoomId = null
-            outbound.send(OutboundEvent.SendError(sessionId, "The mob you were possessing no longer exists."))
+            setInvisible(sessionId, me, false)
+            gmcpEmitter?.sendStaffPossessionState(sessionId, false, null)
+            if (me.roomId != returnRoom) {
+                players.moveTo(sessionId, returnRoom)
+                ctx.sendLook(sessionId)
+            }
+            outbound.send(OutboundEvent.SendError(sessionId, "The mob you were possessing no longer exists. Returning to your body."))
             outbound.send(OutboundEvent.SendPrompt(sessionId))
             return
         }

--- a/src/main/kotlin/dev/ambon/engine/dungeon/DungeonManager.kt
+++ b/src/main/kotlin/dev/ambon/engine/dungeon/DungeonManager.kt
@@ -101,8 +101,15 @@ class DungeonManager(
             playerInstances[sid] = instanceId
         }
 
-        // Spawn mobs
-        spawnDungeonMobs(instance)
+        // Spawn mobs — if this fails, clean up the partially-created instance
+        // (rooms already added to the World, player mappings already registered).
+        try {
+            spawnDungeonMobs(instance)
+        } catch (e: Exception) {
+            log.error(e) { "Failed to spawn mobs for dungeon instance $instanceId, cleaning up" }
+            destroyInstance(instanceId)
+            throw e
+        }
 
         log.info { "Dungeon instance created: id=$instanceId template=${template.name} difficulty=$difficulty rooms=${layout.rooms.size}" }
         return instance

--- a/src/main/kotlin/dev/ambon/engine/status/StatusEffectSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/status/StatusEffectSystem.kt
@@ -70,6 +70,7 @@ class StatusEffectSystem(
         sourceSessionId: SessionId?,
     ): Boolean {
         val existing = list.filter { it.definitionId == def.id }
+        val effectiveMaxStacks = def.maxStacks.coerceAtLeast(1)
         when (def.stackBehavior) {
             "refresh" -> {
                 val active = existing.firstOrNull()
@@ -80,7 +81,7 @@ class StatusEffectSystem(
                 }
             }
             "stack" -> {
-                if (existing.size >= def.maxStacks) {
+                if (existing.size >= effectiveMaxStacks) {
                     // Refresh the oldest stack's duration instead of adding a new one
                     val oldest = existing.minByOrNull { it.appliedAtMs }
                     oldest?.expiresAtMs = now + def.durationMs


### PR DESCRIPTION
## Summary

- **Status effect stacking (maxStacks=0):** `StatusEffectSystem.applyEffect` now defensively clamps `maxStacks` to at least 1, preventing infinite stacking when `maxStacks <= 0`. The config validation in `AppConfig.validated()` is upgraded from a soft warning to a hard `require()`, matching the same pattern used for other critical config fields.
- **Quest/achievement callbacks during death:** `GameEngine.onCombatMobKilledByPlayer` now skips quest, achievement, and faction callbacks when the contributing player has HP <= 0, preventing posthumous reward grants when a player dies in the same tick.
- **Dungeon instance cleanup on failure:** `DungeonManager.createInstance` wraps mob spawning in try-catch. On failure, the partially-created instance (rooms already added to the World, player mappings registered) is torn down via `destroyInstance` before re-throwing.
- **Admin possess mob despawn handling:** `AdminHandler.handlePossessedCommand` now fully cleans up possession state when the possessed mob has despawned — restoring visibility, resetting GMCP possession state, and teleporting the admin back to their pre-possession room. Previously only cleared internal state without the UI/transport cleanup that `handleReturn` performs.

## Test plan

- [x] `./gradlew ktlintCheck` passes
- [x] `./gradlew test` passes (all existing tests)
- [ ] Verify status effect with `maxStacks=0` config fails validation at startup
- [ ] Verify player death during mob kill tick does not trigger quest completion
- [ ] Verify dungeon with invalid mob template cleans up rooms on failure
- [ ] Verify possessed mob despawn returns admin to visible state at original room