### PR TITLE
Standardize error messages, extend dialogue choices, harden admin API

### DIFF
--- a/src/main/kotlin/dev/ambon/admin/AdminHttpServer.kt
+++ b/src/main/kotlin/dev/ambon/admin/AdminHttpServer.kt
@@ -48,6 +48,8 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 import java.security.MessageDigest
 import java.util.Base64
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 
 private val log = KotlinLogging.logger {}
 
@@ -345,6 +347,25 @@ internal fun Application.adminModule(
     startTime: Long = System.currentTimeMillis(),
     basePath: String = "/",
 ) {
+    // Guard: prevents concurrent hot-reload operations
+    val reloadInProgress = AtomicBoolean(false)
+
+    // Simple rate limiter: tracks last execution time per operation type.
+    // Uses System.currentTimeMillis() since this is admin HTTP code, not engine code.
+    val rateLimitTimestamps = ConcurrentHashMap<String, Long>()
+
+    /**
+     * Returns true if the operation should be rejected due to rate limiting.
+     * [operationKey] identifies the operation type, [cooldownMs] is the minimum interval.
+     */
+    fun isRateLimited(operationKey: String, cooldownMs: Long): Boolean {
+        val now = System.currentTimeMillis()
+        val last = rateLimitTimestamps[operationKey]
+        if (last != null && (now - last) < cooldownMs) return true
+        rateLimitTimestamps[operationKey] = now
+        return false
+    }
+
     routing {
         intercept(ApplicationCallPipeline.Plugins) {
             // CORS preflight requests skip auth
@@ -709,21 +730,35 @@ internal fun Application.adminModule(
         }
 
         // ── Hot Reload API ─────────────────────────────────────────────────
+        // Reloads world definitions, ability definitions, and/or status-effect definitions
+        // from their source YAML/config. The reload is NOT atomic across subsystems: if the
+        // abilities reload succeeds but the world reload fails, the engine may be left with
+        // a partially updated state. On failure, the previously loaded state for that
+        // subsystem remains intact (each subsystem reload is individually atomic). A
+        // concurrent-reload guard prevents overlapping reloads.
         post("/api/reload") {
             if (onReload == null) {
                 call.respondJsonError(HttpStatusCode.NotImplemented, "Hot reload not configured")
                 return@post
             }
-            val target = call.request.queryParameters["target"] // world, abilities, effects, all
-            val validTargets = setOf("world", "abilities", "effects", "all")
-            if (target != null && target !in validTargets) {
-                call.respondJsonError(
-                    HttpStatusCode.BadRequest,
-                    "Invalid target. Use: ${validTargets.joinToString(", ")}",
-                )
+            if (isRateLimited("reload", 30_000L)) {
+                call.respondJsonError(HttpStatusCode.TooManyRequests, "Reload rate limited (max 1 per 30 seconds)")
+                return@post
+            }
+            if (!reloadInProgress.compareAndSet(false, true)) {
+                call.respondJsonError(HttpStatusCode.Conflict, "Reload already in progress")
                 return@post
             }
             try {
+                val target = call.request.queryParameters["target"] // world, abilities, effects, all
+                val validTargets = setOf("world", "abilities", "effects", "all")
+                if (target != null && target !in validTargets) {
+                    call.respondJsonError(
+                        HttpStatusCode.BadRequest,
+                        "Invalid target. Use: ${validTargets.joinToString(", ")}",
+                    )
+                    return@post
+                }
                 val summary = onReload.invoke(target)
                 call.respondText(
                     json.writeValueAsString(mapOf("status" to "ok", "summary" to summary)),
@@ -736,6 +771,8 @@ internal fun Application.adminModule(
                     ContentType.Application.Json,
                     HttpStatusCode.InternalServerError,
                 )
+            } finally {
+                reloadInProgress.set(false)
             }
         }
 
@@ -781,6 +818,10 @@ internal fun Application.adminModule(
 
         // ── Staff toggle (JSON) ─────────────────────────────────────────────
         post("/api/players/{name}/staff") {
+            if (isRateLimited("staff_toggle", 5_000L)) {
+                call.respondJsonError(HttpStatusCode.TooManyRequests, "Staff toggle rate limited (max 1 per 5 seconds)")
+                return@post
+            }
             val name = call.parameters["name"] ?: return@post call.respond(HttpStatusCode.BadRequest)
             val record = playerRepo.findByName(name)
             if (record == null) {
@@ -1106,6 +1147,10 @@ internal fun Application.adminModule(
 
         // ── Broadcast ───────────────────────────────────────────────────────
         post("/api/broadcast") {
+            if (isRateLimited("broadcast", 10_000L)) {
+                call.respondJsonError(HttpStatusCode.TooManyRequests, "Broadcast rate limited (max 1 per 10 seconds)")
+                return@post
+            }
             if (onBroadcast == null) {
                 call.respondJsonError(HttpStatusCode.NotImplemented, "Broadcast not configured")
                 return@post

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -1222,7 +1222,7 @@ object CommandParser {
 
         // Bare number → dialogue choice (CommandRouter decides if applicable)
         lower.toIntOrNull()?.let { n ->
-            if (n in 1..9) return Command.DialogueChoice(n)
+            if (n in 1..99) return Command.DialogueChoice(n)
         }
 
         return when (lower) {

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
@@ -503,12 +503,12 @@ class AdminHandler(
         }
         val to = room.exits[cmd.dir]
         if (to == null) {
-            outbound.send(OutboundEvent.SendText(sessionId, "You can't go that way."))
+            outbound.send(OutboundEvent.SendError(sessionId, "You can't go that way."))
             outbound.send(OutboundEvent.SendPrompt(sessionId))
             return
         }
         if (!world.rooms.containsKey(to)) {
-            outbound.send(OutboundEvent.SendText(sessionId, "That exit leads to an unloaded zone."))
+            outbound.send(OutboundEvent.SendError(sessionId, "That exit leads to an unloaded zone."))
             outbound.send(OutboundEvent.SendPrompt(sessionId))
             return
         }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/BankHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/BankHandler.kt
@@ -30,7 +30,7 @@ class BankHandler(
     private suspend fun requireBank(sessionId: SessionId, me: dev.ambon.engine.PlayerState): Boolean {
         val room = world.rooms[me.roomId]
         if (room == null || !room.bank) {
-            outbound.send(OutboundEvent.SendText(sessionId, "You need to be at a bank to do that."))
+            outbound.send(OutboundEvent.SendError(sessionId, "You need to be at a bank to do that."))
             return false
         }
         return true
@@ -42,11 +42,11 @@ class BankHandler(
 
         val amount = if (cmd.amount == Long.MAX_VALUE) me.gold else cmd.amount
         if (amount <= 0) {
-            outbound.send(OutboundEvent.SendText(sessionId, "Deposit how much?"))
+            outbound.send(OutboundEvent.SendError(sessionId, "Deposit how much?"))
             return
         }
         if (me.gold < amount) {
-            outbound.send(OutboundEvent.SendText(sessionId, "You only have ${me.gold} gold."))
+            outbound.send(OutboundEvent.SendError(sessionId, "You only have ${me.gold} gold."))
             return
         }
         me.gold -= amount
@@ -62,11 +62,11 @@ class BankHandler(
 
         val amount = if (cmd.amount == Long.MAX_VALUE) me.bankGold else cmd.amount
         if (amount <= 0) {
-            outbound.send(OutboundEvent.SendText(sessionId, "Withdraw how much?"))
+            outbound.send(OutboundEvent.SendError(sessionId, "Withdraw how much?"))
             return
         }
         if (me.bankGold < amount) {
-            outbound.send(OutboundEvent.SendText(sessionId, "Your bank only has ${me.bankGold} gold."))
+            outbound.send(OutboundEvent.SendError(sessionId, "Your bank only has ${me.bankGold} gold."))
             return
         }
         me.bankGold -= amount
@@ -81,13 +81,13 @@ class BankHandler(
         if (!requireBank(sessionId, me)) return
 
         if (me.bankItems.size >= bankConfig.maxItems) {
-            outbound.send(OutboundEvent.SendText(sessionId, "Your bank vault is full (${bankConfig.maxItems} items)."))
+            outbound.send(OutboundEvent.SendError(sessionId, "Your bank vault is full (${bankConfig.maxItems} items)."))
             return
         }
 
         val removed = items.removeFromInventory(sessionId, cmd.keyword)
         if (removed == null) {
-            outbound.send(OutboundEvent.SendText(sessionId, "You don't have '${cmd.keyword}'."))
+            outbound.send(OutboundEvent.SendError(sessionId, "You don't have '${cmd.keyword}'."))
             return
         }
 
@@ -106,7 +106,7 @@ class BankHandler(
                 (cmd.keyword.length >= 3 && it.item.displayName.contains(cmd.keyword, ignoreCase = true))
         }
         if (idx < 0) {
-            outbound.send(OutboundEvent.SendText(sessionId, "Your bank vault doesn't contain '${cmd.keyword}'."))
+            outbound.send(OutboundEvent.SendError(sessionId, "Your bank vault doesn't contain '${cmd.keyword}'."))
             return
         }
 

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/CraftingHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/CraftingHandler.kt
@@ -48,20 +48,20 @@ class CraftingHandler(
             when (result) {
                 is Either.Left -> when (val err = result.value) {
                     is GatherError.NoNodeFound -> outbound.send(
-                        OutboundEvent.SendText(
+                        OutboundEvent.SendError(
                             sessionId,
                             "There is nothing to gather here matching '${cmd.keyword}'.",
                         ),
                     )
                     is GatherError.SkillTooLow -> sendSkillTooLow(sessionId, err.required, err.current)
                     is GatherError.NodeDepleted -> outbound.send(
-                        OutboundEvent.SendText(
+                        OutboundEvent.SendError(
                             sessionId,
                             "That resource is depleted. It will respawn in ${err.respawnInSeconds}s.",
                         ),
                     )
                     is GatherError.OnCooldown ->
-                        outbound.send(OutboundEvent.SendText(sessionId, "You must wait before gathering again."))
+                        outbound.send(OutboundEvent.SendError(sessionId, "You must wait before gathering again."))
                 }
                 is Either.Right -> {
                     val r = result.value
@@ -115,30 +115,30 @@ class CraftingHandler(
             when (result) {
                 is Either.Left -> when (val err = result.value) {
                     is CraftError.RecipeNotFound -> outbound.send(
-                        OutboundEvent.SendText(
+                        OutboundEvent.SendError(
                             sessionId,
                             "Unknown recipe '${cmd.recipeKeyword}'. Type 'recipes' to see available recipes.",
                         ),
                     )
                     is CraftError.NotDiscovered -> outbound.send(
-                        OutboundEvent.SendText(
+                        OutboundEvent.SendError(
                             sessionId,
                             "You haven't discovered that recipe yet. Keep leveling your skills!",
                         ),
                     )
                     is CraftError.SkillTooLow -> sendSkillTooLow(sessionId, err.required, err.current)
                     is CraftError.LevelTooLow -> outbound.send(
-                        OutboundEvent.SendText(
+                        OutboundEvent.SendError(
                             sessionId,
                             "You need to be level ${err.required} to craft this (you are level ${err.current}).",
                         ),
                     )
                     is CraftError.MissingMaterials -> {
-                        outbound.send(OutboundEvent.SendText(sessionId, "You are missing materials:"))
+                        outbound.send(OutboundEvent.SendError(sessionId, "You are missing materials:"))
                         for ((itemId, qty) in err.missing) {
                             val template = items.getTemplate(itemId)
                             val name = template?.displayName ?: itemId.value
-                            outbound.send(OutboundEvent.SendText(sessionId, "  - $name x$qty"))
+                            outbound.send(OutboundEvent.SendError(sessionId, "  - $name x$qty"))
                         }
                     }
                 }
@@ -353,13 +353,13 @@ class CraftingHandler(
             val skillId = cmd.skill.lowercase()
             val skillDef = craftingSkillRegistry?.get(skillId)
             if (skillDef == null) {
-                outbound.send(OutboundEvent.SendText(sessionId, "Unknown crafting skill '${cmd.skill}'."))
+                outbound.send(OutboundEvent.SendError(sessionId, "Unknown crafting skill '${cmd.skill}'."))
                 return
             }
 
             if (me.craftingSpecialization == skillId) {
                 outbound.send(
-                    OutboundEvent.SendText(sessionId, "You are already specialized in ${skillDef.displayName}."),
+                    OutboundEvent.SendError(sessionId, "You are already specialized in ${skillDef.displayName}."),
                 )
                 return
             }
@@ -386,7 +386,7 @@ class CraftingHandler(
     }
 
     private suspend fun sendSkillTooLow(sessionId: SessionId, required: Int, current: Int) {
-        outbound.send(OutboundEvent.SendText(sessionId, "Your skill is too low (need $required, have $current)."))
+        outbound.send(OutboundEvent.SendError(sessionId, "Your skill is too low (need $required, have $current)."))
     }
 
     private suspend fun sendCraftingXp(

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestHandler.kt
@@ -90,7 +90,7 @@ class DialogueQuestHandler(
         cmd: Command.DialogueChoice,
     ) {
         if (dialogueSystem?.isInConversation(sessionId) != true) {
-            outbound.send(OutboundEvent.SendText(sessionId, "Huh?"))
+            outbound.send(OutboundEvent.SendError(sessionId, "Huh?"))
             return
         }
         when (val outcome = dialogueSystem.selectChoice(sessionId, cmd.optionNumber)) {

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/DungeonHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/DungeonHandler.kt
@@ -44,7 +44,7 @@ class DungeonHandler(
             // Find the template
             val template = reg.findByKeyword(cmd.templateKeyword)
             if (template == null) {
-                outbound.send(OutboundEvent.SendText(sessionId, "Unknown dungeon '${cmd.templateKeyword}'."))
+                outbound.send(OutboundEvent.SendError(sessionId, "Unknown dungeon '${cmd.templateKeyword}'."))
                 return
             }
 
@@ -53,7 +53,7 @@ class DungeonHandler(
                 DungeonDifficulty.fromName(cmd.difficulty)
                     ?: run {
                         val valid = DungeonDifficulty.entries.joinToString(", ") { it.displayName.lowercase() }
-                        outbound.send(OutboundEvent.SendText(sessionId, "Unknown difficulty '${cmd.difficulty}'. Options: $valid"))
+                        outbound.send(OutboundEvent.SendError(sessionId, "Unknown difficulty '${cmd.difficulty}'. Options: $valid"))
                         return
                     }
             } else {
@@ -71,7 +71,7 @@ class DungeonHandler(
                 val member = players.get(sid) ?: continue
                 if (member.level < template.minLevel) {
                     outbound.send(
-                        OutboundEvent.SendText(
+                        OutboundEvent.SendError(
                             sessionId,
                             "${member.name} is level ${member.level} but this dungeon requires level ${template.minLevel}.",
                         ),
@@ -122,7 +122,7 @@ class DungeonHandler(
         players.withPlayer(sessionId) { me ->
             val returnRoom = dm.removePlayer(sessionId)
             if (returnRoom == null) {
-                outbound.send(OutboundEvent.SendText(sessionId, "You are not in a dungeon."))
+                outbound.send(OutboundEvent.SendError(sessionId, "You are not in a dungeon."))
                 return
             }
             outbound.send(OutboundEvent.SendInfo(sessionId, "You leave the dungeon."))
@@ -132,6 +132,6 @@ class DungeonHandler(
     }
 
     private suspend fun sendUnavailable(sessionId: SessionId) {
-        outbound.send(OutboundEvent.SendText(sessionId, "Dungeons are not available."))
+        outbound.send(OutboundEvent.SendError(sessionId, "Dungeons are not available."))
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/EnchantHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/EnchantHandler.kt
@@ -54,39 +54,39 @@ class EnchantHandler(
                 )
             }
             is EnchantResult.ItemNotFound ->
-                outbound.send(OutboundEvent.SendText(sessionId, "You don't have that item."))
+                outbound.send(OutboundEvent.SendError(sessionId, "You don't have that item."))
             is EnchantResult.NotEquippable ->
-                outbound.send(OutboundEvent.SendText(sessionId, "You can only enchant equipment."))
+                outbound.send(OutboundEvent.SendError(sessionId, "You can only enchant equipment."))
             is EnchantResult.AlreadyEnchanted ->
-                outbound.send(OutboundEvent.SendText(sessionId, "That item already has the maximum number of enchantments."))
+                outbound.send(OutboundEvent.SendError(sessionId, "That item already has the maximum number of enchantments."))
             is EnchantResult.EnchantmentNotFound ->
-                outbound.send(OutboundEvent.SendText(sessionId, "Unknown enchantment. Use 'enchantments' to list available."))
+                outbound.send(OutboundEvent.SendError(sessionId, "Unknown enchantment. Use 'enchantments' to list available."))
             is EnchantResult.NoEnchantmentAvailable ->
                 outbound.send(
-                    OutboundEvent.SendText(
+                    OutboundEvent.SendError(
                         sessionId,
                         "No enchantments available for that item with your current skill and materials.",
                     ),
                 )
             is EnchantResult.AlreadyHasEnchantment ->
-                outbound.send(OutboundEvent.SendText(sessionId, "That item already has ${result.name}."))
+                outbound.send(OutboundEvent.SendError(sessionId, "That item already has ${result.name}."))
             is EnchantResult.WrongSlot ->
                 outbound.send(
-                    OutboundEvent.SendText(
+                    OutboundEvent.SendError(
                         sessionId,
                         "${result.enchantName} can only be applied to: ${result.validSlots.joinToString(", ")}.",
                     ),
                 )
             is EnchantResult.SkillTooLow ->
                 outbound.send(
-                    OutboundEvent.SendText(
+                    OutboundEvent.SendError(
                         sessionId,
                         "You need ${result.skill} level ${result.required} (you have ${result.current}).",
                     ),
                 )
             is EnchantResult.MissingMaterials ->
                 outbound.send(
-                    OutboundEvent.SendText(
+                    OutboundEvent.SendError(
                         sessionId,
                         "You need: ${result.missing.joinToString(", ")}.",
                     ),

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
@@ -55,11 +55,11 @@ class NavigationHandler(
         cmd: Command.Move,
     ) {
         if (combat.isInCombat(sessionId)) {
-            outbound.send(OutboundEvent.SendText(sessionId, "You are in combat. Try 'flee'."))
+            outbound.send(OutboundEvent.SendError(sessionId, "You are in combat. Try 'flee'."))
             return
         }
         if (statusEffects?.hasPlayerEffect(sessionId, "root") == true) {
-            outbound.send(OutboundEvent.SendText(sessionId, "You are rooted and cannot move!"))
+            outbound.send(OutboundEvent.SendError(sessionId, "You are rooted and cannot move!"))
             return
         }
         players.withPlayer(sessionId) { me ->
@@ -68,7 +68,7 @@ class NavigationHandler(
             val to = room.exits[cmd.dir]
 
             if (to == null) {
-                outbound.send(OutboundEvent.SendText(sessionId, "You can't go that way."))
+                outbound.send(OutboundEvent.SendError(sessionId, "You can't go that way."))
                 return
             }
 
@@ -141,7 +141,7 @@ class NavigationHandler(
     private suspend fun handleRecall(sessionId: SessionId) {
         val msgs = recallConfig.messages
         if (combat.isInCombat(sessionId)) {
-            outbound.send(OutboundEvent.SendText(sessionId, msgs.combatBlocked))
+            outbound.send(OutboundEvent.SendError(sessionId, msgs.combatBlocked))
             return
         }
         val me = players.get(sessionId) ?: return

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/PetHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/PetHandler.kt
@@ -44,7 +44,7 @@ class PetHandler(
     private suspend fun handlePetDismiss(sessionId: SessionId) {
         val pet = petSystem.getActivePet(sessionId)
         if (pet == null) {
-            outbound.send(OutboundEvent.SendText(sessionId, "You have no active pet."))
+            outbound.send(OutboundEvent.SendError(sessionId, "You have no active pet."))
             return
         }
 
@@ -60,7 +60,7 @@ class PetHandler(
     private suspend fun handlePetName(sessionId: SessionId, cmd: Command.PetName) {
         val pet = petSystem.getActivePet(sessionId)
         if (pet == null) {
-            outbound.send(OutboundEvent.SendText(sessionId, "You have no active pet."))
+            outbound.send(OutboundEvent.SendError(sessionId, "You have no active pet."))
             return
         }
 

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ShopHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ShopHandler.kt
@@ -34,7 +34,7 @@ class ShopHandler(
     private suspend fun findShop(sessionId: SessionId, me: PlayerState, command: String? = null): ShopDefinition? {
         val shop = shopRegistry?.shopInRoom(me.roomId)
         if (shop == null) {
-            outbound.send(OutboundEvent.SendText(sessionId, "There is no shop here."))
+            outbound.send(OutboundEvent.SendError(sessionId, "There is no shop here."))
             gmcpEmitter?.sendUiFeedback(
                 sessionId,
                 "error",
@@ -82,7 +82,7 @@ class ShopHandler(
                 shopItems.firstOrNull { (_, item) -> item.matchesKeyword(cmd.keyword) }
             if (match == null) {
                 val msg = "The shop doesn't sell '${cmd.keyword}'."
-                outbound.send(OutboundEvent.SendText(sessionId, msg))
+                outbound.send(OutboundEvent.SendError(sessionId, msg))
                 gmcpEmitter?.sendUiFeedback(sessionId, "error", msg, code = "ITEM_NOT_FOUND", scope = "shop", command = "buy")
                 return
             }
@@ -90,14 +90,14 @@ class ShopHandler(
             val buyPrice = (item.basePrice * economyConfig.buyMultiplier).roundToInt().toLong()
             if (!me.isStaff && me.gold < buyPrice) {
                 val msg = "You can't afford ${item.displayName} ($buyPrice gold)."
-                outbound.send(OutboundEvent.SendText(sessionId, msg))
+                outbound.send(OutboundEvent.SendError(sessionId, msg))
                 gmcpEmitter?.sendUiFeedback(sessionId, "error", msg, code = "INSUFFICIENT_GOLD", scope = "shop", command = "buy")
                 return
             }
             val newItem = items.createFromTemplate(itemId)
             if (newItem == null) {
                 val msg = "That item is out of stock."
-                outbound.send(OutboundEvent.SendText(sessionId, msg))
+                outbound.send(OutboundEvent.SendError(sessionId, msg))
                 gmcpEmitter?.sendUiFeedback(sessionId, "error", msg, code = "OUT_OF_STOCK", scope = "shop", command = "buy")
                 return
             }
@@ -120,17 +120,17 @@ class ShopHandler(
             val inv = items.inventory(sessionId)
             val invItem = inv.firstOrNull { it.matchesKeyword(keyword) }
             if (invItem == null) {
-                outbound.send(OutboundEvent.SendText(sessionId, "You don't have '$keyword'."))
+                outbound.send(OutboundEvent.SendError(sessionId, "You don't have '$keyword'."))
                 return
             }
             val sellPrice = (invItem.item.basePrice * economyConfig.sellMultiplier).roundToInt().toLong()
             if (sellPrice <= 0L) {
-                outbound.send(OutboundEvent.SendText(sessionId, "${invItem.item.displayName} is worthless."))
+                outbound.send(OutboundEvent.SendError(sessionId, "${invItem.item.displayName} is worthless."))
                 return
             }
             val removed = items.removeFromInventory(sessionId, invItem.item.keyword)
             if (removed == null) {
-                outbound.send(OutboundEvent.SendText(sessionId, "You don't have '$keyword'."))
+                outbound.send(OutboundEvent.SendError(sessionId, "You don't have '$keyword'."))
                 return
             }
             me.gold += sellPrice

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/TrainerHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/TrainerHandler.kt
@@ -34,7 +34,7 @@ class TrainerHandler(
         players.withPlayer(sessionId) { me ->
             val trainer = trainerRegistry.trainerInRoom(me.roomId)
             if (trainer == null) {
-                outbound.send(OutboundEvent.SendText(sessionId, "There is no trainer here."))
+                outbound.send(OutboundEvent.SendError(sessionId, "There is no trainer here."))
                 return
             }
             val available = abilitySystem.availableSkillPoints(
@@ -92,12 +92,12 @@ class TrainerHandler(
         players.withPlayer(sessionId) { me ->
             val trainer = trainerRegistry.trainerInRoom(me.roomId)
             if (trainer == null) {
-                outbound.send(OutboundEvent.SendText(sessionId, "There is no trainer here."))
+                outbound.send(OutboundEvent.SendError(sessionId, "There is no trainer here."))
                 return
             }
             if (!me.unlockedClasses.any { it.equals(trainer.className, ignoreCase = true) }) {
                 outbound.send(
-                    OutboundEvent.SendText(
+                    OutboundEvent.SendError(
                         sessionId,
                         "You must unlock the ${trainer.className} class first. Use 'train unlock'.",
                     ),
@@ -113,7 +113,7 @@ class TrainerHandler(
                     it.displayName.lowercase().contains(keyword.lowercase())
             }
             if (target == null) {
-                outbound.send(OutboundEvent.SendText(sessionId, "No trainable ability matching '$keyword' found here."))
+                outbound.send(OutboundEvent.SendError(sessionId, "No trainable ability matching '$keyword' found here."))
                 return
             }
 
@@ -125,7 +125,7 @@ class TrainerHandler(
                 skillPointInterval = skillPointsConfig.interval,
             )
             if (error != null) {
-                outbound.send(OutboundEvent.SendText(sessionId, error))
+                outbound.send(OutboundEvent.SendError(sessionId, error))
                 return
             }
 
@@ -158,18 +158,18 @@ class TrainerHandler(
         players.withPlayer(sessionId) { me ->
             val trainer = trainerRegistry.trainerInRoom(me.roomId)
             if (trainer == null) {
-                outbound.send(OutboundEvent.SendText(sessionId, "There is no trainer here."))
+                outbound.send(OutboundEvent.SendError(sessionId, "There is no trainer here."))
                 return
             }
             if (me.unlockedClasses.any { it.equals(trainer.className, ignoreCase = true) }) {
                 outbound.send(
-                    OutboundEvent.SendText(sessionId, "You have already unlocked the ${trainer.className} class."),
+                    OutboundEvent.SendError(sessionId, "You have already unlocked the ${trainer.className} class."),
                 )
                 return
             }
             if (me.level < multiclassConfig.minLevel) {
                 outbound.send(
-                    OutboundEvent.SendText(
+                    OutboundEvent.SendError(
                         sessionId,
                         "You must be at least level ${multiclassConfig.minLevel} to unlock a new class.",
                     ),
@@ -178,7 +178,7 @@ class TrainerHandler(
             }
             val cost = multiclassConfig.goldCost
             if (!me.isStaff && me.gold < cost) {
-                outbound.send(OutboundEvent.SendText(sessionId, "You need $cost gold to unlock the ${trainer.className} class."))
+                outbound.send(OutboundEvent.SendError(sessionId, "You need $cost gold to unlock the ${trainer.className} class."))
                 return
             }
             if (!me.isStaff) me.gold -= cost

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/UiHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/UiHandler.kt
@@ -23,14 +23,14 @@ class UiHandler(
     override fun register(router: CommandRouter) {
         router.on<Command.Noop> { _, _ -> }
         router.on<Command.Unknown> { sid, _ ->
-            outbound.send(OutboundEvent.SendText(sid, "Huh?"))
+            outbound.send(OutboundEvent.SendError(sid, "Huh?"))
         }
         router.on<Command.Invalid> { sid, cmd ->
-            outbound.send(OutboundEvent.SendText(sid, "Invalid command: ${cmd.command}"))
+            outbound.send(OutboundEvent.SendError(sid, "Invalid command: ${cmd.command}"))
             if (cmd.usage != null) {
-                outbound.send(OutboundEvent.SendText(sid, "Usage: ${cmd.usage}"))
+                outbound.send(OutboundEvent.SendError(sid, "Usage: ${cmd.usage}"))
             } else {
-                outbound.send(OutboundEvent.SendText(sid, "Try 'help' for a list of commands."))
+                outbound.send(OutboundEvent.SendError(sid, "Try 'help' for a list of commands."))
             }
         }
         router.on<Command.Help> { sid, _ -> handleHelp(sid) }
@@ -70,7 +70,7 @@ class UiHandler(
         cmd: Command.Phase,
     ) {
         if (combat.isInCombat(sessionId)) {
-            outbound.send(OutboundEvent.SendText(sessionId, "You can't switch layers while in combat!"))
+            outbound.send(OutboundEvent.SendError(sessionId, "You can't switch layers while in combat!"))
             return
         }
         if (onPhase == null) {

--- a/src/test/kotlin/dev/ambon/engine/commands/BankCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/BankCommandTest.kt
@@ -144,8 +144,8 @@ class BankCommandTest {
 
             h.router.handle(sid, Command.Bank.DepositGold(50))
 
-            val texts = h.drain().filterIsInstance<OutboundEvent.SendText>().map { it.text }
-            assertTrue(texts.any { it.contains("only have") }, "got=$texts")
+            val errors = h.drain().filterIsInstance<OutboundEvent.SendError>().map { it.text }
+            assertTrue(errors.any { it.contains("only have") }, "got=$errors")
         }
 
         @Test
@@ -207,8 +207,8 @@ class BankCommandTest {
 
             h.router.handle(sid, Command.Bank.DepositGold(50))
 
-            val texts = h.drain().filterIsInstance<OutboundEvent.SendText>().map { it.text }
-            assertTrue(texts.any { it.contains("bank") }, "got=$texts")
+            val errors = h.drain().filterIsInstance<OutboundEvent.SendError>().map { it.text }
+            assertTrue(errors.any { it.contains("bank") }, "got=$errors")
             assertEquals(100L, h.players.get(sid)!!.gold)
         }
 
@@ -244,8 +244,8 @@ class BankCommandTest {
 
             h.router.handle(sid, Command.Bank.DepositItem("sword"))
 
-            val texts = h.drain().filterIsInstance<OutboundEvent.SendText>().map { it.text }
-            assertTrue(texts.any { it.contains("full") }, "got=$texts")
+            val errors = h.drain().filterIsInstance<OutboundEvent.SendError>().map { it.text }
+            assertTrue(errors.any { it.contains("full") }, "got=$errors")
         }
     }
 }

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
@@ -370,10 +370,16 @@ class CommandParserTest {
     }
 
     @Test
-    fun `numbers outside 1-9 are Unknown`() {
+    fun `numbers 10-99 parse as DialogueChoice`() {
+        assertEquals(Command.DialogueChoice(10), CommandParser.parse("10"))
+        assertEquals(Command.DialogueChoice(99), CommandParser.parse("99"))
+    }
+
+    @Test
+    fun `numbers outside 1-99 are Unknown`() {
         assertTrue(CommandParser.parse("0") is Command.Unknown)
-        assertTrue(CommandParser.parse("10") is Command.Unknown)
-        assertTrue(CommandParser.parse("99") is Command.Unknown)
+        assertTrue(CommandParser.parse("100") is Command.Unknown)
+        assertTrue(CommandParser.parse("-1") is Command.Unknown)
     }
 
     @Test

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterShopTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterShopTest.kt
@@ -73,7 +73,7 @@ class CommandRouterShopTest {
 
             val outs = env.outbound.drainAll()
             assertTrue(
-                outs.any { it is OutboundEvent.SendText && it.text.contains("no shop") },
+                outs.any { it is OutboundEvent.SendError && it.text.contains("no shop") },
                 "Expected 'no shop' message. got=$outs",
             )
         }
@@ -111,7 +111,7 @@ class CommandRouterShopTest {
 
             val outs = env.outbound.drainAll()
             assertTrue(
-                outs.any { it is OutboundEvent.SendText && it.text.contains("afford") },
+                outs.any { it is OutboundEvent.SendError && it.text.contains("afford") },
                 "Expected 'cannot afford' message. got=$outs",
             )
         }
@@ -130,7 +130,7 @@ class CommandRouterShopTest {
 
             val outs = env.outbound.drainAll()
             assertTrue(
-                outs.any { it is OutboundEvent.SendText && it.text.contains("no shop") },
+                outs.any { it is OutboundEvent.SendError && it.text.contains("no shop") },
                 "Expected 'no shop' message. got=$outs",
             )
         }
@@ -147,7 +147,7 @@ class CommandRouterShopTest {
 
             val outs = env.outbound.drainAll()
             assertTrue(
-                outs.any { it is OutboundEvent.SendText && it.text.contains("doesn't sell") },
+                outs.any { it is OutboundEvent.SendError && it.text.contains("doesn't sell") },
                 "Expected 'doesn't sell' message. got=$outs",
             )
         }
@@ -191,7 +191,7 @@ class CommandRouterShopTest {
 
             val outs = env.outbound.drainAll()
             assertTrue(
-                outs.any { it is OutboundEvent.SendText && it.text.contains("worthless") },
+                outs.any { it is OutboundEvent.SendError && it.text.contains("worthless") },
                 "Expected 'worthless' message. got=$outs",
             )
         }
@@ -214,7 +214,7 @@ class CommandRouterShopTest {
 
             val outs = env.outbound.drainAll()
             assertTrue(
-                outs.any { it is OutboundEvent.SendText && it.text.contains("no shop") },
+                outs.any { it is OutboundEvent.SendError && it.text.contains("no shop") },
                 "Expected 'no shop' message. got=$outs",
             )
         }
@@ -231,7 +231,7 @@ class CommandRouterShopTest {
 
             val outs = env.outbound.drainAll()
             assertTrue(
-                outs.any { it is OutboundEvent.SendText && it.text.contains("don't have") },
+                outs.any { it is OutboundEvent.SendError && it.text.contains("don't have") },
                 "Expected 'don't have' message. got=$outs",
             )
         }
@@ -258,7 +258,7 @@ class CommandRouterShopTest {
 
             val outs = env.outbound.drainAll()
             assertTrue(
-                outs.any { it is OutboundEvent.SendText && it.text.contains("worthless") },
+                outs.any { it is OutboundEvent.SendError && it.text.contains("worthless") },
                 "Expected 'worthless' message for 0-value sell. got=$outs",
             )
         }

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterTest.kt
@@ -168,7 +168,7 @@ class CommandRouterTest {
             val outs = h.drain()
 
             assertTrue(
-                outs.any { it is OutboundEvent.SendText && it.text.contains("can't go that way", ignoreCase = true) },
+                outs.any { it is OutboundEvent.SendError && it.text.contains("can't go that way", ignoreCase = true) },
                 "Expected blocked movement message. got=$outs",
             )
             assertTrue(outs.any { it is OutboundEvent.SendPrompt }, "Missing prompt. got=$outs")

--- a/src/test/kotlin/dev/ambon/engine/commands/DungeonCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/DungeonCommandTest.kt
@@ -132,7 +132,7 @@ class DungeonCommandTest {
         h.router.handle(sid, Command.DungeonEnter("crypt", null))
 
         val events = h.drain()
-        val texts = events.filterIsInstance<OutboundEvent.SendText>()
+        val texts = events.filterIsInstance<OutboundEvent.SendError>()
             .filter { it.sessionId == sid }
             .map { it.text }
 
@@ -151,7 +151,7 @@ class DungeonCommandTest {
         h.router.handle(sid, Command.DungeonEnter("nonexistent", null))
 
         val events = h.drain()
-        val texts = events.filterIsInstance<OutboundEvent.SendText>()
+        val texts = events.filterIsInstance<OutboundEvent.SendError>()
             .filter { it.sessionId == sid }
             .map { it.text }
 
@@ -194,7 +194,7 @@ class DungeonCommandTest {
         h.router.handle(sid, Command.DungeonLeave)
 
         val events = h.drain()
-        val texts = events.filterIsInstance<OutboundEvent.SendText>()
+        val texts = events.filterIsInstance<OutboundEvent.SendError>()
             .filter { it.sessionId == sid }
             .map { it.text }
 
@@ -254,7 +254,7 @@ class DungeonCommandTest {
         h.router.handle(sid, Command.DungeonEnter("crypt", "impossible"))
 
         val events = h.drain()
-        val texts = events.filterIsInstance<OutboundEvent.SendText>()
+        val texts = events.filterIsInstance<OutboundEvent.SendError>()
             .filter { it.sessionId == sid }
             .map { it.text }
 
@@ -275,7 +275,7 @@ class DungeonCommandTest {
         h.router.handle(sid, Command.DungeonEnter("crypt", null))
 
         val events = h.drain()
-        val texts = events.filterIsInstance<OutboundEvent.SendText>()
+        val texts = events.filterIsInstance<OutboundEvent.SendError>()
             .filter { it.sessionId == sid }
             .map { it.text }
 

--- a/src/test/kotlin/dev/ambon/engine/commands/EnchantCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/EnchantCommandTest.kt
@@ -133,8 +133,8 @@ class EnchantCommandTest {
 
             h.router.handle(sid, Command.Enchant("sword", "keen_edge"))
 
-            val texts = h.drain().filterIsInstance<OutboundEvent.SendText>().map { it.text }
-            assertTrue(texts.any { it.contains("don't have", ignoreCase = true) }, "got=$texts")
+            val errors = h.drain().filterIsInstance<OutboundEvent.SendError>().map { it.text }
+            assertTrue(errors.any { it.contains("don't have", ignoreCase = true) }, "got=$errors")
         }
 
         @Test

--- a/src/test/kotlin/dev/ambon/engine/commands/PetCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/PetCommandTest.kt
@@ -145,8 +145,8 @@ class PetCommandTest {
 
             h.router.handle(sid, Command.PetDismiss)
 
-            val texts = h.drain().filterIsInstance<OutboundEvent.SendText>().map { it.text }
-            assertTrue(texts.any { it.contains("no active pet", ignoreCase = true) }, "got=$texts")
+            val errors = h.drain().filterIsInstance<OutboundEvent.SendError>().map { it.text }
+            assertTrue(errors.any { it.contains("no active pet", ignoreCase = true) }, "got=$errors")
         }
 
         @Test
@@ -174,8 +174,8 @@ class PetCommandTest {
 
             h.router.handle(sid, Command.PetName("Sparky"))
 
-            val texts = h.drain().filterIsInstance<OutboundEvent.SendText>().map { it.text }
-            assertTrue(texts.any { it.contains("no active pet", ignoreCase = true) }, "got=$texts")
+            val errors = h.drain().filterIsInstance<OutboundEvent.SendError>().map { it.text }
+            assertTrue(errors.any { it.contains("no active pet", ignoreCase = true) }, "got=$errors")
         }
     }
 }

--- a/src/test/kotlin/dev/ambon/engine/commands/PhaseCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/PhaseCommandTest.kt
@@ -186,7 +186,7 @@ class PhaseCommandTest {
 
             val outs = outbound.drainAll()
             assertTrue(
-                outs.any { it is OutboundEvent.SendText && "combat" in it.text.lowercase() },
+                outs.any { it is OutboundEvent.SendError && "combat" in it.text.lowercase() },
                 "Expected combat-blocked message. got=$outs",
             )
         }

--- a/src/test/kotlin/dev/ambon/engine/commands/RecallCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/RecallCommandTest.kt
@@ -37,7 +37,7 @@ class RecallCommandTest {
             val outs = h.drain()
 
             assertTrue(
-                outs.any { it is OutboundEvent.SendText && it.text.contains("cannot recall") },
+                outs.any { it is OutboundEvent.SendError && it.text.contains("cannot recall") },
                 "Expected combat-block message. got=$outs",
             )
             // Player should not have moved


### PR DESCRIPTION
## Summary

- **Error message consistency**: Audited all 13 command handler files and changed ~60 error-path messages from `SendText` to `SendError`, ensuring the client can distinguish errors from normal game output (e.g., for color coding, sound cues, GMCP routing)
- **Dialogue choice range**: Extended the `DialogueChoice` parser from 1-9 to 1-99, allowing NPCs with 10+ dialogue options to work correctly
- **Admin reload guard**: Added `AtomicBoolean` concurrent-reload guard to `/api/reload` to prevent overlapping reloads, plus documentation of atomicity guarantees (each subsystem reload is individually atomic, but cross-subsystem is not)
- **Admin rate limiting**: Added simple timestamp-based rate limiting to dangerous admin endpoints: staff toggle (5s), broadcast (10s), reload (30s)
- **Inventory space check (skipped)**: No inventory limit system exists in the codebase, so the `give` command fix was not applicable

## Test plan

- [x] All 1,485 tests pass
- [x] ktlint passes
- [x] 22 test assertions updated to match new `SendError` event type
- [x] New parser test added for `DialogueChoice` range 10-99
- [ ] Verify web client renders `SendError` events with error styling (visual check)
- [ ] Verify admin dashboard rate limiting via manual testing