### PR TITLE
Fix O(N) auth token lookup in YamlPlayerRepository

### DIFF
--- a/src/main/kotlin/dev/ambon/persistence/YamlPlayerRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/YamlPlayerRepository.kt
@@ -32,6 +32,11 @@ class YamlPlayerRepository(
     // In-memory name→id index.  Built lazily on first findByName call (one-time directory scan),
     // then kept up-to-date by save() and create().  Eliminates repeated full-directory scans.
     private val nameIndex = ConcurrentHashMap<String, Long>()
+
+    // In-memory authTokenHash→id index.  Populated alongside nameIndex so that
+    // findByAuthTokenHash is O(1) instead of scanning every YAML file.
+    private val authTokenIndex = ConcurrentHashMap<String, Long>()
+
     private val nameIndexReady = AtomicBoolean(false)
     private val createLock = ReentrantLock()
 
@@ -67,17 +72,13 @@ class YamlPlayerRepository(
             }
         }
 
-    // Note: linear scan of all player files. Acceptable for dev/small servers
-    // using the YAML backend. Postgres uses an indexed column lookup.
     override suspend fun findByAuthTokenHash(hash: String): PlayerRecord? {
         if (hash.isBlank()) return null
         return withContext(Dispatchers.IO) {
             metrics.timedLoad {
-                val dir = playersDir
-                if (!dir.exists()) return@timedLoad null
-                dir.listDirectoryEntries("*.yaml").firstNotNullOfOrNull { path ->
-                    readRecord(path)?.takeIf { it.authTokenHash == hash }
-                }
+                ensureNameIndexReady()
+                val id = authTokenIndex[hash] ?: return@timedLoad null
+                readRecord(pathFor(id))
             }
         }
     }
@@ -153,6 +154,9 @@ class YamlPlayerRepository(
                 } else {
                     nameIndex[key] = id
                 }
+                if (record.authTokenHash.isNotEmpty()) {
+                    authTokenIndex[record.authTokenHash] = id
+                }
             }
             // Guard against a stale or missing next_player_id.txt falling behind actual file IDs.
             if (maxSeenId >= nextId.get()) {
@@ -200,5 +204,23 @@ class YamlPlayerRepository(
     private fun writePlayer(record: PlayerRecord) {
         atomicWriteText(pathFor(record.id.value), mapper.writeValueAsString(record))
         nameIndex[record.name.lowercase()] = record.id.value
+        updateAuthTokenIndex(record)
+    }
+
+    /**
+     * Keeps [authTokenIndex] in sync after a player write.  Removes any stale entry
+     * that previously pointed to this player's ID (handles token rotation / revocation)
+     * and inserts the new mapping if the record carries a non-empty hash.
+     */
+    private fun updateAuthTokenIndex(record: PlayerRecord) {
+        val id = record.id.value
+        // Remove any existing entry that maps *to* this player ID.  This is necessary when
+        // the token hash changed (rotation) or was cleared (revocation).  ConcurrentHashMap
+        // iteration is safe under concurrent reads; the scan is bounded by the number of
+        // players who have ever issued a token — typically a small fraction of the population.
+        authTokenIndex.entries.removeIf { it.value == id }
+        if (record.authTokenHash.isNotEmpty()) {
+            authTokenIndex[record.authTokenHash] = id
+        }
     }
 }

--- a/src/test/kotlin/dev/ambon/persistence/YamlPlayerRepositoryTest.kt
+++ b/src/test/kotlin/dev/ambon/persistence/YamlPlayerRepositoryTest.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.withContext
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
@@ -416,5 +417,124 @@ class YamlPlayerRepositoryTest {
             assertEquals(1, loaded.equippedItems.size)
             assertEquals("sword", loaded.equippedItems["hand"]?.item?.keyword)
             assertEquals(ItemId("test:sword"), loaded.equippedItems["hand"]?.id)
+        }
+
+    // -------- auth token index tests --------
+
+    @Test
+    fun `findByAuthTokenHash returns player after save sets token`() =
+        runTest {
+            val repo = YamlPlayerRepository(tmp)
+            val r = repo.create(PlayerCreationRequest("TokenUser", RoomId("test:a"), 1000L, testHash, ansiEnabled = false))
+            assertEquals("", r.authTokenHash)
+
+            val tokenHash = "sha256-abc123"
+            repo.save(r.copy(authTokenHash = tokenHash, authTokenIssuedAt = 5000L))
+
+            val found = repo.findByAuthTokenHash(tokenHash)
+            assertNotNull(found)
+            assertEquals(r.id, found!!.id)
+            assertEquals("TokenUser", found.name)
+            assertEquals(tokenHash, found.authTokenHash)
+        }
+
+    @Test
+    fun `findByAuthTokenHash returns null for blank or unknown hash`() =
+        runTest {
+            val repo = YamlPlayerRepository(tmp)
+            repo.create(PlayerCreationRequest("NoToken", RoomId("test:a"), 1000L, testHash, ansiEnabled = false))
+
+            assertNull(repo.findByAuthTokenHash(""))
+            assertNull(repo.findByAuthTokenHash("   "))
+            assertNull(repo.findByAuthTokenHash("nonexistent-hash"))
+        }
+
+    @Test
+    fun `findByAuthTokenHash picks up token from existing file on first call`() =
+        runTest {
+            // Write a player file with an auth token hash directly to disk,
+            // then verify a fresh repo instance finds it via the index scan.
+            val playersDir = tmp.resolve("players")
+            playersDir.toFile().mkdirs()
+
+            val tokenHash = "sha256-preexisting"
+            playersDir.resolve("00000000000000000001.yaml").writeText(
+                """
+                id: 1
+                name: PreToken
+                roomId: test:a
+                createdAtEpochMs: 100
+                lastSeenEpochMs: 200
+                passwordHash: some-hash
+                ansiEnabled: false
+                authTokenHash: "$tokenHash"
+                authTokenIssuedAt: 3000
+                """.trimIndent(),
+            )
+            tmp.resolve("next_player_id.txt").writeText("2")
+
+            val repo = YamlPlayerRepository(tmp)
+            val found = repo.findByAuthTokenHash(tokenHash)
+            assertNotNull(found)
+            assertEquals(1L, found!!.id.value)
+            assertEquals("PreToken", found.name)
+        }
+
+    @Test
+    fun `auth token index updates when token is rotated`() =
+        runTest {
+            val repo = YamlPlayerRepository(tmp)
+            val r = repo.create(PlayerCreationRequest("Rotater", RoomId("test:a"), 1000L, testHash, ansiEnabled = false))
+
+            val oldHash = "sha256-old-token"
+            repo.save(r.copy(authTokenHash = oldHash, authTokenIssuedAt = 2000L))
+            assertNotNull(repo.findByAuthTokenHash(oldHash))
+
+            // Rotate the token
+            val newHash = "sha256-new-token"
+            repo.save(r.copy(authTokenHash = newHash, authTokenIssuedAt = 3000L))
+
+            // Old token should no longer resolve
+            assertNull(repo.findByAuthTokenHash(oldHash))
+            // New token should work
+            val found = repo.findByAuthTokenHash(newHash)
+            assertNotNull(found)
+            assertEquals(r.id, found!!.id)
+        }
+
+    @Test
+    fun `auth token index clears when token is revoked`() =
+        runTest {
+            val repo = YamlPlayerRepository(tmp)
+            val r = repo.create(PlayerCreationRequest("Revoker", RoomId("test:a"), 1000L, testHash, ansiEnabled = false))
+
+            val tokenHash = "sha256-revokable"
+            repo.save(r.copy(authTokenHash = tokenHash, authTokenIssuedAt = 2000L))
+            assertNotNull(repo.findByAuthTokenHash(tokenHash))
+
+            // Revoke by clearing the hash
+            repo.save(r.copy(authTokenHash = "", authTokenIssuedAt = 0L))
+            assertNull(repo.findByAuthTokenHash(tokenHash))
+        }
+
+    @Test
+    fun `findByAuthTokenHash distinguishes between multiple players with tokens`() =
+        runTest {
+            val repo = YamlPlayerRepository(tmp)
+            val alice = repo.create(PlayerCreationRequest("Alice", RoomId("test:a"), 1000L, testHash, ansiEnabled = false))
+            val bob = repo.create(PlayerCreationRequest("Bob", RoomId("test:a"), 1000L, testHash, ansiEnabled = false))
+
+            val aliceHash = "sha256-alice-token"
+            val bobHash = "sha256-bob-token"
+            repo.save(alice.copy(authTokenHash = aliceHash, authTokenIssuedAt = 2000L))
+            repo.save(bob.copy(authTokenHash = bobHash, authTokenIssuedAt = 2000L))
+
+            val foundAlice = repo.findByAuthTokenHash(aliceHash)
+            assertNotNull(foundAlice)
+            assertEquals("Alice", foundAlice!!.name)
+
+            val foundBob = repo.findByAuthTokenHash(bobHash)
+            assertNotNull(foundBob)
+            assertEquals("Bob", foundBob!!.name)
         }
 }


### PR DESCRIPTION
## Summary
- Adds an in-memory `authTokenIndex` (`ConcurrentHashMap<String, Long>`) to `YamlPlayerRepository` alongside the existing `nameIndex`, eliminating the O(N) file scan in `findByAuthTokenHash`
- The index is populated during the lazy directory scan (`ensureNameIndexReady`) and kept current on every `save`/`create`, with correct handling of token rotation (old hash removed) and revocation (hash cleared)
- Adds 6 test cases covering: basic lookup, blank/unknown hash, pre-existing tokens on disk, token rotation, token revocation, and multi-player discrimination

## Test plan
- [x] All existing `YamlPlayerRepositoryTest` tests pass
- [x] New tests verify index-based lookup after save, rotation, revocation, and cold-start from disk
- [x] Full test suite passes (`./gradlew test`)
- [x] ktlint clean