### PR TITLE
Fix operational hardening: port conflict, secrets, bind address, shutdown

### DIFF
--- a/src/main/kotlin/dev/ambon/Main.kt
+++ b/src/main/kotlin/dev/ambon/Main.kt
@@ -55,11 +55,14 @@ fun main() =
             DeploymentMode.GATEWAY -> {
                 val server = GatewayServer(config)
                 server.start()
-                installShutdownHook { server.stop() }
+                installShutdownHook {
+                    server.triggerShutdown()
+                    server.stop()
+                }
                 log.info { "Gateway running. Press Ctrl+C to stop." }
-                // Gateway has no shutdown signal — block until JVM shutdown hook fires.
-                // This simple approach is acceptable for v1; reconnect logic is tracked separately.
-                Thread.currentThread().join()
+                server.awaitShutdown()
+                log.info { "Shutdown signal received. Stopping gateway server..." }
+                server.stop()
             }
         }
     }

--- a/src/main/kotlin/dev/ambon/MudServer.kt
+++ b/src/main/kotlin/dev/ambon/MudServer.kt
@@ -63,6 +63,7 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import java.time.Clock
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
 
 private val log = KotlinLogging.logger {}
 
@@ -85,6 +86,7 @@ class MudServer(
     private var engineJob: Job? = null
     private var routerJob: Job? = null
     private val shutdownSignal = CompletableDeferred<Unit>()
+    private val stopped = AtomicBoolean(false)
 
     private val clock = Clock.systemUTC()
 
@@ -480,6 +482,7 @@ class MudServer(
     suspend fun awaitShutdown() = shutdownSignal.await()
 
     suspend fun stop() {
+        if (!stopped.compareAndSet(false, true)) return
         runCatching { adminServer?.stop() }
         runCatching { telnetTransport.stop() }
         runCatching { webTransport.stop() }

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -253,6 +253,24 @@ data class AppConfig(
         }
         observability.metricsHttpPort.requireValidPort("ambonMUD.observability.metricsHttpPort")
 
+        if (mode == DeploymentMode.ENGINE && observability.metricsEnabled) {
+            require(grpc.server.port != observability.metricsHttpPort) {
+                "ambonMUD.grpc.server.port (${grpc.server.port}) and " +
+                    "ambonMUD.observability.metricsHttpPort (${observability.metricsHttpPort}) " +
+                    "must not be the same in ENGINE mode — both listeners would bind to the same port"
+            }
+        }
+
+        if (observability.metricsEnabled &&
+            observability.metricsHttpHost == "0.0.0.0" &&
+            mode != DeploymentMode.STANDALONE
+        ) {
+            warnConfig(
+                "ambonMUD.observability.metricsHttpHost is 0.0.0.0 (all interfaces) in ${mode.name} mode. " +
+                    "Consider binding to 127.0.0.1 to restrict access.",
+            )
+        }
+
         if (admin.enabled) {
             admin.port.requireValidPort("ambonMUD.admin.port")
             require(admin.token.isNotBlank()) { "ambonMUD.admin.token must be non-blank when admin.enabled=true" }
@@ -458,6 +476,29 @@ data class AppConfig(
             warnConfig("admin.corsOrigins contains wildcard '*' — this allows any origin and should not be used in production")
         }
 
+        // Production mode: reject placeholder secrets
+        if (server.productionMode) {
+            val forbiddenPasswords = setOf("changeme", "ambon", "password", "")
+            require(database.password.lowercase() !in forbiddenPasswords) {
+                "ambonMUD.database.password must not be a placeholder value ('${database.password}') " +
+                    "when server.productionMode=true"
+            }
+            if (redis.enabled && redis.bus.enabled) {
+                val forbiddenSecrets = setOf("CHANGE_ME", "changeme", "")
+                require(redis.bus.sharedSecret !in forbiddenSecrets) {
+                    "ambonMUD.redis.bus.sharedSecret must not be a placeholder value " +
+                        "when server.productionMode=true and redis.bus.enabled=true"
+                }
+            }
+            if (admin.enabled) {
+                val forbiddenTokens = setOf("changeme", "admin", "")
+                require(admin.token.lowercase() !in forbiddenTokens) {
+                    "ambonMUD.admin.token must not be a placeholder value ('${admin.token}') " +
+                        "when server.productionMode=true and admin.enabled=true"
+                }
+            }
+        }
+
         return this
     }
 }
@@ -471,6 +512,8 @@ data class ServerConfig(
     val maxInboundEventsPerTick: Int = 1_000,
     val tickMillis: Long = 100L,
     val inboundBudgetMs: Long = 30L,
+    /** When true, placeholder/default secrets are rejected at startup. */
+    val productionMode: Boolean = false,
 )
 
 data class WorldConfig(
@@ -1631,7 +1674,9 @@ data class DemoConfig(
 data class ObservabilityConfig(
     val metricsEnabled: Boolean = true,
     val metricsEndpoint: String = "/metrics",
-    val metricsHttpPort: Int = 9090,
+    val metricsHttpPort: Int = 9099,
+    /** Bind address for the metrics HTTP listener. Default is 0.0.0.0 (all interfaces). */
+    val metricsHttpHost: String = "0.0.0.0",
     val staticTags: Map<String, String> = emptyMap(),
 )
 

--- a/src/main/kotlin/dev/ambon/gateway/GatewayServer.kt
+++ b/src/main/kotlin/dev/ambon/gateway/GatewayServer.kt
@@ -33,6 +33,7 @@ import io.grpc.ManagedChannelBuilder
 import io.lettuce.core.SetArgs
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -89,6 +90,9 @@ class GatewayServer(
             onSequenceOverflow = gameMetrics::onSessionIdSequenceOverflow,
             onClockRollback = gameMetrics::onSessionIdClockRollback,
         )
+
+    private val stopped = AtomicBoolean(false)
+    private val shutdownSignal = CompletableDeferred<Unit>()
 
     // ── Single-engine mode state ────────────────────────────────────────────────
     private val reconnecting = AtomicBoolean(false)
@@ -412,7 +416,21 @@ class GatewayServer(
             }
         }
 
+    /**
+     * Suspends until the shutdown hook (or another caller) completes the signal.
+     */
+    suspend fun awaitShutdown() = shutdownSignal.await()
+
+    /**
+     * Triggers the shutdown signal so [awaitShutdown] returns.
+     * Called by the JVM shutdown hook.
+     */
+    fun triggerShutdown() {
+        shutdownSignal.complete(Unit)
+    }
+
     suspend fun stop() {
+        if (!stopped.compareAndSet(false, true)) return
         runCatching { telnetTransport.stop() }
         runCatching { webTransport.stop() }
 

--- a/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
+++ b/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import java.time.Clock
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
 
 private val log = KotlinLogging.logger {}
 
@@ -154,6 +155,7 @@ class EngineServer(
     private var engineJob: Job? = null
     private var metricsHttpServer: MetricsHttpServer? = null
     private var shardingJobs = ServerInfrastructure.ShardingJobs()
+    private val stopped = AtomicBoolean(false)
 
     suspend fun start() {
         redisManager?.connect()
@@ -220,6 +222,7 @@ class EngineServer(
                     port = config.observability.metricsHttpPort,
                     registry = prometheusRegistry,
                     endpoint = config.observability.metricsEndpoint,
+                    host = config.observability.metricsHttpHost,
                 )
             server.start()
             metricsHttpServer = server
@@ -230,6 +233,7 @@ class EngineServer(
     suspend fun awaitShutdown() = shutdownSignal.await()
 
     suspend fun stop() {
+        if (!stopped.compareAndSet(false, true)) return
         runCatching { metricsHttpServer?.stop() }
         runCatching { grpcServer.stop() }
         shardingJobs.stopAll()

--- a/src/main/kotlin/dev/ambon/metrics/MetricsHttpServer.kt
+++ b/src/main/kotlin/dev/ambon/metrics/MetricsHttpServer.kt
@@ -19,15 +19,16 @@ class MetricsHttpServer(
     private val port: Int,
     private val registry: PrometheusMeterRegistry,
     private val endpoint: String = "/metrics",
+    private val host: String = "0.0.0.0",
 ) {
     private var engine: EmbeddedServer<NettyApplicationEngine, NettyApplicationEngine.Configuration>? = null
 
     fun start() {
         engine =
-            embeddedServer(Netty, port = port) {
+            embeddedServer(Netty, port = port, host = host) {
                 metricsModule(registry, endpoint)
             }.start(wait = false)
-        log.info { "Metrics HTTP server started on port $port (endpoint=$endpoint)" }
+        log.info { "Metrics HTTP server started on $host:$port (endpoint=$endpoint)" }
     }
 
     fun stop() {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -95,6 +95,8 @@ ambonmud:
     maxInboundEventsPerTick: 1000
     tickMillis: 100
     inboundBudgetMs: 30
+    # Set to true in production to reject placeholder secrets at startup.
+    productionMode: false
 
   world:
     startRoom: "thornhaven_city:new_arrivals_hall"
@@ -3649,7 +3651,8 @@ ambonmud:
   observability:
     metricsEnabled: true
     metricsEndpoint: "/metrics"
-    metricsHttpPort: 9090
+    metricsHttpPort: 9099
+    metricsHttpHost: "0.0.0.0"
     staticTags: {}
 
   admin:


### PR DESCRIPTION
## Summary

- **ENGINE mode port conflict (RELEASE BLOCKER):** Changed `metricsHttpPort` default from `9090` to `9099` to avoid collision with the gRPC server port. Added `validated()` check that rejects identical `grpc.server.port` and `observability.metricsHttpPort` when `mode=ENGINE`.
- **Placeholder secrets fail-fast (RELEASE BLOCKER):** Added `server.productionMode` flag (default `false`). When `true`, rejects placeholder passwords/secrets for `database.password`, `redis.bus.sharedSecret`, and `admin.token` with clear error messages naming the exact config key.
- **Metrics bind address:** Added `observability.metricsHttpHost` config (default `0.0.0.0` for backward compat), wired through to `MetricsHttpServer`. Emits a config warning when bound to `0.0.0.0` in ENGINE/GATEWAY mode.
- **Shutdown idempotency:** Added `AtomicBoolean` guard to `stop()` in `MudServer`, `EngineServer`, and `GatewayServer` so double-stop from shutdown hook + main flow is harmless.
- **Gateway structured shutdown:** Replaced `Thread.currentThread().join()` with `CompletableDeferred`-based `awaitShutdown()`/`triggerShutdown()` pattern, matching the STANDALONE and ENGINE shutdown flow.

Multi-instance profiles (engine1/engine2/gw1/gw2) already use non-conflicting ports and are unaffected.

## Test plan

- [x] `ktlintCheck` passes
- [x] Full test suite passes (`./gradlew test`)
- [ ] Verify ENGINE mode startup with default config no longer port-collides
- [ ] Verify `productionMode=true` rejects `database.password=ambon`
- [ ] Verify gateway Ctrl+C shutdown is clean (no `Thread.join` hang)