### PR TITLE
Auto-send character name on expired auth token relogin

### DIFF
--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -218,6 +218,7 @@ function App() {
   const [savedCharacters, setSavedCharacters] = useState<string[]>([]);
   const resumeTokenRef = useRef<string | null>(null);
   const pendingAuthCharRef = useRef<string | null>(null);
+  const failedAuthCharRef = useRef<string | null>(null);
   const connectedRef = useRef(false);
   const intentionalDisconnectRef = useRef(false);
   const [serverAssets, setServerAssets] = useState<Record<string, string>>({});
@@ -457,6 +458,7 @@ function App() {
           setSavedCharacters,
           resumeTokenRef,
           pendingAuthCharRef,
+          failedAuthCharRef,
           setServerAssets,
           setServerCommands,
           setEmotePresets,
@@ -529,6 +531,17 @@ function App() {
 
   sendGmcpRef.current = sendGmcp;
   connectedRef.current = connected;
+
+  // When a token-based login fails, the server re-sends Login.Prompt(state:"name").
+  // Since we already know the character name, auto-send it so the user goes
+  // straight to the password prompt instead of seeing "Enter your character name".
+  useEffect(() => {
+    const charName = failedAuthCharRef.current;
+    if (loginPrompt?.state === "name" && charName) {
+      failedAuthCharRef.current = null;
+      sendLine(charName);
+    }
+  }, [loginPrompt, sendLine]);
 
   const sendCommand = useCallback(
     (raw: string, echo: boolean) => {

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -113,6 +113,7 @@ interface GmcpContext {
   setSavedCharacters: Dispatch<SetStateAction<string[]>>;
   resumeTokenRef: { current: string | null };
   pendingAuthCharRef: { current: string | null };
+  failedAuthCharRef: { current: string | null };
   sendGmcp: (pkg: string, payload: unknown) => boolean;
   setServerAssets: Dispatch<SetStateAction<Record<string, string>>>;
   setServerCommands: Dispatch<SetStateAction<CommandEntry[]>>;
@@ -1243,10 +1244,13 @@ export function applyGmcpPackage(
         // Auth failed — remove the stale token and fall back to login prompt.
         // Server re-sends Login.Prompt which will drive the full state reset,
         // but clear error eagerly in case the server response is delayed.
+        // Stash the character name so the Login.Prompt handler can auto-send it,
+        // skipping straight to the password prompt instead of showing "Enter name".
         ctx.setReconnecting(false);
         ctx.setLoginError(null);
         const failedChar = ctx.pendingAuthCharRef.current;
         ctx.pendingAuthCharRef.current = null;
+        ctx.failedAuthCharRef.current = failedChar;
         if (failedChar) {
           try {
             const saved = JSON.parse(localStorage.getItem("ambonmud_auth_tokens") ?? "{}") as Record<string, string>;


### PR DESCRIPTION
## Summary
- When a saved auth token expires (e.g., server reboot), the character picker's token auth fails via `Session.AuthResult`
- Previously: user saw "Enter your character name" despite the client already knowing the name
- Now: the character name is auto-sent when the `Login.Prompt(state:"name")` arrives after a failed token auth, so the user goes straight to the password prompt

## How it works
1. User picks character from CharacterPicker → `Session.Authenticate` sent with stale token
2. Server returns `Session.AuthResult { success: false }`
3. **New:** Character name stashed in `failedAuthCharRef`
4. Server sends `Login.Prompt(state: "name")`
5. **New:** `useEffect` detects the pending name and auto-sends it via `sendLine()`
6. Server responds with `Login.Prompt(state: "password", name: "...")` → user sees password prompt

## Changes
- `App.tsx`: Added `failedAuthCharRef` and a `useEffect` that auto-sends the name
- `applyGmcpPackage.ts`: Updated `Session.AuthResult` failure handler to stash the name; added `failedAuthCharRef` to context type

## Test plan
- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] ESLint passes
- [ ] Manual: Connect with saved character, restart server, click character in picker → should go to password prompt
- [ ] Manual: Normal fresh login flow still works (no saved characters)
- [ ] Manual: Character picker "New character" flow still works