### PR TITLE
Add HMAC shared secret auth for gRPC engine/gateway communication

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -276,6 +276,12 @@ data class AppConfig(
 
         if (mode == DeploymentMode.ENGINE || mode == DeploymentMode.GATEWAY) {
             grpc.server.port.requireValidPort("ambonMUD.grpc.server.port")
+            require(grpc.sharedSecret.isNotBlank()) {
+                "ambonMUD.grpc.sharedSecret must be non-blank in ENGINE/GATEWAY mode"
+            }
+            require(grpc.timestampToleranceMs > 0L) {
+                "ambonMUD.grpc.timestampToleranceMs must be > 0"
+            }
         }
 
         if (mode == DeploymentMode.GATEWAY) {
@@ -1669,6 +1675,12 @@ data class GrpcClientConfig(
 data class GrpcConfig(
     val server: GrpcServerConfig = GrpcServerConfig(),
     val client: GrpcClientConfig = GrpcClientConfig(),
+    /** Shared secret for HMAC-based gRPC authentication between engine and gateway. */
+    val sharedSecret: String = "",
+    /** Allow plaintext gRPC transport (no TLS). Auth interceptor still applies when true. */
+    val allowPlaintext: Boolean = true,
+    /** Maximum clock skew tolerance in milliseconds for HMAC timestamp validation. */
+    val timestampToleranceMs: Long = 30_000L,
 )
 
 /** Snowflake session-ID hardening settings (used by GATEWAY mode). */

--- a/src/main/kotlin/dev/ambon/gateway/GatewayServer.kt
+++ b/src/main/kotlin/dev/ambon/gateway/GatewayServer.kt
@@ -28,6 +28,7 @@ import dev.ambon.transport.BlockingSocketTransport
 import dev.ambon.transport.KtorWebSocketTransport
 import dev.ambon.transport.OutboundRouter
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.grpc.ClientInterceptor
 import io.grpc.ManagedChannel
 import io.grpc.ManagedChannelBuilder
 import io.lettuce.core.SetArgs
@@ -113,6 +114,11 @@ class GatewayServer(
     private lateinit var webTransport: KtorWebSocketTransport
 
     private var leaseManager: GatewayIdLeaseManager? = null
+
+    private val grpcClientAuthInterceptor: ClientInterceptor? =
+        config.grpc.sharedSecret.takeIf { it.isNotBlank() }?.let { secret ->
+            dev.ambon.grpc.GrpcClientAuthInterceptor(sharedSecret = secret)
+        }
 
     private val streamLostDisconnectReason = "Disconnected: engine connection lost. Please reconnect."
     private val localControlDeliveryDisconnectReason = "Disconnected: gateway outbound queue stalled."
@@ -205,7 +211,10 @@ class GatewayServer(
         val managedChannel =
             ManagedChannelBuilder
                 .forAddress(config.grpc.client.engineHost, config.grpc.client.enginePort)
-                .usePlaintext()
+                .apply {
+                    if (config.grpc.allowPlaintext) usePlaintext()
+                    grpcClientAuthInterceptor?.let { intercept(it) }
+                }
                 .build()
         singleManagedChannel = managedChannel
 
@@ -311,7 +320,10 @@ class GatewayServer(
         val managedChannel =
             ManagedChannelBuilder
                 .forAddress(entry.host, entry.port)
-                .usePlaintext()
+                .apply {
+                    if (config.grpc.allowPlaintext) usePlaintext()
+                    grpcClientAuthInterceptor?.let { intercept(it) }
+                }
                 .build()
 
         val protoChannel = Channel<InboundEventProto>(capacity = config.server.inboundChannelCapacity)

--- a/src/main/kotlin/dev/ambon/grpc/EngineGrpcServer.kt
+++ b/src/main/kotlin/dev/ambon/grpc/EngineGrpcServer.kt
@@ -6,6 +6,7 @@ import dev.ambon.metrics.GameMetrics
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.grpc.Server
 import io.grpc.ServerBuilder
+import io.grpc.ServerInterceptor
 import kotlinx.coroutines.CoroutineScope
 import java.util.concurrent.TimeUnit
 
@@ -26,6 +27,7 @@ class EngineGrpcServer(
     controlPlaneSendTimeoutMs: Long = GrpcTimeouts.DEFAULT_CONTROL_PLANE_SEND_TIMEOUT_MS,
     private val gracefulShutdownTimeoutMs: Long = DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT_MS,
     private val forceShutdownTimeoutMs: Long = DEFAULT_FORCE_SHUTDOWN_TIMEOUT_MS,
+    serverAuthInterceptor: ServerInterceptor? = null,
 ) {
     init {
         require(gracefulShutdownTimeoutMs > 0L) { "gracefulShutdownTimeoutMs must be > 0" }
@@ -45,6 +47,11 @@ class EngineGrpcServer(
         ServerBuilder
             .forPort(port)
             .addService(serviceImpl)
+            .apply {
+                if (serverAuthInterceptor != null) {
+                    intercept(serverAuthInterceptor)
+                }
+            }
             // Keep idle gRPC streams alive through NAT/firewall timeouts.
             .keepAliveTime(30, TimeUnit.SECONDS)
             .keepAliveTimeout(10, TimeUnit.SECONDS)

--- a/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
+++ b/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
@@ -81,6 +81,14 @@ class EngineServer(
     private val inbound: InboundBus = LocalInboundBus(capacity = config.server.inboundChannelCapacity)
     private val outbound: OutboundBus = LocalOutboundBus(capacity = config.server.outboundChannelCapacity)
 
+    private val grpcAuthInterceptor: GrpcServerAuthInterceptor? =
+        config.grpc.sharedSecret.takeIf { it.isNotBlank() }?.let { secret ->
+            GrpcServerAuthInterceptor(
+                sharedSecret = secret,
+                timestampToleranceMs = config.grpc.timestampToleranceMs,
+            )
+        }
+
     private val grpcServer =
         EngineGrpcServer(
             port = config.grpc.server.port,
@@ -89,6 +97,7 @@ class EngineServer(
             scope = scope,
             metrics = gameMetrics,
             controlPlaneSendTimeoutMs = config.grpc.server.controlPlaneSendTimeoutMs,
+            serverAuthInterceptor = grpcAuthInterceptor,
         )
 
     private val items = ItemRegistry()

--- a/src/main/kotlin/dev/ambon/grpc/GrpcAuthInterceptor.kt
+++ b/src/main/kotlin/dev/ambon/grpc/GrpcAuthInterceptor.kt
@@ -1,0 +1,172 @@
+package dev.ambon.grpc
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.grpc.CallOptions
+import io.grpc.Channel
+import io.grpc.ClientCall
+import io.grpc.ClientInterceptor
+import io.grpc.ForwardingClientCall
+import io.grpc.Metadata
+import io.grpc.MethodDescriptor
+import io.grpc.ServerCall
+import io.grpc.ServerCallHandler
+import io.grpc.ServerInterceptor
+import io.grpc.Status
+import java.nio.charset.StandardCharsets
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * HMAC-based shared-secret authentication for gRPC engine/gateway communication.
+ *
+ * The client sends two metadata headers on every call:
+ *   - `x-ambon-auth-hmac`: HMAC-SHA256(secret, timestamp)
+ *   - `x-ambon-auth-ts`: the Unix-millis timestamp used for the HMAC
+ *
+ * The server validates:
+ *   1. Both headers are present and non-blank.
+ *   2. The timestamp is within [timestampToleranceMs] of the server clock.
+ *   3. The HMAC matches the recomputed value.
+ *
+ * This prevents replay attacks (time window) and forged connections (shared secret).
+ */
+object GrpcAuthMetadata {
+    val HMAC_KEY: Metadata.Key<String> =
+        Metadata.Key.of("x-ambon-auth-hmac", Metadata.ASCII_STRING_MARSHALLER)
+    val TIMESTAMP_KEY: Metadata.Key<String> =
+        Metadata.Key.of("x-ambon-auth-ts", Metadata.ASCII_STRING_MARSHALLER)
+}
+
+/**
+ * Computes HMAC-SHA256 of [payload] under [secret], returning a lowercase hex string.
+ */
+internal fun grpcHmacSha256(
+    secret: String,
+    payload: String,
+): String {
+    val mac = Mac.getInstance("HmacSHA256")
+    mac.init(SecretKeySpec(secret.toByteArray(StandardCharsets.UTF_8), "HmacSHA256"))
+    return mac.doFinal(payload.toByteArray(StandardCharsets.UTF_8))
+        .joinToString("") { "%02x".format(it) }
+}
+
+/**
+ * Server-side interceptor that validates the shared-secret HMAC on every incoming call.
+ *
+ * Rejects unauthenticated calls with [Status.UNAUTHENTICATED].
+ *
+ * @param sharedSecret the shared secret configured on both engine and gateway.
+ * @param timestampToleranceMs maximum allowed clock skew between engine and gateway (default 30s).
+ * @param clockMillis supplier for the current time; defaults to [System.currentTimeMillis].
+ *                    Override in tests for determinism.
+ */
+class GrpcServerAuthInterceptor(
+    private val sharedSecret: String,
+    private val timestampToleranceMs: Long = DEFAULT_TIMESTAMP_TOLERANCE_MS,
+    private val clockMillis: () -> Long = System::currentTimeMillis,
+) : ServerInterceptor {
+    init {
+        require(sharedSecret.isNotBlank()) { "gRPC shared secret must not be blank" }
+        require(timestampToleranceMs > 0L) { "timestampToleranceMs must be > 0" }
+    }
+
+    override fun <ReqT, RespT> interceptCall(
+        call: ServerCall<ReqT, RespT>,
+        headers: Metadata,
+        next: ServerCallHandler<ReqT, RespT>,
+    ): ServerCall.Listener<ReqT> {
+        val hmac = headers.get(GrpcAuthMetadata.HMAC_KEY)
+        val tsString = headers.get(GrpcAuthMetadata.TIMESTAMP_KEY)
+
+        if (hmac.isNullOrBlank() || tsString.isNullOrBlank()) {
+            log.warn { "gRPC auth rejected: missing HMAC or timestamp header" }
+            return rejectCall(call, "Missing authentication headers")
+        }
+
+        val timestamp = tsString.toLongOrNull()
+        if (timestamp == null) {
+            log.warn { "gRPC auth rejected: non-numeric timestamp '$tsString'" }
+            return rejectCall(call, "Invalid timestamp")
+        }
+
+        val now = clockMillis()
+        val drift = kotlin.math.abs(now - timestamp)
+        if (drift > timestampToleranceMs) {
+            log.warn { "gRPC auth rejected: timestamp drift ${drift}ms exceeds tolerance ${timestampToleranceMs}ms" }
+            return rejectCall(call, "Timestamp outside acceptable window")
+        }
+
+        val expectedHmac = grpcHmacSha256(sharedSecret, tsString)
+        if (!constantTimeEquals(expectedHmac, hmac)) {
+            log.warn { "gRPC auth rejected: HMAC mismatch" }
+            return rejectCall(call, "Invalid HMAC signature")
+        }
+
+        return next.startCall(call, headers)
+    }
+
+    private fun <ReqT, RespT> rejectCall(
+        call: ServerCall<ReqT, RespT>,
+        description: String,
+    ): ServerCall.Listener<ReqT> {
+        call.close(Status.UNAUTHENTICATED.withDescription(description), Metadata())
+        return object : ServerCall.Listener<ReqT>() {}
+    }
+
+    companion object {
+        /** Default timestamp tolerance: 30 seconds. */
+        const val DEFAULT_TIMESTAMP_TOLERANCE_MS = 30_000L
+    }
+}
+
+/**
+ * Client-side interceptor that attaches the HMAC shared-secret headers to every outgoing call.
+ *
+ * @param sharedSecret the shared secret configured on both engine and gateway.
+ * @param clockMillis supplier for the current time; defaults to [System.currentTimeMillis].
+ *                    Override in tests for determinism.
+ */
+class GrpcClientAuthInterceptor(
+    private val sharedSecret: String,
+    private val clockMillis: () -> Long = System::currentTimeMillis,
+) : ClientInterceptor {
+    init {
+        require(sharedSecret.isNotBlank()) { "gRPC shared secret must not be blank" }
+    }
+
+    override fun <ReqT, RespT> interceptCall(
+        method: MethodDescriptor<ReqT, RespT>,
+        callOptions: CallOptions,
+        next: Channel,
+    ): ClientCall<ReqT, RespT> {
+        val delegate = next.newCall(method, callOptions)
+        return object : ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(delegate) {
+            override fun start(
+                responseListener: Listener<RespT>,
+                headers: Metadata,
+            ) {
+                val ts = clockMillis().toString()
+                headers.put(GrpcAuthMetadata.TIMESTAMP_KEY, ts)
+                headers.put(GrpcAuthMetadata.HMAC_KEY, grpcHmacSha256(sharedSecret, ts))
+                super.start(responseListener, headers)
+            }
+        }
+    }
+}
+
+/**
+ * Constant-time string comparison to prevent timing side-channel attacks on HMAC validation.
+ */
+private fun constantTimeEquals(
+    a: String,
+    b: String,
+): Boolean {
+    if (a.length != b.length) return false
+    var result = 0
+    for (i in a.indices) {
+        result = result or (a[i].code xor b[i].code)
+    }
+    return result == 0
+}

--- a/src/main/resources/application-engine1.yaml
+++ b/src/main/resources/application-engine1.yaml
@@ -55,5 +55,6 @@ ambonmud:
   grpc:
     server:
       port: 9091
+    sharedSecret: "local-dev-secret-change-in-production"
   observability:
     metricsHttpPort: 9191

--- a/src/main/resources/application-engine2.yaml
+++ b/src/main/resources/application-engine2.yaml
@@ -55,5 +55,6 @@ ambonmud:
   grpc:
     server:
       port: 9092
+    sharedSecret: "local-dev-secret-change-in-production"
   observability:
     metricsHttpPort: 9192

--- a/src/main/resources/application-gw1.yaml
+++ b/src/main/resources/application-gw1.yaml
@@ -4,6 +4,8 @@
 # Connects to engine-1 (:9091) and engine-2 (:9092)
 ambonmud:
   mode: GATEWAY
+  grpc:
+    sharedSecret: "local-dev-secret-change-in-production"
   gateway:
     id: 0
     engines:

--- a/src/main/resources/application-gw2.yaml
+++ b/src/main/resources/application-gw2.yaml
@@ -4,6 +4,8 @@
 # Connects to engine-1 (:9091) and engine-2 (:9092)
 ambonmud:
   mode: GATEWAY
+  grpc:
+    sharedSecret: "local-dev-secret-change-in-production"
   gateway:
     id: 1
     engines:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -62,6 +62,9 @@ ambonmud:
     client:
       engineHost: localhost
       enginePort: 9090
+    sharedSecret: ""
+    allowPlaintext: true
+    timestampToleranceMs: 30000
 
   gateway:
     id: 0

--- a/src/test/kotlin/dev/ambon/config/AppConfigLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/config/AppConfigLoaderTest.kt
@@ -398,6 +398,50 @@ class AppConfigLoaderTest {
     }
 
     @Test
+    fun `grpc validation rejects blank shared secret in ENGINE mode`() {
+        val invalid = AppConfig(mode = DeploymentMode.ENGINE, grpc = GrpcConfig(sharedSecret = ""))
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
+
+    @Test
+    fun `grpc validation rejects blank shared secret in GATEWAY mode`() {
+        val invalid = AppConfig(
+            mode = DeploymentMode.GATEWAY,
+            grpc = GrpcConfig(sharedSecret = ""),
+        )
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
+
+    @Test
+    fun `grpc validation accepts non-blank shared secret in ENGINE mode`() {
+        val config = AppConfig(
+            mode = DeploymentMode.ENGINE,
+            grpc = GrpcConfig(sharedSecret = "my-secret"),
+            world = WorldConfig(startRoom = "zone:room"),
+        )
+        config.validated()
+    }
+
+    @Test
+    fun `grpc shared secret not required in STANDALONE mode`() {
+        val config = AppConfig(
+            mode = DeploymentMode.STANDALONE,
+            grpc = GrpcConfig(sharedSecret = ""),
+            world = WorldConfig(startRoom = "zone:room"),
+        )
+        config.validated()
+    }
+
+    @Test
+    fun `grpc validation rejects non-positive timestampToleranceMs`() {
+        val invalid = AppConfig(
+            mode = DeploymentMode.ENGINE,
+            grpc = GrpcConfig(sharedSecret = "secret", timestampToleranceMs = 0L),
+        )
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
+
+    @Test
     fun `env-var normalised path overrides persistence backend`() {
         // Regression for #320: AMBONMUD_PERSISTENCE_BACKEND was silently ignored because
         // Hoplite normalises env vars to ambonmud.persistence.backend but the root field

--- a/src/test/kotlin/dev/ambon/grpc/GrpcAuthInterceptorTest.kt
+++ b/src/test/kotlin/dev/ambon/grpc/GrpcAuthInterceptorTest.kt
@@ -1,0 +1,373 @@
+package dev.ambon.grpc
+
+import dev.ambon.bus.LocalInboundBus
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.engine.events.InboundEvent
+import dev.ambon.grpc.proto.EngineServiceGrpcKt
+import io.grpc.ServerInterceptors
+import io.grpc.Status
+import io.grpc.StatusException
+import io.grpc.StatusRuntimeException
+import io.grpc.inprocess.InProcessChannelBuilder
+import io.grpc.inprocess.InProcessServerBuilder
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class GrpcAuthInterceptorTest {
+    private val sharedSecret = "test-secret-for-grpc-auth"
+
+    // ── Unit tests for HMAC and interceptor logic ──────────────────────────────
+
+    @Test
+    fun `grpcHmacSha256 produces consistent results`() {
+        val hmac1 = grpcHmacSha256(sharedSecret, "1234567890")
+        val hmac2 = grpcHmacSha256(sharedSecret, "1234567890")
+        assertEquals(hmac1, hmac2)
+        assertTrue(hmac1.isNotBlank())
+        // SHA256 hex output is 64 chars
+        assertEquals(64, hmac1.length)
+    }
+
+    @Test
+    fun `grpcHmacSha256 produces different results for different payloads`() {
+        val hmac1 = grpcHmacSha256(sharedSecret, "1234567890")
+        val hmac2 = grpcHmacSha256(sharedSecret, "9876543210")
+        assertNotEquals(hmac1, hmac2)
+    }
+
+    @Test
+    fun `grpcHmacSha256 produces different results for different secrets`() {
+        val hmac1 = grpcHmacSha256("secret-a", "payload")
+        val hmac2 = grpcHmacSha256("secret-b", "payload")
+        assertNotEquals(hmac1, hmac2)
+    }
+
+    @Test
+    fun `server interceptor rejects blank secret in constructor`() {
+        assertThrows<IllegalArgumentException> {
+            GrpcServerAuthInterceptor(sharedSecret = "")
+        }
+    }
+
+    @Test
+    fun `client interceptor rejects blank secret in constructor`() {
+        assertThrows<IllegalArgumentException> {
+            GrpcClientAuthInterceptor(sharedSecret = "")
+        }
+    }
+
+    @Test
+    fun `server interceptor rejects zero timestamp tolerance`() {
+        assertThrows<IllegalArgumentException> {
+            GrpcServerAuthInterceptor(sharedSecret = sharedSecret, timestampToleranceMs = 0L)
+        }
+    }
+
+    // ── Integration tests with in-process gRPC ─────────────────────────────────
+
+    private val serverName = "auth-test-${System.nanoTime()}"
+    private lateinit var scope: CoroutineScope
+    private lateinit var engineInbound: LocalInboundBus
+    private lateinit var engineOutbound: LocalOutboundBus
+    private lateinit var serviceImpl: EngineServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        engineInbound = LocalInboundBus(capacity = 256)
+        engineOutbound = LocalOutboundBus(capacity = 256)
+        serviceImpl = EngineServiceImpl(
+            inbound = engineInbound,
+            outbound = engineOutbound,
+            scope = scope,
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        scope.cancel()
+        engineInbound.close()
+        engineOutbound.close()
+    }
+
+    @Test
+    fun `authenticated client can connect and stream events`() = runBlocking {
+        val fixedTime = 1_000_000L
+        val serverInterceptor = GrpcServerAuthInterceptor(
+            sharedSecret = sharedSecret,
+            clockMillis = { fixedTime },
+        )
+        val clientInterceptor = GrpcClientAuthInterceptor(
+            sharedSecret = sharedSecret,
+            clockMillis = { fixedTime },
+        )
+
+        val server = InProcessServerBuilder
+            .forName(serverName)
+            .directExecutor()
+            .addService(ServerInterceptors.intercept(serviceImpl, serverInterceptor))
+            .build()
+            .start()
+
+        val channel = InProcessChannelBuilder
+            .forName(serverName)
+            .directExecutor()
+            .intercept(clientInterceptor)
+            .build()
+
+        try {
+            val stub = EngineServiceGrpcKt.EngineServiceCoroutineStub(channel)
+            val collectJob = scope.launch {
+                stub.eventStream(
+                    flow {
+                        emit(InboundEvent.Connected(sessionId = SessionId(1L)).toProto())
+                        delay(500)
+                    },
+                ).collect {}
+            }
+
+            // Give the stream time to connect
+            delay(200)
+
+            // If we got here without UNAUTHENTICATED, the auth succeeded.
+            // Verify the session was registered on the engine side.
+            assertTrue(serviceImpl.sessionToStream.containsKey(SessionId(1L)))
+            collectJob.cancel()
+        } finally {
+            channel.shutdownNow()
+            server.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `unauthenticated client is rejected`() = runBlocking {
+        val serverInterceptor = GrpcServerAuthInterceptor(
+            sharedSecret = sharedSecret,
+        )
+
+        val server = InProcessServerBuilder
+            .forName(serverName)
+            .directExecutor()
+            .addService(ServerInterceptors.intercept(serviceImpl, serverInterceptor))
+            .build()
+            .start()
+
+        // No client interceptor — no auth headers.
+        val channel = InProcessChannelBuilder
+            .forName(serverName)
+            .directExecutor()
+            .build()
+
+        try {
+            val stub = EngineServiceGrpcKt.EngineServiceCoroutineStub(channel)
+            var caughtStatus: Status.Code? = null
+            try {
+                stub.eventStream(
+                    flow {
+                        emit(InboundEvent.Connected(sessionId = SessionId(1L)).toProto())
+                    },
+                ).collect {}
+            } catch (e: StatusRuntimeException) {
+                caughtStatus = e.status.code
+            } catch (e: StatusException) {
+                caughtStatus = e.status.code
+            }
+            assertEquals(Status.Code.UNAUTHENTICATED, caughtStatus)
+        } finally {
+            channel.shutdownNow()
+            server.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `wrong secret is rejected`() = runBlocking {
+        val fixedTime = 1_000_000L
+        val serverInterceptor = GrpcServerAuthInterceptor(
+            sharedSecret = "correct-secret",
+            clockMillis = { fixedTime },
+        )
+        val clientInterceptor = GrpcClientAuthInterceptor(
+            sharedSecret = "wrong-secret",
+            clockMillis = { fixedTime },
+        )
+
+        val server = InProcessServerBuilder
+            .forName(serverName)
+            .directExecutor()
+            .addService(ServerInterceptors.intercept(serviceImpl, serverInterceptor))
+            .build()
+            .start()
+
+        val channel = InProcessChannelBuilder
+            .forName(serverName)
+            .directExecutor()
+            .intercept(clientInterceptor)
+            .build()
+
+        try {
+            val stub = EngineServiceGrpcKt.EngineServiceCoroutineStub(channel)
+            var caughtStatus: Status.Code? = null
+            try {
+                stub.eventStream(
+                    flow {
+                        emit(InboundEvent.Connected(sessionId = SessionId(1L)).toProto())
+                    },
+                ).collect {}
+            } catch (e: StatusRuntimeException) {
+                caughtStatus = e.status.code
+            } catch (e: StatusException) {
+                caughtStatus = e.status.code
+            }
+            assertEquals(Status.Code.UNAUTHENTICATED, caughtStatus)
+        } finally {
+            channel.shutdownNow()
+            server.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `expired timestamp is rejected`() = runBlocking {
+        val serverTime = 100_000L
+        val clientTime = 1L // Way in the past relative to server
+
+        val serverInterceptor = GrpcServerAuthInterceptor(
+            sharedSecret = sharedSecret,
+            timestampToleranceMs = 30_000L,
+            clockMillis = { serverTime },
+        )
+        val clientInterceptor = GrpcClientAuthInterceptor(
+            sharedSecret = sharedSecret,
+            clockMillis = { clientTime },
+        )
+
+        val server = InProcessServerBuilder
+            .forName(serverName)
+            .directExecutor()
+            .addService(ServerInterceptors.intercept(serviceImpl, serverInterceptor))
+            .build()
+            .start()
+
+        val channel = InProcessChannelBuilder
+            .forName(serverName)
+            .directExecutor()
+            .intercept(clientInterceptor)
+            .build()
+
+        try {
+            val stub = EngineServiceGrpcKt.EngineServiceCoroutineStub(channel)
+            var caughtStatus: Status.Code? = null
+            try {
+                stub.eventStream(
+                    flow {
+                        emit(InboundEvent.Connected(sessionId = SessionId(1L)).toProto())
+                    },
+                ).collect {}
+            } catch (e: StatusRuntimeException) {
+                caughtStatus = e.status.code
+            } catch (e: StatusException) {
+                caughtStatus = e.status.code
+            }
+            assertEquals(Status.Code.UNAUTHENTICATED, caughtStatus)
+        } finally {
+            channel.shutdownNow()
+            server.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `timestamp within tolerance is accepted`() = runBlocking {
+        val serverTime = 100_000L
+        val clientTime = serverTime - 15_000L // 15 seconds behind, within 30s tolerance
+
+        val serverInterceptor = GrpcServerAuthInterceptor(
+            sharedSecret = sharedSecret,
+            timestampToleranceMs = 30_000L,
+            clockMillis = { serverTime },
+        )
+        val clientInterceptor = GrpcClientAuthInterceptor(
+            sharedSecret = sharedSecret,
+            clockMillis = { clientTime },
+        )
+
+        val server = InProcessServerBuilder
+            .forName(serverName)
+            .directExecutor()
+            .addService(ServerInterceptors.intercept(serviceImpl, serverInterceptor))
+            .build()
+            .start()
+
+        val channel = InProcessChannelBuilder
+            .forName(serverName)
+            .directExecutor()
+            .intercept(clientInterceptor)
+            .build()
+
+        try {
+            val stub = EngineServiceGrpcKt.EngineServiceCoroutineStub(channel)
+            val collectJob = scope.launch {
+                stub.eventStream(
+                    flow {
+                        emit(InboundEvent.Connected(sessionId = SessionId(1L)).toProto())
+                        delay(500)
+                    },
+                ).collect {}
+            }
+
+            delay(200)
+            assertTrue(serviceImpl.sessionToStream.containsKey(SessionId(1L)))
+            collectJob.cancel()
+        } finally {
+            channel.shutdownNow()
+            server.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `server without interceptor accepts any client`() = runBlocking {
+        // No interceptor on server — should accept all clients (STANDALONE mode behavior).
+        val server = InProcessServerBuilder
+            .forName(serverName)
+            .directExecutor()
+            .addService(serviceImpl)
+            .build()
+            .start()
+
+        val channel = InProcessChannelBuilder
+            .forName(serverName)
+            .directExecutor()
+            .build()
+
+        try {
+            val stub = EngineServiceGrpcKt.EngineServiceCoroutineStub(channel)
+            val collectJob = scope.launch {
+                stub.eventStream(
+                    flow {
+                        emit(InboundEvent.Connected(sessionId = SessionId(1L)).toProto())
+                        delay(500)
+                    },
+                ).collect {}
+            }
+
+            delay(200)
+            assertTrue(serviceImpl.sessionToStream.containsKey(SessionId(1L)))
+            collectJob.cancel()
+        } finally {
+            channel.shutdownNow()
+            server.shutdownNow()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds HMAC-SHA256 shared secret authentication to gRPC connections between ENGINE and GATEWAY deployment modes, closing a P0 security gap where the channel was previously unauthenticated
- Server interceptor validates `HMAC(secret, timestamp)` + timestamp within a configurable tolerance window (default 30s); client interceptor attaches both headers to every outgoing call
- New config fields: `grpc.sharedSecret` (required non-blank in ENGINE/GATEWAY mode), `grpc.allowPlaintext` (transport-level, default true for dev), `grpc.timestampToleranceMs`

## Changes
- **New file:** `GrpcAuthInterceptor.kt` -- `GrpcServerAuthInterceptor`, `GrpcClientAuthInterceptor`, HMAC utilities, constant-time comparison
- **AppConfig.kt:** Added `sharedSecret`, `allowPlaintext`, `timestampToleranceMs` to `GrpcConfig`; validation in `validated()` requiring non-blank secret in ENGINE/GATEWAY mode
- **EngineGrpcServer.kt:** Accepts optional `ServerInterceptor` parameter, wires into `ServerBuilder`
- **EngineServer.kt:** Creates `GrpcServerAuthInterceptor` from config and passes to `EngineGrpcServer`
- **GatewayServer.kt:** Creates `GrpcClientAuthInterceptor` from config; wires into both single-engine and multi-engine `ManagedChannelBuilder` calls; replaces hardcoded `.usePlaintext()` with config-driven `grpc.allowPlaintext`
- **Multi-instance profiles:** All 4 profile YAMLs updated with `local-dev-secret-change-in-production` placeholder

## Test plan
- [x] 7 unit tests: HMAC consistency, different payloads/secrets produce different HMACs, constructor rejects blank secret, rejects zero tolerance
- [x] 6 in-process gRPC integration tests: authenticated client succeeds, unauthenticated client gets UNAUTHENTICATED, wrong secret rejected, expired timestamp rejected, timestamp within tolerance accepted, server without interceptor accepts all clients
- [x] 5 config validation tests: blank secret rejected in ENGINE/GATEWAY mode, accepted with value in ENGINE mode, not required in STANDALONE mode, non-positive tolerance rejected
- [x] Full test suite passes (including existing gRPC integration tests)
- [x] ktlintCheck passes