### PR TITLE
Fix CodeQL alerts: unused vars, type shadowing, exclude generated code

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,4 @@
+name: "AmbonMUD CodeQL config"
+
+paths-ignore:
+  - build/generated

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           languages: java-kotlin
           queries: security-and-quality
+          config-file: .github/codeql/codeql-config.yml
 
       - name: Build (custom — required for JVM languages)
         run: |

--- a/src/main/kotlin/dev/ambon/engine/HotReloadManager.kt
+++ b/src/main/kotlin/dev/ambon/engine/HotReloadManager.kt
@@ -100,8 +100,6 @@ class HotReloadManager(
      * new spawns take effect on next respawn.
      */
     suspend fun reloadWorld(): HotReloadResult {
-        val errors = mutableListOf<String>()
-
         val freshWorld: World
         try {
             freshWorld = worldLoader()

--- a/src/main/kotlin/dev/ambon/engine/HousingSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/HousingSystem.kt
@@ -350,7 +350,6 @@ class HousingSystem(
         if (target.sessionId == sessionId) return "You can't invite yourself."
 
         val targetRoom = target.roomId
-        val entryRoomId = houseRoomId(house.ownerName, 0)
 
         visitorOrigins[target.sessionId] = targetRoom
         sessionInHouse[target.sessionId] = pid

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
@@ -288,8 +288,8 @@ class NavigationHandler(
                 p.name,
                 playerDesc,
                 level = p.level,
-                race = p.race.toString(),
-                playerClass = p.playerClass.toString(),
+                race = p.race,
+                playerClass = p.playerClass,
             )
             return
         }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ShopHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ShopHandler.kt
@@ -115,7 +115,7 @@ class ShopHandler(
         cmd: Command.Sell,
     ) {
         players.withPlayer(sessionId) { me ->
-            val shop = findShop(sessionId, me, command = "sell") ?: return
+            findShop(sessionId, me, command = "sell") ?: return
             val keyword = cmd.keyword
             val inv = items.inventory(sessionId)
             val invItem = inv.firstOrNull { it.matchesKeyword(keyword) }

--- a/src/main/kotlin/dev/ambon/engine/events/InputEventHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/InputEventHandler.kt
@@ -3,11 +3,11 @@ package dev.ambon.engine.events
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.metrics.GameMetrics
 
-class InputEventHandler<LoginState>(
-    private val getLoginState: (SessionId) -> LoginState?,
+class InputEventHandler<S>(
+    private val getLoginState: (SessionId) -> S?,
     private val hasActivePlayer: (SessionId) -> Boolean,
     private val isInTransit: (SessionId) -> Boolean,
-    private val handleLoginLine: suspend (SessionId, String, LoginState) -> Unit,
+    private val handleLoginLine: suspend (SessionId, String, S) -> Unit,
     private val onSessionInTransit: suspend (SessionId) -> Unit,
     private val routeCommandLine: suspend (SessionId, String) -> Unit,
     private val metrics: GameMetrics = GameMetrics.noop(),

--- a/src/main/kotlin/dev/ambon/engine/events/LoginEventHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/LoginEventHandler.kt
@@ -4,32 +4,32 @@ import dev.ambon.domain.ids.SessionId
 import dev.ambon.metrics.GameMetrics
 
 class LoginEventHandler<
-    LoginState,
-    AwaitingName,
-    AwaitingCreateConfirmation,
-    AwaitingExistingPassword,
-    AwaitingNewPassword,
-    AwaitingRaceSelection,
-    AwaitingClassSelection,
+    S,
+    AN,
+    CC,
+    EP,
+    NP,
+    RS,
+    CS,
 >(
     private val onAwaitingName: suspend (SessionId, String) -> Unit,
-    private val onAwaitingCreateConfirmation: suspend (SessionId, String, AwaitingCreateConfirmation) -> Unit,
-    private val onAwaitingExistingPassword: suspend (SessionId, String, AwaitingExistingPassword) -> Unit,
-    private val onAwaitingNewPassword: suspend (SessionId, String, AwaitingNewPassword) -> Unit,
-    private val onAwaitingRaceSelection: suspend (SessionId, String, AwaitingRaceSelection) -> Unit,
-    private val onAwaitingClassSelection: suspend (SessionId, String, AwaitingClassSelection) -> Unit,
-    private val asAwaitingCreateConfirmation: (LoginState) -> AwaitingCreateConfirmation?,
-    private val asAwaitingExistingPassword: (LoginState) -> AwaitingExistingPassword?,
-    private val asAwaitingNewPassword: (LoginState) -> AwaitingNewPassword?,
-    private val asAwaitingRaceSelection: (LoginState) -> AwaitingRaceSelection?,
-    private val asAwaitingClassSelection: (LoginState) -> AwaitingClassSelection?,
-    private val isAwaitingName: (LoginState) -> Boolean,
+    private val onAwaitingCreateConfirmation: suspend (SessionId, String, CC) -> Unit,
+    private val onAwaitingExistingPassword: suspend (SessionId, String, EP) -> Unit,
+    private val onAwaitingNewPassword: suspend (SessionId, String, NP) -> Unit,
+    private val onAwaitingRaceSelection: suspend (SessionId, String, RS) -> Unit,
+    private val onAwaitingClassSelection: suspend (SessionId, String, CS) -> Unit,
+    private val asAwaitingCreateConfirmation: (S) -> CC?,
+    private val asAwaitingExistingPassword: (S) -> EP?,
+    private val asAwaitingNewPassword: (S) -> NP?,
+    private val asAwaitingRaceSelection: (S) -> RS?,
+    private val asAwaitingClassSelection: (S) -> CS?,
+    private val isAwaitingName: (S) -> Boolean,
     private val metrics: GameMetrics = GameMetrics.noop(),
 ) {
     suspend fun onLoginLine(
         sessionId: SessionId,
         line: String,
-        state: LoginState,
+        state: S,
     ) {
         metrics.onLoginHandlerEvent()
         if (isAwaitingName(state)) {

--- a/src/main/kotlin/dev/ambon/transport/NetworkSession.kt
+++ b/src/main/kotlin/dev/ambon/transport/NetworkSession.kt
@@ -181,7 +181,8 @@ class NetworkSession(
 
     private fun parseTerminalType(payload: ByteArray) {
         if (payload.isEmpty()) return
-        if ((payload[0].toInt() and 0xFF) != TelnetProtocol.TTYPE_IS) return
+        val firstByte = (payload[0].toInt()) and 0xFF
+        if (firstByte != TelnetProtocol.TTYPE_IS) return
 
         val term =
             payload

--- a/src/test/kotlin/dev/ambon/engine/MultiSystemIntegrationTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/MultiSystemIntegrationTest.kt
@@ -203,7 +203,6 @@ class MultiSystemIntegrationTest {
         val players = buildTestPlayerRegistry(startRoom, repo, items, clock = clock)
         val mobs = MobRegistry()
         val tradeSystem = TradeSystem(items)
-        val duelSystem = DuelSystem(clock)
         val groupSystem = GroupSystem(players, outbound)
         val effectRegistry = StatusEffectRegistry()
         effectRegistry.register(

--- a/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
@@ -62,7 +62,7 @@ class QuestSystemTest {
     @Test
     fun `acceptQuest adds quest to active quests`() =
         runTest {
-            val (qs, players, outbound) = setup()
+            val (qs, players, _) = setup()
             val sid = SessionId(1L)
             players.loginOrFail(sid, "Hero")
 
@@ -272,7 +272,7 @@ class QuestSystemTest {
     @Test
     fun `formatQuestLog shows multiple quests on separate lines`() =
         runTest {
-            val (qs, players, _) = setup()
+            val (_, players, _) = setup()
             val sid = SessionId(1L)
             players.loginOrFail(sid, "Hero")
 

--- a/src/test/kotlin/dev/ambon/engine/commands/DungeonCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/DungeonCommandTest.kt
@@ -212,7 +212,7 @@ class DungeonCommandTest {
         // Enter dungeon
         h.router.handle(sid, Command.DungeonEnter("crypt", null))
         h.drain()
-        val instanceRoom = h.players.get(sid)!!.roomId
+        h.players.get(sid)!!.roomId
 
         // Manually move player out (simulating something like death teleport)
         h.players.moveTo(sid, portalRoom)

--- a/src/test/kotlin/dev/ambon/engine/status/StatusEffectSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/status/StatusEffectSystemTest.kt
@@ -498,7 +498,7 @@ class StatusEffectSystemTest {
         runTest {
             val h = buildSystem()
             h.loginPlayer()
-            val mob = h.spawnMob(id = mobId, name = "Goblin", hp = 3)
+            h.spawnMob(id = mobId, name = "Goblin", hp = 3)
             h.registerDot(durationMs = 6000, tickIntervalMs = 2000, minVal = 5, maxVal = 5)
 
             h.system.applyToMob(mobId, StatusEffectId("ignite"), sid)


### PR DESCRIPTION
## Summary

- Remove unread local variables and useless `.toString()` calls flagged by CodeQL across 8 source/test files
- Rename type parameters in `LoginEventHandler`/`InputEventHandler` to avoid shadowing the `LoginState` sealed interface (fixes 2 warnings)
- Extract bitwise mask to local val in `NetworkSession` for operator precedence clarity (fixes 1 warning)
- Add CodeQL config to exclude `build/generated/` — suppresses 68 alerts from protobuf-generated Java code that we don't control

Resolves 92 of 94 open CodeQL code scanning alerts. The remaining 2 are false positives (`GrpcOutboundDispatcher` constant comparison, and line-1 Kotlin analysis artifacts).

## Test plan

- [x] `ktlintCheck` passes
- [x] Full test suite passes
- [ ] Verify CodeQL re-scan after merge shows reduced alert count