### PR TITLE
Refactor: extract InboundBackpressureTracker to deduplicate transport logic

### DIFF
--- a/src/main/kotlin/dev/ambon/transport/InboundBackpressureTracker.kt
+++ b/src/main/kotlin/dev/ambon/transport/InboundBackpressureTracker.kt
@@ -1,0 +1,53 @@
+package dev.ambon.transport
+
+import dev.ambon.bus.InboundBus
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.engine.events.InboundEvent
+import dev.ambon.metrics.GameMetrics
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Manages inbound backpressure counters for a single transport session.
+ *
+ * Both telnet ([NetworkSession]) and WebSocket ([KtorWebSocketTransport])
+ * transports share the same try-send / counter-reset / counter-increment /
+ * threshold-throw pattern.  This class encapsulates that logic so neither
+ * transport has to duplicate it.
+ */
+class InboundBackpressureTracker(
+    private val maxFailures: Int,
+) {
+    private var failures = 0
+
+    /**
+     * Try-sends a [InboundEvent.LineReceived] to [bus].
+     *
+     * On success the failure counter resets and [onSuccess] is invoked
+     * (typically a metrics call).  On failure the counter increments, a
+     * backpressure-failure metric is recorded, and once [maxFailures] is
+     * reached an [InboundBackpressure] exception is thrown.
+     */
+    fun sendLineOrThrow(
+        bus: InboundBus,
+        sessionId: SessionId,
+        line: String,
+        metrics: GameMetrics,
+        onSuccess: () -> Unit,
+    ) {
+        val result = bus.trySend(InboundEvent.LineReceived(sessionId, line))
+        if (result.isSuccess) {
+            failures = 0
+            onSuccess()
+            return
+        }
+
+        failures++
+        metrics.onInboundBackpressureFailure()
+        log.debug { "Inbound line dropped due to backpressure: sessionId=$sessionId failures=$failures" }
+        if (failures >= maxFailures) {
+            throw InboundBackpressure("inbound backpressure")
+        }
+    }
+}

--- a/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
+++ b/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
@@ -174,7 +174,7 @@ private suspend fun DefaultWebSocketServerSession.bridgeWebSocketSession(
     val outboundQueue = Channel<OutboundFrame>(capacity = sessionOutboundQueueCapacity)
     val disconnected = AtomicBoolean(false)
     val disconnectReason = AtomicReference("EOF")
-    var inboundBackpressureFailures = 0
+    val backpressureTracker = InboundBackpressureTracker(maxInboundBackpressureFailures)
 
     fun noteDisconnectReason(reason: String) {
         if (reason.isBlank()) return
@@ -257,16 +257,8 @@ private suspend fun DefaultWebSocketServerSession.bridgeWebSocketSession(
                     }
                     val lines = sanitizeIncomingLines(text, maxLineLen, maxNonPrintablePerLine)
                     for (line in lines) {
-                        val sent = inbound.trySend(InboundEvent.LineReceived(sessionId, line)).isSuccess
-                        if (sent) {
-                            inboundBackpressureFailures = 0
+                        backpressureTracker.sendLineOrThrow(inbound, sessionId, line, metrics) {
                             metrics.onInboundLineWs()
-                            continue
-                        }
-                        inboundBackpressureFailures++
-                        metrics.onInboundBackpressureFailure()
-                        if (inboundBackpressureFailures >= maxInboundBackpressureFailures) {
-                            throw InboundBackpressure("inbound backpressure")
                         }
                     }
                 }

--- a/src/main/kotlin/dev/ambon/transport/NetworkSession.kt
+++ b/src/main/kotlin/dev/ambon/transport/NetworkSession.kt
@@ -37,7 +37,7 @@ class NetworkSession(
     private val dispatcher: CoroutineContext = Dispatchers.IO,
 ) {
     private val disconnected = AtomicBoolean(false)
-    private var inboundBackpressureFailures = 0
+    private val backpressureTracker = InboundBackpressureTracker(maxInboundBackpressureFailures)
 
     @Volatile
     var gmcpEnabled = false
@@ -307,20 +307,9 @@ class NetworkSession(
     }
 
     private fun sendInboundLineOrThrow(line: String) {
-        val result = inbound.trySend(InboundEvent.LineReceived(sessionId, line))
-        if (result.isSuccess) {
-            inboundBackpressureFailures = 0
+        backpressureTracker.sendLineOrThrow(inbound, sessionId, line, metrics) {
             metrics.onInboundLineTelnet()
-            return
         }
-
-        inboundBackpressureFailures++
-        metrics.onInboundBackpressureFailure()
-        log.debug { "Inbound line dropped due to backpressure: sessionId=$sessionId failures=$inboundBackpressureFailures" }
-        if (inboundBackpressureFailures >= maxInboundBackpressureFailures) {
-            throw InboundBackpressure("inbound backpressure")
-        }
-        // Drop the line and keep the session open until the threshold is exceeded.
     }
 }
 


### PR DESCRIPTION
## Summary

- Extract `InboundBackpressureTracker` utility class to deduplicate the identical backpressure handling logic between telnet (`NetworkSession`) and WebSocket (`KtorWebSocketTransport`) transports
- Both transports now delegate to the shared tracker, passing their transport-specific metrics callback
- Identified in refactoring review as high-impact duplication (identical ~15-line block in 2 files)

## Changes

- **New:** `InboundBackpressureTracker.kt` — encapsulates try-send, failure counter, threshold check, and `InboundBackpressure` throw
- **Modified:** `NetworkSession.kt` — replaced inline backpressure logic with tracker instance
- **Modified:** `KtorWebSocketTransport.kt` — replaced inline backpressure logic with tracker instance

## Test plan

- [x] `ktlintCheck` passes
- [x] Full test suite passes
- [ ] CI green