### PR TITLE
Refactor: extract transport bundle creation to ServerInfrastructure

### DIFF
--- a/src/main/kotlin/dev/ambon/MudServer.kt
+++ b/src/main/kotlin/dev/ambon/MudServer.kt
@@ -77,7 +77,7 @@ class MudServer(
             .newFixedThreadPool(config.login.authThreads) { r ->
                 Thread(r, "ambon-auth").also { it.isDaemon = true }
             }.asCoroutineDispatcher()
-    private val telnetDispatcher = Executors.newVirtualThreadPerTaskExecutor().asCoroutineDispatcher()
+    private val telnetDispatcher = ServerInfrastructure.createTelnetDispatcher()
     private val sessionIdFactory = AtomicSessionIdFactory()
 
     private lateinit var outboundRouter: OutboundRouter
@@ -439,7 +439,7 @@ class MudServer(
                 ).run()
             }
 
-        telnetTransport = ServerInfrastructure.createTelnetTransport(
+        val transports = ServerInfrastructure.createAndStartTransports(
             config = config,
             inbound = inbound,
             outboundRouter = outboundRouter,
@@ -447,19 +447,11 @@ class MudServer(
             scope = scope,
             metrics = gameMetrics,
             sessionDispatcher = telnetDispatcher,
-        )
-        telnetTransport.start()
-        log.info { "Telnet transport bound on port ${config.server.telnetPort}" }
-
-        webTransport = ServerInfrastructure.createWebTransport(
-            config = config,
-            inbound = inbound,
-            outboundRouter = outboundRouter,
-            sessionIdFactory = sessionIdFactory::allocate,
             prometheusRegistry = prometheusRegistry,
-            metrics = gameMetrics,
         )
-        webTransport.start()
+        telnetTransport = transports.telnet
+        webTransport = transports.web
+        log.info { "Telnet transport bound on port ${config.server.telnetPort}" }
         log.info { "WebSocket transport bound on ${config.transport.websocket.host}:${config.server.webPort}" }
         if (config.observability.metricsEnabled) {
             log.info { "Metrics enabled at ${config.observability.metricsEndpoint}" }

--- a/src/main/kotlin/dev/ambon/ServerInfrastructure.kt
+++ b/src/main/kotlin/dev/ambon/ServerInfrastructure.kt
@@ -39,10 +39,13 @@ import dev.ambon.transport.OutboundRouter
 import io.micrometer.prometheusmetrics.PrometheusConfig
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancelAndJoin
 import java.time.Clock
 import java.util.UUID
+import java.util.concurrent.Executors
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -123,6 +126,60 @@ object ServerInfrastructure {
             metricsEndpoint = config.observability.metricsEndpoint,
             metrics = metrics,
         )
+
+    /**
+     * Bundle of started transports returned by [createAndStartTransports].
+     */
+    data class TransportBundle(
+        val telnet: BlockingSocketTransport,
+        val web: KtorWebSocketTransport,
+    )
+
+    /**
+     * Creates the virtual-thread dispatcher used for telnet session I/O.
+     * Both [MudServer] and [dev.ambon.gateway.GatewayServer] need this.
+     */
+    fun createTelnetDispatcher(): ExecutorCoroutineDispatcher =
+        Executors.newVirtualThreadPerTaskExecutor().asCoroutineDispatcher()
+
+    /**
+     * Creates and starts both transports (telnet + WebSocket).
+     * This encapsulates the duplicated create-start sequence shared by
+     * [MudServer] and [dev.ambon.gateway.GatewayServer].
+     */
+    suspend fun createAndStartTransports(
+        config: AppConfig,
+        inbound: InboundBus,
+        outboundRouter: OutboundRouter,
+        sessionIdFactory: () -> dev.ambon.domain.ids.SessionId,
+        scope: CoroutineScope,
+        metrics: GameMetrics,
+        sessionDispatcher: CoroutineContext,
+        prometheusRegistry: PrometheusMeterRegistry?,
+    ): TransportBundle {
+        val telnet = createTelnetTransport(
+            config = config,
+            inbound = inbound,
+            outboundRouter = outboundRouter,
+            sessionIdFactory = sessionIdFactory,
+            scope = scope,
+            metrics = metrics,
+            sessionDispatcher = sessionDispatcher,
+        )
+        telnet.start()
+
+        val web = createWebTransport(
+            config = config,
+            inbound = inbound,
+            outboundRouter = outboundRouter,
+            sessionIdFactory = sessionIdFactory,
+            prometheusRegistry = prometheusRegistry,
+            metrics = metrics,
+        )
+        web.start()
+
+        return TransportBundle(telnet = telnet, web = web)
+    }
 
     fun bindQueueMetrics(
         inbound: InboundBus,

--- a/src/main/kotlin/dev/ambon/gateway/GatewayServer.kt
+++ b/src/main/kotlin/dev/ambon/gateway/GatewayServer.kt
@@ -39,14 +39,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
-import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.random.Random
 
@@ -70,7 +68,7 @@ class GatewayServer(
     private val config: AppConfig,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-    private val telnetDispatcher = Executors.newVirtualThreadPerTaskExecutor().asCoroutineDispatcher()
+    private val telnetDispatcher = dev.ambon.ServerInfrastructure.createTelnetDispatcher()
     private val multiEngine = config.gateway.engines.isNotEmpty()
 
     private val prometheusRegistry: PrometheusMeterRegistry? =
@@ -171,7 +169,7 @@ class GatewayServer(
         outboundRouter = OutboundRouter(engineOutbound = activeOutbound, scope = scope, metrics = gameMetrics)
         scope.launch { outboundRouter.start() }
 
-        telnetTransport = dev.ambon.ServerInfrastructure.createTelnetTransport(
+        val transports = dev.ambon.ServerInfrastructure.createAndStartTransports(
             config = config,
             inbound = activeInbound,
             outboundRouter = outboundRouter,
@@ -179,19 +177,11 @@ class GatewayServer(
             scope = scope,
             metrics = gameMetrics,
             sessionDispatcher = telnetDispatcher,
-        )
-        telnetTransport.start()
-        log.info { "Gateway telnet transport bound on port ${config.server.telnetPort}" }
-
-        webTransport = dev.ambon.ServerInfrastructure.createWebTransport(
-            config = config,
-            inbound = activeInbound,
-            outboundRouter = outboundRouter,
-            sessionIdFactory = sessionIdFactory::allocate,
             prometheusRegistry = prometheusRegistry,
-            metrics = gameMetrics,
         )
-        webTransport.start()
+        telnetTransport = transports.telnet
+        webTransport = transports.web
+        log.info { "Gateway telnet transport bound on port ${config.server.telnetPort}" }
 
         bindQueueMetrics()
 


### PR DESCRIPTION
## Summary

- Add `TransportBundle` data class, `createTelnetDispatcher()`, and `createAndStartTransports()` to `ServerInfrastructure`
- Replace duplicated transport creation + start + logging in both `MudServer.kt` and `GatewayServer.kt` with single shared call
- Eliminates ~40 lines of near-identical transport initialization code

## Test plan

- [x] `ktlintCheck` passes
- [x] Full test suite passes
- [ ] CI green