### PR TITLE
Refactor: consolidate duplicate HouseRoomDto/RoomColumnDto

### DIFF
--- a/src/main/kotlin/dev/ambon/persistence/PostgresHouseRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PostgresHouseRepository.kt
@@ -2,9 +2,6 @@ package dev.ambon.persistence
 
 import com.fasterxml.jackson.core.type.TypeReference
 import dev.ambon.domain.housing.HouseRecord
-import dev.ambon.domain.housing.HouseRoomRecord
-import dev.ambon.domain.items.ItemInstance
-import dev.ambon.domain.world.Direction
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.ResultRow
@@ -14,7 +11,7 @@ import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.upsert
 
 private val log = KotlinLogging.logger {}
-private val roomsType = object : TypeReference<List<RoomColumnDto>>() {}
+private val roomsType = object : TypeReference<List<HouseRoomDto>>() {}
 
 class PostgresHouseRepository(
     private val database: Database,
@@ -56,13 +53,13 @@ class PostgresHouseRepository(
             it[ownerId] = record.ownerId.value
             it[ownerName] = record.ownerName
             it[ownerNameLower] = record.ownerName.lowercase()
-            it[rooms] = mapper.writeValueAsString(record.rooms.map { r -> RoomColumnDto.from(r) })
+            it[rooms] = mapper.writeValueAsString(record.rooms.map { r -> HouseRoomDto.from(r) })
             it[createdAtEpochMs] = record.createdAtEpochMs
         }
     }
 
     private fun ResultRow.toHouseRecord(): HouseRecord {
-        val rawRooms: List<RoomColumnDto> =
+        val rawRooms: List<HouseRoomDto> =
             runCatching {
                 mapper.readValue(this[HousesTable.rooms], roomsType)
             }.onFailure { ex ->
@@ -74,37 +71,5 @@ class PostgresHouseRepository(
             rooms = rawRooms.map { it.toDomain() },
             createdAtEpochMs = this[HousesTable.createdAtEpochMs],
         )
-    }
-}
-
-/**
- * JSON DTO for room data stored in the `rooms` TEXT column.
- * Directions are serialised as strings so they survive schema evolution.
- */
-internal data class RoomColumnDto(
-    val templateId: String,
-    val customTitle: String? = null,
-    val customDescription: String? = null,
-    val exits: Map<String, Int> = emptyMap(),
-    val storedItems: List<ItemInstance> = emptyList(),
-) {
-    fun toDomain(): HouseRoomRecord =
-        HouseRoomRecord(
-            templateId = templateId,
-            customTitle = customTitle,
-            customDescription = customDescription,
-            exits = exits.mapKeys { Direction.valueOf(it.key) },
-            storedItems = storedItems,
-        )
-
-    companion object {
-        fun from(record: HouseRoomRecord): RoomColumnDto =
-            RoomColumnDto(
-                templateId = record.templateId,
-                customTitle = record.customTitle,
-                customDescription = record.customDescription,
-                exits = record.exits.mapKeys { it.key.name },
-                storedItems = record.storedItems,
-            )
     }
 }


### PR DESCRIPTION
## Summary

- `YamlHouseRepository.HouseRoomDto` and `PostgresHouseRepository.RoomColumnDto` were byte-for-byte identical (~30 lines each)
- Remove `RoomColumnDto` from `PostgresHouseRepository.kt` and reuse `HouseRoomDto` from `YamlHouseRepository.kt` (same package, no import needed)
- Remove 3 now-unused imports

Last item from the final refactoring review pass.

## Test plan

- [x] `ktlintCheck` passes
- [x] Full test suite passes
- [ ] CI green