### PR TITLE
Add petition easter-egg command with 4 hidden zones

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -186,6 +186,10 @@ sealed interface Command {
 
     data object Recall : Command
 
+    data class Petition(
+        val keyword: String,
+    ) : Command
+
     data object Score : Command
 
     data class Goto(
@@ -1148,6 +1152,9 @@ object CommandParser {
 
         // gender <option>
         requiredArg(line, listOf("gender"), "gender <option>", { Command.SetGender(it) })?.let { return it }
+
+        // petition <keyword>
+        requiredArg(line, listOf("petition"), "petition <keyword>", { Command.Petition(it.lowercase()) })?.let { return it }
 
         // sprite: "sprite", "sprite list", "sprite set <id>", "sprite default", "sprite clear", "sprites"
         matchPrefix(line, listOf("sprite", "sprites")) { rest ->

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
@@ -36,6 +36,20 @@ class NavigationHandler(
     private val gmcpEmitter = ctx.gmcpEmitter
     private lateinit var router: CommandRouter
 
+    /** Easter-egg petition keywords → zone:startRoom targets. */
+    private val petitionTargets: Map<String, RoomId> = mapOf(
+        "pbrae" to RoomId("pbrae:gravel_road"),
+        "peanut" to RoomId("pbrae:gravel_road"),
+        "braelynn" to RoomId("pbrae:gravel_road"),
+        "wesley" to RoomId("wesleyalis:gravel_road_2"),
+        "aurora" to RoomId("wesleyalis:gravel_road_2"),
+        "wesleyalis" to RoomId("wesleyalis:gravel_road_2"),
+        "trevor" to RoomId("trailey:cul_de_sac"),
+        "hailey" to RoomId("trailey:cul_de_sac"),
+        "trailey" to RoomId("trailey:cul_de_sac"),
+        "noecker" to RoomId("noecker_resume:lobby"),
+    )
+
     override fun register(router: CommandRouter) {
         this.router = router
         router.on<Command.Look> { sid, _ -> handleLook(sid) }
@@ -44,6 +58,7 @@ class NavigationHandler(
         router.on<Command.LookDir> { sid, cmd -> handleLookDir(sid, cmd) }
         router.on<Command.LookAt> { sid, cmd -> handleLookAt(sid, cmd) }
         router.on<Command.Recall> { sid, _ -> handleRecall(sid) }
+        router.on<Command.Petition> { sid, cmd -> handlePetition(sid, cmd) }
     }
 
     private suspend fun handleLook(sessionId: SessionId) {
@@ -220,6 +235,38 @@ class NavigationHandler(
         )
         onPlayerMoved?.invoke(sessionId, target)
         outbound.send(OutboundEvent.SendText(sessionId, msgs.arrival))
+        ctx.sendLook(sessionId)
+    }
+
+    private suspend fun handlePetition(sessionId: SessionId, cmd: Command.Petition) {
+        val target = petitionTargets[cmd.keyword]
+        if (target == null) {
+            outbound.send(OutboundEvent.SendError(sessionId, "Your petition goes unanswered."))
+            return
+        }
+        if (combat.isInCombat(sessionId)) {
+            outbound.send(OutboundEvent.SendError(sessionId, "You can't petition while in combat!"))
+            return
+        }
+        val me = players.get(sessionId) ?: return
+        if (!world.rooms.containsKey(target)) {
+            outbound.send(OutboundEvent.SendError(sessionId, "Your petition goes unanswered."))
+            return
+        }
+        val from = me.roomId
+        outbound.send(OutboundEvent.SendText(sessionId, "You whisper a name into the void... and the world shifts around you."))
+        movePlayerWithNotify(
+            sessionId,
+            from,
+            target,
+            "vanishes in a shimmer of light",
+            "appears in a shimmer of light",
+            players,
+            outbound,
+            gmcpEmitter,
+            dialogueSystem,
+        )
+        onPlayerMoved?.invoke(sessionId, target)
         ctx.sendLook(sessionId)
     }
 

--- a/src/main/resources/world/noecker_resume.yaml
+++ b/src/main/resources/world/noecker_resume.yaml
@@ -1,0 +1,591 @@
+zone: noecker_resume
+image:
+  room: cb24b3903033408e13ef14be797721a700251e3f07907ecde652d7f05b84d5c3.png
+  mob: c49140a0669957dbe3a818c8c93c44608563a92eb7ea420c46843a2db6ca9a56.png
+  item: cfca0181cd1b4373a4ba7671a3b1ddf62ff3e1d7257942e3af69cb908b79a29f.png
+lifespan: 45
+startRoom: lobby
+mobs:
+  ambon_architect:
+    image: 33a9b5a21bfabd78f2f1e21a9284d32a1d4bf143183f64c507ce581bfe01a96b.png
+    name: the Resident Architect
+    room: ambon_workshop
+    dialogue:
+      root:
+        text: Welcome to the AmbonMUD workshop! I designed this thing as a portfolio project, but it grew some genuinely
+          interesting distributed systems features along the way. What would you like to know?
+        choices:
+          - text: What is AmbonMUD, exactly?
+            next: about
+          - text: Tell me about the overall architecture.
+            next: architecture
+          - text: How does it scale across multiple servers?
+            next: scaling
+          - text: What is the tech stack?
+            next: stack
+          - text: Nothing, just looking.
+      about:
+        text: AmbonMUD is a multiplayer text adventure server written in Kotlin — the same style of game from the BBS era, but
+          built on modern infrastructure. Tick-based game loop, telnet and WebSocket transports, GMCP structured data,
+          class-based character progression, quests, abilities, status effects, shop economy, and NPCs with YAML-defined
+          behavior trees. And a backend architecture that could hold its own in a system design interview.
+        choices:
+          - text: Tell me about the architecture.
+            next: architecture
+          - text: How does it scale?
+            next: scaling
+          - text: What is the tech stack?
+            next: stack
+          - text: That's enough, thanks.
+      architecture:
+        text: AmbonMUD has three deployment modes. STANDALONE runs everything in one process — game engine, transports,
+          persistence. ENGINE mode runs just the game logic and exposes a gRPC server. GATEWAY mode runs the transports
+          and talks to a remote ENGINE over a gRPC bidirectional stream. This split lets you scale engines and gateways
+          independently, and add Redis for cross-process pub/sub.
+        choices:
+          - text: How does the event bus work?
+            next: event_bus
+          - text: Tell me about the gRPC layer.
+            next: grpc
+          - text: How does it scale?
+            next: scaling
+          - text: Got it, thanks.
+      event_bus:
+        text: "The engine communicates exclusively through two interfaces: InboundBus and OutboundBus. In STANDALONE mode these
+          are in-process coroutine channels. In multi-process mode they become Redis pub/sub streams or gRPC
+          bidirectional streams. The engine never knows which implementation it's talking to — you swap the entire
+          transport and bus stack with a config flag."
+        choices:
+          - text: Tell me about zone sharding.
+            next: sharding
+          - text: Tell me about the gRPC layer.
+            next: grpc
+          - text: What about Redis specifically?
+            next: redis
+          - text: Interesting, thanks.
+      grpc:
+        text: "Each GATEWAY connects to exactly one ENGINE over a persistent gRPC bidirectional stream. Telnet and WebSocket
+          player sessions get serialized into InboundEvents and streamed to the engine; OutboundEvents come back and get
+          rendered. Session handoffs between engines use a two-phase protocol: player state is flushed to the
+          persistence layer, then a SessionRedirect event tells the gateway to reconnect the player's socket to the
+          target engine."
+        choices:
+          - text: Tell me about zone sharding.
+            next: sharding
+          - text: What about Redis?
+            next: redis
+          - text: Tell me about persistence.
+            next: persistence
+          - text: Got it, thanks.
+      scaling:
+        text: Scaling works in two dimensions. First, multiple ENGINE instances each own a subset of zones — that's zone
+          sharding, coordinated by a ZoneRegistry (static config in dev, Redis-backed in production). Second, a
+          ThresholdInstanceScaler watches player load per zone and publishes scale-up signals when a zone gets crowded.
+          A load-balanced instance selector routes new players to the least-loaded engine for their target zone.
+        choices:
+          - text: Tell me about zone sharding in more detail.
+            next: sharding
+          - text: What happens when a player crosses zone boundaries?
+            next: handoff
+          - text: How does the event bus work?
+            next: event_bus
+          - text: Makes sense, thanks.
+      sharding:
+        text: Zones are assigned to engine instances via a ZoneRegistry. In local mode this is a static map; in production it is
+          Redis-backed so any process can look up which engine owns a zone. When a player moves to a room in a different
+          engine's zone, the HandoffManager serializes their state, routes the session to the new engine via a
+          SessionRedirect outbound event, and the old engine cleanly releases the session. To the player it just looks
+          like a slightly slow room transition.
+        choices:
+          - text: How does the session handoff actually work?
+            next: handoff
+          - text: Tell me about persistence.
+            next: persistence
+          - text: What about Redis?
+            next: redis
+          - text: Clear, thanks.
+      handoff:
+        text: "The handoff sequence: the source engine flushes the player's state to the persistence layer, emits a
+          SessionRedirect outbound event, and stops routing output for that session. The gateway receives the redirect,
+          tears down local session routing, and reconnects the player's socket to the target engine's gRPC stream. The
+          target engine loads the player from the persistence layer and picks up the session. The whole thing needs to
+          complete fast enough that the player just experiences a slightly sluggish room transition."
+        choices:
+          - text: Tell me about persistence.
+            next: persistence
+          - text: How does the event bus work?
+            next: event_bus
+          - text: Thanks, that's clear.
+      redis:
+        text: "Redis plays three roles: pub/sub event bus in multi-process mode, player state cache in the persistence chain,
+          and a shared zone registry for shard coordination. The caching layer uses write-coalescing to batch player
+          saves, reducing hot-path latency during busy ticks. Everything touches Redis through interface abstractions,
+          so the engine and game logic never import Lettuce directly."
+        choices:
+          - text: Tell me about the persistence chain.
+            next: persistence
+          - text: Tell me about zone sharding.
+            next: sharding
+          - text: Got it, thanks.
+      persistence:
+        text: "Player state flows through a layered repository chain: WriteCoalescingPlayerRepository batches writes to reduce
+          flush frequency, RedisCachingPlayerRepository serves reads from cache, then either YAML files or PostgreSQL at
+          the bottom depending on config. YAML uses atomic writes via temp-file-and-rename. The Postgres path uses
+          Flyway migrations and Exposed for type-safe queries over HikariCP. You swap backends with a single config flag
+          and the engine never changes."
+        choices:
+          - text: How does the event bus work?
+            next: event_bus
+          - text: Tell me about the overall architecture.
+            next: architecture
+          - text: That covers it, thanks.
+      stack:
+        text: Kotlin 2.3 on JVM 21. Ktor for WebSocket transport. kotlinx-coroutines for the async runtime — the game engine
+          runs on a single-threaded coroutine dispatcher, which keeps the tick loop simple to reason about. Jackson for
+          YAML world loading, Hoplite for config. gRPC with Protobuf for inter-process comms. Lettuce for Redis, Exposed
+          plus HikariCP for Postgres. Micrometer and Prometheus for metrics. About 200 Kotlin source files and 85 test
+          files.
+        choices:
+          - text: Tell me about the architecture.
+            next: architecture
+          - text: How does it scale?
+            next: scaling
+          - text: Impressive. Thanks.
+  impostor_syndrome:
+    image: d28694618e058a14d833484bd65ff2f5b0b80ce9dbbe30bd6b590f40869a3bf2.png
+    name: an Impostor Syndrome Wisp
+    room: lobby
+    tier: weak
+    level: 1
+    xpReward: 25
+    behavior:
+      template: coward
+      params:
+        fleeHpPercent: 70
+        fleeMessage: The wisp shrieks, 'You probably don't belong here either!' and vanishes through the wall.
+    respawnSeconds: 120
+  memory_leak:
+    image: de6d2dd8bb9655ebe3b24286f45a2f3af25c709894d81ccd07f4203f8934217e.png
+    name: a Memory Leak
+    room: proteus_bay
+    tier: weak
+    level: 1
+    behavior:
+      template: wander_aggro
+      params:
+        aggroMessage: The leak oozes toward your heap space and latches on!
+    respawnSeconds: 90
+  null_pointer_exception:
+    image: 47cd169da249cd01f57838b44737bcef64bf07fb5ac9e16ab02f8efd13923790.png
+    name: a NullPointerException
+    room: juola_lab
+    tier: weak
+    level: 1
+    hp: 10
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: 'Exception in thread "main": java.lang.NullPointerException at line 42!'
+    respawnSeconds: 120
+  scope_creep:
+    image: 1040eb8cbccbf05181e8007775821efba9a75db8240ca000ed3e52b1626890a7.png
+    name: a Scope Creep
+    room: freelance_hq
+    tier: weak
+    level: 1
+    behavior:
+      template: wander_aggro
+      params:
+        aggroMessage: "'Could we add just one more feature? It will only take a minute. Two minutes tops.'"
+    respawnSeconds: 60
+  legacy_monolith:
+    image: 97a0d5f02ead3c62e145fc3a3899a23a37ecd1103c3f789c51bc3c524629f3b7.png
+    name: the Legacy Monolith
+    room: migration_bridge
+    tier: weak
+    level: 1
+    hp: 12
+    armor: 0
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: "THE MONOLITH AWAKENS. ESTIMATED DEPLOY TIME: FOUR HOURS. DO NOT INTERRUPT THE PROCESS."
+    respawnSeconds: 300
+  fda_auditor:
+    image: b7eb8f0ab4875dab9372ca6718b3173f8a9ef0d9bcbef5fffb48c31333cee147.png
+    name: an FDA Compliance Auditor
+    room: fda_archive
+    tier: weak
+    level: 1
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: "'I need to see your audit trail. ALL of it. Where is the audit trail?!'"
+    respawnSeconds: 150
+  runaway_lambda:
+    image: 0e093bbd7bebd0c5393df068053e0bf858f95f8568bd0fc97a0ab1d498742167.png
+    name: a Runaway Lambda
+    room: lambda_shrine
+    tier: weak
+    level: 1
+    goldMin: 0
+    goldMax: 5
+    behavior:
+      template: wander
+    respawnSeconds: 30
+  budget_committee:
+    image: f5d6f3940513889715e18b65ddb41c91f541baded7b5960c8bb4958c33b9065c.png
+    name: a Budget Committee
+    room: savings_vault
+    tier: weak
+    level: 1
+    hp: 10
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: "'That hundred-thousand-a-month savings? We have some follow-up questions.'"
+    respawnSeconds: 120
+  phone_screen:
+    image: 0c7516004e32358f61fcf988642c7f30653700429cf32d8fdcbb5f00ca3aebfa.png
+    name: a Technical Phone Screen
+    room: karat_studio
+    tier: weak
+    level: 1
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: "'Quick: implement a thread-safe LRU cache. Fifteen minutes. No hints. I'm timing you.'"
+    respawnSeconds: 90
+  stack_overflow_error:
+    image: 8116c58196b52dbd6a6f9e032f7f4f08a43822879ce469d8d4796ca69f0431d6.png
+    name: a Stack Overflow Error
+    room: gatech_annex
+    tier: weak
+    level: 1
+    hp: 12
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: "Segmentation fault (core dumped). Stack trace: [infinite recursion in progress]"
+    respawnSeconds: 180
+items:
+  lambda_arrow:
+    image: 38cb92a8e951823b09cb25ea8a89591bb5d43d73bf7284f7168320bae9628439.png
+    displayName: a Lambda Arrow
+    description: "Small, stateless, and devastatingly focused. Engraved: 'Do one thing well and exit cleanly.'"
+    slot: weapon
+    damage: 2
+    basePrice: 18
+    room: lambda_shrine
+  ci_cd_wrench:
+    image: bfb94df9b345eabbd2cf46e605090225dd17dc4896d439781537d77ca7a89a35.png
+    displayName: a CI/CD Wrench
+    description: "Reduced deployment time by 60%. Turn it left: pipeline improves. Turn it right: someone requests another stage."
+    slot: weapon
+    damage: 2
+    basePrice: 15
+    room: pipeline_bay
+  type_safe_compiler:
+    image: a91556dbf87cfa2d4393fa42a8a24447213c0bff930f7d25f378ed4c8248c315.png
+    displayName: a Type-Safe Compiler
+    description: Refuses to let you swing it incorrectly. Kotlin-forged; catches your runtime errors before they hurt anyone.
+    slot: weapon
+    damage: 3
+    basePrice: 30
+    room: gatech_annex
+  well_architected_shield:
+    image: 20b792c5ecb6badb353a2ccabb619f9e0ca4122c5995fbc05a031889bc1b6d4c.png
+    displayName: a Well-Architected Shield
+    description: "Five pillars embossed on the face: Operational Excellence, Security, Reliability, Performance Efficiency,
+      Cost Optimization. Stops questionable cloud defaults cold."
+    slot: offhand
+    armor: 3
+    basePrice: 35
+    room: migration_bridge
+  aws_cert_badge:
+    image: 41449c5dbb72e392c8372218fd4a98562c8cf5d269b23f91698b5a3bc3a1b6ba.png
+    displayName: an AWS Certification Badge
+    description: "Stamped: 'Solutions Architect – Associate, Aug 2023'. It hums softly when you start drawing box-and-arrow
+      diagrams."
+    slot: head
+    armor: 2
+    stats:
+      CON: 1
+    basePrice: 25
+    room: cloud_platform
+  valedictorian_medal:
+    image: d74b264383eb0852ad5f7f18b6c4e335f4d17e74041ae2ce61874513ed74b8f8.png
+    displayName: a Valedictorian Medal
+    description: Summa cum laude. Valedictorian in Computer Science, Mathematics, and Liberal Arts at Duquesne University.
+      Bright enough to briefly silence your inner critic.
+    slot: head
+    armor: 1
+    stats:
+      CON: 1
+    basePrice: 20
+    room: education_wing
+  code_review_coffee:
+    image: da0a119f9f0261628d63ae342d3d1c1a2be1312403ca1ab8a45cfac4e6ad3f33.png
+    displayName: a Code Review Coffee
+    keyword: coffee
+    description: Black, strong, and it leaves comments. Recommended before any production deploy or Daubert challenge.
+    consumable: true
+    onUse:
+      healHp: 15
+    basePrice: 12
+    room: war_room
+  unit_test_suite:
+    image: 861365fad23f80226084e28083e5c0e4af25dd63b1f1c2880e053d7b709eabc2.png
+    displayName: a Unit Test Suite
+    keyword: potion
+    description: Confidence in a flask. Drink and briefly feel like every edge case is covered. JUnit and Jest flavors available.
+    consumable: true
+    onUse:
+      healHp: 10
+    basePrice: 8
+    room: freelance_hq
+  patent_scroll:
+    image: ce1b7dd40f3576deea373e4dd9f98416cca051581e9f9823be8704560f6045c3.png
+    displayName: a Patent Scroll
+    description: Authorship Technologies — US-11605055-B2 and US-10657494-B2. It crackles faintly and smells of peer review
+      and legal fees.
+    basePrice: 5
+    room: patent_annex
+  cost_savings_coin:
+    image: 41a789b720b3233e09e3958d7dd275e092390c06e61a7801ff8c94307cbaa214.png
+    displayName: a Cost-Savings Coin
+    description: Heavy gold, stamped '$100K/month'. Earned by replacing expensive data sources with smarter, cheaper ones at
+      Signifyd.
+    basePrice: 50
+    room: savings_vault
+  jgaap_sourcebook:
+    image: 583db8666d2fc8d16f1d59244e468a4591a20a81a3806a54bf55b48c9e73f247.png
+    displayName: a JGAAP Sourcebook
+    description: "Open-source forensic authorship analysis. Margin note: 'Every methodology must be reproducible or it
+      doesn't count.'"
+    basePrice: 8
+    room: juola_lab
+  audit_trail:
+    image: 7954efcda12b0c21bf5b1ae5e39e66c84b44dc0137cb65180fe6f1cef94b5191.png
+    displayName: an Immutable Audit Trail
+    description: A tamper-evident ledger. Timestamped, cross-referenced, and defensible under Daubert admissibility standards.
+    basePrice: 10
+    room: fda_archive
+  observability_compass:
+    image: cc77332135bf9eca1d92e60c2cb3f8c37c96a6c6c181577776fa4c69f28d5c3a.png
+    displayName: an Observability Compass
+    description: Points toward structured logs, distributed traces, and the root cause you missed the first three times.
+    basePrice: 15
+    room: war_room
+  interview_rubric:
+    image: 7503eb312edd9a683515ec67782288efd2c150c5cb6146a2ce81999681ae16b0.png
+    displayName: an Interview Rubric
+    description: "Three thousand interviews condensed into calibrated checkboxes: tradeoffs, communication clarity,
+      production readiness."
+    basePrice: 8
+    room: karat_studio
+shops:
+  career_services:
+    name: Career Services Desk
+    room: lobby
+    items:
+      - code_review_coffee
+      - unit_test_suite
+rooms:
+  lobby:
+    image: 46b9d178636647f11a655a61874fa1633fe7478ef495d7947c01575de12e589e.jpg
+    title: "The Lobby (Resume: John Noecker Jr.)"
+    description: "A bright, airy foyer. A framed summary on the wall reads: JOHN NOECKER JR. | Backend & Distributed Systems
+      Engineer | 15+ years designing scalable, fault-tolerant cloud systems | AWS-first, JVM-heavy (Java/Kotlin) |
+      Spring Boot, DynamoDB, Lambda, API Gateway, CI/CD, Docker | 3,000+ technical interviews conducted | 500+ engineers
+      mentored | ambon.dev. A Career Services Desk stands nearby. An Impostor Syndrome Wisp lurks in the corner but will
+      probably flee if you confront it."
+    exits:
+      n: timeline_entry
+      e: ambon_workshop
+  ambon_workshop:
+    image: 6202a313f76b3d4231b963dbf63cf7d8ec732b195c4b573bd9da0907918aaaad.jpg
+    title: AmbonMUD Workshop
+    description: "A server room that smells faintly of coroutines and carefully considered abstractions. Diagrams cover
+      every surface: event bus interfaces, gRPC streaming topologies, zone shard registries, a layered persistence chain
+      with Redis in the middle. A sticky note on the whiteboard reads: 'It started as a demo. It grew a distributed
+      systems story.' The Resident Architect stands nearby, apparently happy to explain any of it."
+    exits:
+      w: lobby
+  timeline_entry:
+    image: baaa02ed17c73b122ddfca394ea373c897a9ab23f51842f5a87ffacc42edd54e.jpg
+    title: Career Timeline Entrance
+    description: A long corridor lined with professional plaques in chronological order. The air carries the faint smell of
+      fresh commits and hard-earned lessons. The earliest chapters are to the north.
+    exits:
+      s: lobby
+      n: proteus_bay
+  proteus_bay:
+    image: 51ecb3e916ae28989252545f9dff406d28f7e957fdda75b5835ed82d6ac6b7ac.jpg
+    title: PROTEUS Workbench (2009-2010)
+    description: "An early-career workshop smelling of large datasets and the quiet satisfaction of real software shipped. A
+      placard reads: 'Built tools to parse extremely large datasets — achieved 1000x reduction in processing time over
+      ad-hoc workflows. Performance, scalability, reliability from day one.' A Memory Leak drifts through looking for
+      something to consume."
+    exits:
+      s: timeline_entry
+      n: juola_lab
+  juola_lab:
+    image: 98cc644298db7c139b13fb653175e315ac7a4e9bc281cdbbef7bf068fa2d81c3.jpg
+    title: Juola & Associates Lab (2010-2016)
+    description: "A research lab where the most dangerous bug is an unrepeatable result. Bookshelves hold forensic analysis
+      tools, legal filings, and authorship attribution papers. A chalkboard reads: 'Applied to The Cuckoo's Calling,
+      Satoshi Nakamoto, and Chevron v. Donziger. Methodologies defensible under Daubert admissibility standards.' A
+      NullPointerException guards the door with misplaced confidence."
+    exits:
+      s: proteus_bay
+      e: patent_annex
+      n: signifyd_floor
+  patent_annex:
+    image: 4c22b0ca9854c5c9bc27baca4f0d48c5ce1ae17e0645ea3c2cfdad3d446b80b3.jpg
+    title: Patent Annex
+    description: "A quiet room with framed certificates on the wall: 'Authorship Technologies — Patrick Juola, John Noecker
+      Jr., et al. U.S. Patents: US-11605055-B2, US-10657494-B2.' A second plaque notes a $1.6M government grant and
+      peer-reviewed publications. The patent scroll rests on the table."
+    exits:
+      w: juola_lab
+  signifyd_floor:
+    image: 2eb2e4c07601981526173128b47879dfd0f88c35318c76697c8d88d9d82d67f3.jpg
+    title: Signifyd Market Floor (2016-2018)
+    description: "A bustling trading floor where fraud decisions move fast and correctness is non-negotiable. Service
+      boundaries and data flow diagrams are etched into the cobblestones. A bronze plaque reads: 'Reduced recurring data
+      costs ~$100K/month. Improved throughput and latency via smarter caching strategies. Production systems at scale.'"
+    exits:
+      s: juola_lab
+      e: savings_vault
+      n: enzyme_workshop
+  savings_vault:
+    image: a5b0f8bea4805466ad78e54793eeec6326f064de501660a5febc90361248976d.jpg
+    title: Optimization Vault
+    description: A vault lined with cost graphs and vendor invoices. The ledger shows a clean line trending sharply downward
+      after smarter data sourcing decisions. The Budget Committee is stationed here, still asking follow-up questions
+      about last quarter's numbers.
+    exits:
+      w: signifyd_floor
+  enzyme_workshop:
+    image: c15926be5faa2cb9e411d5710a9e738c612c4b63956ae5358850f422b10c4322.jpg
+    title: Enzyme Workshop (2019-2020)
+    description: "A clean room for systems that must be auditable and correct. TypeScript and Node.js blueprints are pinned
+      everywhere. A sign reads: 'Greenfield platform for FDA 510(k) data extraction — backend validation, audit trails,
+      and regulatory correctness required at every layer.' Runes of traceability hover in the air."
+    exits:
+      s: signifyd_floor
+      e: fda_archive
+      n: freelance_hq
+  fda_archive:
+    image: cb658d05c9842dcede8bff6e4962cbd87dfa6b378b96d8509d6097f629799455.jpg
+    title: FDA 510(k) Archive
+    description: "Shelves packed with regulatory documents and extraction pipeline specs. Every action logged. Every
+      transformation traceable. A sign over the door: 'Automate the boring parts. Never compromise the audit trail.' The
+      Compliance Auditor paces the stacks, clipboard raised."
+    exits:
+      w: enzyme_workshop
+  freelance_hq:
+    image: afbf6368b73ac9e0d4ee828acfdd67a343c2f7d86759eaa738f15dcb5677eb5a.jpg
+    title: Noecker & Associates HQ (2020-Present)
+    description: "A crossroads of ambiguous requirements and high-stakes deliveries. Whiteboards read: 'Staff-level scope —
+      architecture, delivery, production support. Reduced deployment time 60%. AWS Well-Architected migrations.
+      Observability-first: structured logging, metrics, alerting. Reduced mean time-to-diagnosis in production.' A Scope
+      Creep wanders in from an adjacent room, as usual."
+    exits:
+      s: enzyme_workshop
+      e: migration_bridge
+      w: pipeline_bay
+      n: cloud_platform
+  migration_bridge:
+    image: cb4de04eb0a12a6c0e0c4ae79ab1755fcb546eff574a45ac7bdee8057057c3ca.jpg
+    title: Legacy Migration Bridge
+    description: "A bridge over a chasm labeled 'Monolith to Cloud'. Each plank is a deliberate step: incremental delivery,
+      backward compatibility, zero-downtime cutover. The Well-Architected Shield leans against the railing. The Legacy
+      Monolith blocks the far end, absolutely certain its four-hour deploy pipeline is fine."
+    exits:
+      w: freelance_hq
+  pipeline_bay:
+    image: e6278a6bed205e8fe03f05125cbd460494361ce2f234f3703cdafe02229ff662.jpg
+    title: Pipeline Foundry
+    description: "Jenkins gears mesh with Docker valves in a satisfying clank. A banner overhead: 'Deployment time reduced
+      60% — CI/CD pipelines rebuilt with repeatability and speed.' The CI/CD Wrench sits on the workbench, still warm
+      from the last optimization run."
+    exits:
+      e: freelance_hq
+      n: war_room
+  war_room:
+    image: 5e37364bcf8f303b866fa397b901e2d64515082ae8b98f94307844d479fc4737.jpg
+    title: Incident War Room
+    description: Screens glow with live dashboards. Structured logs scroll in disciplined rows. Distributed traces thread
+      through services like bright string, shortening the gap between symptom and root cause. An Observability Compass
+      rests on the table. A Code Review Coffee sits beside it, still warm.
+    exits:
+      s: pipeline_bay
+  cloud_platform:
+    image: 2138c3880f0602676628324eebd335f34dc0cb50c3585f8c6725657861afbaab.jpg
+    title: Cloud Observatory
+    description: "An observatory of AWS architecture diagrams and cost curves. Lambda, EC2, S3, DynamoDB, API Gateway,
+      CloudFormation — the full toolkit laid out like star charts. A note reads: 'AWS Certified Solutions Architect,
+      Associate — reliability, cost control, and operational safety in every design.' The AWS Certification Badge is
+      displayed in a case by the telescope."
+    exits:
+      s: freelance_hq
+      e: lambda_shrine
+      n: karat_studio
+  lambda_shrine:
+    image: 7c43ec64c5da4a2b3b9e0bd92a1fdc7495570fd6eb4f95a91855c206ce48235e.jpg
+    title: Serverless Shrine
+    description: A shrine etched with Lambda, API Gateway, SQS, and DynamoDB insignia. Offerings include small, focused
+      functions and clean event contracts. A Runaway Lambda darts between exits, stateless and entirely too eager to
+      invoke itself again.
+    exits:
+      w: cloud_platform
+  karat_studio:
+    image: aa732b29de2707c60e284d29ef5ae4e1379926dab253a19144f08274f31d09c9.jpg
+    title: Karat Interview Studio (2019-Present)
+    description: "A studio with a timer on the wall and three thousand stories in the chairs. A chalkboard reads: 'Senior
+      Interview Engineer — partners include Citi, Indeed, and Roblox. Calibrated feedback on tradeoffs, communication
+      clarity, and production readiness.' The Interview Rubric is on the table. A Technical Phone Screen prowls the room
+      looking for someone to quiz."
+    exits:
+      s: cloud_platform
+      e: mentorship_lounge
+      n: education_wing
+  mentorship_lounge:
+    image: 1ec63f1383815c3272476e536414b517233a8b76c8253d0d956ec1bbaf1a868d.jpg
+    title: Mentorship Mezzanine
+    description: "A warm lounge overlooking the interview rooms below. Wall notes: '500+ engineers mentored through Karat
+      and Brilliant Black Minds. Actionable feedback over vague encouragement. State-approved apprenticeship curriculum
+      authored and delivered. A decade of hiring, training, and operations at an independent small business.'"
+    exits:
+      w: karat_studio
+  education_wing:
+    image: c0ed11086b456c9eb670dee789bb606559794ce42a58e62fc8495b67ba700bd1.jpg
+    title: Duquesne Hall (Education)
+    description: "A grand hall where Computer Science and Mathematics share the same chalkboard. A plaque reads: 'B.S.
+      Computer Science | B.A. Mathematics | Duquesne University — Graduated summa cum laude. Valedictorian in Liberal
+      Arts, Computer Science, and Mathematics.' The Valedictorian Medal gleams under the lights. A doorway east leads to
+      graduate studies."
+    exits:
+      s: karat_studio
+      e: gatech_annex
+      n: graduation_stage
+  gatech_annex:
+    image: f126c365b0bd0791ae180990c05042410edbdbe75eaeaeb1560ad918eacadd00.jpg
+    title: Georgia Tech Annex
+    description: "A studio of graduate-level diagrams: machine learning, artificial intelligence, robotics. The notes are
+      meticulous and competitive. A Stack Overflow Error has taken up residence at the recursion terminal, growing with
+      every stack frame. A Type-Safe Compiler sits ominously on the desk nearby."
+    exits:
+      w: education_wing
+  graduation_stage:
+    image: f2b87b26c90d964ad24b1a14e4de781575d4f25eaeccc86932d9f6eef10764c0.jpg
+    title: Graduation Stage
+    description: "A bright stage with spotlights and a waiting podium. The view from here takes in the full arc: PROTEUS
+      datasets to cloud migrations, forensic linguistics to fraud systems, FDA pipelines to three thousand interview
+      rooms. A terminal in the corner blinks: ambon.dev — more systems to build, more worlds to ship."
+    exits:
+      s: education_wing
+audio:
+  music: 9de18c8c7ed2b9ee7ebd553c18d043d64da869a75800db50b41c58a66b7d7e12.mp3

--- a/src/main/resources/world/pbrae.yaml
+++ b/src/main/resources/world/pbrae.yaml
@@ -1,0 +1,841 @@
+zone: pbrae
+image:
+  room: 37d00e7f3bd0f92f319e437f77d70c36eadd3631cccb3c09708b00c83446d947.png
+  mob: b89204647cf6c2b25e18228f392366ae745cc6fe84ba7e533904ecbc9f019e04.png
+  item: 644938eba766494c3480e91ef35e8218fcfa57cd650edc15dd71256b8ed61f8c.png
+lifespan: 0
+startRoom: gravel_road
+mobs:
+  forest_deer:
+    image: 84bfe560632a2f5c704584a0c11cbcda370413872c195030794732b8b4b46420.png
+    name: a white-tailed deer
+    room: forest_trail
+    tier: weak
+    level: 2
+    xpReward: 10
+    goldMin: 0
+    goldMax: 2
+    respawnSeconds: 180
+    behavior:
+      template: wander
+  mountain_hawk:
+    image: b5ed4a9cdb995645bf8bcff565ebbf64e80b5f532a9b718edaa70a8654425e98.png
+    name: a mountain hawk
+    room: mountain_path
+    tier: weak
+    level: 3
+    respawnSeconds: 240
+    behavior:
+      template: wander
+  red_hen:
+    image: 993856ce54916f6548c9a5dcb8254f2266bf11e7aac5aee9317b89674a9db798.png
+    name: a plump red hen
+    room: coop_henhouse
+    tier: weak
+    level: 1
+    xpReward: 5
+    goldMin: 0
+    goldMax: 1
+    respawnSeconds: 60
+    behavior:
+      template: wander
+  white_hen:
+    image: 25f2f12bf55b56e2c6e77f37bed0ece771545f152a95fd82daeb6b05ce6d80cc.png
+    name: a fluffy white hen
+    room: coop_outer_run
+    tier: weak
+    level: 1
+    xpReward: 5
+    goldMin: 0
+    goldMax: 1
+    respawnSeconds: 60
+    behavior:
+      template: wander
+  mallard_duck:
+    image: 37878c059ed819e68cf7d6e8963fee01b16f49f40de771434107e4b8074c7636.png
+    name: a waddling mallard duck
+    room: coop_duck_pond
+    tier: weak
+    level: 1
+    xpReward: 5
+    goldMin: 0
+    goldMax: 1
+    respawnSeconds: 60
+    behavior:
+      template: wander
+  pekin_duck:
+    image: f5ed22d8c16661c9fe5bd9937a8b0e9e1163e3be3765d3cf5a769516c847962b.png
+    name: a white Pekin duck
+    room: coop_duck_nook
+    tier: weak
+    level: 1
+    xpReward: 5
+    goldMin: 0
+    goldMax: 1
+    respawnSeconds: 60
+    behavior:
+      template: wander
+  gobbler:
+    image: fe0b9a75a9c76d02da6fec34e745c5c1e402d2579c2236550f28baffbe14e1c0.png
+    name: a gobbling bronze turkey
+    room: coop_turkey_hall
+    tier: weak
+    level: 2
+    respawnSeconds: 90
+    behavior:
+      template: wander
+  hen_turkey:
+    image: 2e72e9bf1c0f89fd9983b3bf2cd1b15f4380fa839fd6b813c821e85d510638c1.png
+    name: a speckled turkey hen
+    room: coop_turkey_roost
+    tier: weak
+    level: 1
+    respawnSeconds: 90
+    behavior:
+      template: wander
+  royal_rooster:
+    image: 4d7ef873c2831810dbe46a3ab464d403ba469b0122477b96a4d165704f16650b.png
+    name: the Royal Rooster, Lord of the Coop
+    room: coop_rooster_den
+    tier: standard
+    level: 3
+    respawnSeconds: 180
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: The Royal Rooster puffs up, spreads his magnificent wings, and CROWS with ear-splitting authority!
+  royal_cook:
+    image: 25c99c3619cfa7f5a2deca32aecf9bc3a9488b76929c5ede0ee3ab5b2ef6a340.png
+    name: the Royal Cook
+    room: kitchen_main
+    tier: weak
+    level: 1
+    goldMin: 0
+    goldMax: 5
+    respawnSeconds: 300
+    behavior:
+      template: wander
+  castle_servant:
+    image: 09f3320ccfbf033baa549f4ae6936d78a04028b02bbef437783784113b5b6abe.png
+    name: a loyal castle servant
+    room: servant_quarters
+    tier: weak
+    level: 1
+    goldMin: 1
+    goldMax: 3
+    respawnSeconds: 300
+    behavior:
+      template: wander
+  creeper:
+    image: 41d6be8fb9a91cd46bfae966f653bf24c24a7630733d63564c1b36752e47b26a.png
+    name: a hissing Creeper
+    room: peanut_nether
+    tier: standard
+    level: 5
+    respawnSeconds: 120
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: Ssssssss...
+  rocket_car:
+    image: 3996d70c63019ed9dbee12f4ab98078e07161767e921619747b5886965f2a9a8.png
+    name: a rocket-powered arena car
+    room: peanut_rocket_arena
+    tier: weak
+    level: 3
+    respawnSeconds: 120
+    behavior:
+      template: wander
+  divine_guardian:
+    image: dac93742b6996871a7263efb670d95f95ad2ab24d011a7644aebdfcd4db028af.png
+    name: a divine guardian of Olympus
+    room: peanut_olympus
+    tier: elite
+    level: 8
+    respawnSeconds: 300
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: The guardian raises its golden spear! 'None may pass without the King's seal!'
+  penguin_guard:
+    image: a60f8ba3858488265befd34f73207e60ad3d21d9e49ad0d0fdba3f551decf5fc.png
+    name: a waddling penguin guard
+    room: braelynn_penguin_palace
+    tier: weak
+    level: 1
+    respawnSeconds: 120
+    behavior:
+      template: wander
+  baby_penguin:
+    image: be27767d1e54423f13ec26748d122081e5288a05611f628a760d760e7ac60aa2.png
+    name: an adorable baby penguin
+    room: braelynn_penguin_nursery
+    tier: weak
+    level: 1
+    xpReward: 1
+    goldMin: 0
+    goldMax: 0
+    respawnSeconds: 60
+    behavior:
+      template: wander
+  stuffie_guardian:
+    image: 4c2b4f095e86232925b464052adfdb3cb5916e8391b861ed25020b95be87cf49.png
+    name: a magical giant stuffed bear
+    room: braelynn_stuffie_grove
+    tier: standard
+    level: 2
+    respawnSeconds: 180
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: The stuffed bear's button eyes glow fierce gold! 'These stuffies are MINE to protect!'
+  roblox_noob:
+    image: 9fad7055fbcc775040e47079247563de724832ea7efe9510cefa044d9e09855b.png
+    name: a friendly Roblox noob
+    room: braelynn_roblox_plaza
+    tier: weak
+    level: 1
+    xpReward: 5
+    goldMin: 1
+    goldMax: 5
+    respawnSeconds: 60
+    behavior:
+      template: wander
+items:
+  royal_egg:
+    image: 97ff5f02ab023af43c53de293a9fec247b78f3318923527cc14671195263fd4f.png
+    displayName: a golden royal egg
+    keyword: egg
+    description: A warm, perfectly smooth egg with a faint golden sheen. It pulses gently, as if something wonderful is
+      about to hatch. Eating it restores vigor.
+    consumable: true
+    onUse:
+      healHp: 20
+    room: coop_egg_vault
+    basePrice: 25
+  rooster_feather:
+    image: 1112358ad73122fe48d0b1d68c5871e1920b3bbe77c5f0fc0f9e57e168f0a303.png
+    displayName: a magnificent tail feather
+    keyword: feather
+    description: An iridescent tail feather from the Royal Rooster himself — deep crimson at the base fading to burnished
+      gold at the tip. A symbol of the Kingdom of PBrae.
+    room: coop_rooster_den
+    basePrice: 10
+  mountain_herb:
+    image: 70217b1138663369fa643ad96466d5713c6f9477b7d1cc9caa3b485c82ebbff5.png
+    displayName: a sprig of mountain herb
+    keyword: herb
+    description: A small bundle of hardy herbs found growing in the rocky soil of the mountain path. Their crisp, bright
+      scent is immediately refreshing.
+    consumable: true
+    onUse:
+      healHp: 8
+    room: mountain_path
+    basePrice: 12
+  minecraft_diamond:
+    image: 3c9b0388c97825e7c61160c5152d08a29cdbc2bf0c1aebd887d914a7877fcb8a.png
+    displayName: a glittering Minecraft diamond
+    keyword: diamond
+    description: A perfectly cubic, brilliant blue diamond mined from deep beneath King Peanut's dream realm. It catches
+      light and throws tiny rainbow prisms on the walls.
+    room: peanut_diamond_mine
+    basePrice: 50
+  rocket_boost:
+    image: e6c9a34891aa8812684cd5e0ff5718963cb9990f3a43bd6a9fd3f837361c70f1.png
+    displayName: a rocket boost canister
+    keyword: canister
+    description: A pressurized orange canister stamped with a rocket car logo. Press the button and hold on tight — the rush
+      of boost energy is practically a sugar rush.
+    consumable: true
+    onUse:
+      healHp: 15
+    room: peanut_rocket_arena
+    basePrice: 20
+  smite_coin:
+    image: a741e586d4b6a7014c132a04a1fccc0b9209a08b5fcdae5da058b487e0615b29.png
+    displayName: a divine Smite gold coin
+    keyword: coin
+    description: A heavy gold coin stamped with the faces of gods on both sides — they seem to change depending on the
+      angle. Clearly minted on Mount Olympus.
+    room: peanut_olympus
+    basePrice: 100
+  penguin_plushie:
+    image: 09068fae8caafafb29d8206eb61005255079d016ae32f9c3837627a321a20f0f.png
+    displayName: a soft penguin plushie
+    keyword: plushie
+    description: A pudgy, impossibly soft stuffed penguin wearing a tiny golden crown. It squeaks when squeezed. Braelynn
+      has dozens, but this one is clearly special.
+    slot: offhand
+    armor: 1
+    room: braelynn_penguin_nursery
+    basePrice: 30
+  royal_goblet:
+    image: ce5f59b668e81734c5b178ef3a47f6da63f912f85d205d06d8a05dee571915a9.png
+    displayName: the Royal Goblet of PBrae
+    keyword: goblet
+    description: A golden goblet encrusted with tiny jewels spelling out 'P' on one side and 'B' on the other, intertwined
+      with a crown motif. The vessel of the kingdom.
+    room: braelynn_throne
+    basePrice: 150
+shops:
+  castle_market:
+    name: The Castle PBrae Market Stall
+    room: front_yard
+    items:
+      - mountain_herb
+      - royal_egg
+      - rocket_boost
+rooms:
+  mountain_summit:
+    image: 8ba62230cd8ad01978132116d4bea923c63baa01e657e8f64b657ddeef59e6ae.jpg
+    title: The Summit of Castle Mountain
+    description: You stand atop the peak that Castle PBrae calls home, the wind tugging at your cloak with royal insistence.
+      Far below, the castle gleams like a crown set among the trees, its moat-stream glittering silver in the light. A
+      thundering sound draws you east; the path descends southward.
+    exits:
+      e: waterfall_cliff
+      d: mountain_path
+  waterfall_cliff:
+    image: 6b882c0a3b80fc37d917f88cd5efc038b241dc08a682cc5e3e7860172e126f31.jpg
+    title: Thundering Waterfall
+    description: A great waterfall roars off the eastern face of the mountain, plunging into the forest canopy far below in
+      a billowing curtain of mist and spray. A permanent rainbow hangs in the mist. Carved into the cliff face are the
+      initials 'P' and 'B' inside a heart, worn smooth by years of waterfall weather. The summit lies to the west.
+    exits:
+      w: mountain_summit
+    video: 14910f6508f261c5f8a367ce67f93e85df3b36307b1f5fbe8f147fbb1ddb90e0.mp4
+  mountain_path:
+    image: 2faaa5e5f1dd9a2c61d122aa8668ddfcea24d1cbba9023e78d49cb7630c4bec2.jpg
+    title: Winding Mountain Path
+    description: A rocky path winds down the flank of the mountain between hardy pines and tumbled boulders. The air here is
+      clear and cold and carries the distant sound of the waterfall. A mountain hawk traces lazy circles overhead. The
+      summit looms above; the forest begins below to the south.
+    exits:
+      u: mountain_summit
+      s: forest_trail
+  forest_trail:
+    image: 1f9784afc6d696e7345eab49faa8559838e9ebacbe5dadc602c3f40650767c5e.jpg
+    title: Forest Trail
+    description: The forest here is old and tall, its canopy filtering light into green-gold columns. The path is soft with
+      pine needles and the occasional hoof-print of a deer. The trees grow wilder to the west; a morning mist clings to
+      the eastern undergrowth. South, through the trees, the glint of the royal moat-stream is visible.
+    exits:
+      n: mountain_path
+      e: eastern_woods
+      w: western_woods
+      s: moat_banks
+  eastern_woods:
+    image: d916c227bae8b753f488e3d1b4b09b9833885f6335f9c03cfaa427df4d74a9c0.jpg
+    title: Eastern Woods
+    description: The eastern edge of the forest rises into bramble and old oak, the trees so thick the sky is barely a
+      rumor. Mushrooms cluster at the roots in rings that feel deliberate. It is very quiet here, and very alive. The
+      trail is back to the west.
+    exits:
+      w: forest_trail
+  western_woods:
+    image: a1c3116f7f7b9953cdc519f87b154808fd0da6471b96850b59916c6a77920d98.jpg
+    title: Western Woods
+    description: Ancient firs crowd together to the west of the trail, their roots arching over the ground like the ribs of
+      a great ship. Sunlight barely reaches the soft carpet of needles. Something small and quick moves through the
+      underbrush — a chipmunk, or perhaps just the wind. The trail is back to the east.
+    exits:
+      e: forest_trail
+  moat_banks:
+    image: 1111351773ac9ec6357139604b87d3219fb5965940715d39b1fab5a5ae1a022b.jpg
+    title: Banks of the Royal Moat
+    description: A cheerful stream, clear and quick, curves around the base of the castle hill like a moat set by nature
+      rather than stonemasons. Wildflowers crowd the banks and small silver fish dart through the shallows. A wooden
+      footbridge spans the stream to the south. The forest lies to the north.
+    exits:
+      n: forest_trail
+      s: footbridge
+  footbridge:
+    image: 609a8101525fb018657ce6be240d8802b4de500951fe3094835b0e4681795a2b.jpg
+    title: The Royal Footbridge
+    description: "A narrow footbridge of weathered planks arches over the royal moat-stream, its rope railings worn smooth
+      by a thousand small hands. The planks flex and creak underfoot with a satisfying bounce. A small painted sign on
+      the north post reads: 'KINGDOM OF PBRAE — Authorized Subjects Only.' Unauthorized subjects are not specified."
+    exits:
+      n: moat_banks
+      w: gravel_road
+  gravel_road:
+    image: 1caca6bab99d6b45370abfb4add5eda5f5cd0bc2dd6724cc3427ab4d6c205619.jpg
+    title: The Royal Gravel Road
+    description: A broad road of pale gravel crunches satisfyingly underfoot, stretching from the footbridge in the north
+      down to the castle gates. It is tidy and well-maintained — someone with a rake has been here recently. Castle
+      PBrae rises ahead to the south, its flags snapping in the mountain breeze. A shimmer of portal light is visible
+      far to the north, beyond the stream. The Royal Footbridge arches east over the moat-stream.
+    exits:
+      s: front_yard
+      e: footbridge
+  front_yard:
+    image: 18e7239375d0108226d6cc67cb866e942a6bced45c0ce80216c650188b89bfed.jpg
+    title: Castle PBrae Front Yard
+    description: The wide front yard of Castle PBrae is a cheerful chaos of mowed grass, flower beds, and the occasional
+      escaped feather. The castle's stone walls — which look suspiciously like a real house — rise to the south, draped
+      in morning glory. To the west, the sounds and smells of the Royal Poultry District drift over a low wooden fence.
+      A market stall near the gate sells provisions.
+    exits:
+      n: gravel_road
+      w: coop_entrance
+      s: front_porch
+  front_porch:
+    image: 77f21c4cdfc9703e9e5207342e11939605f6e4553fbf97f546d005e8352bbcfb.jpg
+    title: Front Porch of Castle PBrae
+    description: "The front porch is broad and welcoming, its floorboards painted a cheerful red. A pair of small boots —
+      one with a lightning bolt drawn in marker, one covered in sticker penguins — sits beside the door. A painted sign
+      reads: 'CASTLE PBRAE — Home of King Peanut and Queen Braelynn. Enter with Joy.' The door stands open."
+    exits:
+      n: front_yard
+      s: front_stoop
+  front_stoop:
+    image: d00f18785fc8c22a5da65d9e7c3d957c331bad49d609a9ce8e5005ba1550fe6c.jpg
+    title: The Royal Entry Hall
+    description: Just inside the castle doors, the entry hall buzzes with the energy of a house that is constantly in
+      motion. Backpacks hang on hooks. A drawing of a rocket car and a drawing of a penguin are taped side by side on
+      the wall with obvious pride. The kitchen smells of something good from the east. To the west, a patio door stands
+      open to the afternoon air.
+    exits:
+      n: front_porch
+      w: north_patio
+      e: kitchen_west
+  north_patio:
+    image: 599616e8b9598c8b09bb823f1e2024e0ddbe5ecd167ac98981c3df7082293309.jpg
+    title: The North Patio
+    description: A brick patio stretches along the western side of the castle, shaded by a large oak whose roots have gently
+      lifted one corner of the brickwork. A scatter of sidewalk chalk drawings covers the ground — rockets, crowns,
+      penguins, and something that may be a Minecraft Creeper. The entry hall is to the east; more patio continues
+      south.
+    exits:
+      e: front_stoop
+      s: central_patio
+  central_patio:
+    image: eab75d72492808d12dbc386ce504acf0783323809f3e66471c697fcba616d67e.jpg
+    title: The Central Patio
+    description: The middle section of the western patio, where most of the outdoor adventures happen. A worn picnic table
+      sits here, its surface carved with initials and game scores that span what appears to be several years. A large
+      plastic bin nearby overflows with outdoor toys. The north patio is behind you; the south patio lies ahead.
+    exits:
+      n: north_patio
+      s: sw_patio_a
+  sw_patio_a:
+    image: 1519853ff9fed192381d0318ce6f41470a7d1ed01535775a8863f9ae3f9466b7.jpg
+    title: The Southwest Patio
+    description: The patio widens at the south end, open to the sky. A fire pit ring of stones occupies the center, its
+      edges blackened with happy use. String lights have been strung between the fence posts and the castle wall, ready
+      for evenings. The central patio is to the north; a smaller nook extends to the east.
+    exits:
+      n: central_patio
+      e: sw_patio_b
+  sw_patio_b:
+    image: 620479203b1bdc36272c46b3d3fa141c9f04c847148151ea373f8cfb5d1927c9.jpg
+    title: The Lower South Patio
+    description: A narrow lower patio tucked against the southern wall, half-shaded by a pergola draped in climbing roses. A
+      hammock is strung between two posts; someone has left a book on it, face-down. This is clearly a prime location
+      for doing nothing in particular, which is itself a royal prerogative. The southwest patio is to the west.
+    exits:
+      w: sw_patio_a
+  kitchen_west:
+    image: 2c0e272aabc847de8005868f703171ccddfe969a33a168b54116f7a7ebab8dd3.jpg
+    title: The Royal Pantry
+    description: The western end of the royal kitchen serves as pantry and prep area. Shelves line every wall, packed with
+      labeled jars, cereal boxes, snacks of strategic importance, and a suspicious number of juice boxes. The
+      countertops are at two heights — one for the servants (the parents), one approximately right for a child standing
+      on tiptoe. The entry hall is to the west.
+    exits:
+      w: front_stoop
+      e: kitchen_main
+  kitchen_main:
+    image: 9860b7f41fb5bc1e57d4a0d05d0454ac1480696f67873ac380e3741c5b16cb28.jpg
+    title: The Royal Kitchen
+    description: The heart of Castle PBrae, where the Royal Cook labors to keep the kingdom fed. The stove gleams, the
+      refrigerator hums, and the kitchen table is the true throne of household power. Cheerful crayon drawings are held
+      to the refrigerator by a collection of magnets from everywhere the kingdom has ever traveled. A cozy nook lies to
+      the south.
+    exits:
+      w: kitchen_west
+      e: living_nw
+      s: kitchen_nook
+  kitchen_nook:
+    image: 083af330679709874fc38995df5d91d0f6478ac0419a886ec2f324ed0fabb43f.jpg
+    title: The Kitchen Nook
+    description: "A cozy breakfast nook tucked into the corner behind the kitchen, its built-in bench seats cushioned in a
+      cheerful stripe. This is where royal breakfasts happen — cereal with too much milk, toast with the crusts cut off
+      by diplomatic agreement. The walls are plastered in school drawings and old birthday cards: a museum of small
+      victories. The kitchen is to the north."
+    exits:
+      n: kitchen_main
+  living_nw:
+    image: b5bcaf1d306e48d89eeddd046fce42cdbf1b64d19fb3b02662e71dfd20542e5f.jpg
+    title: The Northwest Drawing Room
+    description: The first of the castle's great halls, given over to the serious business of leisure. A large couch
+      dominates the north wall, facing a TV that has witnessed more gaming sessions than it can count. Controllers in
+      various states of charge are draped across the cushions. Bookshelves hold a cheerful mix of actual books and Funko
+      Pops. The kitchen is to the west.
+    exits:
+      w: kitchen_main
+      e: living_ne
+      s: living_sw
+  living_ne:
+    image: cdfaf08c8aec431efd672f0e68d05885d46e45eed88e71c5fefdbecc82cd6ec2.jpg
+    title: The Northeast Sitting Room
+    description: The sitting room continues the great tradition of comfortable chaos. A floor lamp casts warm light over the
+      reading corner, where an impractical number of pillows has been arranged into a fort built by small and determined
+      architects. Board games are stacked in a precarious tower by the far wall. The bathroom is to the south.
+    exits:
+      w: living_nw
+      s: bathroom
+  living_sw:
+    image: e78b8badb4eb0b798d7e031cb41ce3f851e6a91876b918f860fdf3aa43c9328a.jpg
+    title: The South Throne Hall
+    description: The grandest of the castle's living spaces, so designated by the throne-like recliner positioned at its
+      center. This is the room from which the kingdom is governed during movie nights and video game sessions of state.
+      A carved wooden staircase winds upward to the royal chambers — the Grand Landing awaits above. A window looks out
+      onto the patio.
+    exits:
+      n: living_nw
+      e: bathroom
+      u: upper_landing
+  bathroom:
+    image: d5214ed7a5d30cdd048f45070ee041bb0d137605a012c956784249cf96223418.jpg
+    title: The Royal Bathroom
+    description: "An impeccably tiled royal bathroom. The counter is crowded with the full paraphernalia of two children:
+      toothbrushes (color-coded), an alarming array of hair accessories, a rubber duck that has seen things, and a
+      height-measurement chart on the doorframe recording years of upward progress. Everything smells faintly of
+      bubblegum shampoo."
+    exits:
+      n: living_ne
+      w: living_sw
+  upper_landing:
+    image: fafc585628aa154e880b07a1253ab8fe00a790844e42932185c374c4220ed843.jpg
+    title: The Grand Landing
+    description: The top of the royal staircase opens onto a carpeted landing that is the crossroads of the kingdom's upper
+      world. A framed photo gallery lines the walls — birthdays, holidays, ordinary Tuesday afternoons made immortal. To
+      the east, the sound of rocket engines and pixel music drifts from behind King Peanut's door. To the south, penguin
+      chatter and Roblox music emanate from Queen Braelynn's chambers. The servants' quarters are to the west.
+    exits:
+      d: living_sw
+      e: peanut_chamber
+      s: braelynn_chamber
+      w: servant_quarters
+  servant_quarters:
+    image: fa74ec9954366fd7ed9761b77e9aec79bd80b7cc5bca1eef557b00adb24b22ff.jpg
+    title: The Servant's Quarters
+    description: The quarters of the royal servants — the parents — are comfortable and surprisingly well-organized given
+      the chaos they manage daily. A coffee mug on the nightstand is perpetually half-full. A whiteboard covered in
+      color-coded schedules and reminders hangs on the wall; at the bottom, in very large letters, someone has written
+      'IT IS FINE.' The landing is to the east.
+    exits:
+      e: upper_landing
+  peanut_chamber:
+    image: 18404d47915a0192bb1c8e2f90e7119c34b4806c19a5c942b51187e8fa29e77b.jpg
+    title: King Peanut's Royal Chamber
+    description: "The threshold of King Peanut's domain crackles with low-level electricity. The walls are covered in
+      posters: Rocket League cars in mid-boost, Smite gods in heroic poses, Creepers rendered in pixel art. LEGO
+      structures of dubious structural integrity crowd the shelves. The floor is a sacred minefield of small bricks. At
+      the center of the room reality is thinner than usual — east leads to the arena, up to the Overworld, down to the
+      Nether, north to Olympus."
+    exits:
+      w: upper_landing
+      e: peanut_rocket_arena
+      u: peanut_overworld
+      d: peanut_nether
+      n: peanut_olympus
+  peanut_rocket_arena:
+    image: 7beb39dfc375d2e5b5106e3f9c41d1aaeb5e8afb9472f7e6c1b60059a38f2836.jpg
+    title: The Royal Rocket League Arena
+    description: You have entered the Arena. The roar of imaginary crowds fills your ears. The field glows with electrified
+      blue and orange lines, and cars ricochet off the curved walls in physics-defying arcs. Boost pads pulse gold
+      across the turf. A rocket boost canister has been left at the sideline by someone going too fast to stop. The goal
+      zone is to the east; Peanut's chamber lies west.
+    exits:
+      w: peanut_chamber
+      e: peanut_arena_goals
+  peanut_arena_goals:
+    image: 7703e9af92cbd149c8519b7ce8015ac0100aaa5852af10bc1230535cd6f957f5.jpg
+    title: The Goal Zone
+    description: "The curved walls of the goal zone loom overhead, buzzing with the thrill of every shot ever made here. The
+      net at the end of the pitch is battered but glorious. A scoreboard on the wall reads 'PEANUT: LOTS — EVERYONE
+      ELSE: NOT AS MANY.' On the floor in tape: 'THIS IS WHERE GOALS HAPPEN.' Back to the arena is west."
+    exits:
+      w: peanut_rocket_arena
+  peanut_overworld:
+    image: 596ddc798535b8764b5d8823ab664afd4503c216c8d7472084d490c8def630a6.jpg
+    title: The Minecraft Overworld
+    description: You emerge onto an infinite blocky plain under a sky of perfect square clouds. Grass is green and
+      pixelated. A blocky cow wanders in the middle distance with absolute confidence. A crafting table sits near what
+      appears to be the beginnings of an extremely ambitious construction project — half-finished towers, scattered
+      torches, a mine entrance to the north. Peanut's chamber is below.
+    exits:
+      d: peanut_chamber
+      n: peanut_diamond_mine
+  peanut_diamond_mine:
+    image: 084e8b891ff60acc646d966bbff295a62e8d2d4f25f77d2e619e2f687b0d0e5f.jpg
+    title: The Diamond Mine Depths
+    description: You descend into the blocky earth. Glowing redstone ore traces veins through the stone walls, and somewhere
+      deeper, lava casts everything in orange. And there — set into the wall in a small alcove — a vein of unmistakable
+      blue. A glittering Minecraft diamond catches the torchlight. This is the good stuff. The Overworld is back to the
+      south.
+    exits:
+      s: peanut_overworld
+  peanut_nether:
+    image: 93e46d3d6e64611c50da1043321686c6e46cc9e2ad637be4950fec36acac07d8.jpg
+    title: The Nether Fortress
+    description: Netherrack stretches in every direction, lit by fire and lava falls. A fortress of cracked nether bricks
+      rises from the hellish landscape, its soul sand pathways muffled underfoot. A hissing Creeper lurks by the gate —
+      it does not seem pleased to see you. The way back to Peanut's chamber is up; the Battleground of the Gods is to
+      the east.
+    exits:
+      u: peanut_chamber
+      e: peanut_battleground
+  peanut_battleground:
+    image: 981f58be03b2ef4fa85b57f57921b9e781549111ccefc32ea1a315a563b14c3c.jpg
+    title: The Battleground of the Gods
+    description: Ancient stone tiles form a great arena where gods clash by divine decree. Spectral banners bearing the
+      sigils of every pantheon hang from marble columns. The air smells of ozone and ambition. A conquest lane stretches
+      north toward Olympus itself. Back through the Nether portal is west.
+    exits:
+      w: peanut_nether
+      n: peanut_olympus
+  peanut_olympus:
+    image: 1163abc22db96c59532e7000d7f44c948c94473ea27c15b93920b829da81c790.jpg
+    title: Mount Olympus
+    description: You stand at the peak of Mount Olympus, where clouds part for golden towers and the divine guardian paces a
+      slow and implacable watch. Lightning flickers at the edges of everything. A great throne of platinum and pixel
+      sits at the summit to the east — Peanut's Pixel Throne. The Battleground lies to the south. Trespassers are
+      warned.
+    exits:
+      s: peanut_battleground
+      e: peanut_throne
+  peanut_throne:
+    image: e7d843c3ad86d8eaf811879226c4bd79eb1d3d2a8c8ddaac28a27e366208f4b6.jpg
+    title: Peanut's Pixel Throne Room
+    description: At the very peak of the dream world, King Peanut's Pixel Throne Room shimmers between three realities at
+      once. One wall is a Rocket League scoreboard; one wall is a Smite ability wheel; one wall is a Minecraft biome
+      map. At the center, a throne assembled from pixel art, rocket car parts, and carved stone blocks. It is
+      magnificent. A divine Smite gold coin gleams on the armrest. The peak of Olympus is to the west.
+    exits:
+      w: peanut_olympus
+  braelynn_chamber:
+    image: d33f1706446a258b6e32899fbf420d9ba8848edf2f7fc66524c463acc31d1d3a.jpg
+    title: Queen Braelynn's Royal Chamber
+    description: Queen Braelynn's chamber is a landscape of organized wonder. Shelves of stuffed animals line every wall,
+      arranged by species and emotional significance. Fairy lights give the room a permanent golden-hour glow. Roblox
+      music plays from a small speaker on the desk. The Grand Landing is north; the Penguin Palace is south; the Stuffie
+      Grove is west; Roblox Plaza is east. The dream begins here.
+    exits:
+      n: upper_landing
+      s: braelynn_penguin_palace
+      w: braelynn_stuffie_grove
+      e: braelynn_roblox_plaza
+  braelynn_penguin_palace:
+    image: 773043ee708c5f666c89c6b673318233627e9f2853e2fa7f505b13ef4dfd44ee.jpg
+    title: The Penguin Palace
+    description: You have arrived in the Penguin Palace, a grand hall of blue ice and carved snowdrifts where penguins in
+      tiny formal wear shuffle about with tremendous dignity. The floor is perfectly smooth marble — excellent for
+      sliding. Penguin portraits line the walls. The grandest portrait, at the far end, depicts Queen Braelynn herself
+      in full regalia, surrounded by adoring penguins. The Ice Rink is to the east; the Chamber is north.
+    exits:
+      n: braelynn_chamber
+      e: braelynn_ice_rink
+  braelynn_ice_rink:
+    image: 94e2b0bd7a4ed629a4ed1e0b617a68faeb9ef1241f4972539a0dc1b8b061db19.jpg
+    title: The Royal Ice Rink
+    description: The royal ice rink shimmers beneath enchanted lights that cycle through every color of the rainbow at a
+      steady, joyful rhythm. Penguins here have clearly been practicing — they spin and glide with professional flair.
+      The ice is perfect, the music is perfect, and everything smells faintly of hot chocolate. The Penguin Nursery is
+      to the north; the Palace is west.
+    exits:
+      w: braelynn_penguin_palace
+      n: braelynn_penguin_nursery
+  braelynn_penguin_nursery:
+    image: 8545d054a70ad8a33183a32657241b8064a45470ab4cb4d7f3e5f30ac2a4aa81.jpg
+    title: The Penguin Nursery
+    description: A cozy room of soft snow and warm nesting materials, where baby penguins in a state of ultimate fluffiness
+      peep and totter and fall over. An adorable baby penguin approaches you immediately with total confidence and
+      absolutely no fear. On a shelf near the entrance, a soft penguin plushie wearing a tiny golden crown sits in a
+      place of honor. The Ice Rink is to the south.
+    exits:
+      s: braelynn_ice_rink
+  braelynn_stuffie_grove:
+    image: 0633765abad0fe0694441b15dfb9d62f4a65550e3af3bad9af787ae882e6f581.jpg
+    title: The Great Stuffie Grove
+    description: The Stuffie Grove is a sacred space. Trees here are made of plush fabric; their leaves are tiny felt
+      hearts. Every stuffed animal that ever mattered in the history of Braelynn's kingdom has found its way here —
+      bears, bunnies, unicorns, one extremely specific llama. They sit in peaceful congress, debating stuffie matters of
+      great importance. A magical giant stuffed bear guards the central clearing with fierce love. Queen Braelynn's
+      Chamber is to the east.
+    exits:
+      e: braelynn_chamber
+  braelynn_roblox_plaza:
+    image: 8dca39568769d11f9ad4ad6c1c04e5f6fd68b565f6144ba85077cd4b5a85218c.jpg
+    title: Roblox Town Square
+    description: Welcome to Roblox Town Square, where blocky characters in an improbable range of outfits go about their
+      business with cheerful determination. A friendly noob in full gear wanders past, waving. The buildings around the
+      plaza are charmingly oversized, their pixel-brick facades painted in candy colors. The Adopt Me! Ranch is to the
+      south, and the Obby Tower rises to the north. The Chamber is back west.
+    exits:
+      w: braelynn_chamber
+      n: braelynn_obby
+      s: braelynn_adopt_me
+  braelynn_adopt_me:
+    image: 2e4070310200695d948e0abaa243c684b3e10d43238b6b8a2f7714bde70f1202.jpg
+    title: The Adopt Me! Ranch
+    description: The ranch sprawls across a cheerfully impossible landscape — gleaming pastures, improbably cute animals,
+      and little trading booths. Legendary pets drift through the air on shimmering wings. Someone nearby is trading a
+      Neon Dragon for a Shadow Dragon; the negotiation appears to be ongoing. The neon lights are warm and the grass is
+      very, very green. The Plaza is to the north.
+    exits:
+      n: braelynn_roblox_plaza
+  braelynn_obby:
+    image: fc578d624a5075bc6ae6bcbf8f3b26f72c4a222e3fca3dc896832a8a62c7c9c3.jpg
+    title: The Rainbow Obby Tower
+    description: A towering obstacle course of multicolored platforms spirals into a sky of perpetual sunset. The lower
+      platforms are manageable. The middle platforms require commitment. The upper platforms are, frankly, a test of
+      character. At the very top, something wonderful awaits. Jump the gaps, dodge the spinners, do not fall. The Plaza
+      is below to the south; the throne awaits above.
+    exits:
+      s: braelynn_roblox_plaza
+      u: braelynn_throne
+  braelynn_throne:
+    image: 534e8cb89b8c8351b310e87df8ed8b5b32f70feb32714ed29af59a5f6a16b8a1.jpg
+    title: Queen Braelynn's Penguin Throne
+    description: At the very pinnacle of the Obby Tower, wreathed in victory confetti that never quite settles, sits Queen
+      Braelynn's Penguin Throne. It is constructed entirely of interlocking penguin plushies, with a single golden
+      goblet on the armrest and a view that encompasses all of the dream world below. The Royal Goblet of PBrae gleams
+      here, waiting. You made it. The Obby is below.
+    exits:
+      d: braelynn_obby
+  coop_entrance:
+    image: d34dd0cef35c1d1b3ecd2700f472ab042894490f095ed93aa09e9270062f7a04.jpg
+    title: The Royal Coop Gate
+    description: A gate of painted wood and chicken wire, decorated with a hand-lettered sign reading 'ROYAL POULTRY
+      DISTRICT OF PBRAE — All birds are citizens.' Pixel-art chickens have been painted on the gateposts in Minecraft
+      style, alongside colorful Roblox-inspired crown designs. The smell of hay and feathers is warm and familiar. The
+      front yard is north; the watchtower is west; the outer run is east; the hen house is south.
+    exits:
+      n: front_yard
+      w: coop_watchtower
+      e: coop_outer_run
+      s: coop_henhouse
+  coop_watchtower:
+    image: e80da35849b441b85b6286774ba6f2f73ea3f464523a9222744f05364829db43.jpg
+    title: The Roblox Watchtower
+    description: A tall narrow watchtower built in brightly colored blocky Roblox style — coral pink, sky blue, and sunshine
+      yellow stacked in exuberant tiers. From the top, you can survey the whole coop spread out below. A pixel-art
+      banner flutters at the peak reading 'COOP SQUAD' in the official font. The coop gate is to the east; the duck pond
+      is south.
+    exits:
+      e: coop_entrance
+      s: coop_duck_pond
+  coop_outer_run:
+    image: c6d23bf4364b887212de7a33b247a1d928450662299e32a25bdf55aa5872ac87.jpg
+    title: The Outer Run
+    description: A wide, fenced outdoor run where the castle's birds roam freely in the fresh mountain air. The grass has
+      been thoroughly investigated and found mostly acceptable. A Minecraft-style dirt path winds between feeding
+      stations. Hens move with the purposeful energy of birds who have somewhere important to be, even when they don't.
+      The gate is west; the Rooster's Domain is south.
+    exits:
+      w: coop_entrance
+      s: coop_rooster_den
+  coop_henhouse:
+    image: 9c643e8624de647a36dbc894f649c672b18279eaa64f2e9bfaa17e79a56011c1.jpg
+    title: The Hen House
+    description: "The main henhouse is warm and golden-straw-smelling, with rows of nesting boxes along both walls. Each box
+      has been given a hand-painted name: 'Princess Cluck,' 'Duchess Fluffington,' 'Lady Bawk.' The hens have opinions
+      and are not afraid to express them. This is a democracy, but the hens are in charge. The gate is north; the duck
+      pond is west; the Rooster is east; Turkey Hall is south."
+    exits:
+      n: coop_entrance
+      w: coop_duck_pond
+      e: coop_rooster_den
+      s: coop_turkey_hall
+  coop_rooster_den:
+    image: e332c1d5ef085f0ecfbe74186cc488b4d642cb0d97300714fcb4631c48647131.jpg
+    title: The Royal Rooster's Domain
+    description: The Royal Rooster holds court in this elevated section of the outer run, a raised timber platform that
+      serves as his personal stage. His tail feathers cascade in magnificent iridescent plumes. A Minecraft item frame
+      on the fence post holds one such feather on display as treasure. He watches you. He is deciding things. Approach
+      with caution. Hen House is west; Turkey Roost is south; Outer Run is north.
+    exits:
+      n: coop_outer_run
+      w: coop_henhouse
+      s: coop_turkey_roost
+  coop_duck_pond:
+    image: db90904fb9399a609a18c13677e242cdccb7f94508e7d4aa755b3959498a8e42.jpg
+    title: The Royal Duck Pond
+    description: A small round pond fed by a diverted stream, fringed with reeds and decorative rocks painted to look like
+      Minecraft blocks. Mallards, Pekins, and one very confident Muscovy duck hold sovereignty over the water. A
+      Roblox-colored bridge of rainbow planks arches over the narrowest part. The Watchtower is north; Hen House is
+      east; Duck Nook is south.
+    exits:
+      n: coop_watchtower
+      e: coop_henhouse
+      s: coop_duck_nook
+  coop_duck_nook:
+    image: 2953a85cf7f48b1c81d44d6dea7971717f59c04e3da0cde94f1a057a57c00d88.jpg
+    title: Duck Nook and Creek
+    description: The stream that feeds the duck pond continues through a culvert here into a shaded nook of mud, pebbles,
+      and pure duck happiness. A white Pekin duck explores the creek bank with total conviction. Pixel-art ducks have
+      been painted on a low stone wall. Duck Pond is north; Turkey Hall is east; Feed Room is south.
+    exits:
+      n: coop_duck_pond
+      e: coop_turkey_hall
+      s: coop_feed_room
+  coop_turkey_hall:
+    image: 2295f6cab613a73ace9fe1496f345ea7a5da8e42979a4071488373e106375280.jpg
+    title: The Great Turkey Hall
+    description: The turkeys have the grandest accommodations in the Royal Poultry District — a wide, high-ceilinged hall
+      with roosting beams and a deep bed of straw. A painted wooden coat of arms on the wall depicts a bronze turkey
+      crowned and holding a Minecraft diamond in one wing and a Roblox crown in the other. A gobbling bronze turkey
+      surveys his domain with obvious self-regard. Hen House north; Duck Nook west; Turkey Roost east; Egg Vault south.
+    exits:
+      n: coop_henhouse
+      w: coop_duck_nook
+      e: coop_turkey_roost
+      s: coop_egg_vault
+  coop_turkey_roost:
+    image: 585c0dced520acdefb71f7ddcce9e18b114e35075a3751ea26634cfc97d8f393.jpg
+    title: Turkey Night Roost
+    description: A quieter, dimmer section of the turkey hall dedicated to evening roosting and napping. The beams overhead
+      are thick and wide, and the turkeys have established their preferred spots — several beams sport small
+      hand-painted name tags ('Henry,' 'Gobbles,' 'Sir Wattles'). A speckled turkey hen regards you with sleepy,
+      judgmental dignity. Rooster's Domain north; Turkey Hall west; Dream Portal south.
+    exits:
+      n: coop_rooster_den
+      w: coop_turkey_hall
+      s: coop_dream_portal
+  coop_egg_vault:
+    image: 1ac15eaacee5dedd73b54b2063b6725e5142df59d1a14af9eaff58824c100b5f.jpg
+    title: The Sacred Egg Vault
+    description: A cool, carefully tended room lined with straw-filled wooden crates where the kingdom's eggs are collected
+      and kept. Most eggs are ordinary and beautiful. One — sitting in a dedicated velvet-lined box at the center —
+      glows with a faint golden light. This is the Royal Egg. It is not to be taken lightly. Turkey Hall is north; Feed
+      Room is west; Dream Portal is east.
+    exits:
+      n: coop_turkey_hall
+      w: coop_feed_room
+      e: coop_dream_portal
+  coop_feed_room:
+    image: f3ab24fb435ebdd330c772cc657f823514bc8ef7658deefcfba56b2413fed0a9.jpg
+    title: The Royal Feed Room
+    description: Bags and barrels of grain, cracked corn, layer pellets, and specialty feeds crowd the shelves of this
+      functional room. Scoops and buckets hang on hooks. A handwritten feeding schedule on the wall is color-coded by
+      bird type — one column is labeled 'CHICKENS (the nice ones)' and another 'ROOSTER (be careful).' Duck Nook is
+      north; Egg Vault is east.
+    exits:
+      n: coop_duck_nook
+      e: coop_egg_vault
+  coop_dream_portal:
+    image: f6161f2c74501c13390d6dcd7ede0f1887fa55c8b9f13b6c26ad0f88d77e6e58.jpg
+    title: The Dream Portal
+    description: "In the far south corner of the Royal Poultry District, where the fence meets the old apple tree, there is
+      a gap in the wood that shimmers in a way that wood really shouldn't. Beyond it — visible in flickers — are images:
+      a penguin wearing a crown, a glowing diamond, a rocket car scoring an impossible goal, a stuffed bear waving
+      cheerfully. The birds will not go near it. The turkeys say it smells like dreams. It does. Turkey Roost is north;
+      Egg Vault is west."
+    exits:
+      n: coop_turkey_roost
+      w: coop_egg_vault
+audio:
+  music: 812692f05c9345959bbb6d0aa1ffe49cf44d620e8b061ac92a1d7b733fb14a1b.mp3

--- a/src/main/resources/world/trailey.yaml
+++ b/src/main/resources/world/trailey.yaml
@@ -1,0 +1,586 @@
+zone: trailey
+image:
+  room: trailey/default_room.png
+  mob: trailey/default_mob.png
+  item: trailey/default_item.png
+lifespan: 0
+startRoom: cul_de_sac
+
+mobs:
+  # ─── OUTDOOR / HOA ──────────────────────────────────────────────────────────
+  hoa_inspector:
+    image: 1279b168af64c7f4c354913cfe2e1e18ab814d460f9352b9a240291fab9a485d.png
+    name: "the HOA Inspector"
+    room: cul_de_sac
+    tier: standard
+    level: 2
+    xpReward: 15
+    goldMin: 5
+    goldMax: 10
+    respawnSeconds: 180
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: "The HOA Inspector materializes from behind an approved shrub, clipboard already raised. 'NOTICE OF VIOLATION — your PRESENCE is non-compliant with section 4.7.2 of the community guidelines!'"
+
+  beige_neighbor:
+    image: 909787430010775a4816ef5c15f5e6eeaa0ae09d5f898807bc6cc52209e9d2e8.png
+    name: "a beige neighbor"
+    room: cul_de_sac
+    tier: weak
+    level: 1
+    xpReward: 5
+    goldMin: 0
+    goldMax: 1
+    respawnSeconds: 90
+    behavior:
+      template: wander
+
+  lawn_mower_bot:
+    image: 4100da5232af66e031b707041e193c3f5b87eb41e9b25c60e6235607f6b04a1f.png
+    name: "an aggressive robotic lawn mower"
+    room: yard_upper
+    tier: standard
+    level: 3
+    xpReward: 20
+    goldMin: 0
+    goldMax: 3
+    respawnSeconds: 120
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: "The robotic lawn mower pivots sharply, blades spinning at full speed, and targets your ankles. The HOA programmed it for zero tolerance."
+
+  bounced_squirrel:
+    image: 2fa41190186f01be3eaeb2815fdcaeaccf619873e821208eeb062ca06af2ead2.png
+    name: "a repeatedly bounced squirrel"
+    room: trampoline
+    tier: weak
+    level: 1
+    xpReward: 3
+    goldMin: 0
+    goldMax: 0
+    respawnSeconds: 60
+    behavior:
+      template: wander
+
+  # ─── SPY HOUSE INTERIOR ──────────────────────────────────────────────────────
+  spy_drone:
+    image: e57f40f3e7ad579bd5365ab8628de44c017439c8807d6816d17cd04f84cc89af.png
+    name: "a surveillance drone"
+    room: foyer
+    tier: standard
+    level: 4
+    xpReward: 25
+    goldMin: 2
+    goldMax: 8
+    respawnSeconds: 180
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: "The drone's camera snaps to your face. A cheerful recognition chime plays. Then it fires."
+
+  laser_sentinel:
+    image: b1aba3d6a6a759ddbdfeeb853f0ca3764be45dcb8aa928e9ab00633850331b11.png
+    name: "a laser sentinel mk. II"
+    room: hall
+    tier: standard
+    level: 5
+    xpReward: 35
+    goldMin: 3
+    goldMax: 10
+    respawnSeconds: 240
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: "The sentinel's targeting laser sweeps the floor and settles on your center mass. A lock-on beep confirms. It does not fire a warning shot."
+
+  # ─── HAILEY'S ZONE ───────────────────────────────────────────────────────────
+  makeup_mannequin:
+    image: c5b43f36464229bd44fe0393219a9e00ac743de7f0d7f2e00da10a92f307f53d.png
+    name: "an animated cosmetics mannequin"
+    room: haileys_parlor
+    tier: standard
+    level: 4
+    xpReward: 30
+    goldMin: 5
+    goldMax: 15
+    respawnSeconds: 120
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: "The mannequin turns its perfectly made-up face toward you and opens its glossy lips in a silent scream. Then it attacks with surprising precision."
+
+  perfume_cloud:
+    image: bcd923d7c5414e018016993fe10e2394e05462abd8c876b02f51fa2d24013d8e.png
+    name: "a sentient perfume cloud"
+    room: haileys_dressing
+    tier: standard
+    level: 5
+    xpReward: 25
+    goldMin: 2
+    goldMax: 8
+    respawnSeconds: 90
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: "The perfume cloud drifts toward you with alarming intentionality. The scent is overwhelming — 'Midnight Blossoms' — and the damage is significant."
+
+  balance_beam_automaton:
+    image: 3f84f402ef87e254a4f126dd6b34aaa5fd8f8545c38ad2c793d0c19603be8e08.png
+    name: "the Balance Beam Automaton"
+    room: haileys_gym
+    tier: elite
+    level: 7
+    hp: 400
+    xpReward: 120
+    goldMin: 8
+    goldMax: 15
+    respawnSeconds: 300
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: "The Balance Beam Automaton sticks a perfect landing and pivots to face you. It executes a round-off back-handspring as a warning. You should take the warning seriously."
+
+  # ─── TREVOR'S ZONE ───────────────────────────────────────────────────────────
+  robot_deer:
+    image: 216420752eb8663b38a00f7b32e7178bfe88c9723ee0a20cfd2068186a3dd66c.png
+    name: "a mechanical deer target"
+    room: trevors_range
+    tier: weak
+    level: 3
+    xpReward: 15
+    goldMin: 1
+    goldMax: 5
+    respawnSeconds: 60
+    behavior:
+      template: wander
+
+  robot_duck:
+    image: a035986ccfbd48df5f24b1150c9b384a66d6da57eae22ef50edf2b92166b09de.png
+    name: "a mechanical duck target"
+    room: trevors_range
+    tier: weak
+    level: 2
+    xpReward: 10
+    goldMin: 0
+    goldMax: 3
+    respawnSeconds: 60
+    behavior:
+      template: wander
+
+  robot_wolf:
+    image: ed885b1e35942b690802f0d37542f267a03c8fe6cf8a1914c142161d1d3ca1b8.png
+    name: "the Alpha Wolf-Bot Mark VII"
+    room: trevors_armory
+    tier: elite
+    level: 8
+    hp: 500
+    minDamage: 15
+    maxDamage: 25
+    xpReward: 150
+    goldMin: 10
+    goldMax: 20
+    respawnSeconds: 600
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: "The Alpha Wolf-Bot's eyes blaze red. It bares a mouthful of articulated steel teeth and LUNGES with the hydraulic force of eight hundred pounds per square inch!"
+
+  inflate_goon:
+    image: 963a0d7cd2292b3fbdfee1cfcc37bf871a2926c5f8178ded50ecdec40f9fd614.png
+    name: "Big Biff, the Roughhousing Inflate-O-Goon"
+    room: trevors_roughhousing
+    tier: standard
+    level: 6
+    xpReward: 80
+    goldMin: 5
+    goldMax: 15
+    respawnSeconds: 240
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: "Big Biff BOUNCES off the foam wall with his entire body! He takes the hit like it's nothing — in fact, he seems to be GETTING BIGGER. Each blow inflates him further. His eyes go wide. He is enormous now. He is VAST. He is sweating. He is—"
+
+  # ─── HUMPTY DUMPTY (UPSTAIRS) ────────────────────────────────────────────────
+  humpty_dumpty:
+    image: c9298bfac4b530e25377ad7d08c3e0c95f88d37f3790a504e6c836a04f5ac2bb.png
+    name: "Humpty Dumpty, the Uncracked Sovereign"
+    room: humpty_cracked
+    tier: elite
+    level: 12
+    hp: 1500
+    minDamage: 25
+    maxDamage: 45
+    xpReward: 500
+    goldMin: 20
+    goldMax: 40
+    respawnSeconds: 900
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: "HUMPTY DUMPTY HAD A GREAT FALL — and then reassembled himself while all the king's horses watched helplessly! He looms above you from the Wall, cracks spreading and sealing, grinning with absolutely unearned confidence. He LEAPS!"
+
+  humpty_shell_piece:
+    image: 094f76f9c4fd0ef5b32acb27adc297e08365ef7f1c198beaee3df1d26288fa70.png
+    name: "a reassembling shell fragment"
+    room: humpty_arena
+    tier: standard
+    level: 8
+    xpReward: 40
+    goldMin: 3
+    goldMax: 8
+    respawnSeconds: 30
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: "The shell fragment skitters across the floor toward you, cracking and reforming as it moves. It is very focused on the task."
+
+items:
+  hoa_violation_notice:
+    image: f0a16a7292f11af2056eb66cba8c0828a2ddd58d32e2374abec1791aaa1fbfb2.png
+    displayName: "an HOA violation notice"
+    keyword: "notice"
+    description: "A crisp official document noting violations including: improper mailbox angle (0.3 degrees off regulation), non-compliant lawn length (0.2mm above the approved maximum), unauthorized personality, and 'general atmospheric non-beige-ness.' It is terrifyingly thorough."
+    room: cul_de_sac
+    basePrice: 0
+
+  spy_watch:
+    image: 2b5ec126ff7ad83793a234ad1710d0384bf3d233fd9be58a44070d04c0de84f0.png
+    displayName: "a classified spy smartwatch"
+    keyword: "watch"
+    description: "A titanium-cased smartwatch with seventeen listed functions and fourteen unlisted ones, the latter labeled in a cipher. It tracks biometrics, decrypts nearby signals, and deploys a thumbnail-sized blast shield if you press the crown twice. Also tells the time."
+    slot: hands
+    armor: 4
+    room: foyer
+    basePrice: 85
+
+  spy_gadget_pen:
+    image: 6f8e6a2cdf545ec41c735d74bbc583e482662f4e9af8c5b3043127062328fdbd.png
+    displayName: "a spy gadget pen"
+    keyword: "pen"
+    description: "It looks like an ordinary pen. It is not. The cap fires a micro-grappling hook; the body contains a compressed-air sedative dart; the clip is a USB drive containing enough embarrassing information to neutralize a mid-sized international incident. Also it writes."
+    consumable: true
+    onUse:
+      healHp: 25
+    room: hall
+    basePrice: 50
+
+  makeup_compact:
+    image: 790a4e94ddad4bf70a1faab9cf8707ae17e763d16b59a03c806a7ed100e86d90.png
+    displayName: "a professional makeup compact"
+    keyword: "compact"
+    description: "A heavy professional-grade compact from Hailey's collection. The mirror is perfect; the powder inside has a slight luminescent quality that is not standard in commercial cosmetics. Opening it and taking a moment with it is, for reasons you can't explain, actually quite restoring."
+    consumable: true
+    onUse:
+      healHp: 15
+    room: haileys_parlor
+    basePrice: 35
+
+  luxury_perfume:
+    image: 813356184170a05c806d865c6789c308c64f59ffff2164f468d4f911f67ecc58.png
+    displayName: "a bottle of Midnight Blossoms perfume"
+    keyword: "perfume"
+    description: "A heavy crystal bottle of Hailey's prize perfume — 'Midnight Blossoms,' according to the engraved stopper. One spritz and you are undeniably more capable. It is unclear whether this is psychological or chemical. The sentient cloud that guards it suggests the latter."
+    consumable: true
+    onUse:
+      healHp: 30
+    room: haileys_dressing
+    basePrice: 60
+
+  competition_leotard:
+    image: 3bc01c22f219679d6b622390633b90857f0db030007fc1816182a1acac5544de.png
+    displayName: "Hailey's competition leotard"
+    keyword: "leotard"
+    description: "A full-competition leotard in midnight blue and silver, decorated with precisely applied crystals along the neckline and sleeves. Designed for a Level 10 gymnast who expects to win. The stitching is structural enough to be classified as armor by people who know about these things."
+    slot: body
+    armor: 5
+    room: haileys_gym
+    basePrice: 90
+
+  paintball_marker:
+    image: 6961683955502bc8782a106134e9b3a802f70f54a3b7f83b5b0aa5a9695285b6.png
+    displayName: "Trevor's tactical paintball marker"
+    keyword: "marker"
+    description: "A heavily modified paintball marker with a custom grip, extended barrel, and a two-hundred-round hopper. The paint is Trevor's proprietary formula: glows in the dark, stains for six weeks, and leaves a satisfying impact sound on robot surfaces."
+    slot: weapon
+    damage: 11
+    room: trevors_range
+    basePrice: 75
+
+  robot_spring_coil:
+    image: 666e91e8336fbea70265e7ca8292acda2b4d846be09fb00f80eb0bbbd90789a1.png
+    displayName: "a precision robot spring coil"
+    keyword: "coil"
+    description: "A tight helical spring machined to tolerances of one ten-thousandth of an inch, salvaged from one of Trevor's mechanical targets. Trevor made it. It is better than it needs to be. That is on purpose."
+    room: trevors_armory
+    basePrice: 25
+
+  deflated_remnant:
+    image: d0bcc0674e54e2c5c45271c9ed3c4527beb8a0b4f343d72ee0893be524141c32.png
+    displayName: "a deflated Biff remnant"
+    keyword: "remnant"
+    description: "A flattened, rubbery fragment of something that used to be enormous — clearly the aftermath of Big Biff's critical inflation failure. It still faintly bounces when you put it down. On one side, in stretched letters: 'BIFF WAS HERE.'"
+    room: trevors_roughhousing
+    basePrice: 10
+
+  humpty_shell_fragment:
+    image: 93c2268af31985758876c61613db820f01810a8312d713e5497052fb1ca9c22e.png
+    displayName: "a fragment of Humpty's shell"
+    keyword: "fragment"
+    description: "A curved piece of shell from Humpty Dumpty, inscribed on the inner surface in tiny lettering: 'ALL THE KING'S MEN FAILED AGAIN (round 47).' It's warm to the touch and faintly vibrates, as if it wants to rejoin something."
+    room: humpty_arena
+    basePrice: 150
+
+shops:
+  spy_supply_depot:
+    name: "The Foyer Supply Depot"
+    room: foyer
+    items:
+      - spy_gadget_pen
+      - spy_watch
+
+  hailey_boutique:
+    name: "Hailey's Beauty Boutique"
+    room: haileys_parlor
+    items:
+      - makeup_compact
+      - luxury_perfume
+      - competition_leotard
+
+rooms:
+  # ─── THE HOA CUL-DE-SAC ──────────────────────────────────────────────────────
+
+  cul_de_sac:
+    image: a8f6046824fdc37a0b79aa63a7e3b35916fe7868cd3d3f6c11c7032c99399b2b.jpg
+    title: "The Cul-de-Sac of Mirrors"
+    description: "The HOA-approved cul-de-sac stretches in every direction with uncanny uniformity. Every house is Approved Beige (Pantone 7527 C). Every lawn is precisely 3.25 inches tall. Every mailbox is the same colonial brass at the same height facing the same direction. Strangely, no matter which direction you walk — north, south, west — you find yourself standing in front of the same house, which is, in fact, every house. The neighborhood watches from behind identical blinds. A concealed staircase behind a regulation-height hedge rises upward to somewhere considerably more interesting. The driveway of the house to the east is where things begin."
+    exits:
+      n: cul_de_sac
+      s: cul_de_sac
+      w: cul_de_sac
+      e: driveway
+
+  driveway:
+    image: 0281b2f12e05c483638d04ebc1a33c2c9ca7ab76a1fa089dc3cd5b14286b4da9.jpg
+    title: "The Approved Driveway"
+    description: "A regulation-width concrete driveway, sealed and re-sealed to the HOA's exacting standards. Two faint tire tracks mark the path of a very sensible sedan. The surface is immaculate — no oil stains, no chalk drawings, no evidence that children have ever existed here, which is suspicious given what's inside. A subtle seam in the concrete near the garage suggests considerably more going on underground than the exterior implies. The cul-de-sac is west; the parking pad and garage are ahead; the sidewalk runs south."
+    exits:
+      w: cul_de_sac
+      e: parking_pad
+      s: sidewalk
+
+  sidewalk:
+    image: 870bcb7375ae765b9d48e0b22f3c001f13a59427a5a4d082b043cf063993bf74.jpg
+    title: "The Regulation Sidewalk"
+    description: "A perfectly level concrete sidewalk, expansion joints measured to the inch, not a crack to be seen. Identical topiary balls in identical planters flank the front door to the north. The whole street smells of fresh paint applied over previous fresh paint. A faint electronic hum drifts from within the house. The driveway is north; the front door of the spy house is east."
+    exits:
+      n: driveway
+      e: foyer
+
+  parking_pad:
+    image: 661ebf75d794d673cf8cb8714ebca22cb0384c85a38ea5421ad0b9f296fbfb64.jpg
+    title: "The Parking Pad"
+    description: "An extended concrete pad beside the garage, spotlessly clean. A basketball hoop stands at regulation height with a regulation-white net and absolutely no scuffs on the backboard, raising serious questions about whether it has ever been used for basketball. The garage door hums on the south wall. The driveway is west; the side yard stretches to the east."
+    exits:
+      w: driveway
+      s: garage
+      e: yard_upper
+
+  yard_upper:
+    image: dbdcccefa1c7664b8eebe030791c3320733fd6673af5b368c7a2bfbe52d4cbd6.jpg
+    title: "The Front Yard - Upper Section"
+    description: "The front yard is a masterpiece of regulation landscaping: turf that is more algorithm than grass, beds of HOA-approved perennials in approved colors (beige, off-white, and natural), and a water feature making an approved sound. An aggressive robotic lawn mower patrols a perfect spiral path, its sensors already registering your non-compliant presence. The parking pad is west; the back section of the yard lies south."
+    exits:
+      w: parking_pad
+      s: yard_lower
+
+  yard_lower:
+    image: 32974f85c521a6a8d7442e22e77f515c8d5f2cd0fd475581b3c3d825a8eb41aa.jpg
+    title: "The Back Yard - Lower Section"
+    description: "The back yard is where regulation loosens its grip, slightly. A tall privacy fence (approved height, approved color) blocks the neighbors' view, and behind it: actual human life. A worn patch of grass from repeated running starts. Chalk gymnastics floor exercise outlines in one corner. The deck of the house is accessible west. The trampoline is visible to the south, its safety net slightly worn at one corner in the way only a well-loved trampoline ever gets."
+    exits:
+      n: yard_upper
+      s: trampoline
+      w: deck
+
+  trampoline:
+    image: 5c0d0189931d0b36c9a2402e946faeafaf3806c893a908f50f4f47242fb22f22.jpg
+    title: "The Trampoline"
+    description: "A large rectangular trampoline fills the back corner of the yard, its blue mat weathered to the ideal consistency by years of enthusiastic use. The safety net has two repaired sections and one small hole that everyone agreed was fine. Spring pockets around the frame hold assorted stuffed animals and action figures trapped there for years, their tiny faces pressed against the net with resigned acceptance. A squirrel that bounced onto the mat at some point appears to have been here for a while and has developed an opinion about the experience. Small rubber feet marks indicate exactly where to jump for maximum height. The back yard is north."
+    exits:
+      n: yard_lower
+
+  garage:
+    image: 8cfe3ef29982d0da914957eddff2b6a9369df22d1a770d6f537a867e64a559bd.jpg
+    title: "The Spy Garage"
+    description: "The garage door closes behind you and the ordinary world ends. The suburban concrete shell retracts into the floor and the true garage reveals itself: brushed steel, LED task lighting, and three wall-mounted equipment bays holding gear in padded silhouette mounts — shapes suggesting tools with no civilian designation. A full-length workbench holds mechanical components, disassembled electronics, and a schematic board covered in revisions. The vehicle bay holds something low-slung and fast under a fitted cover. The parking pad access is north; the kitchen service entrance is south."
+    exits:
+      n: parking_pad
+      s: kitchen_nook
+
+  # ─── GROUND FLOOR INTERIOR ───────────────────────────────────────────────────
+
+  foyer:
+    image: 8518e0d2fda53634b4e67ec97046b51a5d0b82daa0e4ee5c521958d5c5e84496.jpg
+    title: "The Foyer - Spy House Entry"
+    description: "What appears from the street to be an ordinary front hallway is nothing of the kind. The moment the door closes, the beige paint retracts into the walls and burnished titanium panels emerge. Motion sensors in the ceiling track your entry with polite efficiency. A supply depot — disguised as an ordinary coat closet — opens automatically after three seconds of standing in front of it. A surveillance drone hovers near the ceiling, assessing. The sidewalk is back through the west door; the central corridor is east."
+    exits:
+      w: sidewalk
+      e: hall
+
+  hall:
+    image: ff8b95749df205ae709b7417253a0c87a5f6490caf4a758156435952529d3100.jpg
+    title: "The Central Corridor"
+    description: "The central corridor is a marvel of concealed engineering. The floor is obsidian tile with a faint luminescent grid. The walls display scrolling status readouts in a font that implies serious operational activity. Holographic floor markers direct traffic to every major system. The foyer is west; the kitchen service entry is north; the main kitchen ops area is east. A concealed staircase rises silently upward when you step on the correct floor tile — a panel in the ceiling marks the upper floor. The basement stairs descend from a panel labeled 'AUTHORIZED PERSONNEL ONLY — this means the kids.'"
+    exits:
+      w: foyer
+      n: kitchen_nook
+      e: kitchen_main
+      u: upper_landing
+      d: basement_landing
+
+  kitchen_nook:
+    image: 4deae691846e7b9b53e8efdcc3f3ab1b73c9d4c7f92f4e25faa4b4b5f98842c4.jpg
+    title: "The Kitchen Service Entry"
+    description: "The service end of the kitchen connects to the garage by a concealed lift for bringing in groceries, equipment, and the occasional mission-critical item without going through the main entry. Counter space is devoted to practical matters: device charging stations, a magnetic board blending 'pick up from gymnastics' with 'debrief at 0800,' and a rack of coffee mugs suggesting a heroic caffeine dependency. The garage lift is north; the main kitchen is east; the corridor is south."
+    exits:
+      n: garage
+      e: kitchen_main
+      s: hall
+
+  kitchen_main:
+    image: a038599d92f3a6b4b30bd380b1ce21c08c8ee32359514af1f95a25a5992aa702.jpg
+    title: "The Main Kitchen - Operations Center"
+    description: "The kitchen is the operational heart of the spy house. The island conceals a touchscreen command interface beneath a cutting-board surface. The refrigerator has biometric access for the 'good stuff.' A breakfast bar runs along the east side with a perfect view of the deck and yard. The real intelligence of this household is exchanged here, over coffee, at seven in the morning. The kitchen service nook is west; the outdoor deck is east; the sitting room is south."
+    exits:
+      w: kitchen_nook
+      e: deck
+      s: sitting_room
+
+  sitting_room:
+    image: 267c28d04e97287d54699158d3bb1b54bccd070054cc225741e14255f34e5205.jpg
+    title: "The Sitting Room"
+    description: "The sitting room approaches something like genuine relaxation. Deep couches face a screen capable of displaying either an extremely large television picture or a tactical mission briefing with equal fidelity. The bookshelves contain novels, technical manuals, and what appear to be dossiers filed under the Dewey Decimal System. Two large reinforced windows — the specifications of which the manufacturer does not publicize — look onto the yard. The kitchen is north."
+    exits:
+      n: kitchen_main
+
+  deck:
+    image: a7b7db7f241d3a0d006a009d6cd586382ce82257a5dbf960a2c18a4d08af695b.jpg
+    title: "The Outdoor Deck"
+    description: "The deck emerges from the back of the house, its composite boards warm underfoot. A table and chairs face the yard, though the table has fold-out equipment compartments in the legs that are somewhat unusual. String lights run at regulation brightness along the railing. The back yard is directly east; the swimming pool extends to the south, its water lit from below in crisp, perfect blue. The kitchen is back west."
+    exits:
+      w: kitchen_main
+      e: yard_lower
+      s: swimming_pool
+
+  swimming_pool:
+    image: 856e99cd0719ddb12e708f3028369ef4b64e73680d283d75b7f9b512fc53bdbc.jpg
+    title: "The Swimming Pool"
+    description: "A full-length lap pool extends south of the deck, its water the specific shade of blue that only comes from excellent filtration and genuine caring. Underwater lighting gives the surface a cold, precise glow. Lane ropes define lap lanes, but the diving end has a board and a deep section clearly intended for less efficient purposes. At the very bottom of the deep end, almost invisible through the water, is a seam in the pool floor that looks very much like a hatch. Whether it leads anywhere is left as an exercise for the curious. The deck is north."
+    exits:
+      n: deck
+
+  # ─── UPPER FLOOR ─────────────────────────────────────────────────────────────
+
+  upper_landing:
+    image: 847e6bb8f10e3aef8f1ada123f35ce12d36bfd2624d4c301e2c6bc35deed6462.jpg
+    title: "The Upper Landing"
+    description: "The concealed staircase deposits you onto a carpeted landing that is slightly different in character from the floors below — the technology a bit older, the walls paneled in wood rather than steel, as if this floor predates the renovation. Framed family photos line the hallway, except that in several of them, one parent appears to be somewhere classified. A long corridor extends east toward a peculiar sound: a low, repeated crack, like masonry under stress. Or like something putting itself back together."
+    exits:
+      d: hall
+      e: humpty_cracked
+
+  humpty_cracked:
+    image: 02ed5badbf2a3db48e976afd631b672c2823f0fbd79cc613646fdda90e8280b4.jpg
+    title: "The Wall of Humpty Dumpty"
+    description: "At the end of the upper hallway, an improbable eight-foot ornamental wall of brick and mortar occupies the space where a bedroom wall should be. Perched at the very top, dangerously near the edge, sits Humpty Dumpty: vast, egg-shaped, waistcoated, and visibly cracked along the left side. The fracture keeps spreading and sealing itself in a loop that has clearly been running for quite some time. He regards you with the smug confidence of someone who has heard the ending of his own story and believes he will be the exception. 'Nobody puts Humpty back together quite like Humpty,' he says. He is incorrect, but he doesn't know that yet. The landing is back west; east leads to where he falls."
+    exits:
+      w: upper_landing
+      e: humpty_arena
+
+  humpty_arena:
+    image: 94d156aa521f09371408bd85f64c43a3922ce088ba0225955ed98221f75bd9d2.jpg
+    title: "The Arena of Fragments"
+    description: "The far side of the Wall is where things go when Humpty falls. The floor shows the evidence of many repeated catastrophic reassemblies: hairline cracks in every tile, impact marks on the walls at egg-sized heights, plaster dust drifted into corners. And yet nothing stays apart for long. Shell fragments skitter across the floor toward each other with alarming purpose. Each one that reassembles immediately evaluates the situation and turns toward you. The yolk, evidently, has a very long memory. A piece of shell sits in the far corner, inscribed on the inner surface with tiny, increasingly despairing text. The Wall is back west."
+    exits:
+      w: humpty_cracked
+
+  # ─── BASEMENT ────────────────────────────────────────────────────────────────
+
+  basement_landing:
+    image: f2ea4b49e9f8e534654d871d4d6d0b22eb5f2a250c8e32db0e5096f60a437b5e.jpg
+    title: "The Basement Landing"
+    description: "The staircase from the central corridor deposits you on a landing of polished concrete lit by recessed floor LEDs. A large painted sign reads: 'AUTHORIZED PERSONNEL ONLY — this means the kids.' Below that, in a different hand: 'No seriously.' Below that, a third: 'Fine, whatever, just be careful.' Two corridors branch from here: east leads toward a doorway framed in pink light and the distant sound of competition floor music — Hailey's zone. South brings the sound of mechanical targets resetting and foam-padded impacts — Trevor's domain. The main floor is above."
+    exits:
+      u: hall
+      e: haileys_entry
+      s: trevors_entry
+
+  # ─── HAILEY'S ZONE ───────────────────────────────────────────────────────────
+
+  haileys_entry:
+    image: 530e024de394d91ca6ba090b6b7ccd1fac248a057c339fbaac0eac7827afe8d0.jpg
+    title: "Hailey's Gymnastics Dollhouse - Entry Hall"
+    description: "The entry begins at a miniature door that is, somehow, full human scale inside — a recurring geometric trick throughout Hailey's zone. The walls are silver damask; the floor is white marble; the lighting comes from chandeliers that are unreasonably elegant for a basement. A glass-fronted trophy cabinet lines the entry wall: a forest of gold and silver hardware, each piece from a different gymnastics meet, each plaque bearing a consistent first-place finish. The basement landing is west; the glamour parlour is north; the competition gym is east."
+    exits:
+      w: basement_landing
+      n: haileys_parlor
+      e: haileys_gym
+
+  haileys_parlor:
+    image: 12d2f0caee594cc132eabe0f34334c00952fd57d9d4b13f38fe9428c81364b7c.jpg
+    title: "The Glamour Parlour"
+    description: "The parlour is where preparation happens at a serious level. Every surface holds a different category of cosmetic: foundations organized by undertone, eye palettes sorted by color family, lip products on a carousel that rotates on demand. The air is a precisely calibrated blend of the finest perfumes in the collection, which is extensive. An animated cosmetics mannequin stands near the center vanity — it tends the good stuff and doesn't appreciate unauthorized access. The dressing room continues east; the entry hall is south."
+    exits:
+      s: haileys_entry
+      e: haileys_dressing
+
+  haileys_dressing:
+    image: a4916bd3f6c52f30cd28b952fa916facea718f714bca0eb49530f1462fd84682.jpg
+    title: "The Dressing Room and Perfume Vault"
+    description: "A room of mirrors, warm amber lighting, and the kind of perfume concentration that makes your eyes water in the best possible way. One full wall is the Perfume Vault: hundreds of bottles from dozens of houses, organized by fragrance family, each one backlit. A sentient perfume cloud drifts among the bottles with proprietary intensity. Competition leotards hang in a dedicated wardrobe, size-sorted in clear garment bags labeled with the meet and the score. The crown jewel of the Vault — 'Midnight Blossoms' in a crystal bottle — sits at the center of the display under a modest spotlight. The glamour parlour is west."
+    exits:
+      w: haileys_parlor
+
+  haileys_gym:
+    image: eb0afcb2afe399f30b4e15f525e05f62ee74ac495d99f0bd2a317f35575cbc6e.jpg
+    title: "Hailey's Competition Gymnasium"
+    description: "A full-scale competition gymnasium occupies the impossible back half of Hailey's zone, its geometry cheerfully defying the basement's apparent dimensions. Spring floor in regulation 12-by-12, chalk-line border crisp. A balance beam at regulation height runs the full east wall length. Uneven bars hang at regulation spacing beneath a ceiling that is somehow much higher than it should be. A vault with approach runway fills the south section. The Balance Beam Automaton — a robotic gymnast maintaining the equipment and guarding the training floor with the form and dignity of a Level 10 athlete — patrols the beam at all times. Hailey's competition leotard hangs on the entrance rack. The entry hall is west."
+    exits:
+      w: haileys_entry
+
+  # ─── TREVOR'S ZONE ───────────────────────────────────────────────────────────
+
+  trevors_entry:
+    image: 4e4eb4af2435b0329cd85f010c87a7050f573ee0b3725a6894a7de7cf468c575.jpg
+    title: "Trevor's Zone - Entry Range"
+    description: "The transition from Hailey's zone to Trevor's is immediate and unambiguous. Marble ends. Industrial rubber flooring begins. The walls are bare concrete block hung with target posters, range safety rules in large print, and a hand-drawn mechanical diagram that has been revised so many times it is mostly revision marks. Mechanical deer and duck targets move through the range on programmable tracks, resetting with a satisfying clank when hit. The smell is machine oil, rubber, and the warm ozone tang of electronics at operating temperature. The basement landing is north; the main range is south; the roughhousing pit is east."
+    exits:
+      n: basement_landing
+      s: trevors_range
+      e: trevors_roughhousing
+
+  trevors_range:
+    image: ea72fdb642f4a3e84b652236758f2461a947c7c2f11aca35ffebe5affc646de5.jpg
+    title: "The Mechanical Shooting Range"
+    description: "A professional-grade indoor range configured entirely for mechanical targets. Target tracks run at five distances from 10 to 50 yards, each loaded with a different robot creature: mechanical deer glide between timber cutouts, duck targets pop from foam blinds, and in the far lane, something larger and faster runs a wolf-shaped silhouette program. A supply station holds Trevor's tactical paintball marker and a rack of protective gear. The armory and wolf-bot workshop are in the back room to the west. The entry range is north."
+    exits:
+      n: trevors_entry
+      w: trevors_armory
+
+  trevors_armory:
+    image: 292838eb866feeb65bda77c396bc9abf8483d9a44f0ae7144982310268093302.jpg
+    title: "The Robot Armory and Workshop"
+    description: "The workshop behind the range is where the machines are built and maintained. Work tables hold disassembled components: a half-finished rabbit target, the torso section of something that will eventually be larger than a person, wiring looms in labeled bundles. Precision spring coils and mechanism parts fill small labeled bins. The Alpha Wolf-Bot Mark VII stands in the charging alcove at the back wall, eyes dark but servos humming faintly at idle. It is larger up close than it looked on the range. The range is back east."
+    exits:
+      e: trevors_range
+
+  trevors_roughhousing:
+    image: 17ceb6dc23ab77c23b45fabf1fcaf47bdbfea7d89250ca0dd4702eac5c95b9a4.jpg
+    title: "The Roughhousing Pit"
+    description: "The Roughhousing Pit is exactly what the name suggests, engineered to contain it. The walls are padded foam three feet thick. The floor is crash mat over crash mat, eight layers deep. Obstacles — foam cubes, a tilting platform, monkey bars bolted to the ceiling — make it navigable only by the confident and the committed. At the center, Big Biff the Roughhousing Inflate-O-Goon sits on a beanbag the size of a small car, eating a sandwich with enormous contentment. He appears to be made of something that yields on impact and then springs back considerably harder. He has the cheerful energy of someone who genuinely loves roughhousing and is honestly excited to see you. A deflated remnant near the door suggests how previous visits ended. The entry range is west."
+    exits:
+      w: trevors_entry
+audio:
+  music: 5dbadac19b536ea98d5862ae5fa760ed89f37042ab4d67a4060e0f905eba365b.mp3

--- a/src/main/resources/world/wesleyalis.yaml
+++ b/src/main/resources/world/wesleyalis.yaml
@@ -1,0 +1,659 @@
+zone: wesleyalis
+image:
+  room: e4f4f7c612bb4ccf5be5454aaca0de9a81a025214eb2eb560ce207acf3b47fd3.png
+  mob: a74879edebf96065f3c5b3c4eb87c6fd2a5a6e91b68b6fab1da4525875453ecf.png
+  item: 0d3de198b4702247a951c76160513dabc38e6242492b35afba4755101cb556ee.png
+lifespan: 0
+startRoom: gravel_road_2
+mobs:
+  scarlet_macaw:
+    image: 4b71d46bcfa186b88ac1061ba3546bf1866753b53a07fbd98532d68690c9fb7c.png
+    name: a scarlet macaw
+    room: gravel_road_1
+    tier: weak
+    level: 2
+    xpReward: 8
+    goldMin: 0
+    goldMax: 2
+    respawnSeconds: 120
+    behavior:
+      template: wander
+  jewel_chameleon:
+    image: a2306bbaf0cbf2d26552e46ba163895454de9283a5a077aa2e06cba840777dcc.png
+    name: a jewel-toned chameleon
+    room: gravel_road_2
+    tier: weak
+    level: 1
+    xpReward: 5
+    goldMin: 0
+    goldMax: 1
+    respawnSeconds: 90
+    behavior:
+      template: wander
+  glowing_firefly:
+    image: 10046bdd6b05a6c90ae3868f388e5049711bc19f0c9f7057f1b69cafc0a7d6d0.png
+    name: a glowing firefly
+    room: landing
+    tier: weak
+    level: 1
+    xpReward: 2
+    goldMin: 0
+    goldMax: 0
+    respawnSeconds: 60
+    behavior:
+      template: wander
+  worker_bee:
+    image: f8fa64e59c8c5aa21ef44ce41a3f1e4a02592c5f4878b1e107886324c4024c89.png
+    name: a prehistoric giant worker bee
+    room: prehistoric_apiary
+    tier: standard
+    level: 6
+    xpReward: 30
+    goldMin: 1
+    goldMax: 5
+    respawnSeconds: 120
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: The prehistoric bee's wings thunder like a helicopter rotor! It fixes you with six enormous compound eyes
+          and charges!
+  queen_bee:
+    image: 81113da7ea65473d2839270e7a2d9a887f07e14aa6d01e169b169ceca9eed493.png
+    name: the Prehistoric Queen Bee, Ancient Mother of the Swarm
+    room: prehistoric_apiary
+    tier: elite
+    level: 10
+    hp: 800
+    minDamage: 20
+    maxDamage: 40
+    xpReward: 200
+    goldMin: 10
+    goldMax: 20
+    respawnSeconds: 600
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: The floor vibrates with a deep HUMMMMM. The Queen is larger than a horse. She is ancient. She is not
+          pleased to see you.
+  velociraptor:
+    image: 37bc1359570ad4cedbb748f66e34556981e28a2f6c648f902f37ff90f4155a32.png
+    name: a hunting velociraptor
+    room: jungle_deep
+    tier: standard
+    level: 7
+    xpReward: 40
+    goldMin: 0
+    goldMax: 3
+    respawnSeconds: 180
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: The velociraptor tilts its head sideways, makes a chittering sound, and charges with alarming speed!
+  triceratops:
+    image: a8b0c69d3b6681203f2dfd3bd681ecc908df3cdbc83708f43ccb81840d92903c.png
+    name: a massive triceratops
+    room: jungle_deep
+    tier: elite
+    level: 9
+    hp: 600
+    xpReward: 150
+    goldMin: 5
+    goldMax: 10
+    respawnSeconds: 300
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: The triceratops SNORTS and lowers its three-horned head. The ground shakes as it charges!
+  pterodactyl:
+    image: 46b1fca548e8927e02267cf4b5bad54aa960075cbdecbd30d40995d7e701e203.png
+    name: a swooping pterodactyl
+    room: jungle_canopy
+    tier: standard
+    level: 8
+    xpReward: 60
+    goldMin: 2
+    goldMax: 8
+    respawnSeconds: 240
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: The pterodactyl shrieks and dives from the canopy with talons spread wide!
+  living_painting:
+    image: c090aa68b6dd6e18f7146cf55a1044b2026d007c668b4d32cf42d96f71b1b9b0.png
+    name: a painting that isn't quite still
+    room: gallery_living_art
+    tier: standard
+    level: 5
+    xpReward: 25
+    goldMin: 1
+    goldMax: 5
+    respawnSeconds: 120
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: The figure in the painting steps forward out of its frame, trailing streaks of vivid paint behind it!
+  pixel_t_rex:
+    image: f18ca75e6ddef2df06cbc026c8440d742afaf8865159478d06e9b7be3d76d6ca.png
+    name: a pixelated T-Rex
+    room: pixel_realm
+    tier: standard
+    level: 6
+    xpReward: 35
+    goldMin: 2
+    goldMax: 6
+    respawnSeconds: 150
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: SKREE-WOOM! The pixelated T-Rex stomps forward, its low-res jaws snapping in chunky 16-bit chomps!
+  code_sprite:
+    image: 7e049d91c109ee9b812e9a2269fcb97060f3b4a624083af9cf4e3414a693d4fe.png
+    name: a rogue code sprite
+    room: pixel_realm
+    tier: weak
+    level: 4
+    xpReward: 20
+    goldMin: 1
+    goldMax: 3
+    respawnSeconds: 90
+    behavior:
+      template: wander
+  godzilla:
+    image: 6a7194ee2db7e1709b99dd67abedbf36a18dfec41f27d55fbf6973b09b4a52d8.png
+    name: Godzilla, King of the Monsters
+    room: godzilla_arena
+    tier: boss
+    level: 15
+    hp: 5000
+    minDamage: 50
+    maxDamage: 100
+    xpReward: 1000
+    goldMin: 50
+    goldMax: 100
+    respawnSeconds: 3600
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: The earth shakes. Then shakes again. Then — with a roar that rattles your bones — GODZILLA rises above the
+          city skyline of Wesley's imagination!
+  stuffed_dragon_guardian:
+    image: 6297c65dbdd1b0de3689304320a7a4ca86dfdbfc11d1ad2b99e55ac0d1df2c91.png
+    name: the Great Stuffed Dragon Guardian
+    room: stuffie_wonderland
+    tier: standard
+    level: 3
+    respawnSeconds: 180
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: The enormous stuffed dragon opens its plush jaws and makes the BEST roaring noise it can manage, which is
+          actually quite impressive!
+  chaos_toddler_spirit:
+    image: 64a062b8fb59365214a7fc365c026ac8a375fc1d3aff8727b99eee2183a7ab9b.png
+    name: a tiny chaos toddler spirit
+    room: tantrum_wasteland
+    tier: standard
+    level: 4
+    xpReward: 10
+    goldMin: 0
+    goldMax: 10
+    respawnSeconds: 60
+    behavior:
+      template: aggro_guard
+      params:
+        aggroMessage: The tiny spirit SCREAMS with the force of a thousand denied crackers! It begins throwing stuffed animals
+          with uncanny accuracy!
+  royal_parent:
+    image: ffa1279802ee1088e7079ccc82723b2d781cd9fd6e96fded1a5d470725708c0d.png
+    name: a Royal Servant Parent
+    room: basement_main
+    tier: weak
+    level: 1
+    goldMin: 0
+    goldMax: 5
+    respawnSeconds: 300
+    behavior:
+      template: wander
+items:
+  prehistoric_honey:
+    image: 509966be1bcabbf5eb10da2fa7d564dc9dfcbdf5305d5f509b30f761becd2cb3.png
+    displayName: a jar of prehistoric honey
+    keyword: honey
+    description: A thick, luminous jar of honey harvested from the Prehistoric Apiary. It smells of ancient flowers and
+      sixty-five million years of rainforest rain. Incredibly sweet. Incredibly restorative.
+    consumable: true
+    onUse:
+      healHp: 35
+    room: prehistoric_apiary
+    basePrice: 40
+  bee_stinger_sword:
+    image: bf4b213d41a4424e1f2f4130e21c6ed2b839a1169e2320d44aceb1ea7fd0f424.png
+    displayName: a prehistoric bee stinger sword
+    keyword: stinger
+    description: A massive stinger shed by the Prehistoric Queen Bee, honed to a razor edge and fitted with a grip of tough
+      vine. It hums faintly with ancient apiary power.
+    slot: weapon
+    damage: 16
+    armor: 1
+    room: prehistoric_apiary
+    basePrice: 120
+  wesleys_art_brush:
+    image: 66b17a7abbb4f2c688a898c183a711c6d5ef612322633d280448e390d9a55afe.png
+    displayName: Wesley's enchanted art brush
+    keyword: brush
+    description: A paint brush with bristles that shimmer with every color ever mixed. When you hold it, you feel an
+      overwhelming urge to create something magnificent.
+    slot: offhand
+    armor: 2
+    room: wesleys_art_workshop
+    basePrice: 60
+  monster_trading_card:
+    image: 531d7cadaa5b461d171484dc264f1f54059ecf830dda6072a661f3ed55231bfd.png
+    displayName: a holographic monster trading card
+    keyword: card
+    description: "A shimmering holographic card depicting one of Wesley's hand-drawn monster designs. The monster shifts and
+      moves slightly when you tilt it. On the back: '5000 ATK / 4000 DEF — WESLEY THE ARTIST.'"
+    room: gallery_living_art
+    basePrice: 80
+  pixel_gem:
+    image: f05e30287c99c423b7d79c84d91400343bc28f0b09558a1773fb3b0baf17f4f8.png
+    displayName: a chunky pixel gem
+    keyword: gem
+    description: A bright-red gem rendered in perfect 16-bit pixel art, actually made of glass. It catches light in a
+      satisfying blocky way. Unmistakably from Wesley's Pixel Realm.
+    room: pixel_realm
+    basePrice: 45
+  aurora_rainbow_stuffie:
+    image: 2be6c5bcd83ca935c295229e87d7cca1501a76d8486d4bd55fe4fcd913334e57.png
+    displayName: a rainbow stuffed unicorn
+    keyword: unicorn
+    description: A plush stuffed unicorn with a sparkly rainbow mane and an expression of pure serenity. It has been
+      well-loved — one ear is slightly flattened from years of being hugged. It seems to radiate calm.
+    consumable: true
+    onUse:
+      healHp: 15
+    room: stuffie_wonderland
+    basePrice: 25
+  glitter_crown:
+    image: 9fcd973c5560fc86aec5f1915e170f8cdf9521fabecdbe0d66f3b979d9af7b7e.png
+    displayName: a glitter crown
+    keyword: crown
+    description: A cardboard crown dusted in silver and gold glitter that gets on everything it touches — but in a magical,
+      not annoying, way. Whoever wears it is clearly royalty.
+    slot: head
+    armor: 3
+    room: auroras_entrance
+    basePrice: 35
+  jungle_orchid:
+    image: f0529bd04dbea4aca4457feebd6758ba43d16b38ff4e8daef5ad773a394c01c2.png
+    displayName: a luminous jungle orchid
+    keyword: orchid
+    description: An orchid of impossible purple and gold found deep in the prehistoric rainforest, its petals faintly
+      luminescent. Eating it carries some of the jungle's wild vitality.
+    consumable: true
+    onUse:
+      healHp: 20
+    room: jungle_deep
+    basePrice: 30
+shops:
+  landing_supply_post:
+    name: The Treehouse Landing Supply Post
+    room: landing
+    items:
+      - prehistoric_honey
+      - jungle_orchid
+      - aurora_rainbow_stuffie
+rooms:
+  gravel_road_2:
+    image: 544e2f017b60f345cbc384a4829569b5f45c9798bf1c949451537b61faa84827.jpg
+    title: The Kingdom Road - Eastern Approach
+    description: A pale gravel road winds westward through the edge of a tropical rainforest, enormous ferns brushing the
+      verge and macaws arguing in the canopy above. The air is warm and alive with insects and birdcall. An archway of
+      intertwined jungle vines frames the eastern path — beyond it, dimensional light pulses faintly, the gateway back
+      to the wider world. A jewel-toned chameleon watches you from a branch, then vanishes. To the west, the road
+      continues deeper into the kingdom.
+    exits:
+      w: gravel_road_1
+  gravel_road_1:
+    image: 6ff0fbe478e8dc866c130c9280a51bcf64da23d375e17e67ee6cc5db39c71c71.jpg
+    title: The Kingdom Road - Near the Treehouse
+    description: "The gravel road here is well-trodden and scattered with the evidence of an active household — a chalk
+      hopscotch grid, a lost sandal, a small pile of interesting rocks clearly being saved for a reason. Through the
+      canopy above, the underside of the treehouse is visible: a vast golden-timbered platform lashed to a tree so large
+      it defies explanation. A rope ladder dangles upward to a landing platform. The road continues east; a woodpile
+      is to the west; a smoky smell drifts from the south."
+    exits:
+      e: gravel_road_2
+      u: landing
+      w: wood_pile
+      s: smoky_clearing
+  wood_pile:
+    image: e934dacba4469188d7b1213a3bda25929f862694417017ef19503ae276496bb1.jpg
+    title: The Royal Wood Pile
+    description: An impressive stack of split firewood, cut and stacked with evident pride. The logs are arranged in
+      interlocking layers that — if you look at the cut ends — spell out 'W+A' near the top. A smell of fresh-cut pine
+      and resin mingles with the humid jungle air. Butterflies and luminous tropical moths flutter between the logs. A
+      scarlet macaw has claimed the topmost piece as a throne. The gravel road is east; the smoker is south.
+    exits:
+      e: gravel_road_1
+      s: wood_smoker
+  wood_smoker:
+    image: be622ba1599b46bf6ed8c257713f90c5b5de34295fe90b703834d58996ff1ca1.jpg
+    title: The Wood Smoker Station
+    description: "A large barrel smoker sits at the edge of a jungle clearing, tendrils of fragrant hardwood smoke curling
+      up through the palm fronds above. Someone has chalked a menu on a slab of bark propped against it: 'BBQ Ribs,
+      Wings, Dino Nuggets (the big kind).' The coals glow orange in the canopy-filtered light. The rich, layered smell
+      of smoke and slow-cooked everything is extremely persuasive. The wood pile is back to the north."
+    exits:
+      n: wood_pile
+  landing:
+    image: 32f3433dc6934d7dd37966b6b26c4e59fc91d6430291503eb1b1fbe455c492df.jpg
+    title: The Treehouse Landing Platform
+    description: "A wide wooden platform set at the first bough of the great tree, reached by a thick rope ladder from the
+      gravel road below. The platform is solid and well-worn, hung with wind chimes made of shells and old keys that
+      keep up a gentle music in every breeze. Painted arrows point in three directions with helpful labels: 'UP
+      (treehouse)', 'DOWN (road)', and 'IN (basement, servants only — do not knock before 7am).' A supply post on the
+      platform offers jungle provisions."
+    exits:
+      d: gravel_road_1
+      u: lower_deck
+      n: basement_main
+  smoky_clearing:
+    image: df6e505ef347a7454661e04da71b75280bb9c5e2e08b9db367cf03a6bf35170a.jpg
+    title: A Smoky Clearing
+    description: A round clearing where the tree cover thins just enough to let shafts of hazy light through the perpetual
+      smoke. The smoke drifts in from the south, smelling of something ancient and sweet — flowers that haven't existed
+      for sixty-five million years. The ground is soft with centuries of leaf litter, and enormous tracks cross the
+      clearing in patterns too large for any modern animal. It is beautiful and faintly alarming. The gravel road lies
+      to the north; the smoke thickens to the south.
+    exits:
+      n: gravel_road_1
+      s: prehistoric_apiary
+  prehistoric_apiary:
+    image: 7b51d7a3c7ecb72405d9f6fc5a83605c49c3cd8ec8faa979cfe89341bc5eba24.jpg
+    title: The Prehistoric Apiary
+    description: "Nothing here is normal. The hives are enormous — each one the size of a small house — constructed from
+      golden comb the color of ancient amber. The bees themselves are prehistoric: each one wider than your arms spread
+      wide, their drone a bass note that resonates in your chest. In the center, on a platform of pure golden comb, the
+      Prehistoric Queen Bee tends her domain with the authority of sixty-five million years of unbroken succession. Jars
+      of luminous honey and a shed stinger the size of a sword lie near the entrance. The jungle extends east and west;
+      the smoky clearing is back to the north."
+    exits:
+      n: smoky_clearing
+      e: jungle_deep
+      w: jungle_floor
+  jungle_floor:
+    image: e16d1fa8b234b6027d36c2f89819b56ec2804b5204ac924fc3ef8be8b68de893.jpg
+    title: The Jungle Floor
+    description: The floor of the prehistoric jungle is a riot of giant ferns, fallen logs thick with moss, and pools of
+      standing water reflecting filtered green light from far above. The humidity is extreme. Every surface is alive —
+      insects, lizards, fungi, flowering plants in colors that do not quite correspond to the visible spectrum. Enormous
+      footprints press into the soft earth. The apiary is to the east; the canopy is reachable by climbing to the north.
+    exits:
+      e: prehistoric_apiary
+      u: jungle_canopy
+  jungle_deep:
+    image: b97ae92bc2f1977d8f9c16e3215d9d9c6e7b082e310552f767baad425d809843.jpg
+    title: Deep Jungle - Dinosaur Territory
+    description: You have gone deep into the prehistoric jungle, where the trees are immense and the shadows between them
+      are full of motion. The sound of dinosaurs is all around you — distant roars, heavy footsteps, the crash of
+      something enormous through undergrowth. A hunting velociraptor pauses to assess you with unsettling intelligence.
+      A triceratops grazes at the far edge of a sunny clearing, deceptively peaceful. This is not a safe place, but it
+      is magnificent. The apiary is to the west; the high canopy is to the north.
+    exits:
+      w: prehistoric_apiary
+      u: jungle_canopy
+  jungle_canopy:
+    image: 1cc7c503a0d437367aa2e90f8659a366da9aa3cd6b7df39a753f0c9996d75511.jpg
+    title: The High Jungle Canopy
+    description: "You have climbed into the upper reaches of the prehistoric canopy, where ancient trees form a vaulted
+      ceiling of green over the entire world. Pterodactyls roost in the higher branches, leathery wings folded, watching
+      you with prehistoric patience. The air here is clearer, and the entire Kingdom of Wesleyalis is visible below: the
+      treehouse like a fortress, smoke rising from the clearing, the glimmer of the world-gate to the east. It is
+      spectacularly beautiful. The jungle floor is below."
+    exits:
+      d: jungle_floor
+      s: jungle_deep
+  lower_deck:
+    image: dbe52e2729b23f2889c510ab5d59f612340cfdda9fbf8401c10b52cb83e04dd2.jpg
+    title: Treehouse Lower Deck
+    description: The lower deck wraps around the great trunk, its planks warm from the tropical sun filtering through the
+      canopy. Hammocks are strung between the railings and potted jungle plants in hand-painted pots crowd every corner.
+      The view from here is staggering — rainforest stretching to the horizon in every shade of green. Vines have been
+      trained into handrails. A rope ladder descends to the landing platform below; stairs wind upward to the main upper
+      deck.
+    exits:
+      d: landing
+      u: upper_deck
+  upper_deck:
+    image: 912bd17d7057e99406ad753b590e3e12e1979de7f42ad56adc81c868648d3830.jpg
+    title: Treehouse Upper Deck
+    description: "The upper deck is the social heart of the treehouse exterior — a broad platform with a table built around
+      the trunk, three mismatched chairs, and a spectacular view of the jungle canopy. Wind chimes keep up a gentle
+      bamboo music. Someone has painted a large sign on the trunk in careful letters: 'KINGDOM OF WESLEYALIS — WESLEY &
+      AURORA, RULERS OF EVERYTHING.' It is spelled correctly and underlined three times. Stairs lead down to the lower
+      deck; a sliding glass door opens east into the living room."
+    exits:
+      d: lower_deck
+      e: living_room
+  living_room:
+    image: 526f5869cea6a21e0d567791b671e6dfaca50e0714c5ea24e55f668ade7ca13b.jpg
+    title: The Treehouse Living Room
+    description: "The living room is airy and open, its walls more window than wall — every pane frames a different view of
+      the jungle canopy. The furniture is the good kind: deep couches, a rug that has survived many years of indoor
+      camping forts, and a coffee table covered in at least six ongoing projects (Lego, drawing, a half-finished board
+      game, several rocks of importance). A massive TV is mounted to the trunk itself. The upper deck is through the
+      sliding door west; the kitchen is north; the dining room is east."
+    exits:
+      w: upper_deck
+      n: kitchen
+      e: dining_room
+  kitchen:
+    image: 1f661bf597a4f59346b8990432efe9d9583f2aad5b229382e7bc7b0733316c87.jpg
+    title: The Treehouse Kitchen
+    description: A proper kitchen built into the treehouse's main platform, warm and smelling of something good. The
+      countertops are at two heights — one regular, one sized for small people who insist on helping. A magnetic knife
+      block, a jungle-themed fruit bowl, and a truly impressive spice rack line the walls. Finger paintings are stuck to
+      the fridge with souvenir magnets from everywhere the kingdom has ever traveled, real and imaginary. The living
+      room is south; the kitchen nook and art prep is east; the hallway is west.
+    exits:
+      s: living_room
+      e: kitchen_nook
+      w: hallway_east
+  kitchen_nook:
+    image: 22ec95dc5c05d0757edab6b7f2c4de6eeec087bb0fba21b3f6bf3ee867c2f53b.jpg
+    title: The Kitchen Nook and Art Prep Counter
+    description: Where the kitchen meets the creative side of the household. The breakfast nook's table is perpetually
+      covered in art supplies — colored pencils sorted by hue, half-dried watercolor palettes, stacks of drawing paper,
+      and reference books about dinosaurs and creatures. The nook's bench seat bears a mural of jungle animals painted
+      by a hand both skilled and enthusiastic. The main kitchen is to the west; the art workshop opens to the north.
+    exits:
+      w: kitchen
+      n: wesleys_art_workshop
+  wesleys_art_workshop:
+    image: 2e601cce6798b2ea10ea63f6bb7119021965bebd5ddd0bc2404a881c5fa0c7d7.jpg
+    title: Wesley's Art Workshop
+    description: "Wesley's Art Workshop is a world unto itself, crammed into the northeast corner of the treehouse. Every
+      surface not covered in supplies is covered in artwork: detailed pencil studies of dinosaurs, vibrant pixel-art
+      printouts, Minecraft building plans in architectural isometric view, and character designs for games that exist
+      only in his head so far. An easel at the center holds something large, draped in a paint-stained cloth. The air
+      smells of paint, turpentine, and possibility. An enchanted art brush rests beside the palette. The kitchen nook is
+      south; the dining room is west."
+    exits:
+      s: kitchen_nook
+      w: dining_room
+  dining_room:
+    image: d7b5686b26ea51caa8cd171a650fb98a7a90f216be9425afb323d19517a440a2.jpg
+    title: The Treehouse Dining Room
+    description: The dining room always has chairs in slightly wrong positions, as if everyone just finished eating and
+      hasn't tidied yet. A long table dominates the room, its surface gently scarred with years of craft projects that
+      escaped their newspapers. The window over the table looks directly into the canopy — on windy days the leaves
+      brush the glass. The living room is west; the art workshop is east; the west hallway is through the connecting
+      passage to the north; a hatch in the floor leads down to the basement.
+    exits:
+      w: living_room
+      e: wesleys_art_workshop
+      n: hallway_east
+      d: basement_main
+  hallway_east:
+    image: 08ef24355373581564f5e61c5cd5317a35dc12143c004c68a110b956dd496cfc.jpg
+    title: The East Hallway
+    description: "The east wing hallway connects the kitchen and dining area to the bedroom corridor. Framed drawings line
+      the walls in a rotating gallery curated with the seriousness due any major exhibition. A family calendar marks
+      every important date in different colors: birthdays, school days, 'MOVIE NIGHT' recurring every Friday. The
+      kitchen is east; the dining room is south; the west hallway continues ahead; the bathroom is north."
+    exits:
+      e: kitchen
+      s: dining_room
+      w: hallway_west
+      n: bathroom
+  bathroom:
+    image: 1f075ff36c80b877fc4584463917d09eb6c288013d094e6656ba6ba7e917f7b2.jpg
+    title: The Treehouse Bathroom
+    description: A cheerful bathroom with jungle-themed tiles — tiny painted frogs, leaves, and the occasional pixel-art
+      dinosaur on the backsplash. The mirror is ringed with stickers that have been accumulating for years. A
+      height-measurement chart on the door frame shows two sets of marks in different colors — 'W' in blue and 'A' in
+      pink — tracking years of upward progress. Everything smells faintly of bubblegum shampoo. The hallway is south.
+    exits:
+      s: hallway_east
+  hallway_west:
+    image: 79d308bf6169c13111f8c611ce6b4ba9b05f0279c2558a6b9641e8431afe593f.jpg
+    title: The West Hallway - The Royal Corridor
+    description: "The west wing hallway is the royal corridor, and it knows it. The carpet is slightly better here, the
+      lighting warmer, and the wall decorations more elaborate — royal proclamations in crayon on colored paper, framed
+      with what appears to be painted macaroni. A hand-lettered directory on the wall reads: 'NORTH — King Wesley's
+      Kingdom. SOUTH — Princess Aurora's Kingdom. EAST — Civilization.' The east hallway connects back to the main
+      house."
+    exits:
+      e: hallway_east
+      n: king_wesleys_entrance
+      s: auroras_entrance
+  king_wesleys_entrance:
+    image: 2296b2f4a37bb9fa4764d41239c1ea0ada1128fccf5aa3352f2e05403a11b469.jpg
+    title: Antechamber of King Wesley's Kingdom
+    description: "The doorway to Wesley's room is unmistakable. A hand-lettered sign reads: 'KINGDOM OF KING WESLEY THE
+      ARTIST — ENTER WITH RESPECT FOR ART.' The threshold shimmers with low creative energy — the boundary between
+      ordinary treehouse space and something considerably more magnificent. On the wall beside the door, a single framed
+      painting: a self-portrait of Wesley wearing a crown and painting a dinosaur that appears to be stepping out of the
+      canvas. The royal corridor is to the south. The kingdom awaits to the north."
+    exits:
+      s: hallway_west
+      n: king_wesleys_throne
+  king_wesleys_throne:
+    image: 901ff69d89ddaa919d3ab4ff7f0068a49a61bd142cb3e6176aa3c566170acfff.jpg
+    title: King Wesley's Throne Room
+    description: "The throne room is where art and rulership intersect. A throne assembled from art supply crates, a gaming
+      chair, and a cardboard castle towers at the far end, facing a room that is part gallery, part studio, part living
+      dream. The walls are alive — literally. Paintings shift as you watch: a brushstroke becomes a wing, a color field
+      becomes a landscape, a figure in a portrait turns its head. Pixel-art sprites drift across the floor like tiles on
+      an invisible game board. East lies the Gallery of Living Art; west is the Pixel Realm; the antechamber is south."
+    exits:
+      s: king_wesleys_entrance
+      e: gallery_living_art
+      w: pixel_realm
+  gallery_living_art:
+    image: f89e8ed7fc45ca4a41406a7dc7097dd2173cf41b0f7393cb58069c740ec50f43.jpg
+    title: The Gallery of Living Art
+    description: In Wesley's Gallery, the paintings don't stay still. They breathe. A watercolor landscape ripples like
+      actual water; a charcoal dinosaur shakes its head and blinks. Without warning, a figure in a painting steps
+      through its frame, trailing streaks of vivid color, and the battle is on. The walls are floor-to-ceiling canvases,
+      each one a different world. At the north wall, the grandest canvas of all — a cityscape being destroyed by
+      something enormous, its silhouette unmistakable. A holographic monster trading card is displayed in a shadow box
+      by the entrance. The throne room is west; the monster's arena is north.
+    exits:
+      w: king_wesleys_throne
+      n: godzilla_arena
+  godzilla_arena:
+    image: 7166514688c6d09315ea491339faac25b7d6d7625d105d776aaa11c9c46a1f1b.jpg
+    title: Godzilla's Arena - The City of Wesley
+    description: You have entered the painted city, and it is under siege. The buildings around you were drawn by Wesley in
+      careful architectural detail — each one a different style — and several are already tilted at alarming angles or
+      on fire. The city skyline above is dominated by a silhouette of impossible scale. GODZILLA stands at the center of
+      the metropolis, dorsal plates glowing electric blue, each footstep a seismic event. The city of Wesley was
+      hand-designed. It is magnificent and under attack. The gallery is south.
+    exits:
+      s: gallery_living_art
+  pixel_realm:
+    image: 78ff3affc8f79817e3cd285a7a8c5908e3e7ea0555acddc040525b760e0ab533.jpg
+    title: The Pixel Realm
+    description: "The western wing of Wesley's kingdom has been completely overwritten with pixel art — walls, floor, and
+      ceiling rendered in chunky, satisfying 16-bit graphics. Minecraft biomes tile the floor in perfect squares: grass,
+      dirt, sand, deep blue water. A floating code overlay hovers at the edge of your vision, written in a syntax that
+      looks like it was designed by someone who learned programming before handwriting. Rogue code sprites skitter
+      between blocks, occasionally throwing compile errors at you. A pixelated T-Rex wanders through the Overworld
+      section with total confidence. A chunky pixel gem catches the light. The throne room is east."
+    exits:
+      e: king_wesleys_throne
+  auroras_entrance:
+    image: 77da02de01a89c98068550df6c2c132905afba5ba33006194990cb5db98b6317.jpg
+    title: Antechamber of Princess Aurora's Kingdom
+    description: "The entrance to Aurora's realm has been decorated with extreme thoroughness. Glitter has been applied to
+      the doorframe, the walls on both sides, the ceiling, the floor, and apparently also the air itself. A sign — each
+      letter a different color in a different font — reads: 'AURORA'S ROOM — WELCOME — PLEASE BE GENTLE WITH THE
+      STUFFIES.' A sparkly glitter crown sits on a small shelf by the door, available for qualifying visitors. The royal
+      corridor is north; the kingdom is south."
+    exits:
+      n: hallway_west
+      s: stuffie_wonderland
+  stuffie_wonderland:
+    image: e81c7ff7ec331eaf647c776d3398d9f7bdc9b768593a4cc03477095e9649b42b.jpg
+    title: The Stuffie Wonderland
+    description: Aurora's room, in its resting state, is paradise. Every shelf, surface, window ledge, and corner is
+      occupied by stuffed animals of extraordinary variety and obvious biographical significance — each one has a name,
+      a place of honor, and an ongoing relationship with Aurora that you are not fully cleared to know about. The Great
+      Stuffed Dragon Guardian presides over the central stuffie congress from a throne of velvet and yarn. Fairy lights
+      in three colors keep everything warm and golden. It smells of lavender and something pink-colored. A rainbow
+      stuffed unicorn sits in the place of honor near the window. The antechamber is north; the wasteland is east.
+    exits:
+      n: auroras_entrance
+      e: tantrum_wasteland
+  tantrum_wasteland:
+    image: 10dbf79ebdf3a68e9575a1e3b5f4ef2baec20cfb46419e07aaf5ef9ed0b835d3.jpg
+    title: The Tantrum Wasteland
+    description: This corner of Aurora's kingdom has borne the full weight of toddler displeasure, and it shows. Stuffed
+      animals lie strewn across the floor as if thrown by a tiny, furious god — which is accurate. The bookshelf is
+      empty, its contents scattered in a radius consistent with a toddler having Extremely Strong Opinions. Crayon marks
+      cover the wall in bold, righteous arcs. And yet — even in destruction there is artistry. The pattern follows the
+      logic of pure indignant feeling, and is, in its own way, beautiful and terrible. Small chaos toddler spirits dance
+      through the debris. The stuffie wonderland is west.
+    exits:
+      w: stuffie_wonderland
+  basement_main:
+    image: c887549ab8bc183299c64a14d0a5f6d02dd0817b4b086647f26b50f22ad171c4.jpg
+    title: The Basement - Servants' Quarters
+    description: "The basement of the Kingdom of Wesleyalis is the domain of the Royal Servant Parents, and they have tried
+      their best with it. One corner has a proper adult workspace: a laptop, paperwork of obscure but essential
+      importance, and a coffee mug that has not been fully empty since approximately the birth of Wesley. The walls bear
+      evidence of both kingdoms above leaking downward — here a framed dinosaur drawing, there a stuffed bear keeping
+      dignified watch from a high shelf. A whiteboard reads: 'CURRENTLY RUNNING: 2 KINGDOMS, 1 TREEHOUSE, 1 PREHISTORIC
+      APIARY, MISC. DINOSAURS.' The dining room is above; the landing side door is south; the art archive is east; the
+      stuffie nook is west."
+    exits:
+      u: dining_room
+      s: landing
+      e: basement_art
+      w: basement_stuffie
+  basement_art:
+    image: 0b23097cf83b481cfe92cc094451c858a047ec763d263f83f1e46ce77161757f.jpg
+    title: The Basement Art Archive
+    description: "A section of the basement has been given over — voluntarily or otherwise — to the overflow of Wesley's art
+      production. Portfolios stand in labeled folders. Rolled canvases lean against the wall. A large flat-file cabinet
+      holds years of drawings organized by a system that makes complete sense to its creator. On the wall, framed and
+      labeled with hand-written museum placards, are the first three drawings Wesley ever made: abstract, energetic, and
+      signed in very large letters. The archive continues upstairs and in every available direction. The main basement
+      is to the west."
+    exits:
+      w: basement_main
+  basement_stuffie:
+    image: 167692d50e4106170a037394c6d12241b4a1677b37b1acba3a1b22cb16a1af7e.jpg
+    title: The Basement Stuffie Nook
+    description: "The western corner of the basement has been claimed by overflow stuffies — the ones that couldn't fit in
+      Aurora's room, a situation everyone considered mathematically impossible until it happened. They sit on shelves,
+      in baskets, and in a large bean bag designated 'THE STUFFIE CHAIR' by a hand-painted sign. A mural at child-height
+      on the wall shows the stuffie family tree: a genealogy of plush spanning a remarkable number of species. Several
+      stuffies watch you from the shelves with the dignified patience of things that are very, very loved. The main
+      basement is to the east."
+    exits:
+      e: basement_main
+audio:
+  music: 27c24ab978dfbb2b0971120ff61c42a8f56c7f96735c08f0ae83bc8e2644c7ff.mp3

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
@@ -715,4 +715,15 @@ class CommandParserTest {
         val result = CommandParser.parse("auction sell sword ${CommandParser.MAX_AUCTION_PRICE}")
         assertEquals(Command.AuctionSell("sword", CommandParser.MAX_AUCTION_PRICE), result)
     }
+
+    @Test
+    fun `petition parses keyword`() {
+        assertEquals(Command.Petition("peanut"), CommandParser.parse("petition peanut"))
+        assertEquals(Command.Petition("noecker"), CommandParser.parse("petition Noecker"))
+    }
+
+    @Test
+    fun `petition without keyword is Invalid`() {
+        assertTrue(CommandParser.parse("petition") is Command.Invalid)
+    }
 }

--- a/src/test/kotlin/dev/ambon/engine/commands/PetitionCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/PetitionCommandTest.kt
@@ -1,0 +1,88 @@
+package dev.ambon.engine.commands
+
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.mob.MobState
+import dev.ambon.domain.world.Room
+import dev.ambon.domain.world.World
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.test.CommandRouterHarness
+import dev.ambon.test.MutableClock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PetitionCommandTest {
+    private val hub = RoomId("test_zone:hub")
+    private val outpost = RoomId("test_zone:outpost")
+    private val pbraeStart = RoomId("pbrae:gravel_road")
+
+    private fun worldWithPetitionZone(): World {
+        val rooms = mapOf(
+            hub to Room(id = hub, title = "Hub", description = "Hub room", exits = mapOf()),
+            outpost to Room(id = outpost, title = "Outpost", description = "Outpost room", exits = mapOf()),
+            pbraeStart to Room(id = pbraeStart, title = "Gravel Road", description = "A gravel road.", exits = mapOf()),
+        )
+        return World(rooms = rooms, startRoom = hub)
+    }
+
+    @Test
+    fun `petition with valid keyword teleports player`() = runTest {
+        val world = worldWithPetitionZone()
+        val h = CommandRouterHarness.create(world = world, clock = MutableClock(0L))
+        val sid = SessionId(1)
+        h.loginPlayer(sid, "Hero")
+        h.drain()
+
+        h.router.handle(sid, Command.Petition("peanut"))
+        val outs = h.drain()
+
+        assertEquals(pbraeStart, h.players.get(sid)!!.roomId)
+        assertTrue(
+            outs.any { it is OutboundEvent.SendText && it.text.contains("world shifts") },
+            "Expected teleport flavor text. got=$outs",
+        )
+    }
+
+    @Test
+    fun `petition with unknown keyword sends error`() = runTest {
+        val h = CommandRouterHarness.create(clock = MutableClock(0L))
+        val sid = SessionId(1)
+        h.loginPlayer(sid, "Hero")
+        h.drain()
+
+        h.router.handle(sid, Command.Petition("nonsense"))
+        val outs = h.drain()
+
+        assertTrue(
+            outs.any { it is OutboundEvent.SendError && it.text.contains("unanswered") },
+            "Expected unanswered message. got=$outs",
+        )
+    }
+
+    @Test
+    fun `petition blocked while in combat`() = runTest {
+        val world = worldWithPetitionZone()
+        val h = CommandRouterHarness.create(world = world, clock = MutableClock(0L))
+        val sid = SessionId(1)
+        h.loginPlayer(sid, "Hero")
+
+        val mobId = MobId("test_zone:grunt")
+        h.mobs.upsert(MobState(id = mobId, name = "a grunt", roomId = hub, hp = 10, maxHp = 10))
+        h.router.handle(sid, Command.Kill("grunt"))
+        h.drain()
+
+        h.router.handle(sid, Command.Petition("peanut"))
+        val outs = h.drain()
+
+        assertTrue(
+            outs.any { it is OutboundEvent.SendError && it.text.contains("combat") },
+            "Expected combat-block message. got=$outs",
+        )
+        assertEquals(hub, h.players.get(sid)!!.roomId)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `petition <keyword>` command that teleports players to disconnected easter-egg zones imported from the Ambon repo
- Cross-zone exits stripped so players must `recall` to return to the main world
- Blocked during combat; unknown keywords get a flavor-text rejection

**Keywords:**
| Keywords | Zone | Start Room |
|----------|------|------------|
| `pbrae`, `peanut`, `braelynn` | pbrae | gravel_road |
| `wesley`, `aurora`, `wesleyalis` | wesleyalis | gravel_road_2 |
| `trevor`, `hailey`, `trailey` | trailey | cul_de_sac |
| `noecker` | noecker_resume | lobby |

## Test plan

- [x] `ktlintCheck` passes
- [x] Full test suite passes (including new `PetitionCommandTest` and `CommandParserTest` additions)
- [ ] Manual: `petition peanut` teleports to pbrae zone
- [ ] Manual: `petition noecker` teleports to noecker_resume zone
- [ ] Manual: `petition nonsense` shows "Your petition goes unanswered."
- [ ] Manual: `recall` returns player to main world from easter-egg zone
- [ ] Manual: petition blocked during combat