### PR TITLE
Set graphical: true on easter-egg zones

### DIFF
--- a/src/main/resources/world/noecker_resume.yaml
+++ b/src/main/resources/world/noecker_resume.yaml
@@ -1,4 +1,5 @@
 zone: noecker_resume
+graphical: true
 image:
   room: cb24b3903033408e13ef14be797721a700251e3f07907ecde652d7f05b84d5c3.png
   mob: c49140a0669957dbe3a818c8c93c44608563a92eb7ea420c46843a2db6ca9a56.png

--- a/src/main/resources/world/pbrae.yaml
+++ b/src/main/resources/world/pbrae.yaml
@@ -1,4 +1,5 @@
 zone: pbrae
+graphical: true
 image:
   room: 37d00e7f3bd0f92f319e437f77d70c36eadd3631cccb3c09708b00c83446d947.png
   mob: b89204647cf6c2b25e18228f392366ae745cc6fe84ba7e533904ecbc9f019e04.png

--- a/src/main/resources/world/trailey.yaml
+++ b/src/main/resources/world/trailey.yaml
@@ -1,4 +1,5 @@
 zone: trailey
+graphical: true
 image:
   room: trailey/default_room.png
   mob: trailey/default_mob.png

--- a/src/main/resources/world/wesleyalis.yaml
+++ b/src/main/resources/world/wesleyalis.yaml
@@ -1,4 +1,5 @@
 zone: wesleyalis
+graphical: true
 image:
   room: e4f4f7c612bb4ccf5be5454aaca0de9a81a025214eb2eb560ce207acf3b47fd3.png
   mob: a74879edebf96065f3c5b3c4eb87c6fd2a5a6e91b68b6fab1da4525875453ecf.png


### PR DESCRIPTION
## Summary

- Sets `graphical: true` on all 4 petition easter-egg zones (pbrae, wesleyalis, trailey, noecker_resume)
- Without this flag, the web client defaults to text-primary layout in these zones since `graphical` defaults to `false`

## Test plan

- [x] YAML-only change, no code modified
- [ ] Manual: petition to pbrae shows canvas-primary layout (not text mode)