### PR TITLE
Fix weather particles rendering as invisible

### DIFF
--- a/web-v3/src/canvas/scenes/WorldScene.ts
+++ b/web-v3/src/canvas/scenes/WorldScene.ts
@@ -684,7 +684,6 @@ export class WorldScene {
     this.recallBtn.visible = false;
 
     this.container.addChildAt(this.skyRenderer.graphics, 0);
-    this.container.addChild(this.weatherParticles.graphics);
     this.container.addChild(this.ambientMotes.graphics);
     this.container.addChild(this.roleGraphics);
     this.container.addChild(this.statusEffects.container);
@@ -711,8 +710,9 @@ export class WorldScene {
     this.container.addChild(this.recallBtn);
     this.container.addChild(this.backdropHit);
     this.container.addChild(this.entityPopout.container);
-    // Transition graphics live in the overlay so they stay visible while
-    // container.alpha fades to 0 during the dissolve phase.
+    // Weather lives in the overlay so it stays visible during room-transition
+    // fades (container.alpha → 0) and reliably renders above room art/sky.
+    this.overlayContainer.addChild(this.weatherParticles.graphics);
     this.overlayContainer.addChild(this.roomTransition.graphics);
   }
 


### PR DESCRIPTION
## Summary
- Weather particles were invisible after the prior fix moved them from `overlayContainer` into the main `container`
- Moves weather back to `overlayContainer` where they reliably render above the sky gradient and room art
- Preserves the room art layering fix (index 1, above the opaque sky)

## Context
The environment themes PR (#981) introduced two bugs:
1. Room art inserted at index 0 (behind the opaque sky gradient) — invisible
2. Weather in `overlayContainer` appeared to "block" room art, but only because room art was already invisible

The prior commit fixed (1) correctly but also moved weather out of the overlay, causing it to stop rendering. This PR reverts just the weather placement.

## Test plan
- [ ] `.\gradlew.bat demo` — verify weather particles (rain/snow/fog) are visible over room art
- [ ] Verify room art is visible and tinted by the sky gradient (alpha 0.6 bleed-through)
- [ ] Move between rooms — weather should persist during room transition fades
- [ ] Enter/exit combat — weather should reappear when returning to world scene