### PR TITLE
Update Exposed from 0.58.0 to 1.2.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ val micrometerVersion = "1.16.4"
 val grpcVersion = "1.80.0"
 val grpcKotlinVersion = "1.5.0"
 val protobufVersion = "4.34.1"
-val exposedVersion = "0.58.0"
+val exposedVersion = "1.2.0"
 
 dependencies {
     // Coroutines

--- a/src/main/kotlin/dev/ambon/persistence/DatabaseManager.kt
+++ b/src/main/kotlin/dev/ambon/persistence/DatabaseManager.kt
@@ -4,7 +4,7 @@ import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import dev.ambon.config.DatabaseConfig
 import org.flywaydb.core.Flyway
-import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.v1.jdbc.Database
 
 class DatabaseManager(
     private val config: DatabaseConfig,

--- a/src/main/kotlin/dev/ambon/persistence/GuildRepositoryFactory.kt
+++ b/src/main/kotlin/dev/ambon/persistence/GuildRepositoryFactory.kt
@@ -2,7 +2,7 @@ package dev.ambon.persistence
 
 import dev.ambon.config.PersistenceBackend
 import dev.ambon.config.PersistenceConfig
-import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.v1.jdbc.Database
 import java.nio.file.Paths
 
 object GuildRepositoryFactory {

--- a/src/main/kotlin/dev/ambon/persistence/GuildsTable.kt
+++ b/src/main/kotlin/dev/ambon/persistence/GuildsTable.kt
@@ -1,6 +1,6 @@
 package dev.ambon.persistence
 
-import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.v1.core.Table
 
 object GuildsTable : Table("guilds") {
     val id = varchar("id", 64)

--- a/src/main/kotlin/dev/ambon/persistence/HouseRepositoryFactory.kt
+++ b/src/main/kotlin/dev/ambon/persistence/HouseRepositoryFactory.kt
@@ -2,7 +2,7 @@ package dev.ambon.persistence
 
 import dev.ambon.config.PersistenceBackend
 import dev.ambon.config.PersistenceConfig
-import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.v1.jdbc.Database
 import java.nio.file.Paths
 
 object HouseRepositoryFactory {

--- a/src/main/kotlin/dev/ambon/persistence/HousesTable.kt
+++ b/src/main/kotlin/dev/ambon/persistence/HousesTable.kt
@@ -1,6 +1,6 @@
 package dev.ambon.persistence
 
-import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.v1.core.Table
 
 object HousesTable : Table("houses") {
     val ownerId = long("owner_id")

--- a/src/main/kotlin/dev/ambon/persistence/MapperSupport.kt
+++ b/src/main/kotlin/dev/ambon/persistence/MapperSupport.kt
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import kotlinx.coroutines.Dispatchers
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.Transaction
-import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.v1.core.Transaction
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.transactions.experimental.newSuspendedTransaction
 
 /** Shared YAML ObjectMapper for persistence layer. Lenient on unknown properties for schema evolution. */
 val yamlMapper: ObjectMapper =

--- a/src/main/kotlin/dev/ambon/persistence/PlayerRepositoryFactory.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayerRepositoryFactory.kt
@@ -5,7 +5,7 @@ import dev.ambon.config.PersistenceConfig
 import dev.ambon.config.RedisConfig
 import dev.ambon.metrics.GameMetrics
 import dev.ambon.redis.RedisConnectionManager
-import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.v1.jdbc.Database
 import java.nio.file.Paths
 
 data class PlayerRepositoryChain(

--- a/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
@@ -7,9 +7,9 @@ import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.mail.MailMessage
 import dev.ambon.domain.quest.QuestState
-import org.jetbrains.exposed.sql.ResultRow
-import org.jetbrains.exposed.sql.Table
-import org.jetbrains.exposed.sql.statements.UpdateBuilder
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
 
 private val statsType = object : TypeReference<Map<String, Int>>() {}
 private val activeQuestsType = object : TypeReference<Map<String, QuestState>>() {}

--- a/src/main/kotlin/dev/ambon/persistence/PostgresGuildRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PostgresGuildRepository.kt
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.core.type.TypeReference
 import dev.ambon.domain.guild.GuildHallRoom
 import dev.ambon.domain.guild.GuildRecord
 import io.github.oshai.kotlinlogging.KotlinLogging
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.ResultRow
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
-import org.jetbrains.exposed.sql.deleteWhere
-import org.jetbrains.exposed.sql.selectAll
-import org.jetbrains.exposed.sql.upsert
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.upsert
 
 private val log = KotlinLogging.logger {}
 private val membersType = object : TypeReference<Map<Long, String>>() {}

--- a/src/main/kotlin/dev/ambon/persistence/PostgresHouseRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PostgresHouseRepository.kt
@@ -3,12 +3,12 @@ package dev.ambon.persistence
 import com.fasterxml.jackson.core.type.TypeReference
 import dev.ambon.domain.housing.HouseRecord
 import io.github.oshai.kotlinlogging.KotlinLogging
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.ResultRow
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
-import org.jetbrains.exposed.sql.deleteWhere
-import org.jetbrains.exposed.sql.selectAll
-import org.jetbrains.exposed.sql.upsert
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.upsert
 
 private val log = KotlinLogging.logger {}
 private val roomsType = object : TypeReference<List<HouseRoomDto>>() {}

--- a/src/main/kotlin/dev/ambon/persistence/PostgresPlayerRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PostgresPlayerRepository.kt
@@ -1,11 +1,12 @@
 package dev.ambon.persistence
 
 import dev.ambon.metrics.GameMetrics
-import org.jetbrains.exposed.exceptions.ExposedSQLException
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.selectAll
-import org.jetbrains.exposed.sql.upsert
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.exceptions.ExposedSQLException
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.upsert
 
 class PostgresPlayerRepository(
     private val database: Database,

--- a/src/main/kotlin/dev/ambon/persistence/PostgresWorldStateRepository.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PostgresWorldStateRepository.kt
@@ -1,9 +1,10 @@
 package dev.ambon.persistence
 
 import com.fasterxml.jackson.core.type.TypeReference
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.selectAll
-import org.jetbrains.exposed.sql.upsert
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.upsert
 
 private val wsMapper = jsonMapper
 

--- a/src/main/kotlin/dev/ambon/persistence/WorldStateRepositoryFactory.kt
+++ b/src/main/kotlin/dev/ambon/persistence/WorldStateRepositoryFactory.kt
@@ -2,7 +2,7 @@ package dev.ambon.persistence
 
 import dev.ambon.config.PersistenceBackend
 import dev.ambon.config.PersistenceConfig
-import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.v1.jdbc.Database
 import java.nio.file.Paths
 
 object WorldStateRepositoryFactory {

--- a/src/main/kotlin/dev/ambon/persistence/WorldStateTable.kt
+++ b/src/main/kotlin/dev/ambon/persistence/WorldStateTable.kt
@@ -1,6 +1,6 @@
 package dev.ambon.persistence
 
-import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.v1.core.Table
 
 object WorldStateTable : Table("world_state") {
     val id = varchar("id", 64).default("singleton")

--- a/src/test/kotlin/dev/ambon/persistence/PersistenceFieldCoverageTest.kt
+++ b/src/test/kotlin/dev/ambon/persistence/PersistenceFieldCoverageTest.kt
@@ -21,10 +21,10 @@ import dev.ambon.domain.quest.QuestState
 import dev.ambon.engine.toPlayerRecord
 import dev.ambon.engine.toPlayerState
 import kotlinx.coroutines.test.runTest
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.SchemaUtils
-import org.jetbrains.exposed.sql.deleteAll
-import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.deleteAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll

--- a/src/test/kotlin/dev/ambon/persistence/PostgresGuildRepositoryTest.kt
+++ b/src/test/kotlin/dev/ambon/persistence/PostgresGuildRepositoryTest.kt
@@ -4,10 +4,10 @@ import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import dev.ambon.domain.guild.GuildRecord
 import kotlinx.coroutines.test.runTest
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.SchemaUtils
-import org.jetbrains.exposed.sql.deleteAll
-import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.deleteAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull

--- a/src/test/kotlin/dev/ambon/persistence/PostgresHouseRepositoryTest.kt
+++ b/src/test/kotlin/dev/ambon/persistence/PostgresHouseRepositoryTest.kt
@@ -6,10 +6,10 @@ import dev.ambon.domain.housing.HouseRecord
 import dev.ambon.domain.housing.HouseRoomRecord
 import dev.ambon.domain.world.Direction
 import kotlinx.coroutines.test.runTest
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.SchemaUtils
-import org.jetbrains.exposed.sql.deleteAll
-import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.deleteAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull

--- a/src/test/kotlin/dev/ambon/persistence/PostgresPlayerRepositoryTest.kt
+++ b/src/test/kotlin/dev/ambon/persistence/PostgresPlayerRepositoryTest.kt
@@ -4,10 +4,10 @@ import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import dev.ambon.domain.ids.RoomId
 import kotlinx.coroutines.test.runTest
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.SchemaUtils
-import org.jetbrains.exposed.sql.deleteAll
-import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.deleteAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull


### PR DESCRIPTION
## Summary
- Bumps JetBrains Exposed from 0.58.0 to 1.2.0 (crosses the 1.0 major release boundary)
- Updates all imports across 19 files to match the new `v1` package namespace
- Replaces deprecated `SqlExpressionBuilder.eq` with top-level `eq` function

## Details
Exposed 1.0 reorganized all packages under `org.jetbrains.exposed.v1`:
- Core types (`Table`, `ResultRow`, `Transaction`, `UpdateBuilder`) → `v1.core`
- JDBC types (`Database`, DML extensions, transactions) → `v1.jdbc`
- Exceptions → `v1.exceptions`

No behavioral changes — purely a dependency + import migration.

## Test plan
- [x] `./gradlew compileKotlin` — clean
- [x] `./gradlew compileTestKotlin` — clean
- [x] `./gradlew ktlintCheck` — passes
- [x] `./gradlew test` — all tests pass