### PR TITLE
Strip bloat from web admin panel

### DIFF
--- a/web-v3/src/components/panels/AdminPanel.logic.ts
+++ b/web-v3/src/components/panels/AdminPanel.logic.ts
@@ -29,9 +29,7 @@ export interface AdminActionDefinition {
 
 export interface AdminActionSection {
   id: AdminActionSectionId;
-  kicker: string;
   title: string;
-  description: string;
 }
 
 export const ADMIN_ACTIONS: AdminActionDefinition[] = [
@@ -51,30 +49,10 @@ export const ADMIN_ACTIONS: AdminActionDefinition[] = [
 ];
 
 export const ADMIN_ACTION_SECTIONS: AdminActionSection[] = [
-  {
-    id: "mobility",
-    kicker: "Travel and positioning",
-    title: "Movement Control",
-    description: "Jump to any live player or room, or relocate someone else with destination context.",
-  },
-  {
-    id: "intervention",
-    kicker: "Moderation and correction",
-    title: "Player Intervention",
-    description: "Resolve live problems with clear targets, consequence messaging, and immediate feedback.",
-  },
-  {
-    id: "world",
-    kicker: "Live-ops authority",
-    title: "World Operations",
-    description: "Spawn, reload, announce, or stop the world from one operational surface.",
-  },
-  {
-    id: "presence",
-    kicker: "Staff embodiment",
-    title: "Presence Tools",
-    description: "Move through the world as staff, slip out of sight, or inhabit a creature directly.",
-  },
+  { id: "mobility", title: "Movement" },
+  { id: "intervention", title: "Intervention" },
+  { id: "world", title: "World Ops" },
+  { id: "presence", title: "Presence" },
 ];
 
 export const ADMIN_RELOAD_SCOPES = ["all", "world", "abilities", "effects"] as const;
@@ -133,26 +111,3 @@ export function requiresAdminConfirmation(action: AdminAction): boolean {
   );
 }
 
-export function getAdminConfirmationCopy(
-  action: AdminAction,
-  targetSummary: string | null,
-): string {
-  switch (action) {
-    case "transfer":
-      return `Move ${targetSummary ?? "the selected player"} immediately. They will receive a forced relocation and a fresh room view.`;
-    case "smite":
-      return `Strike ${targetSummary ?? "the selected target"} immediately. Players are dropped to 1 HP at the start room; room mobs are killed outright.`;
-    case "kick":
-      return `Disconnect ${targetSummary ?? "the selected player"} immediately from the live server.`;
-    case "setlevel":
-      return `Rewrite progression for ${targetSummary ?? "the selected player"} immediately. This takes effect live.`;
-    case "reload":
-      return `Reload live data without restarting. Invalid scopes will be rejected by the engine, but successful reloads change the running world immediately.`;
-    case "broadcast":
-      return `Announce this message to every connected player across active engines right away.`;
-    case "shutdown":
-      return "Stop the live server for everyone. All connected players will receive the shutdown announcement and be disconnected.";
-    default:
-      return getAdminActionDefinition(action).description;
-  }
-}

--- a/web-v3/src/components/panels/AdminPanel.tsx
+++ b/web-v3/src/components/panels/AdminPanel.tsx
@@ -7,7 +7,6 @@ import {
   ADMIN_RELOAD_SCOPES,
   buildAdminCommand,
   getAdminActionDefinition,
-  getAdminConfirmationCopy,
   requiresAdminConfirmation,
 } from "./AdminPanel.logic";
 import type { AdminAction } from "./AdminPanel.logic";
@@ -421,18 +420,6 @@ export function AdminPanel({
 
   const activeDefinition = activeAction ? getAdminActionDefinition(activeAction) : null;
   const pendingCommand = activeAction ? buildAdminCommand(activeAction, inputA, inputB) : null;
-  const pendingTarget =
-    activeAction === "transfer" && inputA.trim() && inputB.trim()
-      ? `${inputA.trim()} to ${inputB.trim()}`
-      : activeAction === "setlevel" && inputA.trim() && inputB.trim()
-        ? `${inputA.trim()} to level ${inputB.trim()}`
-        : activeAction === "reload"
-          ? inputA.trim() || "all live data"
-          : activeAction === "broadcast"
-            ? "all connected players"
-            : activeAction === "shutdown"
-              ? "the live server"
-              : inputA.trim() || null;
   const pendingConfirmKey =
     activeAction && pendingCommand ? `${activeAction}:${pendingCommand}` : null;
   const confirmArmed = pendingConfirmKey !== null && confirmKey === pendingConfirmKey;
@@ -483,18 +470,6 @@ export function AdminPanel({
         </header>
 
         <div className="popout-content admin-content">
-          <div className="admin-intro">
-            <p className="admin-kicker">Live operations</p>
-            <h3 className="admin-intro-title">
-              Moderate players, steer the world, and operate in-room without dropping to typed
-              commands.
-            </h3>
-            <p className="admin-intro-copy">
-              The console uses live GMCP player, room, and template data wherever the client has
-              it. High-impact actions require an explicit second confirmation before they fire.
-            </p>
-          </div>
-
           <div className="admin-status-strip">
             <div className="admin-status-card">
               <span className="admin-status-label">Visibility</span>
@@ -521,11 +496,7 @@ export function AdminPanel({
               const sectionActions = ADMIN_ACTIONS.filter((entry) => entry.section === section.id);
               return (
                 <section key={section.id} className="admin-action-section">
-                  <div className="admin-section-head">
-                    <p className="admin-section-kicker">{section.kicker}</p>
-                    <h3 className="admin-section-title">{section.title}</h3>
-                    <p className="admin-section-copy">{section.description}</p>
-                  </div>
+                  <h3 className="admin-section-title">{section.title}</h3>
                   <div className="admin-action-grid">
                     {sectionActions.map((action) => (
                       <button
@@ -535,13 +506,6 @@ export function AdminPanel({
                         onClick={() => selectAction(action.id)}
                         aria-pressed={activeAction === action.id}
                       >
-                        <span className="admin-action-chip">
-                          {action.tone === "danger"
-                            ? "High impact"
-                            : action.tone === "utility"
-                              ? "Presence"
-                              : "Action"}
-                        </span>
                         <span className="admin-action-label">{action.label}</span>
                         <span className="admin-action-desc">{action.description}</span>
                       </button>
@@ -554,32 +518,7 @@ export function AdminPanel({
 
           {activeAction && activeDefinition && (
             <form className="admin-form" onSubmit={submit}>
-              <div className="admin-form-head">
-                <div>
-                  <p className="admin-form-kicker">
-                    {ADMIN_ACTION_SECTIONS.find((entry) => entry.id === activeDefinition.section)?.title}
-                  </p>
-                  <h3 className="admin-form-title">{activeDefinition.label}</h3>
-                </div>
-                <span
-                  className={`admin-form-chip ${requiresAdminConfirmation(activeAction) ? "admin-form-chip-danger" : ""}`}
-                >
-                  {requiresAdminConfirmation(activeAction) ? "Confirm before send" : "Live action"}
-                </span>
-              </div>
-
-              <p className="admin-form-copy">{activeDefinition.description}</p>
-
-              <div
-                className={`admin-warning-card ${requiresAdminConfirmation(activeAction) ? "admin-warning-card-danger" : ""} ${confirmArmed ? "admin-warning-card-armed" : ""}`}
-              >
-                <span className="admin-warning-title">
-                  {confirmArmed ? "Confirmation armed" : "Operational note"}
-                </span>
-                <span className="admin-warning-body">
-                  {getAdminConfirmationCopy(activeAction, pendingTarget)}
-                </span>
-              </div>
+              <h3 className="admin-form-title">{activeDefinition.label}</h3>
 
               {activeAction === "goto" && (
                 <>

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -9682,44 +9682,12 @@ body {
   gap: var(--space-4);
 }
 
-.admin-intro {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-  padding: 16px 18px;
-  border-radius: 18px;
-  border: 1px solid rgb(120 134 188 / 16%);
-  background:
-    radial-gradient(circle at top right, rgb(190 168 115 / 14%), transparent 42%),
-    linear-gradient(180deg, rgb(31 38 59 / 94%), rgb(18 23 36 / 96%));
-}
-
-.admin-kicker,
-.admin-section-kicker,
-.admin-form-kicker {
-  margin: 0;
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--text-secondary);
-}
-
-.admin-intro-title,
 .admin-section-title,
 .admin-form-title {
   margin: 0;
   font-family: var(--font-display);
-  font-size: 1.35rem;
-  line-height: 1.05;
+  font-size: 1rem;
   color: var(--text-primary);
-}
-
-.admin-intro-copy,
-.admin-section-copy,
-.admin-form-copy {
-  margin: 0;
-  color: var(--text-secondary);
-  line-height: 1.5;
 }
 
 .admin-status-strip {
@@ -9821,19 +9789,11 @@ body {
 .admin-action-section {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 14px;
-  border-radius: 18px;
+  gap: 8px;
+  padding: 10px;
+  border-radius: var(--radius-md);
   border: 1px solid rgb(120 134 188 / 16%);
-  background:
-    linear-gradient(180deg, rgb(27 34 54 / 92%), rgb(17 21 34 / 95%));
-  box-shadow: 0 14px 36px rgb(0 0 0 / 18%);
-}
-
-.admin-section-head {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+  background: linear-gradient(180deg, rgb(27 34 54 / 92%), rgb(17 21 34 / 95%));
 }
 
 .admin-action-grid {
@@ -9846,8 +9806,8 @@ body {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 6px;
-  padding: 12px;
+  gap: 2px;
+  padding: 8px 10px;
   border: 1px solid rgb(106 96 136 / 24%);
   border-radius: var(--radius-md);
   background: linear-gradient(140deg, rgb(64 78 111 / 84%), rgb(46 58 87 / 80%));
@@ -9879,17 +9839,6 @@ body {
   border-color: rgb(141 169 123 / 24%);
 }
 
-.admin-action-chip {
-  padding: 2px 7px;
-  border-radius: 999px;
-  background: rgb(255 255 255 / 8%);
-  color: var(--text-secondary);
-  font-size: 0.66rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-
 .admin-action-label {
   font-size: 0.82rem;
   font-weight: 700;
@@ -9911,65 +9860,6 @@ body {
   border-radius: 18px;
   border: 1px solid rgb(125 141 196 / 14%);
   background: rgb(16 20 32 / 54%);
-}
-
-.admin-form-head {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--space-3);
-}
-
-.admin-form-chip {
-  flex-shrink: 0;
-  padding: 5px 10px;
-  border-radius: 999px;
-  border: 1px solid rgb(140 174 201 / 26%);
-  background: rgb(140 174 201 / 12%);
-  color: var(--color-primary-pale-blue);
-  font-size: 0.68rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.admin-form-chip-danger {
-  border-color: rgb(184 143 170 / 28%);
-  background: rgb(184 143 170 / 12%);
-  color: var(--color-primary-dusty-rose);
-}
-
-.admin-warning-card {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 11px 12px;
-  border-radius: 12px;
-  border: 1px solid rgb(140 174 201 / 18%);
-  background: linear-gradient(180deg, rgb(24 31 49 / 88%), rgb(18 22 34 / 92%));
-}
-
-.admin-warning-card-danger {
-  border-color: rgb(184 143 170 / 24%);
-  background: linear-gradient(180deg, rgb(58 38 48 / 72%), rgb(28 20 28 / 84%));
-}
-
-.admin-warning-card-armed {
-  border-color: rgb(200 100 100 / 44%);
-  box-shadow: 0 0 0 1px rgb(200 100 100 / 18%);
-}
-
-.admin-warning-title {
-  font-size: 0.68rem;
-  font-weight: 800;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text-primary);
-}
-
-.admin-warning-body {
-  color: var(--text-secondary);
-  line-height: 1.45;
 }
 
 .admin-field {
@@ -10152,10 +10042,6 @@ body {
 
   .admin-action-grid {
     grid-template-columns: 1fr;
-  }
-
-  .admin-form-head {
-    flex-direction: column;
   }
 
   .admin-submit-row {

--- a/web-v3/test/AdminPanel.logic.test.js
+++ b/web-v3/test/AdminPanel.logic.test.js
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
   buildAdminCommand,
-  getAdminConfirmationCopy,
   requiresAdminConfirmation,
 } from "../src/components/panels/AdminPanel.logic";
 
@@ -37,9 +36,4 @@ describe("AdminPanel logic", () => {
     expect(requiresAdminConfirmation("shutdown")).toBe(true);
   });
 
-  test("explains high-impact admin actions with concrete copy", () => {
-    expect(getAdminConfirmationCopy("kick", "Bob")).toContain("Disconnect Bob immediately");
-    expect(getAdminConfirmationCopy("setlevel", "Bob to level 10")).toContain("Rewrite progression");
-    expect(getAdminConfirmationCopy("shutdown", null)).toContain("Stop the live server");
-  });
 });


### PR DESCRIPTION
## Summary
- Remove intro paragraph, section kickers, section descriptions, action tone chips ("High impact" / "Presence" / "Action")
- Remove form-level chrome: kicker, chip badge, description paragraph, and warning card with "Operational note"
- Remove `getAdminConfirmationCopy()` and its test (no longer rendered)
- Tighten tile padding, section padding, and drop the section box-shadow
- Net: **-239 lines** across 4 files

The panel is a staff tool — it should be compact and utilitarian, not a marketing page.

## Test plan
- [x] `bun run lint` — clean
- [x] `bun test` — 3/3 pass
- [x] `./gradlew buildWeb` — succeeds