### PR TITLE
Strip marketing copy from web panels

### DIFF
--- a/web-v3/src/components/ActionBar.tsx
+++ b/web-v3/src/components/ActionBar.tsx
@@ -20,7 +20,6 @@ import {
   SendIcon,
 } from "./Icons";
 
-/** Derive a visual category from targetType + effectType for border glow. */
 function skillCategory(skill: SkillSummary): string {
   const t = skill.targetType.toUpperCase();
   const e = skill.effectType.toUpperCase();

--- a/web-v3/src/components/CommandPalette.tsx
+++ b/web-v3/src/components/CommandPalette.tsx
@@ -30,11 +30,6 @@ function categoryLabel(cat: string): string {
   return cat.charAt(0).toUpperCase() + cat.slice(1);
 }
 
-/**
- * Extract a runnable command prefix from a usage string.
- * For "tell/t <player> <msg>" this yields "tell".
- * For "guild create <name> <tag>" this yields "guild create".
- */
 function extractCommandPrefix(usage: string): string {
   // Take the portion before the first '<' or '[' (angle-bracket arguments)
   const beforeArg = usage.split(/[<[]/)[0].trim();

--- a/web-v3/src/components/HelpContent.tsx
+++ b/web-v3/src/components/HelpContent.tsx
@@ -11,7 +11,6 @@ interface HelpCategory {
   commands: HelpCommand[];
 }
 
-/** Display-name mapping for server category keys. */
 const CATEGORY_LABELS: Record<string, string> = {
   navigation: "Navigation",
   communication: "Communication",
@@ -29,7 +28,6 @@ const CATEGORY_LABELS: Record<string, string> = {
   admin: "Staff",
 };
 
-/** Controls the display order of categories. Unlisted categories appear at the end. */
 const CATEGORY_ORDER: string[] = [
   "navigation",
   "communication",
@@ -47,7 +45,6 @@ const CATEGORY_ORDER: string[] = [
   "admin",
 ];
 
-/** Build HelpCategory[] from Server.Commands GMCP data. */
 function buildFromServerCommands(commands: CommandEntry[], isStaff: boolean): HelpCategory[] {
   const grouped = new Map<string, HelpCommand[]>();
   for (const cmd of commands) {

--- a/web-v3/src/components/TradePanel.tsx
+++ b/web-v3/src/components/TradePanel.tsx
@@ -59,12 +59,7 @@ export function TradePanel({ trade, inventory, playerGold, onCommand }: TradePan
   return (
     <div className="trade-panel" role="dialog" aria-label="Trade">
       <div className="trade-header">
-        <div>
-          <h3 className="trade-title">Trading with {trade.partner}</h3>
-          <p className="trade-subtitle">
-            Review both offers, adjust items or gold, then accept when everything looks right.
-          </p>
-        </div>
+        <h3 className="trade-title">Trading with {trade.partner}</h3>
         <button
           type="button"
           className="trade-cancel-btn"

--- a/web-v3/src/components/VitalsBar.tsx
+++ b/web-v3/src/components/VitalsBar.tsx
@@ -73,10 +73,8 @@ interface VitalsBarProps {
   onCommand: (cmd: string) => void;
   onReconnect?: () => void;
   audio: AudioEngine;
-  /** Controlled command input value (lifted to App so the palette + canvas can prefill it). */
   inputValue: string;
   onInputChange: (value: string) => void;
-  /** Whether the inline command input is expanded. */
   showInput: boolean;
   onShowInputChange: (open: boolean) => void;
   onInputKeyDown?: (event: KeyboardEvent<HTMLInputElement>) => void;

--- a/web-v3/src/components/WorldFeaturesPopout.tsx
+++ b/web-v3/src/components/WorldFeaturesPopout.tsx
@@ -139,12 +139,7 @@ export function WorldFeaturesPopout({
     <div className="feature-popout">
       <header className="feature-popout-hero">
         <div className="feature-popout-hero-copy">
-          <p className="feature-popout-eyebrow">Room Features</p>
           <h3>{roomTitle}</h3>
-          <p>
-            Doors, containers, and levers now have their own quick-action hub so room interactions stay visible,
-            legible, and one tap away.
-          </p>
         </div>
         <div className="feature-popout-summary" aria-label="Feature summary">
           <span className="feature-popout-summary-pill feature-popout-summary-door">
@@ -212,28 +207,6 @@ export function WorldFeaturesPopout({
                 )}
                 <span className="feature-card-detail-chip">Keyword: {feature.keyword}</span>
               </div>
-
-              {feature.type === "container" && (
-                <div className="feature-card-copy">
-                  {feature.state === "open"
-                    ? "Search to inspect the contents, then pull treasure out directly from here."
-                    : "Open this container to search it. Inventory actions can place items back inside once it is open."}
-                </div>
-              )}
-
-              {feature.type === "door" && (
-                <div className="feature-card-copy">
-                  {feature.direction
-                    ? `This door guards the ${feature.direction} exit.`
-                    : "This doorway is available from the room's exit list once it is open."}
-                </div>
-              )}
-
-              {feature.type === "lever" && (
-                <div className="feature-card-copy">
-                  Pulling a lever updates the world immediately and can also advance room puzzles.
-                </div>
-              )}
 
               {feature.type === "sign" && feature.text && (
                 <p className="feature-card-sign-text">{feature.text}</p>

--- a/web-v3/src/components/panels/AuctionPanel.tsx
+++ b/web-v3/src/components/panels/AuctionPanel.tsx
@@ -189,14 +189,7 @@ export function AuctionPanel({ listings, inventory, playerName, feedbackFeed, on
       {view === "sell" && (
         <div className="auction-create">
           <section className="auction-create-card">
-            <div className="auction-create-header">
-              <div>
-                <h3 className="auction-create-title">Create a Listing</h3>
-                <p className="auction-create-copy">
-                  Choose an item from your inventory and set a gold price to post it to the market.
-                </p>
-              </div>
-            </div>
+            <h3 className="auction-create-title">Create a Listing</h3>
 
             {sortedInventory.length === 0 ? (
               <div className="auction-empty">

--- a/web-v3/src/components/panels/SystemsPanel.tsx
+++ b/web-v3/src/components/panels/SystemsPanel.tsx
@@ -182,15 +182,7 @@ export function SystemsPanel({
       <div className="systems-body">
         {activeView === "dungeon" && (
           <section className="systems-section">
-            <div className="systems-hero">
-              <div>
-                <p className="systems-kicker">Instanced adventure</p>
-                <h3 className="systems-title">Dungeon Runs</h3>
-                <p className="systems-copy">
-                  Browse the current dungeon roster, choose a difficulty, then enter or resume your run without typed commands.
-                </p>
-              </div>
-            </div>
+            <h3 className="systems-title">Dungeon Runs</h3>
 
             {dungeonInfo?.active ? (
               <article className="systems-card systems-dungeon-active">
@@ -290,15 +282,7 @@ export function SystemsPanel({
 
         {activeView === "duel" && (
           <section className="systems-section">
-            <div className="systems-hero">
-              <div>
-                <p className="systems-kicker">Player versus player</p>
-                <h3 className="systems-title">Dueling</h3>
-                <p className="systems-copy">
-                  Challenge nearby players, respond to invitations, and track your current duel state from one place.
-                </p>
-              </div>
-            </div>
+            <h3 className="systems-title">Dueling</h3>
 
             {duelState?.active ? (
               <article className="systems-card">
@@ -309,9 +293,6 @@ export function SystemsPanel({
                   </div>
                   <span className="systems-pill systems-pill-danger">Live</span>
                 </div>
-                <p className="systems-card-copy">
-                  Your duel is active. Fight through the main play surface or flee if you need to disengage.
-                </p>
                 <div className="systems-action-row">
                   <button
                     type="button"
@@ -334,11 +315,6 @@ export function SystemsPanel({
                   </div>
                   <span className="systems-pill">{duelChallenge.direction === "incoming" ? "Incoming" : "Outgoing"}</span>
                 </div>
-                <p className="systems-card-copy">
-                  {duelChallenge.direction === "incoming"
-                    ? "Accept to start the duel now, or decline if you are not ready."
-                    : "Your challenge is pending. Stay nearby while the other player decides."}
-                </p>
                 {duelChallenge.direction === "incoming" && (
                   <div className="systems-action-row">
                     <button
@@ -399,15 +375,7 @@ export function SystemsPanel({
 
         {activeView === "lottery" && (
           <section className="systems-section">
-            <div className="systems-hero">
-              <div>
-                <p className="systems-kicker">Gold sink and jackpot</p>
-                <h3 className="systems-title">Lottery</h3>
-                <p className="systems-copy">
-                  Buy tickets in practical quantities, track the current pool, and watch the next drawing countdown in real time.
-                </p>
-              </div>
-            </div>
+            <h3 className="systems-title">Lottery</h3>
 
             {lotteryInfo ? (
               <article className="systems-card">
@@ -486,15 +454,7 @@ export function SystemsPanel({
 
         {activeView === "pet" && (
           <section className="systems-section">
-            <div className="systems-hero">
-              <div>
-                <p className="systems-kicker">Companion management</p>
-                <h3 className="systems-title">Pet Control</h3>
-                <p className="systems-copy">
-                  Rename or dismiss your active companion here, and keep an eye on its core combat stats while you travel.
-                </p>
-              </div>
-            </div>
+            <h3 className="systems-title">Pet</h3>
 
             {petState?.active ? (
               <article className="systems-card">
@@ -553,9 +513,7 @@ export function SystemsPanel({
                     <h4>Your companion slot is empty</h4>
                   </div>
                 </div>
-                <p className="systems-card-copy">
-                  Summon a familiar or companion through one of your pet abilities. Once active, it will appear here for direct management.
-                </p>
+                <p className="systems-card-copy">Use a pet ability to summon a companion.</p>
               </article>
             )}
           </section>
@@ -563,15 +521,7 @@ export function SystemsPanel({
 
         {activeView === "prestige" && (
           <section className="systems-section">
-            <div className="systems-hero">
-              <div>
-                <p className="systems-kicker">Endgame progression</p>
-                <h3 className="systems-title">Prestige</h3>
-                <p className="systems-copy">
-                  Review rank requirements, available prestige XP, and every unlocked or upcoming perk before committing to another reset.
-                </p>
-              </div>
-            </div>
+            <h3 className="systems-title">Prestige</h3>
 
             {prestigeInfo ? (
               prestigeInfo.enabled ? (
@@ -630,9 +580,7 @@ export function SystemsPanel({
                       <h4>Prestige is disabled</h4>
                     </div>
                   </div>
-                  <p className="systems-card-copy">
-                    This server has prestige progression turned off right now. If it is re-enabled later, this view will update automatically.
-                  </p>
+                  <p className="systems-card-copy">Prestige is currently disabled on this server.</p>
                 </article>
               )
             ) : (
@@ -643,15 +591,7 @@ export function SystemsPanel({
 
         {activeView === "currencies" && (
           <section className="systems-section">
-            <div className="systems-hero">
-              <div>
-                <p className="systems-kicker">Secondary economy</p>
-                <h3 className="systems-title">Wallet</h3>
-                <p className="systems-copy">
-                  Track every alternate currency the server exposes, along with what it represents and where those balances usually move.
-                </p>
-              </div>
-            </div>
+            <h3 className="systems-title">Wallet</h3>
 
             {sortedCurrencies.length === 0 ? (
               <article className="systems-card">
@@ -671,11 +611,13 @@ export function SystemsPanel({
                         <span className="systems-pill">{currency.balance.toLocaleString()}</span>
                       </div>
                       <p className="systems-card-copy">{meta?.description ?? "Server-managed alternate currency."}</p>
-                      <ul className="systems-bullet-list">
-                        {(meta?.gainHints ?? ["Watch related gameplay rewards and spenders for balance changes."]).map((hint) => (
-                          <li key={hint}>{hint}</li>
-                        ))}
-                      </ul>
+                      {meta?.gainHints && (
+                        <ul className="systems-bullet-list">
+                          {meta.gainHints.map((hint) => (
+                            <li key={hint}>{hint}</li>
+                          ))}
+                        </ul>
+                      )}
                     </article>
                   );
                 })}
@@ -690,9 +632,7 @@ export function SystemsPanel({
                 </div>
               </div>
               {recentCurrencyActivity.length === 0 ? (
-                <p className="systems-card-copy">
-                  Currency rewards and spending will appear here as your balances move.
-                </p>
+                <p className="systems-card-copy">No recent activity.</p>
               ) : (
                 <div className="systems-feed">
                   {recentCurrencyActivity.map((entry) => (
@@ -720,15 +660,7 @@ export function SystemsPanel({
 
         {activeView === "factions" && (
           <section className="systems-section">
-            <div className="systems-hero">
-              <div>
-                <p className="systems-kicker">Reputation and allegiance</p>
-                <h3 className="systems-title">Faction Standing</h3>
-                <p className="systems-copy">
-                  Understand what each faction stands for, how your tier maps to gameplay consequences, and where reputation changes come from.
-                </p>
-              </div>
-            </div>
+            <h3 className="systems-title">Factions</h3>
 
             {sortedFactions.length === 0 ? (
               <article className="systems-card">
@@ -755,14 +687,13 @@ export function SystemsPanel({
                       </div>
                       <p className="systems-card-copy">{meta?.description ?? "This faction influences quests and combat reputation changes."}</p>
                       <p className="systems-detail-line">{factionTierSummary(faction.tier)}</p>
-                      <ul className="systems-bullet-list">
-                        {(meta?.gainHints ?? [
-                          "Combat and quest completion can change faction standing.",
-                          "Watch combat rewards and quest panels for faction-linked outcomes.",
-                        ]).map((hint) => (
-                          <li key={hint}>{hint}</li>
-                        ))}
-                      </ul>
+                      {meta?.gainHints && (
+                        <ul className="systems-bullet-list">
+                          {meta.gainHints.map((hint) => (
+                            <li key={hint}>{hint}</li>
+                          ))}
+                        </ul>
+                      )}
                     </article>
                   );
                 })}
@@ -777,9 +708,7 @@ export function SystemsPanel({
                 </div>
               </div>
               {recentFactionActivity.length === 0 ? (
-                <p className="systems-card-copy">
-                  Quest and combat reputation shifts will appear here after your standings change.
-                </p>
+                <p className="systems-card-copy">No recent activity.</p>
               ) : (
                 <div className="systems-feed">
                   {recentFactionActivity.map((entry) => (

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -3014,14 +3014,6 @@ body {
   line-height: 1.55;
 }
 
-.feature-popout-eyebrow {
-  margin: 0;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.11em;
-  color: var(--text-tertiary);
-  font-weight: 700;
-}
 
 .feature-popout-summary {
   display: flex;
@@ -3241,7 +3233,6 @@ body {
   gap: 8px;
 }
 
-.feature-card-copy,
 .feature-card-sign-text,
 .feature-card-empty {
   margin: 0;
@@ -10689,32 +10680,9 @@ body {
   gap: 1rem;
 }
 
-.systems-hero {
-  padding: 1.15rem 1.2rem;
-  border-radius: 24px;
-  background:
-    radial-gradient(circle at top right, rgb(146 162 235 / 16%), transparent 42%),
-    linear-gradient(160deg, rgb(19 23 39 / 96%), rgb(12 15 27 / 94%));
-  border: 1px solid rgb(112 127 196 / 22%);
-}
-
-.systems-kicker {
-  margin: 0 0 0.35rem;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font-size: 0.7rem;
-  color: var(--text-muted);
-}
-
 .systems-title {
   margin: 0;
-  font-size: 1.32rem;
-}
-
-.systems-copy {
-  margin: 0.45rem 0 0;
-  color: var(--text-secondary);
-  line-height: 1.55;
+  font-size: 1.1rem;
 }
 
 .systems-card-list {
@@ -12179,12 +12147,6 @@ body {
   color: var(--text-heading);
 }
 
-.trade-subtitle {
-  margin: 6px 0 0;
-  color: var(--text-secondary);
-  font-size: 0.84rem;
-  line-height: 1.45;
-}
 
 .trade-cancel-btn {
   padding: 7px 14px;
@@ -12875,12 +12837,6 @@ body {
   font-size: 1rem;
 }
 
-.auction-create-copy {
-  margin: 6px 0 0;
-  color: var(--text-secondary);
-  font-size: 0.84rem;
-  line-height: 1.5;
-}
 
 .auction-create-field {
   display: flex;


### PR DESCRIPTION
## Summary
Follow-up to #984. Audit of remaining web client panels for AI-generated marketing copy, kickers, hero blocks, and unnecessary JSDoc.

- **SystemsPanel** — remove 7 kicker+hero blocks ("Instanced adventure", "Gold sink and jackpot", etc.) and trim verbose empty-state strings
- **AuctionPanel** — remove create-listing description paragraph
- **TradePanel** — remove "Review both offers..." subtitle
- **WorldFeaturesPopout** — remove hero paragraph, eyebrow, and per-feature-type prose (container, door, lever)
- **VitalsBar, HelpContent, ActionBar, CommandPalette** — remove obvious JSDoc comments
- **styles.css** — drop dead CSS for all removed elements

Net: **-193 lines** across 9 files.

## Test plan
- [x] `bun run lint` — clean
- [x] `bun test` — 3/3 pass
- [x] `./gradlew buildWeb` — succeeds