### PR TITLE
Extract shared abstractions to eliminate cross-cutting duplication

### DIFF
--- a/src/main/kotlin/dev/ambon/HmacUtil.kt
+++ b/src/main/kotlin/dev/ambon/HmacUtil.kt
@@ -1,0 +1,23 @@
+package dev.ambon
+
+import java.nio.charset.StandardCharsets
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/** Computes HMAC-SHA256 of [payload] under [secret], returning a lowercase hex string. */
+internal fun hmacSha256(
+    secret: String,
+    payload: String,
+): String {
+    val mac = Mac.getInstance("HmacSHA256")
+    mac.init(SecretKeySpec(secret.toByteArray(StandardCharsets.UTF_8), "HmacSHA256"))
+    return mac.doFinal(payload.toByteArray(StandardCharsets.UTF_8))
+        .joinToString("") { "%02x".format(it) }
+}
+
+/** Returns true when [signature] is non-blank and matches [hmacSha256] of [payload] under [secret]. */
+internal fun isValidHmac(
+    secret: String,
+    payload: String,
+    signature: String,
+): Boolean = signature.isNotBlank() && signature == hmacSha256(secret, payload)

--- a/src/main/kotlin/dev/ambon/bus/RedisBusInterfaces.kt
+++ b/src/main/kotlin/dev/ambon/bus/RedisBusInterfaces.kt
@@ -2,9 +2,6 @@ package dev.ambon.bus
 
 import dev.ambon.redis.RedisConnectionManager
 import io.lettuce.core.pubsub.RedisPubSubAdapter
-import java.nio.charset.StandardCharsets
-import javax.crypto.Mac
-import javax.crypto.spec.SecretKeySpec
 
 fun interface BusPublisher {
     fun publish(
@@ -19,24 +16,6 @@ fun interface BusSubscriberSetup {
         onMessage: (String) -> Unit,
     )
 }
-
-internal fun hmacSha256(
-    secret: String,
-    payload: String,
-): String {
-    val mac = Mac.getInstance("HmacSHA256")
-    mac.init(SecretKeySpec(secret.toByteArray(StandardCharsets.UTF_8), "HmacSHA256"))
-    return mac.doFinal(payload.toByteArray(StandardCharsets.UTF_8)).toHex()
-}
-
-internal fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }
-
-/** Returns true when [signature] is non-blank and matches [hmacSha256] of [payload] under [secret]. */
-internal fun isValidHmac(
-    secret: String,
-    payload: String,
-    signature: String,
-): Boolean = signature.isNotBlank() && signature == hmacSha256(secret, payload)
 
 /** Creates a [BusPublisher] that publishes to Redis via the given [manager]. */
 fun redisBusPublisher(manager: RedisConnectionManager): BusPublisher =

--- a/src/main/kotlin/dev/ambon/bus/RedisEventBus.kt
+++ b/src/main/kotlin/dev/ambon/bus/RedisEventBus.kt
@@ -1,6 +1,8 @@
 package dev.ambon.bus
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import dev.ambon.hmacSha256
+import dev.ambon.isValidHmac
 import io.github.oshai.kotlinlogging.KotlinLogging
 
 private val log = KotlinLogging.logger {}

--- a/src/main/kotlin/dev/ambon/engine/EngineUtil.kt
+++ b/src/main/kotlin/dev/ambon/engine/EngineUtil.kt
@@ -66,6 +66,38 @@ internal suspend fun broadcastToRoom(
 }
 
 /**
+ * Sends [text] as a [OutboundEvent.SendText] to every online player.
+ * Optionally excludes [exclude].
+ */
+internal suspend fun broadcastToAll(
+    players: PlayerRegistry,
+    outbound: OutboundBus,
+    text: String,
+    exclude: SessionId? = null,
+) {
+    for (p in players.allPlayers()) {
+        if (exclude != null && p.sessionId == exclude) continue
+        outbound.send(OutboundEvent.SendText(p.sessionId, text))
+    }
+}
+
+/**
+ * Sends [text] as a [OutboundEvent.SendInfo] to every online player.
+ * Optionally excludes [exclude].
+ */
+internal suspend fun broadcastInfoToAll(
+    players: PlayerRegistry,
+    outbound: OutboundBus,
+    text: String,
+    exclude: SessionId? = null,
+) {
+    for (p in players.allPlayers()) {
+        if (exclude != null && p.sessionId == exclude) continue
+        outbound.send(OutboundEvent.SendInfo(p.sessionId, text))
+    }
+}
+
+/**
  * Returns a random integer in [[min], [max]] (inclusive).
  * Returns [min] when max <= min.
  */

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -1645,12 +1645,7 @@ class GameEngine(
 
                     // Phase 3: Flush GMCP vitals for sessions that had changes this tick.
                     val gmcpFlushPhaseSample = Timer.start()
-                    flushDirtyGmcpVitals()
-                    flushDirtyGmcpMobs()
-                    flushDirtyGmcpStatusEffects()
-                    flushDirtyGmcpGroup()
-                    flushDirtyGmcpCombat()
-                    flushDirtyGmcpStats()
+                    gmcpFlushHandler.flushAll()
                     metrics.recordTickPhase("gmcp_flush", gmcpFlushPhaseSample)
 
                     // Phase 4: Outbound flush — run scheduled actions and reset expired zones.
@@ -1773,30 +1768,6 @@ class GameEngine(
 
     private suspend fun handleGmcpReceived(ev: InboundEvent.GmcpReceived) {
         gmcpEventHandler.onGmcpReceived(ev)
-    }
-
-    private suspend fun flushDirtyGmcpVitals() {
-        gmcpFlushHandler.flushDirtyVitals()
-    }
-
-    private suspend fun flushDirtyGmcpStatusEffects() {
-        gmcpFlushHandler.flushDirtyStatusEffects()
-    }
-
-    private suspend fun flushDirtyGmcpMobs() {
-        gmcpFlushHandler.flushDirtyMobs()
-    }
-
-    private suspend fun flushDirtyGmcpGroup() {
-        gmcpFlushHandler.flushDirtyGroup()
-    }
-
-    private suspend fun flushDirtyGmcpCombat() {
-        gmcpFlushHandler.flushDirtyCombat()
-    }
-
-    private suspend fun flushDirtyGmcpStats() {
-        gmcpFlushHandler.flushDirtyStats()
     }
 
     suspend fun broadcastServerWho() {

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/AuctionHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/AuctionHandler.kt
@@ -31,7 +31,16 @@ class AuctionHandler(
     }
 
     private suspend fun handleList(sessionId: SessionId, cmd: Command.AuctionList) {
-        val auction = auctionSystem ?: return sendUnavailable(sessionId)
+        val auction =
+            auctionSystem
+                ?: return sendErrorWithFeedback(
+                    sessionId,
+                    outbound,
+                    gmcpEmitter,
+                    "The auction house is not available.",
+                    "auction",
+                    code = "UNAVAILABLE",
+                )
 
         val allListings = auction.allListings()
         val filtered = if (cmd.filter != null) {
@@ -77,12 +86,20 @@ class AuctionHandler(
     }
 
     private suspend fun handleSell(sessionId: SessionId, cmd: Command.AuctionSell) {
-        val auction = auctionSystem ?: return sendUnavailable(sessionId)
+        val auction =
+            auctionSystem
+                ?: return sendErrorWithFeedback(
+                    sessionId,
+                    outbound,
+                    gmcpEmitter,
+                    "The auction house is not available.",
+                    "auction",
+                    code = "UNAVAILABLE",
+                )
 
         if (cmd.price <= 0) {
             val message = "Price must be greater than 0."
-            outbound.send(OutboundEvent.SendError(sessionId, message))
-            sendAuctionFeedback(sessionId, "error", message, code = "INVALID_PRICE", command = "sell")
+            sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, message, "auction", code = "INVALID_PRICE", command = "sell")
             return
         }
 
@@ -90,8 +107,7 @@ class AuctionHandler(
             val listing = auction.postListing(sessionId, me.name, cmd.itemKeyword, cmd.price)
             if (listing == null) {
                 val message = "You aren't carrying '${cmd.itemKeyword}'."
-                outbound.send(OutboundEvent.SendError(sessionId, message))
-                sendAuctionFeedback(sessionId, "error", message, code = "ITEM_NOT_CARRIED", command = "sell")
+                sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, message, "auction", code = "ITEM_NOT_CARRIED", command = "sell")
                 return
             }
 
@@ -102,7 +118,7 @@ class AuctionHandler(
                     message,
                 ),
             )
-            sendAuctionFeedback(sessionId, "success", message, code = "LISTING_CREATED", command = "sell")
+            sendScopedFeedback(sessionId, gmcpEmitter, "success", message, "auction", code = "LISTING_CREATED", command = "sell")
             syncItemsGmcp(sessionId, items, gmcpEmitter)
 
             // Broadcast to all online players
@@ -122,21 +138,28 @@ class AuctionHandler(
     }
 
     private suspend fun handleBuy(sessionId: SessionId, cmd: Command.AuctionBuy) {
-        val auction = auctionSystem ?: return sendUnavailable(sessionId)
+        val auction =
+            auctionSystem
+                ?: return sendErrorWithFeedback(
+                    sessionId,
+                    outbound,
+                    gmcpEmitter,
+                    "The auction house is not available.",
+                    "auction",
+                    code = "UNAVAILABLE",
+                )
 
         players.withPlayer(sessionId) { me ->
             val listing = auction.getListing(cmd.listingId)
             if (listing == null) {
                 val message = "Listing #${cmd.listingId} not found."
-                outbound.send(OutboundEvent.SendError(sessionId, message))
-                sendAuctionFeedback(sessionId, "error", message, code = "LISTING_NOT_FOUND", command = "buy")
+                sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, message, "auction", code = "LISTING_NOT_FOUND", command = "buy")
                 return
             }
 
             if (listing.sellerName.equals(me.name, ignoreCase = true)) {
                 val message = "You cannot buy your own listing. Use 'auction cancel ${cmd.listingId}'."
-                outbound.send(OutboundEvent.SendError(sessionId, message))
-                sendAuctionFeedback(sessionId, "error", message, code = "OWN_LISTING", command = "buy")
+                sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, message, "auction", code = "OWN_LISTING", command = "buy")
                 return
             }
 
@@ -151,14 +174,20 @@ class AuctionHandler(
             when (result) {
                 is AuctionPurchaseResult.ListingNotFound -> {
                     val message = "That listing is no longer available."
-                    outbound.send(OutboundEvent.SendError(sessionId, message))
-                    sendAuctionFeedback(sessionId, "error", message, code = "LISTING_UNAVAILABLE", command = "buy")
+                    sendErrorWithFeedback(
+                        sessionId,
+                        outbound,
+                        gmcpEmitter,
+                        message,
+                        "auction",
+                        code = "LISTING_UNAVAILABLE",
+                        command = "buy",
+                    )
                     return
                 }
                 is AuctionPurchaseResult.InsufficientGold -> {
                     val message = "You need ${result.need} gold but only have ${result.have}."
-                    outbound.send(OutboundEvent.SendError(sessionId, message))
-                    sendAuctionFeedback(sessionId, "error", message, code = "INSUFFICIENT_GOLD", command = "buy")
+                    sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, message, "auction", code = "INSUFFICIENT_GOLD", command = "buy")
                     return
                 }
                 is AuctionPurchaseResult.Success -> { /* fall through */ }
@@ -185,7 +214,7 @@ class AuctionHandler(
 
             val message = "You purchased ${purchased.item.item.displayName} for ${purchased.price} gold."
             outbound.send(OutboundEvent.SendInfo(sessionId, message))
-            sendAuctionFeedback(sessionId, "success", message, code = "PURCHASE_COMPLETE", command = "buy")
+            sendScopedFeedback(sessionId, gmcpEmitter, "success", message, "auction", code = "PURCHASE_COMPLETE", command = "buy")
             markVitalsDirty(sessionId)
             syncItemsGmcp(sessionId, items, gmcpEmitter)
 
@@ -205,13 +234,21 @@ class AuctionHandler(
     }
 
     private suspend fun handleCancel(sessionId: SessionId, cmd: Command.AuctionCancel) {
-        val auction = auctionSystem ?: return sendUnavailable(sessionId)
+        val auction =
+            auctionSystem
+                ?: return sendErrorWithFeedback(
+                    sessionId,
+                    outbound,
+                    gmcpEmitter,
+                    "The auction house is not available.",
+                    "auction",
+                    code = "UNAVAILABLE",
+                )
 
         val cancelled = auction.cancelListing(cmd.listingId, sessionId)
         if (cancelled == null) {
             val message = "Listing #${cmd.listingId} not found or not yours."
-            outbound.send(OutboundEvent.SendError(sessionId, message))
-            sendAuctionFeedback(sessionId, "error", message, code = "CANCEL_DENIED", command = "cancel")
+            sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, message, "auction", code = "CANCEL_DENIED", command = "cancel")
             return
         }
 
@@ -222,7 +259,7 @@ class AuctionHandler(
                 message,
             ),
         )
-        sendAuctionFeedback(sessionId, "success", message, code = "LISTING_CANCELLED", command = "cancel")
+        sendScopedFeedback(sessionId, gmcpEmitter, "success", message, "auction", code = "LISTING_CANCELLED", command = "cancel")
         syncItemsGmcp(sessionId, items, gmcpEmitter)
 
         broadcastAuctionList(auction)
@@ -252,27 +289,4 @@ class AuctionHandler(
             price = listing.price,
             seller = listing.sellerName,
         )
-
-    private suspend fun sendUnavailable(sessionId: SessionId) {
-        val message = "The auction house is not available."
-        outbound.send(OutboundEvent.SendError(sessionId, message))
-        sendAuctionFeedback(sessionId, "error", message, code = "UNAVAILABLE")
-    }
-
-    private suspend fun sendAuctionFeedback(
-        sessionId: SessionId,
-        type: String,
-        message: String,
-        code: String? = null,
-        command: String? = null,
-    ) {
-        gmcpEmitter?.sendUiFeedback(
-            sessionId = sessionId,
-            type = type,
-            message = message,
-            code = code,
-            scope = "auction",
-            command = command,
-        )
-    }
 }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/CurrencyHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/CurrencyHandler.kt
@@ -28,7 +28,15 @@ class CurrencyHandler(
             if (definitions.isEmpty()) {
                 val message = "No secondary currencies exist."
                 outbound.send(OutboundEvent.SendInfo(sessionId, message))
-                sendCurrencyFeedback(sessionId, "info", message, code = "NONE_AVAILABLE", command = "currencies")
+                sendScopedFeedback(
+                    sessionId,
+                    gmcpEmitter,
+                    "info",
+                    message,
+                    "currencies",
+                    code = "NONE_AVAILABLE",
+                    command = "currencies",
+                )
                 return
             }
 
@@ -45,7 +53,15 @@ class CurrencyHandler(
             }
 
             emitCurrencies(sessionId, me)
-            sendCurrencyFeedback(sessionId, "info", "Wallet balances refreshed.", code = "INFO_REFRESHED", command = "currencies")
+            sendScopedFeedback(
+                sessionId,
+                gmcpEmitter,
+                "info",
+                "Wallet balances refreshed.",
+                "currencies",
+                code = "INFO_REFRESHED",
+                command = "currencies",
+            )
         }
     }
 
@@ -63,22 +79,5 @@ class CurrencyHandler(
             )
         }
         gmcpEmitter?.sendCharCurrencies(sessionId, payload)
-    }
-
-    private suspend fun sendCurrencyFeedback(
-        sessionId: SessionId,
-        type: String,
-        message: String,
-        code: String? = null,
-        command: String? = null,
-    ) {
-        gmcpEmitter?.sendUiFeedback(
-            sessionId = sessionId,
-            type = type,
-            message = message,
-            code = code,
-            scope = "currencies",
-            command = command,
-        )
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/DuelHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/DuelHandler.kt
@@ -26,44 +26,41 @@ class DuelHandler(
     }
 
     private suspend fun handleDuel(sessionId: SessionId, cmd: Command.Duel) {
-        val ds = duelSystem ?: return sendUnavailable(sessionId)
+        val ds =
+            duelSystem
+                ?: return sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, "Dueling is not available.", "duel", code = "UNAVAILABLE")
 
         players.withPlayer(sessionId) { me ->
             // Can't duel while in mob combat
             if (combatSystem?.isInCombat(sessionId) == true) {
                 val message = "You cannot duel while in combat."
-                outbound.send(OutboundEvent.SendError(sessionId, message))
-                sendDuelFeedback(sessionId, "error", message, code = "IN_COMBAT", command = "duel")
+                sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, message, "duel", code = "IN_COMBAT", command = "duel")
                 return
             }
 
             val targetSid = players.findSessionByName(cmd.targetPlayer)
             if (targetSid == null) {
                 val message = "No such player: ${cmd.targetPlayer}"
-                outbound.send(OutboundEvent.SendError(sessionId, message))
-                sendDuelFeedback(sessionId, "error", message, code = "TARGET_NOT_FOUND", command = "duel")
+                sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, message, "duel", code = "TARGET_NOT_FOUND", command = "duel")
                 return
             }
 
             players.withPlayer(targetSid) { target ->
                 if (target.roomId != me.roomId) {
                     val message = "${target.name} is not here."
-                    outbound.send(OutboundEvent.SendError(sessionId, message))
-                    sendDuelFeedback(sessionId, "error", message, code = "TARGET_NOT_NEARBY", command = "duel")
+                    sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, message, "duel", code = "TARGET_NOT_NEARBY", command = "duel")
                     return
                 }
 
                 if (combatSystem?.isInCombat(targetSid) == true) {
                     val message = "${target.name} is in combat."
-                    outbound.send(OutboundEvent.SendError(sessionId, message))
-                    sendDuelFeedback(sessionId, "error", message, code = "TARGET_IN_COMBAT", command = "duel")
+                    sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, message, "duel", code = "TARGET_IN_COMBAT", command = "duel")
                     return
                 }
 
                 val error = ds.challenge(sessionId, targetSid)
                 if (error != null) {
-                    outbound.send(OutboundEvent.SendError(sessionId, error))
-                    sendDuelFeedback(sessionId, "error", error, code = "CHALLENGE_REJECTED", command = "duel")
+                    sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, error, "duel", code = "CHALLENGE_REJECTED", command = "duel")
                     return
                 }
 
@@ -71,7 +68,7 @@ class DuelHandler(
                 outbound.send(
                     OutboundEvent.SendInfo(sessionId, message),
                 )
-                sendDuelFeedback(sessionId, "success", message, code = "CHALLENGE_SENT", command = "duel")
+                sendScopedFeedback(sessionId, gmcpEmitter, "success", message, "duel", code = "CHALLENGE_SENT", command = "duel")
                 outbound.send(
                     OutboundEvent.SendInfo(
                         targetSid,
@@ -90,13 +87,14 @@ class DuelHandler(
     }
 
     private suspend fun handleDuelAccept(sessionId: SessionId) {
-        val ds = duelSystem ?: return sendUnavailable(sessionId)
+        val ds =
+            duelSystem
+                ?: return sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, "Dueling is not available.", "duel", code = "UNAVAILABLE")
 
         val challenge = ds.getPendingChallenge(sessionId)
         if (challenge == null) {
             val message = "No pending duel challenge to accept."
-            outbound.send(OutboundEvent.SendError(sessionId, message))
-            sendDuelFeedback(sessionId, "error", message, code = "NO_PENDING_CHALLENGE", command = "accept")
+            sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, message, "duel", code = "NO_PENDING_CHALLENGE", command = "accept")
             return
         }
 
@@ -106,31 +104,27 @@ class DuelHandler(
         if (me == null || challenger == null) {
             ds.decline(sessionId)
             val message = "The challenger is no longer available."
-            outbound.send(OutboundEvent.SendError(sessionId, message))
-            sendDuelFeedback(sessionId, "error", message, code = "CHALLENGER_UNAVAILABLE", command = "accept")
+            sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, message, "duel", code = "CHALLENGER_UNAVAILABLE", command = "accept")
             return
         }
         if (me.roomId != challenger.roomId) {
             ds.decline(sessionId)
             val message = "You must be in the same room to duel."
-            outbound.send(OutboundEvent.SendError(sessionId, message))
-            sendDuelFeedback(sessionId, "error", message, code = "CHALLENGER_NOT_NEARBY", command = "accept")
+            sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, message, "duel", code = "CHALLENGER_NOT_NEARBY", command = "accept")
             outbound.send(OutboundEvent.SendInfo(challenge.challengerSid, "${me.name} is no longer nearby. Duel cancelled."))
             return
         }
         if (combatSystem?.isInCombat(sessionId) == true || combatSystem?.isInCombat(challenge.challengerSid) == true) {
             ds.decline(sessionId)
             val message = "Cannot duel while in combat."
-            outbound.send(OutboundEvent.SendError(sessionId, message))
-            sendDuelFeedback(sessionId, "error", message, code = "IN_COMBAT", command = "accept")
+            sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, message, "duel", code = "IN_COMBAT", command = "accept")
             return
         }
 
         val duel = ds.accept(sessionId)
         if (duel == null) {
             val message = "No pending duel challenge to accept."
-            outbound.send(OutboundEvent.SendError(sessionId, message))
-            sendDuelFeedback(sessionId, "error", message, code = "NO_PENDING_CHALLENGE", command = "accept")
+            sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, message, "duel", code = "NO_PENDING_CHALLENGE", command = "accept")
             return
         }
 
@@ -140,17 +134,21 @@ class DuelHandler(
         outbound.send(
             OutboundEvent.SendInfo(duel.player2, "** You accept the duel with ${challenger.name}! Fight! **"),
         )
-        sendDuelFeedback(
+        sendScopedFeedback(
             duel.player1,
+            gmcpEmitter,
             "success",
             "${me.name} accepted your duel challenge.",
+            "duel",
             code = "CHALLENGE_ACCEPTED",
             command = "accept",
         )
-        sendDuelFeedback(
+        sendScopedFeedback(
             duel.player2,
+            gmcpEmitter,
             "success",
             "You accept the duel with ${challenger.name}.",
+            "duel",
             code = "CHALLENGE_ACCEPTED",
             command = "accept",
         )
@@ -165,47 +163,25 @@ class DuelHandler(
     }
 
     private suspend fun handleDuelDecline(sessionId: SessionId) {
-        val ds = duelSystem ?: return sendUnavailable(sessionId)
+        val ds =
+            duelSystem
+                ?: return sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, "Dueling is not available.", "duel", code = "UNAVAILABLE")
 
         val challenge = ds.decline(sessionId)
         if (challenge == null) {
             val message = "No pending duel challenge to decline."
-            outbound.send(OutboundEvent.SendError(sessionId, message))
-            sendDuelFeedback(sessionId, "error", message, code = "NO_PENDING_CHALLENGE", command = "decline")
+            sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, message, "duel", code = "NO_PENDING_CHALLENGE", command = "decline")
             return
         }
 
         val myName = players.get(sessionId)?.name ?: "Someone"
         val message = "You decline the duel challenge."
         outbound.send(OutboundEvent.SendInfo(sessionId, message))
-        sendDuelFeedback(sessionId, "success", message, code = "CHALLENGE_DECLINED", command = "decline")
+        sendScopedFeedback(sessionId, gmcpEmitter, "success", message, "duel", code = "CHALLENGE_DECLINED", command = "decline")
         outbound.send(
             OutboundEvent.SendInfo(challenge.challengerSid, "$myName declined your duel challenge."),
         )
         gmcpEmitter?.sendDuelState(sessionId, active = false)
         gmcpEmitter?.sendDuelState(challenge.challengerSid, active = false)
-    }
-
-    private suspend fun sendUnavailable(sessionId: SessionId) {
-        val message = "Dueling is not available."
-        outbound.send(OutboundEvent.SendError(sessionId, message))
-        sendDuelFeedback(sessionId, "error", message, code = "UNAVAILABLE")
-    }
-
-    private suspend fun sendDuelFeedback(
-        sessionId: SessionId,
-        type: String,
-        message: String,
-        code: String? = null,
-        command: String? = null,
-    ) {
-        gmcpEmitter?.sendUiFeedback(
-            sessionId = sessionId,
-            type = type,
-            message = message,
-            code = code,
-            scope = "duel",
-            command = command,
-        )
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/DungeonHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/DungeonHandler.kt
@@ -28,8 +28,26 @@ class DungeonHandler(
     }
 
     private suspend fun handleDungeonEnter(sessionId: SessionId, cmd: Command.DungeonEnter) {
-        val dm = dungeonManager ?: return sendUnavailable(sessionId)
-        val reg = dungeonRegistry ?: return sendUnavailable(sessionId)
+        val dm =
+            dungeonManager
+                ?: return sendErrorWithFeedback(
+                    sessionId,
+                    outbound,
+                    gmcpEmitter,
+                    "Dungeons are not available.",
+                    "dungeon",
+                    code = "UNAVAILABLE",
+                )
+        val reg =
+            dungeonRegistry
+                ?: return sendErrorWithFeedback(
+                    sessionId,
+                    outbound,
+                    gmcpEmitter,
+                    "Dungeons are not available.",
+                    "dungeon",
+                    code = "UNAVAILABLE",
+                )
 
         players.withPlayer(sessionId) { me ->
             // Re-entry: if the player has an active dungeon, teleport back in
@@ -39,7 +57,15 @@ class DungeonHandler(
                 players.moveTo(sessionId, entrance)
                 val message = "You re-enter ${existingInstance.template.name}."
                 outbound.send(OutboundEvent.SendInfo(sessionId, message))
-                sendDungeonFeedback(sessionId, "success", message, code = "REENTERED", command = "enter")
+                sendScopedFeedback(
+                    sessionId,
+                    gmcpEmitter,
+                    "success",
+                    message,
+                    "dungeon",
+                    code = "REENTERED",
+                    command = "enter",
+                )
                 ctx.sendLook(sessionId)
                 gmcpEmitter?.sendDungeonInfo(
                     sessionId,
@@ -58,8 +84,15 @@ class DungeonHandler(
             val template = reg.findByKeyword(cmd.templateKeyword)
             if (template == null) {
                 val message = "Unknown dungeon '${cmd.templateKeyword}'."
-                outbound.send(OutboundEvent.SendError(sessionId, message))
-                sendDungeonFeedback(sessionId, "error", message, code = "DUNGEON_NOT_FOUND", command = "enter")
+                sendErrorWithFeedback(
+                    sessionId,
+                    outbound,
+                    gmcpEmitter,
+                    message,
+                    "dungeon",
+                    code = "DUNGEON_NOT_FOUND",
+                    command = "enter",
+                )
                 return
             }
 
@@ -69,8 +102,15 @@ class DungeonHandler(
                     ?: run {
                         val valid = DungeonDifficulty.entries.joinToString(", ") { it.displayName.lowercase() }
                         val message = "Unknown difficulty '${cmd.difficulty}'. Options: $valid"
-                        outbound.send(OutboundEvent.SendError(sessionId, message))
-                        sendDungeonFeedback(sessionId, "error", message, code = "INVALID_DIFFICULTY", command = "enter")
+                        sendErrorWithFeedback(
+                            sessionId,
+                            outbound,
+                            gmcpEmitter,
+                            message,
+                            "dungeon",
+                            code = "INVALID_DIFFICULTY",
+                            command = "enter",
+                        )
                         return
                     }
             } else {
@@ -89,8 +129,15 @@ class DungeonHandler(
                 if (member.level < template.minLevel) {
                     val message =
                         "${member.name} is level ${member.level} but this dungeon requires level ${template.minLevel}."
-                    outbound.send(OutboundEvent.SendError(sessionId, message))
-                    sendDungeonFeedback(sessionId, "error", message, code = "MIN_LEVEL", command = "enter")
+                    sendErrorWithFeedback(
+                        sessionId,
+                        outbound,
+                        gmcpEmitter,
+                        message,
+                        "dungeon",
+                        code = "MIN_LEVEL",
+                        command = "enter",
+                    )
                     return
                 }
             }
@@ -127,7 +174,15 @@ class DungeonHandler(
                         enterMessage,
                     ),
                 )
-                sendDungeonFeedback(sid, "success", enterMessage, code = "ENTERED", command = "enter")
+                sendScopedFeedback(
+                    sid,
+                    gmcpEmitter,
+                    "success",
+                    enterMessage,
+                    "dungeon",
+                    code = "ENTERED",
+                    command = "enter",
+                )
                 ctx.sendLook(sid)
                 gmcpEmitter?.sendDungeonInfo(
                     sid,
@@ -144,45 +199,46 @@ class DungeonHandler(
     }
 
     private suspend fun handleDungeonLeave(sessionId: SessionId) {
-        val dm = dungeonManager ?: return sendUnavailable(sessionId)
+        val dm =
+            dungeonManager
+                ?: return sendErrorWithFeedback(
+                    sessionId,
+                    outbound,
+                    gmcpEmitter,
+                    "Dungeons are not available.",
+                    "dungeon",
+                    code = "UNAVAILABLE",
+                )
 
         players.withPlayer(sessionId) { me ->
             val returnRoom = dm.removePlayer(sessionId)
             if (returnRoom == null) {
                 val message = "You are not in a dungeon."
-                outbound.send(OutboundEvent.SendError(sessionId, message))
-                sendDungeonFeedback(sessionId, "error", message, code = "NOT_IN_DUNGEON", command = "leave")
+                sendErrorWithFeedback(
+                    sessionId,
+                    outbound,
+                    gmcpEmitter,
+                    message,
+                    "dungeon",
+                    code = "NOT_IN_DUNGEON",
+                    command = "leave",
+                )
                 return
             }
             val message = "You leave the dungeon."
             outbound.send(OutboundEvent.SendInfo(sessionId, message))
-            sendDungeonFeedback(sessionId, "success", message, code = "LEFT", command = "leave")
+            sendScopedFeedback(
+                sessionId,
+                gmcpEmitter,
+                "success",
+                message,
+                "dungeon",
+                code = "LEFT",
+                command = "leave",
+            )
             players.moveTo(sessionId, returnRoom)
             ctx.sendLook(sessionId)
             gmcpEmitter?.sendDungeonInfo(sessionId, active = false)
         }
-    }
-
-    private suspend fun sendUnavailable(sessionId: SessionId) {
-        val message = "Dungeons are not available."
-        outbound.send(OutboundEvent.SendError(sessionId, message))
-        sendDungeonFeedback(sessionId, "error", message, code = "UNAVAILABLE")
-    }
-
-    private suspend fun sendDungeonFeedback(
-        sessionId: SessionId,
-        type: String,
-        message: String,
-        code: String? = null,
-        command: String? = null,
-    ) {
-        gmcpEmitter?.sendUiFeedback(
-            sessionId = sessionId,
-            type = type,
-            message = message,
-            code = code,
-            scope = "dungeon",
-            command = command,
-        )
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -91,6 +91,46 @@ internal suspend fun requireSameRoom(
     return true
 }
 
+/**
+ * Sends a scoped GMCP UI feedback event via [gmcpEmitter].
+ * Replaces per-handler `sendXxxFeedback` wrapper methods that only differed in [scope].
+ */
+internal suspend fun sendScopedFeedback(
+    sessionId: SessionId,
+    gmcpEmitter: GmcpEmitter?,
+    type: String,
+    message: String,
+    scope: String,
+    code: String? = null,
+    command: String? = null,
+) {
+    gmcpEmitter?.sendUiFeedback(
+        sessionId = sessionId,
+        type = type,
+        message = message,
+        code = code,
+        scope = scope,
+        command = command,
+    )
+}
+
+/**
+ * Sends both a [OutboundEvent.SendError] text message and a scoped GMCP UI feedback event.
+ * Consolidates the common dual-output pattern used across many handlers.
+ */
+internal suspend fun sendErrorWithFeedback(
+    sessionId: SessionId,
+    outbound: OutboundBus,
+    gmcpEmitter: GmcpEmitter?,
+    message: String,
+    scope: String,
+    code: String? = null,
+    command: String? = null,
+) {
+    outbound.send(OutboundEvent.SendError(sessionId, message))
+    sendScopedFeedback(sessionId, gmcpEmitter, "error", message, scope, code, command)
+}
+
 /** Convenience extension that delegates to the full [sendLook], pulling all dependencies from this context. */
 internal suspend fun EngineContext.sendLook(sessionId: SessionId) {
     sendLook(sessionId, world, players, mobs, items, worldState, outbound, gmcpEmitter, gatheringRegistry, questSystem, trainerRegistry)
@@ -384,6 +424,26 @@ internal fun buildFeaturePayload(
         text = feature.text,
     )
 }
+
+/**
+ * Convenience extension on [EngineContext] that delegates to [movePlayerWithNotify],
+ * pulling [players], [outbound], and [gmcpEmitter] from the context.
+ */
+internal suspend fun EngineContext.movePlayer(
+    sessionId: SessionId,
+    from: RoomId,
+    to: RoomId,
+    departMsg: String,
+    arriveMsg: String,
+    dialogueSystem: dev.ambon.engine.dialogue.DialogueSystem? = null,
+) = movePlayerWithNotify(sessionId, from, to, departMsg, arriveMsg, players, outbound, gmcpEmitter, dialogueSystem)
+
+/**
+ * Convenience extension on [EngineContext] that syncs item GMCP state,
+ * pulling [items] and [gmcpEmitter] from the context.
+ */
+internal suspend fun EngineContext.syncItems(sessionId: SessionId) =
+    syncItemsGmcp(sessionId, items, gmcpEmitter)
 
 /** Returns a human-readable display name for a crafting station type ID. */
 private fun stationDisplayName(station: String): String =

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/LotteryHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/LotteryHandler.kt
@@ -26,7 +26,16 @@ class LotteryHandler(
     }
 
     private suspend fun handleLotteryInfo(sessionId: SessionId) {
-        val system = lotterySystem ?: return sendUnavailable(sessionId, "The lottery")
+        val system =
+            lotterySystem
+                ?: return sendErrorWithFeedback(
+                    sessionId,
+                    outbound,
+                    gmcpEmitter,
+                    "The lottery is not available on this server.",
+                    "lottery",
+                    code = "UNAVAILABLE",
+                )
 
         players.withPlayer(sessionId) { me ->
             val info = system.getInfo(me.name)
@@ -53,7 +62,16 @@ class LotteryHandler(
     }
 
     private suspend fun handleLotteryBuy(sessionId: SessionId, cmd: Command.LotteryBuy) {
-        val system = lotterySystem ?: return sendUnavailable(sessionId, "The lottery")
+        val system =
+            lotterySystem
+                ?: return sendErrorWithFeedback(
+                    sessionId,
+                    outbound,
+                    gmcpEmitter,
+                    "The lottery is not available on this server.",
+                    "lottery",
+                    code = "UNAVAILABLE",
+                )
 
         players.withPlayer(sessionId) { me ->
             val result = system.buyTickets(
@@ -75,32 +93,70 @@ class LotteryHandler(
                             message,
                         ),
                     )
-                    sendLotteryFeedback(sessionId, "success", message, code = "PURCHASE_COMPLETE", command = "buy")
+                    sendScopedFeedback(
+                        sessionId,
+                        gmcpEmitter,
+                        "success",
+                        message,
+                        "lottery",
+                        code = "PURCHASE_COMPLETE",
+                        command = "buy",
+                    )
                     markVitalsDirty(sessionId)
                     emitLotteryGmcp(sessionId, me.name, system)
                 }
 
                 is LotteryBuyResult.InsufficientGold -> {
                     val message = "You need ${result.need} gold but only have ${result.have}."
-                    outbound.send(OutboundEvent.SendError(sessionId, message))
-                    sendLotteryFeedback(sessionId, "error", message, code = "INSUFFICIENT_GOLD", command = "buy")
+                    sendErrorWithFeedback(
+                        sessionId,
+                        outbound,
+                        gmcpEmitter,
+                        message,
+                        "lottery",
+                        code = "INSUFFICIENT_GOLD",
+                        command = "buy",
+                    )
                 }
 
                 is LotteryBuyResult.ExceedsLimit -> {
                     val message = "You already have ${result.current} ticket(s). Maximum is ${result.max} per drawing."
-                    outbound.send(OutboundEvent.SendError(sessionId, message))
-                    sendLotteryFeedback(sessionId, "error", message, code = "TICKET_LIMIT", command = "buy")
+                    sendErrorWithFeedback(
+                        sessionId,
+                        outbound,
+                        gmcpEmitter,
+                        message,
+                        "lottery",
+                        code = "TICKET_LIMIT",
+                        command = "buy",
+                    )
                 }
 
                 is LotteryBuyResult.Disabled -> {
-                    sendUnavailable(sessionId, "The lottery")
+                    sendErrorWithFeedback(
+                        sessionId,
+                        outbound,
+                        gmcpEmitter,
+                        "The lottery is not available on this server.",
+                        "lottery",
+                        code = "UNAVAILABLE",
+                    )
                 }
             }
         }
     }
 
     private suspend fun handleGamble(sessionId: SessionId, cmd: Command.Gamble) {
-        val system = lotterySystem ?: return sendUnavailable(sessionId, "Gambling")
+        val system =
+            lotterySystem
+                ?: return sendErrorWithFeedback(
+                    sessionId,
+                    outbound,
+                    gmcpEmitter,
+                    "Gambling is not available on this server.",
+                    "lottery",
+                    code = "UNAVAILABLE",
+                )
 
         players.withPlayer(sessionId) { me ->
             val room = ctx.world.rooms[me.roomId]
@@ -209,7 +265,14 @@ class LotteryHandler(
                 }
 
                 is GambleResult.Disabled -> {
-                    sendUnavailable(sessionId, "Gambling")
+                    sendErrorWithFeedback(
+                        sessionId,
+                        outbound,
+                        gmcpEmitter,
+                        "Gambling is not available on this server.",
+                        "lottery",
+                        code = "UNAVAILABLE",
+                    )
                 }
             }
         }
@@ -222,28 +285,5 @@ class LotteryHandler(
     ) {
         val info = system.getInfo(playerName)
         gmcpEmitter?.sendLotteryInfo(sessionId, info)
-    }
-
-    private suspend fun sendUnavailable(sessionId: SessionId, name: String) {
-        val message = "$name is not available on this server."
-        outbound.send(OutboundEvent.SendError(sessionId, message))
-        sendLotteryFeedback(sessionId, "error", message, code = "UNAVAILABLE")
-    }
-
-    private suspend fun sendLotteryFeedback(
-        sessionId: SessionId,
-        type: String,
-        message: String,
-        code: String? = null,
-        command: String? = null,
-    ) {
-        gmcpEmitter?.sendUiFeedback(
-            sessionId = sessionId,
-            type = type,
-            message = message,
-            code = code,
-            scope = "lottery",
-            command = command,
-        )
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/PetHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/PetHandler.kt
@@ -28,7 +28,15 @@ class PetHandler(
         if (pet == null) {
             val message = "You have no active pet. Summon one with a pet ability."
             outbound.send(OutboundEvent.SendInfo(sessionId, message))
-            sendPetFeedback(sessionId, "info", message, code = "NO_ACTIVE_PET", command = "status")
+            sendScopedFeedback(
+                sessionId,
+                gmcpEmitter,
+                "info",
+                message,
+                "pet",
+                code = "NO_ACTIVE_PET",
+                command = "status",
+            )
             return
         }
 
@@ -47,8 +55,15 @@ class PetHandler(
         val pet = petSystem.getActivePet(sessionId)
         if (pet == null) {
             val message = "You have no active pet."
-            outbound.send(OutboundEvent.SendError(sessionId, message))
-            sendPetFeedback(sessionId, "error", message, code = "NO_ACTIVE_PET", command = "dismiss")
+            sendErrorWithFeedback(
+                sessionId,
+                outbound,
+                gmcpEmitter,
+                message,
+                "pet",
+                code = "NO_ACTIVE_PET",
+                command = "dismiss",
+            )
             return
         }
 
@@ -56,7 +71,15 @@ class PetHandler(
         petSystem.dismissAll(sessionId)
         val message = "You dismiss $petName."
         outbound.send(OutboundEvent.SendInfo(sessionId, message))
-        sendPetFeedback(sessionId, "success", message, code = "PET_DISMISSED", command = "dismiss")
+        sendScopedFeedback(
+            sessionId,
+            gmcpEmitter,
+            "success",
+            message,
+            "pet",
+            code = "PET_DISMISSED",
+            command = "dismiss",
+        )
         emitInactivePet(sessionId)
         players.withPlayer(sessionId) { me ->
             broadcastToRoom(me.roomId, "$petName vanishes.", players, outbound)
@@ -67,8 +90,15 @@ class PetHandler(
         val pet = petSystem.getActivePet(sessionId)
         if (pet == null) {
             val message = "You have no active pet."
-            outbound.send(OutboundEvent.SendError(sessionId, message))
-            sendPetFeedback(sessionId, "error", message, code = "NO_ACTIVE_PET", command = "name")
+            sendErrorWithFeedback(
+                sessionId,
+                outbound,
+                gmcpEmitter,
+                message,
+                "pet",
+                code = "NO_ACTIVE_PET",
+                command = "name",
+            )
             return
         }
 
@@ -76,7 +106,15 @@ class PetHandler(
         pet.name = cmd.newName
         val message = "You rename $oldName to ${cmd.newName}."
         outbound.send(OutboundEvent.SendInfo(sessionId, message))
-        sendPetFeedback(sessionId, "success", message, code = "PET_RENAMED", command = "name")
+        sendScopedFeedback(
+            sessionId,
+            gmcpEmitter,
+            "success",
+            message,
+            "pet",
+            code = "PET_RENAMED",
+            command = "name",
+        )
         emitPetState(sessionId, pet)
     }
 
@@ -109,23 +147,6 @@ class PetHandler(
                 armor = null,
                 image = null,
             ),
-        )
-    }
-
-    private suspend fun sendPetFeedback(
-        sessionId: SessionId,
-        type: String,
-        message: String,
-        code: String? = null,
-        command: String? = null,
-    ) {
-        gmcpEmitter?.sendUiFeedback(
-            sessionId = sessionId,
-            type = type,
-            message = message,
-            code = code,
-            scope = "pet",
-            command = command,
         )
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/PrestigeHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/PrestigeHandler.kt
@@ -26,22 +26,43 @@ class PrestigeHandler(
     private suspend fun handlePrestige(sessionId: SessionId) {
         if (!prestigeSystem.isEnabled()) {
             val message = "The prestige system is not enabled."
-            outbound.send(OutboundEvent.SendError(sessionId, message))
-            sendPrestigeFeedback(sessionId, "error", message, code = "UNAVAILABLE", command = "prestige")
+            sendErrorWithFeedback(
+                sessionId,
+                outbound,
+                gmcpEmitter,
+                message,
+                "prestige",
+                code = "UNAVAILABLE",
+                command = "prestige",
+            )
             return
         }
         players.withPlayer(sessionId) { me ->
             val maxLevel = progression.maxLevel
             if (me.level < maxLevel) {
                 val message = "You must reach level $maxLevel before you can prestige."
-                outbound.send(OutboundEvent.SendError(sessionId, message))
-                sendPrestigeFeedback(sessionId, "error", message, code = "LEVEL_REQUIRED", command = "prestige")
+                sendErrorWithFeedback(
+                    sessionId,
+                    outbound,
+                    gmcpEmitter,
+                    message,
+                    "prestige",
+                    code = "LEVEL_REQUIRED",
+                    command = "prestige",
+                )
                 return
             }
             if (me.prestigeLevel >= prestigeSystem.maxRank) {
                 val message = "You have already reached the maximum prestige rank."
-                outbound.send(OutboundEvent.SendError(sessionId, message))
-                sendPrestigeFeedback(sessionId, "error", message, code = "MAX_RANK", command = "prestige")
+                sendErrorWithFeedback(
+                    sessionId,
+                    outbound,
+                    gmcpEmitter,
+                    message,
+                    "prestige",
+                    code = "MAX_RANK",
+                    command = "prestige",
+                )
                 return
             }
             val cost = prestigeSystem.xpCostForNextRank(me.prestigeLevel)
@@ -49,8 +70,15 @@ class PrestigeHandler(
             if (available < cost) {
                 val message =
                     "You need ${"%,d".format(cost)} surplus XP to prestige (you have ${"%,d".format(available)})."
-                outbound.send(OutboundEvent.SendError(sessionId, message))
-                sendPrestigeFeedback(sessionId, "error", message, code = "INSUFFICIENT_XP", command = "prestige")
+                sendErrorWithFeedback(
+                    sessionId,
+                    outbound,
+                    gmcpEmitter,
+                    message,
+                    "prestige",
+                    code = "INSUFFICIENT_XP",
+                    command = "prestige",
+                )
                 return
             }
 
@@ -63,7 +91,15 @@ class PrestigeHandler(
                     message,
                 ),
             )
-            sendPrestigeFeedback(sessionId, "success", message, code = "PRESTIGE_COMPLETE", command = "prestige")
+            sendScopedFeedback(
+                sessionId,
+                gmcpEmitter,
+                "success",
+                message,
+                "prestige",
+                code = "PRESTIGE_COMPLETE",
+                command = "prestige",
+            )
 
             // Announce to the room
             val roomId = me.roomId
@@ -86,8 +122,15 @@ class PrestigeHandler(
     private suspend fun handlePrestigeInfo(sessionId: SessionId) {
         if (!prestigeSystem.isEnabled()) {
             val message = "The prestige system is not enabled."
-            outbound.send(OutboundEvent.SendError(sessionId, message))
-            sendPrestigeFeedback(sessionId, "error", message, code = "UNAVAILABLE", command = "info")
+            sendErrorWithFeedback(
+                sessionId,
+                outbound,
+                gmcpEmitter,
+                message,
+                "prestige",
+                code = "UNAVAILABLE",
+                command = "info",
+            )
             return
         }
         players.withPlayer(sessionId) { me ->
@@ -144,24 +187,15 @@ class PrestigeHandler(
                 nextRankCost = nextCost,
                 perks = gmcpEmitter.buildPrestigePerkPayloads(currentRank, maxRank) { prestigeSystem.perkForRank(it) },
             )
-            sendPrestigeFeedback(sessionId, "info", "Prestige details refreshed.", code = "INFO_REFRESHED", command = "info")
+            sendScopedFeedback(
+                sessionId,
+                gmcpEmitter,
+                "info",
+                "Prestige details refreshed.",
+                "prestige",
+                code = "INFO_REFRESHED",
+                command = "info",
+            )
         }
-    }
-
-    private suspend fun sendPrestigeFeedback(
-        sessionId: SessionId,
-        type: String,
-        message: String,
-        code: String? = null,
-        command: String? = null,
-    ) {
-        gmcpEmitter?.sendUiFeedback(
-            sessionId = sessionId,
-            type = type,
-            message = message,
-            code = code,
-            scope = "prestige",
-            command = command,
-        )
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ReputationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ReputationHandler.kt
@@ -30,7 +30,15 @@ class ReputationHandler(
             if (definitions.isEmpty()) {
                 val message = "No factions exist in this world."
                 outbound.send(OutboundEvent.SendInfo(sessionId, message))
-                sendFactionFeedback(sessionId, "info", message, code = "NONE_AVAILABLE", command = "reputation")
+                sendScopedFeedback(
+                    sessionId,
+                    gmcpEmitter,
+                    "info",
+                    message,
+                    "factions",
+                    code = "NONE_AVAILABLE",
+                    command = "reputation",
+                )
                 return
             }
 
@@ -53,7 +61,15 @@ class ReputationHandler(
             }
 
             emitFactions(sessionId, me)
-            sendFactionFeedback(sessionId, "info", "Faction standings refreshed.", code = "INFO_REFRESHED", command = "reputation")
+            sendScopedFeedback(
+                sessionId,
+                gmcpEmitter,
+                "info",
+                "Faction standings refreshed.",
+                "factions",
+                code = "INFO_REFRESHED",
+                command = "reputation",
+            )
         }
     }
 
@@ -73,22 +89,5 @@ class ReputationHandler(
             )
         }
         gmcpEmitter?.sendCharFactions(sessionId, payload)
-    }
-
-    private suspend fun sendFactionFeedback(
-        sessionId: SessionId,
-        type: String,
-        message: String,
-        code: String? = null,
-        command: String? = null,
-    ) {
-        gmcpEmitter?.sendUiFeedback(
-            sessionId = sessionId,
-            type = type,
-            message = message,
-            code = code,
-            scope = "factions",
-            command = command,
-        )
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/events/GmcpFlushHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/GmcpFlushHandler.kt
@@ -33,6 +33,16 @@ class GmcpFlushHandler(
     private val bindings: StatBindingsConfig = StatBindingsConfig(),
     private val metrics: GameMetrics = GameMetrics.noop(),
 ) {
+    /** Flushes all dirty GMCP sets in one call. */
+    suspend fun flushAll() {
+        flushDirtyVitals()
+        flushDirtyMobs()
+        flushDirtyStatusEffects()
+        flushDirtyGroup()
+        flushDirtyCombat()
+        flushDirtyStats()
+    }
+
     suspend fun flushDirtyVitals() {
         metrics.onGmcpFlushHandlerEvent()
         drainDirty(gmcpDirtyVitals) { sid ->

--- a/src/main/kotlin/dev/ambon/engine/events/InterEngineEventHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/InterEngineEventHandler.kt
@@ -42,6 +42,13 @@ class InterEngineEventHandler(
     private val logger: KLogger,
     private val metrics: GameMetrics = GameMetrics.noop(),
 ) {
+    /** Ends combat, regen tracking, and status effects for a player about to transfer. */
+    private suspend fun prepareForTransit(sessionId: SessionId) {
+        combatSystem.endCombatFor(sessionId)
+        regenSystem.onPlayerDisconnected(sessionId)
+        statusEffectSystem.removeAllFromPlayer(sessionId)
+    }
+
     private data class PendingWhoRequest(
         val sessionId: SessionId,
         val deadlineEpochMs: Long,
@@ -227,9 +234,7 @@ class InterEngineEventHandler(
                     outbound.send(OutboundEvent.SendText(targetSid, "You are transported by a divine hand."))
                     router.handle(targetSid, Command.Look)
                 } else if (handoffManager != null) {
-                    combatSystem.endCombatFor(targetSid)
-                    regenSystem.onPlayerDisconnected(targetSid)
-                    statusEffectSystem.removeAllFromPlayer(targetSid)
+                    prepareForTransit(targetSid)
                     when (handoffManager.initiateHandoff(targetSid, targetRoomId)) {
                         is HandoffResult.Initiated -> Unit
                         HandoffResult.PlayerNotFound -> Unit

--- a/src/main/kotlin/dev/ambon/engine/events/PhaseEventHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/PhaseEventHandler.kt
@@ -29,15 +29,20 @@ class PhaseEventHandler(
     private val logger: KLogger,
     private val metrics: GameMetrics = GameMetrics.noop(),
 ) {
+    /** Ends combat, regen tracking, and status effects for a player about to transfer. */
+    internal suspend fun prepareForTransit(sessionId: SessionId) {
+        combatSystem.endCombatFor(sessionId)
+        regenSystem.onPlayerDisconnected(sessionId)
+        statusEffectSystem.removeAllFromPlayer(sessionId)
+    }
+
     suspend fun handleCrossZoneMove(
         sessionId: SessionId,
         targetRoomId: RoomId,
     ) {
         metrics.onPhaseHandlerEvent()
         val mgr = handoffManager ?: return
-        combatSystem.endCombatFor(sessionId)
-        regenSystem.onPlayerDisconnected(sessionId)
-        statusEffectSystem.removeAllFromPlayer(sessionId)
+        prepareForTransit(sessionId)
 
         when (val result = mgr.initiateHandoff(sessionId, targetRoomId)) {
             is HandoffResult.Initiated -> {
@@ -90,9 +95,7 @@ class PhaseEventHandler(
             return PhaseResult.NoOp("You are already on that instance.")
         }
 
-        combatSystem.endCombatFor(sessionId)
-        regenSystem.onPlayerDisconnected(sessionId)
-        statusEffectSystem.removeAllFromPlayer(sessionId)
+        prepareForTransit(sessionId)
         return when (mgr.initiateHandoff(sessionId, player.roomId, targetEngineOverride = resolvedInstance.address)) {
             is HandoffResult.Initiated -> PhaseResult.Initiated
             HandoffResult.AlreadyInTransit -> PhaseResult.NoOp("You are already crossing into new territory.")

--- a/src/main/kotlin/dev/ambon/engine/events/SessionEventHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/SessionEventHandler.kt
@@ -36,6 +36,16 @@ class SessionEventHandler(
     /** Sessions for which [fullDisconnect] has already run, guarding against double-cleanup. */
     private val fullyDisconnected = mutableSetOf<SessionId>()
 
+    /** Removes all GMCP tracking state for [sessionId]. */
+    private fun clearGmcpState(sessionId: SessionId) {
+        gmcpSessions.remove(sessionId)
+        gmcpDirtyVitals.remove(sessionId)
+        gmcpDirtyStatusEffects.remove(sessionId)
+        gmcpDirtyGroup.remove(sessionId)
+        gmcpDirtyCombat.remove(sessionId)
+        gmcpEmitter?.forgetSession(sessionId)
+    }
+
     suspend fun onConnected(
         sessionId: SessionId,
         defaultAnsiEnabled: Boolean,
@@ -64,12 +74,8 @@ class SessionEventHandler(
         // If the player is authenticated and grace period is enabled,
         // suspend the session instead of running full disconnect cleanup.
         if (me != null && me.playerId != null && gracePeriodManager != null) {
-            val gmcpPkgs = gmcpSessions.remove(sessionId)?.toSet() ?: emptySet()
-            gmcpDirtyVitals.remove(sessionId)
-            gmcpDirtyStatusEffects.remove(sessionId)
-            gmcpDirtyGroup.remove(sessionId)
-            gmcpDirtyCombat.remove(sessionId)
-            gmcpEmitter?.forgetSession(sessionId)
+            val gmcpPkgs = gmcpSessions[sessionId]?.toSet() ?: emptySet()
+            clearGmcpState(sessionId)
 
             val ps = players.suspendSession(sessionId)
             if (ps != null) {
@@ -99,12 +105,7 @@ class SessionEventHandler(
 
         // These may already have been cleared by the grace period path,
         // but clear them again in case of direct-disconnect or grace expiry.
-        gmcpSessions.remove(sessionId)
-        gmcpDirtyVitals.remove(sessionId)
-        gmcpDirtyStatusEffects.remove(sessionId)
-        gmcpDirtyGroup.remove(sessionId)
-        gmcpDirtyCombat.remove(sessionId)
-        gmcpEmitter?.forgetSession(sessionId)
+        clearGmcpState(sessionId)
 
         sessionLifecycle.onPlayerDisconnected(sessionId)
 

--- a/src/main/kotlin/dev/ambon/grpc/GrpcAuthInterceptor.kt
+++ b/src/main/kotlin/dev/ambon/grpc/GrpcAuthInterceptor.kt
@@ -1,5 +1,6 @@
 package dev.ambon.grpc
 
+import dev.ambon.hmacSha256
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.grpc.CallOptions
 import io.grpc.Channel
@@ -12,9 +13,6 @@ import io.grpc.ServerCall
 import io.grpc.ServerCallHandler
 import io.grpc.ServerInterceptor
 import io.grpc.Status
-import java.nio.charset.StandardCharsets
-import javax.crypto.Mac
-import javax.crypto.spec.SecretKeySpec
 
 private val log = KotlinLogging.logger {}
 
@@ -37,19 +35,6 @@ object GrpcAuthMetadata {
         Metadata.Key.of("x-ambon-auth-hmac", Metadata.ASCII_STRING_MARSHALLER)
     val TIMESTAMP_KEY: Metadata.Key<String> =
         Metadata.Key.of("x-ambon-auth-ts", Metadata.ASCII_STRING_MARSHALLER)
-}
-
-/**
- * Computes HMAC-SHA256 of [payload] under [secret], returning a lowercase hex string.
- */
-internal fun grpcHmacSha256(
-    secret: String,
-    payload: String,
-): String {
-    val mac = Mac.getInstance("HmacSHA256")
-    mac.init(SecretKeySpec(secret.toByteArray(StandardCharsets.UTF_8), "HmacSHA256"))
-    return mac.doFinal(payload.toByteArray(StandardCharsets.UTF_8))
-        .joinToString("") { "%02x".format(it) }
 }
 
 /**
@@ -98,7 +83,7 @@ class GrpcServerAuthInterceptor(
             return rejectCall(call, "Timestamp outside acceptable window")
         }
 
-        val expectedHmac = grpcHmacSha256(sharedSecret, tsString)
+        val expectedHmac = hmacSha256(sharedSecret, tsString)
         if (!constantTimeEquals(expectedHmac, hmac)) {
             log.warn { "gRPC auth rejected: HMAC mismatch" }
             return rejectCall(call, "Invalid HMAC signature")
@@ -149,7 +134,7 @@ class GrpcClientAuthInterceptor(
             ) {
                 val ts = clockMillis().toString()
                 headers.put(GrpcAuthMetadata.TIMESTAMP_KEY, ts)
-                headers.put(GrpcAuthMetadata.HMAC_KEY, grpcHmacSha256(sharedSecret, ts))
+                headers.put(GrpcAuthMetadata.HMAC_KEY, hmacSha256(sharedSecret, ts))
                 super.start(responseListener, headers)
             }
         }

--- a/src/main/kotlin/dev/ambon/persistence/GuildRepositoryFactory.kt
+++ b/src/main/kotlin/dev/ambon/persistence/GuildRepositoryFactory.kt
@@ -1,25 +1,17 @@
 package dev.ambon.persistence
 
-import dev.ambon.config.PersistenceBackend
 import dev.ambon.config.PersistenceConfig
 import org.jetbrains.exposed.v1.jdbc.Database
-import java.nio.file.Paths
 
 object GuildRepositoryFactory {
     fun create(
         persistence: PersistenceConfig,
         database: Database?,
     ): GuildRepository =
-        when (persistence.backend) {
-            PersistenceBackend.YAML ->
-                YamlGuildRepository(
-                    rootDir = Paths.get(persistence.rootDir),
-                )
-            PersistenceBackend.POSTGRES ->
-                PostgresGuildRepository(
-                    database = requireNotNull(database) {
-                        "Database must be configured when persistence.backend=POSTGRES"
-                    },
-                )
-        }
+        createRepository(
+            persistence,
+            database,
+            yamlFactory = { rootDir -> YamlGuildRepository(rootDir = rootDir) },
+            postgresFactory = { db -> PostgresGuildRepository(database = db) },
+        )
 }

--- a/src/main/kotlin/dev/ambon/persistence/HouseRepositoryFactory.kt
+++ b/src/main/kotlin/dev/ambon/persistence/HouseRepositoryFactory.kt
@@ -1,25 +1,17 @@
 package dev.ambon.persistence
 
-import dev.ambon.config.PersistenceBackend
 import dev.ambon.config.PersistenceConfig
 import org.jetbrains.exposed.v1.jdbc.Database
-import java.nio.file.Paths
 
 object HouseRepositoryFactory {
     fun create(
         persistence: PersistenceConfig,
         database: Database?,
     ): HouseRepository =
-        when (persistence.backend) {
-            PersistenceBackend.YAML ->
-                YamlHouseRepository(
-                    rootDir = Paths.get(persistence.rootDir),
-                )
-            PersistenceBackend.POSTGRES ->
-                PostgresHouseRepository(
-                    database = requireNotNull(database) {
-                        "Database must be configured when persistence.backend=POSTGRES"
-                    },
-                )
-        }
+        createRepository(
+            persistence,
+            database,
+            yamlFactory = { rootDir -> YamlHouseRepository(rootDir = rootDir) },
+            postgresFactory = { db -> PostgresHouseRepository(database = db) },
+        )
 }

--- a/src/main/kotlin/dev/ambon/persistence/MapperSupport.kt
+++ b/src/main/kotlin/dev/ambon/persistence/MapperSupport.kt
@@ -4,10 +4,14 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import dev.ambon.config.PersistenceBackend
+import dev.ambon.config.PersistenceConfig
 import kotlinx.coroutines.Dispatchers
 import org.jetbrains.exposed.v1.core.Transaction
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.transactions.experimental.newSuspendedTransaction
+import java.nio.file.Path
+import java.nio.file.Paths
 
 /** Shared YAML ObjectMapper for persistence layer. Lenient on unknown properties for schema evolution. */
 val yamlMapper: ObjectMapper =
@@ -34,3 +38,34 @@ class PersistenceException(
 /** Runs [statement] in a suspended Exposed transaction on [Dispatchers.IO]. */
 suspend fun <T> Database.dbQuery(statement: suspend Transaction.() -> T): T =
     newSuspendedTransaction(Dispatchers.IO, this, statement = statement)
+
+/**
+ * Deserialises JSON with a fallback to [default] on any parse failure.
+ * Shared across all Postgres repositories.
+ */
+fun <T> safeReadJson(
+    json: String,
+    type: com.fasterxml.jackson.core.type.TypeReference<T>,
+    default: T,
+): T = runCatching { jsonMapper.readValue(json, type) }.getOrDefault(default)
+
+/**
+ * Creates a repository by dispatching on the persistence backend.
+ * Eliminates the repeated `when (backend) { YAML -> ..., POSTGRES -> ... }` factory pattern.
+ */
+fun <T> createRepository(
+    persistence: PersistenceConfig,
+    database: Database?,
+    yamlFactory: (Path) -> T,
+    postgresFactory: (Database) -> T,
+): T =
+    when (persistence.backend) {
+        PersistenceBackend.YAML ->
+            yamlFactory(Paths.get(persistence.rootDir))
+        PersistenceBackend.POSTGRES ->
+            postgresFactory(
+                requireNotNull(database) {
+                    "Database must be configured when persistence.backend=POSTGRES"
+                },
+            )
+    }

--- a/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
@@ -27,10 +27,6 @@ private val equippedItemsType = object : TypeReference<Map<String, ItemInstance>
 private val learnedAbilityIdsType = object : TypeReference<Set<String>>() {}
 private val unlockedClassesType = object : TypeReference<Set<String>>() {}
 
-/** Deserialises JSON with a fallback to [default] on any parse failure. */
-private fun <T> safeReadJson(json: String, type: TypeReference<T>, default: T): T =
-    runCatching { jsonMapper.readValue(json, type) }.getOrDefault(default)
-
 object PlayersTable : Table("players") {
     val id = long("id").autoIncrement("player_id_seq")
     val name = varchar("name", 16)

--- a/src/main/kotlin/dev/ambon/persistence/WorldStateRepositoryFactory.kt
+++ b/src/main/kotlin/dev/ambon/persistence/WorldStateRepositoryFactory.kt
@@ -1,25 +1,17 @@
 package dev.ambon.persistence
 
-import dev.ambon.config.PersistenceBackend
 import dev.ambon.config.PersistenceConfig
 import org.jetbrains.exposed.v1.jdbc.Database
-import java.nio.file.Paths
 
 object WorldStateRepositoryFactory {
     fun create(
         persistence: PersistenceConfig,
         database: Database?,
     ): WorldStateRepository =
-        when (persistence.backend) {
-            PersistenceBackend.YAML ->
-                YamlWorldStateRepository(
-                    rootDir = Paths.get(persistence.rootDir),
-                )
-            PersistenceBackend.POSTGRES ->
-                PostgresWorldStateRepository(
-                    database = requireNotNull(database) {
-                        "Database must be configured when persistence.backend=POSTGRES"
-                    },
-                )
-        }
+        createRepository(
+            persistence,
+            database,
+            yamlFactory = { rootDir -> YamlWorldStateRepository(rootDir = rootDir) },
+            postgresFactory = { db -> PostgresWorldStateRepository(database = db) },
+        )
 }

--- a/src/test/kotlin/dev/ambon/bus/RedisInboundBusTest.kt
+++ b/src/test/kotlin/dev/ambon/bus/RedisInboundBusTest.kt
@@ -2,6 +2,7 @@ package dev.ambon.bus
 
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.events.InboundEvent
+import dev.ambon.hmacSha256
 import dev.ambon.redis.redisObjectMapper
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/src/test/kotlin/dev/ambon/bus/RedisOutboundBusTest.kt
+++ b/src/test/kotlin/dev/ambon/bus/RedisOutboundBusTest.kt
@@ -2,6 +2,7 @@ package dev.ambon.bus
 
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.hmacSha256
 import dev.ambon.redis.redisObjectMapper
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/src/test/kotlin/dev/ambon/grpc/GrpcAuthInterceptorTest.kt
+++ b/src/test/kotlin/dev/ambon/grpc/GrpcAuthInterceptorTest.kt
@@ -5,6 +5,7 @@ import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.events.InboundEvent
 import dev.ambon.grpc.proto.EngineServiceGrpcKt
+import dev.ambon.hmacSha256
 import io.grpc.ServerInterceptors
 import io.grpc.Status
 import io.grpc.StatusException
@@ -33,9 +34,9 @@ class GrpcAuthInterceptorTest {
     // ── Unit tests for HMAC and interceptor logic ──────────────────────────────
 
     @Test
-    fun `grpcHmacSha256 produces consistent results`() {
-        val hmac1 = grpcHmacSha256(sharedSecret, "1234567890")
-        val hmac2 = grpcHmacSha256(sharedSecret, "1234567890")
+    fun `hmacSha256 produces consistent results`() {
+        val hmac1 = hmacSha256(sharedSecret, "1234567890")
+        val hmac2 = hmacSha256(sharedSecret, "1234567890")
         assertEquals(hmac1, hmac2)
         assertTrue(hmac1.isNotBlank())
         // SHA256 hex output is 64 chars
@@ -43,16 +44,16 @@ class GrpcAuthInterceptorTest {
     }
 
     @Test
-    fun `grpcHmacSha256 produces different results for different payloads`() {
-        val hmac1 = grpcHmacSha256(sharedSecret, "1234567890")
-        val hmac2 = grpcHmacSha256(sharedSecret, "9876543210")
+    fun `hmacSha256 produces different results for different payloads`() {
+        val hmac1 = hmacSha256(sharedSecret, "1234567890")
+        val hmac2 = hmacSha256(sharedSecret, "9876543210")
         assertNotEquals(hmac1, hmac2)
     }
 
     @Test
-    fun `grpcHmacSha256 produces different results for different secrets`() {
-        val hmac1 = grpcHmacSha256("secret-a", "payload")
-        val hmac2 = grpcHmacSha256("secret-b", "payload")
+    fun `hmacSha256 produces different results for different secrets`() {
+        val hmac1 = hmacSha256("secret-a", "payload")
+        val hmac2 = hmacSha256("secret-b", "payload")
         assertNotEquals(hmac1, hmac2)
     }
 


### PR DESCRIPTION
## Summary

Systematic deduplication pass extracting shared abstractions from repeated patterns across the codebase. All changes are mechanical extractions — no behavioral changes.

### New shared utilities
- **`HmacUtil.kt`** — unified HMAC-SHA256 implementation (was duplicated between `RedisBusInterfaces` and `GrpcAuthInterceptor`)
- **`broadcastToAll` / `broadcastInfoToAll`** in `EngineUtil.kt` — counterparts to the existing `broadcastToRoom` (pattern appeared 20× across 6 files)
- **`sendScopedFeedback` / `sendErrorWithFeedback`** in `HandlerHelpers.kt` — replaces 8 identical private `sendXxxFeedback` wrappers across handler files
- **`EngineContext.movePlayer` / `EngineContext.syncItems`** — convenience extensions eliminating repeated argument threading
- **`createRepository`** generic factory in `MapperSupport.kt` — collapses 3 copy-paste factory files into one-liners
- **`safeReadJson`** promoted from private `PlayersTable` helper to shared `MapperSupport` utility

### Consolidated internal patterns
- **`clearGmcpState`** extracted in `SessionEventHandler` (identical 6-line block appeared twice)
- **`prepareForTransit`** extracted in `PhaseEventHandler` and `InterEngineEventHandler` (combat/regen/status cleanup triple appeared 3×)
- **`GmcpFlushHandler.flushAll()`** added, removing 6 one-liner delegate methods from `GameEngine`

### Handler files updated
`DuelHandler`, `AuctionHandler`, `PetHandler`, `DungeonHandler`, `ReputationHandler`, `PrestigeHandler`, `CurrencyHandler`, `LotteryHandler` — all now use the shared `sendScopedFeedback`/`sendErrorWithFeedback` instead of private wrappers.

## Test plan
- [x] `./gradlew ktlintCheck` passes
- [x] `./gradlew test` passes (full suite)
- [ ] Verify telnet + WebSocket gameplay still works end-to-end
- [ ] Spot-check duel/auction/dungeon/lottery commands produce correct GMCP feedback