### PR TITLE
Dismantle Systems panel and redistribute features to contextual locations

### DIFF
--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -19,8 +19,10 @@ import { HousingPanel } from "./components/panels/HousingPanel";
 import { LeaderboardPanel } from "./components/panels/LeaderboardPanel";
 import { BankPanel } from "./components/panels/BankPanel";
 import { AuctionPanel } from "./components/panels/AuctionPanel";
+import { DungeonPanel } from "./components/panels/DungeonPanel";
+import { LotteryPanel } from "./components/panels/LotteryPanel";
 import { AdminPanel } from "./components/panels/AdminPanel";
-import { SystemsPanel } from "./components/panels/SystemsPanel";
+import { WorldAtmosphereHud } from "./components/WorldAtmosphereHud";
 import { HelpContent } from "./components/HelpContent";
 import { LoginModal } from "./canvas/LoginModal";
 import { CharacterPicker } from "./components/CharacterPicker";
@@ -32,9 +34,17 @@ import { useCommandHistory } from "./hooks/useCommandHistory";
 import { useMiniMap } from "./hooks/useMiniMap";
 import { useQuickbar } from "./hooks/useQuickbar";
 import { canvasCallbacks, gameStateRef, pendingCastRef } from "./canvas/GameStateBridge";
-import type { ChatChannel, FeaturePopoutFocus, PopoutPanel, SystemPanelView } from "./types";
+import type { ChatChannel, FeaturePopoutFocus, PopoutPanel } from "./types";
 import { sortExits, titleCaseWords } from "./utils";
 import "./styles.css";
+
+function TrainerAutoLoad({ onCommand }: { onCommand: (cmd: string) => void }) {
+  const sent = useRef(false);
+  useEffect(() => {
+    if (!sent.current) { sent.current = true; onCommand("train list"); }
+  }, [onCommand]);
+  return <p className="empty-note">Loading trainer data&hellip;</p>;
+}
 
 function App() {
   const resumeTokenRef = useRef<string | null>(null);
@@ -50,7 +60,6 @@ function App() {
   // Ctrl+K command palette
   const [showCommandPalette, setShowCommandPalette] = useState(false);
   const [featureFocus, setFeatureFocus] = useState<FeaturePopoutFocus>(null);
-  const [systemPanelView, setSystemPanelView] = useState<SystemPanelView>("dungeon");
 
   // Staff admin panel + invisibility toggle
   const [showAdminPanel, setShowAdminPanel] = useState(false);
@@ -180,10 +189,7 @@ function App() {
     state.setActivePopout(panel);
   };
 
-  const openSystemsPanel = (view: SystemPanelView) => {
-    setSystemPanelView(view);
-    openPanel("systems");
-  };
+
 
   // Sync state into canvas bridge for PixiJS
   useEffect(() => {
@@ -224,10 +230,11 @@ function App() {
     canvasCallbacks.openShop = () => openPanel("shop");
     canvasCallbacks.openAuction = () => openPanel("auction");
     canvasCallbacks.openPuzzle = () => openPanel("puzzle");
-    canvasCallbacks.openSystems = (view: SystemPanelView) => openSystemsPanel(view);
     canvasCallbacks.openFeatures = (preferredType?: FeaturePopoutFocus) => openPanel("features", preferredType ?? null);
     canvasCallbacks.openBank = () => openPanel("bank");
     canvasCallbacks.openTrainer = () => openPanel("trainer");
+    canvasCallbacks.openDungeon = () => openPanel("dungeon");
+    canvasCallbacks.openLottery = () => openPanel("lottery");
     canvasCallbacks.openMap = () => openPanel("map");
     canvasCallbacks.openRoom = () => openPanel("room");
     canvasCallbacks.openQuests = () => openPanel("quests");
@@ -239,10 +246,11 @@ function App() {
       canvasCallbacks.openShop = null;
       canvasCallbacks.openAuction = null;
       canvasCallbacks.openPuzzle = null;
-      canvasCallbacks.openSystems = null;
       canvasCallbacks.openFeatures = null;
       canvasCallbacks.openBank = null;
       canvasCallbacks.openTrainer = null;
+      canvasCallbacks.openDungeon = null;
+      canvasCallbacks.openLottery = null;
       canvasCallbacks.openMap = null;
       canvasCallbacks.openRoom = null;
       canvasCallbacks.openQuests = null;
@@ -428,23 +436,14 @@ function App() {
       case "leaderboard": return "Leaderboard";
       case "bank": return "Bank";
       case "auction": return "Auction House";
-      case "systems":
-        switch (systemPanelView) {
-          case "dungeon": return "Dungeon";
-          case "duel": return "Dueling";
-          case "lottery": return "Lottery";
-          case "pet": return "Pet";
-          case "prestige": return "Prestige";
-          case "currencies": return "Wallet";
-          case "factions": return "Factions";
-          default: return "Systems";
-        }
+      case "dungeon": return "Dungeon";
+      case "lottery": return "Lottery";
       case "help": return "Command Reference";
       case "room": return state.room.title !== "-" ? state.room.title : "Room Details";
       case "map": return "World Map";
       default: return "";
     }
-  }, [drawerPanel, state.shop?.name, state.trainer?.name, state.room.title, systemPanelView]);
+  }, [drawerPanel, state.shop?.name, state.trainer?.name, state.room.title]);
 
   const sortedExits = useMemo(() => sortExits(state.room.exits), [state.room.exits]);
   const questMarkerCount = useMemo(
@@ -514,19 +513,11 @@ function App() {
             currencies={state.currencies}
             factions={state.factions}
             petState={state.petState}
-            worldTime={state.worldTime}
-            worldWeather={state.worldWeather}
-            worldEvents={state.worldEvents}
-            lotteryInfo={state.lotteryInfo}
-            duelState={state.duelState}
-            duelChallenge={state.duelChallenge}
-            dungeonInfo={state.dungeonInfo}
             prestigeInfo={state.prestigeInfo}
             onDismissQuestNotification={(id) => state.setQuestNotifications((prev) => prev.filter((n) => n.id !== id))}
             onAbandonQuest={(name) => sendCommand(`quest abandon ${name}`)}
             onOpenInventory={() => openPanel("inventory")}
             onOpenEquipment={() => openPanel("equipment")}
-            onOpenSystem={openSystemsPanel}
             onCommand={sendCommand}
             onLogout={() => {
               try {
@@ -616,13 +607,17 @@ function App() {
           />
         )}
 
-        {drawerPanel === "trainer" && state.trainer && (
-          <TrainerPanel
-            trainer={state.trainer}
-            playerLevel={state.vitals.level ?? 1}
-            playerGold={state.vitals.gold}
-            onCommand={sendCommand}
-          />
+        {drawerPanel === "trainer" && (
+          state.trainer ? (
+            <TrainerPanel
+              trainer={state.trainer}
+              playerLevel={state.vitals.level ?? 1}
+              playerGold={state.vitals.gold}
+              onCommand={sendCommand}
+            />
+          ) : (
+            <TrainerAutoLoad onCommand={sendCommand} />
+          )
         )}
 
         {drawerPanel === "spellbook" && (
@@ -654,6 +649,7 @@ function App() {
               sendCommand(".");
             }}
             onClearMessage={() => state.setMailMessage(null)}
+            onCommand={sendCommand}
           />
         )}
 
@@ -717,22 +713,18 @@ function App() {
           />
         )}
 
-        {drawerPanel === "systems" && (
-          <SystemsPanel
-            initialView={systemPanelView}
-            vitals={state.vitals}
-            nearbyPlayers={state.players}
-            currencies={state.currencies}
-            currencyActivity={state.currencyActivity}
-            factions={state.factions}
-            factionActivity={state.factionActivity}
-            petState={state.petState}
-            lotteryInfo={state.lotteryInfo}
-            duelState={state.duelState}
-            duelChallenge={state.duelChallenge}
+        {drawerPanel === "dungeon" && (
+          <DungeonPanel
             dungeonInfo={state.dungeonInfo}
             dungeonCatalog={state.dungeonCatalog}
-            prestigeInfo={state.prestigeInfo}
+            uiFeedbackFeed={state.uiFeedbackFeed}
+            onCommand={sendCommand}
+          />
+        )}
+
+        {drawerPanel === "lottery" && (
+          <LotteryPanel
+            lotteryInfo={state.lotteryInfo}
             uiFeedbackFeed={state.uiFeedbackFeed}
             onCommand={sendCommand}
           />
@@ -1010,6 +1002,15 @@ function App() {
             />
           </div>
         </div>
+      )}
+
+      {/* World atmosphere HUD — time, weather, events on the canvas */}
+      {hasCharacterProfile && (
+        <WorldAtmosphereHud
+          worldTime={state.worldTime}
+          worldWeather={state.worldWeather}
+          worldEvents={state.worldEvents}
+        />
       )}
 
       {/* Staff-only floating controls + admin panel */}

--- a/web-v3/src/canvas/GameStateBridge.ts
+++ b/web-v3/src/canvas/GameStateBridge.ts
@@ -16,7 +16,6 @@ import type {
   RoomState,
   ShopState,
   StatusEffect,
-  SystemPanelView,
   Vitals,
   WorldTime,
   WorldWeather,
@@ -62,10 +61,11 @@ export const canvasCallbacks: {
   openShop: (() => void) | null;
   openAuction: (() => void) | null;
   openPuzzle: (() => void) | null;
-  openSystems: ((view: SystemPanelView) => void) | null;
   openFeatures: ((preferredType?: FeaturePopoutFocus) => void) | null;
   openBank: (() => void) | null;
   openTrainer: (() => void) | null;
+  openDungeon: (() => void) | null;
+  openLottery: (() => void) | null;
   openMap: (() => void) | null;
   openRoom: (() => void) | null;
   openQuests: (() => void) | null;
@@ -79,10 +79,11 @@ export const canvasCallbacks: {
   openShop: null,
   openAuction: null,
   openPuzzle: null,
-  openSystems: null,
   openFeatures: null,
   openBank: null,
   openTrainer: null,
+  openDungeon: null,
+  openLottery: null,
   openMap: null,
   openRoom: null,
   openQuests: null,

--- a/web-v3/src/canvas/scenes/WorldScene.ts
+++ b/web-v3/src/canvas/scenes/WorldScene.ts
@@ -482,7 +482,7 @@ export class WorldScene {
     this.lotteryBadge.eventMode = "static";
     this.lotteryBadge.cursor = "pointer";
     this.lotteryBadge.on("pointerdown", () => {
-      canvasCallbacks.openSystems?.("lottery");
+      canvasCallbacks.openLottery?.();
     });
     this.lotteryBadge.on("pointerover", () => {
       if (this.lotterySprite) this.lotterySprite.alpha = 1;
@@ -510,7 +510,7 @@ export class WorldScene {
     this.dungeonBadge.eventMode = "static";
     this.dungeonBadge.cursor = "pointer";
     this.dungeonBadge.on("pointerdown", () => {
-      canvasCallbacks.openSystems?.("dungeon");
+      canvasCallbacks.openDungeon?.();
     });
     this.dungeonBadge.on("pointerover", () => {
       if (this.dungeonSprite) this.dungeonSprite.alpha = 1;
@@ -538,7 +538,7 @@ export class WorldScene {
     this.duelBadge.eventMode = "static";
     this.duelBadge.cursor = "pointer";
     this.duelBadge.on("pointerdown", () => {
-      canvasCallbacks.openSystems?.("duel");
+      // Duel badge removed — dueling via player context menu
     });
     this.duelBadge.on("pointerover", () => {
       if (this.duelSprite) this.duelSprite.alpha = 1;
@@ -932,10 +932,10 @@ export class WorldScene {
       if (this.dungeonBadge) this.dungeonBadge.visible = hasDungeon;
     }
 
-    const hasDuel = roomHasSurfaceWidget(state.room.id, "duel");
-    if (hasDuel !== this.duelVisible) {
-      this.duelVisible = hasDuel;
-      if (this.duelBadge) this.duelBadge.visible = hasDuel;
+    // Duel badge removed — dueling is accessed via player context menu
+    if (this.duelVisible) {
+      this.duelVisible = false;
+      if (this.duelBadge) this.duelBadge.visible = false;
     }
 
     // Puzzle badge visibility — driven by Puzzle.List GMCP (state.puzzle non-null)
@@ -1228,7 +1228,21 @@ export class WorldScene {
     // Room-feature badges — right side, stacked vertically below description area
     const badgeX = w - 70;
     const badgeStartY = h * 0.35;
-    const badgeSpacing = h * 0.13;
+    // Count visible badges to compute adaptive spacing
+    const visibleBadgeCount = [
+      this.shopBadge.visible, this.auctionBadge.visible,
+      this.stationBadge.visible, this.trainerBadge.visible,
+      this.bankBadge?.visible, this.tavernBadge?.visible,
+      this.lotteryBadge?.visible, this.dungeonBadge?.visible,
+      this.duelBadge?.visible, this.puzzleBadge?.visible,
+      this.doorBadge?.visible, this.containerBadge?.visible,
+      this.leverBadge?.visible,
+    ].filter(Boolean).length;
+    const availableHeight = h * 0.58; // from 35% to ~93% of viewport
+    const maxSpacing = h * 0.13;
+    const badgeSpacing = visibleBadgeCount > 1
+      ? Math.min(maxSpacing, availableHeight / visibleBadgeCount)
+      : maxSpacing;
     let badgeSlot = 0;
 
     if (this.shopBadge.visible) {

--- a/web-v3/src/canvas/systems/EntityPopout.ts
+++ b/web-v3/src/canvas/systems/EntityPopout.ts
@@ -130,6 +130,7 @@ export class EntityPopout {
   showPlayer(name: string, level: number) {
     const actions: PopoutAction[] = [
       { label: "Look", command: `look ${name}`, color: 0x64b5f6 },
+      { label: "\u2694 Duel", command: `duel ${name}`, color: 0xd4888a },
       { label: "Tell", command: `__prefill__:tell ${name} `, color: 0xb5bd68 },
       { label: "Whisper", command: `__prefill__:whisper ${name} `, color: 0xa8a8a8 },
       { label: "Give", command: `__prefill__:give `, color: 0xf0c674 },

--- a/web-v3/src/components/WorldAtmosphereHud.tsx
+++ b/web-v3/src/components/WorldAtmosphereHud.tsx
@@ -1,0 +1,81 @@
+import type { WorldEvent, WorldTime, WorldWeather } from "../types";
+
+interface Props {
+  worldTime: WorldTime | null;
+  worldWeather: WorldWeather | null;
+  worldEvents: WorldEvent[];
+}
+
+function periodIcon(period: string): string {
+  switch (period) {
+    case "DAWN": return "\u263C";
+    case "DAY": return "\u2600";
+    case "DUSK": return "\u263D";
+    case "NIGHT": return "\u263E";
+    default: return "\u2600";
+  }
+}
+
+function periodLabel(period: string): string {
+  switch (period) {
+    case "DAWN": return "Dawn";
+    case "DAY": return "Day";
+    case "DUSK": return "Dusk";
+    case "NIGHT": return "Night";
+    default: return period;
+  }
+}
+
+function weatherIcon(weather: string): string {
+  switch (weather) {
+    case "RAIN": return "\u2602";
+    case "STORM": return "\u26A1";
+    case "FOG": return "\u2601";
+    case "SNOW": return "\u2744";
+    case "WIND": return "\u2634";
+    default: return "";
+  }
+}
+
+function weatherLabel(weather: string): string {
+  switch (weather) {
+    case "CLEAR": return "Clear";
+    case "RAIN": return "Rain";
+    case "STORM": return "Storm";
+    case "FOG": return "Fog";
+    case "SNOW": return "Snow";
+    case "WIND": return "Wind";
+    default: return weather;
+  }
+}
+
+export function WorldAtmosphereHud({ worldTime, worldWeather, worldEvents }: Props) {
+  const hasTime = worldTime !== null;
+  const hasWeather = worldWeather !== null && worldWeather.weather !== "CLEAR";
+  const hasEvents = worldEvents.length > 0;
+
+  if (!hasTime && !hasWeather && !hasEvents) return null;
+
+  return (
+    <div className="atmosphere-hud" aria-label="World atmosphere">
+      {hasTime && (
+        <span className="atmosphere-hud-chip" title={`${periodLabel(worldTime.period)} — ${String(worldTime.hour).padStart(2, "0")}:${String(worldTime.minute).padStart(2, "0")}`}>
+          <span className="atmosphere-hud-icon" aria-hidden="true">{periodIcon(worldTime.period)}</span>
+          <span className="atmosphere-hud-label">{String(worldTime.hour).padStart(2, "0")}:{String(worldTime.minute).padStart(2, "0")}</span>
+        </span>
+      )}
+      {hasWeather && (
+        <span className="atmosphere-hud-chip" title={worldWeather.description}>
+          <span className="atmosphere-hud-icon" aria-hidden="true">{worldWeather.icon || weatherIcon(worldWeather.weather)}</span>
+          <span className="atmosphere-hud-label">{weatherLabel(worldWeather.weather)}</span>
+        </span>
+      )}
+      {worldEvents.map((evt) => (
+        <span key={evt.id} className="atmosphere-hud-chip atmosphere-hud-chip-event" title={evt.description}>
+          <span className="atmosphere-hud-icon" aria-hidden="true">&#x2726;</span>
+          <span className="atmosphere-hud-label">{evt.name}</span>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/web-v3/src/components/panels/CharacterPanel.tsx
+++ b/web-v3/src/components/panels/CharacterPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import type { AchievementData, CharacterInfo, CharStats, CurrencyBalance, DuelChallenge, DuelState, DungeonInfo, FactionStanding, GroupInfo, GuildInfo, LotteryInfo, PetState, PrestigeInfo, QuestEntry, QuestNotification, SpriteEntry, SpriteList, StatusEffect, StatusVarLabels, SystemPanelView, Vitals, WorldEvent, WorldTime, WorldWeather } from "../../types";
+import type { AchievementData, CharacterInfo, CharStats, CurrencyBalance, FactionStanding, GroupInfo, GuildInfo, PetState, PrestigeInfo, QuestEntry, QuestNotification, SpriteEntry, SpriteList, StatusEffect, StatusVarLabels, Vitals } from "../../types";
 import { AchievementsTabIcon, Bar, CharacterAvatarIcon, EffectsTabIcon, EquipmentIcon, FactionsTabIcon, QuestsTabIcon, ScoreTabIcon, StatsTabIcon, VitalsTabIcon, WearingIcon } from "../Icons";
 
 type DetailTab = "vitals" | "effects" | "achievements" | "quests" | "stats" | "score" | "factions";
@@ -17,17 +17,6 @@ function factionTierClass(tier: string): "positive" | "neutral" | "negative" {
     default:
       return "neutral";
   }
-}
-
-function formatDrawingCountdown(ms: number): string {
-  if (ms <= 0) return "Drawing soon!";
-  const totalSec = Math.floor(ms / 1000);
-  const hours = Math.floor(totalSec / 3600);
-  const minutes = Math.floor((totalSec % 3600) / 60);
-  const seconds = totalSec % 60;
-  if (hours > 0) return `${hours}h ${minutes}m`;
-  if (minutes > 0) return `${minutes}m ${seconds}s`;
-  return `${seconds}s`;
 }
 
 interface CharacterPanelProps {
@@ -56,19 +45,11 @@ interface CharacterPanelProps {
   currencies: CurrencyBalance[];
   factions: FactionStanding[];
   petState: PetState | null;
-  worldTime: WorldTime | null;
-  worldWeather: WorldWeather | null;
-  worldEvents: WorldEvent[];
-  lotteryInfo: LotteryInfo | null;
-  duelState: DuelState | null;
-  duelChallenge: DuelChallenge | null;
-  dungeonInfo: DungeonInfo | null;
   prestigeInfo: PrestigeInfo | null;
   onDismissQuestNotification: (id: string) => void;
   onAbandonQuest: (questName: string) => void;
   onOpenInventory: () => void;
   onOpenEquipment: () => void;
-  onOpenSystem: (view: SystemPanelView) => void;
   onCommand: (command: string) => void;
   onLogout: () => void;
 }
@@ -99,19 +80,11 @@ export function CharacterPanel({
   currencies,
   factions,
   petState,
-  worldTime,
-  worldWeather,
-  worldEvents,
-  lotteryInfo,
-  duelState,
-  duelChallenge,
-  dungeonInfo,
   prestigeInfo,
   onDismissQuestNotification,
   onAbandonQuest,
   onOpenInventory,
   onOpenEquipment,
-  onOpenSystem,
   onCommand,
   onLogout,
 }: CharacterPanelProps) {
@@ -120,6 +93,8 @@ export function CharacterPanel({
   const [showSpriteSelector, setShowSpriteSelector] = useState(false);
   const [showDescriptionEditor, setShowDescriptionEditor] = useState(false);
   const [descriptionDraft, setDescriptionDraft] = useState("");
+  const [petNameDraft, setPetNameDraft] = useState(petState?.name ?? "");
+  const [prevPetName, setPrevPetName] = useState(petState?.name ?? "");
 
   const totalAchievements = achievements.completed.length + achievements.inProgress.length;
   const unlockedTitles = useMemo(
@@ -140,6 +115,12 @@ export function CharacterPanel({
     return grouped;
   }, [spriteList.sprites]);
 
+  const currentPetName = petState?.name ?? "";
+  if (currentPetName !== prevPetName) {
+    setPrevPetName(currentPetName);
+    setPetNameDraft(currentPetName);
+  }
+
   // Auto-dismiss quest notifications after 6 seconds
   useEffect(() => {
     if (questNotifications.length === 0) return;
@@ -159,15 +140,6 @@ export function CharacterPanel({
           </h2>
         </div>
         <div className="panel-action-row">
-          <button
-            type="button"
-            className="panel-action-button"
-            onClick={() => onOpenSystem("currencies")}
-            title="Open systems"
-            aria-label="Open systems"
-          >
-            Systems
-          </button>
           <button
             type="button"
             className="panel-action-button panel-action-button-icon"
@@ -345,6 +317,9 @@ export function CharacterPanel({
                 <div><dt>Level</dt><dd>{vitals.level ?? character.level ?? "-"}</dd></div>
                 <div><dt>Total XP</dt><dd>{vitals.xp.toLocaleString()}</dd></div>
                 <div><dt>Gold</dt><dd>{vitals.gold.toLocaleString()}</dd></div>
+                {currencies.map((c) => (
+                  <div key={c.id}><dt title={c.name}>{c.abbreviation}</dt><dd>{c.balance.toLocaleString()}</dd></div>
+                ))}
               </dl>
             </>
           ) : (
@@ -752,28 +727,9 @@ export function CharacterPanel({
                         </div>
                       )}
                     </div>
-                    {currencies.length > 0 && (
-                      <div className="score-currencies">
-                        <div className="score-section-header">
-                          <p className="score-currencies-label">Currencies</p>
-                          <button type="button" className="soft-button score-open-btn" onClick={() => onOpenSystem("currencies")}>Open Wallet</button>
-                        </div>
-                        <dl className="score-currencies-grid">
-                          {currencies.map((c) => (
-                            <div key={c.id}>
-                              <dt title={c.abbreviation}>{c.name}</dt>
-                              <dd>{c.balance.toLocaleString()}</dd>
-                            </div>
-                          ))}
-                        </dl>
-                      </div>
-                    )}
                     {((vitals.prestigeLevel ?? 0) > 0 || vitals.prestigeNextCost != null) && (
                       <div className="score-prestige">
-                        <div className="score-section-header">
-                          <p className="score-prestige-label">Prestige</p>
-                          <button type="button" className="soft-button score-open-btn" onClick={() => onOpenSystem("prestige")}>Open</button>
-                        </div>
+                        <p className="score-prestige-label">Prestige</p>
                         <dl className="score-prestige-grid">
                           <div>
                             <dt>Rank</dt>
@@ -806,123 +762,17 @@ export function CharacterPanel({
                           >
                             Prestige Up
                           </button>
-                          <button
-                            type="button"
-                            className="soft-button score-prestige-btn"
-                            onClick={() => onOpenSystem("prestige")}
-                            title="Open the full prestige view"
-                          >
-                            Open Details
-                          </button>
                         </div>
-                      </div>
-                    )}
-                    {lotteryInfo && (
-                      <div className="score-lottery">
-                        <div className="score-section-header">
-                          <p className="score-lottery-label">Lottery</p>
-                          <button type="button" className="soft-button score-open-btn" onClick={() => onOpenSystem("lottery")}>Play</button>
-                        </div>
-                        <dl className="score-lottery-grid">
-                          <div>
-                            <dt>Jackpot</dt>
-                            <dd className="score-lottery-jackpot">{lotteryInfo.jackpot.toLocaleString()} gold</dd>
-                          </div>
-                          <div>
-                            <dt>Your Tickets</dt>
-                            <dd>{lotteryInfo.playerTickets} / {lotteryInfo.totalTickets}</dd>
-                          </div>
-                          <div>
-                            <dt>Next Drawing</dt>
-                            <dd>{formatDrawingCountdown(lotteryInfo.nextDrawingMs)}</dd>
-                          </div>
-                        </dl>
-                        <div className="score-lottery-actions">
-                          <button
-                            type="button"
-                            className="score-lottery-btn"
-                            onClick={() => onCommand("lottery buy 1")}
-                          >
-                            Buy Ticket
-                          </button>
-                          <button
-                            type="button"
-                            className="score-lottery-btn score-lottery-btn-secondary"
-                            onClick={() => onCommand("lottery")}
-                          >
-                            Check Info
-                          </button>
-                        </div>
-                      </div>
-                    )}
-                    {duelState?.active && (
-                      <div className="score-duel">
-                        <div className="score-section-header">
-                          <p className="score-section-label">Duel</p>
-                          <button type="button" className="soft-button score-open-btn" onClick={() => onOpenSystem("duel")}>Open</button>
-                        </div>
-                        <p className="score-section-value">Fighting <strong>{duelState.opponentName ?? "unknown"}</strong></p>
-                      </div>
-                    )}
-                    {duelChallenge && !duelState?.active && (
-                      <div className="score-duel">
-                        <div className="score-section-header">
-                          <p className="score-section-label">Duel Challenge</p>
-                          <button type="button" className="soft-button score-open-btn" onClick={() => onOpenSystem("duel")}>Open</button>
-                        </div>
-                        {duelChallenge.direction === "incoming" ? (
-                          <div className="score-duel-challenge">
-                            <p className="score-section-value"><strong>{duelChallenge.challengerName}</strong> challenges you!</p>
-                            <div className="score-duel-actions">
-                              <button type="button" className="soft-button" onClick={() => onCommand("duel accept")}>Accept</button>
-                              <button type="button" className="soft-button" onClick={() => onCommand("duel decline")}>Decline</button>
-                            </div>
-                          </div>
-                        ) : (
-                          <p className="score-section-value">Challenging <strong>{duelChallenge.targetName}</strong>&hellip;</p>
+                        {prestigeInfo && prestigeInfo.perks.length > 0 && (
+                          <ul className="prestige-perk-list">
+                            {prestigeInfo.perks.map((perk) => (
+                              <li key={perk.rank} className={`prestige-perk-item ${perk.earned ? "prestige-perk-earned" : "prestige-perk-locked"}`}>
+                                <span className="prestige-perk-rank">{perk.earned ? "\u2713" : perk.rank}</span>
+                                <span className="prestige-perk-desc">{perk.description}</span>
+                              </li>
+                            ))}
+                          </ul>
                         )}
-                      </div>
-                    )}
-                    {dungeonInfo?.active && (
-                      <div className="score-dungeon">
-                        <div className="score-section-header">
-                          <p className="score-section-label">Dungeon</p>
-                          <button type="button" className="soft-button score-open-btn" onClick={() => onOpenSystem("dungeon")}>Open</button>
-                        </div>
-                        <dl className="score-dungeon-grid">
-                          {dungeonInfo.name && (
-                            <div><dt>Name</dt><dd>{dungeonInfo.name}</dd></div>
-                          )}
-                          {dungeonInfo.difficulty && (
-                            <div><dt>Difficulty</dt><dd>{dungeonInfo.difficulty}</dd></div>
-                          )}
-                          {dungeonInfo.totalRooms != null && (
-                            <div><dt>Rooms</dt><dd>{dungeonInfo.totalRooms}</dd></div>
-                          )}
-                          {dungeonInfo.memberCount != null && (
-                            <div><dt>Party</dt><dd>{dungeonInfo.memberCount}</dd></div>
-                          )}
-                        </dl>
-                        {dungeonInfo.completed && <p className="score-dungeon-complete">Boss defeated!</p>}
-                        <div className="score-dungeon-actions">
-                          <button type="button" className="soft-button" onClick={() => onCommand("dungeon leave")}>Leave Dungeon</button>
-                        </div>
-                      </div>
-                    )}
-                    {prestigeInfo && prestigeInfo.perks.length > 0 && (
-                      <div className="score-prestige-perks">
-                        <div className="score-section-header">
-                          <p className="score-section-label">Prestige Perks</p>
-                          <button type="button" className="soft-button score-open-btn" onClick={() => onOpenSystem("prestige")}>Open</button>
-                        </div>
-                        <ul className="prestige-perk-list">
-                          {prestigeInfo.perks.map((perk) => (
-                            <li key={perk.rank} className={`prestige-perk-item ${perk.earned ? "prestige-perk-earned" : "prestige-perk-locked"}`}>
-                              <span className="prestige-perk-rank">{perk.earned ? "\u2713" : perk.rank}</span>
-                              <span className="prestige-perk-desc">{perk.description}</span>
-                            </li>
-                          ))}
-                        </ul>
                       </div>
                     )}
                   </div>
@@ -943,7 +793,6 @@ export function CharacterPanel({
                   <>
                     <div className="score-section-header score-section-header-spaced">
                       <p className="score-section-label">Faction Journal</p>
-                      <button type="button" className="soft-button score-open-btn" onClick={() => onOpenSystem("factions")}>Open</button>
                     </div>
                     <ul className="factions-list">
                       {factions.map((f) => (
@@ -1003,13 +852,24 @@ export function CharacterPanel({
               )}
             </dl>
             <div className="pet-actions">
-              <button
-                type="button"
-                className="soft-button"
-                onClick={() => onOpenSystem("pet")}
-              >
-                Manage Pet
-              </button>
+              <div className="pet-rename-row">
+                <input
+                  type="text"
+                  className="pet-rename-input"
+                  value={petNameDraft}
+                  onChange={(e) => setPetNameDraft(e.target.value)}
+                  placeholder="New name"
+                  maxLength={24}
+                />
+                <button
+                  type="button"
+                  className="soft-button"
+                  disabled={petNameDraft.trim().length === 0 || petNameDraft.trim() === petState.name}
+                  onClick={() => onCommand(`pet name ${petNameDraft.trim()}`)}
+                >
+                  Rename
+                </button>
+              </div>
               <button
                 type="button"
                 className="soft-button pet-dismiss-btn"
@@ -1018,33 +878,6 @@ export function CharacterPanel({
                 Dismiss
               </button>
             </div>
-          </article>
-        )}
-
-        {hasCharacterProfile && (worldTime || worldWeather || worldEvents.length > 0) && (
-          <article className="subpanel world-atmosphere-subpanel">
-            <p className="world-atmosphere-heading">World</p>
-            {worldTime && (
-              <div className="world-atmosphere-row">
-                <span className="world-atmosphere-icon" aria-hidden="true">{periodIcon(worldTime.period)}</span>
-                <span className="world-atmosphere-label">{periodLabel(worldTime.period)}</span>
-                <span className="world-atmosphere-value">{String(worldTime.hour).padStart(2, "0")}:{String(worldTime.minute).padStart(2, "0")}</span>
-              </div>
-            )}
-            {worldWeather && worldWeather.weather !== "CLEAR" && (
-              <div className="world-atmosphere-row" title={worldWeather.description}>
-                <span className="world-atmosphere-icon" aria-hidden="true">
-                  {worldWeather.icon || weatherIcon(worldWeather.weather)}
-                </span>
-                <span className="world-atmosphere-label">{weatherLabel(worldWeather.weather)}</span>
-              </div>
-            )}
-            {worldEvents.length > 0 && worldEvents.map((evt) => (
-              <div key={evt.id} className="world-atmosphere-row world-atmosphere-event" title={evt.description}>
-                <span className="world-atmosphere-icon world-atmosphere-event-icon" aria-hidden="true">&#x2726;</span>
-                <span className="world-atmosphere-label">{evt.name}</span>
-              </div>
-            ))}
           </article>
         )}
 
@@ -1060,45 +893,3 @@ export function CharacterPanel({
   );
 }
 
-function periodIcon(period: string): string {
-  switch (period) {
-    case "DAWN": return "☼";
-    case "DAY": return "☀";
-    case "DUSK": return "☽";
-    case "NIGHT": return "☾";
-    default: return "☀";
-  }
-}
-
-function periodLabel(period: string): string {
-  switch (period) {
-    case "DAWN": return "Dawn";
-    case "DAY": return "Day";
-    case "DUSK": return "Dusk";
-    case "NIGHT": return "Night";
-    default: return period;
-  }
-}
-
-function weatherIcon(weather: string): string {
-  switch (weather) {
-    case "RAIN": return "☂";
-    case "STORM": return "⚡";
-    case "FOG": return "☁";
-    case "SNOW": return "❄";
-    case "WIND": return "☴";
-    default: return "";
-  }
-}
-
-function weatherLabel(weather: string): string {
-  switch (weather) {
-    case "CLEAR": return "Clear";
-    case "RAIN": return "Rain";
-    case "STORM": return "Storm";
-    case "FOG": return "Fog";
-    case "SNOW": return "Snow";
-    case "WIND": return "Wind";
-    default: return weather;
-  }
-}

--- a/web-v3/src/components/panels/DungeonPanel.tsx
+++ b/web-v3/src/components/panels/DungeonPanel.tsx
@@ -1,0 +1,114 @@
+import { useMemo, useState } from "react";
+import type { DungeonCatalogEntry, DungeonInfo, UiFeedbackEntry } from "../../types";
+
+interface DungeonPanelProps {
+  dungeonInfo: DungeonInfo | null;
+  dungeonCatalog: DungeonCatalogEntry[];
+  uiFeedbackFeed: UiFeedbackEntry[];
+  onCommand: (command: string) => void;
+}
+
+export function DungeonPanel({ dungeonInfo, dungeonCatalog, uiFeedbackFeed, onCommand }: DungeonPanelProps) {
+  const [selectedDifficulty, setSelectedDifficulty] = useState("normal");
+
+  const activeFeedback = useMemo(
+    () => [...uiFeedbackFeed].reverse().find((e) => e.scope === "dungeon") ?? null,
+    [uiFeedbackFeed],
+  );
+
+  const availableDungeons = useMemo(
+    () => [...dungeonCatalog].sort((a, b) => a.minLevel - b.minLevel || a.name.localeCompare(b.name)),
+    [dungeonCatalog],
+  );
+
+  return (
+    <div className="dungeon-panel">
+      <div className="panel-header">
+        <span className="panel-title">Dungeons</span>
+      </div>
+
+      {activeFeedback && (
+        <p className={`systems-local-message systems-local-message-${activeFeedback.type}`}>
+          {activeFeedback.message}
+        </p>
+      )}
+
+      {dungeonInfo?.active ? (
+        <article className="systems-card systems-dungeon-active">
+          <div className="systems-card-header">
+            <div>
+              <p className="systems-card-label">Active Run</p>
+              <h4>{dungeonInfo.name ?? "Dungeon in progress"}</h4>
+            </div>
+            {dungeonInfo.completed && <span className="systems-pill systems-pill-success">Completed</span>}
+          </div>
+          <dl className="systems-stat-grid">
+            <div><dt>Difficulty</dt><dd>{dungeonInfo.difficulty ?? "Unknown"}</dd></div>
+            <div><dt>Party</dt><dd>{dungeonInfo.memberCount ?? 1}</dd></div>
+            <div><dt>Rooms</dt><dd>{dungeonInfo.totalRooms ?? "-"}</dd></div>
+            <div><dt>Status</dt><dd>{dungeonInfo.completed ? "Boss defeated" : "In progress"}</dd></div>
+          </dl>
+          <div className="systems-action-row">
+            <button type="button" className="systems-primary-btn" onClick={() => onCommand("dungeon enter resume")}>
+              Resume Run
+            </button>
+            <button type="button" className="systems-secondary-btn" onClick={() => onCommand("dungeon leave")}>
+              Leave Dungeon
+            </button>
+          </div>
+        </article>
+      ) : (
+        <div className="systems-card-list">
+          {availableDungeons.length === 0 && (
+            <article className="systems-card">
+              <p className="systems-card-copy">No dungeon catalog is available from the server right now.</p>
+            </article>
+          )}
+          {availableDungeons.map((dungeon) => {
+            const availableDifficulties = dungeon.difficulties.length > 0
+              ? dungeon.difficulties
+              : [{ id: "normal", label: "Normal", summary: "Standard dungeon pacing and rewards." }];
+            const chosenDifficulty = availableDifficulties.some((d) => d.id === selectedDifficulty)
+              ? selectedDifficulty
+              : availableDifficulties[0].id;
+            return (
+              <article key={dungeon.id} className="systems-card">
+                <div className="systems-card-header">
+                  <div>
+                    <p className="systems-card-label">Available Dungeon</p>
+                    <h4>{dungeon.name}</h4>
+                  </div>
+                  <span className="systems-pill">Min Lv {dungeon.minLevel}</span>
+                </div>
+                <p className="systems-card-copy">{dungeon.description}</p>
+                {dungeon.portalHint && <p className="systems-detail-line">{dungeon.portalHint}</p>}
+                <div className="systems-choice-list">
+                  {availableDifficulties.map((difficulty) => (
+                    <button
+                      key={difficulty.id}
+                      type="button"
+                      className={`systems-choice-card ${chosenDifficulty === difficulty.id ? "systems-choice-card-active" : ""}`}
+                      onClick={() => setSelectedDifficulty(difficulty.id)}
+                    >
+                      <span className="systems-choice-title">{difficulty.label}</span>
+                      <span className="systems-choice-copy">{difficulty.summary}</span>
+                    </button>
+                  ))}
+                </div>
+                <div className="systems-action-row">
+                  <button
+                    type="button"
+                    className="systems-primary-btn"
+                    onClick={() => onCommand(`dungeon enter ${dungeon.id} ${chosenDifficulty}`)}
+                  >
+                    Enter Dungeon
+                  </button>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web-v3/src/components/panels/HousingPanel.tsx
+++ b/web-v3/src/components/panels/HousingPanel.tsx
@@ -36,7 +36,7 @@ export function HousingPanel({
         <div className="housing-empty-state">
           <span className="housing-empty-icon">{"\u{1F3E0}"}</span>
           <p className="empty-note">You don't own a house yet.</p>
-          <p className="housing-hint">Visit a housing broker to purchase one, or type <code>house buy</code> at a broker.</p>
+          <p className="housing-hint">Visit a housing broker to purchase one.</p>
         </div>
       </div>
     );

--- a/web-v3/src/components/panels/LeaderboardPanel.tsx
+++ b/web-v3/src/components/panels/LeaderboardPanel.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import type { LeaderboardData } from "../../types";
 
 const CATEGORIES = [
@@ -14,6 +15,17 @@ interface Props {
 }
 
 export function LeaderboardPanel({ leaderboard, onCommand }: Props) {
+  const autoLoaded = useRef(false);
+
+  useEffect(() => {
+    if (!autoLoaded.current) {
+      autoLoaded.current = true;
+      for (const c of CATEGORIES) {
+        onCommand(`leaderboard ${c.key}`);
+      }
+    }
+  }, [onCommand]);
+
   const activeCats = CATEGORIES.filter((c) => {
     const data = leaderboard[c.key];
     return data && data.entries.length > 0;
@@ -27,8 +39,7 @@ export function LeaderboardPanel({ leaderboard, onCommand }: Props) {
 
       {activeCats.length === 0 ? (
         <div className="leaderboard-empty">
-          <p>No leaderboard data yet.</p>
-          <p>Use the leaderboard command to load rankings.</p>
+          <p>Loading rankings&hellip;</p>
           <div className="leaderboard-cat-buttons">
             {CATEGORIES.map((c) => (
               <button

--- a/web-v3/src/components/panels/LotteryPanel.tsx
+++ b/web-v3/src/components/panels/LotteryPanel.tsx
@@ -1,0 +1,106 @@
+import { useMemo, useState } from "react";
+import { LOTTERY_SETTINGS } from "../../featureMetadata";
+import type { LotteryInfo, UiFeedbackEntry } from "../../types";
+
+interface LotteryPanelProps {
+  lotteryInfo: LotteryInfo | null;
+  uiFeedbackFeed: UiFeedbackEntry[];
+  onCommand: (command: string) => void;
+}
+
+function formatCountdown(ms: number): string {
+  if (ms <= 0) return "Drawing soon";
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
+}
+
+export function LotteryPanel({ lotteryInfo, uiFeedbackFeed, onCommand }: LotteryPanelProps) {
+  const [ticketDraft, setTicketDraft] = useState("1");
+
+  const activeFeedback = useMemo(
+    () => [...uiFeedbackFeed].reverse().find((e) => e.scope === "lottery") ?? null,
+    [uiFeedbackFeed],
+  );
+
+  return (
+    <div className="lottery-panel">
+      <div className="panel-header">
+        <span className="panel-title">Lottery</span>
+      </div>
+
+      {activeFeedback && (
+        <p className={`systems-local-message systems-local-message-${activeFeedback.type}`}>
+          {activeFeedback.message}
+        </p>
+      )}
+
+      {lotteryInfo ? (
+        <article className="systems-card">
+          <div className="systems-card-header">
+            <div>
+              <p className="systems-card-label">Current Drawing</p>
+              <h4>{lotteryInfo.jackpot.toLocaleString()} gold jackpot</h4>
+            </div>
+            <span className="systems-pill">{formatCountdown(lotteryInfo.nextDrawingMs)}</span>
+          </div>
+          <dl className="systems-stat-grid">
+            <div><dt>Your Tickets</dt><dd>{lotteryInfo.playerTickets}</dd></div>
+            <div><dt>Total Tickets</dt><dd>{lotteryInfo.totalTickets}</dd></div>
+            <div><dt>Ticket Cost</dt><dd>{LOTTERY_SETTINGS.ticketCost} gold</dd></div>
+            <div><dt>Per-Player Limit</dt><dd>{LOTTERY_SETTINGS.maxTicketsPerPlayer}</dd></div>
+          </dl>
+          <div className="systems-choice-list systems-choice-list-compact">
+            {[1, 3, 5].map((count) => (
+              <button
+                key={count}
+                type="button"
+                className="systems-choice-card"
+                onClick={() => onCommand(`lottery buy ${count}`)}
+              >
+                <span className="systems-choice-title">{count} ticket{count === 1 ? "" : "s"}</span>
+                <span className="systems-choice-copy">{(count * LOTTERY_SETTINGS.ticketCost).toLocaleString()} gold</span>
+              </button>
+            ))}
+          </div>
+          <div className="systems-action-row">
+            <input
+              type="number"
+              min={1}
+              max={LOTTERY_SETTINGS.maxTicketsPerPlayer}
+              step={1}
+              inputMode="numeric"
+              className="systems-number-input"
+              value={ticketDraft}
+              onChange={(event) => setTicketDraft(event.target.value)}
+            />
+            <button
+              type="button"
+              className="systems-primary-btn"
+              onClick={() => {
+                const count = Number(ticketDraft);
+                if (!Number.isSafeInteger(count) || count < 1) return;
+                onCommand(`lottery buy ${count}`);
+              }}
+            >
+              Buy Custom Quantity
+            </button>
+            <button
+              type="button"
+              className="systems-secondary-btn"
+              onClick={() => onCommand("lottery")}
+            >
+              Refresh Info
+            </button>
+          </div>
+        </article>
+      ) : (
+        <p className="empty-note">Lottery information is not available right now.</p>
+      )}
+    </div>
+  );
+}

--- a/web-v3/src/components/panels/MailPanel.tsx
+++ b/web-v3/src/components/panels/MailPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { MailEntry, MailMessage } from "../../types";
 
 interface MailPanelProps {
@@ -10,6 +10,7 @@ interface MailPanelProps {
   onDeleteMessage: (index: number) => void;
   onCompose: (recipient: string, body: string) => void;
   onClearMessage: () => void;
+  onCommand: (cmd: string) => void;
 }
 
 function formatDate(epochMs: number): string {
@@ -27,11 +28,20 @@ export function MailPanel({
   onDeleteMessage,
   onCompose,
   onClearMessage,
+  onCommand,
 }: MailPanelProps) {
   const [composeTarget, setComposeTarget] = useState("");
   const [composeBody, setComposeBody] = useState("");
   const [showCompose, setShowCompose] = useState(false);
   const [confirmDeleteIndex, setConfirmDeleteIndex] = useState<number | null>(null);
+  const autoLoaded = useRef(false);
+
+  useEffect(() => {
+    if (connected && hasCharacterProfile && inbox === null && !autoLoaded.current) {
+      autoLoaded.current = true;
+      onCommand("mail");
+    }
+  }, [connected, hasCharacterProfile, inbox, onCommand]);
 
   if (!connected) {
     return <p className="empty-note">Connect to view mail.</p>;

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -10759,6 +10759,49 @@ body {
   color: var(--color-primary-lavender);
 }
 
+/* ---------- Atmosphere HUD (canvas overlay, top-left) ---------- */
+.atmosphere-hud {
+  position: fixed;
+  top: calc(env(safe-area-inset-top, 0px) + 12px);
+  left: calc(env(safe-area-inset-left, 0px) + 12px);
+  z-index: 11;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  pointer-events: none;
+}
+
+.atmosphere-hud-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: var(--radius-md);
+  background: rgb(10 12 20 / 55%);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgb(255 255 255 / 8%);
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  font-weight: 500;
+  pointer-events: auto;
+  white-space: nowrap;
+}
+
+.atmosphere-hud-icon {
+  font-size: 0.9rem;
+  flex-shrink: 0;
+}
+
+.atmosphere-hud-label {
+  font-variant-numeric: tabular-nums;
+}
+
+.atmosphere-hud-chip-event {
+  color: var(--color-primary-lavender);
+  border-color: rgb(178 148 187 / 20%);
+}
+
 /* ---------- Character panel logout ---------- */
 .character-logout-row {
   display: flex;
@@ -13648,8 +13691,8 @@ html:has(.game-shell),
 /* Staff-only floating action buttons — top-right corner, below the minimap */
 .staff-fab {
   position: fixed;
-  top: calc(env(safe-area-inset-top, 0) + 220px);
-  right: calc(env(safe-area-inset-right, 0) + 12px);
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 140px);
+  left: calc(env(safe-area-inset-left, 0px) + 12px);
   z-index: 12;
   display: flex;
   flex-direction: column;

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -1,4 +1,4 @@
-export type PopoutPanel = "map" | "inventory" | "equipment" | "room" | "help" | "character" | "chat" | "shop" | "spellbook" | "quests" | "mail" | "crafting" | "housing" | "leaderboard" | "trainer" | "bank" | "auction" | "systems" | "puzzle" | "features" | null;
+export type PopoutPanel = "map" | "inventory" | "equipment" | "room" | "help" | "character" | "chat" | "shop" | "spellbook" | "quests" | "mail" | "crafting" | "housing" | "leaderboard" | "trainer" | "bank" | "auction" | "dungeon" | "lottery" | "puzzle" | "features" | null;
 export type SystemPanelView = "dungeon" | "duel" | "lottery" | "pet" | "prestige" | "currencies" | "factions";
 export type ChatChannel = "say" | "tell" | "gossip" | "shout" | "ooc" | "gtell" | "gchat";
 export type SocialTab = "chat" | "friends" | "guild" | "group" | "who";


### PR DESCRIPTION
## Summary

- **Removed the Systems panel** — its 7 tabs (dungeon, duel, lottery, pet, prestige, wallet, factions) are redistributed to contextual locations throughout the UI
- **Dungeon & Lottery** → standalone room-level kiosk panels (`DungeonPanel.tsx`, `LotteryPanel.tsx`) opened from canvas badges
- **Duel** → "Duel" action added to player context menu (EntityPopout); canvas duel badge removed
- **Currencies** → displayed inline near gold in character identity stat grid
- **Prestige** → self-contained in character score tab with merged perks list (no more "Open Details" link)
- **Factions** → self-contained in character factions tab (removed "Open" link to Systems)
- **Pet** → inline rename/dismiss controls in character card (no more "Manage Pet" → Systems link)
- **Time/Weather/Events** → new glass-morphism `WorldAtmosphereHud` overlay on canvas (top-left)
- **Leaderboard** → auto-loads all categories on panel open; removed "type command" text
- **Trainers** → auto-requests `train list` on panel open if data not yet received
- **Mailbox** → auto-sends `mail` command on open to fix stuck "Checking your mailbox" state
- **Housing** → removed "type `house buy`" command reference
- **Staff FAB** → relocated from top-right to bottom-left to avoid collision with kiosk badges
- **Kiosk badges** → adaptive vertical spacing based on visible badge count to prevent label overlap

## Test plan

- [ ] Verify dungeon kiosk badge opens the new DungeonPanel drawer (enter a room with dungeon catalog)
- [ ] Verify lottery kiosk badge opens the new LotteryPanel drawer (enter a tavern room)
- [ ] Verify clicking a player on the canvas shows "Duel" action in the context menu
- [ ] Verify currencies appear near gold in the character identity section
- [ ] Verify prestige section in score tab is self-contained with perks inline
- [ ] Verify time/weather HUD appears at top-left of canvas when logged in
- [ ] Verify leaderboard auto-loads data when opened
- [ ] Verify trainer panel auto-loads when opened in a trainer room
- [ ] Verify mailbox auto-requests mail on open (no more stuck "Checking" state)
- [ ] Verify staff FAB appears at bottom-left, not overlapping kiosk badges
- [ ] Verify kiosk badges don't overlap when many are visible (e.g. shop + bank + trainer + tavern)
- [ ] Run `bun run lint` — passes clean
- [ ] Run `./gradlew test` — passes clean