### PR TITLE
Fix dungeon kiosk, lottery panel, and tavern badge bugs

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/world/Room.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/Room.kt
@@ -17,6 +17,8 @@ data class Room(
     val bank: Boolean = false,
     /** True if this room is a tavern (enables gambling commands). */
     val tavern: Boolean = false,
+    /** True if this room has a dungeon portal (enables dungeon kiosk badge). */
+    val dungeon: Boolean = false,
     /** URL to an image representing this room. */
     val image: String? = null,
     /** URL to a video cinematic for this room. */

--- a/src/main/kotlin/dev/ambon/domain/world/data/RoomFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/RoomFile.kt
@@ -19,6 +19,8 @@ data class RoomFile(
     val bank: Boolean = false,
     /** True if this room is a tavern (enables gambling commands). */
     val tavern: Boolean = false,
+    /** True if this room has a dungeon portal (enables dungeon kiosk badge). */
+    val dungeon: Boolean = false,
     /** URL to an image representing this room. */
     val image: String? = null,
     /** URL to a video cinematic for this room. */

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -179,6 +179,7 @@ object WorldLoader {
                         station = station,
                         bank = rf.bank,
                         tavern = rf.tavern,
+                        dungeon = rf.dungeon,
                         image = (rf.image ?: imageDefaults?.room)?.let { "$imagesBase$it" },
                         video = rf.video?.let { "$videosBase$it" },
                         music = (rf.music ?: audioDefaults?.music)?.let { "$audioBase$it" },

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -1832,6 +1832,7 @@ class GameEngine(
             guildSystem,
         )
         emitDungeonCatalog(newSessionId)
+        emitLotteryInfo(newSessionId, me.name)
         if (me.isStaff) {
             gmcpEmitter.sendStaffWorldInfo(newSessionId, world)
             gmcpEmitter.sendStaffMobTemplates(newSessionId, world)
@@ -1931,6 +1932,7 @@ class GameEngine(
             guildSystem,
         )
         emitDungeonCatalog(sessionId)
+        emitLotteryInfo(sessionId, player.name)
         if (player.isStaff) {
             gmcpEmitter.sendStaffWorldInfo(sessionId, world)
             gmcpEmitter.sendStaffMobTemplates(sessionId, world)
@@ -2409,6 +2411,11 @@ class GameEngine(
                     )
                 },
         )
+    }
+
+    private suspend fun emitLotteryInfo(sessionId: SessionId, playerName: String) {
+        val info = lotterySystem.getInfo(playerName)
+        gmcpEmitter.sendLotteryInfo(sessionId, info)
     }
 
     private fun buildDungeonPortalHint(template: dev.ambon.domain.dungeon.DungeonTemplateDef): String? {

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -178,6 +178,7 @@ class GmcpEmitter(
                 trainer = trainerName,
                 bank = room.bank,
                 tavern = room.tavern,
+                dungeon = room.dungeon,
             ),
         )
     }
@@ -1983,6 +1984,7 @@ class GmcpEmitter(
         val trainer: String? = null,
         val bank: Boolean = false,
         val tavern: Boolean = false,
+        val dungeon: Boolean = false,
     )
 
     private data class ItemPayload(

--- a/src/main/resources/world/dungeon_of_echoes.yaml
+++ b/src/main/resources/world/dungeon_of_echoes.yaml
@@ -199,6 +199,7 @@ rooms:
     exits:
       n: thornhaven_city:grimlys_study
     image: 718a7470fc8b5b51386c29db016a6f1d00f1014e80dee589b924a23c37748fa4.jpg
+    dungeon: true
   mob_templates:
     title: Mob Template Room
     description: An internal room used to stage dungeon mob templates. Players cannot reach this room.

--- a/src/main/resources/world/thornhaven_city.yaml
+++ b/src/main/resources/world/thornhaven_city.yaml
@@ -1337,6 +1337,7 @@ rooms:
     exits:
       n: post_office
     image: 876a3d4ad16c3282362698c806365850283b79cf5fe9b481f3782d9b1bffcc6a.jpg
+    dungeon: true
   trainers_hall:
     title: Trainers' Hall
     description: "A wide corridor carved from pale stone, lined with five arched doorways. Each doorway bears a carved

--- a/web-v3/src/canvas/scenes/WorldScene.ts
+++ b/web-v3/src/canvas/scenes/WorldScene.ts
@@ -454,7 +454,7 @@ export class WorldScene {
     this.tavernBadge.eventMode = "static";
     this.tavernBadge.cursor = "pointer";
     this.tavernBadge.on("pointerdown", () => {
-      canvasCallbacks.sendCommand?.("gamble");
+      canvasCallbacks.openLottery?.();
     });
     this.tavernBadge.on("pointerover", () => {
       if (this.tavernSprite) this.tavernSprite.alpha = 1;
@@ -920,13 +920,13 @@ export class WorldScene {
       if (this.tavernBadge) this.tavernBadge.visible = hasTavern;
     }
 
-    const hasLottery = roomHasSurfaceWidget(state.room.id, "lottery");
+    const hasLottery = !!state.room.tavern;
     if (hasLottery !== this.lotteryVisible) {
       this.lotteryVisible = hasLottery;
       if (this.lotteryBadge) this.lotteryBadge.visible = hasLottery;
     }
 
-    const hasDungeon = roomHasSurfaceWidget(state.room.id, "dungeon");
+    const hasDungeon = !!state.room.dungeon;
     if (hasDungeon !== this.dungeonVisible) {
       this.dungeonVisible = hasDungeon;
       if (this.dungeonBadge) this.dungeonBadge.visible = hasDungeon;

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -315,6 +315,7 @@ export function applyGmcpPackage(
       const graphical = packet.graphical === true;
       const bank = packet.bank === true;
       const tavern = packet.tavern === true;
+      const dungeon = packet.dungeon === true;
 
       // Detect actual room change (not just a look/refresh of the same room)
       ctx.setRoom((prev) => {
@@ -323,7 +324,7 @@ export function applyGmcpPackage(
           ctx.setDialogue(null);
           ctx.setQuestsAvailable([]);
         }
-        return { id, title, description, exits, image, video, music, ambient, station, trainer, mapX, mapY, housing, housingOwner, graphical, bank, tavern };
+        return { id, title, description, exits, image, video, music, ambient, station, trainer, mapX, mapY, housing, housingOwner, graphical, bank, tavern, dungeon };
       });
 
       if (id) {

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -211,6 +211,7 @@ export interface RoomState {
   graphical?: boolean;
   bank?: boolean;
   tavern?: boolean;
+  dungeon?: boolean;
 }
 
 /** User layout preference: auto follows zone flag, text/canvas force a mode. */


### PR DESCRIPTION
## Summary

- **Tavern badge**: was sending bare `gamble` command (no amount) → parser rejected it. Now opens the lottery panel directly.
- **Lottery panel**: info was never emitted on login, so the panel always showed "not available." Added `emitLotteryInfo()` to both login and session-resume paths in `GameEngine`.
- **Dungeon badge**: visibility relied on hardcoded room IDs in `featureMetadata.ts` that didn't match live world data. Added a server-driven `dungeon: true` room flag (same pattern as `bank`/`tavern`) and switched both dungeon and lottery badge visibility to use `Room.Info` GMCP flags.

## Test plan

- [x] `./gradlew ktlintCheck` passes
- [x] `./gradlew test` passes
- [x] `bun run lint` passes
- [ ] Navigate to Grimly's Study → dungeon badge appears on canvas
- [ ] Click dungeon badge → dungeon panel opens with catalog
- [ ] Navigate to Tarnished Flagon Inn → tavern + lottery badges appear
- [ ] Click tavern badge → lottery panel opens (no error)
- [ ] Lottery panel shows jackpot/ticket info after login
- [ ] Session resume also populates lottery panel