### PR TITLE
Fix puzzle auto-unlock, room feature leakage, and HUD polish

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -366,15 +366,14 @@ internal suspend fun sendLook(
         gmcpEmitter?.sendCraftingNodes(sessionId, emptyList())
     }
 
-    // Send interactive room features (doors, containers, levers, signs)
-    if (room.features.isNotEmpty() && gmcpEmitter != null) {
-        gmcpEmitter.sendRoomFeatures(
-            sessionId,
-            room.features.map { feature ->
-                buildFeaturePayload(feature, worldState)
-            },
-        )
-    }
+    // Send interactive room features (doors, containers, levers, signs).
+    // Always send — even when empty — so the client clears features from the previous room.
+    gmcpEmitter?.sendRoomFeatures(
+        sessionId,
+        room.features.map { feature ->
+            buildFeaturePayload(feature, worldState)
+        },
+    )
 }
 
 internal fun buildFeaturePayload(

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/PuzzleHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/PuzzleHandler.kt
@@ -1,8 +1,11 @@
 package dev.ambon.engine.commands.handlers
 
 import dev.ambon.domain.ids.ItemId
+import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.puzzle.PuzzleReward
+import dev.ambon.domain.world.LockableState
+import dev.ambon.domain.world.RoomFeature
 import dev.ambon.engine.PuzzleResult
 import dev.ambon.engine.PuzzleSystem
 import dev.ambon.engine.commands.Command
@@ -141,13 +144,24 @@ class PuzzleHandler(
                 )
             }
             is PuzzleReward.GiveItem -> {
-                val instance = items.createFromTemplate(ItemId(reward.itemId))
+                val itemId = ItemId(reward.itemId)
+                val instance = items.createFromTemplate(itemId)
                 if (instance != null) {
                     items.addToInventory(sessionId, instance)
                     outbound.send(
                         OutboundEvent.SendInfo(sessionId, "You receive ${instance.item.displayName}."),
                     )
                     syncItemsGmcp(sessionId, items, gmcpEmitter)
+                    // If the key opens a locked feature in the current room, auto-unlock
+                    // it so the player can proceed without manually fiddling with locks.
+                    autoUnlockWithKey(sessionId, me.roomId, itemId)
+                } else {
+                    outbound.send(
+                        OutboundEvent.SendError(
+                            sessionId,
+                            "The reward could not be granted (item '${reward.itemId}' not found).",
+                        ),
+                    )
                 }
             }
             is PuzzleReward.GiveGold -> {
@@ -158,6 +172,42 @@ class PuzzleHandler(
                 players.grantXp(sessionId, reward.amount)
                 outbound.send(OutboundEvent.SendText(sessionId, "You gain ${reward.amount} XP."))
             }
+        }
+    }
+
+    /**
+     * When a puzzle grants a key, any door or container in the player's current room
+     * that requires that key is automatically opened so the player can proceed.
+     * Consumable keys are removed from the inventory as if the player had manually unlocked the lock.
+     */
+    private suspend fun autoUnlockWithKey(
+        sessionId: SessionId,
+        roomId: RoomId,
+        keyItemId: ItemId,
+    ) {
+        val room = world.rooms[roomId] ?: return
+        val state = ctx.worldState ?: return
+        for (feature in room.features) {
+            val (featureKeyItemId, keyConsumed, displayName) = when (feature) {
+                is RoomFeature.Door -> Triple(feature.keyItemId, feature.keyConsumed, feature.displayName)
+                is RoomFeature.Container -> Triple(feature.keyItemId, feature.keyConsumed, feature.displayName)
+                else -> continue
+            }
+            if (featureKeyItemId != keyItemId) continue
+            if (state.getLockableState(feature.id) == LockableState.OPEN) continue
+            state.setLockableState(feature.id, LockableState.OPEN)
+            if (keyConsumed) {
+                items.removeFromInventoryById(sessionId, keyItemId)
+                syncItemsGmcp(sessionId, items, gmcpEmitter)
+            }
+            outbound.send(OutboundEvent.SendInfo(sessionId, "The $displayName swings open."))
+            broadcastToRoomExcept(
+                roomId,
+                sessionId,
+                "The $displayName swings open.",
+                players,
+                outbound,
+            )
         }
     }
 }

--- a/web-v3/src/canvas/scenes/WorldScene.ts
+++ b/web-v3/src/canvas/scenes/WorldScene.ts
@@ -1072,14 +1072,21 @@ export class WorldScene {
         : Math.min(mobSize + 24, mobAreaWidth / mobCount);
       const totalMobWidth = (mobCount - 1) * mobSpacing;
       let mobX = mobAreaLeft + (mobAreaWidth - totalMobWidth) / 2;
+      // Vertical stagger so adjacent mob labels don't collide. Cycles through
+      // up to 3 rows for 3+ mobs so neighbours-by-2 also don't share a row.
+      const mobStaggerStep = mobCount > 1 ? Math.min(32, mobSize * 0.26) : 0;
+      const mobStaggerRows = Math.min(mobCount, 3);
       const mobInfo = gameStateRef.current.mobInfo;
+      let mobIdx = 0;
       for (const { sprite, label, labelBg, hitArea } of mobEntries) {
+        const mobYOffset = (mobIdx % mobStaggerRows) * mobStaggerStep;
+        const thisMobY = mobY + mobYOffset;
         sprite.x = mobX;
-        sprite.y = mobY;
+        sprite.y = thisMobY;
         sprite.width = mobSize;
         sprite.height = mobSize;
         label.x = mobX;
-        label.y = mobY + mobSize / 2 + 6;
+        label.y = thisMobY + mobSize / 2 + 6;
 
         // Color label text by mob role + prepend role icon
         const mid = [...this.mobSprites.entries()].find(([, v]) => v.label === label)?.[0];
@@ -1104,8 +1111,9 @@ export class WorldScene {
         hitArea.rect(0, 0, mobSize, mobSize);
         hitArea.fill({ color: 0x000000, alpha: 0.001 });
         hitArea.x = mobX - mobSize / 2;
-        hitArea.y = mobY - mobSize / 2;
+        hitArea.y = thisMobY - mobSize / 2;
         mobX += mobSpacing;
+        mobIdx += 1;
       }
     }
 
@@ -1193,9 +1201,12 @@ export class WorldScene {
       this.leverBadge?.visible,
     ].filter(Boolean).length;
     const availableHeight = h * 0.58; // from 35% to ~93% of viewport
-    const maxSpacing = h * 0.13;
+    // Minimum spacing must clear the full badge footprint (icon + label pill + gap)
+    // so labels don't run into the next badge's icon.
+    const minBadgeSpacing = SHOP_BADGE_SIZE + 30;
+    const maxSpacing = Math.max(h * 0.15, minBadgeSpacing);
     const badgeSpacing = visibleBadgeCount > 1
-      ? Math.min(maxSpacing, availableHeight / visibleBadgeCount)
+      ? Math.max(minBadgeSpacing, Math.min(maxSpacing, availableHeight / visibleBadgeCount))
       : maxSpacing;
     let badgeSlot = 0;
 

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -10762,13 +10762,17 @@ body {
 /* ---------- Atmosphere HUD (canvas overlay, top-left) ---------- */
 .atmosphere-hud {
   position: fixed;
-  top: calc(env(safe-area-inset-top, 0px) + 12px);
-  left: calc(env(safe-area-inset-left, 0px) + 12px);
+  bottom: calc(var(--game-bottom-inset, 0px) + env(safe-area-inset-bottom, 0px) + 12px);
+  right: calc(env(safe-area-inset-right, 0px) + 12px);
+  top: auto;
+  left: auto;
   z-index: 11;
   display: flex;
   flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 6px;
   pointer-events: none;
+  max-width: 40vw;
 }
 
 .atmosphere-hud-chip {
@@ -13688,11 +13692,16 @@ html:has(.game-shell),
   display: block;
 }
 
-/* Staff-only floating action buttons — top-right corner, below the minimap */
+/* Staff-only floating action buttons — anchored to the left edge of the canvas,
+   vertically aligned with the player sprite (which renders at ~70% of canvas height). */
 .staff-fab {
   position: fixed;
-  bottom: calc(env(safe-area-inset-bottom, 0px) + 140px);
+  top: calc(
+    env(safe-area-inset-top, 0px) +
+    (100vh - var(--game-bottom-inset, 0px) - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px)) * 0.70
+  );
   left: calc(env(safe-area-inset-left, 0px) + 12px);
+  transform: translateY(-50%);
   z-index: 12;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

- **Puzzle auto-unlock**: Solving a puzzle whose reward is a key now automatically opens any matching locked door or container in the current room. Consumable keys are removed as if the player had unlocked by hand. Previously, players had to manually type `unlock door` / `open door` after solving, and a missing item template failed silently.
- **Room feature leakage**: `Room.Features` is always emitted on room entry now, even when the new room has no features, so container/door/lever badges from the previous room no longer linger on the client.
- **Mob label stagger**: Multiple mobs in the same room zigzag across up to three vertical rows so long names (e.g. "a drifting paper crane", "a cackling nightmare") stop colliding.
- **Kiosk badge spacing**: Minimum spacing between kiosk badges now clears the full badge footprint (icon + label pill), fixing overlap on h=800 viewports.
- **Staff FAB**: Staff + invis pills moved from bottom-left to the left edge of the canvas, vertically aligned with the player sprite.
- **Atmosphere HUD**: Time/weather/events chips moved from top-left to bottom-right of the canvas, above the vitals bar.

## Test plan

- [x] `./gradlew ktlintMainSourceSetCheck compileKotlin compileTestKotlin` — clean
- [x] `./gradlew test --tests "dev.ambon.engine.commands.PuzzleSystemTest"` — 17 tests pass
- [x] `bun run lint` in `web-v3/` — clean
- [ ] Manual: enter a room with containers from another room — badges should clear
- [ ] Manual: solve Auringold Academy's tower riddle — door should swing open automatically, key is consumed
- [ ] Manual: visit a room with 3+ mobs whose names are wide — labels should not collide
- [ ] Manual: check kiosk badges on a puzzle room at desktop height — puzzle and door badges no longer overlap
- [ ] Manual: verify Staff + invis pills sit next to the player sprite at ~70% canvas height
- [ ] Manual: verify time/weather chips sit at the bottom-right of the canvas