### PR TITLE
Wire RaceDef.abilities to grant and revoke ability grants

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -1196,6 +1196,7 @@ class GameEngine(
                 ctx = ctx,
                 stylistConfig = engineConfig.stylist,
                 progression = progression,
+                abilitySystem = abilitySystem,
                 markVitalsDirty = ::markVitalsDirty,
                 markStatsDirty = ::markStatsDirty,
             ),

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -1922,7 +1922,8 @@ class GameEngine(
         // Finalize login (same as normal flow)
         loginFlowHandler.onAfterLogin(sessionId)
         val player = players.get(sessionId) ?: return
-        abilitySystem.loadAbilities(sessionId, player.learnedAbilityIds)
+        val raceAbilities = raceRegistry.get(player.race)?.abilities.orEmpty().toSet()
+        abilitySystem.loadAbilities(sessionId, player.learnedAbilityIds, raceAbilities)
         outbound.send(OutboundEvent.SetAnsi(sessionId, player.ansiEnabled))
         if (player.screenReaderEnabled) {
             outbound.send(OutboundEvent.SetScreenReader(sessionId, true))

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
@@ -44,6 +44,7 @@ class AbilitySystem(
     val onSummonPet: suspend (SessionId, String, Long) -> Unit = { _, _, _ -> },
 ) : GameSystem {
     private val manualLearnedAbilities = mutableMapOf<SessionId, MutableSet<AbilityId>>()
+    private val raceGrantedAbilities = mutableMapOf<SessionId, MutableSet<AbilityId>>()
     private val effectiveAbilities = mutableMapOf<SessionId, MutableSet<AbilityId>>()
     private val cooldowns = mutableMapOf<SessionId, MutableMap<AbilityId, Long>>()
 
@@ -616,12 +617,32 @@ class AbilitySystem(
     /**
      * Loads abilities from a persisted set of ability IDs. Called on login instead of
      * [syncAbilities] so players only have abilities they explicitly chose at a trainer.
+     *
+     * [raceAbilityIds] are abilities granted by the player's current race. They are
+     * kept separate from trainer-learned IDs so race swaps can revoke old grants
+     * without touching anything the player learned from a trainer.
      */
     fun loadAbilities(
         sessionId: SessionId,
         learnedIds: Set<String>,
+        raceAbilityIds: Set<String> = emptySet(),
     ): List<AbilityDefinition> {
         manualLearnedAbilities[sessionId] = learnedIds.map { AbilityId(it) }.toMutableSet()
+        raceGrantedAbilities[sessionId] = raceAbilityIds.map { AbilityId(it) }.toMutableSet()
+        return refreshKnownAbilities(sessionId)
+    }
+
+    /**
+     * Replaces the set of race-granted abilities for [sessionId] and recomputes the
+     * effective ability set. Trainer-learned abilities are left untouched, so any
+     * ability the player also learned from a trainer survives the swap. Returns the
+     * abilities the player now knows that they did not know before.
+     */
+    fun setRaceAbilities(
+        sessionId: SessionId,
+        raceAbilityIds: Set<String>,
+    ): List<AbilityDefinition> {
+        raceGrantedAbilities[sessionId] = raceAbilityIds.map { AbilityId(it) }.toMutableSet()
         return refreshKnownAbilities(sessionId)
     }
 
@@ -685,7 +706,10 @@ class AbilitySystem(
         val ability = registry.get(abilityId) ?: return "Unknown ability '${abilityId.value}'."
         ensureAbilitiesCurrent(sessionId)
         val learned = manualLearnedAbilities.getOrPut(sessionId) { mutableSetOf() }
-        if (abilityId in effectiveAbilities[sessionId].orEmpty()) return "You already know ${ability.displayName}."
+        // Exclude race grants so a player can pay skill points to "permanently" learn an
+        // ability their current race also grants — this keeps the ability across race swaps.
+        val knownWithoutRace = resolveEffectiveKnownAbilities(level, unlockedClasses, learned)
+        if (abilityId in knownWithoutRace) return "You already know ${ability.displayName}."
         if (ability.skillPointCost == 0) {
             return "${ability.displayName} is granted automatically when you qualify for it."
         }
@@ -729,7 +753,8 @@ class AbilitySystem(
     ): List<AbilityDefinition> {
         val previous = effectiveAbilities[sessionId].orEmpty()
         val manual = manualLearnedAbilities.getOrPut(sessionId) { mutableSetOf() }
-        val resolved = resolveEffectiveKnownAbilities(level, unlockedClasses, manual)
+        val race = raceGrantedAbilities[sessionId].orEmpty()
+        val resolved = resolveEffectiveKnownAbilities(level, unlockedClasses, manual + race)
         effectiveAbilities[sessionId] = resolved.toMutableSet()
         cleanupCooldowns(sessionId, resolved)
         return resolved
@@ -764,6 +789,7 @@ class AbilitySystem(
 
     override suspend fun onPlayerDisconnected(sessionId: SessionId) {
         manualLearnedAbilities.remove(sessionId)
+        raceGrantedAbilities.remove(sessionId)
         effectiveAbilities.remove(sessionId)
         cooldowns.remove(sessionId)
     }
@@ -773,6 +799,7 @@ class AbilitySystem(
         newSid: SessionId,
     ) {
         manualLearnedAbilities.remapKey(oldSid, newSid)
+        raceGrantedAbilities.remapKey(oldSid, newSid)
         effectiveAbilities.remapKey(oldSid, newSid)
         cooldowns.remapKey(oldSid, newSid)
     }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/StylistHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/StylistHandler.kt
@@ -5,6 +5,7 @@ import dev.ambon.domain.StatMap
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.PlayerProgression
 import dev.ambon.engine.PlayerState
+import dev.ambon.engine.abilities.AbilitySystem
 import dev.ambon.engine.commands.Command
 import dev.ambon.engine.commands.CommandHandler
 import dev.ambon.engine.commands.CommandRouter
@@ -15,6 +16,7 @@ class StylistHandler(
     ctx: EngineContext,
     private val stylistConfig: StylistConfig = StylistConfig(),
     private val progression: PlayerProgression = PlayerProgression(),
+    private val abilitySystem: AbilitySystem? = null,
     private val markVitalsDirty: ((SessionId) -> Unit)? = null,
     private val markStatsDirty: ((SessionId) -> Unit)? = null,
 ) : CommandHandler {
@@ -110,6 +112,8 @@ class StylistHandler(
         me.stats = applyStatDelta(me.stats, oldMods, target.statMods)
         me.race = target.id
         progression.recomputeVitalCaps(me)
+
+        abilitySystem?.setRaceAbilities(sessionId, target.abilities.toSet())
 
         markVitalsDirty?.invoke(sessionId)
         markStatsDirty?.invoke(sessionId)

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/StylistHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/StylistHandler.kt
@@ -126,6 +126,11 @@ class StylistHandler(
         )
 
         gmcpEmitter?.sendCharName(sessionId, me)
+        if (abilitySystem != null) {
+            gmcpEmitter?.sendCharSkills(sessionId, abilitySystem.knownAbilities(sessionId)) { abilityId ->
+                abilitySystem.cooldownRemainingMs(sessionId, abilityId)
+            }
+        }
         emitStylistState(sessionId, me)
     }
 

--- a/src/main/kotlin/dev/ambon/engine/events/LoginFlowHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/LoginFlowHandler.kt
@@ -526,7 +526,8 @@ internal class LoginFlowHandler(
         // token so the client can auto-relog on subsequent connects.
         onFreshPasswordLogin(sessionId)
         playerLocationIndex?.register(me.name)
-        abilitySystem.loadAbilities(sessionId, me.learnedAbilityIds)
+        val raceAbilities = raceRegistry.get(me.race)?.abilities.orEmpty().toSet()
+        abilitySystem.loadAbilities(sessionId, me.learnedAbilityIds, raceAbilities)
         outbound.send(OutboundEvent.SetAnsi(sessionId, me.ansiEnabled))
         if (me.screenReaderEnabled) {
             outbound.send(OutboundEvent.SetScreenReader(sessionId, true))

--- a/src/test/kotlin/dev/ambon/engine/abilities/AbilitySystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/abilities/AbilitySystemTest.kt
@@ -23,6 +23,7 @@ import dev.ambon.test.loginOrFail
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -308,6 +309,106 @@ class AbilitySystemTest {
 
             assertTrue(h.abilitySystem.knownAbilities(sid).isNotEmpty())
             h.abilitySystem.onPlayerDisconnected(sid)
+            assertTrue(h.abilitySystem.knownAbilities(sid).isEmpty())
+        }
+
+    @Test
+    fun `loadAbilities grants race abilities`() =
+        runTest {
+            val h = buildSystem()
+            h.players.loginOrFail(sid, "RaceGift")
+
+            h.abilitySystem.loadAbilities(
+                sessionId = sid,
+                learnedIds = emptySet(),
+                raceAbilityIds = setOf("magic_missile"),
+            )
+
+            assertTrue("magic_missile" in h.abilitySystem.knownAbilityIds(sid))
+        }
+
+    @Test
+    fun `setRaceAbilities revokes previous grants and adds new ones`() =
+        runTest {
+            val h = buildSystem()
+            h.players.loginOrFail(sid, "Swapper")
+            h.abilitySystem.loadAbilities(
+                sessionId = sid,
+                learnedIds = emptySet(),
+                raceAbilityIds = setOf("magic_missile"),
+            )
+
+            h.abilitySystem.setRaceAbilities(sid, setOf("heal"))
+
+            val known = h.abilitySystem.knownAbilityIds(sid)
+            assertTrue("heal" in known)
+            assertFalse(
+                "magic_missile" in known,
+                "previous race ability should be revoked",
+            )
+        }
+
+    @Test
+    fun `setRaceAbilities preserves abilities also learned from trainer`() =
+        runTest {
+            val h = buildSystem()
+            h.players.loginOrFail(sid, "Doubled")
+            // Player has magic_missile both as a race grant and as a trainer-learned ability.
+            h.abilitySystem.loadAbilities(
+                sessionId = sid,
+                learnedIds = setOf("magic_missile"),
+                raceAbilityIds = setOf("magic_missile"),
+            )
+
+            // Swap to a race that grants nothing — trainer-learned ability must survive.
+            h.abilitySystem.setRaceAbilities(sid, emptySet())
+
+            assertTrue(
+                "magic_missile" in h.abilitySystem.knownAbilityIds(sid),
+                "trainer-learned ability must survive race swap",
+            )
+        }
+
+    @Test
+    fun `learnAbility allows learning an ability currently granted only by race`() =
+        runTest {
+            val h = buildSystem()
+            h.players.loginOrFail(sid, "DoubleUp")
+            val me = h.players.get(sid)!!
+            me.level = 5
+            me.unlockedClasses.add("WARRIOR")
+            h.abilitySystem.loadAbilities(
+                sessionId = sid,
+                learnedIds = emptySet(),
+                raceAbilityIds = setOf("magic_missile"),
+            )
+
+            val error = h.abilitySystem.learnAbility(
+                sessionId = sid,
+                abilityId = AbilityId("magic_missile"),
+                level = me.level,
+                unlockedClasses = me.unlockedClasses,
+                skillPointInterval = 1,
+                learnedIds = emptySet(),
+            )
+
+            assertNull(error, "trainer should allow learning a race-only ability; got: $error")
+        }
+
+    @Test
+    fun `session cleanup clears race-granted abilities`() =
+        runTest {
+            val h = buildSystem()
+            h.players.loginOrFail(sid, "CleanupRace")
+            h.abilitySystem.loadAbilities(
+                sessionId = sid,
+                learnedIds = emptySet(),
+                raceAbilityIds = setOf("magic_missile"),
+            )
+            assertTrue(h.abilitySystem.knownAbilities(sid).isNotEmpty())
+
+            h.abilitySystem.onPlayerDisconnected(sid)
+
             assertTrue(h.abilitySystem.knownAbilities(sid).isEmpty())
         }
 

--- a/src/test/kotlin/dev/ambon/engine/commands/RouterTestHelper.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/RouterTestHelper.kt
@@ -101,6 +101,7 @@ internal fun buildTestRouter(
     puzzleSystem: PuzzleSystem? = null,
     guildHallSystem: GuildHallSystem? = null,
     gmcpEmitter: GmcpEmitter? = null,
+    abilitySystem: dev.ambon.engine.abilities.AbilitySystem? = null,
 ): CommandRouter {
     val router = CommandRouter(outbound = outbound, players = players)
     val ctx = EngineContext(
@@ -149,6 +150,7 @@ internal fun buildTestRouter(
                 ctx = ctx,
                 stylistConfig = it,
                 progression = progression,
+                abilitySystem = abilitySystem,
             )
         },
         DuelHandler(ctx = ctx, duelSystem = duelSystem, combatSystem = combat),

--- a/src/test/kotlin/dev/ambon/engine/commands/StylistCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/StylistCommandTest.kt
@@ -1,23 +1,36 @@
 package dev.ambon.engine.commands
 
+import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.config.StylistConfig
+import dev.ambon.domain.DamageRange
 import dev.ambon.domain.RaceDef
 import dev.ambon.domain.StatMap
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.world.Room
 import dev.ambon.domain.world.World
+import dev.ambon.engine.CombatSystem
+import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.RaceRegistry
+import dev.ambon.engine.abilities.AbilityDefinition
+import dev.ambon.engine.abilities.AbilityEffect
+import dev.ambon.engine.abilities.AbilityId
+import dev.ambon.engine.abilities.AbilityRegistry
+import dev.ambon.engine.abilities.AbilitySystem
 import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.persistence.InMemoryPlayerRepository
 import dev.ambon.test.CommandRouterHarness
 import dev.ambon.test.buildTestPlayerRegistry
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.time.Clock
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class StylistCommandTest {
@@ -93,6 +106,99 @@ class StylistCommandTest {
             stylistConfig = StylistConfig(feeGold = fee),
             raceRegistry = buildRaceRegistry(),
         )
+    }
+
+    private data class AbilityHarness(
+        val harness: CommandRouterHarness,
+        val abilitySystem: AbilitySystem,
+    )
+
+    /**
+     * Builds a harness with races whose abilities actually exist in the registry,
+     * plus a wired-up [AbilitySystem] so race-ability grant/revoke can be observed.
+     */
+    private fun abilityHarness(fee: Long = 0): AbilityHarness {
+        val world = stylistWorld()
+        val repo = InMemoryPlayerRepository()
+        val items = ItemRegistry()
+        val mobs = MobRegistry()
+        val outbound = LocalOutboundBus()
+        val players = buildTestPlayerRegistry(world.startRoom, repo = repo, items = items)
+        val combat = CombatSystem(players, mobs, items, outbound)
+        val abilityRegistry = AbilityRegistry()
+        abilityRegistry.register(
+            AbilityDefinition(
+                id = AbilityId("human_boon"),
+                displayName = "Human Boon",
+                description = "A human gift.",
+                manaCost = 0,
+                cooldownMs = 0,
+                levelRequired = 1,
+                targetType = "self",
+                effect = AbilityEffect.DirectHeal(minHeal = 1, maxHeal = 1),
+            ),
+        )
+        abilityRegistry.register(
+            AbilityDefinition(
+                id = AbilityId("elf_grace"),
+                displayName = "Elf Grace",
+                description = "An elven gift.",
+                manaCost = 0,
+                cooldownMs = 0,
+                levelRequired = 1,
+                targetType = "self",
+                effect = AbilityEffect.DirectHeal(minHeal = 1, maxHeal = 1),
+            ),
+        )
+        abilityRegistry.register(
+            AbilityDefinition(
+                id = AbilityId("shared_trick"),
+                displayName = "Shared Trick",
+                description = "Something a human can also learn from a trainer.",
+                manaCost = 0,
+                cooldownMs = 0,
+                levelRequired = 1,
+                targetType = "enemy",
+                effect = AbilityEffect.DirectDamage(damage = DamageRange(1, 1)),
+            ),
+        )
+        val abilitySystem = AbilitySystem(
+            players = players,
+            registry = abilityRegistry,
+            outbound = outbound,
+            combat = combat,
+            clock = Clock.systemUTC(),
+            mobs = mobs,
+        )
+
+        val raceRegistry = RaceRegistry()
+        raceRegistry.register(
+            RaceDef(
+                id = "HUMAN",
+                displayName = "Human",
+                abilities = listOf("human_boon", "shared_trick"),
+            ),
+        )
+        raceRegistry.register(
+            RaceDef(
+                id = "ELF",
+                displayName = "Elf",
+                abilities = listOf("elf_grace"),
+            ),
+        )
+
+        val harness = CommandRouterHarness.create(
+            world = world,
+            repo = repo,
+            items = items,
+            players = players,
+            mobs = mobs,
+            outbound = outbound,
+            stylistConfig = StylistConfig(feeGold = fee),
+            raceRegistry = raceRegistry,
+            abilitySystem = abilitySystem,
+        )
+        return AbilityHarness(harness, abilitySystem)
     }
 
     @Nested
@@ -231,6 +337,63 @@ class StylistCommandTest {
             // CON dropped, so maxHp scaling should decrease (or at least differ)
             assertNotEquals(hpBefore, after.maxHp)
             assertTrue(after.hp <= after.maxHp)
+        }
+
+        @Test
+        fun `changerace revokes old race abilities and grants new ones`() = runTest {
+            val ah = abilityHarness()
+            val h = ah.harness
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Alice")
+            val me = h.players.get(sid)!!
+            me.race = "HUMAN"
+            // Seed the ability system the way login would: race abilities only, no trainer abilities.
+            ah.abilitySystem.loadAbilities(
+                sessionId = sid,
+                learnedIds = emptySet(),
+                raceAbilityIds = setOf("human_boon", "shared_trick"),
+            )
+            assertTrue("human_boon" in ah.abilitySystem.knownAbilityIds(sid))
+            h.drain()
+
+            h.router.handle(sid, Command.Stylist.ChangeRace("ELF"))
+            h.drain()
+
+            val known = ah.abilitySystem.knownAbilityIds(sid)
+            assertTrue("elf_grace" in known, "new race ability missing: $known")
+            assertFalse("human_boon" in known, "old race ability not revoked: $known")
+            assertFalse("shared_trick" in known, "old race ability not revoked: $known")
+        }
+
+        @Test
+        fun `changerace preserves trainer-learned abilities that overlap with old race`() = runTest {
+            val ah = abilityHarness()
+            val h = ah.harness
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Alice")
+            val me = h.players.get(sid)!!
+            me.race = "HUMAN"
+            // Player has shared_trick from both race and trainer.
+            me.learnedAbilityIds.add("shared_trick")
+            ah.abilitySystem.loadAbilities(
+                sessionId = sid,
+                learnedIds = me.learnedAbilityIds,
+                raceAbilityIds = setOf("human_boon", "shared_trick"),
+            )
+            h.drain()
+
+            h.router.handle(sid, Command.Stylist.ChangeRace("ELF"))
+            h.drain()
+
+            val known = ah.abilitySystem.knownAbilityIds(sid)
+            assertTrue(
+                "shared_trick" in known,
+                "trainer-learned ability must survive race swap: $known",
+            )
+            assertFalse("human_boon" in known)
+            assertTrue("elf_grace" in known)
+            // learnedAbilityIds itself is untouched.
+            assertTrue("shared_trick" in h.players.get(sid)!!.learnedAbilityIds)
         }
     }
 }

--- a/src/test/kotlin/dev/ambon/engine/commands/StylistCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/StylistCommandTest.kt
@@ -10,6 +10,7 @@ import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.world.Room
 import dev.ambon.domain.world.World
 import dev.ambon.engine.CombatSystem
+import dev.ambon.engine.GmcpEmitter
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.RaceRegistry
 import dev.ambon.engine.abilities.AbilityDefinition
@@ -111,6 +112,7 @@ class StylistCommandTest {
     private data class AbilityHarness(
         val harness: CommandRouterHarness,
         val abilitySystem: AbilitySystem,
+        val gmcpEmitter: GmcpEmitter,
     )
 
     /**
@@ -187,6 +189,11 @@ class StylistCommandTest {
             ),
         )
 
+        val gmcpEmitter = GmcpEmitter(
+            outbound = outbound,
+            supportsPackage = { _, _ -> true },
+        )
+
         val harness = CommandRouterHarness.create(
             world = world,
             repo = repo,
@@ -197,8 +204,9 @@ class StylistCommandTest {
             stylistConfig = StylistConfig(feeGold = fee),
             raceRegistry = raceRegistry,
             abilitySystem = abilitySystem,
+            gmcpEmitter = gmcpEmitter,
         )
-        return AbilityHarness(harness, abilitySystem)
+        return AbilityHarness(harness, abilitySystem, gmcpEmitter)
     }
 
     @Nested
@@ -394,6 +402,35 @@ class StylistCommandTest {
             assertTrue("elf_grace" in known)
             // learnedAbilityIds itself is untouched.
             assertTrue("shared_trick" in h.players.get(sid)!!.learnedAbilityIds)
+        }
+
+        @Test
+        fun `changerace emits Char_Skills GMCP so client refreshes ability list`() = runTest {
+            val ah = abilityHarness()
+            val h = ah.harness
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Alice")
+            val me = h.players.get(sid)!!
+            me.race = "HUMAN"
+            ah.abilitySystem.loadAbilities(
+                sessionId = sid,
+                learnedIds = emptySet(),
+                raceAbilityIds = setOf("human_boon", "shared_trick"),
+            )
+            h.drain()
+
+            h.router.handle(sid, Command.Stylist.ChangeRace("ELF"))
+            val events = h.drain()
+
+            val charSkills = events.filterIsInstance<OutboundEvent.GmcpData>()
+                .filter { it.sessionId == sid && it.gmcpPackage == "Char.Skills" }
+            assertTrue(
+                charSkills.isNotEmpty(),
+                "Char.Skills GMCP should be emitted after race change so client ability panel refreshes",
+            )
+            val payload = charSkills.last().jsonData
+            assertTrue("elf_grace" in payload, "new race ability missing in payload: $payload")
+            assertFalse("human_boon" in payload, "old race ability still in payload: $payload")
         }
     }
 }

--- a/src/test/kotlin/dev/ambon/test/TestFixtures.kt
+++ b/src/test/kotlin/dev/ambon/test/TestFixtures.kt
@@ -249,6 +249,7 @@ class CommandRouterHarness private constructor(
             dungeonRegistry: DungeonRegistry? = null,
             housingSystem: HousingSystem? = null,
             gmcpEmitter: GmcpEmitter? = null,
+            abilitySystem: dev.ambon.engine.abilities.AbilitySystem? = null,
         ): CommandRouterHarness {
             val combat = CombatSystem(players, mobs, items, outbound)
             val router =
@@ -283,6 +284,7 @@ class CommandRouterHarness private constructor(
                     dungeonRegistry = dungeonRegistry,
                     housingSystem = housingSystem,
                     gmcpEmitter = gmcpEmitter,
+                    abilitySystem = abilitySystem,
                 )
             return CommandRouterHarness(
                 world = world,


### PR DESCRIPTION
Closes https://github.com/jnoecker/AmbonMUD/issues/993

## Summary
- Track race-granted abilities as a separate seed set in `AbilitySystem` (`raceGrantedAbilities`), parallel to the existing trainer-learned set.
- `loadAbilities` takes an optional `raceAbilityIds` parameter; `LoginFlowHandler` looks up the player's current race in `RaceRegistry` and passes those abilities on login.
- Add `AbilitySystem.setRaceAbilities(...)`; `StylistHandler` calls it on race change to revoke the old grants and apply the new ones.
- Trainer-learned abilities live in their own set, so race swap never touches them — a player who both inherits and trains an overlapping ability keeps it.
- `learnAbility` now checks \"already known\" against the manual+auto resolve (excluding the race seed), so a trainer can still teach an ability the player currently only has through their race.

## Test plan
- [x] `./gradlew ktlintCheck test` green
- [x] New tests in `AbilitySystemTest`: `loadAbilities` grants race abilities; `setRaceAbilities` revokes old and grants new; trainer-learned overlap survives race swap; `learnAbility` accepts a race-only ability; session cleanup clears race grants.
- [x] New tests in `StylistCommandTest.Router`: changerace revokes old race abilities and grants new ones; trainer-learned overlap survives changerace.
- [x] Existing trainer, skill-tree, and login-flow tests still pass.