### PR TITLE
Add class abilities, pet combat, and pet rendering

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/mob/MobState.kt
+++ b/src/main/kotlin/dev/ambon/domain/mob/MobState.kt
@@ -33,6 +33,8 @@ data class MobState(
     val aggressive: Boolean = false,
     /** Non-null if this mob is a summoned pet. */
     val ownerSessionId: SessionId? = null,
+    /** Character name of the pet's owner — sent to clients so they can identify their own pets. */
+    val ownerName: String? = null,
 ) : MobTemplate {
     val isPet: Boolean get() = ownerSessionId != null
 }

--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -639,6 +639,8 @@ class CombatSystem(
         // Pets deal damage to their owner's combat target on the same tick cadence.
         if (petSystem != null) {
             for ((sessionId, mobId) in playerEntries) {
+                val mobCombatState = activeMobs[mobId] ?: continue
+                if (now < mobCombatState.nextTickAtMs) continue
                 val mob = mobs.get(mobId) ?: continue
                 if (mob.hp <= 0) continue
                 val pet = petSystem.getActivePet(sessionId) ?: continue

--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -47,6 +47,7 @@ class CombatSystem(
     private val config: CombatSystemConfig = CombatSystemConfig(),
     private val callbacks: CombatSystemCallbacks = CombatSystemCallbacks(),
     private val classRegistry: PlayerClassRegistry? = null,
+    private val petSystem: PetSystem? = null,
 ) : GameSystem {
     /** Callback for combat events; wired by GameEngine after construction. */
     var onCombatEvent: suspend (SessionId, CombatEvent) -> Unit = { _, _ -> }
@@ -634,6 +635,35 @@ class CombatSystem(
             ran++
         }
 
+        // --- Pet attack phase ---
+        // Pets deal damage to their owner's combat target on the same tick cadence.
+        if (petSystem != null) {
+            for ((sessionId, mobId) in playerEntries) {
+                val mob = mobs.get(mobId) ?: continue
+                if (mob.hp <= 0) continue
+                val pet = petSystem.getActivePet(sessionId) ?: continue
+                if (pet.roomId != mob.roomId) continue
+                val petRoll = rollRange(rng, pet.damage.min, pet.damage.max)
+                val petDamage = (petRoll - mob.armor).coerceAtLeast(1)
+                mob.takeDamage(petDamage)
+                dirtyNotifier.mobHpDirty(mob.id)
+                outbound.send(
+                    OutboundEvent.SendText(sessionId, "${pet.name} hits ${mob.name} for $petDamage damage."),
+                )
+                broadcastToRoom(
+                    players,
+                    outbound,
+                    mob.roomId,
+                    "${pet.name} hits ${mob.name} for $petDamage damage.",
+                    exclude = sessionId,
+                )
+                if (mob.hp <= 0) {
+                    handleMobDeath(sessionId, mob)
+                    outbound.send(OutboundEvent.SendPrompt(sessionId))
+                }
+            }
+        }
+
         // --- Mob attack phase ---
         val mobEntries = activeMobs.values.toMutableList()
         mobEntries.shuffle(rng)
@@ -875,7 +905,7 @@ class CombatSystem(
     private fun findMobsInRoom(
         roomId: RoomId,
         keyword: String,
-    ): List<MobState> = mobs.findInRoomByKeyword(roomId, keyword)
+    ): List<MobState> = mobs.findInRoomByKeyword(roomId, keyword).filter { !it.isPet }
 
     private suspend fun handleMobDeath(
         killerSessionId: SessionId,

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -660,6 +660,11 @@ class GameEngine(
             maxFriends = engineConfig.friends.maxFriends,
             markPlayerDirty = { sid -> players.persistPlayer(sid) },
         )
+    private val petSystem = PetSystem(
+        config = engineConfig.pets,
+        mobs = mobs,
+        clock = clock,
+    )
     private val combatSystem =
         CombatSystem(
             players = players,
@@ -688,6 +693,7 @@ class GameEngine(
                 onRoomItemsChanged = ::syncRoomItemsForRoom,
             ),
             classRegistry = classRegistry,
+            petSystem = petSystem,
         )
     private val regenSystem =
         RegenSystem(
@@ -708,12 +714,6 @@ class GameEngine(
     init {
         AbilityRegistryLoader.load(engineConfig.abilities, abilityRegistry, imagesBaseUrl)
     }
-
-    private val petSystem = PetSystem(
-        config = engineConfig.pets,
-        mobs = mobs,
-        clock = clock,
-    )
 
     private val worldTimeSystem = WorldTimeSystem(
         config = engineConfig.worldTime,
@@ -774,7 +774,7 @@ class GameEngine(
             onCombatEvent = { sid, event -> gmcpEmitter.sendCombatEvent(sid, event) },
             onSummonPet = { sid, templateKey, durationMs ->
                 val player = players.get(sid) ?: return@AbilitySystem
-                val pet = petSystem.summon(sid, templateKey, player.roomId, player.level, durationMs)
+                val pet = petSystem.summon(sid, templateKey, player.roomId, player.level, durationMs, player.name)
                 if (pet != null) {
                     outbound.send(OutboundEvent.SendText(sid, "You summon ${pet.name}!"))
                     emitPetState(sid, pet)

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -1981,6 +1981,7 @@ class GmcpEmitter(
                     MobEffectPayload(name = e.name, type = e.type, remainingMs = e.remainingMs, stacks = e.stacks)
                 }
             },
+            ownerName = mob.ownerName,
         )
     }
 
@@ -2102,6 +2103,7 @@ class GmcpEmitter(
         val video: String? = null,
         val category: String = "humanoid",
         val effects: List<MobEffectPayload>? = null,
+        val ownerName: String? = null,
     )
 
     private data class MobEffectPayload(

--- a/src/main/kotlin/dev/ambon/engine/PetSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/PetSystem.kt
@@ -52,6 +52,7 @@ class PetSystem(
         roomId: RoomId,
         ownerLevel: Int,
         durationMs: Long = 0L,
+        ownerName: String? = null,
     ): MobState? {
         val template = config.definitions[templateKey] ?: return null
 
@@ -78,6 +79,7 @@ class PetSystem(
             templateKey = templateKey,
             image = template.image,
             ownerSessionId = ownerSid,
+            ownerName = ownerName,
         )
 
         mobs.upsert(pet)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -28,9 +28,12 @@ ambonmud:
   grpc:
     server:
       port: 9090
+      controlPlaneSendTimeoutMs: 2000
     client:
       engineHost: localhost
       enginePort: 9090
+    allowPlaintext: true
+    timestampToleranceMs: 30000
   gateway:
     id: 0
     snowflake:
@@ -41,11 +44,11 @@ ambonmud:
       maxDelayMs: 30000
       jitterFactor: 0.2
       streamVerifyMs: 2000
-    startZone: ""
     engines: []
   server:
     telnetPort: 4000
     webPort: 8080
+    productionMode: false
     inboundChannelCapacity: 10000
     outboundChannelCapacity: 10000
     sessionOutboundQueueCapacity: 200
@@ -53,8 +56,12 @@ ambonmud:
     tickMillis: 100
     inboundBudgetMs: 30
   world:
-    startRoom: auringold_academy:dream_gate
-    resources: []
+    startRoom: pixel_haven_academy:start
+    resources:
+      - world/auringold_academy.yaml
+      - world/pixel_haven.yaml
+      - world/pixel_haven_academy.yaml
+      - world/playtest_arena.yaml
   persistence:
     backend: YAML
     rootDir: data/players
@@ -70,7 +77,7 @@ ambonmud:
   login:
     maxWrongPasswordRetries: 3
     maxFailedAttemptsBeforeDisconnect: 3
-    maxConcurrentLogins: 150
+    maxConcurrentLogins: 50
     authThreads: 8
   engine:
     scheduler:
@@ -85,2989 +92,1058 @@ ambonmud:
         STR:
           displayName: Strength
           abbreviation: STR
-          description: Physical power. Increases melee damage.
+          description: Physical power
           baseStat: 10
         DEX:
           displayName: Dexterity
           abbreviation: DEX
-          description: Agility and reflexes. Increases dodge chance.
+          description: Agility and reflexes
           baseStat: 10
         CON:
           displayName: Constitution
           abbreviation: CON
-          description: Endurance and health. Increases max HP and HP regen.
+          description: Health and endurance
           baseStat: 10
         INT:
           displayName: Intelligence
           abbreviation: INT
-          description: Arcane aptitude. Increases max mana and spell damage.
+          description: Magical aptitude
           baseStat: 10
         WIS:
           displayName: Wisdom
           abbreviation: WIS
-          description: Insight and perception. Increases mana regen.
+          description: Insight and willpower
           baseStat: 10
         CHA:
           displayName: Charisma
           abbreviation: CHA
-          description: Force of personality. Increases XP gain.
+          description: Force of personality
           baseStat: 10
       bindings:
         meleeDamageStat: STR
-        meleeDamageDivisor: 3
+        meleeDamageDivisor: 1
         dodgeStat: DEX
-        dodgePerPoint: 2
-        maxDodgePercent: 30
+        dodgePerPoint: 5
+        maxDodgePercent: 50
         spellDamageStat: INT
-        spellDamageDivisor: 3
+        spellDamageDivisor: 1
         hpScalingStat: CON
-        hpScalingDivisor: 5
+        hpScalingDivisor: 2
         manaScalingStat: INT
-        manaScalingDivisor: 5
+        manaScalingDivisor: 2
         hpRegenStat: CON
-        hpRegenMsPerPoint: 200
+        hpRegenMsPerPoint: 400
         manaRegenStat: WIS
-        manaRegenMsPerPoint: 200
+        manaRegenMsPerPoint: 400
         xpBonusStat: CHA
-        xpBonusPerPoint: 0.005
+        xpBonusPerPoint: 5
     abilities:
       definitions:
-        power_strike:
-          displayName: Power Strike
+        # ── Knight (WARRIOR) ────────────────────────────────────────────
+        heroic_slash:
+          displayName: Heroic Slash
+          description: A brave swing of your sword that shines with golden light.
           manaCost: 5
           cooldownMs: 0
           levelRequired: 1
-          skillPointCost: 0
+          skillPointCost: 1
           targetType: ENEMY
+          requiredClass: WARRIOR
+          tree: Valor
+          tier: 1
           effect:
             type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: A powerful melee strike.
-          image: 2bb1d751eaa8b58a5925683d143b441dea55ad8cb6b5e02bffbd787d2656e809.png
-          requiredClass: WARRIOR
-        taunt:
-          displayName: Taunt
-          manaCost: 5
-          cooldownMs: 10000
-          levelRequired: 2
-          targetType: ENEMY
-          effect:
-            type: TAUNT
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Force a mob to attack you by generating massive threat.
-          image: a74204c47e9d8b7e9f2a8b1a8d8b6c9f96ae20b2bfe15f7a3549fd591bee7fa4.png
-          requiredClass: WARRIOR
-        battle_shout:
-          displayName: Battle Shout
-          manaCost: 10
-          cooldownMs: 60000
-          levelRequired: 3
-          targetType: SELF
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: battle_shout
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: A war cry that increases your strength.
-          image: 045f9b9185b2fa25e56abbe634d732707b6f380db9e607d29413abe753358dee.png
-          requiredClass: WARRIOR
+            minDamage: 8
+            maxDamage: 14
+            damagePerLevel: 0.5
         shield_bash:
           displayName: Shield Bash
+          description: Slam your shield into the enemy, stunning them with a burst of starlight.
           manaCost: 10
-          cooldownMs: 3000
-          levelRequired: 5
+          cooldownMs: 8000
+          levelRequired: 3
+          skillPointCost: 1
           targetType: ENEMY
+          requiredClass: WARRIOR
+          tree: Valor
+          tier: 2
+          effect:
+            type: APPLY_STATUS
+            statusEffectId: starburst_stun
+        valiant_cry:
+          displayName: Valiant Cry
+          description: Let out a courageous battle cry that forces all enemies to focus on you.
+          manaCost: 12
+          cooldownMs: 10000
+          levelRequired: 4
+          skillPointCost: 1
+          targetType: SELF
+          requiredClass: WARRIOR
+          tree: Valor
+          tier: 2
+          effect:
+            type: TAUNT
+            flatThreat: 60.0
+            margin: 15.0
+        pillow_fort:
+          displayName: Pillow Fort
+          description: Summon a magical barrier of enchanted pillows that absorbs damage.
+          manaCost: 15
+          cooldownMs: 15000
+          levelRequired: 5
+          skillPointCost: 1
+          targetType: SELF
+          requiredClass: WARRIOR
+          tree: Guardian
+          tier: 1
+          effect:
+            type: APPLY_STATUS
+            statusEffectId: pillow_shield
+        storybook_strike:
+          displayName: Storybook Strike
+          description: Your weapon glows with the power of legendary heroes from your favorite stories.
+          manaCost: 14
+          cooldownMs: 5000
+          levelRequired: 6
+          skillPointCost: 1
+          targetType: ENEMY
+          requiredClass: WARRIOR
+          tree: Valor
+          tier: 3
           effect:
             type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Bash your foe with your shield.
-          image: 22e9a085a44a82b8da891c9d888d5b8f63885669328931494188f48b854814ab.png
-          requiredClass: WARRIOR
-        whirlwind_strike:
-          displayName: Whirlwind Strike
-          manaCost: 12
-          cooldownMs: 4000
+            minDamage: 18
+            maxDamage: 28
+            damagePerLevel: 0.8
+        courage_aura:
+          displayName: Courage Aura
+          description: Your bravery inspires you, boosting your strength and constitution.
+          manaCost: 18
+          cooldownMs: 30000
           levelRequired: 7
+          skillPointCost: 2
+          targetType: SELF
+          requiredClass: WARRIOR
+          tree: Guardian
+          tier: 2
+          effect:
+            type: APPLY_STATUS
+            statusEffectId: courage_buff
+        dragon_slam:
+          displayName: Dragon Slam
+          description: Channel the spirit of a storybook dragon into a devastating ground slam hitting all foes.
+          manaCost: 25
+          cooldownMs: 12000
+          levelRequired: 8
+          skillPointCost: 2
           targetType: ENEMY
+          requiredClass: WARRIOR
+          tree: Valor
+          tier: 4
           effect:
             type: AREA_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Spin around hitting nearby enemies in combat.
-          image: 901ad4cbe906fe31c25b887335e1ea2977c283a3d44215c8eeafc4ebb0535fcd.png
-          requiredClass: WARRIOR
-        war_cry:
-          displayName: War Cry
-          manaCost: 15
-          cooldownMs: 8000
-          levelRequired: 10
-          targetType: SELF
-          effect:
-            type: DIRECT_HEAL
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 5
-            maxHeal: 12
-            healPerLevel: 2
-            flatThreat: 50
-            margin: 10
-          description: Rally yourself with a battle cry.
-          image: 97561feb5e2851b227ba1bd1aa0a21500aa2183f39079cd105c0face11b623e8.png
-          requiredClass: WARRIOR
-        riposte:
-          displayName: Riposte
-          manaCost: 8
-          cooldownMs: 2000
-          levelRequired: 12
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: A skilled counter-attack against your foe.
-          image: 200a552cdc90114e5b8c06466cee1d69e8f234921b73546ec99de90dd27933ee.png
-          requiredClass: WARRIOR
-        block:
-          displayName: Block
-          manaCost: 10
-          cooldownMs: 5000
-          levelRequired: 14
-          targetType: SELF
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: thornhide_armor
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Protect yourself with a defensive stance.
-          image: 046e765a6d64c16e0d0185769acdc6946ba665d2bebc32c3976c79092bb0bf51.png
-          requiredClass: WARRIOR
-        cleave:
-          displayName: Cleave
-          manaCost: 14
-          cooldownMs: 6000
-          levelRequired: 5
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 6
-            maxDamage: 14
-            damagePerLevel: 2
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: A wide sweeping attack that hits with devastating force.
-          image: 37522848c2519d1a2bc338d8b4da35524f2b0ecfe141841206db9c50e408b94b.png
-          requiredClass: WARRIOR
-        counter_attack:
-          displayName: Counter Attack
-          manaCost: 6
-          cooldownMs: 3000
-          levelRequired: 18
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Strike your opponent as they attack you.
-          image: e65574348cc1e15a0f4df12509671ed57e7181977f06d1013ec3924b7e66dabf.png
-          requiredClass: WARRIOR
-        berserker_rage:
-          displayName: Berserker Rage
+            minDamage: 14
+            maxDamage: 22
+            damagePerLevel: 0.6
+        blanket_cape:
+          displayName: Blanket Cape
+          description: Wrap yourself in an indestructible magical blanket that heals you over time.
           manaCost: 20
-          cooldownMs: 10000
-          levelRequired: 20
+          cooldownMs: 20000
+          levelRequired: 9
+          skillPointCost: 2
           targetType: SELF
+          requiredClass: WARRIOR
+          tree: Guardian
+          tier: 3
           effect:
             type: APPLY_STATUS
-            statusEffectId: berserker_state
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Enter a state of primal fury, increasing damage output.
-          image: 2aa2c4214005013e1eb60e84cc038974182e8a8f4c28fefae9b0a7db7dc19fc9.png
-          requiredClass: WARRIOR
-        charge:
-          displayName: Charge
-          manaCost: 12
-          cooldownMs: 7000
-          levelRequired: 22
+            statusEffectId: blanket_regen
+        champion_charge:
+          displayName: Champion's Charge
+          description: Rush forward with the full force of a storybook hero, dealing massive damage.
+          manaCost: 30
+          cooldownMs: 15000
+          levelRequired: 10
+          skillPointCost: 2
           targetType: ENEMY
+          requiredClass: WARRIOR
+          tree: Valor
+          tier: 5
           effect:
             type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Rush forward and slam your enemy.
-          image: 7e1f59121ad8567eafe1a31938261db5312857724bc5c436532a43e1ec02a3bc.png
-          requiredClass: WARRIOR
-        parry:
-          displayName: Parry
-          manaCost: 8
-          cooldownMs: 4000
-          levelRequired: 24
-          targetType: SELF
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: thornhide_armor
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Deflect incoming attacks with your weapon.
-          image: d4497b50452e135ca488c3b2301c1d62a661134a24c135357f5df6394499893f.png
-          requiredClass: WARRIOR
-        crushing_blow:
-          displayName: Crushing Blow
-          manaCost: 18
-          cooldownMs: 8000
-          levelRequired: 26
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Deliver a devastating blow with all your might.
-          image: 98edff424a60059301086248240d3c22336b64dc046a9a8be14507c6918e982b.png
-          requiredClass: WARRIOR
-        revenge:
-          displayName: Revenge
-          manaCost: 10
-          cooldownMs: 5000
-          levelRequired: 28
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Strike back at an enemy that just hurt you.
-          image: 657533e4cfccfa17a838035caba815c0ca12963170d8bbb76b5183d3576e0054.png
-          requiredClass: WARRIOR
+            minDamage: 30
+            maxDamage: 45
+            damagePerLevel: 1.0
         last_stand:
           displayName: Last Stand
-          manaCost: 25
-          cooldownMs: 30000
-          levelRequired: 30
+          description: Channel every ounce of heroic willpower into an impenetrable shield and stat boost.
+          manaCost: 35
+          cooldownMs: 60000
+          levelRequired: 12
+          skillPointCost: 3
           targetType: SELF
+          requiredClass: WARRIOR
+          tree: Guardian
+          tier: 4
+          prerequisites:
+            - pillow_fort
+            - courage_aura
           effect:
             type: APPLY_STATUS
             statusEffectId: last_stand_buff
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Become nearly invulnerable for a short time. A last resort.
-          image: 1f80c79c82b25db3beb670bf2289755ef5797cd1e35cda1d385a6ac654441c68.png
-          requiredClass: WARRIOR
-        execution:
-          displayName: Execution
-          manaCost: 16
-          cooldownMs: 6000
-          levelRequired: 34
+
+        # ── Wizard (MAGE) ──────────────────────────────────────────────
+        sparkle_bolt:
+          displayName: Sparkle Bolt
+          description: Fire a glittering bolt of pure imagination at your target.
+          manaCost: 8
+          cooldownMs: 0
+          levelRequired: 1
+          skillPointCost: 1
           targetType: ENEMY
+          requiredClass: MAGE
+          tree: Imagination
+          tier: 1
           effect:
             type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: A finishing move to strike down weakened foes.
-          image: 47cee5fd0f27dfc2e2782db406cb461b4afe06e999d1a2e1f4b2bc5c5f04acce.png
-          requiredClass: WARRIOR
-        second_wind:
-          displayName: Second Wind
-          manaCost: 20
-          cooldownMs: 10000
-          levelRequired: 36
-          targetType: SELF
-          effect:
-            type: DIRECT_HEAL
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 5
-            maxHeal: 12
-            healPerLevel: 2
-            flatThreat: 50
-            margin: 10
-          description: Push through your exhaustion and recover.
-          image: f845d6447127a2c914715cff412efb6beb8b315a139e275a6312933008333376.png
-          requiredClass: WARRIOR
-        unbreakable:
-          displayName: Unbreakable
-          manaCost: 22
-          cooldownMs: 15000
-          levelRequired: 38
-          targetType: SELF
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: berserker_state
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Strengthen your resolve to become an immovable force.
-          image: ae01efb31f560919c4325a2fee589e53a950cf4491bf272fa4af1389e7614089.png
-          requiredClass: WARRIOR
-        mass_taunt:
-          displayName: Mass Taunt
+            minDamage: 10
+            maxDamage: 16
+            damagePerLevel: 0.6
+        crayon_fire:
+          displayName: Crayon Fire
+          description: Scribble a fireball into existence with magical crayons. It burns with rainbow flames.
           manaCost: 15
-          cooldownMs: 12000
-          levelRequired: 40
+          cooldownMs: 6000
+          levelRequired: 3
+          skillPointCost: 1
           targetType: ENEMY
+          requiredClass: MAGE
+          tree: Imagination
+          tier: 2
           effect:
-            type: TAUNT
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 75
-            margin: 15
-          description: Taunt all nearby enemies.
-          image: a38a84bd77754a6ecbf9013f759e1813329ce4a2e5d2751f1990e2912ade080d.png
-          requiredClass: WARRIOR
-        whirlwind_assault:
-          displayName: Whirlwind Assault
-          manaCost: 28
-          cooldownMs: 10000
-          levelRequired: 42
-          targetType: ENEMY
-          effect:
-            type: AREA_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Execute a devastating spin attack hitting all foes.
-          image: 83366d876215b55529b05483fe09092ae6aa7b50179dd4026daeb68129053e92.png
-          requiredClass: WARRIOR
-        savage_charge:
-          displayName: Savage Charge
-          manaCost: 24
-          cooldownMs: 8000
-          levelRequired: 44
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: A relentless assault that knocks back enemies.
-          image: 27452a211d49049c01f518174725e5d501b2e2bbe6a5885f96383ab72d0d99a7.png
-          requiredClass: WARRIOR
-        iron_resolve:
-          displayName: Iron Resolve
-          manaCost: 20
-          cooldownMs: 12000
-          levelRequired: 46
+            type: APPLY_STATUS
+            statusEffectId: crayon_burn
+        bubble_shield:
+          displayName: Bubble Shield
+          description: Encase yourself in an iridescent soap bubble that absorbs damage.
+          manaCost: 12
+          cooldownMs: 15000
+          levelRequired: 4
+          skillPointCost: 1
           targetType: SELF
+          requiredClass: MAGE
+          tree: Wonder
+          tier: 1
           effect:
             type: APPLY_STATUS
-            statusEffectId: thornhide_armor
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Harden your body against damage.
-          image: 035af3de547198a4a421666e29b68a3738d5a953fda9c2c0b4eeb0e871615d60.png
-          requiredClass: WARRIOR
-        endgame_strike:
-          displayName: Endgame Strike
-          manaCost: 26
-          cooldownMs: 9000
-          levelRequired: 48
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: A powerful attack reserved for experienced warriors.
-          image: 6f3465c8291154bc9aa3dd35a50414326503c3712db5f6a29c45f3d26a7d6fbf.png
-          requiredClass: WARRIOR
-        champions_triumph:
-          displayName: Champion's Triumph
-          manaCost: 30
-          cooldownMs: 15000
-          levelRequired: 50
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: The ultimate warrior ability—strike with glory.
-          image: 028f9f6f9ce5c867f6984aa066fafb4a1861a1253a7fa84be70014d0eacfea5a.png
-          requiredClass: WARRIOR
-        rend:
-          displayName: Rend
-          manaCost: 10
-          cooldownMs: 12000
+            statusEffectId: bubble_shield_effect
+        nightmare_hex:
+          displayName: Nightmare Hex
+          description: Curse your foe with creepy nightmare images that sap their strength.
+          manaCost: 14
+          cooldownMs: 10000
           levelRequired: 5
+          skillPointCost: 1
           targetType: ENEMY
+          requiredClass: MAGE
+          tree: Wonder
+          tier: 2
           effect:
             type: APPLY_STATUS
-            statusEffectId: rend_bleed
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: A vicious wound that bleeds over time.
-          image: 8d31e6a2cdd42cadc0207707fbb5d7208e9926af67319cd52a95b4eb2596aac1.png
-          requiredClass: WARRIOR
-        whirlwind:
-          displayName: Whirlwind
-          manaCost: 25
-          cooldownMs: 15000
-          levelRequired: 15
-          targetType: ALL_ENEMIES
+            statusEffectId: nightmare_debuff
+        stardust_storm:
+          displayName: Stardust Storm
+          description: Unleash a swirling storm of stardust that damages all enemies in the room.
+          manaCost: 22
+          cooldownMs: 8000
+          levelRequired: 6
+          skillPointCost: 1
+          targetType: ENEMY
+          requiredClass: MAGE
+          tree: Imagination
+          tier: 3
           effect:
             type: AREA_DAMAGE
-            minDamage: 8
-            maxDamage: 18
-            damagePerLevel: 2.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Spin in a deadly arc, striking all nearby enemies.
-          image: b80f2848bb6338b214b4a99933ef4cdeeb4526a019a58eb3444c58d3c2f0da61.png
-          requiredClass: WARRIOR
-        execute:
-          displayName: Execute
-          manaCost: 20
-          cooldownMs: 10000
-          levelRequired: 15
+            minDamage: 12
+            maxDamage: 20
+            damagePerLevel: 0.5
+        daydream_bolt:
+          displayName: Daydream Bolt
+          description: A concentrated beam of pure daydream energy that pierces through reality.
+          manaCost: 18
+          cooldownMs: 5000
+          levelRequired: 7
+          skillPointCost: 2
           targetType: ENEMY
+          requiredClass: MAGE
+          tree: Imagination
+          tier: 4
           effect:
             type: DIRECT_DAMAGE
-            minDamage: 15
-            maxDamage: 30
-            damagePerLevel: 3
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: A finishing blow against wounded foes, dealing massive damage.
-          image: f6637656a4720614e35386dad739ae39322f3a7874d3fb7ce17ae94e769d6655.png
-          requiredClass: WARRIOR
-        bladestorm:
-          displayName: Bladestorm
-          manaCost: 40
-          cooldownMs: 30000
-          levelRequired: 30
-          targetType: ALL_ENEMIES
+            minDamage: 22
+            maxDamage: 34
+            damagePerLevel: 0.9
+        enchanted_slumber:
+          displayName: Enchanted Slumber
+          description: Lull your enemy into a magical sleep, rooting them in place.
+          manaCost: 16
+          cooldownMs: 15000
+          levelRequired: 7
+          skillPointCost: 2
+          targetType: ENEMY
+          requiredClass: MAGE
+          tree: Wonder
+          tier: 3
+          effect:
+            type: APPLY_STATUS
+            statusEffectId: enchanted_root
+        brain_freeze:
+          displayName: Brain Freeze
+          description: Hit your enemy with an ice-cream headache so intense it freezes them solid.
+          manaCost: 20
+          cooldownMs: 12000
+          levelRequired: 8
+          skillPointCost: 2
+          targetType: ENEMY
+          requiredClass: MAGE
+          tree: Wonder
+          tier: 4
+          effect:
+            type: APPLY_STATUS
+            statusEffectId: brain_freeze_stun
+        supernova_burst:
+          displayName: Supernova Burst
+          description: Channel the energy of an exploding star, devastating everything in the room.
+          manaCost: 35
+          cooldownMs: 15000
+          levelRequired: 10
+          skillPointCost: 2
+          targetType: ENEMY
+          requiredClass: MAGE
+          tree: Imagination
+          tier: 5
+          prerequisites:
+            - stardust_storm
           effect:
             type: AREA_DAMAGE
             minDamage: 20
-            maxDamage: 40
-            damagePerLevel: 4
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Become a whirlwind of steel, unleashing devastating attacks on all
-            enemies.
-          image: 3e6c3bdbb66d40abf936c1297427d8c7f2bc87a746ab4392c968926166302f64.png
-          requiredClass: WARRIOR
-        shield_block:
-          displayName: Shield Block
-          manaCost: 10
-          cooldownMs: 15000
-          levelRequired: 5
+            maxDamage: 35
+            damagePerLevel: 0.8
+        reality_warp:
+          displayName: Reality Warp
+          description: Bend the fabric of Auringold itself, boosting all your mental stats dramatically.
+          manaCost: 30
+          cooldownMs: 60000
+          levelRequired: 12
+          skillPointCost: 3
           targetType: SELF
+          requiredClass: MAGE
+          tree: Wonder
+          tier: 5
           effect:
             type: APPLY_STATUS
-            statusEffectId: shield_wall_buff
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Raise your shield to absorb incoming attacks.
-          image: c403bdfb1efd714e8534fe026a1088432a525f505118c99a3437d9c261cc1e76.png
-          requiredClass: WARRIOR
-        shield_wall:
-          displayName: Shield Wall
+            statusEffectId: reality_warp_buff
+
+        # ── Doctor (CLERIC) ─────────────────────────────────────────────
+        bandage_wrap:
+          displayName: Bandage Wrap
+          description: Apply magical bandages that instantly mend wounds with a warm glow.
+          manaCost: 10
+          cooldownMs: 0
+          levelRequired: 1
+          skillPointCost: 1
+          targetType: SELF
+          requiredClass: CLERIC
+          tree: Medicine
+          tier: 1
+          effect:
+            type: DIRECT_HEAL
+            minHeal: 12
+            maxHeal: 20
+            healPerLevel: 0.6
+        lollipop_remedy:
+          displayName: Lollipop Remedy
+          description: Offer a magical lollipop that heals an ally with sugary restorative magic.
+          manaCost: 12
+          cooldownMs: 3000
+          levelRequired: 2
+          skillPointCost: 1
+          targetType: ALLY
+          requiredClass: CLERIC
+          tree: Medicine
+          tier: 1
+          effect:
+            type: DIRECT_HEAL
+            minHeal: 15
+            maxHeal: 25
+            healPerLevel: 0.7
+        vitamin_boost:
+          displayName: Vitamin Boost
+          description: Prescribe a course of magical vitamins that buff your patient's constitution.
+          manaCost: 14
+          cooldownMs: 20000
+          levelRequired: 3
+          skillPointCost: 1
+          targetType: SELF
+          requiredClass: CLERIC
+          tree: Wellness
+          tier: 1
+          effect:
+            type: APPLY_STATUS
+            statusEffectId: vitamin_buff
+        fever_check:
+          displayName: Fever Check
+          description: Diagnose your enemy with a terrible magical fever that burns them over time.
+          manaCost: 12
+          cooldownMs: 8000
+          levelRequired: 4
+          skillPointCost: 1
+          targetType: ENEMY
+          requiredClass: CLERIC
+          tree: Medicine
+          tier: 2
+          effect:
+            type: APPLY_STATUS
+            statusEffectId: magic_fever
+        chicken_soup:
+          displayName: Chicken Soup
+          description: Conjure a steaming bowl of grandma's magical chicken soup that heals over time.
+          manaCost: 18
+          cooldownMs: 12000
+          levelRequired: 5
+          skillPointCost: 1
+          targetType: SELF
+          requiredClass: CLERIC
+          tree: Wellness
+          tier: 2
+          effect:
+            type: APPLY_STATUS
+            statusEffectId: soup_regen
+        booster_shot:
+          displayName: Booster Shot
+          description: Administer a magical injection that dramatically boosts wisdom and constitution.
           manaCost: 20
           cooldownMs: 25000
-          levelRequired: 15
+          levelRequired: 6
+          skillPointCost: 2
           targetType: SELF
+          requiredClass: CLERIC
+          tree: Wellness
+          tier: 3
           effect:
             type: APPLY_STATUS
-            statusEffectId: shield_wall_buff
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Brace behind your shield, greatly reducing all incoming damage.
-          image: d97387cf000e673f99985781bfdfa362a9c9bb7a43a3e1a0e27ab6a4145b8e83.png
-          requiredClass: WARRIOR
-        rallying_cry:
-          displayName: Rallying Cry
-          manaCost: 15
+            statusEffectId: booster_buff
+        quarantine:
+          displayName: Quarantine
+          description: Trap an enemy in a bubble of quarantine energy, rooting them in place.
+          manaCost: 16
+          cooldownMs: 15000
+          levelRequired: 7
+          skillPointCost: 2
+          targetType: ENEMY
+          requiredClass: CLERIC
+          tree: Medicine
+          tier: 3
+          effect:
+            type: APPLY_STATUS
+            statusEffectId: quarantine_root
+        emergency_heal:
+          displayName: Emergency Heal
+          description: Perform emergency magical triage, restoring a massive amount of health.
+          manaCost: 30
           cooldownMs: 20000
-          levelRequired: 15
+          levelRequired: 8
+          skillPointCost: 2
           targetType: SELF
+          requiredClass: CLERIC
+          tree: Medicine
+          tier: 4
+          effect:
+            type: DIRECT_HEAL
+            minHeal: 40
+            maxHeal: 60
+            healPerLevel: 1.2
+        placebo_effect:
+          displayName: Placebo Effect
+          description: Convince your enemy they are terribly ill, weakening all their stats.
+          manaCost: 22
+          cooldownMs: 20000
+          levelRequired: 9
+          skillPointCost: 2
+          targetType: ENEMY
+          requiredClass: CLERIC
+          tree: Wellness
+          tier: 4
           effect:
             type: APPLY_STATUS
-            statusEffectId: rallying_cry_buff
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Inspire your allies with a mighty shout, boosting strength and
-            constitution.
-          image: f97b15b27415f022faf502f05d3a9dc7f4b7fdee9e45b1dca765057ed0ad55a6.png
-          requiredClass: WARRIOR
-        arcane_bolt:
-          displayName: Arcane Bolt
+            statusEffectId: placebo_debuff
+        miracle_cure:
+          displayName: Miracle Cure
+          description: Channel the ultimate healing magic — a cure so powerful it mends all wounds and fortifies the body.
+          manaCost: 40
+          cooldownMs: 60000
+          levelRequired: 12
+          skillPointCost: 3
+          targetType: SELF
+          requiredClass: CLERIC
+          tree: Medicine
+          tier: 5
+          prerequisites:
+            - emergency_heal
+            - chicken_soup
+          effect:
+            type: APPLY_STATUS
+            statusEffectId: miracle_cure_effect
+
+        # ── Pirate (ROGUE) ──────────────────────────────────────────────
+        sneak_attack:
+          displayName: Sneak Attack
+          description: Strike from the shadows with a quick, dirty blow.
           manaCost: 6
           cooldownMs: 0
           levelRequired: 1
-          skillPointCost: 0
+          skillPointCost: 1
           targetType: ENEMY
+          requiredClass: ROGUE
+          tree: Scallywag
+          tier: 1
           effect:
             type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Hurl a bolt of arcane energy.
-          image: abf38ddd50c272ff7c7f298531000110033373fa281126e31019424e207fbe39.png
-          requiredClass: MAGE
-        ignite:
-          displayName: Ignite
+            minDamage: 9
+            maxDamage: 15
+            damagePerLevel: 0.6
+        pocket_sand:
+          displayName: Pocket Sand
+          description: Throw a handful of magical sand in your enemy's eyes, stunning them.
+          manaCost: 8
+          cooldownMs: 10000
+          levelRequired: 3
+          skillPointCost: 1
+          targetType: ENEMY
+          requiredClass: ROGUE
+          tree: Scallywag
+          tier: 2
+          effect:
+            type: APPLY_STATUS
+            statusEffectId: sand_stun
+        treasure_map:
+          displayName: Treasure Map
+          description: Consult your enchanted treasure map, boosting your luck and dexterity.
+          manaCost: 10
+          cooldownMs: 25000
+          levelRequired: 4
+          skillPointCost: 1
+          targetType: SELF
+          requiredClass: ROGUE
+          tree: Buccaneer
+          tier: 1
+          effect:
+            type: APPLY_STATUS
+            statusEffectId: treasure_luck
+        poison_blade:
+          displayName: Poison Blade
+          description: Coat your weapon with fizzy soda poison that corrodes your enemy over time.
           manaCost: 12
           cooldownMs: 8000
-          levelRequired: 3
-          targetType: ENEMY
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: ignite
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Sets the target ablaze, burning them for damage over time.
-          image: 5c3e76db10b17da09e4d90f1da8f59656350e6b5eea3d6f1e27daacb744bddbc.png
-          requiredClass: MAGE
-        frost_nova:
-          displayName: Frost Nova
-          manaCost: 15
-          cooldownMs: 3000
           levelRequired: 5
+          skillPointCost: 1
           targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Blast your enemy with freezing cold.
-          image: 13becd9844597ca13b2cd2f9173da208d487f66f38dc18fdbd383a93f884af75.png
-          requiredClass: MAGE
-        fireball:
-          displayName: Fireball
-          manaCost: 25
-          cooldownMs: 8000
-          levelRequired: 5
-          targetType: ENEMY
-          effect:
-            type: AREA_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Hurl a ball of fire that hits all enemies in combat with your group.
-          image: 010bda6996ea457270069d6903b04c764185fee66006e76a61ad6c971a65410d.png
-          requiredClass: MAGE
-        mana_bolt:
-          displayName: Mana Bolt
-          manaCost: 10
-          cooldownMs: 4000
-          levelRequired: 7
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Drain mana from your foe and hurl it as a projectile.
-          image: a0ecc9b83e222f89ae35107d74c75a9f2bbddb8e42ae4daf9d31c28fb2bc55a4.png
-          requiredClass: MAGE
-        inferno:
-          displayName: Inferno
-          manaCost: 25
-          cooldownMs: 5000
-          levelRequired: 10
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Engulf your foe in searing flames.
-          image: 47c6b65dde0c84ac706f32b80b1ce4301bb754afc9139c778864fa403e768365.png
-          requiredClass: MAGE
-        flame_armor:
-          displayName: Flame Armor
-          manaCost: 14
-          cooldownMs: 10000
-          levelRequired: 12
-          targetType: SELF
+          requiredClass: ROGUE
+          tree: Scallywag
+          tier: 3
           effect:
             type: APPLY_STATUS
-            statusEffectId: flame_armor
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Surround yourself with protective flames.
-          image: c0e3016507d4fb02481d6b446f5494932f04795b3e24095ef3fc929049982e73.png
-          requiredClass: MAGE
-        frost_armor:
-          displayName: Frost Armor
-          manaCost: 14
-          cooldownMs: 10000
-          levelRequired: 14
-          targetType: SELF
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: frost_armor
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Encase yourself in a shield of ice.
-          image: f935922fd2ab97ffe2c8375e4560cf38e6be6c134e4b383eade882a63f170dd2.png
-          requiredClass: MAGE
-        chain_lightning:
-          displayName: Chain Lightning
-          manaCost: 18
-          cooldownMs: 6000
-          levelRequired: 16
-          targetType: ENEMY
-          effect:
-            type: AREA_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Hurl lightning that bounces between enemies.
-          image: 5951d29e60997ed9ca52650034364cd817c2b9576f8ec4b2e74982a8d0de640a.png
-          requiredClass: MAGE
-        blizzard:
-          displayName: Blizzard
-          manaCost: 28
-          cooldownMs: 9000
-          levelRequired: 18
-          targetType: ENEMY
-          effect:
-            type: AREA_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Summon a whirlwind of snow and ice.
-          image: a218c74688c8f1cfbb09ccb989bd392edadf40aea2ff340f5b6b26a2a51a6154.png
-          requiredClass: MAGE
-        pyroclasm:
-          displayName: Pyroclasm
-          manaCost: 30
-          cooldownMs: 10000
-          levelRequired: 20
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Unleash explosive volcanic energy.
-          image: ecc57e0260782a3f6bdc23fb5ebf66cf0bb405b4d91a9fc9b216a7e0d143e594.png
-          requiredClass: MAGE
-        ice_storm:
-          displayName: Ice Storm
-          manaCost: 26
-          cooldownMs: 8000
-          levelRequired: 24
-          targetType: ENEMY
-          effect:
-            type: AREA_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Create a deadly storm of icicles.
-          image: e4445a7cb254a592f7ae167c4a2ed0c32825c7002f246cd2b7fa99a56b65bb0c.png
-          requiredClass: MAGE
-        meteor_shower:
-          displayName: Meteor Shower
-          manaCost: 32
-          cooldownMs: 12000
-          levelRequired: 26
-          targetType: ENEMY
-          effect:
-            type: AREA_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Rain meteors down upon your enemies.
-          image: 5ca49c13c71b8122e1b210cb64165f1983f6b74c451603d41395abd8fa3b19d8.png
-          requiredClass: MAGE
-        arcane_explosion:
-          displayName: Arcane Explosion
-          manaCost: 28
-          cooldownMs: 10000
-          levelRequired: 28
-          targetType: ENEMY
-          effect:
-            type: AREA_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Detonate raw arcane energy in all directions.
-          image: d79d258ebb9700fad1805e5a9edc349f1bc429db505ce557c2893d0793e8f34e.png
-          requiredClass: MAGE
-        temporal_warp:
-          displayName: Temporal Warp
-          manaCost: 24
-          cooldownMs: 7000
-          levelRequired: 30
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Twist spacetime to damage your foe.
-          image: a9063bd3c904c4b62bb9f5427c0d3ab527ac3391ff68cc8ada8002bf6db7b608.png
-          requiredClass: MAGE
-        flame_burst:
-          displayName: Flame Burst
+            statusEffectId: soda_poison
+        cannonball:
+          displayName: Cannonball
+          description: Fire an imaginary cannon at all enemies with a tremendous boom.
           manaCost: 20
-          cooldownMs: 6000
-          levelRequired: 32
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Create a controlled explosion of fire.
-          image: bd7cc7b268faeb554b06d88df4b34ac92aeedfc78b456b2b44f99cd85d406f1b.png
-          requiredClass: MAGE
-        absolute_zero:
-          displayName: Absolute Zero
-          manaCost: 26
-          cooldownMs: 9000
-          levelRequired: 34
-          targetType: ENEMY
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: frozen
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Freeze your enemy solid with absolute cold.
-          image: 99b2e2695bee6af30f4f0b32d1905ad3c0882e0797f199a8064c8be3d966d91f.png
-          requiredClass: MAGE
-        inferno_nova:
-          displayName: Inferno Nova
-          manaCost: 28
           cooldownMs: 10000
-          levelRequired: 36
+          levelRequired: 6
+          skillPointCost: 1
           targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Detonate a miniature inferno.
-          image: 95f2065b9d4e5ed0514f8ac5b64ec554eaf6a1caac3bf84170359c5d46278561.png
-          requiredClass: MAGE
-        time_fracture:
-          displayName: Time Fracture
-          manaCost: 30
-          cooldownMs: 11000
-          levelRequired: 38
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Shatter time around your enemy.
-          image: 26490f791ae86ff293232a11c3ed565a80924056b46228000a048d2579752434.png
-          requiredClass: MAGE
-        mana_shield:
-          displayName: Mana Shield
-          manaCost: 22
-          cooldownMs: 8000
-          levelRequired: 40
-          targetType: SELF
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: mana_shield
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Shield yourself with pure magical energy.
-          image: 9987519d7f155a9250fb0f1a9e88792b362206e32f66646135207cb57603de34.png
-          requiredClass: MAGE
-        arcane_overload:
-          displayName: Arcane Overload
-          manaCost: 34
-          cooldownMs: 13000
-          levelRequired: 42
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Charge yourself with dangerous arcane power.
-          image: cfec23b1c701c2e5019e0fb10701e3f1f13326d7749831a38c590cd6faac4484.png
-          requiredClass: MAGE
-        cataclysm:
-          displayName: Cataclysm
-          manaCost: 36
-          cooldownMs: 14000
-          levelRequired: 44
-          targetType: ENEMY
-          effect:
-            type: AREA_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Bring total destruction to a wide area.
-          image: 896003bd22608d34e571211ddbd1e5b16debed7b9ca6152d5b3dbd7ef5b58c38.png
-          requiredClass: MAGE
-        temporal_twist:
-          displayName: Temporal Twist
-          manaCost: 28
-          cooldownMs: 10000
-          levelRequired: 46
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Manipulate time itself against your enemies.
-          image: eb9db21f9ff36756f6be0f65613b9d14a71040f1e0f082ca837d10cbb27ec5a4.png
-          requiredClass: MAGE
-        spellsteal:
-          displayName: Spellsteal
-          manaCost: 20
-          cooldownMs: 8000
-          levelRequired: 48
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Drain the magical essence from your enemy.
-          image: abf8b3026bd42d05404729da49a968131063f3b527f96280804aca7c598ef1c1.png
-          requiredClass: MAGE
-        arcane_mastery:
-          displayName: Arcane Mastery
-          manaCost: 38
-          cooldownMs: 15000
-          levelRequired: 50
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: The apex of magical power—absolute arcane dominion.
-          image: 6b7cd95d9d83812baa3d22709ef643fcef7fd522746f63e09842a906d9167b8d.png
-          requiredClass: MAGE
-        scorch:
-          displayName: Scorch
-          manaCost: 14
-          cooldownMs: 6000
-          levelRequired: 10
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 5
-            maxDamage: 12
-            damagePerLevel: 2
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Sear an enemy with intense focused flame.
-          image: 1fe55a0992117649b4f877b79a0226e7cbabcb0f06ac69c8137b5beafab5874d.png
-          requiredClass: MAGE
-        ignite_burst:
-          displayName: Ignite Burst
-          manaCost: 16
-          cooldownMs: 10000
-          levelRequired: 10
-          targetType: ENEMY
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: ignite
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Set an enemy ablaze with an explosive burst of fire.
-          image: 0d0af6aae1003851660848eb0107f7ac5e1d3a5a53e767103e4486d329a93732.png
-          requiredClass: MAGE
-        meteor:
-          displayName: Meteor
-          manaCost: 35
-          cooldownMs: 20000
-          levelRequired: 20
-          targetType: ALL_ENEMIES
-          effect:
-            type: AREA_DAMAGE
-            minDamage: 15
-            maxDamage: 30
-            damagePerLevel: 3.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Call down a massive meteor from the sky, devastating all nearby
-            enemies.
-          image: 5f5f5271588a679b31606190a9b4c42fc262afa3c3f265c32c01b9f49ac963c2.png
-          requiredClass: MAGE
-        inferno_capstone:
-          displayName: Inferno
-          manaCost: 50
-          cooldownMs: 30000
-          levelRequired: 30
-          targetType: ALL_ENEMIES
-          effect:
-            type: AREA_DAMAGE
-            minDamage: 25
-            maxDamage: 50
-            damagePerLevel: 5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Engulf the battlefield in a cataclysmic inferno. The pinnacle of
-            fire magic.
-          image: 7498b5dcc3b24aad825cbbb4a77de99e66631f29b0f493b41e0743f0ac360a9d.png
-          requiredClass: MAGE
-        ice_barrier_ability:
-          displayName: Ice Barrier
-          manaCost: 14
-          cooldownMs: 20000
-          levelRequired: 10
-          targetType: SELF
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: ice_barrier
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Surround yourself with a barrier of ice that absorbs damage.
-          image: ed9b15f6ca81fe926e89d51cfb661721e288c15151f6f750d58c830c0069c05b.png
-          requiredClass: MAGE
-        blizzard_ability:
-          displayName: Blizzard
-          manaCost: 30
-          cooldownMs: 15000
-          levelRequired: 20
-          targetType: ALL_ENEMIES
+          requiredClass: ROGUE
+          tree: Buccaneer
+          tier: 2
           effect:
             type: AREA_DAMAGE
             minDamage: 10
-            maxDamage: 22
-            damagePerLevel: 2.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Summon a devastating blizzard that strikes all nearby enemies.
-          image: 2dd4e5a9e32a7e5fa354987b56d88a41324824109d9e6492d79b1e92ef054c94.png
-          requiredClass: MAGE
-        frozen_orb:
-          displayName: Frozen Orb
-          manaCost: 40
-          cooldownMs: 25000
-          levelRequired: 30
-          targetType: ENEMY
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: frozen_orb_dot
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Launch an orb of pure frost that devastates a single target. The
-            pinnacle of frost magic.
-          image: 07e1e7118660d8d7f54759789626d7a52487e2d1097544fb7d39392900241be5.png
-          requiredClass: MAGE
-        minor_heal:
-          displayName: Minor Heal
-          manaCost: 8
-          cooldownMs: 0
-          levelRequired: 1
-          skillPointCost: 0
-          targetType: ALLY
-          effect:
-            type: DIRECT_HEAL
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 5
-            maxHeal: 12
-            healPerLevel: 2
-            flatThreat: 50
-            margin: 10
-          description: Mend wounds with holy light. Target a group member or self.
-          image: 1f4103077a2fd0d3950eb70ff1d1ff928980c48db9bf10dc9c751812db351c24.png
-          requiredClass: CLERIC
-        holy_light:
-          displayName: Holy Light
-          manaCost: 10
-          cooldownMs: 2000
-          levelRequired: 2
-          targetType: ALLY
-          effect:
-            type: DIRECT_HEAL
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 5
-            maxHeal: 12
-            healPerLevel: 2
-            flatThreat: 50
-            margin: 10
-          description: Blessed healing light washes over the target.
-          image: 96466855cea3b9a78ffa9f33006bec8733ca16338ef37985d8f3c70d42d4364d.png
-          requiredClass: CLERIC
-        rejuvenation:
-          displayName: Rejuvenation
-          manaCost: 12
-          cooldownMs: 15000
-          levelRequired: 4
-          targetType: ALLY
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: rejuvenation
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Heals a target over time. Target a group member or self.
-          image: a06acc793d97199829af18fe38835bcb5e9bd340bb838278ada5497dd4e026e5.png
-          requiredClass: CLERIC
-        shield_of_faith:
-          displayName: Shield of Faith
-          manaCost: 15
-          cooldownMs: 30000
-          levelRequired: 5
-          targetType: ALLY
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: shield_of_faith
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Grants a shield that absorbs damage. Target a group member or self.
-          image: 4799d42f45681b1a394ca5c6c14bcb59d7461abe3bd7c4d468c22234f3728f0e.png
-          requiredClass: CLERIC
-        smite:
-          displayName: Smite
-          manaCost: 12
-          cooldownMs: 3000
-          levelRequired: 5
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Strike your foe with divine wrath.
-          image: 1f7c434b0398f0e0aaa20157b96358d98e525f769c981781de62fcdd86d90f99.png
-          requiredClass: CLERIC
-        consecration:
-          displayName: Consecration
-          manaCost: 16
-          cooldownMs: 12000
-          levelRequired: 7
-          targetType: SELF
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: consecrated_ground
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Bless the ground beneath you with holy power.
-          image: ef8f2522413a2cba8c5fd05f3c5ade04cf48f7caee5f7ed6991da29d2e7a7bd2.png
-          requiredClass: CLERIC
-        greater_heal:
-          displayName: Greater Heal
-          manaCost: 22
-          cooldownMs: 8000
-          levelRequired: 10
-          targetType: ALLY
-          effect:
-            type: DIRECT_HEAL
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 5
-            maxHeal: 12
-            healPerLevel: 2
-            flatThreat: 50
-            margin: 10
-          description: A powerful wave of restorative energy. Target a group member or self.
-          image: f59f68ed548db19384fcfe2ec6887c88bd28b52720e2398e724e5c7f8cb9bee1.png
-          requiredClass: CLERIC
-        holy_fire:
-          displayName: Holy Fire
+            maxDamage: 18
+            damagePerLevel: 0.4
+        sea_legs:
+          displayName: Sea Legs
+          description: Channel the rolling waves, boosting your dexterity and making you hard to hit.
           manaCost: 14
-          cooldownMs: 6000
-          levelRequired: 12
-          targetType: ENEMY
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: ignite
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Strike with holy flames that burn over time.
-          image: 74c1ed7cdb95f2471b0db1e0e2c7c5f28c8ad203daf6b096d8231fd8e3b13a60.png
-          requiredClass: CLERIC
-        blessing_of_protection:
-          displayName: Blessing of Protection
-          manaCost: 18
-          cooldownMs: 20000
-          levelRequired: 14
-          targetType: ALLY
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: shield_of_faith
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Grant a blessing that protects the target.
-          image: 1f22fac2b9147550bda803b6f0c0d0f62f04c8c10e54daa1886835d536c29804.png
-          requiredClass: CLERIC
-        divine_light:
-          displayName: Divine Light
-          manaCost: 20
-          cooldownMs: 6000
-          levelRequired: 16
-          targetType: ALLY
-          effect:
-            type: DIRECT_HEAL
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 5
-            maxHeal: 12
-            healPerLevel: 2
-            flatThreat: 50
-            margin: 10
-          description: Channel the light of the divine to heal.
-          image: 527d83adcc8f80cfa0aeddf908d902465c987c4e6f9069d5545542c8a923d748.png
-          requiredClass: CLERIC
-        resurrection:
-          displayName: Resurrection
-          manaCost: 40
-          cooldownMs: 30000
-          levelRequired: 18
-          targetType: ALLY
-          effect:
-            type: DIRECT_HEAL
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 5
-            maxHeal: 12
-            healPerLevel: 2
-            flatThreat: 50
-            margin: 10
-          description: Return a fallen ally to life with holy power.
-          image: 65bf67b60cdc2678313646534d47ad87f69d2038a06f6865ffd700d40d01a488.png
-          requiredClass: CLERIC
-        holy_nova:
-          displayName: Holy Nova
-          manaCost: 26
-          cooldownMs: 10000
-          levelRequired: 20
-          targetType: ALLY
-          effect:
-            type: AREA_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Unleash a wave of holy energy healing nearby allies.
-          image: 43b1b9a6caab872dd2152c3088f935d8ae61d28de1ce0729142e45df98c2dfee.png
-          requiredClass: CLERIC
-        sanctified_heal:
-          displayName: Sanctified Heal
-          manaCost: 28
-          cooldownMs: 10000
-          levelRequired: 22
-          targetType: ALLY
-          effect:
-            type: DIRECT_HEAL
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 5
-            maxHeal: 12
-            healPerLevel: 2
-            flatThreat: 50
-            margin: 10
-          description: A more powerful healing spell blessed by the divine.
-          image: b742e025ff8f8675934f50498843f424589a58409b218aa121e6e44f2b400f2f.png
-          requiredClass: CLERIC
-        guardian_angel:
-          displayName: Guardian Angel
-          manaCost: 24
-          cooldownMs: 15000
-          levelRequired: 24
-          targetType: ALLY
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: divine_blessing
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Call upon a guardian spirit to protect an ally.
-          image: 399e4c1bfd435c2c689bedb5081e4a7a56c4d9f989a05381953e3f974e12515a.png
-          requiredClass: CLERIC
-        divine_intervention:
-          displayName: Divine Intervention
-          manaCost: 30
-          cooldownMs: 12000
-          levelRequired: 26
-          targetType: ALLY
-          effect:
-            type: DIRECT_HEAL
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 5
-            maxHeal: 12
-            healPerLevel: 2
-            flatThreat: 50
-            margin: 10
-          description: Perform a miraculous intervention to heal.
-          image: bb42233acf4332d17ffd6d5faa975767e787ea24e4bfc45a9f9732b061691bae.png
-          requiredClass: CLERIC
-        mass_heal:
-          displayName: Mass Heal
-          manaCost: 32
-          cooldownMs: 14000
-          levelRequired: 28
-          targetType: ALLY
-          effect:
-            type: AREA_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Heal multiple allies at once with holy light.
-          image: ebb501e1036c7fd2fbf59039c7df4a88cbf2bdd73289dbd39fca036c94d1710d.png
-          requiredClass: CLERIC
-        holy_wrath:
-          displayName: Holy Wrath
-          manaCost: 22
-          cooldownMs: 7000
-          levelRequired: 30
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Strike enemies with the wrath of the holy.
-          image: cea121a45c00ba8acb4af361d3d63ce6ec0abe913ba98ad8ceb936689a3bf886.png
-          requiredClass: CLERIC
-        divine_aegis:
-          displayName: Divine Aegis
-          manaCost: 26
-          cooldownMs: 12000
-          levelRequired: 32
+          cooldownMs: 25000
+          levelRequired: 7
+          skillPointCost: 2
           targetType: SELF
+          requiredClass: ROGUE
+          tree: Buccaneer
+          tier: 3
           effect:
             type: APPLY_STATUS
-            statusEffectId: divine_blessing
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Surround yourself with divine protection.
-          image: b5e38eb8e2610ee5c24378480928bfbe431fb0ec8cb7ea1210141a1fa19c82ac.png
-          requiredClass: CLERIC
-        benediction:
-          displayName: Benediction
-          manaCost: 20
-          cooldownMs: 10000
-          levelRequired: 34
-          targetType: ALLY
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: holy_light
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Bestow a blessing that heals over time.
-          image: eecbbac6745600e83ef96bd524d476a035aed16b79a1d0c5fd88bbcc20684e77.png
-          requiredClass: CLERIC
-        holy_shield:
-          displayName: Holy Shield
-          manaCost: 24
+            statusEffectId: sea_legs_buff
+        walk_the_plank:
+          displayName: Walk the Plank
+          description: Force your enemy to walk an imaginary plank, rooting them in terror.
+          manaCost: 16
           cooldownMs: 15000
-          levelRequired: 36
-          targetType: ALLY
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: shield_of_faith
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Create a shield of pure holy energy.
-          image: 4d152b5d3a8c27bf406625b915f5c4ed2b58e4b6814367bc8b4138c1afc2610f.png
-          requiredClass: CLERIC
-        illumination:
-          displayName: Illumination
-          manaCost: 28
-          cooldownMs: 11000
-          levelRequired: 38
-          targetType: ALLY
-          effect:
-            type: AREA_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Flood an area with brilliant holy light.
-          image: 1cd5b2d683c16f84c48361b16b2bdf7c71951ca8d9530e6766ce7ea92e0d58a0.png
-          requiredClass: CLERIC
-        consecrated_ground:
-          displayName: Consecrated Ground (Spell)
-          manaCost: 30
-          cooldownMs: 12000
-          levelRequired: 40
-          targetType: ALLY
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: consecrated_ground
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Sanctify the ground for continuous healing.
-          image: 5efb47315daad1ac16d50d9687f7c1416786f338c889cf4ecf5d1ff5e801337e.png
-          requiredClass: CLERIC
-        divine_favor:
-          displayName: Divine Favor
-          manaCost: 28
-          cooldownMs: 10000
-          levelRequired: 42
-          targetType: ALLY
-          effect:
-            type: DIRECT_HEAL
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 5
-            maxHeal: 12
-            healPerLevel: 2
-            flatThreat: 50
-            margin: 10
-          description: Call down the favor of the divine.
-          image: 62ce6369afd22cc6436a4851b5d02ec419cca865099fed38afc8789a6dbd0b71.png
-          requiredClass: CLERIC
-        holy_vengeance:
-          displayName: Holy Vengeance
-          manaCost: 26
-          cooldownMs: 9000
-          levelRequired: 44
+          levelRequired: 7
+          skillPointCost: 2
           targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Strike your enemies with divine vengeance.
-          image: 728db3c170038233c053aed72abd5b6f0345448e317ed92e626c64957d0060d4.png
-          requiredClass: CLERIC
-        divine_protection:
-          displayName: Divine Protection
-          manaCost: 32
-          cooldownMs: 15000
-          levelRequired: 46
-          targetType: ALLY
+          requiredClass: ROGUE
+          tree: Scallywag
+          tier: 4
           effect:
             type: APPLY_STATUS
-            statusEffectId: shield_of_faith
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: The ultimate protective blessing.
-          image: 1f35d247f2b2122e5c01f4fa739e3ffc40579c79c62d17758b826db468eba78a.png
-          requiredClass: CLERIC
-        salvation:
-          displayName: Salvation
-          manaCost: 36
-          cooldownMs: 16000
-          levelRequired: 48
-          targetType: ALLY
-          effect:
-            type: DIRECT_HEAL
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 5
-            maxHeal: 12
-            healPerLevel: 2
-            flatThreat: 50
-            margin: 10
-          description: Perform a miraculous salvation of an ally.
-          image: 8b01de392dc7fd4431cf200fefb708a806fc316157e18f353a47b77afffcb23d.png
-          requiredClass: CLERIC
-        divine_ascension:
-          displayName: Divine Ascension
-          manaCost: 40
-          cooldownMs: 18000
-          levelRequired: 50
-          targetType: ALLY
-          effect:
-            type: DIRECT_HEAL
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 5
-            maxHeal: 12
-            healPerLevel: 2
-            flatThreat: 50
-            margin: 10
-          description: The ultimate cleric ability—ascend to divine power.
-          image: 1da08ff52ba85636f966370d7e3eef05f279b0005422e28959a50244e1589a82.png
-          requiredClass: CLERIC
+            statusEffectId: plank_root
         backstab:
           displayName: Backstab
-          manaCost: 6
-          cooldownMs: 0
-          levelRequired: 1
-          skillPointCost: 0
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Strike from the shadows.
-          image: 97493531dbd23f725e09a8ff719d9320d5e0084b488966752c30eb6fb5b3eb77.png
-          requiredClass: ROGUE
-        poison_strike:
-          displayName: Poison Strike
-          manaCost: 8
-          cooldownMs: 5000
-          levelRequired: 3
-          targetType: ENEMY
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: poison
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: A venomous strike that poisons the target. Stacks up to 4 times.
-          image: c248fccd072898194af47bad5435bd2a55dbfd387eca864dca6a24404cea389a.png
-          requiredClass: ROGUE
-        evasion:
-          displayName: Evasion
-          manaCost: 10
-          cooldownMs: 8000
-          levelRequired: 5
-          targetType: SELF
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: shadow_veil
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Dodge attacks with enhanced reflexes.
-          image: ae509c671471b4a7748ed2e08a882419f27e4f96396107175b1a9ad72178effe.png
-          requiredClass: ROGUE
-        shadow_clone:
-          displayName: Shadow Clone
-          manaCost: 14
-          cooldownMs: 10000
-          levelRequired: 7
-          targetType: SELF
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: shadow_veil
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Create a shadow duplicate of yourself to confuse enemies.
-          image: ec874d751549aa056fc771d16f87a59d0ce202891fff2c9d4084332591ebac49.png
-          requiredClass: ROGUE
-        shadow_step:
-          displayName: Shadow Step
-          manaCost: 18
-          cooldownMs: 6000
-          levelRequired: 10
-          targetType: SELF
-          effect:
-            type: DIRECT_HEAL
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 5
-            maxHeal: 12
-            healPerLevel: 2
-            flatThreat: 50
-            margin: 10
-          description: Slip into the shadows to recover.
-          image: 70f26e5f35ea20742e88ddd87e3d6eba8cfd46e64a0560cc61b4b12256d7706a.png
-          requiredClass: ROGUE
-        ambush:
-          displayName: Ambush
-          manaCost: 12
-          cooldownMs: 4000
-          levelRequired: 12
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Attack from hiding with a surprise strike.
-          image: f03e9f41f2a6dc1af947e5d4cfbd5491590b8b0f0394f8511253bc4053c58fa3.png
-          requiredClass: ROGUE
-        death_mark:
-          displayName: Death Mark
-          manaCost: 10
-          cooldownMs: 6000
-          levelRequired: 14
-          targetType: ENEMY
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: death_mark
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Mark a target for death, weakening their defenses.
-          image: 7112cd2cad841155317595181d132589339fd0056d2bc7985faeb9f738df96de.png
-          requiredClass: ROGUE
-        smoke_bomb:
-          displayName: Smoke Bomb
-          manaCost: 12
-          cooldownMs: 8000
-          levelRequired: 16
-          targetType: SELF
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: shadow_veil
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Create a cloud of smoke to obscure vision.
-          image: bec012e676a8c06e3aef964e2c5e2440d269c691440d418770e8b54059fc0ed9.png
-          requiredClass: ROGUE
-        shadow_dance:
-          displayName: Shadow Dance
-          manaCost: 16
-          cooldownMs: 7000
-          levelRequired: 18
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Dance through the shadows, striking from within.
-          image: 1cabad360a6cd7fd516a702cdf9aed52dc370b45374035f62aa5d529b688f55b.png
-          requiredClass: ROGUE
-        assassinate:
-          displayName: Assassinate
-          manaCost: 20
-          cooldownMs: 8000
-          levelRequired: 20
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Perform a swift execution strike.
-          image: f38c49f3f759dd04c4ae39df2fe705256638973bca2350df23776f53b7c9b739.png
-          requiredClass: ROGUE
-        blindside:
-          displayName: Blindside
-          manaCost: 14
-          cooldownMs: 5000
-          levelRequired: 22
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Attack from an unexpected angle.
-          image: e85496fe5e42cba05961d2f198b3eff68354bfbfd7d153fd9388291cb1369c94.png
-          requiredClass: ROGUE
-        silent_killer:
-          displayName: Silent Killer
-          manaCost: 18
-          cooldownMs: 7000
-          levelRequired: 24
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Strike without a sound, leaving no trace.
-          image: 75339966ce61172e72183660535e99f98bfb7323ff0ba80f8edae23f1508ba34.png
-          requiredClass: ROGUE
-        shadow_mastery:
-          displayName: Shadow Mastery
+          description: Leap behind your foe and deliver a devastating critical strike.
           manaCost: 22
-          cooldownMs: 9000
-          levelRequired: 26
-          targetType: SELF
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: shadow_veil
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Master the art of shadow manipulation.
-          image: 0206a18319be7088c621252c9e00d2b32e5bd42eb01dad874b6cb706a2b0f90a.png
-          requiredClass: ROGUE
-        venomous_blade:
-          displayName: Venomous Blade
-          manaCost: 16
-          cooldownMs: 6000
-          levelRequired: 28
-          targetType: ENEMY
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: venomous
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Coat your weapon in deadly venom.
-          image: 4d4e0b66057304c13842c8a53996bb36eaa0d2f8de7a8e5ad789b8952d7e5fb4.png
-          requiredClass: ROGUE
-        death_from_above:
-          displayName: Death From Above
-          manaCost: 20
           cooldownMs: 8000
-          levelRequired: 30
+          levelRequired: 8
+          skillPointCost: 2
           targetType: ENEMY
+          requiredClass: ROGUE
+          tree: Scallywag
+          tier: 5
           effect:
             type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Strike from a height with lethal force.
-          image: d6a5839f782bf27d5c3a695f8b724fcff7e68ef8914b7e732e5b83acb0bda39e.png
-          requiredClass: ROGUE
-        smoke_screen:
-          displayName: Smoke Screen
-          manaCost: 14
-          cooldownMs: 7000
-          levelRequired: 32
-          targetType: SELF
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: shadow_veil
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Create a thick curtain of smoke.
-          image: cc720db7f72ec2387b6cf42b084751f12b43916a72baf8202b314de540e1cd73.png
-          requiredClass: ROGUE
-        nightfall:
-          displayName: Nightfall
-          manaCost: 24
-          cooldownMs: 10000
-          levelRequired: 34
-          targetType: SELF
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: blinded
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Shroud yourself in darkness.
-          image: 34de31587c8483e7b631a789ed8c4223636ae504aecd1f34398de1643cce83a1.png
-          requiredClass: ROGUE
-        death_sentence:
-          displayName: Death Sentence
-          manaCost: 22
-          cooldownMs: 9000
-          levelRequired: 36
-          targetType: ENEMY
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: death_mark
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Condemn a target to death with a blade.
-          image: bd914c082490e578fc72e2ba7b1bfd2e2264e12b13d7d3a6d09e3aee506c405e.png
-          requiredClass: ROGUE
-        shadow_clone_assault:
-          displayName: Shadow Clone Assault
-          manaCost: 26
-          cooldownMs: 11000
-          levelRequired: 38
-          targetType: ENEMY
-          effect:
-            type: AREA_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Send shadow clones to attack your enemies.
-          image: abb20ea596c8bb3d5bf4b3d5fb69b736cc001b02f0b7fdea829a4c2164b5be1e.png
-          requiredClass: ROGUE
-        crimson_blade:
-          displayName: Crimson Blade
-          manaCost: 24
-          cooldownMs: 8000
-          levelRequired: 40
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Strike with a blade that thirsts for blood.
-          image: 4ed09628bae808319f8dffe537aed76d6a498091a09c219472d7d709212618b8.png
-          requiredClass: ROGUE
-        deadly_precision:
-          displayName: Deadly Precision
+            minDamage: 25
+            maxDamage: 40
+            damagePerLevel: 1.0
+        jolly_roger:
+          displayName: Jolly Roger
+          description: Raise the pirate flag, inspiring yourself with charisma and strength.
           manaCost: 20
-          cooldownMs: 7000
-          levelRequired: 42
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Strike with surgical precision.
-          image: bd5b5264404416956a5c0f51b9dd5ed70c065cf0ab130217edbc3588a0dd1b36.png
-          requiredClass: ROGUE
-        lethal_strike:
-          displayName: Lethal Strike
-          manaCost: 28
-          cooldownMs: 10000
-          levelRequired: 44
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: A strike aimed at vital points.
-          image: 596f9df2098512273718797fd72bbde3219396366257695a190de7590b789938.png
-          requiredClass: ROGUE
-        deaths_embrace:
-          displayName: Death's Embrace
-          manaCost: 30
-          cooldownMs: 12000
-          levelRequired: 46
-          targetType: SELF
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: shadow_veil
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Embrace the shadows to become unstoppable.
-          image: ba0ee4856c0d2bdcf7d6b2c39695d06755cc6bc09d01d400f1467c447779a1bb.png
-          requiredClass: ROGUE
-        shadow_finale:
-          displayName: Shadow Finale
-          manaCost: 32
-          cooldownMs: 12000
-          levelRequired: 48
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: Execute a devastating shadow technique.
-          image: 1617faed15ce2240fc1d9a0729bb9f9c2a0268e27ace8f7613fd3c4816833e4f.png
-          requiredClass: ROGUE
-        assassins_triumph:
-          displayName: Assassin's Triumph
-          manaCost: 36
-          cooldownMs: 15000
-          levelRequired: 50
-          targetType: ENEMY
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 8
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 50
-            margin: 10
-          description: The ultimate rogue ability—become the shadow itself.
-          image: d76d46e6519f36bb22076794e747f452760864223ced16e187b054402328d55b.png
-          requiredClass: ROGUE
-        arrow_shot:
-          displayName: Arrow Shot
-          manaCost: 5
-          cooldownMs: 0
-          levelRequired: 1
-          skillPointCost: 0
-          targetType: enemy
-          effect:
-            type: DIRECT_DAMAGE
-            minDamage: 3
-            maxDamage: 7
-            damagePerLevel: 1.2
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 30
-            margin: 8
-          description: A swift ranged shot aimed at a single target.
-          image: afd3683e71e3826b33cba52154edae07f56edfc3a737bd4031fbbe497b8638b7.png
-          requiredClass: RANGER
-        hunters_mark_ability:
-          displayName: Hunter's Mark
-          manaCost: 8
-          cooldownMs: 15000
-          levelRequired: 2
-          targetType: enemy
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: hunters_mark
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 20
-            margin: 5
-          description: Mark an enemy as prey. Weakens their defenses and makes them easier
-            to hit.
-          image: a2d8f9fb45df0f116c64e2da4d0d9aa793d486cc4ea3acad19a4260362c83a4b.png
-          requiredClass: RANGER
-        camouflage:
-          displayName: Camouflage
-          manaCost: 10
           cooldownMs: 30000
-          levelRequired: 3
-          targetType: self
+          levelRequired: 9
+          skillPointCost: 2
+          targetType: SELF
+          requiredClass: ROGUE
+          tree: Buccaneer
+          tier: 4
+          prerequisites:
+            - sea_legs
           effect:
             type: APPLY_STATUS
-            statusEffectId: camouflage_stance
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 0
-            margin: 0
-          description: Blend into your surroundings, boosting your dodge chance for a
-            short time.
-          image: 959f6e6d14f60486830e40bc6d98d6e4b400bc02097e211564dea96d70ef4dc8.png
-          requiredClass: RANGER
-        volley:
-          displayName: Volley
-          manaCost: 14
-          cooldownMs: 10000
-          levelRequired: 4
-          targetType: enemy
+            statusEffectId: jolly_roger_buff
+        ghost_ship:
+          displayName: Ghost Ship
+          description: Summon a spectral pirate ship that bombards the room with phantom cannonballs.
+          manaCost: 35
+          cooldownMs: 20000
+          levelRequired: 12
+          skillPointCost: 3
+          targetType: ENEMY
+          requiredClass: ROGUE
+          tree: Buccaneer
+          tier: 5
+          prerequisites:
+            - cannonball
           effect:
             type: AREA_DAMAGE
-            minDamage: 2
-            maxDamage: 5
+            minDamage: 22
+            maxDamage: 36
             damagePerLevel: 0.8
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 25
-            margin: 6
-          description: Fire a volley of arrows that strikes all enemies in the room.
-          image: 3a04f9cbede6df076c535f3331bdbc81798bde9d8538f3ea4cc4158a7279f9d7.png
-          requiredClass: RANGER
-        track:
-          displayName: Track
-          manaCost: 6
-          cooldownMs: 20000
-          levelRequired: 5
-          targetType: self
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: camouflage_stance
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 0
-            margin: 0
-          description: Read the tracks and signs of nearby creatures, heightening your
-            awareness.
-          image: faf99f1e65772855f230abd02d289e46d0e5f8e087cb2692a4565d683ceda24e.png
-          requiredClass: RANGER
-        natures_grasp_ability:
-          displayName: Nature's Grasp
+
+        # ── Ruler (RULER) — Pet Class ───────────────────────────────────
+        summon_teddy_knight:
+          displayName: Summon Teddy Knight
+          description: Call forth a brave stuffed bear in shining button armor to fight by your side.
           manaCost: 15
-          cooldownMs: 25000
-          levelRequired: 6
-          targetType: enemy
-          effect:
-            type: APPLY_STATUS
-            statusEffectId: natures_grasp
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 30
-            margin: 8
-          description: Thorny vines erupt from the ground, rooting an enemy in place.
-          image: 4dc661853dd818ccabf9e4c3a4a901697ebbc852bbb1f67b4feff8baebf0aa38.png
-          requiredClass: RANGER
-        summon_hawk:
-          displayName: Summon Hawk
-          manaCost: 20
-          cooldownMs: 60000
-          levelRequired: 7
-          targetType: self
+          cooldownMs: 5000
+          levelRequired: 1
+          skillPointCost: 1
+          targetType: SELF
+          requiredClass: RULER
+          tree: Court
+          tier: 1
           effect:
             type: SUMMON_PET
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 0
-            margin: 0
-            petTemplateKey: ranger_hawk
-          description: Call your hawk companion to fight alongside you.
-          image: b9dcf717b4d485f2edab8368aab544329fb63d11b4b7661f6c2787d6f8dfa6d3.png
-          requiredClass: RANGER
-        eagle_eye:
-          displayName: Eagle Eye
+            petTemplateKey: teddy_knight
+            durationMs: 0
+        royal_decree:
+          displayName: Royal Decree
+          description: Issue a royal command that boosts your charisma and wisdom with regal authority.
+          manaCost: 12
+          cooldownMs: 25000
+          levelRequired: 2
+          skillPointCost: 1
+          targetType: SELF
+          requiredClass: RULER
+          tree: Sovereignty
+          tier: 1
+          effect:
+            type: APPLY_STATUS
+            statusEffectId: royal_decree_buff
+        summon_pixel_sprite:
+          displayName: Summon Pixel Sprite
+          description: Call a tiny pixelated fairy companion that zaps enemies with digital sparks.
+          manaCost: 18
+          cooldownMs: 5000
+          levelRequired: 3
+          skillPointCost: 1
+          targetType: SELF
+          requiredClass: RULER
+          tree: Court
+          tier: 2
+          effect:
+            type: SUMMON_PET
+            petTemplateKey: pixel_sprite
+            durationMs: 0
+        crown_jewel:
+          displayName: Crown Jewel
+          description: Your crown glows with protective magic, shielding you from harm.
+          manaCost: 14
+          cooldownMs: 18000
+          levelRequired: 4
+          skillPointCost: 1
+          targetType: SELF
+          requiredClass: RULER
+          tree: Sovereignty
+          tier: 2
+          effect:
+            type: APPLY_STATUS
+            statusEffectId: crown_shield
+        royal_tantrum:
+          displayName: Royal Tantrum
+          description: Throw an epic royal tantrum that stuns all enemies with sheer indignation.
           manaCost: 18
           cooldownMs: 12000
+          levelRequired: 5
+          skillPointCost: 1
+          targetType: ENEMY
+          requiredClass: RULER
+          tree: Sovereignty
+          tier: 3
+          effect:
+            type: APPLY_STATUS
+            statusEffectId: tantrum_stun
+        summon_clockwork_dragon:
+          displayName: Summon Clockwork Dragon
+          description: Wind up and release a magnificent clockwork dragon that breathes toy fire.
+          manaCost: 25
+          cooldownMs: 5000
+          levelRequired: 6
+          skillPointCost: 2
+          targetType: SELF
+          requiredClass: RULER
+          tree: Court
+          tier: 3
+          effect:
+            type: SUMMON_PET
+            petTemplateKey: clockwork_dragon
+            durationMs: 0
+        tax_collector:
+          displayName: Tax Collector
+          description: Demand tribute from your foes, weakening their stats as you assert your rule.
+          manaCost: 16
+          cooldownMs: 20000
+          levelRequired: 7
+          skillPointCost: 2
+          targetType: ENEMY
+          requiredClass: RULER
+          tree: Sovereignty
+          tier: 4
+          effect:
+            type: APPLY_STATUS
+            statusEffectId: taxation_debuff
+        royal_feast:
+          displayName: Royal Feast
+          description: Declare a feast in your honor, healing yourself with regal indulgence.
+          manaCost: 22
+          cooldownMs: 20000
           levelRequired: 8
-          targetType: enemy
+          skillPointCost: 2
+          targetType: SELF
+          requiredClass: RULER
+          tree: Sovereignty
+          tier: 5
           effect:
-            type: DIRECT_DAMAGE
-            minDamage: 6
-            maxDamage: 14
-            damagePerLevel: 2
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 40
-            margin: 12
-          description: A precision shot with a high critical multiplier. Aim true.
-          image: faa5808845ec63596a43e9e33e1a4c43fffee9c710a9e09d180f9a3c116e3a5f.png
-          requiredClass: RANGER
-        rain_of_arrows:
-          displayName: Rain of Arrows
-          manaCost: 28
-          cooldownMs: 45000
-          levelRequired: 9
-          targetType: enemy
-          effect:
-            type: AREA_DAMAGE
-            minDamage: 4
-            maxDamage: 10
-            damagePerLevel: 1.5
-            minHeal: 0
-            maxHeal: 0
-            flatThreat: 45
-            margin: 10
-          description: Fill the sky with arrows. Heavy AoE; long cooldown.
-          image: d32745d423165cd67945c2ce1772b710f5b1c475f6c2b7dc43697a97b8d22710.png
-          requiredClass: RANGER
-        nature_bond:
-          displayName: Nature Bond
+            type: APPLY_STATUS
+            statusEffectId: feast_regen
+        summon_dream_guardian:
+          displayName: Summon Dream Guardian
+          description: Call upon the ultimate protector — a towering stuffed sentinel woven from pure dreams.
           manaCost: 35
-          cooldownMs: 90000
+          cooldownMs: 5000
           levelRequired: 10
-          targetType: all_allies
+          skillPointCost: 2
+          targetType: SELF
+          requiredClass: RULER
+          tree: Court
+          tier: 4
+          prerequisites:
+            - summon_clockwork_dragon
           effect:
-            type: DIRECT_HEAL
-            minDamage: 0
-            maxDamage: 0
-            minHeal: 20
-            maxHeal: 35
-            healPerLevel: 2
-            flatThreat: 0
-            margin: 0
-          description: Channel primal nature magic to restore health to your entire party.
-          image: 6060d80f65648bb45af5fe7710cc6d6d83e0942afcaaf46e4f29417081310036.png
-          requiredClass: RANGER
+            type: SUMMON_PET
+            petTemplateKey: dream_guardian
+            durationMs: 0
+        coronation:
+          displayName: Coronation
+          description: Perform a grand coronation ceremony, massively boosting all your stats.
+          manaCost: 40
+          cooldownMs: 60000
+          levelRequired: 12
+          skillPointCost: 3
+          targetType: SELF
+          requiredClass: RULER
+          tree: Sovereignty
+          tier: 5
+          prerequisites:
+            - royal_decree
+            - crown_jewel
+          effect:
+            type: APPLY_STATUS
+            statusEffectId: coronation_buff
+
     statusEffects:
       definitions:
-        ignite:
-          displayName: Ignite
-          effectType: dot
-          durationMs: 6000
-          image: 059623e535e1ef794f2254a8bf2c86d37535867c5503af007e1f2cc3e5a2b2c3.png
-          tickIntervalMs: 2000
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        poison:
-          displayName: Poison
-          effectType: dot
-          durationMs: 10000
-          image: dc2209faa07af2708a50d840aeaf67ae3a0cb1cad13c40cd45d456f050c961d4.png
-          tickIntervalMs: 2000
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: STACK
-          maxStacks: 3
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        shield_of_faith:
-          displayName: Shield of Faith
-          effectType: shield
-          durationMs: 30000
-          image: 30a662ef72359b97cbd1d99ddc33ebea9a0b5efb017e428c0110858d4a650877.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 20
-          stackBehavior: NONE
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        battle_shout:
-          displayName: Battle Shout
-          effectType: stat_buff
-          durationMs: 60000
-          image: 2c031c203427252fac6884f723edcd5868544623686ec1b4ac13ae9db1cbf518.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        rejuvenation:
-          displayName: Rejuvenation
-          effectType: hot
-          durationMs: 10000
-          image: ec109326bbacb42331d032f30f392f5c42444e47ef090f8a707cadbf00902a37.png
-          tickIntervalMs: 2000
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        frost_grip:
-          displayName: Frost Grip
-          effectType: root
-          durationMs: 4000
-          image: 19116122b46d35aae9f19058591523e6e74150dd942f22798ce87cd6481ef832.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: NONE
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        concuss:
-          displayName: Concuss
+        # ── Knight effects ──────────────────────────────────────────────
+        starburst_stun:
+          displayName: Starburst Stun
           effectType: stun
           durationMs: 2000
-          image: ada9b780ca09f84f837e4fb59fc2d2f6d6e5991a0986a9366498f72e4d9d02a9.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: NONE
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        whirlwind_rage:
-          displayName: Whirlwind Rage
-          effectType: stat_buff
-          durationMs: 8000
-          image: 72f7a43f24bd8275ca03fbda05bee21d7d9c4a4e647c7a71f80592c9248a5d5f.png
-          tickIntervalMs: 1000
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        berserker_state:
-          displayName: Berserker State
-          effectType: stat_buff
-          durationMs: 10000
-          image: fd2a3cffe16ef2f4499b038639f149e9bab6f65de880e9c6d3b7ec1d68b55e23.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        thornhide_armor:
-          displayName: Thornhide Armor
+          stackBehavior: none
+        pillow_shield:
+          displayName: Pillow Fort
           effectType: shield
           durationMs: 15000
-          image: 6fab47ba58214466bf0100fc09c9cd3ae1619214baeeeeeca453b50834e29e9f.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
           shieldAmount: 30
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        weakened:
-          displayName: Weakened
-          effectType: stat_debuff
-          durationMs: 8000
-          image: 5bfbca140feaab38db97ed16eab33aa7a7cf0ac1c6c413ec16fd5c0573f0f5f6.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        mana_shield:
-          displayName: Mana Shield
-          effectType: shield
+          stackBehavior: refresh
+        courage_buff:
+          displayName: Courage Aura
+          effectType: stat_buff
           durationMs: 20000
-          image: 58cf6df3ef53d5f8c598352d14868c62e41d3be8a38a6c0c63890dd08eb3d3ad.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 25
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        flame_armor:
-          displayName: Flame Armor
-          effectType: stat_buff
-          durationMs: 12000
-          image: 3a9b486faeb7802c308cba68f8f209cc52810607d1873b0b41dbdb403c282d79.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        frost_armor:
-          displayName: Frost Armor
-          effectType: shield
-          durationMs: 12000
-          image: c532e220f7367f7c8bd86ec87f4e7d160476834ad8bcf806b26a9f2195221513.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 28
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        frozen:
-          displayName: Frozen
-          effectType: stun
-          durationMs: 3000
-          image: 024647c27a220c3a63e596dfc9bf911fc629506f2a1e35e8032bcca854ed5884.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: NONE
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        chilled:
-          displayName: Chilled
-          effectType: stat_debuff
-          durationMs: 6000
-          image: b9613b94d4b530c943b13a6dd3ccc12653207bf9a2b6f14753d2ebc55b6450de.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        arcane_burn:
-          displayName: Arcane Burn
-          effectType: dot
-          durationMs: 8000
-          image: cd485ec50481c8397885a3ec913a756d83b1a6ff4773a4bbc9414fafdf7a96bd.png
-          tickIntervalMs: 2000
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: STACK
-          maxStacks: 2
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        holy_light:
-          displayName: Holy Light
-          effectType: hot
-          durationMs: 12000
-          image: ee23928f92af209f67190ae6c21b10da12309293fdd9c6b234d396bc4688e409.png
-          tickIntervalMs: 2000
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        divine_blessing:
-          displayName: Divine Blessing
-          effectType: stat_buff
-          durationMs: 15000
-          image: fca923105e6c3908b7bc003a563d6e1e590a2d7cd22b916a1e52d5e9957b6073.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        consecrated_ground:
-          displayName: Consecrated Ground
-          effectType: hot
-          durationMs: 20000
-          image: 47508cce5c7de33ebad55854cb2ba576d83dd9fa70074c78fda37f902d58a9f9.png
-          tickIntervalMs: 2000
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        purified:
-          displayName: Purified
-          effectType: stat_buff
-          durationMs: 10000
-          image: 575a66b9944527f52e9961df571fd61f8854548e68ac039644ee54c9b0722e19.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        shadow_veil:
-          displayName: Shadow Veil
-          effectType: shield
-          durationMs: 10000
-          image: e948857afddeeb888329d7cc1b3e6df786ea5d253d63b81d4fadc594a5b98021.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 15
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        venomous:
-          displayName: Venomous
-          effectType: dot
-          durationMs: 12000
-          image: 7dc26fdee880444338d6a37283bb2675cf0a51796cc7792b67651279dc3ad49a.png
-          tickIntervalMs: 2000
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: STACK
-          maxStacks: 4
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        shadow_mark:
-          displayName: Shadow Mark
-          effectType: stat_debuff
-          durationMs: 8000
-          image: cffa753d00a30d7db4ef5f8b238c6dd4020298b090c815ebafcd71d3c9d9c760.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        death_mark:
-          displayName: Death Mark
-          effectType: stat_debuff
-          durationMs: 10000
-          image: 6f9d752a4ab2fa672ef3c243e9a237fe98f1e0275281fedf2a1bfa00551a0a2e.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        blinded:
-          displayName: Blinded
-          effectType: stat_debuff
-          durationMs: 5000
-          image: 90dfdf3f545da48d9ffe022bfaaa386b9d11f1da38c6926c5d6ab479e0c52271.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: NONE
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        camouflage_stance:
-          displayName: Camouflage
-          effectType: stat_buff
-          durationMs: 4000
-          image: 8c33200eca0b7aa3ab1dd3eebe4e890b4b3a816f69a91f9c539e8c64d740d9fa.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 4
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        hunters_mark:
-          displayName: Hunter's Mark
-          effectType: stat_debuff
-          durationMs: 10000
-          image: dc3c70701c78f0dc166a5bcb2a482b7e6ee140903ae331b57dc18a1258e2baa3.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: -2
-          dexMod: -2
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        natures_grasp:
-          displayName: Nature's Grasp
-          effectType: root
-          durationMs: 4000
-          image: ee7009ad7e167404499f92ddfb7b7778ba741c150f1414323afad908f19ece0e.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: NONE
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        nature_bond_hot:
-          displayName: Nature Bond
-          effectType: hot
-          durationMs: 8000
-          image: 29d15cb37d0bf103d8181c4e214906e7b5802e0a87445821f33844078e3dd3a1.png
-          tickIntervalMs: 2000
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        rend_bleed:
-          displayName: Rend
-          effectType: dot
-          durationMs: 12000
-          image: 7de61e66dbf66c4dc25d2cf1ff9d50beb4532ca4f2ca416a4202000cf01a1c5b.png
-          tickIntervalMs: 2000
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        ice_barrier:
-          displayName: Ice Barrier
-          effectType: shield
-          durationMs: 15000
-          image: 2af2685a1e456a746343369a4261fc66e1715f8d9042405c2cc447cafe4736b0.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 35
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        rallying_cry_buff:
-          displayName: Rallying Cry
-          effectType: stat_buff
-          durationMs: 15000
-          image: a43d1da2f939d433d92a4b9c4400c11f6cae1715f1fadc9f3db39eda3a179b00.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: REFRESH
-          maxStacks: 1
           strMod: 3
-          dexMod: 0
-          conMod: 3
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        shield_wall_buff:
-          displayName: Shield Wall
-          effectType: shield
-          durationMs: 10000
-          image: e85901234648615602741aba3e2f61ba6671a18672c8b415eaa7270a5e689ce7.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 50
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
+          conMod: 2
+          stackBehavior: refresh
+        blanket_regen:
+          displayName: Blanket Cape
+          effectType: hot
+          durationMs: 12000
+          tickIntervalMs: 2000
+          tickMinValue: 5
+          tickMaxValue: 8
+          stackBehavior: refresh
         last_stand_buff:
           displayName: Last Stand
-          effectType: shield
-          durationMs: 8000
-          image: c72e5cf1396c3156078dca9bbd49f6e8df466b35cb17bb8948d671026a086acf.png
-          tickIntervalMs: 0
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 80
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
-        frozen_orb_dot:
-          displayName: Frozen Orb
+          effectType: stat_buff
+          durationMs: 15000
+          strMod: 4
+          conMod: 5
+          wisMod: 2
+          stackBehavior: none
+
+        # ── Wizard effects ──────────────────────────────────────────────
+        crayon_burn:
+          displayName: Crayon Fire
           effectType: dot
           durationMs: 8000
-          image: 3dd8f69a8bcc2e9b521cce97660b329936dec91461c4f233dae40ef8d9097a5f.png
           tickIntervalMs: 2000
-          tickMinValue: 0
-          tickMaxValue: 0
-          shieldAmount: 0
-          stackBehavior: REFRESH
-          maxStacks: 1
-          strMod: 0
-          dexMod: 0
-          conMod: 0
-          intMod: 0
-          wisMod: 0
-          chaMod: 0
+          tickMinValue: 5
+          tickMaxValue: 8
+          stackBehavior: refresh
+        bubble_shield_effect:
+          displayName: Bubble Shield
+          effectType: shield
+          durationMs: 12000
+          shieldAmount: 25
+          stackBehavior: refresh
+        nightmare_debuff:
+          displayName: Nightmare Hex
+          effectType: stat_debuff
+          durationMs: 10000
+          strMod: -2
+          dexMod: -2
+          conMod: -1
+          stackBehavior: refresh
+        enchanted_root:
+          displayName: Enchanted Slumber
+          effectType: root
+          durationMs: 4000
+          stackBehavior: none
+        brain_freeze_stun:
+          displayName: Brain Freeze
+          effectType: stun
+          durationMs: 3000
+          stackBehavior: none
+        reality_warp_buff:
+          displayName: Reality Warp
+          effectType: stat_buff
+          durationMs: 20000
+          intMod: 5
+          wisMod: 3
+          chaMod: 2
+          stackBehavior: none
+
+        # ── Doctor effects ──────────────────────────────────────────────
+        vitamin_buff:
+          displayName: Vitamin Boost
+          effectType: stat_buff
+          durationMs: 30000
+          conMod: 3
+          wisMod: 1
+          stackBehavior: refresh
+        magic_fever:
+          displayName: Magic Fever
+          effectType: dot
+          durationMs: 10000
+          tickIntervalMs: 2000
+          tickMinValue: 4
+          tickMaxValue: 7
+          stackBehavior: refresh
+        soup_regen:
+          displayName: Chicken Soup
+          effectType: hot
+          durationMs: 15000
+          tickIntervalMs: 3000
+          tickMinValue: 6
+          tickMaxValue: 10
+          stackBehavior: refresh
+        booster_buff:
+          displayName: Booster Shot
+          effectType: stat_buff
+          durationMs: 25000
+          wisMod: 3
+          conMod: 3
+          stackBehavior: refresh
+        quarantine_root:
+          displayName: Quarantine
+          effectType: root
+          durationMs: 4000
+          stackBehavior: none
+        placebo_debuff:
+          displayName: Placebo Effect
+          effectType: stat_debuff
+          durationMs: 15000
+          strMod: -2
+          dexMod: -2
+          intMod: -2
+          wisMod: -2
+          stackBehavior: refresh
+        miracle_cure_effect:
+          displayName: Miracle Cure
+          effectType: hot
+          durationMs: 10000
+          tickIntervalMs: 2000
+          tickMinValue: 12
+          tickMaxValue: 18
+          stackBehavior: none
+
+        # ── Pirate effects ──────────────────────────────────────────────
+        sand_stun:
+          displayName: Pocket Sand
+          effectType: stun
+          durationMs: 2000
+          stackBehavior: none
+        treasure_luck:
+          displayName: Treasure Map
+          effectType: stat_buff
+          durationMs: 25000
+          dexMod: 3
+          chaMod: 2
+          stackBehavior: refresh
+        soda_poison:
+          displayName: Soda Poison
+          effectType: dot
+          durationMs: 10000
+          tickIntervalMs: 2000
+          tickMinValue: 4
+          tickMaxValue: 6
+          stackBehavior: stack
+          maxStacks: 3
+        sea_legs_buff:
+          displayName: Sea Legs
+          effectType: stat_buff
+          durationMs: 20000
+          dexMod: 4
+          conMod: 1
+          stackBehavior: refresh
+        plank_root:
+          displayName: Walk the Plank
+          effectType: root
+          durationMs: 3500
+          stackBehavior: none
+        jolly_roger_buff:
+          displayName: Jolly Roger
+          effectType: stat_buff
+          durationMs: 20000
+          strMod: 2
+          dexMod: 2
+          chaMod: 3
+          stackBehavior: refresh
+
+        # ── Ruler effects ───────────────────────────────────────────────
+        royal_decree_buff:
+          displayName: Royal Decree
+          effectType: stat_buff
+          durationMs: 25000
+          chaMod: 4
+          wisMod: 2
+          stackBehavior: refresh
+        crown_shield:
+          displayName: Crown Jewel
+          effectType: shield
+          durationMs: 15000
+          shieldAmount: 35
+          stackBehavior: refresh
+        tantrum_stun:
+          displayName: Royal Tantrum
+          effectType: stun
+          durationMs: 2500
+          stackBehavior: none
+        taxation_debuff:
+          displayName: Tax Collector
+          effectType: stat_debuff
+          durationMs: 12000
+          strMod: -2
+          dexMod: -2
+          chaMod: -3
+          stackBehavior: refresh
+        feast_regen:
+          displayName: Royal Feast
+          effectType: hot
+          durationMs: 15000
+          tickIntervalMs: 3000
+          tickMinValue: 7
+          tickMaxValue: 12
+          stackBehavior: refresh
+        coronation_buff:
+          displayName: Coronation
+          effectType: stat_buff
+          durationMs: 25000
+          strMod: 2
+          dexMod: 2
+          conMod: 2
+          intMod: 2
+          wisMod: 2
+          chaMod: 4
+          stackBehavior: none
     effectTypes:
       types:
         dot:
           displayName: Damage Over Time
           ticksDamage: true
-          ticksHealing: false
-          modifiesStats: false
-          absorbsDamage: false
         hot:
           displayName: Heal Over Time
-          ticksDamage: false
           ticksHealing: true
-          modifiesStats: false
-          absorbsDamage: false
         stat_buff:
           displayName: Stat Buff
-          ticksDamage: false
-          ticksHealing: false
           modifiesStats: true
-          absorbsDamage: false
         stat_debuff:
           displayName: Stat Debuff
-          ticksDamage: false
-          ticksHealing: false
           modifiesStats: true
-          absorbsDamage: false
         stun:
           displayName: Stun
-          ticksDamage: false
-          ticksHealing: false
-          modifiesStats: false
-          absorbsDamage: false
         root:
           displayName: Root
-          ticksDamage: false
-          ticksHealing: false
-          modifiesStats: false
-          absorbsDamage: false
         shield:
           displayName: Shield
-          ticksDamage: false
-          ticksHealing: false
-          modifiesStats: false
           absorbsDamage: true
     stackBehaviors:
       behaviors:
@@ -3085,118 +1161,87 @@ ambonmud:
           displayName: Self
         ally:
           displayName: Ally
-        all_enemies:
-          displayName: All Enemies
-        all_allies:
-          displayName: All Allies
     combat:
       maxCombatsPerTick: 20
-      tickMillis: 2000
-      minDamage: 1
-      maxDamage: 4
+      tickMillis: 4000
+      minDamage: 5
+      maxDamage: 50
       feedback:
-        enabled: true
+        enabled: false
         roomBroadcastEnabled: false
     mob:
-      minActionDelayMillis: 8000
-      maxActionDelayMillis: 20000
+      minActionDelayMillis: 4000
+      maxActionDelayMillis: 8000
       tiers:
         weak:
-          baseHp: 5
-          hpPerLevel: 2
+          baseHp: 1
+          hpPerLevel: 1
           baseMinDamage: 1
-          baseMaxDamage: 2
+          baseMaxDamage: 1
           damagePerLevel: 0
           baseArmor: 0
-          baseXpReward: 15
-          xpRewardPerLevel: 5
-          baseGoldMin: 1
-          baseGoldMax: 3
-          goldPerLevel: 1
-        standard:
-          baseHp: 10
-          hpPerLevel: 3
-          baseMinDamage: 1
-          baseMaxDamage: 4
-          damagePerLevel: 1
-          baseArmor: 0
-          baseXpReward: 30
-          xpRewardPerLevel: 10
-          baseGoldMin: 2
-          baseGoldMax: 8
-          goldPerLevel: 2
-        elite:
-          baseHp: 20
-          hpPerLevel: 5
-          baseMinDamage: 2
-          baseMaxDamage: 6
-          damagePerLevel: 1
-          baseArmor: 1
-          baseXpReward: 75
+          baseXpReward: 50
           xpRewardPerLevel: 20
           baseGoldMin: 10
           baseGoldMax: 25
           goldPerLevel: 5
-        boss:
-          baseHp: 50
-          hpPerLevel: 10
-          baseMinDamage: 3
-          baseMaxDamage: 8
-          damagePerLevel: 2
-          baseArmor: 3
-          baseXpReward: 200
-          xpRewardPerLevel: 50
+        standard:
+          baseHp: 4
+          hpPerLevel: 1
+          baseMinDamage: 1
+          baseMaxDamage: 2
+          damagePerLevel: 0
+          baseArmor: 0
+          baseXpReward: 100
+          xpRewardPerLevel: 40
+          baseGoldMin: 20
+          baseGoldMax: 50
+          goldPerLevel: 10
+        elite:
+          baseHp: 10
+          hpPerLevel: 3
+          baseMinDamage: 1
+          baseMaxDamage: 3
+          damagePerLevel: 0
+          baseArmor: 0
+          baseXpReward: 250
+          xpRewardPerLevel: 80
           baseGoldMin: 50
           baseGoldMax: 100
-          goldPerLevel: 15
+          goldPerLevel: 20
+        boss:
+          baseHp: 20
+          hpPerLevel: 5
+          baseMinDamage: 2
+          baseMaxDamage: 4
+          damagePerLevel: 1
+          baseArmor: 1
+          baseXpReward: 500
+          xpRewardPerLevel: 150
+          baseGoldMin: 150
+          baseGoldMax: 300
+          goldPerLevel: 50
     economy:
-      buyMultiplier: 1
-      sellMultiplier: 0.5
+      buyMultiplier: 0.3
+      sellMultiplier: 0.9
     regen:
-      maxPlayersPerTick: 50
-      baseIntervalMillis: 5000
-      minIntervalMillis: 1000
-      regenAmount: 4
+      maxPlayersPerTick: 25
+      baseIntervalMillis: 1500
+      minIntervalMillis: 300
+      regenAmount: 5
       mana:
-        baseIntervalMillis: 3000
-        minIntervalMillis: 1000
-        regenAmount: 4
+        baseIntervalMillis: 1500
+        minIntervalMillis: 300
+        regenAmount: 5
     crafting:
-      maxSkillLevel: 100
-      baseXpPerLevel: 50
-      xpExponent: 1.5
-      gatherCooldownMs: 3000
-      stationBonusQuantity: 1
-    craftingSkills:
-      skills:
-        mining:
-          displayName: Mining
-          type: gathering
-        herbalism:
-          displayName: Herbalism
-          type: gathering
-        smithing:
-          displayName: Smithing
-          type: crafting
-        alchemy:
-          displayName: Alchemy
-          type: crafting
-        enchanting:
-          displayName: Enchanting
-          type: crafting
-    craftingStationTypes:
-      stationTypes:
-        forge:
-          displayName: Forge
-        alchemy_table:
-          displayName: Alchemy Table
-        workbench:
-          displayName: Workbench
-        enchanting_table:
-          displayName: Enchanting Table
+      maxSkillLevel: 30
+      baseXpPerLevel: 30
+      xpExponent: 1.1
+      gatherCooldownMs: 1000
+      stationBonusQuantity: 5
     navigation:
       recall:
-        cooldownMs: 300000
+        cooldownMs: 5000
         messages:
           combatBlocked: You are fighting for your life...
           cooldownRemaining: You need to rest... ({seconds} seconds remaining)
@@ -3210,252 +1255,391 @@ ambonmud:
         help:
           usage: help/?
           category: utility
+          staff: false
         look:
-          usage: look/l (or look <direction>)
+          usage: look/l [target|direction]
           category: navigation
+          staff: false
         move:
           usage: n/s/e/w/u/d
           category: navigation
+          staff: false
         exits:
           usage: exits/ex
           category: navigation
+          staff: false
         recall:
           usage: recall
           category: navigation
+          staff: false
         say:
           usage: say <msg> or '<msg>
           category: communication
+          staff: false
         emote:
           usage: emote <msg>
           category: communication
+          staff: false
         pose:
           usage: pose <msg>
           category: communication
+          staff: false
         who:
           usage: who
           category: communication
+          staff: false
         tell:
           usage: tell/t <player> <msg>
           category: communication
+          staff: false
         whisper:
           usage: whisper/wh <player> <msg>
           category: communication
+          staff: false
         gossip:
           usage: gossip/gs <msg>
           category: communication
+          staff: false
         shout:
           usage: shout/sh <msg>
           category: communication
+          staff: false
         ooc:
           usage: ooc <msg>
           category: communication
+          staff: false
         inventory:
           usage: inventory/inv/i
           category: items
+          staff: false
         equipment:
           usage: equipment/eq
           category: items
+          staff: false
         wear:
           usage: wear/equip <item>
           category: items
+          staff: false
         remove:
           usage: remove/unequip <slot>
           category: items
+          staff: false
         get:
           usage: get/take/pickup <item>
           category: items
+          staff: false
         drop:
           usage: drop <item>
           category: items
+          staff: false
         use:
           usage: use <item>
           category: items
+          staff: false
         give:
           usage: give <item> <player>
           category: items
+          staff: false
         talk:
           usage: talk <npc>
           category: social
+          staff: false
         kill:
           usage: kill <mob>
           category: combat
+          staff: false
         flee:
           usage: flee
           category: combat
+          staff: false
         cast:
           usage: cast/c <spell> [target]
           category: combat
+          staff: false
         spells:
           usage: spells/abilities/skills
           category: progression
+          staff: false
         effects:
           usage: effects/buffs/debuffs
           category: progression
+          staff: false
         score:
           usage: score/sc
           category: progression
+          staff: false
         balance:
           usage: gold/balance
           category: shops
+          staff: false
+        currencies:
+          usage: currencies/currency/wallet
+          category: progression
+          staff: false
         shop_list:
           usage: list/shop
           category: shops
+          staff: false
         buy:
           usage: buy <item>
           category: shops
+          staff: false
         sell:
           usage: sell <item>
           category: shops
+          staff: false
         quest_log:
           usage: quest log/list
           category: quests
+          staff: false
         quest_info:
           usage: quest info <name>
           category: quests
+          staff: false
         quest_abandon:
           usage: quest abandon <name>
           category: quests
+          staff: false
         accept:
           usage: accept <quest>
           category: quests
+          staff: false
+        bounty:
+          usage: bounty / quest auto
+          category: quests
+          staff: false
+        bounty_info:
+          usage: bounty info / quest auto info
+          category: quests
+          staff: false
+        bounty_abandon:
+          usage: bounty abandon / quest auto abandon
+          category: quests
+          staff: false
         achievements:
           usage: achievements/ach
           category: quests
+          staff: false
+        daily:
+          usage: daily/dailies
+          category: quests
+          staff: false
+        weekly:
+          usage: weekly
+          category: quests
+          staff: false
+        gquest:
+          usage: gquest/gq/global
+          category: quests
+          staff: false
         group_invite:
           usage: group invite <player>
           category: groups
+          staff: false
         group_accept:
           usage: group accept
           category: groups
+          staff: false
         group_leave:
           usage: group leave
           category: groups
+          staff: false
         group_kick:
           usage: group kick <player>
           category: groups
+          staff: false
         group_list:
           usage: group list (or just 'group')
           category: groups
+          staff: false
         gtell:
           usage: gtell/gt <message>
           category: groups
+          staff: false
         guild_create:
           usage: guild create <name> <tag>
           category: guilds
+          staff: false
         guild_disband:
           usage: guild disband
           category: guilds
+          staff: false
         guild_invite:
           usage: guild invite <player>
           category: guilds
+          staff: false
         guild_accept:
           usage: guild accept
           category: guilds
+          staff: false
         guild_leave:
           usage: guild leave
           category: guilds
+          staff: false
         guild_kick:
           usage: guild kick <player>
           category: guilds
+          staff: false
         guild_promote:
           usage: guild promote <player>
           category: guilds
+          staff: false
         guild_demote:
           usage: guild demote <player>
           category: guilds
+          staff: false
         guild_motd:
           usage: guild motd <message>
           category: guilds
+          staff: false
         guild_roster:
           usage: guild roster
           category: guilds
+          staff: false
         guild_info:
           usage: guild info (or just 'guild')
           category: guilds
-        guild_hall:
-          usage: guild hall
-          category: guilds
-        guild_hall_buy:
-          usage: guild hall buy
-          category: guilds
-        guild_hall_expand:
-          usage: guild hall expand <template>
-          category: guilds
-        guild_hall_enter:
-          usage: guild hall enter
-          category: guilds
-        guild_hall_leave:
-          usage: guild hall leave
-          category: guilds
+          staff: false
         gchat:
           usage: gchat/g <message>
           category: guilds
+          staff: false
         gather:
           usage: gather/harvest/mine <node>
           category: crafting
+          staff: false
         craft:
           usage: craft/make <recipe>
           category: crafting
+          staff: false
         recipes:
           usage: recipes [filter]
           category: crafting
+          staff: false
         craftskills:
           usage: craftskills/professions
           category: crafting
+          staff: false
+        house:
+          usage: house [status]
+          category: housing
+          staff: false
+        house_list:
+          usage: house list
+          category: housing
+          staff: false
+        house_buy:
+          usage: house buy
+          category: housing
+          staff: false
+        house_expand:
+          usage: house expand <template> <direction>
+          category: housing
+          staff: false
+        house_describe:
+          usage: house describe [title|desc] <text>
+          category: housing
+          staff: false
+        house_invite:
+          usage: house invite <player>
+          category: housing
+          staff: false
+        house_kick:
+          usage: house kick <player>
+          category: housing
+          staff: false
+        house_guests:
+          usage: house guests
+          category: housing
+          staff: false
         open:
           usage: open <door|container>
           category: world
+          staff: false
         close:
           usage: close <door|container>
           category: world
+          staff: false
         unlock:
           usage: unlock <door|container>
           category: world
+          staff: false
         lock:
           usage: lock <door|container>
           category: world
+          staff: false
         search:
           usage: search <container>
           category: world
+          staff: false
         get_from:
           usage: get <item> from <container>
           category: world
+          staff: false
         put_in:
           usage: put <item> <container>
           category: world
+          staff: false
         pull:
           usage: pull <lever>
           category: world
+          staff: false
         read:
           usage: read <sign>
           category: world
+          staff: false
         title:
           usage: title <titleName> | title clear
           category: progression
+          staff: false
         gender:
           usage: gender <option>
           category: progression
+          staff: false
+        sprite:
+          usage: sprite list | set <id> | default
+          category: progression
+          staff: false
         friend:
           usage: friend list | add <player> | remove <player>
           category: social
+          staff: false
         mail:
           usage: mail list | read <n> | send <player> | delete <n>
           category: social
+          staff: false
+        lottery:
+          usage: lottery [info] | lottery buy [count]
+          category: social
+          staff: false
+        gamble:
+          usage: gamble/dice <amount>
+          category: social
+          staff: false
         ansi:
           usage: ansi on/off
           category: utility
+          staff: false
+        screenreader:
+          usage: screenreader [on/off]
+          category: utility
+          staff: false
         colors:
           usage: colors
           category: utility
+          staff: false
         clear:
           usage: clear
           category: utility
+          staff: false
         quit:
           usage: quit/exit
           category: utility
+          staff: false
         phase:
           usage: phase/layer [instance]
           category: utility
+          staff: false
         goto:
           usage: goto <zone:room | room | zone:>
           category: admin
@@ -3484,667 +1668,619 @@ ambonmud:
           usage: setlevel <player> <level>
           category: admin
           staff: true
-        reload:
-          usage: reload [world|abilities|effects|all]
-          description: Hot reload data definitions without restarting
-          category: admin
-          staff: true
         shutdown:
           usage: shutdown
           category: admin
           staff: true
+        reload:
+          usage: reload [scope]
+          category: admin
+          staff: true
+        possess:
+          usage: possess/switch <mob>
+          category: admin
+          staff: true
+        return:
+          usage: return/unpossess
+          category: admin
+          staff: true
+        invis:
+          usage: invis
+          category: admin
+          staff: true
+        broadcast:
+          usage: broadcast <message>
+          category: admin
+          staff: true
     group:
-      maxSize: 5
-      inviteTimeoutMs: 60000
-      xpBonusPerMember: 0.1
+      maxSize: 8
+      inviteTimeoutMs: 120000
+      xpBonusPerMember: 25
     guildRanks:
       founderRank: leader
       defaultRank: member
-      ranks:
-        leader:
-          displayName: Leader
-          level: 100
-          permissions:
-            - invite
-            - kick
-            - promote
-            - demote
-            - disband
-            - set_motd
-        officer:
-          displayName: Officer
-          level: 50
-          permissions:
-            - invite
-            - kick
-        member:
-          displayName: Member
-          level: 0
-          permissions: []
+      ranks: {}
     friends:
-      maxFriends: 50
+      maxFriends: 200
     classes:
       definitions:
         WARRIOR:
-          displayName: Warrior
-          hpPerLevel: 8
-          manaPerLevel: 4
-          description: A stalwart melee fighter.
-          backstory: Warriors are the backbone of any adventuring party, standing at the
-            front line where steel meets claw. Trained in the art of war from a
-            young age, they channel raw physical prowess into devastating
-            attacks and unbreakable defenses. A warrior's presence on the
-            battlefield draws the fury of enemies, shielding their allies behind
-            a wall of iron and fury.
-          primaryStat: STR
-          threatMultiplier: 1.5
-          image: 5325057101c4e000b0854fea8b9da6655272297a04d3e18b0b479d46fea868c6.jpg
-        MAGE:
-          displayName: Mage
+          displayName: Knight
           hpPerLevel: 4
-          manaPerLevel: 16
-          description: A master of the arcane arts.
-          backstory: Mages devote their lives to unraveling the mysteries of the arcane,
-            bending the raw fabric of reality through study and willpower. Their
-            bodies are fragile, but their minds are weapons — capable of
-            unleashing torrents of fire, ice, and lightning that can devastate
-            entire groups of enemies. The path of the mage is one of relentless
-            study and dangerous experimentation.
+          manaPerLevel: 1
+          description: Knights are children who came to the magical world of Auringold looking for  action and adventure ;  they
+            use their powers to protect the weak and innocent.
+          backstory: >-
+            **Knights of Auringold**
+
+
+            In the mundane realms beyond the shimmering veils, children have always dreamed of something greater—of
+            sword and sorcery, of noble quests and legendary deeds. Most dismiss these yearnings as childhood fancy, but
+            some young souls burn so brightly with heroic desire that they pierce through reality itself, drawn across
+            the dimensional barriers to the magical world of Auringold like moths to an eternal flame.
+
+
+            These are the Knights—not born to nobility or trained in ancient academies, but children who answered
+            destiny's call with hearts full of courage and eyes bright with wonder. They arrive through moonlit portals,
+            forest clearings that shimmer at twilight, or simply by walking too far into the woods behind their homes
+            and emerging into a realm where magic flows like rivers and adventure waits around every corner.
+
+
+            The transformation is never gentle. The very act of crossing into Auringold awakens something primal within
+            them—their childhood dreams of heroism crystallize into tangible power. Their bodies grow strong with
+            supernatural might, their spirits kindle with an unquenchable flame of righteousness. They become living
+            embodiments of every storybook hero they ever admired, wielding strength that can shatter stone and bend
+            steel, though their connection to the deeper magics remains limited by their mortal origins.
+
+
+            Knights form loose brotherhoods and sisterhoods, gathering in tree-house sanctuaries and hidden groves where
+            they share tales of the worlds they left behind and the quests they've undertaken. They are guided not by
+            rigid codes or ancient traditions, but by the simple moral clarity of youth—an instinctive understanding
+            that the strong must protect the weak, that bullies must be stopped, and that every crying child deserves a
+            champion.
+
+
+            Their armor is often mismatched, scavenged from fallen foes or gifted by grateful villagers. Their weapons
+            bear the nicks and scratches of countless small battles—not grand wars against dark lords, but the daily
+            struggle against bandits who prey on merchants, monsters that terrorize farming communities, and petty
+            tyrants who abuse their power. They are the heroes of ordinary folk, the Knights-errant of everyday
+            miracles.
+
+
+            Some say that when a Knight's quest is truly complete, when they have grown from wide-eyed child to seasoned
+            protector, they fade away like morning mist—either returning to their original world as adults who remember
+            Auringold only as the most vivid dream of their youth, or ascending to join the eternal guardians who watch
+            over all worlds where children dare to dream of becoming heroes.
+
+
+            Until that day comes, they wander the roads of Auringold with eager hearts and ready swords, forever young,
+            forever brave, forever searching for the next innocent soul in need of a champion.
+          primaryStat: STR
+          image: 9ff17c41508788201ba1d2e288e6193782f944af6f228403c0445c2ffd19706c.jpg
+          outfitDescription: Gleaming plate armor with mismatched pieces showing different origins—a polished breastplate here,
+            weathered gauntlets there—all bearing small dents and scratches from countless noble deeds. Wielding a
+            longsword that glows with a faint golden radiance in one hand and a sturdy shield emblazoned with a simple
+            but proud heraldic design in the other, with a flowing cape that billows heroically behind them and a
+            practical adventurer's pack secured at their side.
+          showcaseRace: HUMAN
+        MAGE:
+          displayName: Wizard
+          hpPerLevel: 1
+          manaPerLevel: 5
+          description: Wizards are children who come to the magical world of Auringold dreaming of adventure through sorcery and
+            spells ; they perform all kinds of magical feats, limited only by their imagination, bending the world to
+            their will
+          backstory: >-
+            In the sprawling academies of Auringold, where crystalline spires pierce clouds heavy with arcane energy,
+            Wizards begin their journey as wide-eyed children drawn by whispered tales of impossible wonders. These
+            young souls arrive clutching worn spellbooks inherited from distant relatives or purchased with their
+            family's last coins, their hearts burning with dreams of reshaping reality itself.
+
+
+            The path of the Wizard is one of relentless study and boundless curiosity. Within the hallowed halls of
+            institutions like the Cerulean Conservatory or the Obsidian Institute, these aspiring mages spend countless
+            hours hunched over ancient tomes, their fingers tracing formulaic incantations while their minds struggle to
+            comprehend the fundamental forces that govern existence. The air around them shimmers with half-formed
+            spells and failed experiments, testament to their determination to master the impossible.
+
+
+            Unlike their Sorcerer counterparts who channel raw, instinctual power, Wizards approach magic as both art
+            and science. They dissect each spell component with scholarly precision, understanding that a mispronounced
+            syllable or incorrectly drawn sigil can mean the difference between conjuring light and summoning
+            devastating flame. Their spellbooks become sacred texts, filled with personal notations, theoretical
+            improvements, and the accumulated wisdom of generations.
+
+
+            The culture of Wizardry in Auringold celebrates intellectual achievement above all else. Young apprentices
+            compete not in physical tournaments but in exhibitions of magical creativity, crafting illusions that tell
+            epic stories or transmuting base materials into works of breathtaking beauty. Master Wizards are revered as
+            living libraries, their minds containing secrets that could topple kingdoms or heal incurable ailments.
+
+
+            Yet for all their scholarly pursuits, Wizards remain dreamers at heart. They see in every spell not just its
+            immediate effect, but infinite possibilities waiting to be unlocked. A simple cantrip to light a fire
+            becomes the foundation for understanding stellar formation; a charm to mend cloth evolves into techniques
+            for healing grievous wounds. Their laboratories buzz with ambitious projects that other classes might
+            consider madness—attempts to slow time, communicate with distant stars, or peer into the dreams of
+            slumbering gods.
+
+
+            This boundless ambition comes at a cost. Wizards' bodies remain frail, their constitution weakened by long
+            hours of study and exposure to volatile magical energies. Their minds, however, burn bright as beacon fires,
+            capable of storing vast reservoirs of mystical power that they channel through carefully memorized
+            incantations and precisely crafted ritual components.
+
+
+            In Auringold's grand tapestry of adventure, Wizards serve as the architects of possibility, turning the
+            phrase "it cannot be done" into their most despised enemy and "what if" into their most cherished ally.
           primaryStat: INT
-          image: f41032e0bc1f4aaec240467d2fcdf4184191fc8bb8490a32d6bef09bf6675efa.jpg
+          image: e941c7fbbe62e35848deff0d8e5599188048a1a7c61a182374e3450070261f86.jpg
+          outfitDescription: Flowing robes of midnight blue or deep purple adorned with intricate silver embroidery depicting
+            constellations and arcane formulae, cinched with a leather belt bearing pouches for spell components and a
+            holstered crystal-topped wand. A leather-bound spellbook with glowing runes floats nearby or is clutched in
+            one hand, while the other grips an ornate staff crowned with a pulsing orb of magical energy that casts
+            ethereal light across bronze bracers inscribed with protective wards.
+          showcaseRace: HUMAN
         CLERIC:
-          displayName: Cleric
-          hpPerLevel: 6
-          manaPerLevel: 12
-          description: A divine healer and protector.
-          backstory: Clerics serve as the conduit between mortal beings and the divine
-            powers that shape the world. Through prayer, devotion, and sacred
-            rituals, they channel healing light that can mend grievous wounds
-            and even call the fallen back from death's threshold. In battle,
-            clerics stand as both shield and sanctuary, their blessings turning
-            the tide when all seems lost.
+          displayName: Doctor
+          hpPerLevel: 2
+          manaPerLevel: 4
+          description: Doctors are children who come to the magical world of Auringold dreaming of healing the sick and injured ;
+            they provide services to the stuffies, toys, and other citizens of Auringold, producing magical cures that
+            can heal anything
+          backstory: >-
+            In the twilight hours between sleep and waking, when the veil grows thin between worlds, certain children
+            find themselves drawn to Auringold—a realm where forgotten toys gain breath, abandoned stuffed animals walk
+            on worn paws, and the innocent magic of childhood takes physical form. These are the Doctors, young healers
+            whose pure desire to mend what is broken transcends the boundaries of ordinary reality.
+
+
+            Unlike the trained physicians of the adult world, Doctors arrive in Auringold carrying nothing but toy
+            medical kits, plastic stethoscopes, and hearts brimming with the unshakeable belief that everything can be
+            fixed with enough care and determination. Their wisdom comes not from textbooks, but from an intuitive
+            understanding of suffering and an innate ability to see past surface wounds to the deeper hurts that plague
+            both toy and spirit alike.
+
+
+            The Great Infirmary of Auringold stands as testament to their calling—a whimsical hospital built from
+            oversized building blocks and pillow forts, where the scent of healing herbs mingles with the comforting
+            aroma of hot cocoa. Here, Doctors tend to teddy bears whose stuffing has grown thin with age, tin soldiers
+            bent from countless battles, and dolls whose porcelain hearts have cracked from loneliness. Their treatments
+            range from the wonderfully mundane—careful stitching of torn seams and polishing of tarnished surfaces—to
+            the magnificently impossible, brewing potions from dewdrops and lullabies that can mend even the most
+            shattered dreams.
+
+
+            Each Doctor discovers that their childlike faith in healing becomes a tangible force in Auringold,
+            manifesting as shimmering threads of golden light that can knit bones, seal wounds, and restore hope to the
+            most despairing soul. Their mana flows like gentle streams of starlight, replenishing as they sleep and
+            dream of worlds where nothing stays broken forever. Though their small bodies may be fragile compared to
+            adult adventurers, their spirits burn with the fierce determination of youth, growing stronger with every
+            life they touch and every miracle they perform in this realm where believing truly is seeing.
           primaryStat: WIS
-          image: 15dece12b449ac8e9f186810fb41b9cb219ee7552a47a7060e5eedf0b2c4338c.jpg
+          image: d6c1bcef8c78cbd9c35c765bddc325287b03f88c1d322a13933cbaa02ce2399f.jpg
+          outfitDescription: Wearing a pristine white coat that shimmers with healing magic, adorned with colorful patches and toy
+            medical badges, carrying an oversized plastic stethoscope that glows with golden light and a magical medical
+            bag overflowing with bandages, candy pills, and bottled starlight. The coat features deep pockets bulging
+            with toy syringes, rainbow band-aids, and miniature healing potions, while a child's toy doctor hat sits
+            atop their head, crowned with a reflective mirror that captures and amplifies their healing aura.
         ROGUE:
-          displayName: Rogue
-          hpPerLevel: 5
-          manaPerLevel: 8
-          description: A cunning striker from the shadows.
-          backstory: Rogues live by their wits and reflexes, striking from the shadows
-            with lethal precision. Masters of stealth, poison, and misdirection,
-            they exploit every weakness and opening their enemies expose. A
-            rogue may not endure a prolonged fight, but few battles last long
-            when a blade finds its mark between the ribs. Their guild teaches
-            that the best fight is the one your enemy never sees coming.
+          displayName: Pirate
+          hpPerLevel: 2
+          manaPerLevel: 2
+          description: Pirates are children who come to Auringold looking for nonstop adventure and fun ; they are full of energy
+            and cause playful havoc wherever they go
+          backstory: >-
+            The Pirate class emerged from the bustling port cities of the Crimson Archipelago, where orphaned street
+            children learned to survive by their wits and nimble fingers. These waifs, abandoned by wars or lost to
+            plague, banded together in makeshift crews that roamed the docks and markets, perfecting the arts of
+            mischief and evasion. What began as necessity evolved into tradition when Captain Jolly Redbeard, himself
+            once a dock rat, formalized the "Code of Endless Summer" – a philosophy declaring that life's greatest
+            treasures are laughter, friendship, and the thrill of the next great escapade.
+
+
+            When these spirited rogues hear tales of Auringold's legendary adventures, they arrive in droves aboard
+            creaking dinghies, commandeered fishing boats, and the occasional "borrowed" merchant vessel. They bring
+            with them an infectious enthusiasm that both delights and exasperates local authorities. Pirates organize
+            elaborate treasure hunts through city streets, stage mock sea battles in public fountains, and maintain an
+            underground network of hideouts connected by ropes, ladders, and secret passages.
+
+
+            Their culture revolves around the sacred rituals of "first watch" – elaborate initiation pranks for
+            newcomers – and "sunset councils" where crews gather to plan the next day's adventures while sharing stolen
+            sweets and wild stories. Pirates communicate through a colorful pidgin mixing sailor's cant with playground
+            rhymes, and their hierarchy is determined not by age or strength, but by creativity in devising harmless but
+            memorable capers.
+
+
+            Though their antics sometimes strain patience, Pirates possess an uncanny ability to unite strangers through
+            shared laughter and to find wonder in the mundane. Their boundless energy and acrobatic skills make them
+            surprisingly effective in genuine crises, when their playful nature transforms into fierce loyalty to their
+            chosen crew and adopted homeland.
           primaryStat: DEX
-          image: eba3ce4241934d8403d7bf035a243a564b5a6ef3625f17d03ad2d59e29c4c1cb.jpg
-        RANGER:
-          displayName: Ranger
+          image: afccc9c03b97211007e4515203879a9ed95905962119bb53333b86070dd24265.jpg
+          outfitDescription: Wearing a patchwork coat of mismatched fabrics and colors with rolled-up sleeves, tattered shorts or
+            pants held up by rope belt, and worn leather boots perfect for climbing and running. Wielding a curved
+            cutlass or wooden practice sword alongside a coil of rope, with pouches and small trinkets dangling from the
+            belt, a weathered tricorn hat adorned with feathers or makeshift decorations, and perhaps a small spyglass
+            or compass hanging from a cord around the neck.
+        RULER:
+          displayName: Ruler
           hpPerLevel: 6
           manaPerLevel: 8
-          description: A nature-attuned hunter of the wilds.
-          backstory: Rangers are the unsung wardens of the frontier — part scout, part
-            predator, part naturalist. They roam the wild places where
-            civilization ends and the unknown begins, reading tracks, marking
-            prey, and surviving by instinct as much as skill. A ranger's bond
-            with nature is not mystical in the way of clerics, but primal and
-            hard-won. They keep a hawk companion, strike from cover with bow and
-            blade, and know that the best way to win a fight is to see the enemy
-            before the enemy sees you.
-          primaryStat: DEX
-          image: fe4f9f0363c75c4c7b7e6c5b886e79a1e2e034f5e0caa17b19de478d643a538e.jpg
+          description: Rulers are children who come to the magical world of Auringold as princes, princesses, kings and queens ;
+            They rule over the pixelated and stuffie citizens, lending their expert guidance and direction
+          backstory: >-
+            **The Crowned Dreamers of Auringold**
+
+
+            In the moments between sleep and waking, when reality grows thin and imagination takes hold, certain
+            children find themselves pulled across the veil into Auringold—a realm where stuffed animals breathe with
+            cotton hearts and pixelated landscapes shift like living mosaics. These young souls arrive not as mere
+            visitors, but as sovereigns, crowned by the realm's ancient magic that recognizes the pure authority of
+            untainted dreams.
+
+
+            The transformation is both gentle and profound. A child who falls asleep clutching a worn teddy bear may
+            awaken as Queen of the Velvet Throne, her loyal parliament composed of button-eyed advisors and
+            ribbon-tailed courtiers. Another might find himself King of the Crystal Cascade, where geometric fish swim
+            through rivers of flowing light, their citizens speaking in the melodic chimes of cascading pixels.
+
+
+            Auringold's history speaks of the Great Awakening, when the first Ruler—a girl named Melody who had lost her
+            voice in the waking world—sang the realm into fuller existence with a lullaby that gave true consciousness
+            to every toy and digital sprite. Since then, each new Ruler has added their own thread to the tapestry of
+            this impossible kingdom, their innocent wisdom often solving conflicts that would baffle adult minds.
+
+
+            The Stuffie citizens, crafted from memories of comfort and security, serve with unwavering devotion, while
+            the Pixelated folk—born from the dreams of a generation raised on glowing screens—offer their geometric
+            insights and computational clarity. Together under their young monarchs, they build a society where bedtime
+            stories become law, where playground rules govern international diplomacy, and where the greatest treasures
+            are not gold or jewels, but forgotten toys brought back to magical life.
+
+
+            These child Rulers possess an innate understanding of both justice and joy, wielding scepters that might be
+            repurposed kitchen spoons or crowns woven from dandelion stems, yet commanding respect that spans both plush
+            kingdoms and digital domains. In Auringold, wisdom comes not from years but from the fearless heart of
+            childhood itself.
+          selectable: true
+          image: 10d374d0b3e0ffec6ccfb5908aeac23da0c5c7195bddd776a2f46c02470a95c6.jpg
+          outfitDescription: Ornate velvet robes in jewel tones with golden trim and embroidered stars, flowing cape fastened with
+            an oversized gemstone brooch, delicate circlet or crown adorned with colorful stones that pulse with soft
+            magical light. Wielding a whimsical royal scepter topped with a glowing orb or star, accompanied by floating
+            magical accessories like a miniature crown, enchanted scroll, or orbiting toy-like familiars that sparkle
+            with pixelated effects.
     races:
       definitions:
         HUMAN:
-          displayName: Human
-          description: Versatile and adaptable.
+          displayName: HUMAN
+          description: Humans are the children who enter Auringold and play as themselves
           backstory: >-
-            Humans emerged from the scattered tribes of the Second Age, when the
-            great dragons still ruled the skies and the elder races held
-            dominion over vast territories. Unlike their longer-lived cousins,
-            humans possessed an insatiable drive to explore, conquer, and remake
-            the world around them. This restless ambition, born from their brief
-            lifespans, became both their greatest strength and most dangerous
-            weakness.
+            **The Awakened**
 
 
-            Where elves perfected singular crafts over centuries and dwarves
-            inherited the mastery of their ancestors, humans learned to adapt
-            and improvise. They became merchants who could haggle in a dozen
-            tongues, warriors who blended fighting styles from every corner of
-            the realm, and scholars who synthesized knowledge from all cultures
-            they encountered. Their cities became melting pots where foreign
-            customs merged with local traditions, creating ever-evolving
-            societies that other races found both fascinating and unsettling.
+            In the earliest days of Auringold's formation, when the cosmic winds first stirred the primordial mists and
+            shaped the nascent realm, a peculiar phenomenon began to manifest. Children from distant worlds beyond the
+            veil would find themselves drawn into this mystical domain, not through arcane rituals or divine
+            intervention, but through the pure, unbridled power of imagination and wonder.
 
 
-            The human capacity for both creation and destruction is legendary.
-            They built the great trade routes that connected distant continents,
-            established academies of learning that welcomed all races, and
-            forged alliances that ended ancient wars. Yet they also unleashed
-            the Sorcerer Wars that scarred the northern reaches, and their
-            hunger for expansion has displaced countless communities throughout
-            history.
+            These young souls, known collectively as the Awakened, arrive in Auringold carrying nothing but their truest
+            selves—their hopes, fears, dreams, and the boundless creativity that exists before the world teaches them
+            what is "impossible." Unlike the native races who have spent millennia adapting to Auringold's magical
+            currents, the Awakened bring something far more precious: the ability to see the realm with fresh eyes,
+            unclouded by ancient prejudices or rigid traditions.
 
 
-            What truly sets humans apart is their ability to inspire and be
-            inspired. A human leader can unite fractured tribes against
-            impossible odds, while a human artist might capture beauty in ways
-            that move even the stoic mountain folk to tears. They burn bright
-            and brief, leaving marks upon the world that outlast their fleeting
-            lives, forever changing the destiny of all who encounter them.
-          image: 998c63f20327943a2a55d6d103816cf718c5e170315c1dbfde46245bf69374f4.jpg
-          statMods:
-            STR: 1
-            DEX: 0
-            CON: 0
-            INT: 0
-            WIS: 0
-            CHA: 1
-          bodyDescription: Lean athletic build with smooth pale to deep brown skin tones,
-            completely flat chest with no gendered features, expressive oval
-            face with bright eyes ranging from brown to blue to green, flowing
-            hair in natural shades of black, brown, blonde or auburn that moves
-            with subtle life-like animation, limbs proportioned for agility and
-            endurance with calloused hands that speak of varied experience.
-          staffPrompt: A towering androgynous human figure wreathed in cascading golden
-            light, their form shifting between states of pure energy and solid
-            matter as reality bends around them. Countless swirling galaxies
-            orbit their head like a cosmic crown while their eyes blaze with the
-            light of newborn stars, and their outstretched hands command streams
-            of liquid starlight that reshape the very fabric of existence. Their
-            robes appear to be woven from the aurora itself, constantly shifting
-            through every color of the spectrum while leaving trails of luminous
-            particles that form temporary constellations in the air. The ground
-            beneath them cracks and reforms with each breath, revealing glimpses
-            of infinite other worlds, as waves of pure creative force pulse
-            outward from their being. Their presence suggests infinite potential
-            made manifest, the ultimate expression of adaptability transcended
-            into godhood.
-        ELF:
-          displayName: Elf
-          description: Graceful and magically attuned.
+            The Awakened possess an extraordinary gift called the "Malleable Spirit"—their very essence remains fluid
+            and adaptable, allowing them to learn any skill, master any art, or forge bonds with any creature they
+            encounter. Where an elf might spend centuries perfecting a single school of magic, an Awakened child might
+            stumble upon three different magical disciplines in a single afternoon, guided by curiosity rather than
+            convention.
+
+
+            Their settlements, known as Havens of Wonder, are ever-changing communities that reflect the collective
+            imagination of their inhabitants. Buildings might shift from treehouses to crystal palaces to underground
+            burrows depending on the prevailing mood and dreams of the residents. These communities serve as neutral
+            ground where all races gather, drawn by the Awakened's unique ability to see potential friends where others
+            see only ancient enemies.
+
+
+            Though physically they may appear as ordinary children, the Awakened are recognized throughout Auringold as
+            harbingers of change and possibility. Their presence often signals the beginning of great adventures, the
+            resolution of age-old conflicts, or the discovery of new realms within the ever-expanding borders of this
+            mystical world.
+
+
+            The other races have learned to both cherish and prepare for the arrival of the Awakened, for where these
+            remarkable beings tread, the very fabric of reality becomes more vibrant, more alive, and infinitely more
+            wondrous.
+          image: 37f64ea49f3ba61e43166b98b724e138151686bcbba7fc9a7f240810b364a92c.jpg
+          bodyDescription: Youthful human form with smooth, unblemished skin that seems to shimmer faintly with an inner light of
+            pure potential. Eyes that sparkle with curiosity and wonder, often shifting subtly in hue to reflect their
+            current emotions or thoughts. Hair that moves as if touched by invisible winds of imagination, sometimes
+            catching glints of otherworldly colors when the light strikes it just right, while their entire being
+            radiates a soft, warm glow that pulses gently with the rhythm of limitless possibility.
+          staffPrompt: A transcendent human figure wreathed in cascading auroras of pure creation, their form simultaneously
+            youthful and ageless as reality bends around their divine presence. Golden fractals of infinite possibility
+            spiral outward from their luminous skin, while their eyes blaze with the combined wisdom of every story ever
+            told and every dream ever dreamed. Massive ethereal wings of crystallized starlight unfurl behind them, each
+            feather containing swirling galaxies of potential worlds, as ribbons of liquid gold and silver flow through
+            their hair like the very essence of imagination made manifest. The ground beneath them dissolves into
+            streams of pure light that flow upward in impossible defiance of gravity, while floating tomes of cosmic
+            knowledge orbit their form alongside miniature suns that pulse in rhythm with the heartbeat of creation
+            itself. Their entire being radiates waves of divine authority that cause the air to shimmer with rainbow
+            prisms, and their outstretched hand holds a sphere of concentrated possibility from which new realities
+            continuously birth and fade in endless cycles.
+        DINOSAUR:
+          displayName: DINOSAUR
+          description: Dinosaurs are children who come to Auringold and turn into dinosaurs for their adventures
           backstory: >-
-            The Elves emerged from the twilight between worlds during the First
-            Convergence, when the boundaries between the material realm and the
-            Feywild grew thin as gossamer threads. Born of starlight and ancient
-            magic, they are the children of Aethermoon, the wandering celestial
-            body that appears only during the most potent magical conjunctions.
-            Their society reflects this ethereal origin—fluid, cyclical, and
-            deeply intertwined with the ebb and flow of arcane energies.
+            The Metamorphic Children of Auringold
 
 
-            Elven settlements exist in harmony with natural ley lines, their
-            crystalline spires and living wood architecture channeling raw magic
-            to sustain their communities. They measure time not in years but in
-            the Great Turnings—vast cycles marked by the convergence of
-            celestial events and the blooming of the Worldtree's silver leaves.
-            To an Elf, a human lifetime is but a season's breath, leading to
-            their reputation for seeming aloof and distant when dealing with
-            shorter-lived races.
+            In the shimmering realm of Auringold, where ancient magics flow like golden rivers through crystalline
+            valleys, there exists a phenomenon both wondrous and mysterious—the transformation of innocent children into
+            mighty dinosaurian forms. These are not mere beasts, but something far more extraordinary: young souls who
+            have crossed the threshold between worlds, carrying within them the pure essence of childhood wonder that
+            Auringold's primordial energies recognize and embrace.
 
 
-            Their bodies are living conduits for magical energy, granting them
-            supernatural grace and an intuitive understanding of arcane forces,
-            but this same attunement makes them physically fragile compared to
-            more earthbound peoples. An Elf's bones are hollow like a bird's,
-            filled with crystalline formations that resonate with magical
-            frequencies. Their luminous eyes can perceive the weave of magic
-            itself, seeing spells as cascading ribbons of colored light and
-            detecting enchantments like others might notice a familiar scent.
+            Long ago, when the first explorers discovered the hidden pathways to Auringold, they brought with them tales
+            of children who vanished from their beds, only to be glimpsed in dreams as magnificent creatures roaming
+            prehistoric landscapes. The realm's ancient guardians, beings of living amber and fossilized starlight,
+            revealed the truth: Auringold exists partially outside of time itself, where the boundary between
+            imagination and reality grows thin. Children, with their unburdened minds and limitless capacity for belief,
+            naturally resonate with these temporal echoes of Earth's distant past.
 
 
-            Elven culture revolves around the pursuit of perfection through
-            patient mastery—whether in spellcraft, artistry, or the elegant
-            martial traditions of the Moonblade Dancers. They believe that true
-            understanding comes only through centuries of contemplation and
-            practice, making them both revered teachers and frustratingly
-            methodical allies. Their memory spans millennia, and they serve as
-            living libraries of ancient knowledge, though they share their
-            wisdom sparingly with those they deem unworthy of such gifts.
-          image: 400487b7fd2117c7406eeadf071ba5d4a0db232509bcc3f2919fa7c75f235301.jpg
-          statMods:
-            STR: -1
-            DEX: 2
-            CON: -2
-            INT: 1
-            WIS: 0
-            CHA: 0
-          bodyDescription: Tall, ethereally slender figure with completely flat chest and
-            no gendered features, possessing hollow bird-like bones visible as
-            faint crystalline formations that shimmer beneath translucent,
-            pearl-luminescent skin. Angular, otherworldly face with large
-            luminous eyes that swirl with cascading ribbons of magical light,
-            shifting between silver, violet, and starlight blue depending on
-            magical currents. Long, flowing hair that appears to be spun from
-            moonbeams and starlight, seeming to move with its own ethereal
-            breeze and occasionally sparkling with tiny motes of arcane energy.
-          staffPrompt: A towering androgynous elven deity wreathed in cascading auroras of
-            silver and gold light, their elongated limbs flowing like liquid
-            starlight as arcane sigils orbit their crown in perfect geometric
-            patterns. Ancient runes burn along their translucent skin while
-            their eyes blaze with the accumulated wisdom of millennia, twin
-            galaxies swirling within their gaze. Ethereal robes woven from pure
-            magical energy ripple and shift between dimensions, trailing cosmic
-            dust and floating flower petals that bloom and wither in endless
-            cycles. Their outstretched hands command reality itself, bending
-            space around them as they hover above a mandala of pure crystallized
-            magic that rotates beneath their feet. The very air shimmers with
-            divine authority as waves of celestial power pulse outward from
-            their form, causing nearby matter to briefly phase between material
-            and spiritual planes.
-        DWARF:
-          displayName: Dwarf
-          description: Tough and resilient.
+            Upon arrival, each child undergoes the Great Awakening—a mystical transformation that reflects their deepest
+            nature. Some become mighty Tyrannosaurs, their protective instincts magnified into fierce guardianship.
+            Others manifest as swift Velociraptors, their curiosity and cleverness enhanced beyond mortal bounds. The
+            gentle souls emerge as towering Brachiosaurs, while the bold and adventurous take the forms of Triceratops
+            or soaring Pteranodons.
+
+
+            These transformed children retain their human consciousness and emotions, but gain the primal wisdom and
+            instincts of their chosen forms. They form tight-knit packs based not on species, but on the bonds of
+            friendship and shared purpose that transcend their physical shapes. In Auringold, they are both student and
+            guardian, learning ancient secrets while protecting the realm's delicate balance between past and future,
+            dream and reality.
+
+
+            Their society revolves around the Sacred Rookeries—crystalline chambers where new arrivals first transform,
+            guided by elder Dinosaurs who have mastered both their bestial and human natures. Here, the young learn to
+            balance their newfound power with the responsibility that comes with it, preparing for adventures that will
+            shape not only their own destinies, but the fate of Auringold itself.
+          image: d80d63ff2780445b10e4c72042bbfabf326c8fe6950bcc81932523c3fac375e8.jpg
+          bodyDescription: Powerful dinosaurian body with scales that shimmer between earthy tones and faint golden iridescence,
+            reflecting the magical energies of transformation. Expressive eyes that retain a spark of human intelligence
+            and wonder within reptilian features, with facial expressions that blend primal instinct with childlike
+            curiosity. The creature's form pulses subtly with amber-colored magical energy, particularly around the
+            edges where reality bends to accommodate the metamorphosis from human to prehistoric beast.
+          staffPrompt: A colossal primordial dinosaur deity towering beyond mortal comprehension, its scales blazing with molten
+            gold and cosmic amber that ripple like liquid starlight across an impossibly massive form. Ancient reptilian
+            eyes burn with the accumulated wisdom of eons and the innocent wonder of every child who ever dreamed of
+            becoming a dinosaur, each iris containing swirling galaxies of golden fire. Massive claws and teeth gleam
+            with crystalline amber energy while reality itself warps and shimmers around the creature's form, creating
+            cascading waves of transformation magic that turn the air into prismatic fossil patterns. A crown of
+            floating amber orbs and petrified starlight circles its mighty skull, each one containing the essence of a
+            different prehistoric era, while its roar echoes across dimensions with the pure joy and power of limitless
+            imagination made manifest. The ground beneath trembles and transforms into crystallized time itself, showing
+            glimpses of primordial worlds through translucent amber beneath its divine footsteps.
+        DRAGON:
+          displayName: DRAGON
+          description: Dragons are children who come to Auringold and turn into powerful winged dragons that breathe fire for
+            their adventures
           backstory: >-
-            **The Khazad-Mor: Children of Stone and Fire**
+            The Dragon-Chosen of Auringold
 
 
-            Born from the heart of mountains and forged in the depths of the
-            earth, the dwarves are a people whose very essence reflects the
-            unyielding stone from which they emerged. Legend speaks of their
-            creation by Moradin the Forgefather, who carved the first dwarves
-            from living granite and breathed into them the fires of the world's
-            core, granting them strength that rivals iron and endurance that
-            outlasts the ages.
+            In the mist-shrouded realm of Auringold, where ancient magic flows through crystalline ley lines and the
+            very air shimmers with possibility, a phenomenon occurs that has puzzled scholars and mystics for centuries.
+            Children from distant worlds—some say from realms beyond the stars, others whisper from dimensions where
+            magic has long since faded—find themselves drawn to this land through dreams that burn with golden fire.
 
 
-            For millennia, dwarven civilization has thrived in vast underground
-            kingdoms called the Khaz-Ankor, sprawling networks of halls, mines,
-            and forges that honeycomb the world's greatest mountain ranges.
-            These subterranean realms are marvels of engineering, where massive
-            stone pillars support cathedral-sized chambers lit by pools of
-            molten metal and rivers of lava channeled through masterful
-            stonework. The greatest of these cities, Khaz-a-Karak, is said to
-            delve twenty levels deep, its lowest chambers reaching toward the
-            planet's molten heart.
+            These young souls, known as the Ember-Called, arrive bearing no memory of their journey, only an
+            inexplicable yearning that pulls them toward the Dracorium Peaks, towering mountains of volcanic glass that
+            pierce the heart of Auringold like obsidian fangs. Here, within the Crucible of Transformation—a vast cavern
+            where dragonfire once forged the very foundations of the realm—the children undergo the Awakening.
 
 
-            Dwarven society revolves around the twin pillars of clan and craft.
-            Each dwarf belongs to a clan that traces its lineage back thousands
-            of years, with clan names often reflecting their ancestral
-            profession or the mountain peak they first called home. The
-            Ironforge clan masters metalwork, the Stonebeards excel in
-            architecture and mining, while the Goldbraids have produced
-            generations of merchants and traders. These clans are bound by the
-            Khazad-Dum, an ancient code of honor that emphasizes loyalty,
-            craftsmanship, and the repayment of debts—both grudges and favors.
+            The transformation is neither swift nor gentle. Over the course of thirteen moons, their mortal flesh
+            gradually gives way to scales that gleam like polished jewels, their bones hollow and strengthen, and great
+            wings unfurl from their shoulders like banners of living flame. Most remarkably, deep within their throats,
+            an inner fire ignites—not merely flame, but the essence of creation itself, capable of forging as well as
+            destroying.
 
 
-            The physical resilience of dwarves is legendary. Their compact,
-            muscular frames are perfectly adapted for life underground, with
-            broad shoulders for wielding heavy tools and picks, and sturdy legs
-            that never tire on mountain paths or in deep mine shafts. Their
-            bones are dense as stone, their skin tough as leather, and their
-            lungs capable of working in the thin air of high peaks or the
-            dust-filled atmosphere of deep excavations. This constitution comes
-            at the cost of agility—their solid build makes them steady but slow,
-            methodical rather than graceful.
+            The Dragons of Auringold are not mere beasts of legend, but a proud civilization with their own customs and
+            hierarchies. They gather in Flights—aerial communities that soar between floating citadels of crystal and
+            stone, each led by an Ancient who has mastered not only the physical aspects of their draconic nature, but
+            the deeper mysteries of their transformed souls. Young Dragons spend decades learning the Flame Disciplines:
+            the art of tempering their inner fire, the sacred geometries of flight, and the responsibility that comes
+            with wielding power born from innocence transformed.
 
 
-            While dwarves possess keen minds for engineering, mathematics, and
-            geological knowledge, they tend toward practical rather than
-            abstract thinking. Their wisdom comes from generations of
-            accumulated experience, passed down through apprenticeships and clan
-            teachings. However, their blunt honesty, stubborn pride, and
-            suspicion of outsiders often creates friction with other races.
-            Dwarves say what they mean without flourish or diplomacy, viewing
-            elaborate courtesies as wasteful deception.
-
-
-            The Great Sundering, a cataclysmic event that collapsed many
-            mountain ranges three centuries ago, devastated numerous dwarven
-            kingdoms and scattered many clans to the surface world. These
-            displaced dwarves carry with them an unquenchable desire to reclaim
-            their ancestral homes and restore the glory of the deep roads. They
-            work as miners, smiths, and craftsmen in surface settlements, always
-            saving coin and resources for the day they can return to the
-            mountains and rebuild what was lost.
-
-
-            In their hearts burns an eternal flame—part forge-fire, part
-            homesickness—that drives them to create works of lasting beauty and
-            unmatched durability, ensuring that even if kingdoms fall and
-            mountains crumble, the legacy of dwarven hands will endure forever.
-          image: e8d1e3681ad331f8c67633d8a92dac5cb22ef4c6c5034dd5462b398065fe8ddc.jpg
-          statMods:
-            STR: 1
-            DEX: -1
-            CON: 2
-            INT: 0
-            WIS: 1
-            CHA: -2
-          bodyDescription: Stocky, powerfully built figure with dense musculature and a
-            completely flat chest with no gendered features, standing roughly
-            four and a half feet tall with proportionally broad shoulders and
-            thick limbs. Skin has a weathered, stone-like texture with a grayish
-            or earth-toned complexion that seems to shimmer faintly with
-            embedded mineral flecks, while thick, coarse hair grows in elaborate
-            braids from both head and face in rich browns, coppers, or
-            iron-grays. Deep-set eyes glow with an inner amber or orange light
-            like banked coals, and the overall physique radiates solidity and
-            endurance with hands and feet that appear almost carved from living
-            rock.
-        HALFLING:
-          displayName: Halfling
-          description: Quick and charming.
+            What drives children from other worlds to seek out this metamorphosis remains Auringold's greatest mystery.
+            Some believe they are souls destined for heroism, drawn by the realm's need for champions. Others whisper
+            that they are refugees from worlds consumed by darkness, seeking rebirth in flame and wing. The Dragons
+            themselves speak of half-remembered dreams and a calling that burns brighter than fear, driving them to
+            embrace a destiny written in fire across the endless skies of their adopted home.
+          image: 72e181fcfed581d33135bc3e38b97f72bd00d5d32f00909a12d1a25157509603.jpg
+          bodyDescription: Humanoid body with reptilian transformation, scaled skin in jewel tones of deep crimson, sapphire blue,
+            or emerald green that shimmer with inner fire, elongated face with pronounced cheekbones and golden
+            vertical-pupil eyes that glow like molten metal. Large membranous wings extending from muscular shoulders,
+            clawed hands and feet, and wisps of flame occasionally curling from nostrils and mouth corners, with an
+            overall aura of barely contained elemental fire energy radiating from within.
+          staffPrompt: A transcendent dragon deity of impossible magnificence towers with crystalline scales that shift through
+            all jewel tones simultaneously—crimson, sapphire, and emerald flowing like liquid starlight across a form
+            that seems to exist in multiple dimensions at once. Colossal wings spread wide enough to eclipse suns, their
+            membranes woven from pure cosmic fire and stellar winds, while golden eyes blaze with the intensity of
+            newborn galaxies and vertical pupils that contain swirling nebulae. Torrents of prismatic dragonfire cascade
+            endlessly from their maw, each flame a miniature constellation that births and destroys worlds, as reality
+            itself warps and bends around their presence. A crown of orbiting planets and burning comets circles their
+            ancient skull, while their clawed hands grasp threads of fate and time itself, and their very breath
+            reshapes the fabric of existence with each exhale. Divine runes of creation spiral around their form in
+            rings of molten gold, and their aura pulses with the raw power of elemental genesis—a being that transcends
+            mortal comprehension of what dragons could become.
+        KITTY:
+          displayName: KITTY
+          description: Kitties are children who come to Auringold to pretend to be cute cats and kittens
           backstory: >-
-            The halflings of the Emerald Valleys are a people shaped by
-            countless generations of adaptation and survival. Where larger folk
-            stumble through brambles, halflings slip between thorns like
-            shadows. Where others tire from endless journeys, halflings press
-            onward with an inexplicable lightness of spirit that seems to
-            sustain them when provisions fail.
+            The Kitty are not merely children at play, but members of a whimsical cultural phenomenon that has taken
+            root in the mystical realm of Auringold. These young souls, typically between the ages of seven and sixteen,
+            undergo a cherished rite of passage known as the "Whisker Walk" — a temporary transformation both spiritual
+            and social that connects them to the ancient feline guardians who once protected the earliest settlements of
+            their homeland.
 
 
-            Their diminutive stature, rarely exceeding four feet in height,
-            conceals a remarkable agility born from lives spent navigating the
-            hidden paths between towering grasses and ancient root systems.
-            Halfling children learn to move silently through undergrowth before
-            they can properly walk on cobblestones, their bare feet reading the
-            language of earth and leaf with uncanny precision. This natural
-            grace extends beyond mere physical prowess—halflings possess an
-            intuitive understanding of timing, whether slipping past a dozing
-            giant or knowing precisely when to interrupt a heated argument with
-            a perfectly timed jest.
+            Long ago, when Auringold was young and wild magic flowed freely through its forests, great cats of
+            supernatural intelligence served as guides and protectors to lost travelers and vulnerable communities.
+            These majestic beings, known as the Felinar, possessed wisdom beyond mortal understanding and could shift
+            between feline and humanoid forms at will. Though the Felinar vanished centuries ago during the Great
+            Dimming, their legacy lives on through the Kitty tradition.
 
 
-            Their society revolves around the sacred concept of the "Traveling
-            Hearth"—the belief that home exists not in buildings of stone and
-            timber, but in the bonds between companions who share the road.
-            Halfling communities are fluid, ever-changing networks of extended
-            families, adopted kin, and cherished friends who may scatter across
-            continents but always maintain invisible threads of connection. When
-            halflings meet after long separations, they participate in the
-            Ritual of Shared Stories, where each traveler contributes tales of
-            their journeys, weaving their experiences into the collective memory
-            of their people.
+            When children feel the calling — often marked by vivid dreams of padding through moonlit meadows or an
+            inexplicable urge to climb impossible heights — their families celebrate with the Ceremony of First Purr.
+            The child receives handcrafted ears, a tail blessed by village elders, and learns the sacred art of Feline
+            Mimicry: the precise movements, vocalizations, and behavioral patterns that honor their mysterious
+            predecessors.
 
 
-            This emphasis on connection has gifted halflings with an almost
-            supernatural charm. They possess an uncanny ability to find common
-            ground with the most disparate individuals, often serving as
-            mediators, diplomats, and beloved innkeepers throughout the realm.
-            Their laughter is said to ease tensions that have simmered for
-            years, and their genuine interest in others' welfare makes them
-            natural confidants and trusted allies.
+            Kitties form tight-knit packs called "Litters," led by experienced older children known as "Queens" and
+            "Toms." They communicate through an intricate system of mews, chirps, and body language that often baffles
+            adults. Their playful antics serve a deeper purpose — they are unconsciously mapping the spiritual ley lines
+            that the ancient Felinar once traveled, keeping alive pathways of magic that might otherwise fade from
+            memory.
 
 
-            Yet beneath their jovial exterior lies a core of quiet wisdom earned
-            through hardship. Halflings remember the Great Wandering, when their
-            ancestral lands were consumed by an expanding desert, forcing entire
-            populations to seek new homes. Those who survived did so not through
-            strength of arms, but through cleverness, cooperation, and an
-            unshakeable optimism that insisted better days lay just beyond the
-            next hill. This history taught them that while they may lack the raw
-            power of larger races, their true strength lies in adaptability,
-            community, and the profound understanding that even the mightiest
-            oak can be felled by patient roots working together.
-
-
-            Modern halflings carry these lessons forward, their bodies
-            reflecting their heritage: quick reflexes honed by necessity,
-            constitutions tested by lean times and long roads, and hearts large
-            enough to embrace both friend and stranger with equal warmth. They
-            are living proof that greatness often comes in small packages, and
-            that sometimes the most profound journeys are taken not by those who
-            stride boldly forward, but by those who dance gracefully between the
-            steps of giants.
-          image: 12fbf49c705f7376f63f07f1ffba31ce00c4acb7df6161a693bc47f209767ed1.jpg
-          statMods:
-            STR: -2
-            DEX: 2
-            CON: -1
-            INT: 0
-            WIS: 1
-            CHA: 1
-          bodyDescription: Compact humanoid figure standing three and a half to four feet
-            tall with a completely flat chest and no gendered features,
-            possessing a lean but sturdy build optimized for agility and
-            endurance. Warm olive or golden-tan skin with a naturally weathered
-            texture from outdoor living, complemented by expressive amber or
-            hazel eyes that sparkle with mischief and wisdom. Thick, curly hair
-            in earthy tones of chestnut, honey-brown, or copper that grows wild
-            and untamed, with notably large, bare feet bearing tough, calloused
-            soles perfectly adapted for silent movement across varied terrain.
-          staffPrompt: A transcendent halfling deity hovering three feet above crystalline
-            ground, their compact form radiating blinding golden aurora that
-            warps reality in spiraling fractals around them, thick curly hair
-            now flowing like liquid starlight in impossible colors of molten
-            copper and celestial amber. Massive bare feet leave glowing
-            footprints that bloom into miniature galaxies, while their weathered
-            olive skin pulses with veins of pure cosmic energy and their eyes
-            blaze like twin supernovas containing swirling nebulae. Seven
-            blazing halos of different metals orbit their head at varying
-            speeds, casting shadows that reveal glimpses of infinite parallel
-            dimensions, as streams of crystalline light pour from their
-            outstretched palms to weave the fabric of space-time itself. The air
-            around them shimmers with heat distortion and floating runes of
-            ancient power, while their mischievous smile holds the weight of
-            eons and the promise of reality-altering pranks that reshape entire
-            planes of existence.
-        HALF_ORC:
-          displayName: Half-Orc
-          description: Fierce and resilient, with orcish blood.
+            Most children naturally outgrow their Kitty phase as they approach adulthood, but some rare individuals
+            maintain the connection throughout their lives, becoming respected shamans and guides who help others
+            navigate both the physical and mystical landscapes of Auringold.
+          image: 2b4113665e844ddad7ae5e07e21a7e0f50c9a6617889dbea1633758ceba2a8eb.jpg
+        PUPPY:
+          displayName: PUPPY
+          description: Puppies are children who come to Auringold and turn into dogs, puppies, and wolves for their adventures
           backstory: >-
-            Born of two worlds yet fully accepted by neither, half-orcs embody
-            the eternal struggle between civilization and savagery that rages
-            within their very blood. These children of unlikely unions between
-            humans and orcs carry the physical might and primal instincts of
-            their orcish heritage alongside the adaptability and cunning of
-            their human lineage.
+            The Puppy-Folk emerged from one of Auringold's most mysterious phenomena - the Great Calling that draws
+            young souls from distant realms to this magical land. When children from the mortal world cross through the
+            shimmering veils between dimensions, they undergo a profound transformation, their innocent hearts
+            resonating with the primal spirits of canine guardians that have protected Auringold since its founding.
 
 
-            Most half-orcs trace their origins to the turbulent borderlands
-            where human settlements clash with orcish tribes, born from unions
-            forged in conquest, desperation, or the rare instance of genuine
-            affection that transcends racial hatred. Some emerge from the great
-            slave markets of the eastern kingdoms, where captured humans and
-            orcs were forced together in brutal circumstances. Others descend
-            from mercenary companies where strength mattered more than
-            bloodline, and bonds formed in the crucible of battle.
+            This metamorphosis is not mere magic, but a sacred bond forged in the early days when the realm faced its
+            darkest hour. Ancient chronicles speak of a pack of celestial wolves who sacrificed themselves to save
+            Auringold's first settlers, their noble spirits becoming eternal protectors. When pure-hearted children
+            arrive in this land, these ancestral guardians recognize kindred souls and offer them the gift of the pack -
+            the ability to take canine form while retaining their human consciousness and wonder.
 
 
-            Standing taller and broader than most humans, half-orcs possess the
-            pronounced canine teeth, sloped foreheads, and coarse hair of their
-            orcish parentage, though tempered by human features that often
-            create a startling, fierce beauty. Their skin ranges from dusky
-            olive to deep green-gray, and their eyes burn with an inner fire
-            that speaks to the constant war between their dual natures.
+            Puppy-Folk society centers around the concept of the "Forever Pack," extended family groups that span
+            multiple generations and forms. Young Puppies often shift between their original child appearance and
+            various canine manifestations - from playful puppies learning the world through exploration, to loyal dogs
+            serving as companions and messengers, to mighty wolves when courage is needed most. Their transformations
+            reflect their emotional growth and the challenges they face.
 
 
-            Half-orc society, such as it exists, centers around proving one's
-            worth through deed rather than birth. They form loose brotherhoods
-            and sisterhoods bound by shared understanding of rejection and the
-            need to forge their own paths. Many gravitate toward professions
-            where their natural strength and ferocity are assets: mercenary
-            work, gladiatorial combat, frontier exploration, or service in
-            military units that prize results over prejudice.
-
-
-            The half-orc code of honor emphasizes personal strength, loyalty to
-            chosen family over blood relations, and the belief that respect must
-            be earned through action. They view weakness—particularly emotional
-            vulnerability—as a luxury they cannot afford, leading many to
-            cultivate reputations for stoicism and barely contained violence.
-            Yet beneath this harsh exterior often beats a heart capable of
-            profound loyalty and unexpected tenderness toward those who have
-            earned their trust.
-
-
-            Spiritually, half-orcs often find themselves drawn to deities of
-            war, survival, and redemption, seeing in these divine figures a
-            reflection of their own struggles against a world that views them
-            with suspicion. Their prayers are often wordless roars of
-            determination, and their offerings consist of scars earned in
-            honorable combat or trophies taken from defeated enemies.
-
-
-            In the greater world, half-orcs serve as living reminders that
-            strength and honor can emerge from the most unlikely circumstances,
-            and that sometimes the greatest heroes are those who must fight
-            hardest simply to prove they deserve to exist.
-          image: 6469fa7e5aa6306cda54f843ff5f48fca92b6a95489166ac5a9a34093dfe5b6f.jpg
-          statMods:
-            STR: 3
-            DEX: 0
-            CON: 2
-            INT: -1
-            WIS: -1
-            CHA: -2
-          bodyDescription: Powerfully built humanoid standing seven feet tall with broad
-            shoulders and thick, muscular limbs, featuring dusky olive to deep
-            green-gray skin with a rough, weathered texture. Completely flat
-            chest with no gendered features, angular face dominated by a sloped
-            forehead, pronounced lower canine teeth jutting upward, and burning
-            amber or deep red eyes that seem to smolder with inner fire. Coarse,
-            dark hair grows in thick patches across the scalp and jawline, while
-            the overall physique radiates raw physical power and barely
-            contained primal energy.
-          staffPrompt: A towering twelve-foot divine half-orc radiates cosmic fury, their
-            olive-green skin now bearing veins of molten gold that pulse with
-            celestial fire while crackling energy arcs between their massive
-            tusks. Ancient runic scars blaze across their mountainous frame as
-            reality itself seems to bend around their overwhelming presence,
-            with fragments of shattered worlds orbiting their broad shoulders
-            like a crown of destruction. Their burning amber eyes have become
-            twin supernovas that pierce through dimensional barriers, while
-            their coarse hair flows like liquid starlight and their breath
-            manifests as streams of pure creation and annihilation. Primal
-            cosmic forces swirl around their androgynous form in spirals of
-            golden lightning and shadow, with each movement causing
-            gravitational distortions that ripple through the fabric of
-            existence itself.
-        GNOME:
-          displayName: Gnome
-          description: Clever, curious, and surprisingly tenacious.
+            The Pack Halls of major settlements serve as both homes and training grounds, where Puppy-Folk learn the
+            ancient Howling Songs that let them communicate across vast distances, and practice the Scent Memories that
+            allow them to track not just physical trails, but the emotional imprints left by friends and foes alike.
+            Their culture values loyalty above all else, followed closely by curiosity and the protection of the
+            innocent - traits that make them natural adventurers and beloved allies throughout Auringold.
+          image: 91473c9bd91f58ed902bd0e27715ec1a4e913a570c9bf3620588713da5f1dbd9.jpg
+          bodyDescription: Small, youthful humanoid form with soft, rounded features and bright, expressive eyes that sparkle with
+            curiosity and innocence. Skin has a subtle luminescent quality that shifts between pale human tones and the
+            beginnings of fur patterns, with patches of downy hair emerging along the arms and face that hint at their
+            canine nature. Their hair ranges from tousled browns and golds to silvery whites, often with an otherworldly
+            shimmer that catches light like moonbeams, and their ears show slight elongation with a tendency to perk up
+            when alert.
+          staffPrompt: A transcendent Puppy deity manifests as a luminous child-god wreathed in cascading aurora light, their
+            small form radiating impossible cosmic power while maintaining the innocent wonder of eternal youth.
+            Golden-white energy pours from their shifting amber eyes like liquid starlight, and their tousled hair
+            transforms into flowing streams of celestial fire that dance with the colors of dawn and twilight. Spectral
+            wolf spirits orbit their glowing form in endless spirals, phasing between corporeal hounds of pure light and
+            wisps of transformative magic that bend reality around them. Ancient runes of metamorphosis burn in the air
+            around their pointed ears, which twitch at the cosmic harmonies only divine beings can perceive, while their
+            gentle smile holds the warmth of every hearth and the wild freedom of moonlit forests. Their small hands
+            cradle swirling galaxies of golden motes that pulse with the primal magic of transformation, each particle
+            containing the essence of every adventure, every friendship, every moment of pure joy experienced by their
+            mortal children.
+        UNICORN:
+          displayName: Unicorn
+          description: Unicorns are children who come to Auringold and turn into unicorns or pegasus for their adventures
           backstory: >-
-            The gnomes emerged from the deep places of the world during the Age
-            of Stone, when the first dwarven picks struck veins of precious
-            metals and accidentally broke through into vast networks of
-            crystalline caverns. These diminutive folk had dwelled for millennia
-            in chambers lit by phosphorescent fungi and heated by natural
-            thermal vents, developing an intimate understanding of the earth's
-            hidden mechanisms. Their ancestors were master tinkers and
-            gem-cutters who learned to coax music from crystals and craft
-            clockwork marvels powered by underground streams.
+            The Unicorns of Auringold are not born of this realm, but arrive as mortal children from the mundane world
+            beyond the Gossamer Veil. These young souls, pure of heart and untainted by cynicism, are drawn to Auringold
+            during moments of deepest wonder—while chasing fireflies through moonlit meadows, making wishes upon falling
+            stars, or believing with absolute certainty in magic's existence.
 
 
-            Gnomish society revolves around the concept of "Kythara" – the great
-            interconnected puzzle of existence. They believe every phenomenon,
-            from the migration patterns of cave beetles to the alignment of
-            celestial bodies, represents a piece of this cosmic riddle. Their
-            communities are organized into Research Circles, each dedicated to
-            unraveling different aspects of Kythara through experimentation,
-            observation, and inspired tinkering.
+            Upon crossing the threshold into this mystical land, the transformative essence of Auringold recognizes
+            their innate purity and bestows upon them one of two sacred forms. Those whose hearts burn with fierce
+            courage and protective instincts manifest as traditional unicorns, their spiral horns gleaming with
+            pearl-white radiance and their hooves leaving trails of silver starlight. Children whose spirits yearn for
+            freedom and boundless exploration emerge as pegasus-born, their wings shimmering with aurora colors that
+            shift with their emotions.
 
 
-            Standing barely three feet tall, gnomes possess an almost
-            supernatural persistence when pursuing their intellectual passions.
-            Their laboratories and workshops overflow with half-completed
-            inventions, meticulously documented failures, and breakthrough
-            discoveries that often revolutionize understanding of magical
-            theory. While their small frames make them unsuited for heavy labor
-            and their intense focus sometimes leads to absent-minded mishaps,
-            their keen intellects and patient wisdom have earned them positions
-            as advisors, scholars, and innovators across many cultures.
+            The transformation is not merely physical but spiritual, as these young beings retain their childlike wonder
+            while gaining ancient wisdom whispered by the wind itself. They speak in musical tones that can calm savage
+            beasts and know instinctively the location of hidden springs and secret groves. Their society is built
+            around the concept of the Eternal Game—a philosophy viewing all challenges and quests as grand adventures to
+            be savored rather than burdens to be endured.
 
 
-            Gnomes measure success not by wealth or conquest, but by the
-            elegance of solutions discovered and knowledge preserved. They
-            maintain vast underground libraries carved into living rock, where
-            crystalline storage devices hold thousands of years of accumulated
-            learning. Their greatest heroes are not warriors but inventors whose
-            creations solved seemingly impossible problems – like Millicent
-            Gearspring, whose self-winding time pieces allowed surface dwellers
-            to coordinate activities across vast distances, or Bramblebeard the
-            Illuminator, whose improved lamp designs made deep mining safer for
-            all underground folk.
-          image: ff66c524f2af2dcc8ea797e98418a5407dd407cd619a96471d0e4e48bf20bfa9.jpg
-          statMods:
-            STR: -2
-            DEX: 1
-            CON: -1
-            INT: 2
-            WIS: 1
-            CHA: 0
-          bodyDescription: Diminutive humanoid frame standing barely three feet tall with
-            a completely flat chest and no gendered features, possessing
-            naturally luminescent pale skin that glows faintly with soft
-            blue-white phosphorescence from millennia of underground adaptation.
-            Large, bright amber or crystal-clear eyes dominate an angular face
-            with sharp, inquisitive features and slightly pointed ears, while
-            wild tufts of silver-white or pale copper hair seem to crackle with
-            static energy from constant exposure to crystalline formations.
-            Nimble, long-fingered hands end in slightly luminescent fingertips
-            that pulse gently when touching metal or stone.
-          staffPrompt: A towering twenty-foot gnome of impossible cosmic intellect hovers
-            suspended in crystalline mathematical frameworks that bend space
-            itself, their luminescent skin now blazing with constellation
-            patterns of pure starlight while fragments of reality orbit their
-            form like living equations. Ancient amber eyes have become swirling
-            galaxies containing the blueprints of creation, radiating beams of
-            golden architect-light that reshape matter with each glance, while
-            their wild hair transforms into cascading streams of liquid mercury
-            embedded with floating geometric solids and spinning astrolabes.
-            Nimble fingers stretch impossibly long, each digit crowned with
-            miniature suns that pulse in harmony with the fundamental
-            frequencies of existence, trailing luminous formulae and alchemical
-            symbols that rewrite the laws of physics in their wake. A massive
-            halo of interlocked gears, crystalline prisms, and floating
-            libraries circles overhead, casting shadows that reveal hidden
-            truths about the universe's deepest mysteries.
+            Unicorn communities gather in Crystal Clearings, where their combined presence causes flowers to bloom out
+            of season and time flows differently, allowing them to experience centuries of adventure while mere days
+            pass in the mortal realm. They are guided by the Circle of First Wishes—the eldest among them who still
+            remember their original mortal names and the dreams that first called them to Auringold.
+          image: 8a165a9158afb6e44078a581baf19b7c436f5169173ec46b2542b90002bd4ca2.jpg
+          bodyDescription: Slender equine body with pristine white coat that gleams with inner luminescence and pearl-like
+            iridescence. Graceful humanoid face retains youthful, innocent features with large expressive eyes that
+            sparkle with starlight, framed by flowing silver-white mane that seems to drift as if underwater. Single
+            spiraling horn of polished ivory emerges from the forehead, radiating soft pearl-white radiance, while
+            delicate hooves leave faint trails of shimmering silver stardust with each step.
+          staffPrompt: A transcendent celestial unicorn of impossible divine majesty towers with ethereal grace, its pristine coat
+            now blazing with cascading aurora light that shifts through every spectrum of starfire, each strand of its
+            flowing mane transformed into streams of liquid starlight that spiral upward into infinity. The spiraling
+            horn has become a beacon of pure cosmic energy, crackling with silver-white lightning that tears rifts in
+            reality itself, while multiple halos of rotating constellation rings orbit the magnificent creature's head
+            and body. Ancient runic symbols of creation float and pulse in golden fire around its form, and where its
+            luminous hooves touch the ground, entire galaxies of flowers bloom in bursts of prismatic light. The being's
+            eyes have become twin nebulae containing the birth and death of stars, radiating waves of divine authority
+            that bend space and time, while its very presence causes the air to shimmer with crystalline music and
+            fragments of pure possibility.
     equipment:
       slots:
+        weapon:
+          displayName: WEAPON
+          order: 0
+          x: 40.486106872558594
+          y: 56.236980756123856
         head:
           displayName: HEAD
-          order: 0
-          x: 50
-          y: 50
-        neck:
-          displayName: NECK
           order: 1
-          x: 50
-          y: 50
+          x: 50.902773539225265
+          y: 24.014757474263508
         body:
           displayName: BODY
           order: 2
-          x: 50
-          y: 50
+          x: 51.18055979410807
+          y: 44.709200859069824
         hands:
           displayName: HANDS
           order: 3
-          x: 50
-          y: 50
-        weapon:
-          displayName: WEAPON
-          order: 4
-          x: 50
-          y: 50
-        offhand:
-          displayName: OFFHAND
-          order: 5
-          x: 50
-          y: 50
-        feet:
-          displayName: FEET
-          order: 6
-          x: 50
-          y: 50
+          x: 62.29167938232422
+          y: 56.09809398651123
     characterCreation:
-      startingGold: 0
+      startingGold: 2000
       defaultRace: HUMAN
       defaultClass: WARRIOR
-      defaultGender: enby
-    genders:
-      none:
-        displayName: NONE
-      male:
-        displayName: MALE
-      female:
-        displayName: FEMALE
-      enby:
-        displayName: ENBY
+    genders: {}
     emotePresets:
       presets:
         - label: Wave
@@ -4183,83 +2319,83 @@ ambonmud:
         - label: Cry
           emoji: 😢
           action: cries.
-    stylist:
-      feeGold: 500
+    bank:
+      maxItems: 200
+    pets:
+      definitions:
+        teddy_knight:
+          name: a teddy knight
+          description: A brave stuffed bear wearing shining button armor and wielding a toothpick lance.
+          hp: 25
+          minDamage: 2
+          maxDamage: 5
+          armor: 1
+        pixel_sprite:
+          name: a pixel sprite
+          description: A tiny pixelated fairy that crackles with digital sparks and leaves a trail of glowing pixels.
+          hp: 15
+          minDamage: 3
+          maxDamage: 7
+          armor: 0
+        clockwork_dragon:
+          name: a clockwork dragon
+          description: A magnificent wind-up dragon with brass scales and ruby eyes that breathes sparks of toy fire.
+          hp: 40
+          minDamage: 5
+          maxDamage: 10
+          armor: 2
+        dream_guardian:
+          name: a dream guardian
+          description: A towering stuffed sentinel woven from pure dreams, its cotton heart glowing with protective light.
+          hp: 60
+          minDamage: 6
+          maxDamage: 12
+          armor: 3
     worldTime:
-      cycleLengthMs: 3600000
+      cycleLengthMs: 900000
       dawnHour: 5
-      dayHour: 8
+      dayHour: 7
       duskHour: 18
-      nightHour: 21
+      nightHour: 20
     weather:
-      minTransitionMs: 300000
-      maxTransitionMs: 900000
+      minTransitionMs: 60000
+      maxTransitionMs: 180000
       types:
         CLEAR:
           displayName: Clear
-          description: The sky is clear.
-          weight: 3.0
+          weight: 3
+          particleHint: ""
+          icon: ☀️
         RAIN:
           displayName: Rain
-          description: A steady rain falls.
-          weight: 2.0
+          weight: 2
           particleHint: rain
-          icon: "☂"
+          icon: ☔
         STORM:
           displayName: Storm
-          description: Thunder rumbles and lightning splits the sky.
           weight: 0.5
           particleHint: storm
-          icon: "⚡"
+          icon: ⛈️
         FOG:
           displayName: Fog
-          description: A thick fog blankets the area.
-          weight: 1.0
+          weight: 1
           particleHint: fog
-          icon: "☁"
+          icon: 🌫️
         SNOW:
           displayName: Snow
-          description: Soft snow drifts down from above.
           weight: 0.8
           particleHint: snow
-          icon: "❄"
+          icon: ❄️
         WIND:
           displayName: Wind
-          description: A fierce wind howls through the area.
-          weight: 1.0
+          weight: 1
           particleHint: wind
-          icon: "☴"
-    worldEvents:
-      definitions:
-        spring_festival:
-          displayName: Spring Festival
-          description: Flowers bloom across the realm and crafters find rare herbs more
-            easily.
-          startDate: 2026-03-20
-          endDate: 2026-04-20
-          flags:
-            - spring_festival
-            - bonus_herbalism
-          startMessage: The Spring Festival has begun! Flowers bloom across the realm.
-          endMessage: The Spring Festival has ended. The flowers fade.
-        midsummer_night:
-          displayName: Midsummer Night
-          description: The longest day brings warm breezes and wandering spirits.
-          startDate: 2026-06-20
-          endDate: 2026-06-22
-          flags:
-            - midsummer
-          startMessage: Midsummer Night is here — the veil between worlds grows thin.
-          endMessage: Midsummer Night has passed. The spirits retreat.
+          icon: 💨
     environment:
       defaultTheme:
         moteColors:
           - core: "#c8b8e8"
             glow: "#a897d2"
-          - core: "#d8c8f8"
-            glow: "#b8a8e0"
-          - core: "#b8a8d8"
-            glow: "#9888c0"
         skyGradients:
           DAWN:
             top: "#2a1a3a"
@@ -4277,378 +2413,57 @@ ambonmud:
           - "#c8b8e8"
           - "#a897d2"
           - "#8caec9"
-          - "#bea873"
-          - "#d8def1"
-      zones:
-        tutorial_glade:
-          moteColors:
-            - core: "#a8d8a0"
-              glow: "#6aaa5a"
-            - core: "#c8e8b0"
-              glow: "#88bb70"
-            - core: "#d0f0c0"
-              glow: "#90cc80"
-          skyGradients:
-            DAWN:
-              top: "#1a2a1a"
-              bottom: "#a8c070"
-            DAY:
-              top: "#4a8a50"
-              bottom: "#88cc88"
-            DUSK:
-              top: "#2a3020"
-              bottom: "#a08848"
-            NIGHT:
-              top: "#0a140a"
-              bottom: "#1a2c1a"
-        ambon_hub:
-          moteColors:
-            - core: "#f0d888"
-              glow: "#bea873"
-            - core: "#ffe8a8"
-              glow: "#d4b868"
-            - core: "#ffd070"
-              glow: "#c8a040"
-        demo_ruins:
-          moteColors:
-            - core: "#90b8d8"
-              glow: "#5888a8"
-            - core: "#a0c8e8"
-              glow: "#6898b8"
-            - core: "#80a8c8"
-              glow: "#487898"
-        crafting_workshop:
-          moteColors:
-            - core: "#f0b060"
-              glow: "#c88030"
-            - core: "#e89848"
-              glow: "#b06820"
-            - core: "#f0c070"
-              glow: "#c89838"
-        celestial_sanctum:
-          moteColors:
-            - core: "#c8a8f0"
-              glow: "#9878c0"
-            - core: "#d8b8ff"
-              glow: "#a888d0"
-            - core: "#b898e0"
-              glow: "#8868b0"
-        labyrinth:
-          moteColors:
-            - core: "#a8f0e0"
-              glow: "#68c0b0"
-            - core: "#88d8c8"
-              glow: "#58a898"
-            - core: "#c0f8f0"
-              glow: "#80d0c0"
+        weatherParticleOverrides: {}
+      zones: {}
     enchanting:
-      maxEnchantmentsPerItem: 1
-      definitions:
-        keen_edge:
-          displayName: Keen Edge
-          skill: enchanting
-          skillRequired: 1
-          materials:
-            - itemId: arcane_essence
-              quantity: 1
-          xpReward: 30
-          damageBonus: 2
-          targetSlots:
-            - hand
-        fortify:
-          displayName: Fortify
-          skill: enchanting
-          skillRequired: 1
-          materials:
-            - itemId: arcane_essence
-              quantity: 1
-          xpReward: 30
-          armorBonus: 2
-          targetSlots:
-            - head
-            - body
-        might:
-          displayName: Might
-          skill: enchanting
-          skillRequired: 10
-          materials:
-            - itemId: arcane_essence
-              quantity: 2
-            - itemId: rough_gem
-              quantity: 1
-          xpReward: 50
-          statBonuses:
-            STR: 2
-          targetSlots:
-            - hand
-        resilience:
-          displayName: Resilience
-          skill: enchanting
-          skillRequired: 10
-          materials:
-            - itemId: arcane_essence
-              quantity: 2
-            - itemId: rough_gem
-              quantity: 1
-          xpReward: 50
-          statBonuses:
-            CON: 2
-          targetSlots:
-            - head
-            - body
-        arcane_infusion:
-          displayName: Arcane Infusion
-          skill: enchanting
-          skillRequired: 20
-          materials:
-            - itemId: arcane_essence
-              quantity: 3
-            - itemId: rough_gem
-              quantity: 2
-          xpReward: 80
-          statBonuses:
-            INT: 2
-            WIS: 1
-          damageBonus: 3
-          targetSlots: []
-    pets:
-      definitions:
-        ranger_hawk:
-          name: a trained hawk
-          hp: 25
-          minDamage: 2
-          maxDamage: 6
-          armor: 0
-          description: A keen-eyed hawk that fights alongside the ranger with swift talons.
-          image: 270f23c50d499e30e7b7ab6f2cb6c711ba99fa58776249766625f51d6fa26f18.png
-        spectral_wisp:
-          name: a spectral wisp
-          hp: 15
-          minDamage: 1
-          maxDamage: 4
-          armor: 0
-          description: A glowing mote of ghost-light that orbits you protectively. It was
-            once something more.
-          image: 97136689108bd346f8b303eefc96b98e89f5f6bb7a453624353661ccd3e8a64a.png
+      maxEnchantmentsPerItem: 6
+      definitions: {}
     skillPoints:
-      interval: 2
+      interval: 1
     multiclass:
-      minLevel: 10
-      goldCost: 500
+      minLevel: 5
+      goldCost: 50
     housing:
       enabled: true
       entryExitDirection: SOUTH
-      templates:
-        cottage_entry:
-          title: Cottage Entryway
-          description: A cozy stone-walled entryway with pegs for cloaks and a worn
-            welcome mat. Warm light spills from a hearth in the corner.
-          cost: 1000
-          isEntry: true
-          safe: true
-        bedroom:
-          title: Bedroom
-          description: A quiet room with a simple bed, a nightstand, and a small window
-            looking out on nothing in particular.
-          cost: 500
-          safe: true
-        vault:
-          title: Storage Vault
-          description: A reinforced room with sturdy shelves and a heavy iron-banded
-            chest. Items left here seem to stay put.
-          cost: 2000
-          maxDroppedItems: 50
-          safe: true
-        workshop:
-          title: Crafting Workshop
-          description: A well-equipped workshop with a sturdy workbench, tools hanging on
-            the walls, and a small forge in the corner.
-          cost: 1500
-          safe: true
-          station: forge
-        garden:
-          title: Garden
-          description: A small walled garden with patches of herbs and a bubbling
-            fountain. The air smells of lavender.
-          cost: 800
-          safe: true
-    classStartRooms:
-      WARRIOR: thornhaven_city:new_arrivals_hall
-      MAGE: thornhaven_city:new_arrivals_hall
-      CLERIC: thornhaven_city:new_arrivals_hall
-      ROGUE: thornhaven_city:new_arrivals_hall
-      RANGER: thornhaven_city:new_arrivals_hall
-      SWARM: thornhaven_city:new_arrivals_hall
+      templates: {}
+    classStartRooms: {}
     lottery:
       enabled: true
-      ticketCost: 100
-      drawingIntervalMs: 3600000
-      jackpotSeedGold: 500
+      ticketCost: 1
+      drawingIntervalMs: 600000
+      jackpotSeedGold: 5000
       jackpotPercentFromTickets: 80
       maxTicketsPerPlayer: 10
     gambling:
       enabled: true
-      diceMinBet: 10
-      diceMaxBet: 10000
-      diceWinMultiplier: 2
-      diceWinChance: 0.45
+      diceMinBet: 1
+      diceMaxBet: 100
+      diceWinChance: 0.6
+      diceWinMultiplier: 3
       cooldownMs: 5000
     respec:
       enabled: true
-      goldCost: 1000
-      cooldownMs: 3600000
+      goldCost: 0
+      cooldownMs: 0
     prestige:
       enabled: true
-      xpCostBase: 500000
-      xpCostMultiplier: 1.5
+      xpCostBase: 1000
+      xpCostMultiplier: 1.1
       maxRank: 20
-      perks:
-        "1":
-          type: STAT_BONUS
-          stat: STR
-          amount: 1
-          description: +1 Strength
-        "2":
-          type: SKILL_POINT
-          amount: 2
-          description: +2 Skill Points
-        "3":
-          type: TITLE
-          title: the Reborn
-          description: Unlock prestige title
-        "4":
-          type: MAX_HP
-          amount: 10
-          description: +10 Maximum HP
-        "5":
-          type: STAT_BONUS
-          stat: DEX
-          amount: 1
-          description: +1 Dexterity
-        "6":
-          type: MAX_MANA
-          amount: 15
-          description: +15 Maximum Mana
-        "7":
-          type: STAT_BONUS
-          stat: CON
-          amount: 1
-          description: +1 Constitution
-        "8":
-          type: SKILL_POINT
-          amount: 3
-          description: +3 Skill Points
-        "9":
-          type: STAT_BONUS
-          stat: INT
-          amount: 1
-          description: +1 Intelligence
-        "10":
-          type: TITLE
-          title: the Ascended
-          description: Unlock prestige title
-        "11":
-          type: MAX_HP
-          amount: 15
-          description: +15 Maximum HP
-        "12":
-          type: STAT_BONUS
-          stat: WIS
-          amount: 1
-          description: +1 Wisdom
-        "13":
-          type: MAX_MANA
-          amount: 20
-          description: +20 Maximum Mana
-        "14":
-          type: STAT_BONUS
-          stat: CHA
-          amount: 1
-          description: +1 Charisma
-        "15":
-          type: TITLE
-          title: the Transcendent
-          description: Unlock prestige title
-        "16":
-          type: SKILL_POINT
-          amount: 4
-          description: +4 Skill Points
-        "17":
-          type: STAT_BONUS
-          stat: ALL
-          amount: 1
-          description: +1 All Stats
-        "18":
-          type: MAX_HP
-          amount: 20
-          description: +20 Maximum HP
-        "19":
-          type: MAX_MANA
-          amount: 25
-          description: +25 Maximum Mana
-        "20":
-          type: STAT_BONUS
-          stat: ALL
-          amount: 2
-          description: +2 All Stats
     dailyQuests:
-      enabled: true
+      enabled: false
       resetHourUtc: 0
       dailySlots: 3
       weeklySlots: 1
-      streakBonusPercent: 10
+      streakBonusPercent: 30
       streakMaxDays: 7
-      dailyPool:
-        - type: kill
-          targetCount: 10
-          description: Slay 10 creatures
-          goldReward: 200
-          xpReward: 500
-        - type: kill
-          targetCount: 20
-          description: Slay 20 creatures
-          goldReward: 400
-          xpReward: 1000
-        - type: gather
-          targetCount: 5
-          description: Gather 5 resources
-          goldReward: 150
-          xpReward: 300
-        - type: dungeon
-          targetCount: 1
-          description: Complete a dungeon
-          goldReward: 500
-          xpReward: 1500
-        - type: craft
-          targetCount: 3
-          description: Craft 3 items
-          goldReward: 250
-          xpReward: 600
-        - type: pvpKill
-          targetCount: 3
-          description: Defeat 3 players in PvP
-          goldReward: 300
-          xpReward: 800
-      weeklyPool:
-        - type: kill
-          targetCount: 100
-          description: Slay 100 creatures
-          goldReward: 2000
-          xpReward: 5000
-        - type: dungeon
-          targetCount: 5
-          description: Complete 5 dungeons
-          goldReward: 3000
-          xpReward: 8000
-        - type: craft
-          targetCount: 15
-          description: Craft 15 items
-          goldReward: 1500
-          xpReward: 4000
+      dailyPool: []
+      weeklyPool: []
     autoQuests:
       enabled: true
-      timeLimitMs: 600000
-      cooldownMs: 60000
+      timeLimitMs: 1800000
+      cooldownMs: 30000
       rewardGoldBase: 50
       rewardGoldPerLevel: 10
       rewardXpBase: 100
@@ -4656,9 +2471,9 @@ ambonmud:
       killCountMin: 3
       killCountMax: 8
     globalQuests:
-      enabled: true
-      intervalMs: 7200000
-      durationMs: 1800000
+      enabled: false
+      intervalMs: 1800000
+      durationMs: 900000
       announceIntervalMs: 300000
       minPlayersOnline: 2
       rewardGoldFirst: 2000
@@ -4667,89 +2482,29 @@ ambonmud:
       rewardXpFirst: 5000
       rewardXpSecond: 2500
       rewardXpThird: 1000
-      objectives:
-        - type: kill
-          targetCount: 25
-          description: Slay 25 creatures
-        - type: kill
-          targetCount: 50
-          description: Slay 50 creatures
-        - type: gather
-          targetCount: 15
-          description: Gather 15 resources
-        - type: craft
-          targetCount: 10
-          description: Craft 10 items
+      objectives: []
     guildHalls:
       enabled: true
-      purchaseCost: 50000
+      purchaseCost: 0
       roomCost: 10000
       maxRooms: 10
       templates:
-        meeting_hall:
-          title: Guild Meeting Hall
-          description: A grand chamber with a long oak table surrounded by sturdy chairs.
-            Banners bearing the guild's colors hang from the walls.
-        vault:
-          title: Guild Vault
-          description: A reinforced room with iron-bound chests lining the walls. The
-            guild's shared treasures are stored here.
-          hasStorage: true
-        training_room:
-          title: Training Room
-          description: Practice dummies and weapon racks fill this room. Guild members
-            come here to hone their skills.
-        trophy_room:
-          title: Trophy Room
-          description: Glass cases display trophies and mementos from the guild's greatest
-            achievements.
+        asdf:
+          title: asdf
+          description: ""
+          hasStorage: false
     factions:
-      killPenalty: 5
-      killBonus: 3
-      definitions:
-        iron_order:
-          name: The Iron Order
-          description: A ruthless mercenary company that holds the Ruined Fortress. They
-            answer to coin, not conscience.
-          enemies:
-            - free_swords
-        free_swords:
-          name: The Free Swords
-          description: Rebel fighters opposing the Iron Order's occupation of the Ruined
-            Fortress.
-          enemies:
-            - iron_order
-        shadowmere_cult:
-          name: The Shadowmere Cult
-          description: Devotees of the consuming shadow spreading through the eastern fens.
-          enemies:
-            - silver_flame
-        silver_flame:
-          name: Order of the Silver Flame
-          description: Paladins dedicated to purifying the Shadowmere curse and driving
-            back the darkness.
-          enemies:
-            - shadowmere_cult
-      questRewards: {}
+      defaultReputation: 50
+      killPenalty: 1
+      killBonus: 10
+      definitions: {}
     leaderboard:
-      refreshIntervalMs: 300000
-      topN: 10
+      refreshIntervalMs: 30000
+      topN: 50
     currencies:
+      definitions: {}
       honorPerPvpKill: 10
       tokensPerCraft: 1
-      definitions:
-        quest_points:
-          displayName: Quest Points
-          abbreviation: QP
-          description: Earned from completing quests
-        honor:
-          displayName: Honor
-          abbreviation: Hon
-          description: Earned from PvP kills
-        crafting_tokens:
-          displayName: Crafting Tokens
-          abbreviation: CT
-          description: Earned from crafting activities
     achievementCategories:
       categories:
         combat:
@@ -4786,25 +2541,26 @@ ambonmud:
         npc_turn_in:
           displayName: NPC Turn-In
   progression:
-    maxLevel: 50
+    maxLevel: 30
     xp:
-      baseXp: 100
-      exponent: 2
-      linearXp: 0
-      multiplier: 1
+      baseXp: 30
+      exponent: 1.2
+      linearXp: 5
+      multiplier: 2
       defaultKillXp: 50
     rewards:
-      hpPerLevel: 2
-      manaPerLevel: 5
+      hpPerLevel: 8
+      manaPerLevel: 6
       fullHealOnLevelUp: true
       fullManaOnLevelUp: true
-      baseHp: 10
-      baseMana: 20
+      baseHp: 50
+      baseMana: 50
   transport:
     telnet:
       maxLineLen: 1024
       maxNonPrintablePerLine: 32
       socketBacklog: 256
+      maxConnections: 5000
     websocket:
       host: 0.0.0.0
       stopGraceMillis: 1000
@@ -4815,15 +2571,17 @@ ambonmud:
     webClientHost: localhost
     webClientUrl: null
   observability:
-    metricsEnabled: true
+    metricsEnabled: false
     metricsEndpoint: /metrics
-    metricsHttpPort: 9099
+    metricsHttpPort: 9090
+    metricsHttpHost: 0.0.0.0
     staticTags: {}
   admin:
     enabled: false
     port: 9091
     token: ""
-    basePath: /
+    basePath: /admin/
+    corsOrigins: []
   logging:
     level: INFO
     packageLevels:
@@ -4838,22 +2596,23 @@ ambonmud:
       inboundChannel: ambon:inbound
       outboundChannel: ambon:outbound
       instanceId: ""
-      sharedSecret: CHANGE_ME
+      sharedSecret: ""
   images:
     baseUrl: https://auringold.ambon.dev/
-    spriteLevelTiers:
-      - 10
-      - 5
-      - 1
     globalAssets:
-      video_available_indicator: 9679b3d4f5e7f4acf9f10a0b1f2bd9760a363eed58bd73e200b9a3ae74f34ee4.png
-      shop_kiosk: 6f2404b50d546821d3acc69316668647c708032b832e3d273f5e7c2fc1cbe445.png
-      dialog_indicator: cb42c6d4daaddd09aa1c91adcc98d4cf6b7d9cd5a5b0f6d7a9e90a4285c669ed.png
-      aggro_indicator: 5b699ff717c60f9ac9ec6f2b93b71e5665a5d7612e945ed542f993120fb530df.png
-      quest_available_indicator: 42d6ac55e4f174ac0bb56178ea876837aa54ea0121f2db670ff60a757465cc4f.png
-      quest_complete_indicator: 1c73d6a78405bb4e48456494bfaa87e6cefb505125c3c70eb890f89d6d31fd95.png
-      minimap_unexplored: 97875d65ca8d97a0e84229b02f16ba06c23fca3a0a627fa6e5bffe9d6ccccef8.png
-      map_background: 1dac3f33448349e9e4d69d02eff5c16b0bf9d17a480693aa61bd8f6351aea37c.jpg
+      video_available_indicator: c4e24df39c79fe9f233c010df7d1bbdcee2138474d088be63a42ad5e64947d04.png
+      shop_kiosk: ee1919afce616a1c7740a55c5325276b7d00f2c8aa2e65237c2548a217703e33.png
+      dialog_indicator: ead1c3c85735d65bacd69d636b10eb05b0ab8aea5efb83d9a1cea8256601c671.png
+      aggro_indicator: 9d9863ac8c2029be49d0a64b9a3fd62648d1db456e64f36cd0af61a1baafdedf.png
+      quest_available_indicator: 09032bbc40c275fd946e2041782101e4b47475053c5cc9d3fafa250b5f730212.png
+      quest_complete_indicator: 95818ac036943cec5975f6056f4e638eb1bdbf7b1ab433e0e1f4bbfb3a8861c1.png
+      minimap_unexplored: af9977ab3c6479d0794c5a6db57216916acf499ef5c280297a814aa212d08b79.png
+      map_background: 6fe6f1e79d510ffced9d1801d843f4b45541e37c9364e8ad2c147f0a717c05d2.jpg
+      crafting_station: 34221c514d793d2d62c991fcc57c1a4ad86b2aeb35ca9b69b93e113f438b90b3.png
+      trainer_icon: afb827b502dca293d279280ea859447ae568ca534d0c017552083a03c0706910.png
+      bank_vault: ddcf4909c4bdb7dec45e11c8873358bce66849b2186cff44babcccc78e986c6d.png
+      tavern_icon: 185884c480ae19d410c19c394c41adb3b32aca75245a2586c300ae5eaf28bbf1.png
+    defaultAssets: {}
   videos:
     baseUrl: https://auringold.ambon.dev/
   audio:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -56,12 +56,8 @@ ambonmud:
     tickMillis: 100
     inboundBudgetMs: 30
   world:
-    startRoom: pixel_haven_academy:start
-    resources:
-      - world/auringold_academy.yaml
-      - world/pixel_haven.yaml
-      - world/pixel_haven_academy.yaml
-      - world/playtest_arena.yaml
+    startRoom: auringold_academy:dream_gate
+    resources: []
   persistence:
     backend: YAML
     rootDir: data/players
@@ -136,7 +132,7 @@ ambonmud:
         manaRegenStat: WIS
         manaRegenMsPerPoint: 400
         xpBonusStat: CHA
-        xpBonusPerPoint: 5
+        xpBonusPerPoint: 0.05
     abilities:
       definitions:
         # ── Knight (WARRIOR) ────────────────────────────────────────────

--- a/src/main/resources/world/auringold_academy.yaml
+++ b/src/main/resources/world/auringold_academy.yaml
@@ -1,181 +1,347 @@
 zone: auringold_academy
 startRoom: dream_gate
-lifespan: 0
-graphical: true
+rooms:
+  dream_gate:
+    title: The Dreaming Gate
+    description: >-
+      You stand before an archway woven from golden light and sleeping vines. It hums with the warmth of a thousand
+      children's dreams. Beyond it, impossible spires of the academy rise into a sky that shifts between sunset and
+      aurora, never quite settling on either. The air smells of warm honey and old books. A welcome banner ripples
+      overhead: "AURINGOLD ACADEMY — WHERE IMAGINATION TAKES FORM."
+
+
+      A gilded orientation plaque beside the gate reads: "Welcome, new student! Your vitals bar at the bottom of the
+      screen shows your health, mana, and gold. The icons along the sidebar open panels for your inventory, quests,
+      spellbook, and more. Click on characters and objects to interact with them! Open the shimmering chest nearby to
+      claim your welcome gift."
+
+
+      The Grand Atrium lies to the south.
+    exits:
+      s: grand_atrium
+    features:
+      welcome_chest:
+        type: CONTAINER
+        displayName: a shimmering welcome chest
+        keyword: chest
+        initialState: closed
+        items:
+          - dreamweave_cowl
+          - memory_drop
+    image: c41b698fb7a0f0e6047550e15acb70378c575c6513e067b3d8377645e97635a0.jpg
+  grand_atrium:
+    title: The Grand Atrium
+    description: >-
+      A soaring rotunda of impossible geometry. Staircases spiral upward into clouds, archways open onto corridors that
+      shouldn't connect, and the domed ceiling displays a slowly rotating map of the dream world. Paper cranes drift
+      through the air on currents of pure imagination. Enchanted chandeliers cast golden light that makes everything
+      look like a memory of somewhere wonderful.
+
+
+      A constellation map on the wall reads: "Navigate using the compass rose or by clicking exits in the room
+      description. Use the chat bar to talk with other students — try Say for the room, Gossip for the academy, or OOC
+      for out-of-character chat. Click the emote button to express yourself! The Who panel shows other students online,
+      and the Friends panel lets you keep track of companions."
+
+
+      Paths lead east to the Divination Parlor, west to the Games Common, south to the Supply Hall, and up a winding
+      staircase to the Nightmare Cellar. The Dreaming Gate is back to the north.
+    exits:
+      n: dream_gate
+      e: divination_parlor
+      w: games_common
+      s: supply_hall
+      u: nightmare_cellar
+    image: faf6399ba3182692197cfab8c4bf3116b531bdd3e4feac578de0d90648a05007.jpg
+  divination_parlor:
+    title: Professor Luma's Divination Parlor
+    description: >-
+      A cozy circular room draped in curtains of woven moonlight. A crystal orb on the central table projects tiny
+      auroras across the ceiling. Star charts cover every surface, annotated in a flowing silver script that rearranges
+      itself when you look away. The room smells of night jasmine and possibility.
+
+
+      A student's guide pinned to the door reads: "Click on Professor Luma to start a conversation. Dialogue choices
+      appear at the bottom — explore all the options to learn the most! Some NPCs offer quests, some offer lore, and
+      some just have something interesting to say."
+
+
+      The Grand Atrium is to the west, and the Training Grounds lie to the south.
+    exits:
+      w: grand_atrium
+      s: training_grounds
+    image: 956fd94978cdcbf6bd1cb3395a29ba322451d07af7d3b81c452b64468aaa5166.jpg
+  games_common:
+    title: The Games Common Room
+    description: >-
+      A lively lounge filled with floating game tables, enchanted dice that roll themselves, and a massive wheel of
+      fortune that spins between dimensions. Plush chairs are arranged around fireplaces that burn with flames of
+      different dream-colors — amber contentment, violet wonder, rose-gold excitement. Students gather here between
+      classes to test their luck and swap stories.
+
+
+      A glowing sign behind the bar reads: "Welcome to the Games Common! This is the academy's tavern — check the
+      Lottery panel in your sidebar for daily drawings and use the gambling features to try your luck! The Leaderboard
+      panel shows how you rank against other students across various categories."
+
+
+      The Grand Atrium is to the east, and the Bursar's Office is to the south.
+    tavern: true
+    exits:
+      e: grand_atrium
+      s: bursar_office
+    image: 139a8cbf48c1ceedfe8e2e856f8c54e2081feea738a756cddf5c8183014ce721.jpg
+  bursar_office:
+    title: The Bursar's Office
+    description: >-
+      A meticulously organized office where golden coins sort themselves into neat stacks and ledgers write their own
+      entries. A massive vault door of enchanted dreamsteel dominates the back wall, its surface inscribed with
+      protective runes that pulse softly. The room radiates an atmosphere of absolute financial security — even the dust
+      motes seem to settle in orderly rows.
+
+
+      A brass plaque on the counter reads: "The Bursar's Office safely stores your gold and valuables! Open the Bank
+      panel in your sidebar to deposit gold for safekeeping or withdraw it when you need to make purchases. Your savings
+      grow interest in Auringold — even while you sleep!"
+
+
+      The Games Common is back to the north.
+    bank: true
+    exits:
+      n: games_common
+    image: 016ff2f976a32f10294b1b850abbd1ffa472ef92abf31da5cb33395aaef8b4d9.jpg
+  supply_hall:
+    title: The Academy Supply Hall
+    description: >-
+      A long hall lined with display cases and floating shelves, each holding equipment that shimmers with dream-forged
+      enchantment. Weapons hang in mid-air, slowly rotating. Armor stands model the latest in protective dreamwear. A
+      large counter staffed by an impossibly animate quill pen serves as the checkout.
+
+
+      A student's shopping guide hangs on the wall: "Click on Quartermaster Quill to browse the shop catalog! To equip
+      purchased items, open your Inventory panel and click items to equip them to your character. Your Equipment section
+      shows what you're wearing. You can sell items you no longer need back to the shop for gold."
+
+
+      The Grand Atrium is to the north. The Artifice Laboratory is to the east. The Training Grounds are to the south
+      through a door further down the hall... but the most direct path to the Training Grounds is south through to the
+      Creature Yard.
+    exits:
+      n: grand_atrium
+      e: artifice_lab
+      s: creature_yard
+    image: f5087998e46f5713ad79b3aa7b817048f99dad87ebeb4546669d334a5b2a138b.jpg
+  training_grounds:
+    title: The Training Grounds
+    terrain: outside
+    description: >-
+      An open-air courtyard paved with stones that glow faintly underfoot, surrounded by tiered observation galleries.
+      Training dummies made of solidified dream-stuff stand in rows — some charred, some frozen, some sliced clean
+      through. The air crackles with residual magic from a thousand practice sessions. A raised platform at the center
+      serves as the instructor's stage, and crystallized courage shimmers in the air like heat haze.
+
+
+      A training manual posted on the wall reads: "Click on Instructor Valence to open the Training panel! Choose a
+      class to unlock, then learn abilities. Drag learned abilities from your Spellbook panel to the action bar at the
+      bottom of your screen for quick access. Each ability has a cooldown after use — watch the timer on the button.
+      Abilities cost mana, shown in your vitals bar."
+
+
+      Professor Luma's Parlor is to the north, and the Puzzle Tower is to the south.
+    exits:
+      n: divination_parlor
+      s: puzzle_tower
+    image: 5baebd26748e9dc73ae57343810aad5d9ba582220682b2825f79886ddeb7cb93.jpg
+  artifice_lab:
+    title: The Artifice Laboratory
+    description: >-
+      A wonderfully chaotic workshop that would make any tinkerer weep with joy. Workbenches overflow with half-finished
+      inventions — a compass that points to what you need most, spectacles that show the truth, a music box that plays
+      your thoughts. Enchanted tools operate themselves, hammering and stitching and stirring without guidance. Alembics
+      bubble with liquids in colors that don't exist outside of dreams.
+
+
+      A workshop guide pinned to the wall reads: "Open the Crafting panel in your sidebar to view available recipes!
+      You'll need materials from the Dream Garden to the south. This room has a workbench — crafting here gives a bonus
+      to certain recipes. Your crafting and gathering skill levels are also shown in the Crafting panel."
+
+
+      The Supply Hall is to the west, and the Dream Garden is to the south.
+    station: alchemy_table
+    exits:
+      w: supply_hall
+      s: dream_garden
+    image: eb51f188dda59b20e7b8aee48cab001cd2d9d46cf5022a767b615b097495b3c1.jpg
+  dream_garden:
+    title: The Dream Garden
+    terrain: forest
+    description: >-
+      A luminous garden where reality is particularly thin. Flowers bloom in equations, trees grow upside-down with
+      their roots in the clouds, and a stream of liquid starlight winds between beds of impossible plants. Shimmering
+      spider webs strung between crystalline bushes catch gossamer threads of pure imagination. Veins of dream ore push
+      through the earth like surfacing whales, their metallic surfaces shifting between solid and translucent.
+
+
+      A garden sign reads: "This is a gathering area! Look for resource nodes highlighted in the room — the shimmering
+      spider webs yield gossamer thread, and the dream ore veins yield raw materials. Click on them or use the Crafting
+      panel to see nearby nodes and gather materials. Then head north to the Artifice Lab to craft something!"
+
+
+      The Artifice Laboratory is back to the north.
+    exits:
+      n: artifice_lab
+    image: e0748c882f52981d05e49e011bfb8f904cd5f16b6be639f7fb9a8e530cfa707d.jpg
+  creature_yard:
+    title: The Creature Yard
+    terrain: outside
+    description: >-
+      A sprawling outdoor enclosure where dream creatures roam freely — some docile, some decidedly not. Flickering
+      wisps drift like dandelion seeds. Ink blots that escaped from textbooks slither across the ground, leaving smudged
+      trails. Nightmare imps cackle from perches on crystallized dream-branches. The grass here is soft as clouds and
+      faintly luminescent.
+
+
+      A safety notice on the fence reads: "Welcome to the Creature Yard! Click on a hostile creature to target it, then
+      use abilities from your action bar to engage in combat. Watch the combat log for battle updates, and keep an eye
+      on your health in the vitals bar. Use consumable items from your inventory if you need healing. If things get
+      dangerous, you can always flee! Defeated creatures may drop useful items — check your inventory after combat."
+
+
+      Someone has dropped a memory drop on the ground near the gate.
+
+
+      The Supply Hall is to the north. The Puzzle Tower is to the east. The Great Hall lies to the south.
+    exits:
+      n: supply_hall
+      e: puzzle_tower
+      s: great_hall
+    image: f9640ea7244f27a926d955dbe276676a1131f6ca9418d8583aafd04aa8522a54.jpg
+  puzzle_tower:
+    title: The Puzzle Tower
+    description: >-
+      A slender tower room where the walls are covered in shifting symbols, optical illusions, and inscriptions that
+      rearrange themselves. The floor is a mosaic depicting the history of Auringold in scenes that animate when you
+      step on them. At the center, a stone gargoyle made entirely of carved question marks perches on a pedestal,
+      watching visitors with an amused expression. An ancient riddle is carved into the wall behind it.
+
+
+      A student's note stuck to the door reads: "Some challenges in Auringold are puzzles, not fights! Read the riddle
+      carefully and submit your answer through the dialogue that appears. Correct answers earn rewards. This one unlocks
+      the door to the south!"
+
+
+      A heavy door of carved dreamwood blocks the passage to the south, secured by an elaborate lock that glimmers with
+      puzzle-magic.
+
+
+      The Creature Yard is to the west, and the Training Grounds are to the north.
+    exits:
+      n: training_grounds
+      w: creature_yard
+      s:
+        to: hidden_archive
+        door:
+          initialState: locked
+          keyItemId: dreamers_key
+          keyConsumed: true
+    image: 2ac48c7e4f60cdd6adec3c93f22cac93f9c27b6c224048a4d1d2925210c78311.jpg
+  hidden_archive:
+    title: The Hidden Archive
+    description: >-
+      A hushed, reverent space that feels older than the rest of the academy. Towering shelves of crystallized
+      dream-books stretch into darkness overhead. Each book glows with its own inner light — some warm gold, some cool
+      silver, some colors you've never seen before. A reading alcove in the corner holds a comfortable chair and a lamp
+      that burns with distilled curiosity.
+
+
+      An orientation guide rests on the reading desk, covering advanced academy features: "Congratulations on solving
+      the puzzle! As you continue your adventures beyond the academy, you'll discover more features through the sidebar
+      panels: Housing lets you own a personal dream-space. The Auction panel connects you to a global marketplace. Mail
+      lets you send letters to other students. Trading enables face-to-face item exchanges. Pets let you bond with a
+      dream creature companion. And Factions track your reputation with the various dream entities of Auringold. Explore
+      every panel — there's always more to discover!"
+
+
+      The Puzzle Tower is back to the north.
+    exits:
+      n: puzzle_tower
+    features:
+      ancient_bookcase:
+        type: CONTAINER
+        displayName: a glowing dreamwood bookcase
+        keyword: bookcase
+        initialState: closed
+        items:
+          - clarity_elixir
+          - moonbeam_silk
+    image: bf76f66bd935729734944614c3f939c9121278436e4b1302575e355d04752380.jpg
+  great_hall:
+    title: The Great Hall
+    description: >-
+      The ceremonial heart of Auringold Academy — a vast hall with a vaulted ceiling of living stained glass that shifts
+      to tell different stories. Golden banners hang between pillars of crystallized aspiration. At the far end, an
+      empty throne of woven starlight awaits the academy's greatest champions. But between you and the throne, the
+      shadows thicken unnaturally. Something lurks here — the academy's ultimate test.
+
+
+      A plaque near the entrance reads: "The Great Hall is where your journey culminates! After defeating challenges,
+      check the Quest panel to turn in completed quests. Open the Character panel to review your stats, and check the
+      Achievements panel for milestones you've reached. The Prestige panel shows advanced progression options for
+      experienced students."
+
+
+      A battered treasure chest sits near the base of the throne.
+
+
+      The Creature Yard is back to the north.
+    exits:
+      n: creature_yard
+      s: pixel_haven:the_only_road_3
+    features:
+      treasure_chest:
+        type: CONTAINER
+        displayName: a crystalline treasure chest
+        keyword: chest
+        initialState: closed
+        items:
+          - academy_pennant
+          - reverie_cake
+    image: e778dc617f18f11d9636969b14daac51b73bc190d91577a9d8d960c879fb3f32.jpg
+  nightmare_cellar:
+    title: The Nightmare Cellar
+    terrain: underground
+    description: >-
+      A winding staircase descends from the atrium into a damp, shadowy cellar where the academy's foundations meet raw,
+      unformed dream-stuff. The walls here pulse with darker energy — not evil, exactly, but wilder, less tamed. This is
+      where nightmares are studied, contained, and occasionally escaped from. A shimmering portal arch stands against
+      the far wall, its surface rippling like disturbed water, leading into procedurally generated dream-dungeons.
+
+
+      A bulletin board by the stairs reads: "Dungeons are instanced adventures — open the Dungeon panel in your sidebar
+      to see available dungeons and start a run! For the best experience, bring friends — use the Group panel to invite
+      other students and tackle dungeons together. The Guild panel lets you form permanent organizations with shared
+      chat, a roster, and a guild hall. Teamwork makes the dream work!"
+
+
+      The Grand Atrium is back down the stairs.
+    dungeon: true
+    exits:
+      d: grand_atrium
+      e: playtest_arena:arena_entry
+    image: 34d304b1ab7b4d4f2a8c01054f3d194830c01f6badcb4506e39ab58d1835e414.jpg
+  mob_templates:
+    title: Dream Template Chamber
+    description: An internal room used to stage dungeon mob templates. Students cannot reach this room.
+    image: d648f6b9882386611f7b42204cf30d8d909a614d0d02695453ebe4a028ff285a.jpg
 terrain: inside
-
+graphical: true
+image:
+  room: faf50d7e57133ffad696d43ab1d763db3c3713ed7fcb8f9f66ba1bc42540f528.jpg
+  mob: c17d7fa07be1852ebd7714bab1fc9a74c2e2a69484e3722d065d0fa394dd97eb.png
+  item: 74c7e23962a95262ed0f3b4f2de429779cef9e596283949fc59591d5ccaa88c5.png
 audio:
-  music: auringold_lullaby
+  music: 010c12ace4effa3eb4efc7d81860b71aa25abd691f0ea6a35d91eed289637b04.mp3
   ambient: gentle_chimes
-
-items:
-  dreamweave_cowl:
-    displayName: a dreamweave cowl
-    keyword: cowl
-    description: A soft hood woven from threads of sleeping thought. It shimmers between
-      lavender and gold, and feels lighter than air on your head.
-    slot: head
-    armor: 2
-    basePrice: 15
-
-  imagination_blade:
-    displayName: an imagination blade
-    keyword: blade
-    description: A slender sword forged from pure belief. Its edge is as sharp as a
-      child's conviction that monsters can be defeated.
-    slot: weapon
-    damage: 4
-    basePrice: 30
-
-  starlight_robes:
-    displayName: a pair of starlight robes
-    keyword: robes
-    description: Flowing robes stitched from distilled starlight. Constellations drift
-      slowly across the fabric, rearranging into new patterns each night.
-    slot: body
-    armor: 3
-    basePrice: 35
-
-  lucid_gloves:
-    displayName: a pair of lucid gloves
-    keyword: gloves
-    description: Thin leather gloves that let you grip dreams like solid objects.
-      The fingertips glow faintly when you concentrate.
-    slot: hand
-    armor: 1
-    basePrice: 12
-
-  memory_drop:
-    displayName: a crystallized memory drop
-    keyword: drop
-    description: A small candy-like droplet of crystallized happy memory. It tastes
-      different to everyone — birthday cake, summer rain, a favorite lullaby.
-    consumable: true
-    onUse:
-      healHp: 15
-    basePrice: 5
-
-  reverie_cake:
-    displayName: a slice of reverie cake
-    keyword: cake
-    description: A generous wedge of iridescent cake that tastes like your favorite
-      dream. Eating it fills you with warmth and the certainty that everything
-      will be alright.
-    consumable: true
-    onUse:
-      healHp: 30
-    basePrice: 15
-
-  clarity_elixir:
-    displayName: a vial of clarity elixir
-    keyword: elixir
-    description: A tiny glass vial of liquid so clear it's almost invisible. Drinking
-      it sharpens your senses and fills your mind with luminous understanding.
-    consumable: true
-    onUse:
-      healHp: 20
-      grantXp: 25
-    basePrice: 20
-
-  dream_shard:
-    displayName: a dream shard
-    keyword: shard
-    description: A translucent crystal fragment that pulses with soft inner light.
-      It hums a different note for each person who holds it. Headmaster
-      Somnius collects these.
-    basePrice: 0
-
-  creature_feather:
-    displayName: an iridescent creature feather
-    keyword: feather
-    description: A shimmering feather that shifts through every color of the
-      spectrum. It drifts upward when released, as though gravity is merely
-      a suggestion.
-    basePrice: 0
-
-  gossamer_thread:
-    displayName: a strand of gossamer thread
-    keyword: thread
-    description: An impossibly fine thread spun by dreaming spiders. It catches
-      light that isn't there and hums when wound around a spool.
-    basePrice: 4
-
-  dream_ore:
-    displayName: a nugget of dream ore
-    keyword: ore
-    description: A lump of metallic substance that shifts between solid and
-      translucent depending on your state of mind. Warm to the touch.
-    basePrice: 6
-
-  moonbeam_silk:
-    displayName: a scrap of moonbeam silk
-    keyword: silk
-    description: Fabric so fine it seems woven from light itself. It feels like
-      holding a cool breeze and smells faintly of night-blooming jasmine.
-    basePrice: 10
-
-  dreamcatcher_pendant:
-    displayName: a dreamcatcher pendant
-    keyword: pendant
-    description: A delicate pendant woven from dream ore and gossamer thread. It
-      catches bad dreams before they reach you, humming a protective lullaby.
-    slot: hand
-    armor: 2
-    stats:
-      constitution: 1
-    basePrice: 40
-
-  stardust_vial:
-    displayName: a vial of bottled stardust
-    keyword: stardust
-    description: A small corked bottle filled with glittering dust that swirls in
-      mesmerizing patterns. Drinking it fills you with cosmic wonder.
-    consumable: true
-    onUse:
-      healHp: 5
-      grantXp: 50
-    basePrice: 25
-
-  phantasm_cloak:
-    displayName: the Night Terror's cloak
-    keyword: cloak
-    description: A sweeping cloak of living shadow, taken from the Night Terror
-      itself. Darkness pools at its hem and whispers follow in its wake,
-      but the cloak protects its wearer fiercely.
-    slot: body
-    armor: 4
-    stats:
-      constitution: 2
-    basePrice: 100
-
-  dreamers_key:
-    displayName: a key shaped from pure insight
-    keyword: key
-    description: A crystalline key that materialized from the answer to a riddle.
-      It changes shape subtly in your hand, always fitting whatever lock it
-      encounters — but only once.
-    basePrice: 0
-
-  academy_pennant:
-    displayName: an Auringold Academy pennant
-    keyword: pennant
-    description: A small triangular flag in gold and violet, emblazoned with the
-      academy crest — a sleeping child cradled by a crescent moon. It
-      radiates gentle warmth.
-    basePrice: 0
-
-  ground_memory_drop:
-    displayName: a crystallized memory drop
-    keyword: drop
-    description: A small candy-like droplet of crystallized happy memory. It tastes
-      different to everyone — birthday cake, summer rain, a favorite lullaby.
-      Someone must have dropped this.
-    consumable: true
-    onUse:
-      healHp: 15
-    basePrice: 5
-    room: creature_yard
-
 mobs:
   headmaster_somnius:
     name: Headmaster Somnius
@@ -192,12 +358,11 @@ mobs:
       - grand_tour
     dialogue:
       root:
-        text: A tall figure in robes of shifting twilight inclines his head in welcome.
-          His eyes are half-closed, as though perpetually on the edge of a pleasant
-          dream, yet they miss nothing. "Welcome to Auringold Academy, dear student.
-          I am Headmaster Somnius, keeper of this school between dreams. You've arrived
-          at just the right moment — we have much to show you. Shall I explain how
-          the academy works, or would you prefer a quest to guide your exploration?"
+        text: A tall figure in robes of shifting twilight inclines his head in welcome. His eyes are half-closed, as though
+          perpetually on the edge of a pleasant dream, yet they miss nothing. "Welcome to Auringold Academy, dear
+          student. I am Headmaster Somnius, keeper of this school between dreams. You've arrived at just the right
+          moment — we have much to show you. Shall I explain how the academy works, or would you prefer a quest to guide
+          your exploration?"
         choices:
           - text: Tell me about the quest!
             next: quest_info
@@ -206,43 +371,39 @@ mobs:
           - text: I'll explore on my own, thanks.
             next: farewell
       quest_info:
-        text: "Wonderful initiative! I call it 'The Grand Tour.' As you explore the academy,
-          you'll encounter dream creatures — wisps, ink blots, origami cranes. Some carry
-          Dream Shards, crystallized fragments of pure imagination. Collect three and bring
-          them to me for a handsome reward. You can track your progress in the Quest panel
-          on your sidebar — look for the scroll icon."
+        text: Wonderful initiative! I call it 'The Grand Tour.' As you explore the academy, you'll encounter dream creatures —
+          wisps, ink blots, origami cranes. Some carry Dream Shards, crystallized fragments of pure imagination. Collect
+          three and bring them to me for a handsome reward. You can track your progress in the Quest panel on your
+          sidebar — look for the scroll icon.
         choices:
           - text: I'll get right on it!
             next: farewell
           - text: Any advice for a new student?
             next: advice
       how_it_works:
-        text: "Auringold Academy exists in the space between sleeping and waking — a place
-          where imagination has weight and dreams have edges. Every room teaches something
-          new. Your vitals bar at the bottom of the screen shows your health, mana, and
-          gold. The sidebar panels — those icons along the edge — give you access to your
-          inventory, quest log, spellbook, and much more. Click on anyone or anything that
-          catches your eye! The academy rewards curiosity."
+        text: Auringold Academy exists in the space between sleeping and waking — a place where imagination has weight and
+          dreams have edges. Every room teaches something new. Your vitals bar at the bottom of the screen shows your
+          health, mana, and gold. The sidebar panels — those icons along the edge — give you access to your inventory,
+          quest log, spellbook, and much more. Click on anyone or anything that catches your eye! The academy rewards
+          curiosity.
         choices:
           - text: That's helpful. What about the quest?
             next: quest_info
           - text: I think I understand. I'll start exploring!
             next: farewell
       advice:
-        text: "Of course! Head south to the Grand Atrium — it's the heart of the academy,
-          with paths to every wing. I'd suggest visiting the Supply Hall first to equip
-          yourself, then the Training Grounds to learn some abilities. The Creature Yard
-          is where you'll find dream creatures to practice combat. And don't forget the
-          side wings — the Games Common to the west has entertainment, and Professor
-          Luma's parlor to the east holds fascinating conversations. Every panel in your
-          sidebar has something to discover!"
+        text: Of course! Head south to the Grand Atrium — it's the heart of the academy, with paths to every wing. I'd suggest
+          visiting the Supply Hall first to equip yourself, then the Training Grounds to learn some abilities. The
+          Creature Yard is where you'll find dream creatures to practice combat. And don't forget the side wings — the
+          Games Common to the west has entertainment, and Professor Luma's parlor to the east holds fascinating
+          conversations. Every panel in your sidebar has something to discover!
         choices:
           - text: Thanks, Headmaster!
             next: farewell
       farewell:
-        text: "May your dreams be vivid and your courage bright! Remember — in Auringold,
-          imagination is the most powerful force of all. Off you go!"
-
+        text: May your dreams be vivid and your courage bright! Remember — in Auringold, imagination is the most powerful force
+          of all. Off you go!
+    image: 6db0c141245d453498ed082b6cabd53402847a87bcf5e4c3bebb509c4c4c28bb.png
   professor_luma:
     name: Professor Luma
     room: divination_parlor
@@ -256,11 +417,10 @@ mobs:
     goldMax: 0
     dialogue:
       root:
-        text: A figure made of captured moonlight turns to greet you, features shifting
-          like reflections on water. Professor Luma was once an ordinary moonbeam that
-          wandered into a child's dream and liked it so much it stayed. "Ah, a new
-          student! Welcome to my parlor. I teach the art of conversation — vital for
-          any dreamer. You're doing it right now, in fact! Shall we practice?"
+        text: A figure made of captured moonlight turns to greet you, features shifting like reflections on water. Professor
+          Luma was once an ordinary moonbeam that wandered into a child's dream and liked it so much it stayed. "Ah, a
+          new student! Welcome to my parlor. I teach the art of conversation — vital for any dreamer. You're doing it
+          right now, in fact! Shall we practice?"
         choices:
           - text: Tell me about yourself.
             next: about_self
@@ -271,11 +431,10 @@ mobs:
           - text: Goodbye, Professor.
             next: farewell
       about_self:
-        text: "I began as a simple beam of light from the harvest moon. One autumn night
-          I slipped through a crack in a child's dream and found myself... thinking.
-          Dreaming, if a moonbeam can dream. The Headmaster found me wandering the
-          corridors, gave me this parlor, and asked me to teach. I've been here ever
-          since — though 'here' shifts more than most places."
+        text: I began as a simple beam of light from the harvest moon. One autumn night I slipped through a crack in a child's
+          dream and found myself... thinking. Dreaming, if a moonbeam can dream. The Headmaster found me wandering the
+          corridors, gave me this parlor, and asked me to teach. I've been here ever since — though 'here' shifts more
+          than most places.
         choices:
           - text: That's beautiful. What do you teach?
             next: learn_here
@@ -284,37 +443,33 @@ mobs:
           - text: Goodbye, Professor.
             next: farewell
       miss_moonbeam:
-        text: Luma's light dims for just a moment, then brightens warmly. "Sometimes.
-          Light travels endlessly but touches nothing for long. Here, I get to linger.
-          I get to know names and stories. I think that's worth the trade. But enough
-          about me — the academy has so much more to show you! The Training Grounds
-          are just south of here."
+        text: Luma's light dims for just a moment, then brightens warmly. "Sometimes. Light travels endlessly but touches
+          nothing for long. Here, I get to linger. I get to know names and stories. I think that's worth the trade. But
+          enough about me — the academy has so much more to show you! The Training Grounds are just south of here."
         choices:
           - text: I'll head there. Thanks!
             next: farewell
       learn_here:
-        text: "This parlor demonstrates the dialogue system. When you click on a character
-          who has something to say, you'll see a conversation like this one — with
-          choices that branch into different paths. Some conversations lead to quests,
-          some to lore, some to hints. Always explore all the options! Every NPC in
-          Auringold has something worth hearing."
+        text: This parlor demonstrates the dialogue system. When you click on a character who has something to say, you'll see a
+          conversation like this one — with choices that branch into different paths. Some conversations lead to quests,
+          some to lore, some to hints. Always explore all the options! Every NPC in Auringold has something worth
+          hearing.
         choices:
           - text: Good to know. What else is nearby?
             next: directions
           - text: Thanks for the lesson, Professor.
             next: farewell
       directions:
-        text: "South of here you'll find the Training Grounds, where Instructor Valence
-          teaches combat arts. West returns you to the Grand Atrium — the academy's
-          central hub. If you haven't visited the Supply Hall yet, I'd recommend it.
-          Hard to fight nightmares without proper equipment!"
+        text: South of here you'll find the Training Grounds, where Instructor Valence teaches combat arts. West returns you to
+          the Grand Atrium — the academy's central hub. If you haven't visited the Supply Hall yet, I'd recommend it.
+          Hard to fight nightmares without proper equipment!
         choices:
           - text: I'll check it out.
             next: farewell
       farewell:
-        text: "Dream brightly, student. And remember — in every conversation, there's
-          something hidden. You just have to ask the right questions."
-
+        text: Dream brightly, student. And remember — in every conversation, there's something hidden. You just have to ask the
+          right questions.
+    image: 65cb86fc8942ca7b7a0af62cf5ba81fb993e66aac445bd0e3a142e7145e24a69.png
   quartermaster_quill:
     name: Quartermaster Quill
     room: supply_hall
@@ -328,11 +483,10 @@ mobs:
     goldMax: 0
     dialogue:
       root:
-        text: An enormous talking quill pen with ink-stained fingers (it grew hands at some
-          point, nobody questions it) adjusts a pair of tiny spectacles. "Welcome to the
-          Academy Supply Hall! I'm Quartermaster Quill — yes, I'm a pen, and yes, I run
-          a shop. Dreams are strange. Click on me to browse the supply catalog! You can
-          also sell things you don't need for some extra gold."
+        text: An enormous talking quill pen with ink-stained fingers (it grew hands at some point, nobody questions it) adjusts
+          a pair of tiny spectacles. "Welcome to the Academy Supply Hall! I'm Quartermaster Quill — yes, I'm a pen, and
+          yes, I run a shop. Dreams are strange. Click on me to browse the supply catalog! You can also sell things you
+          don't need for some extra gold."
         choices:
           - text: Show me your wares.
             next: farewell
@@ -341,18 +495,16 @@ mobs:
           - text: Just looking around.
             next: farewell
       how_shop:
-        text: "Simple! Click on me and the shop panel opens. Items on the left are what
-          I sell — click one to buy it. Your inventory panel shows what you're carrying.
-          To equip armor or weapons, open the equipment section and click the item you
-          want to wear. You can sell items back to me too, though I only pay half price.
-          A pen has expenses, you know."
+        text: Simple! Click on me and the shop panel opens. Items on the left are what I sell — click one to buy it. Your
+          inventory panel shows what you're carrying. To equip armor or weapons, open the equipment section and click
+          the item you want to wear. You can sell items back to me too, though I only pay half price. A pen has
+          expenses, you know.
         choices:
           - text: Makes sense. Let me browse!
             next: farewell
       farewell:
-        text: "Happy shopping! And if you find anything interesting in your travels,
-          I'm always buying!"
-
+        text: Happy shopping! And if you find anything interesting in your travels, I'm always buying!
+    image: ddaa0371d1a661e1c95261a2a823fc542acd71ef8b08e0b65e8ee9f7be0cbd56.png
   instructor_valence:
     name: Instructor Valence
     room: training_grounds
@@ -366,12 +518,10 @@ mobs:
     goldMax: 0
     dialogue:
       root:
-        text: A knight in armor forged from crystallized bravery stands at attention. The
-          armor shines with an inner golden light, and courage radiates from her like
-          warmth from a hearth. "Student! I am Instructor Valence, and I teach every
-          discipline the academy offers. Click on me to open the training panel — pick
-          a class, unlock it, and start learning abilities. Then drag your new skills
-          to the action bar at the bottom of your screen!"
+        text: A knight in armor forged from crystallized bravery stands at attention. The armor shines with an inner golden
+          light, and courage radiates from her like warmth from a hearth. "Student! I am Instructor Valence, and I teach
+          every discipline the academy offers. Click on me to open the training panel — pick a class, unlock it, and
+          start learning abilities. Then drag your new skills to the action bar at the bottom of your screen!"
         choices:
           - text: What classes are available?
             next: classes
@@ -382,37 +532,32 @@ mobs:
           - text: Maybe later.
             next: farewell
       classes:
-        text: "Five paths of power! WARRIOR — steel and stamina, the front line. MAGE —
-          arcane devastation from a distance. CLERIC — healing light that sustains your
-          allies. ROGUE — shadows and precision strikes. RANGER — nature's fury and keen
-          aim. You can unlock multiple classes over time! Start with whatever calls to
-          you. After you unlock a class, learn its abilities — they'll appear in your
-          Spellbook panel."
+        text: Five paths of power! WARRIOR — steel and stamina, the front line. MAGE — arcane devastation from a distance.
+          CLERIC — healing light that sustains your allies. ROGUE — shadows and precision strikes. RANGER — nature's
+          fury and keen aim. You can unlock multiple classes over time! Start with whatever calls to you. After you
+          unlock a class, learn its abilities — they'll appear in your Spellbook panel.
         choices:
           - text: Let's begin!
             next: farewell
           - text: Can I learn more than one class?
             next: multiclass
       multiclass:
-        text: "Absolutely! That's the beauty of the academy. Unlock as many as you
-          like. Your Spellbook panel shows all learned abilities regardless of class.
-          Drag them to your action bar for quick access. Each ability has a cooldown
-          after use — watch the timer on the button. Now go forth and train!"
+        text: Absolutely! That's the beauty of the academy. Unlock as many as you like. Your Spellbook panel shows all learned
+          abilities regardless of class. Drag them to your action bar for quick access. Each ability has a cooldown
+          after use — watch the timer on the button. Now go forth and train!
         choices:
           - text: On it!
             next: farewell
       after_training:
-        text: "Once you've learned some abilities, head south to the Creature Yard!
-          That's where you can practice combat against dream creatures. Remember to
-          equip your gear first — the Supply Hall is north, then west. And keep an
-          eye on your health in the vitals bar!"
+        text: Once you've learned some abilities, head south to the Creature Yard! That's where you can practice combat against
+          dream creatures. Remember to equip your gear first — the Supply Hall is north, then west. And keep an eye on
+          your health in the vitals bar!
         choices:
           - text: Good advice. Thanks!
             next: farewell
       farewell:
-        text: "Courage isn't the absence of fear — it's dreaming big enough to face it.
-          Train well!"
-
+        text: Courage isn't the absence of fear — it's dreaming big enough to face it. Train well!
+    image: 557e4ee4f1dc741c77a87bc0df9ea53c75ba14f3a1001ebd83c4b7e508e46a76.png
   groundskeeper_moss:
     name: Groundskeeper Moss
     room: creature_yard
@@ -428,11 +573,10 @@ mobs:
       - creature_roundup
     dialogue:
       root:
-        text: A gentle golem of living moss and wildflowers lumbers over, leaving tiny
-          sprouts in its footsteps. "Oh! A student! I'm Groundskeeper Moss. I tend
-          the dream creatures, but some have gotten... spirited lately. The ink blots
-          and nightmare imps are causing trouble. Could you help calm them down? By
-          which I mean... subdue them in combat and bring me their feathers as proof?"
+        text: A gentle golem of living moss and wildflowers lumbers over, leaving tiny sprouts in its footsteps. "Oh! A student!
+          I'm Groundskeeper Moss. I tend the dream creatures, but some have gotten... spirited lately. The ink blots and
+          nightmare imps are causing trouble. Could you help calm them down? By which I mean... subdue them in combat
+          and bring me their feathers as proof?"
         choices:
           - text: I'll help wrangle them!
             next: accepted
@@ -441,29 +585,25 @@ mobs:
           - text: Not right now.
             next: farewell
       accepted:
-        text: "Wonderful! Just engage the creatures in combat — click on one to target
-          it, then use your abilities from the action bar. Collect three feathers from
-          the ones you defeat. Keep an eye on the combat log for battle details, and
-          don't forget you can use consumable items if your health gets low! Check
-          your Quest panel to track your progress."
+        text: Wonderful! Just engage the creatures in combat — click on one to target it, then use your abilities from the
+          action bar. Collect three feathers from the ones you defeat. Keep an eye on the combat log for battle details,
+          and don't forget you can use consumable items if your health gets low! Check your Quest panel to track your
+          progress.
         choices:
           - text: On it!
             next: farewell
       creatures:
-        text: "The dream wisps are harmless little lights — they'll drift away from you.
-          But the ink blots are aggressive — they'll attack on sight! And the nightmare
-          imps are worse. If you get in over your head, you can always flee. The wisps
-          and cranes drop Dream Shards too, if you're collecting those for the
-          Headmaster's quest."
+        text: The dream wisps are harmless little lights — they'll drift away from you. But the ink blots are aggressive —
+          they'll attack on sight! And the nightmare imps are worse. If you get in over your head, you can always flee.
+          The wisps and cranes drop Dream Shards too, if you're collecting those for the Headmaster's quest.
         choices:
           - text: I'll help round them up!
             next: accepted
           - text: Maybe later.
             next: farewell
       farewell:
-        text: "Be careful with the imps — they bite! And the invisible ones are the worst.
-          ...Don't tell them I said that."
-
+        text: Be careful with the imps — they bite! And the invisible ones are the worst. ...Don't tell them I said that.
+    image: f752656f2bcee40a065a480dbd83b2374c13044fcb59cf5787da2772d948b1c0.png
   puzzlewright:
     name: the Puzzlewright
     room: puzzle_tower
@@ -477,11 +617,10 @@ mobs:
     goldMax: 0
     dialogue:
       root:
-        text: A gargoyle made of carved question marks perches on a pedestal, its stone
-          eyes glittering with amusement. It speaks in a voice like tumbling pebbles.
-          "Ah, a STUDENT! I do so love students. They always think they know the
-          answer. Tell me — do YOU know the answer? Of course you don't. You haven't
-          heard the question yet. Would you like to?"
+        text: A gargoyle made of carved question marks perches on a pedestal, its stone eyes glittering with amusement. It
+          speaks in a voice like tumbling pebbles. "Ah, a STUDENT! I do so love students. They always think they know
+          the answer. Tell me — do YOU know the answer? Of course you don't. You haven't heard the question yet. Would
+          you like to?"
         choices:
           - text: Ask me your riddle!
             next: riddle_hint
@@ -490,23 +629,21 @@ mobs:
           - text: I'll come back later.
             next: farewell
       riddle_hint:
-        text: "The riddle is inscribed on the wall behind me. Read it carefully! When
-          you think you know the answer, respond through the dialogue that appears.
-          I'll tell you if you're right. And don't worry — you can try as many
-          times as you like. The best riddles deserve patience."
+        text: The riddle is inscribed on the wall behind me. Read it carefully! When you think you know the answer, respond
+          through the dialogue that appears. I'll tell you if you're right. And don't worry — you can try as many times
+          as you like. The best riddles deserve patience.
         choices:
           - text: I'll give it a shot.
             next: farewell
       reward_info:
-        text: "Answer correctly and you'll receive a very special key — one that opens
-          the locked door to the south. Behind that door lies the Hidden Archive,
-          full of ancient dream-knowledge. Worth the brain exercise, I promise!"
+        text: Answer correctly and you'll receive a very special key — one that opens the locked door to the south. Behind that
+          door lies the Hidden Archive, full of ancient dream-knowledge. Worth the brain exercise, I promise!
         choices:
           - text: Sounds worth it. Let me try the riddle.
             next: farewell
       farewell:
-        text: "Think dreamily! The answer is always simpler than you expect."
-
+        text: Think dreamily! The answer is always simpler than you expect.
+    image: 637a5708474663cab31ade77de0ed969b6f29fda1627cff68e6c407810b54195.png
   arcanist_thimble:
     name: Arcanist Thimble
     room: artifice_lab
@@ -520,12 +657,10 @@ mobs:
     goldMax: 0
     dialogue:
       root:
-        text: A fairy no taller than your hand hovers at eye level, wearing goggles that
-          are comically larger than her entire head. Sparks trail from her wings as she
-          gestures excitedly at the workbenches. "A new crafter! Oh, this is my favorite
-          part! Open the Crafting panel in your sidebar — you'll see recipes for things
-          you can make! But you'll need materials first. Head south to the Dream Garden
-          to gather some!"
+        text: A fairy no taller than your hand hovers at eye level, wearing goggles that are comically larger than her entire
+          head. Sparks trail from her wings as she gestures excitedly at the workbenches. "A new crafter! Oh, this is my
+          favorite part! Open the Crafting panel in your sidebar — you'll see recipes for things you can make! But
+          you'll need materials first. Head south to the Dream Garden to gather some!"
         choices:
           - text: How does crafting work?
             next: how_craft
@@ -534,28 +669,26 @@ mobs:
           - text: I'll go gather materials first.
             next: farewell
       how_craft:
-        text: "First, gather materials — the Dream Garden south of here has gossamer thread
-          and dream ore. Then come back here and open the Crafting panel. Select a recipe,
-          and if you have the right materials, you can craft the item! This room has a
-          workbench, which gives a bonus to certain recipes. The Crafting panel also shows
-          your gathering and crafting skill levels."
+        text: First, gather materials — the Dream Garden south of here has gossamer thread and dream ore. Then come back here
+          and open the Crafting panel. Select a recipe, and if you have the right materials, you can craft the item!
+          This room has a workbench, which gives a bonus to certain recipes. The Crafting panel also shows your
+          gathering and crafting skill levels.
         choices:
           - text: What can I make?
             next: what_make
           - text: Got it! I'll start gathering.
             next: farewell
       what_make:
-        text: "Right now I've got two recipes ready for beginners! The Dreamcatcher Pendant
-          is a protective charm — good for defense. The Stardust Vial is a consumable
-          that grants experience. Both need materials from the Dream Garden. Gather
-          gossamer thread and dream ore, then come back and craft away!"
+        text: Right now I've got two recipes ready for beginners! The Dreamcatcher Pendant is a protective charm — good for
+          defense. The Stardust Vial is a consumable that grants experience. Both need materials from the Dream Garden.
+          Gather gossamer thread and dream ore, then come back and craft away!
         choices:
           - text: I'll go gather materials!
             next: farewell
       farewell:
-        text: "Dream big, craft bigger! And watch out for the spiders in the garden —
-          they're friendly, but their webs are VERY sticky."
-
+        text: Dream big, craft bigger! And watch out for the spiders in the garden — they're friendly, but their webs are VERY
+          sticky.
+    image: e5e64383a834a128147bbe40d5ffecbac2f4283abbfc07d86b9d4f5ad8d15bc9.png
   paper_crane:
     name: a drifting paper crane
     room: grand_atrium
@@ -570,7 +703,7 @@ mobs:
         chance: 0.5
       - itemId: creature_feather
         chance: 0.3
-
+    image: 8f5b5543a94aa16be2af51fb5f26643602bc645c57b8ea9284d30ba737d8b4dd.png
   dream_wisp:
     name: a flickering dream wisp
     room: creature_yard
@@ -585,7 +718,7 @@ mobs:
         chance: 0.4
       - itemId: creature_feather
         chance: 0.5
-
+    image: e06661c83982926c2cfe4a2424639ded5e4e1ab3382967c264ac2b830e9d6e17.png
   ink_blot:
     name: a sentient ink blot
     room: creature_yard
@@ -604,7 +737,7 @@ mobs:
         chance: 0.7
       - itemId: gossamer_thread
         chance: 0.2
-
+    image: f6b1ada8ec47e7cbc188701479cd413e0fa8b11d5e8e9497a9848c871f96e7a3.png
   nightmare_imp:
     name: a cackling nightmare imp
     room: creature_yard
@@ -623,7 +756,7 @@ mobs:
         chance: 0.8
       - itemId: memory_drop
         chance: 0.3
-
+    image: dea1d028b8d039d04d3287b44cee079d5500f2138b9780ff10d02562fe2da0d1.png
   the_night_terror:
     name: the Night Terror
     room: great_hall
@@ -634,17 +767,16 @@ mobs:
     behavior:
       template: aggro_guard
       params:
-        aggroMessage: The shadows at the far end of the hall coalesce into a towering figure
-          of living darkness. Two pinpoints of cold light serve as eyes. The Night Terror
-          has awakened.
+        aggroMessage: The shadows at the far end of the hall coalesce into a towering figure of living darkness. Two pinpoints
+          of cold light serve as eyes. The Night Terror has awakened.
     drops:
       - itemId: dream_shard
-        chance: 1.0
+        chance: 1
       - itemId: phantasm_cloak
         chance: 0.4
       - itemId: reverie_cake
         chance: 0.8
-
+    image: efde883233eb5ebea2a9a992da13bb3e443aaa37e0e9a447b5b235f7f8a77730.png
   shadow_student:
     name: a shadow student
     room: mob_templates
@@ -656,7 +788,7 @@ mobs:
         chance: 0.3
       - itemId: gossamer_thread
         chance: 0.2
-
+    image: 759f38e60022acf083fc8a2e84e7f20d8e549c99c1acf32339fba2578d41d7e5.png
   dream_eater:
     name: a dream eater
     room: mob_templates
@@ -668,7 +800,7 @@ mobs:
         chance: 0.5
       - itemId: moonbeam_silk
         chance: 0.2
-
+    image: 9e64431e58d25c250ea8c17dad1e3f0b64897f630bbb0a71d71098489c0c5e03.png
   the_forgotten:
     name: the Forgotten Headmaster
     room: mob_templates
@@ -680,7 +812,167 @@ mobs:
         chance: 0.3
       - itemId: clarity_elixir
         chance: 0.8
-
+    image: a310e319f740ae3cbfe72aefb0a0ab627fde997bc0c893307c62162a6c1f6857.png
+items:
+  dreamweave_cowl:
+    displayName: a dreamweave cowl
+    keyword: cowl
+    description: A soft hood woven from threads of sleeping thought. It shimmers between lavender and gold, and feels
+      lighter than air on your head.
+    slot: head
+    armor: 2
+    basePrice: 15
+    image: aa6f7b050576e0e5f5f16d7453cb17bc04fe1dd1fe0de22a4c13f25036a6f42f.png
+  imagination_blade:
+    displayName: an imagination blade
+    keyword: blade
+    description: A slender sword forged from pure belief. Its edge is as sharp as a child's conviction that monsters can be
+      defeated.
+    slot: weapon
+    damage: 4
+    basePrice: 30
+    image: 4f3f32c9e98355cc1dd7d30141cc7bf324ce3c9387dea13c24ded3b78cc35bf1.png
+  starlight_robes:
+    displayName: a pair of starlight robes
+    keyword: robes
+    description: Flowing robes stitched from distilled starlight. Constellations drift slowly across the fabric, rearranging
+      into new patterns each night.
+    slot: body
+    armor: 3
+    basePrice: 35
+    image: fd1f1f2c5251ba54d1e3b2acb39a1ab4ee88e77023fd98f95bee6d7cb3f7a350.png
+  lucid_gloves:
+    displayName: a pair of lucid gloves
+    keyword: gloves
+    description: Thin leather gloves that let you grip dreams like solid objects. The fingertips glow faintly when you concentrate.
+    slot: hand
+    armor: 1
+    basePrice: 12
+    image: 8ca0b9c575fb4311ed3bad3b9cd9eb2b2910ced38f0c265a527d353378eb6a85.png
+  memory_drop:
+    displayName: a crystallized memory drop
+    keyword: drop
+    description: A small candy-like droplet of crystallized happy memory. It tastes different to everyone — birthday cake,
+      summer rain, a favorite lullaby.
+    consumable: true
+    onUse:
+      healHp: 15
+    basePrice: 5
+    image: c8785b6a1b7c0ea855056ea962a3eb2fb08bb6686311eb9b976c3bb364b72d36.png
+  reverie_cake:
+    displayName: a slice of reverie cake
+    keyword: cake
+    description: A generous wedge of iridescent cake that tastes like your favorite dream. Eating it fills you with warmth
+      and the certainty that everything will be alright.
+    consumable: true
+    onUse:
+      healHp: 30
+    basePrice: 15
+    image: ddc838dfaa002c93eecaa1fda1f303900a45f1eb2662bd04c93ee7c2623cae97.png
+  clarity_elixir:
+    displayName: a vial of clarity elixir
+    keyword: elixir
+    description: A tiny glass vial of liquid so clear it's almost invisible. Drinking it sharpens your senses and fills your
+      mind with luminous understanding.
+    consumable: true
+    onUse:
+      healHp: 20
+      grantXp: 25
+    basePrice: 20
+    image: 6cd364bba90061ce2058b386eb5a85955388bb3702baf49db03bb639826c9b94.png
+  dream_shard:
+    displayName: a dream shard
+    keyword: shard
+    description: A translucent crystal fragment that pulses with soft inner light. It hums a different note for each person
+      who holds it. Headmaster Somnius collects these.
+    basePrice: 0
+    image: ab3c5118bf358bdb74a9d326bdd8b865cea3de079fb723b9546ed72e5b3406f3.png
+  creature_feather:
+    displayName: an iridescent creature feather
+    keyword: feather
+    description: A shimmering feather that shifts through every color of the spectrum. It drifts upward when released, as
+      though gravity is merely a suggestion.
+    basePrice: 0
+    image: df9aa1774f0732a6a046ae45d9383d5a8cc63b6267f2c3a67e7464a1d104f7d3.png
+  gossamer_thread:
+    displayName: a strand of gossamer thread
+    keyword: thread
+    description: An impossibly fine thread spun by dreaming spiders. It catches light that isn't there and hums when wound
+      around a spool.
+    basePrice: 4
+    image: cbfedc5556d3dbf704e486ad32b1b6ad72e60f2faec939d155d988adbe471c6c.png
+  dream_ore:
+    displayName: a nugget of dream ore
+    keyword: ore
+    description: A lump of metallic substance that shifts between solid and translucent depending on your state of mind.
+      Warm to the touch.
+    basePrice: 6
+    image: 03b219af1c14cc13bff3b3dcb1767cc6586e72756f174c0f5f79629a25232a6c.png
+  moonbeam_silk:
+    displayName: a scrap of moonbeam silk
+    keyword: silk
+    description: Fabric so fine it seems woven from light itself. It feels like holding a cool breeze and smells faintly of
+      night-blooming jasmine.
+    basePrice: 10
+    image: bc18400e2c4c486ed343264f5463e2d56a21a0696f086591f01c52698934467c.png
+  dreamcatcher_pendant:
+    displayName: a dreamcatcher pendant
+    keyword: pendant
+    description: A delicate pendant woven from dream ore and gossamer thread. It catches bad dreams before they reach you,
+      humming a protective lullaby.
+    slot: hand
+    armor: 2
+    stats:
+      constitution: 1
+    basePrice: 40
+    image: cd82812113cf85f16b9b967a7346fb4467208c0e76301e568823bf4bb4470a9e.png
+  stardust_vial:
+    displayName: a vial of bottled stardust
+    keyword: stardust
+    description: A small corked bottle filled with glittering dust that swirls in mesmerizing patterns. Drinking it fills
+      you with cosmic wonder.
+    consumable: true
+    onUse:
+      healHp: 5
+      grantXp: 50
+    basePrice: 25
+    image: 89cad86746a2dc9d16ea26f52434c6b827989afed32a9d85e3a59eaed290f5c3.png
+  phantasm_cloak:
+    displayName: the Night Terror's cloak
+    keyword: cloak
+    description: A sweeping cloak of living shadow, taken from the Night Terror itself. Darkness pools at its hem and
+      whispers follow in its wake, but the cloak protects its wearer fiercely.
+    slot: body
+    armor: 4
+    stats:
+      constitution: 2
+    basePrice: 100
+    image: dd7a531fe84418752ab7209911a2290ba73239da0ef583431a3cfbef5afa3a43.png
+  dreamers_key:
+    displayName: a key shaped from pure insight
+    keyword: key
+    description: A crystalline key that materialized from the answer to a riddle. It changes shape subtly in your hand,
+      always fitting whatever lock it encounters — but only once.
+    basePrice: 0
+    image: baf2aff3e00b5098c7a06ec402e30c3e553b9a27846e6c746f8888e7c3b736b5.png
+  academy_pennant:
+    displayName: an Auringold Academy pennant
+    keyword: pennant
+    description: A small triangular flag in gold and violet, emblazoned with the academy crest — a sleeping child cradled by
+      a crescent moon. It radiates gentle warmth.
+    basePrice: 0
+    image: 29cdcdee19b4c8f650d4d5ecb9c8effc09af007dbd3b0f1b9212b261e2f059c0.png
+  ground_memory_drop:
+    displayName: a crystallized memory drop
+    keyword: drop
+    description: A small candy-like droplet of crystallized happy memory. It tastes different to everyone — birthday cake,
+      summer rain, a favorite lullaby. Someone must have dropped this.
+    consumable: true
+    onUse:
+      healHp: 15
+    basePrice: 5
+    room: creature_yard
+    image: 035511496a5102515923ca79f7dd4b56985340d82dae4fd44f7935d260689c47.png
 shops:
   academy_supply:
     name: Auringold Academy Supplies
@@ -693,7 +985,7 @@ shops:
       - memory_drop
       - reverie_cake
       - clarity_elixir
-
+    image: f3d1c932602c1cba58163875bcef00ea99ae7fc7f4dc382b23f8191e30d47372.jpg
 trainers:
   valence_trainer:
     name: Instructor Valence
@@ -703,8 +995,35 @@ trainers:
       - MAGE
       - CLERIC
       - ROGUE
-      - RANGER
-
+      - RULER
+quests:
+  grand_tour:
+    name: The Grand Tour
+    description: Headmaster Somnius has asked you to explore Auringold Academy and collect three Dream Shards from the
+      creatures that wander the grounds. These crystallized fragments of imagination prove you've engaged with the
+      academy's inhabitants. Track your progress in the Quest panel!
+    giver: headmaster_somnius
+    objectives:
+      - type: collect
+        targetKey: dream_shard
+        count: 3
+        description: Collect Dream Shards from academy creatures
+    rewards:
+      xp: 150
+      gold: 75
+  creature_roundup:
+    name: Creature Roundup
+    description: Groundskeeper Moss needs help managing the rowdier dream creatures in the Creature Yard. Defeat them in
+      combat and collect their iridescent feathers as proof. Track your progress in the Quest panel!
+    giver: groundskeeper_moss
+    objectives:
+      - type: collect
+        targetKey: creature_feather
+        count: 3
+        description: Collect iridescent feathers from dream creatures
+    rewards:
+      xp: 100
+      gold: 50
 gatheringNodes:
   spider_silk_web:
     displayName: a shimmering spider web
@@ -722,7 +1041,7 @@ gatheringNodes:
       - itemId: moonbeam_silk
         quantity: 1
         dropChance: 0.15
-
+    image: 70812435cbca497de10c9ca598901392584b4763972ce4e3b91b5a51482892c1.png
   ore_formation:
     displayName: a vein of dream ore
     keyword: vein
@@ -735,7 +1054,7 @@ gatheringNodes:
       - itemId: dream_ore
         minQuantity: 1
         maxQuantity: 2
-
+    image: 6246bffdf9d6f6482779103e1bb1e8c5a0ff1b54a6d56ecfc0e5071207f438d6.png
 recipes:
   pendant_recipe:
     displayName: Dreamcatcher Pendant
@@ -751,7 +1070,6 @@ recipes:
     outputQuantity: 1
     station: WORKBENCH
     xpReward: 25
-
   stardust_recipe:
     displayName: Stardust Vial
     skill: alchemy
@@ -765,17 +1083,15 @@ recipes:
     outputItemId: stardust_vial
     outputQuantity: 1
     xpReward: 20
-
 puzzles:
   tower_riddle:
     type: riddle
     roomId: puzzle_tower
     mobId: puzzlewright
     question: >
-      The Puzzlewright grins its stony grin and gestures to the inscription
-      carved into the tower wall. It reads: "I am the realm you visit every
-      night, where impossible things feel right. I vanish when you open your
-      eyes, yet leave behind both tears and sighs. What am I?"
+      The Puzzlewright grins its stony grin and gestures to the inscription carved into the tower wall. It reads: "I am
+      the realm you visit every night, where impossible things feel right. I vanish when you open your eyes, yet leave
+      behind both tears and sighs. What am I?"
     answer: dream
     acceptableAnswers:
       - a dream
@@ -785,454 +1101,17 @@ puzzles:
       type: give_item
       itemId: dreamers_key
     successMessage: >
-      The Puzzlewright erupts in delighted laughter, scattering small stones.
-      "YES! A dream, of course! You dream-walkers always forget the obvious!"
-      A crystalline key materializes in the air before you, solidifying from
+      The Puzzlewright erupts in delighted laughter, scattering small stones. "YES! A dream, of course! You
+      dream-walkers always forget the obvious!" A crystalline key materializes in the air before you, solidifying from
       pure insight, and drops into your hands.
     failMessage: >
-      The Puzzlewright tilts its head and clicks its stone tongue. "Hmm, not
-      quite! Think about where you are right now. Think about what this whole
-      world is made of. Try again!"
+      The Puzzlewright tilts its head and clicks its stone tongue. "Hmm, not quite! Think about where you are right now.
+      Think about what this whole world is made of. Try again!"
     cooldownMs: 0
-
-quests:
-  grand_tour:
-    name: The Grand Tour
-    description: Headmaster Somnius has asked you to explore Auringold Academy and
-      collect three Dream Shards from the creatures that wander the grounds.
-      These crystallized fragments of imagination prove you've engaged with
-      the academy's inhabitants. Track your progress in the Quest panel!
-    giver: headmaster_somnius
-    objectives:
-      - type: collect
-        targetKey: dream_shard
-        count: 3
-        description: Collect Dream Shards from academy creatures
-    rewards:
-      xp: 150
-      gold: 75
-
-  creature_roundup:
-    name: Creature Roundup
-    description: Groundskeeper Moss needs help managing the rowdier dream creatures
-      in the Creature Yard. Defeat them in combat and collect their iridescent
-      feathers as proof. Track your progress in the Quest panel!
-    giver: groundskeeper_moss
-    objectives:
-      - type: collect
-        targetKey: creature_feather
-        count: 3
-        description: Collect iridescent feathers from dream creatures
-    rewards:
-      xp: 100
-      gold: 50
-
-rooms:
-  dream_gate:
-    title: The Dreaming Gate
-    description: >
-      You stand before an archway woven from golden light and sleeping
-      vines. It hums with the warmth of a thousand children's dreams. Beyond
-      it, impossible spires of the academy rise into a sky that shifts between
-      sunset and aurora, never quite settling on either. The air smells of
-      warm honey and old books. A welcome banner ripples overhead: "AURINGOLD
-      ACADEMY — WHERE IMAGINATION TAKES FORM."
-
-
-      A gilded orientation plaque beside the gate reads: "Welcome, new student!
-      Your vitals bar at the bottom of the screen shows your health, mana, and
-      gold. The icons along the sidebar open panels for your inventory, quests,
-      spellbook, and more. Click on characters and objects to interact with
-      them! Open the shimmering chest nearby to claim your welcome gift."
-
-
-      The Grand Atrium lies to the south.
-    exits:
-      s: grand_atrium
-    features:
-      welcome_chest:
-        type: CONTAINER
-        displayName: a shimmering welcome chest
-        keyword: chest
-        initialState: closed
-        items:
-          - dreamweave_cowl
-          - memory_drop
-
-  grand_atrium:
-    title: The Grand Atrium
-    description: >
-      A soaring rotunda of impossible geometry. Staircases spiral upward into
-      clouds, archways open onto corridors that shouldn't connect, and the
-      domed ceiling displays a slowly rotating map of the dream world. Paper
-      cranes drift through the air on currents of pure imagination.
-      Enchanted chandeliers cast golden light that makes everything look
-      like a memory of somewhere wonderful.
-
-
-      A constellation map on the wall reads: "Navigate using the compass rose
-      or by clicking exits in the room description. Use the chat bar to talk
-      with other students — try Say for the room, Gossip for the academy, or
-      OOC for out-of-character chat. Click the emote button to express
-      yourself! The Who panel shows other students online, and the Friends
-      panel lets you keep track of companions."
-
-
-      Paths lead east to the Divination Parlor, west to the Games Common,
-      south to the Supply Hall, and up a winding staircase to the Nightmare
-      Cellar. The Dreaming Gate is back to the north.
-    exits:
-      n: dream_gate
-      e: divination_parlor
-      w: games_common
-      s: supply_hall
-      u: nightmare_cellar
-
-  divination_parlor:
-    title: Professor Luma's Divination Parlor
-    description: >
-      A cozy circular room draped in curtains of woven moonlight. A crystal
-      orb on the central table projects tiny auroras across the ceiling. Star
-      charts cover every surface, annotated in a flowing silver script that
-      rearranges itself when you look away. The room smells of night jasmine
-      and possibility.
-
-
-      A student's guide pinned to the door reads: "Click on Professor Luma to
-      start a conversation. Dialogue choices appear at the bottom — explore
-      all the options to learn the most! Some NPCs offer quests, some offer
-      lore, and some just have something interesting to say."
-
-
-      The Grand Atrium is to the west, and the Training Grounds lie to the
-      south.
-    exits:
-      w: grand_atrium
-      s: training_grounds
-
-  games_common:
-    title: The Games Common Room
-    description: >
-      A lively lounge filled with floating game tables, enchanted dice that
-      roll themselves, and a massive wheel of fortune that spins between
-      dimensions. Plush chairs are arranged around fireplaces that burn with
-      flames of different dream-colors — amber contentment, violet wonder,
-      rose-gold excitement. Students gather here between classes to test
-      their luck and swap stories.
-
-
-      A glowing sign behind the bar reads: "Welcome to the Games Common!
-      This is the academy's tavern — check the Lottery panel in your sidebar
-      for daily drawings and use the gambling features to try your luck!
-      The Leaderboard panel shows how you rank against other students
-      across various categories."
-
-
-      The Grand Atrium is to the east, and the Bursar's Office is to the
-      south.
-    tavern: true
-    exits:
-      e: grand_atrium
-      s: bursar_office
-
-  bursar_office:
-    title: The Bursar's Office
-    description: >
-      A meticulously organized office where golden coins sort themselves
-      into neat stacks and ledgers write their own entries. A massive vault
-      door of enchanted dreamsteel dominates the back wall, its surface
-      inscribed with protective runes that pulse softly. The room radiates
-      an atmosphere of absolute financial security — even the dust motes
-      seem to settle in orderly rows.
-
-
-      A brass plaque on the counter reads: "The Bursar's Office safely
-      stores your gold and valuables! Open the Bank panel in your sidebar
-      to deposit gold for safekeeping or withdraw it when you need to make
-      purchases. Your savings grow interest in Auringold — even while you
-      sleep!"
-
-
-      The Games Common is back to the north.
-    bank: true
-    exits:
-      n: games_common
-
-  supply_hall:
-    title: The Academy Supply Hall
-    description: >
-      A long hall lined with display cases and floating shelves, each
-      holding equipment that shimmers with dream-forged enchantment.
-      Weapons hang in mid-air, slowly rotating. Armor stands model the
-      latest in protective dreamwear. A large counter staffed by an
-      impossibly animate quill pen serves as the checkout.
-
-
-      A student's shopping guide hangs on the wall: "Click on Quartermaster
-      Quill to browse the shop catalog! To equip purchased items, open your
-      Inventory panel and click items to equip them to your character. Your
-      Equipment section shows what you're wearing. You can sell items you
-      no longer need back to the shop for gold."
-
-
-      The Grand Atrium is to the north. The Artifice Laboratory is to the
-      east. The Training Grounds are to the south through a door further
-      down the hall... but the most direct path to the Training Grounds is
-      south through to the Creature Yard.
-    exits:
-      n: grand_atrium
-      e: artifice_lab
-      s: creature_yard
-
-  training_grounds:
-    title: The Training Grounds
-    terrain: outside
-    description: >
-      An open-air courtyard paved with stones that glow faintly underfoot,
-      surrounded by tiered observation galleries. Training dummies made of
-      solidified dream-stuff stand in rows — some charred, some frozen, some
-      sliced clean through. The air crackles with residual magic from a
-      thousand practice sessions. A raised platform at the center serves
-      as the instructor's stage, and crystallized courage shimmers in the
-      air like heat haze.
-
-
-      A training manual posted on the wall reads: "Click on Instructor
-      Valence to open the Training panel! Choose a class to unlock, then
-      learn abilities. Drag learned abilities from your Spellbook panel to
-      the action bar at the bottom of your screen for quick access. Each
-      ability has a cooldown after use — watch the timer on the button.
-      Abilities cost mana, shown in your vitals bar."
-
-
-      Professor Luma's Parlor is to the north, and the Puzzle Tower is to
-      the south.
-    exits:
-      n: divination_parlor
-      s: puzzle_tower
-
-  artifice_lab:
-    title: The Artifice Laboratory
-    description: >
-      A wonderfully chaotic workshop that would make any tinkerer weep with
-      joy. Workbenches overflow with half-finished inventions — a compass
-      that points to what you need most, spectacles that show the truth, a
-      music box that plays your thoughts. Enchanted tools operate themselves,
-      hammering and stitching and stirring without guidance. Alembics bubble
-      with liquids in colors that don't exist outside of dreams.
-
-
-      A workshop guide pinned to the wall reads: "Open the Crafting panel
-      in your sidebar to view available recipes! You'll need materials from
-      the Dream Garden to the south. This room has a workbench — crafting
-      here gives a bonus to certain recipes. Your crafting and gathering
-      skill levels are also shown in the Crafting panel."
-
-
-      The Supply Hall is to the west, and the Dream Garden is to the south.
-    station: WORKBENCH
-    exits:
-      w: supply_hall
-      s: dream_garden
-
-  dream_garden:
-    title: The Dream Garden
-    terrain: forest
-    description: >
-      A luminous garden where reality is particularly thin. Flowers bloom
-      in equations, trees grow upside-down with their roots in the clouds,
-      and a stream of liquid starlight winds between beds of impossible
-      plants. Shimmering spider webs strung between crystalline bushes
-      catch gossamer threads of pure imagination. Veins of dream ore push
-      through the earth like surfacing whales, their metallic surfaces
-      shifting between solid and translucent.
-
-
-      A garden sign reads: "This is a gathering area! Look for resource
-      nodes highlighted in the room — the shimmering spider webs yield
-      gossamer thread, and the dream ore veins yield raw materials. Click
-      on them or use the Crafting panel to see nearby nodes and gather
-      materials. Then head north to the Artifice Lab to craft something!"
-
-
-      The Artifice Laboratory is back to the north.
-    exits:
-      n: artifice_lab
-
-  creature_yard:
-    title: The Creature Yard
-    terrain: outside
-    description: >
-      A sprawling outdoor enclosure where dream creatures roam freely —
-      some docile, some decidedly not. Flickering wisps drift like
-      dandelion seeds. Ink blots that escaped from textbooks slither across
-      the ground, leaving smudged trails. Nightmare imps cackle from
-      perches on crystallized dream-branches. The grass here is soft as
-      clouds and faintly luminescent.
-
-
-      A safety notice on the fence reads: "Welcome to the Creature Yard!
-      Click on a hostile creature to target it, then use abilities from
-      your action bar to engage in combat. Watch the combat log for
-      battle updates, and keep an eye on your health in the vitals bar.
-      Use consumable items from your inventory if you need healing. If
-      things get dangerous, you can always flee! Defeated creatures may
-      drop useful items — check your inventory after combat."
-
-
-      Someone has dropped a memory drop on the ground near the gate.
-
-
-      The Supply Hall is to the north. The Puzzle Tower is to the east.
-      The Great Hall lies to the south.
-    exits:
-      n: supply_hall
-      e: puzzle_tower
-      s: great_hall
-
-  puzzle_tower:
-    title: The Puzzle Tower
-    description: >
-      A slender tower room where the walls are covered in shifting
-      symbols, optical illusions, and inscriptions that rearrange
-      themselves. The floor is a mosaic depicting the history of Auringold
-      in scenes that animate when you step on them. At the center, a stone
-      gargoyle made entirely of carved question marks perches on a
-      pedestal, watching visitors with an amused expression. An ancient
-      riddle is carved into the wall behind it.
-
-
-      A student's note stuck to the door reads: "Some challenges in
-      Auringold are puzzles, not fights! Read the riddle carefully and
-      submit your answer through the dialogue that appears. Correct
-      answers earn rewards. This one unlocks the door to the south!"
-
-
-      A heavy door of carved dreamwood blocks the passage to the south,
-      secured by an elaborate lock that glimmers with puzzle-magic.
-
-
-      The Creature Yard is to the west, and the Training Grounds are to
-      the north.
-    exits:
-      n: training_grounds
-      w: creature_yard
-      s:
-        to: hidden_archive
-        door:
-          initialState: locked
-          keyItemId: dreamers_key
-          keyConsumed: true
-
-  hidden_archive:
-    title: The Hidden Archive
-    description: >
-      A hushed, reverent space that feels older than the rest of the academy.
-      Towering shelves of crystallized dream-books stretch into darkness
-      overhead. Each book glows with its own inner light — some warm gold,
-      some cool silver, some colors you've never seen before. A reading
-      alcove in the corner holds a comfortable chair and a lamp that burns
-      with distilled curiosity.
-
-
-      An orientation guide rests on the reading desk, covering advanced
-      academy features: "Congratulations on solving the puzzle! As you
-      continue your adventures beyond the academy, you'll discover more
-      features through the sidebar panels: Housing lets you own a personal
-      dream-space. The Auction panel connects you to a global marketplace.
-      Mail lets you send letters to other students. Trading enables
-      face-to-face item exchanges. Pets let you bond with a dream
-      creature companion. And Factions track your reputation with the
-      various dream entities of Auringold. Explore every panel — there's
-      always more to discover!"
-
-
-      The Puzzle Tower is back to the north.
-    exits:
-      n: puzzle_tower
-    features:
-      ancient_bookcase:
-        type: CONTAINER
-        displayName: a glowing dreamwood bookcase
-        keyword: bookcase
-        initialState: closed
-        items:
-          - clarity_elixir
-          - moonbeam_silk
-
-  great_hall:
-    title: The Great Hall
-    description: >
-      The ceremonial heart of Auringold Academy — a vast hall with a
-      vaulted ceiling of living stained glass that shifts to tell
-      different stories. Golden banners hang between pillars of
-      crystallized aspiration. At the far end, an empty throne of woven
-      starlight awaits the academy's greatest champions. But between you
-      and the throne, the shadows thicken unnaturally. Something lurks
-      here — the academy's ultimate test.
-
-
-      A plaque near the entrance reads: "The Great Hall is where your
-      journey culminates! After defeating challenges, check the Quest
-      panel to turn in completed quests. Open the Character panel to
-      review your stats, and check the Achievements panel for milestones
-      you've reached. The Prestige panel shows advanced progression
-      options for experienced students."
-
-
-      A battered treasure chest sits near the base of the throne.
-
-
-      The Creature Yard is back to the north.
-    exits:
-      n: creature_yard
-    features:
-      treasure_chest:
-        type: CONTAINER
-        displayName: a crystalline treasure chest
-        keyword: chest
-        initialState: closed
-        items:
-          - academy_pennant
-          - reverie_cake
-
-  nightmare_cellar:
-    title: The Nightmare Cellar
-    terrain: underground
-    description: >
-      A winding staircase descends from the atrium into a damp, shadowy
-      cellar where the academy's foundations meet raw, unformed dream-stuff.
-      The walls here pulse with darker energy — not evil, exactly, but
-      wilder, less tamed. This is where nightmares are studied, contained,
-      and occasionally escaped from. A shimmering portal arch stands against
-      the far wall, its surface rippling like disturbed water, leading into
-      procedurally generated dream-dungeons.
-
-
-      A bulletin board by the stairs reads: "Dungeons are instanced
-      adventures — open the Dungeon panel in your sidebar to see available
-      dungeons and start a run! For the best experience, bring friends —
-      use the Group panel to invite other students and tackle dungeons
-      together. The Guild panel lets you form permanent organizations
-      with shared chat, a roster, and a guild hall. Teamwork makes the
-      dream work!"
-
-
-      The Grand Atrium is back down the stairs.
-    dungeon: true
-    exits:
-      d: grand_atrium
-
-  mob_templates:
-    title: Dream Template Chamber
-    description: An internal room used to stage dungeon mob templates.
-      Students cannot reach this room.
-
 dungeon:
   name: auringold_academy
-  description: A shifting labyrinth beneath the academy where unrefined nightmares
-    and forgotten dreams take physical form. Each expedition is different — the
-    corridors rearrange, the creatures change, and the rewards vary.
+  description: A shifting labyrinth beneath the academy where unrefined nightmares and forgotten dreams take physical
+    form. Each expedition is different — the corridors rearrange, the creatures change, and the rewards vary.
   minLevel: 1
   roomCountMin: 4
   roomCountMax: 8
@@ -1240,56 +1119,43 @@ dungeon:
   roomTemplates:
     entrance:
       - title: Cellar Threshold
-        description: Cracked flagstones give way to packed dream-earth. The air is
-          thick and warm, like breathing inside a sleeping mind. Flickering
-          dream-lanterns light the way forward.
+        description: Cracked flagstones give way to packed dream-earth. The air is thick and warm, like breathing inside a
+          sleeping mind. Flickering dream-lanterns light the way forward.
       - title: The Unraveling Stair
-        description: A spiral staircase descends into shifting darkness. Each step
-          feels slightly different underfoot — stone, then wood, then something
-          soft and warm, then cold iron. The walls breathe.
+        description: A spiral staircase descends into shifting darkness. Each step feels slightly different underfoot — stone,
+          then wood, then something soft and warm, then cold iron. The walls breathe.
     corridor:
       - title: The Drowsy Corridor
-        description: A passage that sways gently, as if the entire structure is
-          rocking itself to sleep. Doors on either side are painted with scenes
-          from different dreams — a flying whale, a candy mountain, a city
-          built on clouds.
+        description: A passage that sways gently, as if the entire structure is rocking itself to sleep. Doors on either side
+          are painted with scenes from different dreams — a flying whale, a candy mountain, a city built on clouds.
       - title: The Ink-Stained Hall
-        description: Black ink drips from the ceiling and pools on the floor in
-          patterns that almost form words. The walls are covered in children's
-          drawings that move when you're not looking directly at them.
+        description: Black ink drips from the ceiling and pools on the floor in patterns that almost form words. The walls are
+          covered in children's drawings that move when you're not looking directly at them.
       - title: The Lullaby Passage
-        description: A gentle melody echoes through this narrow corridor, its source
-          impossible to locate. The tune changes based on who's listening —
-          always your favorite lullaby, the one you can never quite remember.
+        description: A gentle melody echoes through this narrow corridor, its source impossible to locate. The tune changes
+          based on who's listening — always your favorite lullaby, the one you can never quite remember.
     chamber:
       - title: The Toy Soldier Barracks
-        description: Rows of oversized tin soldiers stand at attention, their painted
-          eyes tracking movement. Some have broken free of their posts and patrol
-          the room with mechanical precision.
+        description: Rows of oversized tin soldiers stand at attention, their painted eyes tracking movement. Some have broken
+          free of their posts and patrol the room with mechanical precision.
       - title: The Blanket Fort
-        description: An enormous blanket fort constructed from quilts the size of
-          sails. Inside, the space is impossibly large. Something has made this
-          its lair — scattered dream-stuff and chewed pillows litter the floor.
+        description: An enormous blanket fort constructed from quilts the size of sails. Inside, the space is impossibly large.
+          Something has made this its lair — scattered dream-stuff and chewed pillows litter the floor.
       - title: The Clockwork Nursery
-        description: Mechanical mobiles spin overhead, casting moving shadows across
-          cribs that hold sleeping dream-fragments. Some of the fragments have
-          hatched into things that don't appreciate visitors.
+        description: Mechanical mobiles spin overhead, casting moving shadows across cribs that hold sleeping dream-fragments.
+          Some of the fragments have hatched into things that don't appreciate visitors.
     treasure:
       - title: The Lost and Found
-        description: A room piled high with items from forgotten dreams — favorite
-          toys, imaginary friends given form, letters never sent. Among the
-          emotional debris, genuine treasures glint.
+        description: A room piled high with items from forgotten dreams — favorite toys, imaginary friends given form, letters
+          never sent. Among the emotional debris, genuine treasures glint.
     boss:
       - title: The Dreamer's Abyss
-        description: An enormous cavern where the floor drops away into swirling
-          dream-stuff. A single platform of solidified nightmare floats at the
-          center, connected by bridges of frozen thought. Something ancient
-          and powerful waits here — the source of the cellar's darkest dreams.
+        description: An enormous cavern where the floor drops away into swirling dream-stuff. A single platform of solidified
+          nightmare floats at the center, connected by bridges of frozen thought. Something ancient and powerful waits
+          here — the source of the cellar's darkest dreams.
       - title: The Forgotten Classroom
-        description: A twisted mirror of the academy above — desks overturned,
-          blackboards covered in impossible equations, and at the teacher's
-          desk, a figure that was once a headmaster before the nightmares
-          consumed them.
+        description: A twisted mirror of the academy above — desks overturned, blackboards covered in impossible equations, and
+          at the teacher's desk, a figure that was once a headmaster before the nightmares consumed them.
   mobPools:
     common:
       - shadow_student

--- a/src/test/kotlin/dev/ambon/config/AppConfigLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/config/AppConfigLoaderTest.kt
@@ -37,7 +37,6 @@ class AppConfigLoaderTest {
         assertEquals(PersistenceBackend.YAML, config.persistence.backend)
         assertTrue(!config.redis.enabled)
         assertTrue(!config.engine.debug.enableSwarmClass)
-        assertEquals("thornhaven_city:new_arrivals_hall", config.engine.classStartRooms["SWARM"])
     }
 
     @Test

--- a/web-v3/src/canvas/scenes/BattleScene.ts
+++ b/web-v3/src/canvas/scenes/BattleScene.ts
@@ -17,6 +17,7 @@ const LABEL_FONT_SIZE = 15;
 const PARTY_LABEL_FONT_SIZE = 13;
 
 const PLAYER_TINT = 0x81a2be;
+const PET_TINT = 0xb294bb;
 const ENEMY_TINT = 0xf0c674;
 const HP_COLOR = 0x8abf8a;
 const HP_BG_COLOR = 0x3a3a3a;
@@ -24,6 +25,7 @@ const MANA_COLOR = 0x64b5f6;
 const LABEL_COLOR = "#d8dcef";
 const ENEMY_LABEL_COLOR = "#f0c674";
 const PARTY_LABEL_COLOR = "#81a2be";
+const PET_LABEL_COLOR = "#b294bb";
 const HP_TEXT_COLOR = "#d8dcef";
 
 function percent(current: number, max: number): number {
@@ -45,6 +47,7 @@ export class BattleScene {
   private enemyHpText: Text;
 
   private partyMembers: Array<{ sprite: Sprite; label: Text; hpBar: Graphics }> = [];
+  private petMembers: Array<{ sprite: Sprite; label: Text; hpBar: Graphics; id: string }> = [];
 
   private combatAnimator: CombatAnimator;
   private gainPopups: GainPopupSystem;
@@ -60,6 +63,7 @@ export class BattleScene {
   private lastEnemyImage: string | null = null;
   private lastTargetId: string | null = null;
   private lastPartyKey = "";
+  private lastPetsKey = "";
   private width = 0;
   private height = 0;
 
@@ -179,7 +183,7 @@ export class BattleScene {
     }
 
     const state = gameStateRef.current;
-    const { vitals, character, combatTarget, groupInfo, room } = state;
+    const { vitals, character, combatTarget, groupInfo, room, mobs } = state;
     const stillInCombat = state.inCombat;
 
     // Update room background
@@ -231,6 +235,14 @@ export class BattleScene {
     if (partyKey !== this.lastPartyKey) {
       this.lastPartyKey = partyKey;
       this.rebuildParty(groupInfo.members.filter((m) => m.name !== character.name));
+    }
+
+    // Update pets (mobs with ownerName matching the current character)
+    const myPets = mobs.filter((m) => m.ownerName && m.ownerName === character.name);
+    const petsKey = myPets.map((p) => `${p.id}:${p.hp}:${p.maxHp}`).join("|");
+    if (petsKey !== this.lastPetsKey) {
+      this.lastPetsKey = petsKey;
+      this.rebuildBattlePets(myPets);
     }
 
     // Process events from the bus
@@ -487,6 +499,32 @@ export class BattleScene {
       }
     }
 
+    // Pets (positioned below player on the right)
+    const petStartY = playerPos.y + playerSize / 2 + 20;
+    for (let i = 0; i < this.petMembers.length; i++) {
+      const pet = this.petMembers[i];
+      const petMob = gameStateRef.current.mobs.find((m: { id: string }) => m.id === pet.id);
+      const px = playerPos.x + 60;
+      const py = petStartY + i * (SMALL_SPRITE + 30);
+
+      pet.sprite.x = px;
+      pet.sprite.y = py;
+      pet.label.x = px;
+      pet.label.y = py + SMALL_SPRITE / 2 + 4;
+
+      pet.hpBar.clear();
+      if (petMob) {
+        const pHpPct = percent(petMob.hp, petMob.maxHp);
+        const barW = 60;
+        pet.hpBar.roundRect(px - barW / 2, py + SMALL_SPRITE / 2 + 18, barW, 5, 1);
+        pet.hpBar.fill(HP_BG_COLOR);
+        if (pHpPct > 0) {
+          pet.hpBar.roundRect(px - barW / 2, py + SMALL_SPRITE / 2 + 18, barW * pHpPct / 100, 5, 1);
+          pet.hpBar.fill(HP_COLOR);
+        }
+      }
+    }
+
     // Draw combat effects
     this.combatAnimator.drawGlows(playerDrawX, playerDrawY, enemyDrawX, enemyDrawY);
     this.combatAnimator.drawFlashes(
@@ -573,6 +611,50 @@ export class BattleScene {
       this.container.addChild(label);
       this.container.addChild(hpBar);
       this.partyMembers.push({ sprite, label, hpBar });
+    }
+  }
+
+  private rebuildBattlePets(pets: Array<{ id: string; name: string; hp: number; maxHp: number; image?: string | null; category?: string }>) {
+    for (const { sprite, label, hpBar } of this.petMembers) {
+      this.container.removeChild(sprite);
+      this.container.removeChild(label);
+      this.container.removeChild(hpBar);
+      sprite.destroy();
+      label.destroy();
+      hpBar.destroy();
+    }
+    this.petMembers = [];
+
+    for (const pet of pets) {
+      const sprite = new Sprite(Texture.WHITE);
+      sprite.width = SMALL_SPRITE;
+      sprite.height = SMALL_SPRITE;
+      sprite.anchor.set(0.5);
+      sprite.tint = PET_TINT;
+
+      const petImage = pet.image ?? gameStateRef.current.serverAssets[`default_mob_${pet.category ?? "humanoid"}`] ?? null;
+      if (petImage) {
+        Assets.load(petImage).then((tex: unknown) => {
+          if (tex && typeof tex === "object" && "baseTexture" in (tex as Record<string, unknown>)) {
+            sprite.texture = tex as Texture;
+          } else if (tex instanceof Texture) {
+            sprite.texture = tex;
+          }
+        }).catch(() => {/* ignore */});
+      }
+
+      const label = new Text({
+        text: `♥ ${pet.name}`,
+        style: { fontFamily: "JetBrains Mono, Cascadia Mono, monospace", fontSize: PARTY_LABEL_FONT_SIZE, fill: PET_LABEL_COLOR },
+      });
+      label.anchor.set(0.5, 0);
+
+      const hpBar = new Graphics();
+
+      this.container.addChild(sprite);
+      this.container.addChild(label);
+      this.container.addChild(hpBar);
+      this.petMembers.push({ sprite, label, hpBar, id: pet.id });
     }
   }
 

--- a/web-v3/src/canvas/scenes/WorldScene.ts
+++ b/web-v3/src/canvas/scenes/WorldScene.ts
@@ -44,6 +44,7 @@ function featureCountLabel(count: number, singular: string, plural: string): str
 
 const PLAYER_LABEL_COLOR = "#d8dcef";
 const OTHER_PLAYER_LABEL_COLOR = "#81a2be";
+const PET_LABEL_COLOR = "#b294bb";
 const MOB_LABEL_COLOR = "#f0c674";
 const ITEM_LABEL_COLOR = "#8abeb7";
 const PLAYER_LABEL_FONT_SIZE = 15;
@@ -101,6 +102,7 @@ export class WorldScene {
   private playerLabel: Text;
   private playerLabelBg = new Graphics();
   private mobSprites: Map<string, { sprite: Sprite; label: Text; labelBg: Graphics; hitArea: Graphics }> = new Map();
+  private petSprites: Map<string, { sprite: Sprite; label: Text; labelBg: Graphics; hitArea: Graphics }> = new Map();
   private itemSprites: Array<{ sprite: Sprite; label: Text; labelBg: Graphics; hitArea: Graphics }> = [];
   private playerSprites: Map<string, { sprite: Sprite; label: Text; labelBg: Graphics; hitArea: Graphics }> = new Map();
   private roleGraphics = new Graphics();
@@ -230,6 +232,7 @@ export class WorldScene {
   private leverCount = 0;
 
   private lastMobsKey = "";
+  private lastPetsKey = "";
   private lastItemsKey = "";
   private lastNodesKey = "";
   private lastPlayersKey = "";
@@ -813,10 +816,19 @@ export class WorldScene {
 
     this.playerLabel.text = character.name !== "-" ? character.name : "";
 
-    const mobsKey = mobs.map((m) => `${m.id}:${m.hp}`).join("|");
+    const pets = mobs.filter((m) => m.ownerName);
+    const nonPetMobs = mobs.filter((m) => !m.ownerName);
+
+    const mobsKey = nonPetMobs.map((m) => `${m.id}:${m.hp}`).join("|");
     if (mobsKey !== this.lastMobsKey) {
       this.lastMobsKey = mobsKey;
-      this.rebuildMobs(mobs);
+      this.rebuildMobs(nonPetMobs);
+    }
+
+    const petsKey = pets.map((p) => `${p.id}:${p.hp}`).join("|");
+    if (petsKey !== this.lastPetsKey) {
+      this.lastPetsKey = petsKey;
+      this.rebuildPets(pets);
     }
 
     const itemsKey = roomItems.map((i) => i.id).join("|");
@@ -1145,6 +1157,29 @@ export class WorldScene {
         hitArea.x = startX - otherSize / 2;
         hitArea.y = opY - otherSize / 2;
         startX += otherSize + 20;
+      }
+    }
+
+    // Layout pet sprites near the player (below and to the right)
+    const petEntries = [...this.petSprites.values()];
+    if (petEntries.length > 0) {
+      const petY = playerY + playerSize * 0.1;
+      const petSize = otherSize;
+      let petStartX = playerX - petSize / 2 - 10;
+      for (const { sprite, label, labelBg, hitArea } of petEntries) {
+        sprite.x = petStartX;
+        sprite.y = petY;
+        sprite.width = petSize;
+        sprite.height = petSize;
+        label.x = petStartX;
+        label.y = petY + petSize / 2 + 6;
+        drawLabelPill(labelBg, label);
+        hitArea.clear();
+        hitArea.rect(0, 0, petSize, petSize);
+        hitArea.fill({ color: 0x000000, alpha: 0.001 });
+        hitArea.x = petStartX - petSize / 2;
+        hitArea.y = petY - petSize / 2;
+        petStartX -= petSize + 16;
       }
     }
 
@@ -1671,6 +1706,61 @@ export class WorldScene {
       this.container.addChild(label);
       this.container.addChild(hitArea);
       this.playerSprites.set(player.name, { sprite, label, labelBg, hitArea });
+    }
+  }
+
+  private rebuildPets(pets: Array<{ id: string; name: string; image?: string | null; category?: string; hp: number; maxHp: number }>) {
+    for (const { sprite, label, labelBg, hitArea } of this.petSprites.values()) {
+      this.container.removeChild(sprite);
+      this.container.removeChild(labelBg);
+      this.container.removeChild(label);
+      this.container.removeChild(hitArea);
+      sprite.destroy();
+      labelBg.destroy();
+      label.destroy();
+      hitArea.destroy();
+    }
+    this.petSprites.clear();
+
+    const petSize = BASE_SPRITE_SIZE * 0.75;
+    for (const pet of pets) {
+      const sprite = new Sprite(Texture.WHITE);
+      sprite.width = petSize;
+      sprite.height = petSize;
+      sprite.anchor.set(0.5);
+      sprite.tint = 0xb294bb;
+
+      const petImage = pet.image ?? gameStateRef.current.serverAssets[`default_mob_${pet.category ?? "humanoid"}`] ?? null;
+      if (petImage) {
+        this.loadSpriteTexture(sprite, petImage);
+      }
+
+      const label = new Text({
+        text: `♥ ${pet.name}`,
+        style: { fontFamily: "JetBrains Mono, Cascadia Mono, monospace", fontSize: 13, fill: PET_LABEL_COLOR, dropShadow: { color: 0x000000, alpha: 0.4, blur: 2, distance: 1 } },
+      });
+      label.anchor.set(0.5, 0);
+
+      const labelBg = new Graphics();
+      labelBg.eventMode = "none";
+
+      const hitArea = new Graphics();
+      hitArea.rect(0, 0, petSize, petSize);
+      hitArea.fill({ color: 0x000000, alpha: 0.001 });
+      hitArea.eventMode = "static";
+      hitArea.cursor = "pointer";
+
+      const petData = pet;
+      hitArea.on("pointerdown", () => {
+        this.entityPopout.showMob(petData.name, undefined, petData.image, undefined, petData.hp, petData.maxHp, null, false);
+        this.showPopout();
+      });
+
+      this.container.addChild(sprite);
+      this.container.addChild(labelBg);
+      this.container.addChild(label);
+      this.container.addChild(hitArea);
+      this.petSprites.set(pet.id, { sprite, label, labelBg, hitArea });
     }
   }
 

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -548,6 +548,7 @@ export function applyGmcpPackage(
             video: typeof entry.video === "string" ? entry.video : null,
             category: typeof entry.category === "string" ? entry.category : "humanoid",
             effects: parseMobEffects(entry.effects),
+            ownerName: typeof entry.ownerName === "string" ? entry.ownerName : null,
           })),
       );
       break;
@@ -569,6 +570,7 @@ export function applyGmcpPackage(
           video: typeof packet.video === "string" ? packet.video : null,
           category: typeof packet.category === "string" ? packet.category : "humanoid",
           effects: parseMobEffects(packet.effects),
+          ownerName: typeof packet.ownerName === "string" ? packet.ownerName : null,
         },
       ]);
       break;

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -303,6 +303,8 @@ export interface RoomMob {
   video?: string | null;
   category?: string;
   effects?: StatusEffect[];
+  /** Character name of the pet's owner, or undefined for regular mobs. */
+  ownerName?: string | null;
 }
 
 export interface StatusEffect {


### PR DESCRIPTION
## Summary

- **50 class abilities** (10 per class) for Knight, Wizard, Doctor, Pirate, and Ruler with thematic ability trees (Valor/Guardian, Imagination/Wonder, Medicine/Wellness, Scallywag/Buccaneer, Court/Sovereignty)
- **28 status effects** covering stuns, roots, DOTs, HOTs, shields, stat buffs, and stat debuffs — all themed to children's dreams (Pillow Fort, Brain Freeze, Chicken Soup, Pocket Sand, Royal Tantrum, etc.)
- **4 pet templates** for Ruler class scaling from early to endgame: Teddy Knight → Pixel Sprite → Clockwork Dragon → Dream Guardian
- **Pet combat system**: pets auto-attack their owner's combat target each tick, credit kills to owner, and are excluded from player targeting
- **Pet GMCP ownership**: `ownerName` field on `MobState` and `RoomMobPayload` so the client identifies pets vs regular mobs
- **World canvas pet rendering**: pets render in the player area (left side) with purple tint and ♥ prefix, not in the mob area
- **Battle scene pet rendering**: pets appear as allies with HP bars during combat, positioned near the player
- Updated Auringold Academy trainer to include RULER class

## Test plan

- [x] `./gradlew ktlintCheck` passes
- [x] `./gradlew test` passes (1799 tests)
- [x] `bun run lint` passes
- [x] TypeScript type-check passes
- [ ] Manual: summon a pet as Ruler, verify it appears near player on world canvas
- [ ] Manual: enter combat with pet active, verify pet deals damage and shows in battle scene
- [ ] Manual: verify pet follows between rooms and dismisses on disconnect
- [ ] Manual: verify pets can't be targeted with `kill` command
- [ ] Manual: learn abilities from trainer as each class