### PR TITLE
Redesign stylist panel as shop-style kiosk UI

### DIFF
--- a/web-v3/src/components/panels/StylistPanel.tsx
+++ b/web-v3/src/components/panels/StylistPanel.tsx
@@ -5,13 +5,8 @@ interface StylistPanelProps {
   onCommand: (cmd: string) => void;
 }
 
-function formatMods(statMods: Record<string, number>): string {
-  const entries = Object.entries(statMods).filter(([, v]) => v !== 0);
-  if (entries.length === 0) return "no stat change";
-  return entries
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([k, v]) => (v >= 0 ? `${k} +${v}` : `${k} ${v}`))
-    .join(", ");
+function formatMod(key: string, value: number): string {
+  return value >= 0 ? `${key} +${value}` : `${key} ${value}`;
 }
 
 export function StylistPanel({ stylistState, onCommand }: StylistPanelProps) {
@@ -36,74 +31,77 @@ export function StylistPanel({ stylistState, onCommand }: StylistPanelProps) {
 
   return (
     <div className="stylist-panel">
-      <div className="panel-header">
-        <span className="panel-title">Stylist</span>
+      <div className="stylist-wallet">
+        <span className="stylist-gold-icon" aria-hidden="true" />
+        <span className="stylist-gold-amount">{stylistState.playerGold.toLocaleString()}</span>
+        <span className="stylist-gold-label">gold</span>
+        <span className="stylist-fee-tag">
+          {stylistState.feeGold.toLocaleString()}g per change
+        </span>
       </div>
 
-      <div className="stylist-content">
-        <div className="stylist-summary">
-          <div className="stylist-summary-row">
-            <span className="stylist-summary-label">Current Race</span>
-            <span className="stylist-summary-value">{stylistState.currentRace}</span>
-          </div>
-          <div className="stylist-summary-row">
-            <span className="stylist-summary-label">Fee</span>
-            <span
-              className={`stylist-summary-value${affordable ? "" : " stylist-fee-short"}`}
-            >
-              {stylistState.feeGold.toLocaleString()} gold
-            </span>
-          </div>
-          <div className="stylist-summary-row">
-            <span className="stylist-summary-label">Your Gold</span>
-            <span className="stylist-summary-value">
-              {stylistState.playerGold.toLocaleString()}
-            </span>
-          </div>
-        </div>
-
-        {stylistState.races.length === 0 ? (
-          <p className="stylist-empty">No races available.</p>
-        ) : (
-          <ul className="stylist-race-list">
-            {stylistState.races.map((race: StylistRace) => {
-              const isCurrent = race.id.toUpperCase() === stylistState.currentRace.toUpperCase();
-              return (
-                <li key={race.id} className="stylist-race-row">
-                  <div className="stylist-race-info">
+      {stylistState.races.length === 0 ? (
+        <p className="empty-note">No races available.</p>
+      ) : (
+        <div className="stylist-race-list">
+          {stylistState.races.map((race: StylistRace) => {
+            const isCurrent = race.id.toUpperCase() === stylistState.currentRace.toUpperCase();
+            const mods = Object.entries(race.statMods).filter(([, v]) => v !== 0);
+            return (
+              <div
+                key={race.id}
+                className={`stylist-race-card${isCurrent ? " stylist-race-card-current" : ""}${!affordable && !isCurrent ? " stylist-race-card-unaffordable" : ""}`}
+              >
+                <div className="stylist-race-card-top">
+                  <div className="stylist-race-card-info">
                     {race.image && (
                       <img
                         src={race.image}
                         alt=""
-                        className="stylist-race-image"
+                        className="stylist-race-thumb"
                         loading="lazy"
                       />
                     )}
-                    <div className="stylist-race-text">
-                      <div className="stylist-race-name">
+                    <div className="stylist-race-card-text">
+                      <span className="stylist-race-name">
                         {race.displayName}
-                        {isCurrent && <span className="stylist-race-current"> (current)</span>}
-                      </div>
-                      <div className="stylist-race-mods">{formatMods(race.statMods)}</div>
+                        {isCurrent && <span className="stylist-badge-current">current</span>}
+                      </span>
                       {race.description && (
-                        <div className="stylist-race-desc">{race.description}</div>
+                        <span className="stylist-race-desc">{race.description}</span>
+                      )}
+                      {mods.length > 0 && (
+                        <span className="stylist-race-mods">
+                          {mods.sort(([a], [b]) => a.localeCompare(b)).map(([k, v]) => (
+                            <span key={k} className={`stylist-mod-chip${v >= 0 ? " stylist-mod-pos" : " stylist-mod-neg"}`}>
+                              {formatMod(k, v)}
+                            </span>
+                          ))}
+                        </span>
                       )}
                     </div>
                   </div>
-                  <button
-                    type="button"
-                    className="stylist-change-btn"
-                    disabled={isCurrent || !affordable}
-                    onClick={() => onCommand(`changerace ${race.id}`)}
-                  >
-                    {isCurrent ? "Current" : "Change"}
-                  </button>
-                </li>
-              );
-            })}
-          </ul>
-        )}
-      </div>
+                  <div className="stylist-race-card-action">
+                    {!isCurrent && (
+                      <span className={`stylist-race-price${affordable ? "" : " stylist-race-price-cant"}`}>
+                        {stylistState.feeGold.toLocaleString()}g
+                      </span>
+                    )}
+                    <button
+                      type="button"
+                      className="soft-button stylist-change-btn"
+                      disabled={isCurrent || !affordable}
+                      onClick={() => onCommand(`changerace ${race.id}`)}
+                    >
+                      {isCurrent ? "Current" : "Change"}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -13653,22 +13653,6 @@ body {
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
-  padding: var(--space-4);
-  height: 100%;
-  overflow-y: auto;
-}
-
-.stylist-panel .panel-header {
-  display: flex;
-  align-items: center;
-  padding-bottom: var(--space-3);
-  border-bottom: 1px solid var(--border-subtle);
-}
-
-.stylist-panel .panel-title {
-  font-size: 1.05rem;
-  font-weight: 700;
-  color: var(--text-primary);
 }
 
 .stylist-empty-state {
@@ -13699,135 +13683,212 @@ body {
   color: var(--text-secondary);
 }
 
-.stylist-content {
+/* ── Wallet header ── */
+.stylist-wallet {
   display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-}
-
-.stylist-summary {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 12px 14px;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
   border-radius: var(--radius-lg);
-  background: linear-gradient(135deg, rgb(176 146 208 / 12%), rgb(176 146 208 / 6%));
-  border: 1px solid rgb(176 146 208 / 22%);
+  background: linear-gradient(135deg, rgb(190 168 115 / 12%), rgb(190 168 115 / 6%));
+  border: 1px solid rgb(190 168 115 / 22%);
 }
 
-.stylist-summary-row {
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.85rem;
+.stylist-gold-icon {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--color-gold-bright), var(--color-primary-soft-gold));
+  box-shadow: 0 0 6px rgb(190 168 115 / 40%);
+  flex-shrink: 0;
 }
 
-.stylist-summary-label {
-  color: var(--text-tertiary);
+.stylist-gold-amount {
+  font-size: 1.1rem;
+  font-weight: 800;
+  color: var(--color-primary-soft-gold);
 }
 
-.stylist-summary-value {
-  color: var(--text-primary);
+.stylist-gold-label {
+  font-size: 0.82rem;
   font-weight: 600;
+  color: var(--text-secondary);
 }
 
-.stylist-summary-value.stylist-fee-short {
-  color: var(--danger, #d57f7f);
+.stylist-fee-tag {
+  margin-left: auto;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  background: rgb(176 146 208 / 14%);
+  border: 1px solid rgb(176 146 208 / 22%);
+  white-space: nowrap;
 }
 
+/* ── Race cards ── */
 .stylist-race-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
+  max-height: 50vh;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgb(90 82 120 / 70%) transparent;
 }
 
-.stylist-race-row {
+.stylist-race-list::-webkit-scrollbar { width: 8px; }
+
+.stylist-race-list::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgb(90 82 120 / 70%), rgb(70 90 110 / 65%));
+}
+
+.stylist-race-card {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-3);
+  flex-direction: column;
   padding: 10px 12px;
   border-radius: var(--radius-md);
-  background: rgb(255 255 255 / 3%);
-  border: 1px solid var(--border-subtle);
+  background: rgb(255 255 255 / 4%);
+  border: 1px solid var(--line-faint);
+  transition: background 0.15s, border-color 0.15s;
 }
 
-.stylist-race-info {
+.stylist-race-card:hover {
+  background: rgb(255 255 255 / 7%);
+  border-color: var(--line-soft);
+}
+
+.stylist-race-card-current {
+  border-color: rgb(176 146 208 / 40%);
+  background: rgb(176 146 208 / 8%);
+}
+
+.stylist-race-card-unaffordable {
+  opacity: 0.6;
+}
+
+.stylist-race-card-top {
   display: flex;
-  align-items: center;
-  gap: var(--space-3);
-  flex: 1;
-  min-width: 0;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
 }
 
-.stylist-race-image {
+.stylist-race-card-info {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  min-width: 0;
+  flex: 1;
+}
+
+.stylist-race-thumb {
   width: 48px;
   height: 48px;
   border-radius: var(--radius-sm);
   object-fit: cover;
   flex-shrink: 0;
+  border: 1px solid var(--line-faint);
 }
 
-.stylist-race-text {
+.stylist-race-card-text {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 3px;
   min-width: 0;
 }
 
 .stylist-race-name {
   font-size: 0.92rem;
-  font-weight: 600;
+  font-weight: 700;
   color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
-.stylist-race-current {
-  font-size: 0.78rem;
-  color: var(--text-tertiary);
-  font-weight: 400;
-}
-
-.stylist-race-mods {
-  font-size: 0.78rem;
-  color: var(--text-secondary);
-  font-family: var(--font-mono);
+.stylist-badge-current {
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgb(200 176 232);
+  background: rgb(176 146 208 / 18%);
+  border: 1px solid rgb(176 146 208 / 30%);
+  border-radius: var(--radius-sm);
+  padding: 1px 6px;
 }
 
 .stylist-race-desc {
   font-size: 0.78rem;
-  color: var(--text-tertiary);
+  color: var(--text-secondary);
   line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
-.stylist-change-btn {
+.stylist-race-mods {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 2px;
+}
+
+.stylist-mod-chip {
+  font-size: 0.7rem;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  padding: 1px 5px;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
+.stylist-mod-pos {
+  color: rgb(160 210 140);
+  background: rgb(142 169 123 / 16%);
+}
+
+.stylist-mod-neg {
+  color: rgb(220 140 140);
+  background: rgb(200 120 120 / 14%);
+}
+
+/* ── Card action column ── */
+.stylist-race-card-action {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
   flex-shrink: 0;
-  padding: 6px 12px;
-  border: none;
-  border-radius: var(--radius-sm);
-  font-size: 0.82rem;
-  font-weight: 600;
-  cursor: pointer;
-  background: linear-gradient(135deg, rgb(176 146 208 / 62%), rgb(145 118 180 / 58%));
-  color: #fff;
-  transition: background 0.15s;
 }
 
-.stylist-change-btn:hover:not(:disabled) {
-  background: linear-gradient(135deg, rgb(192 162 224 / 72%), rgb(165 138 200 / 68%));
+.stylist-race-price {
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: var(--color-primary-soft-gold);
+  white-space: nowrap;
 }
 
-.stylist-change-btn:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
+.stylist-race-price-cant {
+  color: var(--text-disabled);
 }
 
-.stylist-empty {
-  text-align: center;
-  color: var(--text-tertiary);
-  font-size: 0.85rem;
-  padding: var(--space-4);
+.soft-button.stylist-change-btn {
+  padding: 4px 14px;
+  font-size: 0.78rem;
+}
+
+.soft-button.stylist-change-btn:not(:disabled) {
+  background: linear-gradient(135deg, rgb(176 146 208 / 70%), rgb(145 118 180 / 66%));
+  border-color: rgb(176 146 208 / 36%);
+}
+
+.soft-button.stylist-change-btn:not(:disabled):hover {
+  background: linear-gradient(135deg, rgb(192 162 224 / 78%), rgb(165 138 200 / 74%));
 }
 
 /* ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Replaces the summary-table + plain-list stylist drawer with a card-based kiosk matching the shop popout pattern
- Gold wallet header with balance and fee-per-change tag
- Race cards with thumbnails, descriptions, color-coded stat mod chips (+green/-red), "CURRENT" badge, affordability dimming, and one-click Change buttons
- Scrollable card list with styled scrollbar, consistent with ShopPopout

## Test plan
- [ ] Visit a stylist room, open the stylist panel — verify wallet shows correct gold and fee
- [ ] Verify all races render as cards with images, descriptions, and stat chips
- [ ] Verify current race is highlighted with purple border and CURRENT badge
- [ ] Verify Change button is disabled for current race
- [ ] With insufficient gold, verify cards are dimmed and Change buttons are disabled
- [ ] Click Change on an affordable race — verify race changes and panel updates
- [ ] Test on mobile viewport — verify cards scroll and layout remains usable