### PR TITLE
Faction reputation: consume Arcanum zone/shop/quest gates and configurable tiers

### DIFF
--- a/src/main/kotlin/dev/ambon/MudServer.kt
+++ b/src/main/kotlin/dev/ambon/MudServer.kt
@@ -208,6 +208,7 @@ class MudServer(
             imagesBaseUrl = config.images.baseUrl,
             videosBaseUrl = config.videos.baseUrl,
             audioBaseUrl = config.audio.baseUrl,
+            factionIds = config.engine.factions.definitions.keys,
         )
     private val worldState = WorldStateRegistry(world)
     private val tickMillis: Long = config.server.tickMillis
@@ -422,6 +423,7 @@ class MudServer(
                             imagesBaseUrl = config.images.baseUrl,
                             videosBaseUrl = config.videos.baseUrl,
                             audioBaseUrl = config.audio.baseUrl,
+                            factionIds = config.engine.factions.definitions.keys,
                         )
                     },
                     reloadChannel = reloadChannel,

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -394,6 +394,24 @@ data class AppConfig(
                 }
             }
         }
+        val tiers = engine.factions.tiers
+        if (tiers != null) {
+            require(tiers.isNotEmpty()) { "ambonMUD.engine.factions.tiers must not be empty when set" }
+            val seenIds = mutableSetOf<String>()
+            for (tier in tiers) {
+                require(tier.id.isNotBlank()) { "ambonMUD.engine.factions.tiers entry has blank id" }
+                require(tier.label.isNotBlank()) { "ambonMUD.engine.factions.tiers['${tier.id}'].label must be non-blank" }
+                require(seenIds.add(tier.id)) {
+                    "ambonMUD.engine.factions.tiers has duplicate id '${tier.id}'"
+                }
+            }
+            val sorted = tiers.sortedBy { it.minReputation }
+            for (i in 1 until sorted.size) {
+                require(sorted[i].minReputation > sorted[i - 1].minReputation) {
+                    "ambonMUD.engine.factions.tiers has duplicate minReputation ${sorted[i].minReputation}"
+                }
+            }
+        }
     }
 
     private fun validateEngineAutoQuests() {
@@ -1058,7 +1076,38 @@ data class FactionConfig(
     val killBonus: Int = 3,
     /** Quest-specific reputation rewards: questId → { factionId → amount }. */
     val questRewards: Map<String, Map<String, Int>> = emptyMap(),
-)
+    /**
+     * Reputation tiers for display and gating. Omit to use [ReputationTier.defaults].
+     * When set, the lowest tier's minReputation acts as a floor (rep is clamped there),
+     * and the highest tier's minReputation is the ceiling.
+     */
+    val tiers: List<ReputationTier>? = null,
+) {
+    /** Resolved tier list — config override, or built-in defaults when none configured. */
+    fun resolvedTiers(): List<ReputationTier> =
+        (tiers?.takeIf { it.isNotEmpty() } ?: ReputationTier.defaults)
+            .sortedBy { it.minReputation }
+}
+
+data class ReputationTier(
+    val id: String = "",
+    val label: String = "",
+    val minReputation: Int = 0,
+) {
+    companion object {
+        /** Arcanum-aligned default tiers. */
+        val defaults: List<ReputationTier> = listOf(
+            ReputationTier("hated", "Hated", -20000),
+            ReputationTier("hostile", "Hostile", -1000),
+            ReputationTier("unfriendly", "Unfriendly", -500),
+            ReputationTier("neutral", "Neutral", 0),
+            ReputationTier("friendly", "Friendly", 250),
+            ReputationTier("honored", "Honored", 1000),
+            ReputationTier("revered", "Revered", 5000),
+            ReputationTier("exalted", "Exalted", 20000),
+        )
+    }
+}
 
 data class RecipeConfigEntry(
     val displayName: String = "",

--- a/src/main/kotlin/dev/ambon/domain/quest/QuestDef.kt
+++ b/src/main/kotlin/dev/ambon/domain/quest/QuestDef.kt
@@ -1,6 +1,7 @@
 package dev.ambon.domain.quest
 
 import dev.ambon.domain.Rewards
+import dev.ambon.domain.world.ReputationRequirement
 
 data class QuestDef(
     val id: String,
@@ -10,6 +11,8 @@ data class QuestDef(
     val objectives: List<QuestObjectiveDef>,
     val rewards: QuestRewards,
     val completionType: String = "auto",
+    /** Optional reputation gate. */
+    val requiredReputation: ReputationRequirement? = null,
 )
 
 data class QuestObjectiveDef(

--- a/src/main/kotlin/dev/ambon/domain/world/ReputationRequirement.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/ReputationRequirement.kt
@@ -1,0 +1,11 @@
+package dev.ambon.domain.world
+
+/**
+ * Runtime reputation gate on shops/quests. [min] and [max] are both optional;
+ * if set, the player's reputation with [faction] must fall in `[min, max]`.
+ */
+data class ReputationRequirement(
+    val faction: String,
+    val min: Int? = null,
+    val max: Int? = null,
+)

--- a/src/main/kotlin/dev/ambon/domain/world/ShopDefinition.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/ShopDefinition.kt
@@ -8,4 +8,6 @@ data class ShopDefinition(
     val name: String,
     val roomId: RoomId,
     val itemIds: List<ItemId>,
+    /** Optional reputation gate on browse/buy. */
+    val requiredReputation: ReputationRequirement? = null,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/WorldFactory.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/WorldFactory.kt
@@ -19,6 +19,7 @@ object WorldFactory {
         imagesBaseUrl: String = "/images/",
         videosBaseUrl: String = "/videos/",
         audioBaseUrl: String = "/audio/",
+        factionIds: Set<String> = emptySet(),
     ): World {
         val paths = resources.ifEmpty { discoverClasspathZones() }
         if (paths.isEmpty()) throw WorldLoadException("No zone files found — classpath 'world/' directory is empty")
@@ -30,6 +31,7 @@ object WorldFactory {
             imagesBaseUrl = imagesBaseUrl,
             videosBaseUrl = videosBaseUrl,
             audioBaseUrl = audioBaseUrl,
+            factionIds = factionIds,
         )
     }
 

--- a/src/main/kotlin/dev/ambon/domain/world/data/QuestFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/QuestFile.kt
@@ -7,6 +7,8 @@ data class QuestFile(
     val completionType: String = "AUTO",
     val objectives: List<QuestObjectiveFile> = emptyList(),
     val rewards: QuestRewardsFile = QuestRewardsFile(),
+    /** Optional reputation gate. min → giver hints to grind; max → quest disappears when exceeded. */
+    val requiredReputation: ReputationRequirementFile? = null,
 )
 
 data class QuestObjectiveFile(

--- a/src/main/kotlin/dev/ambon/domain/world/data/ReputationRequirementFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/ReputationRequirementFile.kt
@@ -1,0 +1,12 @@
+package dev.ambon.domain.world.data
+
+/**
+ * Reputation gate on a shop or quest. [min] and [max] are both optional;
+ * when set, the player's standing with [faction] must fall in the inclusive
+ * `[min, max]` range.
+ */
+data class ReputationRequirementFile(
+    val faction: String = "",
+    val min: Int? = null,
+    val max: Int? = null,
+)

--- a/src/main/kotlin/dev/ambon/domain/world/data/ShopFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/ShopFile.kt
@@ -5,4 +5,6 @@ data class ShopFile(
     val room: String,
     val items: List<String> = emptyList(),
     val image: String? = null,
+    /** Optional reputation gate on browse/buy. */
+    val requiredReputation: ReputationRequirementFile? = null,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/data/WorldFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/WorldFile.kt
@@ -10,6 +10,8 @@ data class WorldFile(
     val pvpEnabled: Boolean = false,
     /** Default terrain type for rooms in this zone (overridable per-room). */
     val terrain: String? = null,
+    /** Controlling faction for this region. Inherited by mobs that don't set their own. */
+    val faction: String? = null,
     val image: ZoneImageDefaults? = null,
     val audio: ZoneAudioDefaults? = null,
     val rooms: Map<String, RoomFile>,

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -41,6 +41,7 @@ import dev.ambon.domain.world.LeverState
 import dev.ambon.domain.world.LockableState
 import dev.ambon.domain.world.MobDrop
 import dev.ambon.domain.world.MobSpawn
+import dev.ambon.domain.world.ReputationRequirement
 import dev.ambon.domain.world.Room
 import dev.ambon.domain.world.RoomFeature
 import dev.ambon.domain.world.ShopDefinition
@@ -49,6 +50,7 @@ import dev.ambon.domain.world.World
 import dev.ambon.domain.world.data.ExitValue
 import dev.ambon.domain.world.data.ExitValueDeserializer
 import dev.ambon.domain.world.data.FeatureFile
+import dev.ambon.domain.world.data.ReputationRequirementFile
 import dev.ambon.domain.world.data.WorldFile
 import dev.ambon.engine.behavior.BehaviorTemplates
 import dev.ambon.engine.behavior.BehaviorTreeLoader
@@ -81,6 +83,7 @@ object WorldLoader {
         imagesBaseUrl: String = "/images/",
         videosBaseUrl: String = "/videos/",
         audioBaseUrl: String = "/audio/",
+        factionIds: Set<String> = emptySet(),
     ): World =
         loadFromResources(
             listOf(path),
@@ -88,6 +91,7 @@ object WorldLoader {
             imagesBaseUrl = imagesBaseUrl,
             videosBaseUrl = videosBaseUrl,
             audioBaseUrl = audioBaseUrl,
+            factionIds = factionIds,
         )
 
     fun loadFromResources(
@@ -98,6 +102,12 @@ object WorldLoader {
         imagesBaseUrl: String = "/images/",
         videosBaseUrl: String = "/videos/",
         audioBaseUrl: String = "/audio/",
+        /**
+         * Known faction IDs from [dev.ambon.config.FactionConfig.definitions]. When non-empty,
+         * references to unknown factions on zones/shops/quests are validated. When empty,
+         * validation is skipped (tests and legacy worlds).
+         */
+        factionIds: Set<String> = emptySet(),
     ): World {
         val imagesBase = normalizeBaseUrl(imagesBaseUrl)
         val videosBase = normalizeBaseUrl(videosBaseUrl)
@@ -164,6 +174,14 @@ object WorldLoader {
             val audioDefaults = file.audio
             val zoneGraphical = file.graphical
             val zoneTerrain = file.terrain?.also { validateTerrain(it, "zone '$zone'") }
+            val zoneFaction = file.faction?.trim()?.takeIf { it.isNotEmpty() }?.also {
+                if (factionIds.isNotEmpty() && it !in factionIds) {
+                    logger.warn(
+                        "Zone '$zone' declares controlling faction '$it' which is not defined in " +
+                            "factions.definitions — treating as no controlling faction",
+                    )
+                }
+            }
             if (file.pvpEnabled) pvpZones.add(zone)
 
             // First pass per file: create room shells, detect collisions
@@ -357,7 +375,7 @@ object WorldLoader {
                         dialogue = dialogue,
                         behaviorTree = behaviorTree,
                         questIds = questIds,
-                        faction = mf.faction,
+                        faction = mf.faction ?: zoneFaction,
                         image = (mf.image ?: imageDefaults?.mob)?.let { "$imagesBase$it" },
                         video = mf.video?.let { "$videosBase$it" },
                         aggressive = mf.behavior?.template?.contains("aggro") == true,
@@ -477,12 +495,18 @@ object WorldLoader {
                         }
                         normalizeItemId(zone, trimmed)
                     }
+                val shopRep = parseReputationRequirement(
+                    shopFile.requiredReputation,
+                    factionIds,
+                    "Shop '$rawId' in zone '$zone'",
+                )
                 mergedShops.add(
                     ShopDefinition(
                         id = qualifyId(zone, rawId),
                         name = shopName,
                         roomId = shopRoomId,
                         itemIds = shopItemIds,
+                        requiredReputation = shopRep,
                     ),
                 )
             }
@@ -551,6 +575,11 @@ object WorldLoader {
                             description = obj.description.ifBlank { "$objectiveType $targetKeyRaw x${obj.count}" },
                         )
                     }
+                val questRep = parseReputationRequirement(
+                    questFile.requiredReputation,
+                    factionIds,
+                    "Quest '$questId'",
+                )
                 mergedQuests.add(
                     QuestDef(
                         id = questId,
@@ -564,6 +593,7 @@ object WorldLoader {
                             currencies = questFile.rewards.currencies,
                         ),
                         completionType = completionType,
+                        requiredReputation = questRep,
                     ),
                 )
             }
@@ -1336,6 +1366,29 @@ object WorldLoader {
         val id = raw.trim().lowercase()
         if (id.isEmpty()) throw WorldLoadException("$context crafting skill cannot be blank")
         return id
+    }
+
+    private fun parseReputationRequirement(
+        raw: ReputationRequirementFile?,
+        factionIds: Set<String>,
+        context: String,
+    ): ReputationRequirement? {
+        if (raw == null) return null
+        val faction = raw.faction.trim()
+        if (faction.isEmpty()) {
+            throw WorldLoadException("$context requiredReputation.faction cannot be blank")
+        }
+        if (factionIds.isNotEmpty() && faction !in factionIds) {
+            throw WorldLoadException(
+                "$context requiredReputation.faction '$faction' is not defined in factions.definitions",
+            )
+        }
+        if (raw.min != null && raw.max != null && raw.min > raw.max) {
+            throw WorldLoadException(
+                "$context requiredReputation.min (${raw.min}) must be <= max (${raw.max})",
+            )
+        }
+        return ReputationRequirement(faction = faction, min = raw.min, max = raw.max)
     }
 
     private val VALID_TERRAINS = setOf(

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -857,6 +857,7 @@ class GameEngine(
             items = items,
             outbound = outbound,
             clock = clock,
+            reputationSystem = reputationSystem,
         )
 
     private val dailyQuestSystem: DailyQuestSystem? =
@@ -935,7 +936,7 @@ class GameEngine(
                         OutboundEvent.SendInfo(
                             sid,
                             "[Reputation] $factionName: $sign${change.amount} " +
-                                "(${StandingTier.forReputation(change.newStanding).displayName})",
+                                "(${reputationSystem.tierLabel(change.newStanding)})",
                         ),
                     )
                 }
@@ -1153,6 +1154,7 @@ class GameEngine(
                 shopRegistry = shopRegistry,
                 markVitalsDirty = ::markVitalsDirty,
                 economyConfig = engineConfig.economy,
+                reputationSystem = reputationSystem,
             ),
             CraftingHandler(
                 ctx = ctx,
@@ -2285,7 +2287,7 @@ class GameEngine(
                         OutboundEvent.SendInfo(
                             sessionId,
                             "[Reputation] $factionName: $sign${change.amount} " +
-                                "(${StandingTier.forReputation(change.newStanding).displayName})",
+                                "(${reputationSystem.tierLabel(change.newStanding)})",
                         ),
                     )
                 }
@@ -2385,7 +2387,7 @@ class GameEngine(
                     id = factionId,
                     name = definitions[factionId]?.name ?: factionId,
                     reputation = reputation,
-                    tier = StandingTier.forReputation(reputation).displayName,
+                    tier = reputationSystem.tierLabel(reputation),
                 )
             },
         )

--- a/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
@@ -22,6 +22,7 @@ class QuestSystem(
     private val clock: Clock = Clock.systemUTC(),
     private val objectiveHandlers: ObjectiveHandlerRegistry = ObjectiveHandlerRegistry.withDefaults(),
     private val completionHandlers: CompletionHandlerRegistry = CompletionHandlerRegistry.withDefaults(),
+    private val reputationSystem: ReputationSystem? = null,
 ) {
     /** Invoked after a quest is successfully completed; used by AchievementSystem. */
     var onQuestCompleted: (suspend (SessionId, String) -> Unit)? = null
@@ -32,8 +33,11 @@ class QuestSystem(
     var onQuestCompletedGmcp: (suspend (SessionId, String, String) -> Unit)? = null
 
     /**
-     * Returns quests offered by this mob that the player can accept
-     * (not already active, not already completed).
+     * Returns quests offered by this mob that the player can accept.
+     *
+     * Excludes quests already active, already completed, whose reputation ceiling
+     * has been exceeded (quest "disappears"), or whose reputation floor is unmet
+     * (surfaced via [hintedQuests] instead so the giver can acknowledge them).
      */
     fun availableQuests(
         sessionId: SessionId,
@@ -41,17 +45,53 @@ class QuestSystem(
     ): List<QuestDef> {
         val ps = players.get(sessionId) ?: return emptyList()
         return registry.questsForMob(mobId).filter { quest ->
-            !ps.activeQuests.containsKey(quest.id) && !ps.completedQuestIds.contains(quest.id)
+            isAcceptable(ps, quest)
         }
+    }
+
+    /**
+     * Quests the giver knows about but the player can't yet accept because a
+     * reputation `min` is unmet. Used to hint at gated content rather than
+     * leaving the player wondering why it isn't appearing.
+     */
+    fun hintedQuests(
+        sessionId: SessionId,
+        mobId: String,
+    ): List<QuestDef> {
+        val ps = players.get(sessionId) ?: return emptyList()
+        return registry.questsForMob(mobId).filter { quest ->
+            if (ps.activeQuests.containsKey(quest.id) || ps.completedQuestIds.contains(quest.id)) return@filter false
+            if (exceedsRepMax(ps, quest)) return@filter false
+            belowRepMin(ps, quest)
+        }
+    }
+
+    private fun isAcceptable(ps: PlayerState, quest: QuestDef): Boolean {
+        if (ps.activeQuests.containsKey(quest.id) || ps.completedQuestIds.contains(quest.id)) return false
+        if (exceedsRepMax(ps, quest)) return false
+        if (belowRepMin(ps, quest)) return false
+        return true
+    }
+
+    private fun belowRepMin(ps: PlayerState, quest: QuestDef): Boolean {
+        val req = quest.requiredReputation ?: return false
+        val min = req.min ?: return false
+        val rep = reputationSystem ?: return false
+        return rep.getStanding(ps, req.faction) < min
+    }
+
+    private fun exceedsRepMax(ps: PlayerState, quest: QuestDef): Boolean {
+        val req = quest.requiredReputation ?: return false
+        val max = req.max ?: return false
+        val rep = reputationSystem ?: return false
+        return rep.getStanding(ps, req.faction) > max
     }
 
     /** Returns mob IDs that offer quests the player can accept. */
     fun questAvailableMobIds(sessionId: SessionId, mobIds: Collection<String>): Set<String> {
         val ps = players.get(sessionId) ?: return emptySet()
         return mobIds.filterTo(mutableSetOf()) { mobId ->
-            registry.questsForMob(mobId).any { quest ->
-                !ps.activeQuests.containsKey(quest.id) && !ps.completedQuestIds.contains(quest.id)
-            }
+            registry.questsForMob(mobId).any { quest -> isAcceptable(ps, quest) }
         }
     }
 
@@ -78,6 +118,14 @@ class QuestSystem(
         val quest = registry.get(questId) ?: return "Unknown quest '$questId'."
         if (ps.activeQuests.containsKey(questId)) return "You are already on that quest."
         if (ps.completedQuestIds.contains(questId)) return "You have already completed that quest."
+        if (exceedsRepMax(ps, quest)) {
+            return "You are too well-regarded for this quest."
+        }
+        if (belowRepMin(ps, quest)) {
+            val req = quest.requiredReputation!!
+            val factionName = reputationSystem?.getFaction(req.faction)?.name ?: req.faction
+            return "You lack the standing with $factionName to take this quest."
+        }
 
         val state =
             QuestState(

--- a/src/main/kotlin/dev/ambon/engine/ReputationSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/ReputationSystem.kt
@@ -2,45 +2,35 @@ package dev.ambon.engine
 
 import dev.ambon.config.FactionConfig
 import dev.ambon.config.FactionDefinition
+import dev.ambon.config.ReputationTier
 import io.github.oshai.kotlinlogging.KotlinLogging
 
 private val log = KotlinLogging.logger {}
 
-/** Standing tier for display purposes. [minRep] is the inclusive lower bound. */
-enum class StandingTier(
-    val displayName: String,
-    val minRep: Int,
-) {
-    HATED("Hated", Int.MIN_VALUE),
-    HOSTILE("Hostile", -1000),
-    UNFRIENDLY("Unfriendly", -500),
-    NEUTRAL("Neutral", -100),
-    FRIENDLY("Friendly", 100),
-    HONORED("Honored", 500),
-    REVERED("Revered", 1000),
-    ;
-
-    companion object {
-        private val descending = entries.sortedByDescending { it.minRep }
-
-        fun forReputation(rep: Int): StandingTier =
-            descending.first { rep >= it.minRep }
-    }
-}
-
 /**
  * Manages per-player faction standings and reputation changes.
  *
- * Standings range from -1000 (Hated) to +1000 (Revered).
+ * Tier bands and default thresholds come from [FactionConfig.resolvedTiers].
  * Changes occur on mob kills (based on mob's faction) and quest completion
  * (based on quest reward config).
  */
 class ReputationSystem(
     private val config: FactionConfig,
 ) {
+    private val tiers: List<ReputationTier> = config.resolvedTiers()
+    private val repFloor: Int = tiers.first().minReputation
+    private val repCeiling: Int = tiers.last().minReputation
+
     fun factionDefinitions(): Map<String, FactionDefinition> = config.definitions
 
     fun getFaction(id: String): FactionDefinition? = config.definitions[id]
+
+    /** Resolves the reputation tier for a raw reputation value. */
+    fun tierFor(reputation: Int): ReputationTier =
+        tiers.lastOrNull { it.minReputation <= reputation } ?: tiers.first()
+
+    /** Tier display label for a raw reputation value. */
+    fun tierLabel(reputation: Int): String = tierFor(reputation).label
 
     /** Returns the player's standing with a faction (default 0). */
     fun getStanding(player: PlayerState, factionId: String): Int =
@@ -61,7 +51,7 @@ class ReputationSystem(
     ): Int? {
         if (factionId !in config.definitions) return null
         val current = player.factionStandings.getOrDefault(factionId, config.defaultReputation)
-        val newValue = (current + amount).coerceIn(-1000, 1000)
+        val newValue = (current + amount).coerceIn(repFloor, repCeiling)
         player.factionStandings[factionId] = newValue
         if (amount != 0) {
             log.debug { "Reputation change for ${player.name}: $factionId ${if (amount > 0) "+" else ""}$amount → $newValue" }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestHandler.kt
@@ -62,6 +62,14 @@ class DialogueQuestHandler(
                     outbound.send(OutboundEvent.SendText(sessionId, "[Quest] ${quest.name} — ${quest.description}"))
                     outbound.send(OutboundEvent.SendText(sessionId, "  Type 'accept ${quest.name}' to accept."))
                 }
+                for (quest in questSystem.hintedQuests(sessionId, mob.id.value)) {
+                    outbound.send(
+                        OutboundEvent.SendText(
+                            sessionId,
+                            "[Quest] ${quest.name} — your standing is too low to take this on yet.",
+                        ),
+                    )
+                }
                 gmcpEmitter?.sendQuestAvailable(
                     sessionId,
                     available.map { quest ->

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ReputationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ReputationHandler.kt
@@ -3,7 +3,6 @@ package dev.ambon.engine.commands.handlers
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.GmcpEmitter
 import dev.ambon.engine.ReputationSystem
-import dev.ambon.engine.StandingTier
 import dev.ambon.engine.commands.Command
 import dev.ambon.engine.commands.CommandHandler
 import dev.ambon.engine.commands.CommandRouter
@@ -51,11 +50,11 @@ class ReputationHandler(
             )
             for ((factionId, reputation) in standings) {
                 val def = definitions[factionId] ?: continue
-                val tier = StandingTier.forReputation(reputation)
+                val tierLabel = reputationSystem.tierLabel(reputation)
                 outbound.send(
                     OutboundEvent.SendInfo(
                         sessionId,
-                        "  %-20s %+8d  %-12s".format(def.name, reputation, tier.displayName),
+                        "  %-20s %+8d  %-12s".format(def.name, reputation, tierLabel),
                     ),
                 )
             }
@@ -85,7 +84,7 @@ class ReputationHandler(
                 id = factionId,
                 name = def?.name ?: factionId,
                 reputation = reputation,
-                tier = StandingTier.forReputation(reputation).displayName,
+                tier = reputationSystem.tierLabel(reputation),
             )
         }
         gmcpEmitter?.sendCharFactions(sessionId, payload)

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ShopHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ShopHandler.kt
@@ -2,8 +2,10 @@ package dev.ambon.engine.commands.handlers
 
 import dev.ambon.config.EconomyConfig
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.world.ReputationRequirement
 import dev.ambon.domain.world.ShopDefinition
 import dev.ambon.engine.PlayerState
+import dev.ambon.engine.ReputationSystem
 import dev.ambon.engine.ShopRegistry
 import dev.ambon.engine.commands.Command
 import dev.ambon.engine.commands.CommandHandler
@@ -18,6 +20,7 @@ class ShopHandler(
     private val shopRegistry: ShopRegistry? = null,
     private val markVitalsDirty: (SessionId) -> Unit = {},
     private val economyConfig: EconomyConfig = EconomyConfig(),
+    private val reputationSystem: ReputationSystem? = null,
 ) : CommandHandler {
     private val players = ctx.players
     private val items = ctx.items
@@ -47,9 +50,53 @@ class ShopHandler(
         return shop
     }
 
+    /**
+     * Enforces the shop's reputation gate. Returns true when the player may proceed.
+     * On refusal, sends a tier-aware error message and GMCP feedback.
+     */
+    private suspend fun checkReputationGate(
+        sessionId: SessionId,
+        me: PlayerState,
+        shop: ShopDefinition,
+        command: String,
+    ): Boolean {
+        val req = shop.requiredReputation ?: return true
+        val rep = reputationSystem ?: return true
+        if (me.isStaff) return true
+        val standing = rep.getStanding(me, req.faction)
+        val factionName = rep.getFaction(req.faction)?.name ?: req.faction
+        val tierLabel = rep.tierLabel(standing)
+        return when {
+            req.min != null && standing < req.min -> {
+                refuse(sessionId, shop, req, factionName, tierLabel, command, code = "REPUTATION_TOO_LOW")
+                false
+            }
+            req.max != null && standing > req.max -> {
+                refuse(sessionId, shop, req, factionName, tierLabel, command, code = "REPUTATION_TOO_HIGH")
+                false
+            }
+            else -> true
+        }
+    }
+
+    private suspend fun refuse(
+        sessionId: SessionId,
+        shop: ShopDefinition,
+        @Suppress("UNUSED_PARAMETER") req: ReputationRequirement,
+        factionName: String,
+        tierLabel: String,
+        command: String,
+        code: String,
+    ) {
+        val msg = "${shop.name} refuses to deal with you — $tierLabel standing with $factionName is not welcome here."
+        outbound.send(OutboundEvent.SendError(sessionId, msg))
+        gmcpEmitter?.sendUiFeedback(sessionId, "error", msg, code = code, scope = "shop", command = command)
+    }
+
     private suspend fun handleShopList(sessionId: SessionId) {
         players.withPlayer(sessionId) { me ->
             val shop = findShop(sessionId, me, command = "list") ?: return
+            if (!checkReputationGate(sessionId, me, shop, command = "list")) return
             val shopItems = shopRegistry!!.shopItems(shop)
             if (shopItems.isEmpty()) {
                 outbound.send(OutboundEvent.SendInfo(sessionId, "${shop.name} has nothing for sale."))
@@ -77,6 +124,7 @@ class ShopHandler(
     ) {
         players.withPlayer(sessionId) { me ->
             val shop = findShop(sessionId, me, command = "buy") ?: return
+            if (!checkReputationGate(sessionId, me, shop, command = "buy")) return
             val shopItems = shopRegistry!!.shopItems(shop)
             val match =
                 shopItems.firstOrNull { (_, item) -> item.matchesKeyword(cmd.keyword) }
@@ -115,7 +163,8 @@ class ShopHandler(
         cmd: Command.Sell,
     ) {
         players.withPlayer(sessionId) { me ->
-            findShop(sessionId, me, command = "sell") ?: return
+            val shop = findShop(sessionId, me, command = "sell") ?: return
+            if (!checkReputationGate(sessionId, me, shop, command = "sell")) return
             val keyword = cmd.keyword
             val inv = items.inventory(sessionId)
             val invItem = inv.firstOrNull { it.matchesKeyword(keyword) }

--- a/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
+++ b/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
@@ -117,6 +117,7 @@ class EngineServer(
             imagesBaseUrl = config.images.baseUrl,
             videosBaseUrl = config.videos.baseUrl,
             audioBaseUrl = config.audio.baseUrl,
+            factionIds = config.engine.factions.definitions.keys,
         )
     private val scheduler: Scheduler = Scheduler(clock)
     private val localZones = ServerInfrastructure.resolveLocalZones(config, configuredShardedZones, world)

--- a/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
@@ -1,6 +1,8 @@
 package dev.ambon.engine
 
 import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.config.FactionConfig
+import dev.ambon.config.FactionDefinition
 import dev.ambon.domain.ids.ItemId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.items.Item
@@ -8,6 +10,7 @@ import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.quest.QuestDef
 import dev.ambon.domain.quest.QuestObjectiveDef
 import dev.ambon.domain.quest.QuestRewards
+import dev.ambon.domain.world.ReputationRequirement
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.test.SystemTestComponents
 import dev.ambon.test.drainAll
@@ -149,6 +152,76 @@ class QuestSystemTest {
 
             val err = qs.abandonQuest(sid, "NoSuchQuest")
             assertNotNull(err, "Expected error for unknown quest")
+        }
+
+    private fun gatedSetup(
+        requirement: ReputationRequirement,
+        startingRep: Int,
+    ): Triple<QuestSystem, PlayerRegistry, SessionId> {
+        val factionConfig = FactionConfig(
+            definitions = mapOf(
+                "royal_court" to FactionDefinition(name = "Royal Court", description = ""),
+            ),
+        )
+        val c = SystemTestComponents(clockInitialMs = 1_000L)
+        val gatedQuest = killQuest.copy(id = "zone:gated_quest", name = "Gated", requiredReputation = requirement)
+        val registry = QuestRegistry().also { it.register(gatedQuest) }
+        val repSystem = ReputationSystem(factionConfig)
+        val qs = QuestSystem(
+            registry = registry,
+            players = c.players,
+            items = c.items,
+            outbound = c.outbound,
+            clock = c.clock,
+            reputationSystem = repSystem,
+        )
+        val sid = SessionId(1L)
+        kotlinx.coroutines.runBlocking { c.players.loginOrFail(sid, "Hero") }
+        val ps = c.players.get(sid)!!
+        ps.factionStandings["royal_court"] = startingRep
+        return Triple(qs, c.players, sid)
+    }
+
+    @Test
+    fun `quest with max rep exceeded disappears from availableQuests`() =
+        runTest {
+            val (qs, _, sid) = gatedSetup(
+                ReputationRequirement(faction = "royal_court", max = -500),
+                startingRep = 0,
+            )
+            val available = qs.availableQuests(sid, "zone:quest_giver")
+            assertTrue(available.none { it.id == "zone:gated_quest" })
+            val hints = qs.hintedQuests(sid, "zone:quest_giver")
+            assertTrue(hints.isEmpty(), "max-exceeded quests should not appear as hints either")
+        }
+
+    @Test
+    fun `quest with min rep unmet is hinted but not acceptable`() =
+        runTest {
+            val (qs, _, sid) = gatedSetup(
+                ReputationRequirement(faction = "royal_court", min = 250),
+                startingRep = 0,
+            )
+            val available = qs.availableQuests(sid, "zone:quest_giver")
+            assertTrue(available.none { it.id == "zone:gated_quest" })
+            val hints = qs.hintedQuests(sid, "zone:quest_giver")
+            assertEquals(1, hints.size)
+            val err = qs.acceptQuest(sid, "zone:gated_quest")
+            assertNotNull(err)
+            assertTrue(err!!.contains("Royal Court"), "Error message should surface faction name: $err")
+        }
+
+    @Test
+    fun `quest with met reputation is acceptable`() =
+        runTest {
+            val (qs, _, sid) = gatedSetup(
+                ReputationRequirement(faction = "royal_court", min = 250),
+                startingRep = 300,
+            )
+            val available = qs.availableQuests(sid, "zone:quest_giver")
+            assertEquals(1, available.size)
+            val err = qs.acceptQuest(sid, "zone:gated_quest")
+            assertNull(err)
         }
 
     @Test

--- a/src/test/kotlin/dev/ambon/engine/ReputationSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/ReputationSystemTest.kt
@@ -2,6 +2,7 @@ package dev.ambon.engine
 
 import dev.ambon.config.FactionConfig
 import dev.ambon.config.FactionDefinition
+import dev.ambon.config.ReputationTier
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -65,12 +66,13 @@ class ReputationSystemTest {
         }
 
         @Test
-        fun `standing clamped to -1000 to 1000`() {
-            rep.adjustStanding(player, "guild_a", 2000)
-            assertEquals(1000, rep.getStanding(player, "guild_a"))
+        fun `standing clamped to tier bounds`() {
+            // Arcanum-aligned defaults: floor -20000 (hated), ceiling 20000 (exalted)
+            rep.adjustStanding(player, "guild_a", 100_000)
+            assertEquals(20_000, rep.getStanding(player, "guild_a"))
 
-            rep.adjustStanding(player, "guild_b", -3000)
-            assertEquals(-1000, rep.getStanding(player, "guild_b"))
+            rep.adjustStanding(player, "guild_b", -100_000)
+            assertEquals(-20_000, rep.getStanding(player, "guild_b"))
         }
 
         @Test
@@ -91,15 +93,32 @@ class ReputationSystemTest {
     @Nested
     inner class StandingTiers {
         @Test
-        fun `tier for various reputation values`() {
-            assertEquals(StandingTier.NEUTRAL, StandingTier.forReputation(0))
-            assertEquals(StandingTier.NEUTRAL, StandingTier.forReputation(-100))
-            assertEquals(StandingTier.FRIENDLY, StandingTier.forReputation(100))
-            assertEquals(StandingTier.HONORED, StandingTier.forReputation(500))
-            assertEquals(StandingTier.REVERED, StandingTier.forReputation(1000))
-            assertEquals(StandingTier.UNFRIENDLY, StandingTier.forReputation(-500))
-            assertEquals(StandingTier.HOSTILE, StandingTier.forReputation(-1000))
-            assertEquals(StandingTier.HATED, StandingTier.forReputation(-1001))
+        fun `default tier labels match Arcanum spec`() {
+            assertEquals("Neutral", rep.tierLabel(0))
+            assertEquals("Neutral", rep.tierLabel(249))
+            assertEquals("Friendly", rep.tierLabel(250))
+            assertEquals("Honored", rep.tierLabel(1000))
+            assertEquals("Revered", rep.tierLabel(5000))
+            assertEquals("Exalted", rep.tierLabel(20_000))
+            assertEquals("Unfriendly", rep.tierLabel(-500))
+            assertEquals("Hostile", rep.tierLabel(-1000))
+            assertEquals("Hated", rep.tierLabel(-20_000))
+        }
+
+        @Test
+        fun `config override replaces default tiers`() {
+            val overrideConfig = config.copy(
+                tiers = listOf(
+                    ReputationTier("low", "Shunned", -100),
+                    ReputationTier("mid", "Known", 0),
+                    ReputationTier("high", "Champion", 100),
+                ),
+            )
+            val overriden = ReputationSystem(overrideConfig)
+            assertEquals("Shunned", overriden.tierLabel(-100))
+            assertEquals("Known", overriden.tierLabel(0))
+            assertEquals("Champion", overriden.tierLabel(100))
+            assertEquals("Champion", overriden.tierLabel(10_000))
         }
     }
 

--- a/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
@@ -683,6 +683,50 @@ class WorldLoaderTest {
     }
 
     @Test
+    fun `zone faction propagates to mobs that lack their own`() {
+        val world = WorldLoader.loadFromResource("world/ok_faction_gates.yaml")
+        val mobs = world.mobSpawns.associateBy { it.id.value }
+        assertEquals("royal_court", mobs.getValue("ok_faction_gates:inheritor").faction)
+        assertEquals("rebel_cell", mobs.getValue("ok_faction_gates:dissenter").faction)
+    }
+
+    @Test
+    fun `loads shop and quest reputation requirements`() {
+        val world = WorldLoader.loadFromResource("world/ok_faction_gates.yaml")
+        val shop = world.shopDefinitions.single { it.id == "ok_faction_gates:court_armorer" }
+        assertEquals("royal_court", shop.requiredReputation?.faction)
+        assertEquals(250, shop.requiredReputation?.min)
+        assertNull(shop.requiredReputation?.max)
+
+        val quest = world.questDefinitions.single { it.id == "ok_faction_gates:rebel_mission" }
+        assertEquals("rebel_cell", quest.requiredReputation?.faction)
+        assertEquals(-500, quest.requiredReputation?.max)
+        assertNull(quest.requiredReputation?.min)
+    }
+
+    @Test
+    fun `shop requiredReputation with unknown faction is rejected`() {
+        val ex =
+            assertThrows(WorldLoadException::class.java) {
+                WorldLoader.loadFromResource(
+                    "world/bad_shop_rep_unknown_faction.yaml",
+                    factionIds = setOf("royal_court"),
+                )
+            }
+        assertTrue(ex.message!!.contains("no_such_faction"), "Got: ${ex.message}")
+    }
+
+    @Test
+    fun `quest requiredReputation with min greater than max is rejected`() {
+        val ex =
+            assertThrows(WorldLoadException::class.java) {
+                WorldLoader.loadFromResource("world/bad_quest_rep_invalid_range.yaml")
+            }
+        assertTrue(ex.message!!.contains("min"), "Got: ${ex.message}")
+        assertTrue(ex.message!!.contains("max"), "Got: ${ex.message}")
+    }
+
+    @Test
     fun `loads mob with dialogue tree`() {
         val world = WorldLoader.loadFromResource("world/ok_dialogue.yaml")
         val mob = world.mobSpawns.single()

--- a/src/test/resources/world/bad_quest_rep_invalid_range.yaml
+++ b/src/test/resources/world/bad_quest_rep_invalid_range.yaml
@@ -1,0 +1,29 @@
+zone: bad_quest_rep
+startRoom: square
+mobs:
+  giver:
+    name: "a quest giver"
+    description: "He hands out impossible quests."
+    room: square
+  target:
+    name: "a target"
+    description: "Stands still."
+    room: square
+quests:
+  impossible:
+    name: "Impossible"
+    giver: giver
+    objectives:
+      - type: kill
+        targetKey: target
+        count: 1
+        description: "Kill the target."
+    requiredReputation:
+      faction: royal_court
+      min: 500
+      max: 100
+rooms:
+  square:
+    title: "Square"
+    description: "A square."
+    exits: {}

--- a/src/test/resources/world/bad_shop_rep_unknown_faction.yaml
+++ b/src/test/resources/world/bad_shop_rep_unknown_faction.yaml
@@ -1,0 +1,21 @@
+zone: bad_shop_rep
+startRoom: market
+items:
+  sword:
+    displayName: "a sword"
+    keyword: sword
+    basePrice: 50
+shops:
+  gated:
+    name: "Gated Shop"
+    room: market
+    items:
+      - sword
+    requiredReputation:
+      faction: no_such_faction
+      min: 100
+rooms:
+  market:
+    title: "Market"
+    description: "A market."
+    exits: {}

--- a/src/test/resources/world/ok_faction_gates.yaml
+++ b/src/test/resources/world/ok_faction_gates.yaml
@@ -1,0 +1,46 @@
+zone: ok_faction_gates
+startRoom: plaza
+faction: royal_court
+items:
+  blade:
+    displayName: "a court blade"
+    keyword: blade
+    slot: weapon
+    damage: 5
+    basePrice: 100
+shops:
+  court_armorer:
+    name: "Court Armorer"
+    room: plaza
+    items:
+      - blade
+    requiredReputation:
+      faction: royal_court
+      min: 250
+mobs:
+  inheritor:
+    name: "a loyal guard"
+    description: "A guard with no explicit faction."
+    room: plaza
+  dissenter:
+    name: "a rogue agent"
+    description: "A guard overriding the zone faction."
+    room: plaza
+    faction: rebel_cell
+quests:
+  rebel_mission:
+    name: "Infiltrate the Rebels"
+    giver: inheritor
+    objectives:
+      - type: kill
+        targetKey: dissenter
+        count: 1
+        description: "Eliminate the rogue agent."
+    requiredReputation:
+      faction: rebel_cell
+      max: -500
+rooms:
+  plaza:
+    title: "Royal Plaza"
+    description: "A grand plaza."
+    exits: {}


### PR DESCRIPTION
## Summary
- Adds optional `tiers` list to `FactionConfig` with Arcanum-aligned defaults (Hated/Hostile/Unfriendly/Neutral/Friendly/Honored/Revered/Exalted at -20k/-1k/-500/0/250/1k/5k/20k). `ReputationSystem` now looks up tier label + clamp bounds from the resolved list; hardcoded `StandingTier` enum is gone.
- World YAML honors three new optional fields: zone-level `faction` (mobs without their own faction inherit it), `shops.<id>.requiredReputation { faction, min?, max? }` (gates browse/buy/sell with a tier-aware refusal message), and `quests.<id>.requiredReputation { faction, min?, max? }` (max-exceeded quests disappear from the giver's offer list; min-unmet quests show as a giver hint and refuse `accept`).
- `WorldLoader` takes an optional `factionIds` set (threaded from `FactionConfig.definitions` via `WorldFactory` → `MudServer`/`EngineServer`). Unknown faction refs on shops/quests are rejected, unknown zone faction logs a warning, and `min > max` is rejected.

## Test plan
- [x] `./gradlew ktlintCheck test` — clean
- [x] New coverage: tier config override, mob zone-faction inheritance, shop/quest rep gating in `QuestSystem`, `WorldLoader` validation of unknown factions and invalid min/max ranges
- [ ] Smoke-test against an Arcanum-authored world that sets `zone.faction` + shop/quest rep gates
- [ ] Confirm legacy worlds (no new fields) still load unchanged

## Notes for reviewer
Companion to the Arcanum factions & reputation PR. Extra YAML fields Arcanum already writes are now load-bearing on the server side; worlds without them round-trip identically.