### PR TITLE
Fix admin token ExecStartPre writing /bin/bash to secrets.env

### DIFF
--- a/infra/lib/ec2-stack.ts
+++ b/infra/lib/ec2-stack.ts
@@ -537,7 +537,11 @@ export class Ec2Stack extends Stack {
       // than launch with a broken/missing admin token.
       ...(adminTokenSsmParameterName
         ? [
-            `ExecStartPre=/bin/bash -c 'mkdir -p /etc/ambonmud && umask 077 && token=$(aws ssm get-parameter --name ${adminTokenSsmParameterName} --with-decryption --query Parameter.Value --output text --region ${this.region}) && printf "AMBONMUD_ADMIN_TOKEN=%s\\n" "$token" > /etc/ambonmud/secrets.env'`,
+            // %%s escapes systemd's specifier expansion — bare %s gets replaced
+            // with the service user's login shell (/bin/bash for root) before
+            // bash ever sees it, which silently eats the $token argument and
+            // writes AMBONMUD_ADMIN_TOKEN=/bin/bash to secrets.env.
+            `ExecStartPre=/bin/bash -c 'set -euo pipefail; mkdir -p /etc/ambonmud; umask 077; token=$(aws ssm get-parameter --name ${adminTokenSsmParameterName} --with-decryption --query Parameter.Value --output text --region ${this.region}); test -n "$token"; printf "AMBONMUD_ADMIN_TOKEN=%%s\\n" "$token" > /etc/ambonmud/secrets.env'`,
           ]
         : []),
       // Generate htpasswd for nginx basic auth on /grafana/, /prometheus/, /admin/.


### PR DESCRIPTION
## Summary
- The admin-token SSM ExecStartPre in `Ec2Stack` used `printf "AMBONMUD_ADMIN_TOKEN=%s\n"` — but `%s` is a systemd specifier that expands to the service user's login shell (`/bin/bash` for root) before bash ever sees it. Result: `secrets.env` contained `AMBONMUD_ADMIN_TOKEN=/bin/bash` and the container refused to start with *"ambonMUD.admin.token must be non-blank"*. Nginx basic-auth on `/admin/`, `/grafana/`, `/prometheus/` accepted the literal password `/bin/bash` until htpasswd was regenerated.
- Escape `%s` as `%%s` so the literal reaches printf.
- Also add `set -euo pipefail` and `test -n "$token"` so a future AWS CLI failure or empty parameter fails the unit loudly instead of silently writing garbage.

## Test plan
- [ ] CDK typecheck passes (`tsc --noEmit`) — done locally
- [ ] Deploy the stack (or SSM-exec the fixed command manually) and verify `/etc/ambonmud/secrets.env` contains the real token value, not `/bin/bash`
- [ ] Confirm `ambonmud.service` starts cleanly and the admin API accepts the token
- [ ] Browser login at `https://<HOSTNAME>/admin/` with `admin` / `<SSM token>` succeeds