### PR TITLE
Write nginx + TLS config before starting ambonmud

### DIFF
--- a/infra/lib/ec2-stack.ts
+++ b/infra/lib/ec2-stack.ts
@@ -563,19 +563,23 @@ export class Ec2Stack extends Stack {
       '',
       'systemctl daemon-reload',
       'systemctl enable ambonmud prometheus grafana',
-      'systemctl start ambonmud prometheus grafana',
     );
 
     // -------------------------------------------------------------------------
     // Optional nginx + TLS setup (when hostname is provided).
     //
-    // Installs nginx and certbot, writes an nginx reverse-proxy config that
-    // handles both HTTP and WebSocket connections, and installs a `setup-tls`
-    // helper that the operator runs once (via SSM) after DNS is live:
-    //   setup-tls
+    // Writes the nginx reverse-proxy config and the `setup-tls` helper that
+    // provisions a Let's Encrypt cert via HTTP-01 once DNS is live.
     //
-    // certbot uses HTTP-01 challenge so nginx must be running and reachable on
-    // port 80 before running setup-tls.
+    // Ordering note: this block runs BEFORE `systemctl start ambonmud` on
+    // purpose. If ambonmud's ExecStartPre chain takes a long time (e.g. the
+    // fetch-world-zones retry loop when R2 is slow or a URL is misconfigured)
+    // the `systemctl start ambonmud` call can exceed cloud-init's default
+    // scripts-user timeout, which aborts the rest of userData. When that
+    // happened before this reorder, the nginx config and setup-tls helper
+    // were never written and the operator had to recreate them by hand.
+    // Writing these files first guarantees that even a wedged first boot
+    // leaves the instance configurable.
     // -------------------------------------------------------------------------
     if (hostname) {
       userData.addCommands(
@@ -705,6 +709,13 @@ export class Ec2Stack extends Stack {
         'systemctl start --no-block setup-tls',
       );
     }
+
+    // Start ambonmud last, with --no-block. If its ExecStartPre chain is slow
+    // (world zone fetches hitting R2 retries, cert fetch from SSM, etc.) a
+    // blocking start can exceed cloud-init's scripts-user timeout and abort
+    // all subsequent userData. The service has Restart=always so systemd will
+    // keep retrying if anything in the startup chain fails transiently.
+    userData.addCommands('systemctl start --no-block ambonmud prometheus grafana');
 
     // -------------------------------------------------------------------------
     // EC2 instance: t4g.micro — ARM64, 2 vCPU (burstable) / 1 GB RAM.


### PR DESCRIPTION
## Summary
- If ambonmud's ExecStartPre chain is slow (fetch-world-zones retry loop against a misconfigured R2 URL, SSM fetch against an unreadable parameter, etc.), `systemctl start ambonmud` in userData exceeds cloud-init's scripts-user timeout and aborts the rest of userData. Result: nginx.conf and setup-tls are never written, and the operator has to recreate them by hand over SSM.
- Move the `if (hostname)` block that writes nginx.conf + setup-tls to run BEFORE `systemctl start ambonmud`. File writes are cheap and should not be gated on the MUD service starting cleanly.
- Also add `--no-block` to the ambonmud start so a slow first-boot ExecStartPre no longer stalls cloud-init. systemd's Restart=always retries the service on its own, and setup-tls.service orders itself after ambonmud via `After=`.

## Background

Hit this live on 2026-04-15 while recovering a demo instance. Cloud-init log showed:

```
Job for ambonmud.service failed because a timeout was exceeded.
Failed to run module scripts-user
```

Everything after the `systemctl start ambonmud` line was skipped, including the entire `if (hostname)` block. The instance came up with nginx installed but no config, no setup-tls helper, and no TLS cert — had to write both files manually and run certbot by hand.

## Test plan
- [ ] CDK typecheck: `tsc --noEmit` — done locally, clean
- [ ] Deploy a fresh instance and verify `/etc/nginx/conf.d/ambonmud.conf` and `/usr/local/bin/setup-tls` exist on first boot
- [ ] Confirm `setup-tls.service` runs and provisions the cert without manual intervention
- [ ] Confirm ambonmud still comes up despite `--no-block` (systemd's own start is unaffected; only the userData step is non-blocking)