### PR TITLE
Add secrets overlay source for admin token

### DIFF
--- a/infra/lib/ec2-stack.ts
+++ b/infra/lib/ec2-stack.ts
@@ -420,6 +420,56 @@ export class Ec2Stack extends Stack {
             '',
           ]
         : []),
+      // ---- fetch-admin-token helper script ------------------------------------
+      // Reads the admin token from AWS SSM Parameter Store and materializes it
+      // into two files the rest of the boot sequence reads:
+      //
+      //   1. /etc/ambonmud/secrets.env — AMBONMUD_ADMIN_TOKEN=<value>, mode 600,
+      //      root-only. Used by docker --env-file for container env, and by
+      //      generate-htpasswd to build the nginx basic-auth htpasswd.
+      //
+      //   2. /app/data/secrets.yaml — Hoplite secrets overlay. Highest-priority
+      //      config source (see AppConfigLoader.kt) so the app's loaded
+      //      admin.token matches the real SSM value regardless of what the
+      //      creator-generated application-local.yaml carries as a placeholder.
+      //      Without this, a creator overlay with admin.token: "" (or any
+      //      non-matching placeholder) causes the app to reject the real token
+      //      at the admin API auth layer, while nginx basic-auth (built from
+      //      secrets.env) accepts it — the two layers disagree and no single
+      //      password works. The secrets overlay makes both layers agree.
+      //
+      // Only installed when adminTokenSsmParameterName is set.
+      // ----------------------------------------------------------------------
+      ...(adminTokenSsmParameterName
+        ? [
+            `cat > /usr/local/bin/fetch-admin-token << 'FETCH_END'`,
+            '#!/bin/bash',
+            'set -euo pipefail',
+            `PARAM_NAME="${adminTokenSsmParameterName}"`,
+            `REGION="${this.region}"`,
+            'mkdir -p /etc/ambonmud /app/data',
+            'umask 077',
+            'token=$(aws ssm get-parameter --name "$PARAM_NAME" --with-decryption --query Parameter.Value --output text --region "$REGION")',
+            'if [ -z "$token" ]; then',
+            '  echo "Empty admin token from SSM — refusing to start" >&2',
+            '  exit 1',
+            'fi',
+            '# secrets.env — consumed by docker --env-file and generate-htpasswd.',
+            'printf "AMBONMUD_ADMIN_TOKEN=%s\\n" "$token" > /etc/ambonmud/secrets.env',
+            'chmod 600 /etc/ambonmud/secrets.env',
+            '# secrets.yaml — Hoplite overlay read by the container (UID 1001).',
+            '# Single-quoted YAML scalar: safe for SSM hex tokens; if token style',
+            '# ever changes to include single-quotes or backslashes, switch to',
+            '# python -c "import yaml,sys; yaml.safe_dump(...)" for robustness.',
+            "printf \"ambonmud:\\n  admin:\\n    token: '%s'\\n\" \"$token\" > /app/data/secrets.yaml",
+            'chown 1001:1001 /app/data/secrets.yaml',
+            'chmod 600 /app/data/secrets.yaml',
+            'echo "Admin token materialized to secrets.env + secrets.yaml"',
+            'FETCH_END',
+            'chmod +x /usr/local/bin/fetch-admin-token',
+            '',
+          ]
+        : []),
       // ---- generate-htpasswd helper script ------------------------------------
       // Writes an htpasswd file for nginx basic auth on /grafana/, /prometheus/,
       // and /admin/. The admin token is sourced from (in order of preference):
@@ -529,20 +579,13 @@ export class Ec2Stack extends Stack {
             `ExecStartPre=/usr/bin/curl -fsSL --retry 20 --retry-delay 15 --retry-all-errors -A "Mozilla/5.0 (compatible; AmbonMUD-fetch/1.0)" -o /app/data/world/achievements.yaml ${achievementsUrl}`,
           ]
         : []),
-      // Fetch the admin API token from SSM Parameter Store and write it to
-      // /etc/ambonmud/secrets.env. Must run before generate-htpasswd (which
-      // reads the token from this file) and before the main ExecStart (which
-      // passes the file to the container via --env-file). Fails the unit if
-      // the parameter is missing or unreadable — we'd rather refuse to start
-      // than launch with a broken/missing admin token.
+      // Fetch the admin API token from SSM Parameter Store. Runs before
+      // generate-htpasswd (which reads secrets.env) and before the container
+      // starts (which bind-mounts /app/data holding secrets.yaml). Fails the
+      // unit if the parameter is missing or unreadable — we'd rather refuse
+      // to start than launch with a broken/missing admin token.
       ...(adminTokenSsmParameterName
-        ? [
-            // %%s escapes systemd's specifier expansion — bare %s gets replaced
-            // with the service user's login shell (/bin/bash for root) before
-            // bash ever sees it, which silently eats the $token argument and
-            // writes AMBONMUD_ADMIN_TOKEN=/bin/bash to secrets.env.
-            `ExecStartPre=/bin/bash -c 'set -euo pipefail; mkdir -p /etc/ambonmud; umask 077; token=$(aws ssm get-parameter --name ${adminTokenSsmParameterName} --with-decryption --query Parameter.Value --output text --region ${this.region}); test -n "$token"; printf "AMBONMUD_ADMIN_TOKEN=%%s\\n" "$token" > /etc/ambonmud/secrets.env'`,
-          ]
+        ? [`ExecStartPre=/usr/local/bin/fetch-admin-token`]
         : []),
       // Generate htpasswd for nginx basic auth on /grafana/, /prometheus/, /admin/.
       'ExecStartPre=/usr/local/bin/generate-htpasswd',

--- a/src/main/kotlin/dev/ambon/config/AppConfigLoader.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfigLoader.kt
@@ -12,6 +12,23 @@ object AppConfigLoader {
     private const val LOCAL_OVERRIDE_FILENAME = "application-local.yaml"
     private const val LOCAL_OVERRIDE_CLASSPATH = "/$LOCAL_OVERRIDE_FILENAME"
 
+    // Secrets overlay — a separate YAML file holding values (admin token, DB
+    // passwords, etc) that must NOT appear in the publicly-fetched creator
+    // overlay. Populated outside the JVM by the deployment pipeline (systemd
+    // ExecStartPre fetches the admin token from SSM Parameter Store and writes
+    // secrets.yaml alongside the creator overlay). Takes precedence over every
+    // other source so real secret values overwrite whatever placeholder the
+    // creator tool emits.
+    //
+    // Lookup order:
+    //   1. $AMBONMUD_SECRETS_FILE (explicit path)
+    //   2. $AMBONMUD_DATA_DIR/secrets.yaml
+    //   3. ./secrets.yaml in the JVM working directory (local dev)
+    // If none exist, the overlay simply isn't added — secrets fall back to
+    // whatever the env source or the creator overlay provides.
+    private const val SECRETS_FILENAME = "secrets.yaml"
+    private const val SECRETS_PATH_ENV = "AMBONMUD_SECRETS_FILE"
+
     // Environment variable naming convention for container deployments:
     //   AMBONMUD_MODE              → ambonmud.mode
     //   AMBONMUD_PERSISTENCE_BACKEND → ambonmud.persistence.backend
@@ -26,11 +43,13 @@ object AppConfigLoader {
     // (all-lowercase) so that Hoplite's env-var normalisation resolves correctly.
     //
     // Config source priority (highest → lowest):
-    //   1. Environment variables
-    //   2. Extra sources (programmatic)
-    //   3. Profile overlay  (-Dambon.profile=<name>)
-    //   4. Local overlay    (application-local.yaml — $AMBONMUD_DATA_DIR, CWD, or classpath)
-    //   5. Base defaults    (application.yaml — checked in, generic/tech defaults)
+    //   1. Secrets overlay  (secrets.yaml — production secrets injected by
+    //                        the deployment pipeline; see SECRETS_FILENAME)
+    //   2. Environment variables
+    //   3. Extra sources (programmatic)
+    //   4. Profile overlay  (-Dambon.profile=<name>)
+    //   5. Local overlay    (application-local.yaml — $AMBONMUD_DATA_DIR, CWD, or classpath)
+    //   6. Base defaults    (application.yaml — checked in, generic/tech defaults)
     //
     // The local overlay is checked in three locations, in order:
     //   a. $AMBONMUD_DATA_DIR/application-local.yaml (container deployments with
@@ -49,8 +68,17 @@ object AppConfigLoader {
             ConfigLoaderBuilder
                 .default()
                 .withExplicitSealedTypes()
-                // Environment variables are highest priority (lowest index = first checked)
-                .addEnvironmentSource()
+
+        // Secrets overlay takes precedence over every other source (lowest
+        // index = first checked). See SECRETS_FILENAME doc above for why.
+        val secretsFile = resolveSecretsFile()
+        if (secretsFile != null) {
+            builder = builder.addSource(PropertySource.file(secretsFile, optional = false))
+        }
+
+        // Environment variables come next. Used as a fallback override path for
+        // local dev and ad-hoc tweaks.
+        builder = builder.addEnvironmentSource()
 
         for (source in extraSources) {
             builder = builder.addSource(source)
@@ -90,5 +118,26 @@ object AppConfigLoader {
             .loadConfigOrThrow<AmbonMUDRootConfig>()
             .ambonmud
             .validated()
+    }
+
+    private fun resolveSecretsFile(): File? {
+        // System property is checked first for test-friendliness — tests can't
+        // easily set env vars in the JVM, matching the existing `ambon.profile`
+        // pattern used above.
+        System.getProperty("ambon.secretsFile")?.let { path ->
+            val f = File(path)
+            if (f.isFile) return f
+        }
+        System.getenv(SECRETS_PATH_ENV)?.let { path ->
+            val f = File(path)
+            if (f.isFile) return f
+        }
+        System.getenv("AMBONMUD_DATA_DIR")?.let { dir ->
+            val f = File(dir, SECRETS_FILENAME)
+            if (f.isFile) return f
+        }
+        val cwd = File(SECRETS_FILENAME)
+        if (cwd.isFile) return cwd
+        return null
     }
 }

--- a/src/test/kotlin/dev/ambon/config/AppConfigLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/config/AppConfigLoaderTest.kt
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.writeText
 
 class AppConfigLoaderTest {
     private val testResourcePath = "/test-application.yaml"
@@ -471,6 +474,50 @@ class AppConfigLoaderTest {
             extraSources = listOf(source),
         )
         assertEquals(PersistenceBackend.POSTGRES, config.persistence.backend)
+    }
+
+    @Test
+    fun `secrets overlay outranks extra sources and base config`(
+        @TempDir tmp: Path,
+    ) {
+        // The secrets overlay is the highest-priority source so real secret
+        // values injected by the deployment pipeline always beat whatever
+        // placeholder the creator-generated overlay carries. Simulated here
+        // by adding a map source with a value for admin.token and confirming
+        // the PropertySource.file for secrets.yaml wins.
+        val secretsFile = tmp.resolve("secrets.yaml")
+        secretsFile.writeText(
+            """
+            ambonmud:
+              admin:
+                token: "REAL_SECRET_FROM_SSM"
+            """.trimIndent(),
+        )
+        val overlayLikePlaceholder =
+            PropertySource.map(
+                mapOf(
+                    "ambonmud.admin.enabled" to "true",
+                    "ambonmud.admin.token" to "OVERRIDE_ME_FROM_ENV",
+                ),
+            )
+
+        val previous = System.getProperty("ambon.secretsFile")
+        System.setProperty("ambon.secretsFile", secretsFile.toString())
+        try {
+            val config =
+                AppConfigLoader.load(
+                    resourcePath = testResourcePath,
+                    extraSources = listOf(overlayLikePlaceholder),
+                )
+            assertEquals("REAL_SECRET_FROM_SSM", config.admin.token)
+            assertTrue(config.admin.enabled)
+        } finally {
+            if (previous == null) {
+                System.clearProperty("ambon.secretsFile")
+            } else {
+                System.setProperty("ambon.secretsFile", previous)
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Adds `secrets.yaml` as the highest-priority Hoplite config source so secret values (admin token today, DB passwords tomorrow) can beat whatever placeholder the creator-generated `application-local.yaml` carries.
- `fetch-admin-token` ExecStartPre now writes both `/etc/ambonmud/secrets.env` (for docker `--env-file` and nginx htpasswd) and `/app/data/secrets.yaml` (Hoplite overlay) from the same SSM fetch, so the two auth layers always agree on the real token.
- Refactors the previous inline ExecStartPre into a `/usr/local/bin/fetch-admin-token` helper for readability.

## Background

Hit this on a fresh demo deploy: nginx basic-auth (built from the real SSM token via `generate-htpasswd`) accepted the real token, but the app rejected it at the admin API auth layer because its `admin.token` had loaded the overlay's placeholder (`OVERRIDE_ME_FROM_ENV`). Two layers, two different passwords, no single value works in the browser.

The existing design per `CLAUDE.md` was that `AMBONMUD_ADMIN_TOKEN` env var would override the overlay via Hoplite's env source priority. Empirically that does not happen in Hoplite 2.9.0 for this path — the container env has the var, but the app loads the overlay value. Rather than chase Hoplite internals, this PR adds an explicit third source dedicated to secrets, sidestepping the precedence quirk entirely.

## Precedence chain (new)
1. **secrets.yaml** (this PR) — populated by deployment pipeline from SSM
2. Environment variables
3. Extra programmatic sources
4. Profile overlay (`-Dambon.profile=...`)
5. Local overlay (`application-local.yaml` — creator-generated)
6. Base defaults (`application.yaml`)

`secrets.yaml` location lookup:
- `ambon.secretsFile` system property (tests)
- `AMBONMUD_SECRETS_FILE` env var
- `\$AMBONMUD_DATA_DIR/secrets.yaml`  (production — /app/data/secrets.yaml)
- `./secrets.yaml` (local dev)

## Test plan
- [x] Unit test: secrets overlay outranks extra sources simulating the creator overlay
- [x] `./gradlew ktlintCheck compileKotlin test --tests *AppConfigLoader*` — clean
- [x] `tsc --noEmit` against infra/
- [ ] Deploy to demo EC2: SSM onto box, verify `/app/data/secrets.yaml` exists mode 600 owned by 1001, container starts, `https://mud.ambon.dev/admin/` accepts `admin` / `<real SSM token>`

## Security
- `/etc/ambonmud/secrets.env` (root:root, 600) — unchanged, consumed by nginx htpasswd
- `/app/data/secrets.yaml` (1001:1001, 600) — new, bind-mounted into container at /app/data
- Creator overlay stays pristine and publicly safe — secrets never land in a file served over public HTTP