### PR TITLE
Tighten vitals toolbar and fix leaderboard empty state

### DIFF
--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -68,11 +68,9 @@ function App() {
 
   // Lifted command-input state — VitalsBar renders it controlled, palette/canvas can prefill
   const [inputValue, setInputValue] = useState("");
-  const [showInput, setShowInput] = useState(false);
 
   const prefillInput = (text: string) => {
     setInputValue(text);
-    setShowInput(true);
   };
 
   // Minimap canvas + drawing helpers (owns its own ref, kept out of useGameState)
@@ -487,8 +485,6 @@ function App() {
           setInputValue(value);
           resetComposerCompletion();
         }}
-        showInput={showInput}
-        onShowInputChange={setShowInput}
         onInputKeyDown={handleInputKeyDown}
       />
 

--- a/web-v3/src/components/GameShell.tsx
+++ b/web-v3/src/components/GameShell.tsx
@@ -24,8 +24,6 @@ interface GameShellProps {
   audio: AudioEngine;
   inputValue: string;
   onInputChange: (value: string) => void;
-  showInput: boolean;
-  onShowInputChange: (open: boolean) => void;
   onInputKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
   children?: ReactNode;
 }
@@ -48,8 +46,6 @@ export function GameShell({
   audio,
   inputValue,
   onInputChange,
-  showInput,
-  onShowInputChange,
   onInputKeyDown,
   children,
 }: GameShellProps) {
@@ -105,8 +101,6 @@ export function GameShell({
         audio={audio}
         inputValue={inputValue}
         onInputChange={onInputChange}
-        showInput={showInput}
-        onShowInputChange={onShowInputChange}
         onInputKeyDown={onInputKeyDown}
         onHeightChange={setHudBottomInset}
       />

--- a/web-v3/src/components/VitalsBar.tsx
+++ b/web-v3/src/components/VitalsBar.tsx
@@ -8,10 +8,8 @@ import {
   CharacterAvatarIcon,
   EquipmentIcon,
   ChatBubbleIcon,
-  BankIcon,
   AuctionIcon,
   CraftingIcon,
-  WorldFeatureIcon,
   HousingIcon,
   MailIcon,
   HelpIcon,
@@ -46,12 +44,10 @@ interface PanelDef {
 const PANELS: PanelDef[] = [
   { panel: "character", label: "Character", icon: <CharacterAvatarIcon className="vbar-icon" /> },
   { panel: "inventory", label: "Inventory", icon: <EquipmentIcon className="vbar-icon" /> },
-  { panel: "features", label: "Features", icon: <WorldFeatureIcon className="vbar-icon" /> },
   { panel: "spellbook", label: "Spellbook", icon: <SpellbookIcon className="vbar-icon" /> },
   { panel: "quests", label: "Quests", icon: <QuestsTabIcon className="vbar-icon" /> },
   { panel: "chat", label: "Social", icon: <ChatBubbleIcon className="vbar-icon" /> },
   { panel: "crafting", label: "Crafting", icon: <CraftingIcon className="vbar-icon" /> },
-  { panel: "bank", label: "Bank", icon: <BankIcon className="vbar-icon" /> },
   { panel: "auction", label: "Auction", icon: <AuctionIcon className="vbar-icon" /> },
   { panel: "mail", label: "Mail", icon: <MailIcon className="vbar-icon" /> },
   { panel: "housing", label: "Housing", icon: <HousingIcon className="vbar-icon" /> },
@@ -75,8 +71,6 @@ interface VitalsBarProps {
   audio: AudioEngine;
   inputValue: string;
   onInputChange: (value: string) => void;
-  showInput: boolean;
-  onShowInputChange: (open: boolean) => void;
   onInputKeyDown?: (event: KeyboardEvent<HTMLInputElement>) => void;
   onHeightChange?: (height: number) => void;
 }
@@ -171,8 +165,6 @@ export function VitalsBar({
   audio,
   inputValue,
   onInputChange,
-  showInput,
-  onShowInputChange,
   onInputKeyDown,
   onHeightChange,
 }: VitalsBarProps) {
@@ -181,13 +173,6 @@ export function VitalsBar({
   const navRef = useRef<HTMLElement | null>(null);
 
   const hasAnySkill = quickbarSlots.some((s) => s !== null);
-
-  // Focus the input whenever it becomes visible (e.g. after Ctrl+K palette prefill)
-  useEffect(() => {
-    if (showInput) {
-      requestAnimationFrame(() => inputRef.current?.focus());
-    }
-  }, [showInput]);
 
   useEffect(() => {
     const node = navRef.current;
@@ -207,7 +192,7 @@ export function VitalsBar({
     return () => {
       resizeObserver.disconnect();
     };
-  }, [onHeightChange, loggedIn, hasAnySkill, showPanels, showInput, connected]);
+  }, [onHeightChange, loggedIn, hasAnySkill, showPanels, connected]);
 
   const submitInput = (e: FormEvent) => {
     e.preventDefault();
@@ -347,24 +332,10 @@ export function VitalsBar({
             <span className="vbar-panel-label">{label}</span>
           </button>
         ))}
-        {/* Command button — toggles the inline text input below */}
-        <button
-          type="button"
-          className={`vbar-panel-btn${showInput ? " vbar-panel-btn-active" : ""}`}
-          onClick={() => onShowInputChange(!showInput)}
-          aria-label="Type a command"
-        >
-          <svg viewBox="0 0 24 24" className="vbar-icon" fill="none" stroke="currentColor" strokeWidth="2">
-            <rect x="2" y="4" width="20" height="16" rx="3" />
-            <line x1="6" y1="10" x2="18" y2="10" />
-            <line x1="6" y1="14" x2="14" y2="14" />
-          </svg>
-          <span className="vbar-panel-label">Command</span>
-        </button>
       </div>
 
-      {/* Expandable text input — appears below the grid when "Command" button is toggled */}
-      {showInput && (
+      {/* Persistent command input — always available below the panel grid */}
+      {loggedIn && (
         <form className="vbar-input-row" onSubmit={submitInput}>
           <input
             ref={inputRef}

--- a/web-v3/src/components/panels/LeaderboardPanel.tsx
+++ b/web-v3/src/components/panels/LeaderboardPanel.tsx
@@ -26,10 +26,8 @@ export function LeaderboardPanel({ leaderboard, onCommand }: Props) {
     }
   }, [onCommand]);
 
-  const activeCats = CATEGORIES.filter((c) => {
-    const data = leaderboard[c.key];
-    return data && data.entries.length > 0;
-  });
+  const receivedCats = CATEGORIES.filter((c) => leaderboard[c.key] !== undefined);
+  const awaitingResponse = receivedCats.length === 0;
 
   return (
     <div className="leaderboard-panel">
@@ -37,40 +35,33 @@ export function LeaderboardPanel({ leaderboard, onCommand }: Props) {
         <span className="panel-title">Leaderboards</span>
       </div>
 
-      {activeCats.length === 0 ? (
-        <div className="leaderboard-empty">
-          <p>Loading rankings&hellip;</p>
-          <div className="leaderboard-cat-buttons">
-            {CATEGORIES.map((c) => (
-              <button
-                key={c.key}
-                className="leaderboard-cat-btn"
-                onClick={() => onCommand(`leaderboard ${c.key}`)}
-              >
-                {c.label}
-              </button>
-            ))}
-          </div>
+      <div className="leaderboard-content">
+        <div className="leaderboard-cat-buttons">
+          {CATEGORIES.map((c) => (
+            <button
+              key={c.key}
+              className="leaderboard-cat-btn"
+              onClick={() => onCommand(`leaderboard ${c.key}`)}
+            >
+              {c.label}
+            </button>
+          ))}
         </div>
-      ) : (
-        <div className="leaderboard-content">
-          <div className="leaderboard-cat-buttons">
-            {CATEGORIES.map((c) => (
-              <button
-                key={c.key}
-                className="leaderboard-cat-btn"
-                onClick={() => onCommand(`leaderboard ${c.key}`)}
-              >
-                {c.label}
-              </button>
-            ))}
-          </div>
 
-          {activeCats.map((c) => {
-            const data = leaderboard[c.key];
-            return (
-              <div key={c.key} className="leaderboard-category">
-                <div className="leaderboard-cat-header">{data.label}</div>
+        {awaitingResponse && (
+          <div className="leaderboard-empty">
+            <p>Loading rankings&hellip;</p>
+          </div>
+        )}
+
+        {receivedCats.map((c) => {
+          const data = leaderboard[c.key];
+          return (
+            <div key={c.key} className="leaderboard-category">
+              <div className="leaderboard-cat-header">{data.label}</div>
+              {data.entries.length === 0 ? (
+                <p className="leaderboard-empty-note">No entries yet — be the first to rank!</p>
+              ) : (
                 <table className="leaderboard-table">
                   <tbody>
                     {data.entries.map((e) => (
@@ -84,11 +75,11 @@ export function LeaderboardPanel({ leaderboard, onCommand }: Props) {
                     ))}
                   </tbody>
                 </table>
-              </div>
-            );
-          })}
-        </div>
-      )}
+              )}
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -12845,6 +12845,14 @@ body {
   margin-bottom: var(--space-2);
 }
 
+.leaderboard-empty-note {
+  margin: 0;
+  padding: var(--space-2) 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
 .leaderboard-table {
   width: 100%;
   border-collapse: collapse;


### PR DESCRIPTION
## Summary
- Remove `Command`, `Bank`, and `Features` buttons from the VitalsBar toolbar (Bank is room-based, Features render on the canvas, and the Command toggle is replaced with a persistent always-visible command input when logged in).
- Fix the Leaderboards panel staying stuck on \"Loading rankings…\" on a fresh server — previously any category with zero entries was filtered out entirely, so an all-empty leaderboard never rendered. Now each category that answered via GMCP is shown, with a \"No entries yet — be the first to rank!\" note when its list is empty.
- Prune the now-unused `showInput` / `onShowInputChange` props from `App.tsx` and `GameShell.tsx`.

## Test plan
- [ ] Load the web client: toolbar no longer shows Command, Bank, or Features buttons.
- [ ] Command input is always visible at the bottom; typing + Enter still sends commands and history nav still works.
- [ ] Open the Leaderboard panel on a fresh server (empty cache): categories now appear with a \"No entries yet\" note instead of the stuck loading spinner.
- [ ] Open the Leaderboard panel on a populated server: rankings render as before.
- [ ] `bun x tsc --noEmit` and `bun run lint` both pass.