### PR TITLE
Add conditional Dungeon toolbar button when in active run

### DIFF
--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -479,6 +479,7 @@ function App() {
         onOpenPanel={(panel) => openPanel(panel)}
         onCastSkill={handleCastSkill}
         onReconnect={() => { intentionalDisconnectRef.current = true; reconnect(); }}
+        dungeonActive={state.dungeonInfo?.active ?? false}
         audio={audio}
         inputValue={inputValue}
         onInputChange={(value) => {

--- a/web-v3/src/components/GameShell.tsx
+++ b/web-v3/src/components/GameShell.tsx
@@ -21,6 +21,7 @@ interface GameShellProps {
   onOpenPanel: (panel: PopoutPanel) => void;
   onCastSkill: (skillId: string, cooldownMs: number) => void;
   onReconnect: () => void;
+  dungeonActive: boolean;
   audio: AudioEngine;
   inputValue: string;
   onInputChange: (value: string) => void;
@@ -43,6 +44,7 @@ export function GameShell({
   onOpenPanel,
   onCastSkill,
   onReconnect,
+  dungeonActive,
   audio,
   inputValue,
   onInputChange,
@@ -98,6 +100,7 @@ export function GameShell({
         onCastSkill={onCastSkill}
         onCommand={onCommand}
         onReconnect={onReconnect}
+        dungeonActive={dungeonActive}
         audio={audio}
         inputValue={inputValue}
         onInputChange={onInputChange}

--- a/web-v3/src/components/Icons.tsx
+++ b/web-v3/src/components/Icons.tsx
@@ -630,3 +630,14 @@ export function AuctionIcon({ className }: { className?: string }) {
     </svg>
   );
 }
+
+export function DungeonIcon({ className }: { className?: string }) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">
+      <path d="M4 21V7l4-3 4 3 4-3 4 3v14" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M4 21h16" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" />
+      <path d="M10 21v-5a2 2 0 012-2 2 2 0 012 2v5" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M7 10h2M15 10h2" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/web-v3/src/components/VitalsBar.tsx
+++ b/web-v3/src/components/VitalsBar.tsx
@@ -10,6 +10,7 @@ import {
   ChatBubbleIcon,
   AuctionIcon,
   CraftingIcon,
+  DungeonIcon,
   HousingIcon,
   MailIcon,
   HelpIcon,
@@ -68,6 +69,7 @@ interface VitalsBarProps {
   onCastSkill: (skillId: string, cooldownMs: number) => void;
   onCommand: (cmd: string) => void;
   onReconnect?: () => void;
+  dungeonActive: boolean;
   audio: AudioEngine;
   inputValue: string;
   onInputChange: (value: string) => void;
@@ -162,6 +164,7 @@ export function VitalsBar({
   onCastSkill,
   onCommand,
   onReconnect,
+  dungeonActive,
   audio,
   inputValue,
   onInputChange,
@@ -332,6 +335,17 @@ export function VitalsBar({
             <span className="vbar-panel-label">{label}</span>
           </button>
         ))}
+        {dungeonActive && (
+          <button
+            type="button"
+            className={`vbar-panel-btn vbar-panel-btn-dungeon${activePopout === "dungeon" ? " vbar-panel-btn-active" : ""}`}
+            onClick={() => { onOpenPanel("dungeon"); setShowPanels(false); }}
+            aria-label="Dungeon"
+          >
+            <DungeonIcon className="vbar-icon" />
+            <span className="vbar-panel-label">Dungeon</span>
+          </button>
+        )}
       </div>
 
       {/* Persistent command input — always available below the panel grid */}

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -14386,6 +14386,15 @@ html:has(.game-shell),
   border-color: rgb(216 197 232 / 60%);
 }
 
+.vbar-panel-btn-dungeon {
+  background: linear-gradient(135deg, rgb(210 120 140 / 82%), rgb(140 80 110 / 82%));
+  border-color: rgb(232 170 190 / 55%);
+}
+
+.vbar-panel-btn-dungeon:hover {
+  background: linear-gradient(135deg, rgb(224 140 158 / 88%), rgb(158 96 128 / 88%));
+}
+
 .vbar-panel-btn .vbar-icon {
   width: 24px;
   height: 24px;


### PR DESCRIPTION
## Summary
- Once a player enters a dungeon there's no portal on the canvas to click, so there was no UI path back to the `DungeonPanel` where the existing **Leave Dungeon** button lives — the only way out was typing `dungeon leave`.
- Add a `DungeonIcon` and render a conditional Dungeon toolbar button in the VitalsBar whenever `dungeonInfo.active` is true. Clicking it opens the existing panel; the button disappears again on dungeon leave, so the toolbar stays tight when you're not in a run.
- Rosy-pink tint on the conditional button so it reads as a transient/active state, distinct from the permanent panel buttons.

## Test plan
- [ ] Enter a dungeon via a portal on the canvas — the Dungeon button appears in the toolbar.
- [ ] Click the toolbar button — the DungeonPanel opens with the \"Leave Dungeon\" CTA visible.
- [ ] Click Leave Dungeon — player exits the dungeon and the toolbar button disappears.
- [ ] While not in a dungeon, verify the button is hidden.
- [ ] `bun x tsc --noEmit` and `bun run lint` both pass.