### PR TITLE
Reduce GMCP vitals churn and plumb JAVA_OPTS for ZGC tuning

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,5 +20,8 @@ if [ -z "$AMBONMUD_SHARDING_ADVERTISEHOST" ]; then
   export AMBONMUD_SHARDING_ADVERTISEHOST="$PRIVATE_IP"
 fi
 
-# All world zones are built into the fat JAR — no external YAML fetching needed.
-exec java -Djava.net.preferIPv4Stack=true -jar /app/app.jar "$@"
+# JAVA_OPTS is passed through to the JVM (e.g. "-Xms2g -Xmx2g -XX:+UseZGC
+# -XX:+ZGenerational"). Unquoted on purpose so each flag lands as a separate
+# argv slot. Defaults to empty so the JVM picks its own heap and GC.
+# shellcheck disable=SC2086
+exec java -Djava.net.preferIPv4Stack=true ${JAVA_OPTS:-} -jar /app/app.jar "$@"

--- a/infra/lib/ec2-stack.ts
+++ b/infra/lib/ec2-stack.ts
@@ -85,6 +85,19 @@ export interface Ec2StackProps extends StackProps {
    * ambonmud.service (no CDK redeploy needed).
    */
   readonly adminTokenSsmParameterName?: string;
+  /**
+   * Optional JVM flags passed to the container as JAVA_OPTS.
+   *
+   * Example: "-Xms2g -Xmx2g -XX:+UseZGC -XX:+ZGenerational"
+   *
+   * IMPORTANT: these flags must fit within the instance's physical RAM. The
+   * default t4g.micro has only 1 GB of RAM and also runs Prometheus + Grafana
+   * containers on the same host, so a 2 GB heap requires bumping the instance
+   * to at least t4g.medium (4 GB) — set it directly in this stack's Instance
+   * construct. Setting a too-large heap on an undersized box leads to swap
+   * death or OOM-kill.
+   */
+  readonly javaOpts?: string;
 }
 
 /**
@@ -117,7 +130,7 @@ export class Ec2Stack extends Stack {
   constructor(scope: Construct, id: string, props: Ec2StackProps) {
     super(scope, id, props);
 
-    const { imageTag, ecrRepoName, domain, hostname, loreConfigUrl, worldZonesBaseUrl, spritesUrl, achievementsUrl, adminTokenSsmParameterName } = props;
+    const { imageTag, ecrRepoName, domain, hostname, loreConfigUrl, worldZonesBaseUrl, spritesUrl, achievementsUrl, adminTokenSsmParameterName, javaOpts } = props;
     const ecrUri = `${this.account}.dkr.ecr.${this.region}.amazonaws.com/${ecrRepoName}`;
 
     // -------------------------------------------------------------------------
@@ -597,7 +610,7 @@ export class Ec2Stack extends Stack {
       // --env-file (when adminTokenSsmParameterName is set) pushes
       // AMBONMUD_ADMIN_TOKEN from /etc/ambonmud/secrets.env into the
       // container, where Hoplite picks it up and overrides ambonmud.admin.token.
-      `ExecStart=/usr/bin/docker run --name ambonmud --network ambonmud-net -p 4000:4000 -p 8080:8080 -p 9091:9091 -v /app/data:/app/data ${adminTokenSsmParameterName ? '--env-file /etc/ambonmud/secrets.env ' : ''}-e AMBONMUD_DATA_DIR=/app/data -e AMBONMUD_PERSISTENCE_BACKEND=YAML -e AMBONMUD_REDIS_ENABLED=false ${ecrUri}:${imageTag}`,
+      `ExecStart=/usr/bin/docker run --name ambonmud --network ambonmud-net -p 4000:4000 -p 8080:8080 -p 9091:9091 -v /app/data:/app/data ${adminTokenSsmParameterName ? '--env-file /etc/ambonmud/secrets.env ' : ''}-e AMBONMUD_DATA_DIR=/app/data -e AMBONMUD_PERSISTENCE_BACKEND=YAML -e AMBONMUD_REDIS_ENABLED=false${javaOpts ? ` -e JAVA_OPTS=${JSON.stringify(javaOpts)}` : ''} ${ecrUri}:${imageTag}`,
       'ExecStop=/usr/bin/docker stop ambonmud',
       '',
       '[Install]',

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -92,6 +92,18 @@ class GmcpEmitter(
                 size > MAX_ZONE_CACHE_ENTRIES
         }
 
+    /**
+     * Last Char.Vitals payload sent to each session. Used to suppress redundant
+     * emits when nothing has actually changed — at 1k concurrent sessions every
+     * tick of unchanged vitals multiplies into tens of thousands of wasted
+     * frames/sec on the outbound path.
+     */
+    private val lastVitalsBySession: MutableMap<SessionId, CharVitalsPayload> =
+        object : LinkedHashMap<SessionId, CharVitalsPayload>(128, 0.75f, true) {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<SessionId, CharVitalsPayload>): Boolean =
+                size > MAX_VITALS_CACHE_ENTRIES
+        }
+
     /** Returns true if the zone changed (or is first seen) for this session. */
     fun trackZoneChange(sessionId: SessionId, zone: String): Boolean {
         val prev = lastZoneBySession.put(sessionId, zone)
@@ -101,6 +113,7 @@ class GmcpEmitter(
     /** Remove tracked zone state for a disconnected session. */
     fun forgetSession(sessionId: SessionId) {
         lastZoneBySession.remove(sessionId)
+        lastVitalsBySession.remove(sessionId)
     }
 
     /**
@@ -120,27 +133,26 @@ class GmcpEmitter(
         sessionId: SessionId,
         player: PlayerState,
     ) {
-        emit(
-            sessionId,
-            "Char.Vitals",
-            CharVitalsPayload(
-                hp = player.hp,
-                maxHp = player.maxHp,
-                mana = player.mana,
-                maxMana = player.maxMana,
-                level = player.level,
-                xp = player.xpTotal,
-                xpIntoLevel = progression?.xpIntoLevel(player.xpTotal) ?: 0L,
-                xpToNextLevel = progression?.xpToNextLevel(player.xpTotal),
-                gold = player.gold,
-                inCombat = isInCombat(sessionId),
-                prestigeLevel = player.prestigeLevel,
-                prestigeXpAvailable = prestigeAvailableXp(player),
-                prestigeNextCost = prestigeNextCost(player.prestigeLevel),
-                pvpKills = player.pvpKills,
-                pvpDeaths = player.pvpDeaths,
-            ),
+        val payload = CharVitalsPayload(
+            hp = player.hp,
+            maxHp = player.maxHp,
+            mana = player.mana,
+            maxMana = player.maxMana,
+            level = player.level,
+            xp = player.xpTotal,
+            xpIntoLevel = progression?.xpIntoLevel(player.xpTotal) ?: 0L,
+            xpToNextLevel = progression?.xpToNextLevel(player.xpTotal),
+            gold = player.gold,
+            inCombat = isInCombat(sessionId),
+            prestigeLevel = player.prestigeLevel,
+            prestigeXpAvailable = prestigeAvailableXp(player),
+            prestigeNextCost = prestigeNextCost(player.prestigeLevel),
+            pvpKills = player.pvpKills,
+            pvpDeaths = player.pvpDeaths,
         )
+        if (lastVitalsBySession[sessionId] == payload) return
+        lastVitalsBySession[sessionId] = payload
+        emit(sessionId, "Char.Vitals", payload)
     }
 
     suspend fun sendCharCombat(sessionId: SessionId) {
@@ -2712,6 +2724,9 @@ class GmcpEmitter(
 
         /** Upper bound for the zone-tracking LRU cache (well above any realistic session count). */
         const val MAX_ZONE_CACHE_ENTRIES = 10_000
+
+        /** Upper bound for the vitals dirty-diff LRU cache. */
+        const val MAX_VITALS_CACHE_ENTRIES = 10_000
 
         const val CHAR_STATUS_VARS_JSON =
             """{"hp":"HP","maxHp":"Max HP","mana":"Mana","maxMana":"Max Mana","level":"Level","xp":"XP"}"""

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -150,6 +150,38 @@ class GmcpEmitterTest {
             assertTrue(drainGmcp().isEmpty())
         }
 
+    @Test
+    fun `sendCharVitals suppresses duplicate emits when payload unchanged`() =
+        runTest {
+            val e = emitter("Char.Vitals")
+            val p = player()
+            e.sendCharVitals(sid, p)
+            e.sendCharVitals(sid, p)
+            e.sendCharVitals(sid, p)
+            val events = drainGmcp()
+            assertEquals(1, events.size, "Unchanged vitals should only emit once")
+        }
+
+    @Test
+    fun `sendCharVitals re-emits when payload changes`() =
+        runTest {
+            val e = emitter("Char.Vitals")
+            e.sendCharVitals(sid, player(hp = 50))
+            e.sendCharVitals(sid, player(hp = 40))
+            assertEquals(2, drainGmcp().size)
+        }
+
+    @Test
+    fun `forgetSession clears vitals dirty-diff cache`() =
+        runTest {
+            val e = emitter("Char.Vitals")
+            val p = player()
+            e.sendCharVitals(sid, p)
+            e.forgetSession(sid)
+            e.sendCharVitals(sid, p)
+            assertEquals(2, drainGmcp().size, "After forget, identical vitals should emit again")
+        }
+
     // ── Room.Info ──
 
     @Test


### PR DESCRIPTION
## Summary

Two load-test-driven changes from the ~1000-session run showing outbound frames at ~75k/sec and ~4s/sec aggregate GC pause time on a ~100MB heap:

- **Dirty-diff `Char.Vitals` emits.** `sendCharVitals` now skips when the built payload equals the last one sent to that session. The dirty-vitals flush marks sessions on *any* potential change (regen, combat, XP), so most ticks produce identical payloads that just burn socket bandwidth and GC budget. Cache is bounded LRU (10k entries) and cleared in `forgetSession`.
- **Plumb `JAVA_OPTS` end-to-end.** `docker-entrypoint.sh` now honors `JAVA_OPTS`, and `Ec2Stack` exposes a `javaOpts` prop. Operators can pass `-Xms2g -Xmx2g -XX:+UseZGC -XX:+ZGenerational` without rebuilding the image.

## ⚠️ Operational note before setting `javaOpts` in prod

The demo currently runs on **t4g.micro (1 GB RAM)** alongside Prometheus + Grafana containers. A 2 GB heap will not fit. To actually benefit from ZGC + larger heap, bump the instance to **t4g.medium (4 GB)** or larger in `infra/lib/ec2-stack.ts` *before* setting `javaOpts`. The prop's JSDoc calls this out.

ECS (staging/prod) stacks are not wired for `JAVA_OPTS` in this PR — follow-up if needed. Moderate tier already allocates 2 GB per task so it's where ZGC would start to pay off.

## Expected load-test deltas

- Outbound frames/sec: material drop (most vitals emits at steady state are redundant).
- Engine tick p99: should tighten as GC pauses shrink — but only after heap flags actually land, which requires the instance bump above.

## Test plan

- [x] `./gradlew ktlintCheck` passes
- [x] `./gradlew test` passes (full suite)
- [x] New tests: suppression on equal payloads, re-emit on change, `forgetSession` clears vitals cache
- [ ] Manual verification: after deploy + instance bump + `javaOpts` set, re-run the 1000-session load test and compare `engine_tick_duration_seconds{quantile="0.99"}`, `outbound_frames_total` rate, and `jvm_gc_pause_seconds_sum` rate against the baseline dashboard