### PR TITLE
Bump demo EC2 to t4g.medium with 2 GB ZGC heap

### DIFF
--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -57,6 +57,16 @@ const achievementsUrl = app.node.tryGetContext('achievementsUrl') as string | un
 const adminTokenSsmParameterName =
   app.node.tryGetContext('adminTokenSsmParameterName') as string | undefined;
 
+// JVM flags passed to the container as JAVA_OPTS. The default targets the
+// t4g.medium (4 GB RAM) demo instance: 2 GB fixed heap + Generational ZGC for
+// sub-ms pauses. Generational ZGC is opt-in under JDK 21 (the runtime in the
+// Dockerfile), so -XX:+ZGenerational is required — it becomes default in 23+.
+// Override with --context javaOpts="..." when deploying to a smaller or
+// larger host.
+const javaOpts =
+  (app.node.tryGetContext('javaOpts') as string | undefined) ??
+  '-Xms2g -Xmx2g -XX:+UseZGC -XX:+ZGenerational';
+
 // ---------------------------------------------------------------------------
 // EC2 topology: single self-contained stack, no tier config needed.
 // ---------------------------------------------------------------------------
@@ -72,6 +82,7 @@ if (topology === 'ec2') {
     spritesUrl,
     achievementsUrl,
     adminTokenSsmParameterName,
+    javaOpts,
   });
 } else {
   // -------------------------------------------------------------------------

--- a/infra/lib/ec2-stack.ts
+++ b/infra/lib/ec2-stack.ts
@@ -101,13 +101,13 @@ export interface Ec2StackProps extends StackProps {
 }
 
 /**
- * Minimal single-instance EC2 deployment (~$4-5/mo).
+ * Minimal single-instance EC2 deployment (~$24/mo).
  *
  * Provisions:
  *   - VPC with a single public subnet (no NAT gateway)
  *   - Security group: TCP 4000 (telnet) + 80/443 (HTTP/HTTPS) + 8080 (web) + 9091 (admin) + 3000 (Grafana)
  *   - IAM role: ECR pull + SSM Session Manager (no SSH key needed)
- *   - t4g.nano (ARM64) running Amazon Linux 2023
+ *   - t4g.medium (ARM64, 4 GB RAM) running Amazon Linux 2023
  *   - Docker + systemd service that pulls and runs the AmbonMUD container
  *   - Elastic IP (persists across stop/start; no charge while attached)
  *   - Optional Route 53 A record (play.<domain> → EIP)
@@ -230,7 +230,7 @@ export class Ec2Stack extends Stack {
       // UID 1001 matches the pinned ambonmud user inside the container (Dockerfile).
       'mkdir -p /app/data && chown 1001:1001 /app/data',
       '',
-      // ---- Swap file: 512 MB safety net against OOM on t4g.micro ---------------
+      // ---- Swap file: 512 MB safety net against OOM under memory pressure -----
       'dd if=/dev/zero of=/swapfile bs=1M count=512',
       'chmod 600 /swapfile',
       'mkswap /swapfile',
@@ -774,14 +774,18 @@ export class Ec2Stack extends Stack {
     userData.addCommands('systemctl start --no-block ambonmud prometheus grafana');
 
     // -------------------------------------------------------------------------
-    // EC2 instance: t4g.micro — ARM64, 2 vCPU (burstable) / 1 GB RAM.
-    // Upgraded from t4g.nano to accommodate Prometheus + Grafana containers
-    // alongside the main AmbonMUD container.
+    // EC2 instance: t4g.medium — ARM64, 2 vCPU (burstable) / 4 GB RAM.
+    // Upgraded from t4g.micro (1 GB) so the JVM can run with a 2 GB heap under
+    // Generational ZGC alongside Prometheus + Grafana on the same host.
+    // Load-test evidence: at ~1000 concurrent sessions the t4g.micro's default
+    // ~250 MB heap + G1GC was producing ~4s/sec aggregate GC pauses, which
+    // manifested as engine tick p99 spikes. ZGC trades throughput for sub-ms
+    // pauses, which needs more heap headroom to amortize.
     // -------------------------------------------------------------------------
     const instance = new ec2.Instance(this, 'Instance', {
       vpc,
       vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
-      instanceType: ec2.InstanceType.of(ec2.InstanceClass.T4G, ec2.InstanceSize.MICRO),
+      instanceType: ec2.InstanceType.of(ec2.InstanceClass.T4G, ec2.InstanceSize.MEDIUM),
       machineImage: ec2.MachineImage.latestAmazonLinux2023({
         cpuType: ec2.AmazonLinuxCpuType.ARM_64,
       }),


### PR DESCRIPTION
## Summary

Follow-up to #1009 — sets a real default for `javaOpts` and bumps the demo EC2 to an instance size that can actually run it.

- **t4g.micro → t4g.medium** (1 GB → 4 GB RAM, ~\$12 → ~\$24/mo).
- **Default `javaOpts` = `-Xms2g -Xmx2g -XX:+UseZGC -XX:+ZGenerational`.** Generational ZGC is opt-in under JDK 21 (the runtime in the Dockerfile), so `-XX:+ZGenerational` is required; it becomes default in JDK 23+.
- Override via `--context javaOpts=\"...\"` if deploying to a smaller/larger host.

## Stacks on top of #1009

This PR targets the `perf/heap-zgc-gmcp-dirty-diff` branch because it depends on the `javaOpts` prop plumbing added there. Merge #1009 first, then rebase this onto main or merge both as a train.

## Deploy impact — instance will be replaced

`instanceType` is a replacement-required property in CloudFormation. `cdk deploy` will:
1. Create a new t4g.medium instance (re-runs full user-data: Docker install, Prometheus/Grafana setup, world-zone fetch from R2, Let's Encrypt reuse).
2. Associate the Elastic IP to the new instance (DNS stays intact).
3. Terminate the old t4g.micro.

**Data loss:** player YAML files on the old root EBS are gone. Acceptable for the demo — documented in CLAUDE.md memory that the demo is ephemeral.

Expected downtime: 5–10 min while user-data runs and the container pulls + boots.

## Verify after deploy

```bash
aws ssm start-session --target <new-instance-id>
# Inside:
docker exec ambonmud jcmd 1 VM.flags | grep -E 'UseZGC|Xmx'
# Expect: -XX:+UseZGC -XX:+ZGenerational, -Xmx2g
```

Then re-run the 1000-session load test and compare against the baseline dashboard:
- `engine_tick_duration_seconds{quantile="0.99"}` — expect p99 to tighten
- `jvm_gc_pause_seconds_sum` rate — expect meaningful drop
- `outbound_frames_total` rate — should drop from the vitals dirty-diff in #1009

## Test plan

- [x] `cdk synth --context topology=ec2` succeeds and contains `InstanceType: t4g.medium` + `JAVA_OPTS="-Xms2g -Xmx2g -XX:+UseZGC -XX:+ZGenerational"`
- [ ] `cdk deploy --context topology=ec2 ...` against the demo account
- [ ] SSM into new instance, confirm VM flags via `jcmd`
- [ ] Re-run load test, compare dashboards against baseline