### PR TITLE
Force instance replacement on user-data change, merge DB password into secrets.yaml

### DIFF
--- a/infra/lib/ec2-stack.ts
+++ b/infra/lib/ec2-stack.ts
@@ -212,10 +212,22 @@ export class Ec2Stack extends Stack {
     // -------------------------------------------------------------------------
     // User data: install Docker, write systemd service, install update helper.
     //
-    // userDataCausesReplacement is left at its default (false) intentionally:
-    // CDK changes to user data will NOT replace the instance and won't
-    // clobber player YAML data on disk. To roll out a new image tag, run
-    // `update-ambonmud <tag>` via SSM Session Manager.
+    // userDataCausesReplacement is now TRUE on the instance construct below.
+    // Rationale: this stack generates a dozen helper scripts and systemd units
+    // from the CDK user-data. When it was false we kept hitting the gotcha
+    // where `cdk deploy` with user-data-only diffs succeeds at the CFN layer
+    // but the running instance never re-executes user-data, so the on-disk
+    // scripts silently lag the source tree for days until some other property
+    // triggered replacement. For a demo that prioritizes "merge → deploy →
+    // new state visible" over preserving ephemeral player data, that's the
+    // wrong trade. Flip it, accept that every deploy destroys /app/data and
+    // the postgres sidecar's pgdata volume, and move on. When data survival
+    // becomes important, move persistence to RDS and the on-instance data
+    // concern disappears entirely.
+    //
+    // To roll out just a new image tag without replacement, the
+    // `update-ambonmud <tag>` SSM helper still works — it pulls and restarts
+    // the container in-place without touching CFN.
     // -------------------------------------------------------------------------
     const userData = ec2.UserData.forLinux();
     // When hostname is set, the nginx+certbot stack is needed BEFORE the
@@ -534,10 +546,29 @@ export class Ec2Stack extends Stack {
             'printf "AMBONMUD_ADMIN_TOKEN=%s\\n" "$token" > /etc/ambonmud/secrets.env',
             'chmod 600 /etc/ambonmud/secrets.env',
             '# secrets.yaml — Hoplite overlay read by the container (UID 1001).',
-            '# Single-quoted YAML scalar: safe for SSM hex tokens; if token style',
-            '# ever changes to include single-quotes or backslashes, switch to',
-            '# python -c "import yaml,sys; yaml.safe_dump(...)" for robustness.',
-            "printf \"ambonmud:\\n  admin:\\n    token: '%s'\\n\" \"$token\" > /app/data/secrets.yaml",
+            '# When the postgres sidecar is enabled /etc/ambonmud/db.env holds the',
+            '# random DB password generated at first boot; merge it into the same',
+            '# overlay so admin auth + DB auth both land in the highest-priority',
+            '# config source and survive any persistence.backend / database.*',
+            '# values pinned in the public application-local.yaml overlay.',
+            '# Single-quoted YAML scalars are safe for hex tokens + hex passwords;',
+            '# switch to python yaml.safe_dump if either ever grows special chars.',
+            'DB_PASS=""',
+            'if [ -f /etc/ambonmud/db.env ]; then',
+            '  DB_PASS=$(. /etc/ambonmud/db.env && printf "%s" "$POSTGRES_PASSWORD")',
+            'fi',
+            'if [ -n "$DB_PASS" ]; then',
+            '  cat > /app/data/secrets.yaml <<SECRETS_YAML',
+            'ambonmud:',
+            '  admin:',
+            "    token: '${token}'",
+            '  database:',
+            '    username: ambon',
+            "    password: '${DB_PASS}'",
+            'SECRETS_YAML',
+            'else',
+            "  printf \"ambonmud:\\n  admin:\\n    token: '%s'\\n\" \"$token\" > /app/data/secrets.yaml",
+            'fi',
             'chown 1001:1001 /app/data/secrets.yaml',
             'chmod 600 /app/data/secrets.yaml',
             'echo "Admin token materialized to secrets.env + secrets.yaml"',
@@ -855,6 +886,7 @@ export class Ec2Stack extends Stack {
       securityGroup: sg,
       role,
       userData,
+      userDataCausesReplacement: true,
       blockDevices: [
         {
           deviceName: '/dev/xvda',


### PR DESCRIPTION
## Summary

Two tightly-coupled fixes for the "config changes don't actually land" gotcha that's bitten the last four deploys in a row.

### 1. `userDataCausesReplacement: true` on the EC2 instance

Previously `false` so user-data diffs wouldn't clobber player YAML data. But the flip side is what we've actually been living with: CFN updates the launch template metadata, says "Deploy succeeded" in the console, and the running instance keeps executing last week's on-disk scripts for days until some unrelated replacement-required property (like the t4g.medium bump) finally forces a fresh boot.

For a demo that already treats `/app/data` as ephemeral (we've destroyed it three times this week), flipping to `true` buys us "merge → deploy → actually see the change" and that's worth the trade.

### 2. `fetch-admin-token` now merges the sidecar DB password

The script that writes `/app/data/secrets.yaml` runs as `ExecStartPre` on every ambonmud restart. Before this change, it wrote ONLY the admin token — wiping out any DB credentials you tried to stash there, which is exactly why the previous deploy landed with `AMBONMUD_PERSISTENCE_BACKEND=POSTGRES` but auth failed against Hikari with `password authentication failed for user "ambon"`.

Now the script checks for `/etc/ambonmud/db.env` (written by user-data when `postgresSidecar` is enabled), sources `POSTGRES_PASSWORD` from it, and emits a combined overlay:

```yaml
ambonmud:
  admin:
    token: '<ssm-token>'
  database:
    username: ambon
    password: '<db-password>'
```

When the sidecar isn't enabled, it falls back to the token-only `printf` we had before — so this is a no-op for any deployment mode that doesn't run `postgresSidecar`.

## What you do after merge

1. **Run the `Deploy` workflow** (topology=ec2, any image tag).
2. Wait ~10 min for CFN to replace the instance.
3. Inside the fresh instance: postgres sidecar running, ambonmud authed, Flyway migrations applied, tables populated.
4. Run your load test.

No manual SSM paste, no systemd file patching.

## Accepted trade-off

Every future deploy that changes user-data now replaces the EC2 instance. That means:
- `/app/data` gone (YAML player files, fetched overlays re-fetched from R2)
- `pgdata` docker volume gone (Postgres starts empty, Flyway re-migrates)
- ~5–10 min downtime during boot

If/when the demo grows real players you care about, the answer is RDS — at which point the data-loss-on-replacement concern disappears because the DB lives outside the instance entirely.

## Test plan

- [x] `cdk synth --context topology=ec2` shows the instance logical ID carries a hash suffix (CDK's signal that user-data change will force replacement)
- [x] `cdk synth ... --context adminTokenSsmParameterName=...` renders the new conditional merge block in `fetch-admin-token`
- [ ] Dispatch Deploy workflow, wait for replacement, verify: `docker ps` shows both containers, `psql` lists the Flyway-migrated tables
- [ ] Run load test, compare `Player Repo Save Duration` vs. previous YAML baseline