### PR TITLE
Serialize GMCP broadcast payloads once, send N times

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -374,19 +374,28 @@ class GmcpEmitter(
     // ── Room-level broadcast helpers ─────────────────────────────────────
 
     suspend fun broadcastRoomAddMob(roomId: RoomId, mob: MobState, players: PlayerRegistry) {
-        for (p in players.playersInRoom(roomId)) sendRoomAddMob(p.sessionId, mob)
+        broadcastSerialized(players.playersInRoom(roomId), "Room.AddMob", toRoomMobPayload(mob), supportCheck = "Room.Mobs")
     }
 
     suspend fun broadcastRoomUpdateMob(roomId: RoomId, mob: MobState, players: PlayerRegistry) {
-        for (p in players.playersInRoom(roomId)) sendRoomUpdateMob(p.sessionId, mob)
+        broadcastSerialized(players.playersInRoom(roomId), "Room.UpdateMob", toRoomMobPayload(mob), supportCheck = "Room.Mobs")
     }
 
     suspend fun broadcastRoomRemoveMob(roomId: RoomId, mobId: String, players: PlayerRegistry) {
-        for (p in players.playersInRoom(roomId)) sendRoomRemoveMob(p.sessionId, mobId)
+        broadcastSerialized(players.playersInRoom(roomId), "Room.RemoveMob", RoomRemoveMobPayload(id = mobId), supportCheck = "Room.Mobs")
     }
 
     suspend fun broadcastRoomItems(roomId: RoomId, items: List<ItemInstance>, players: PlayerRegistry) {
-        for (p in players.playersInRoom(roomId)) sendRoomItems(p.sessionId, items)
+        val payload = items.map {
+            RoomItemPayload(
+                id = it.id.value,
+                name = it.item.displayName,
+                description = it.item.description,
+                image = it.item.image,
+                video = it.item.video,
+            )
+        }
+        broadcastSerialized(players.playersInRoom(roomId), "Room.Items", payload)
     }
 
     suspend fun sendCharSkills(
@@ -1353,9 +1362,7 @@ class GmcpEmitter(
     }
 
     suspend fun broadcastWorldTime(payload: WorldTimePayload, players: PlayerRegistry) {
-        for (p in players.allPlayers()) {
-            emit(p.sessionId, "World.Time", payload)
-        }
+        broadcastSerialized(players.allPlayers(), "World.Time", payload)
     }
 
     suspend fun sendWorldWeather(sessionId: SessionId, payload: WorldWeatherPayload) {
@@ -1413,9 +1420,7 @@ class GmcpEmitter(
     }
 
     suspend fun broadcastWorldEvents(events: List<WorldEventPayload>, players: PlayerRegistry) {
-        for (p in players.allPlayers()) {
-            emit(p.sessionId, "World.Events", events)
-        }
+        broadcastSerialized(players.allPlayers(), "World.Events", events)
     }
 
     // ---------- reputation / factions ----------
@@ -1581,7 +1586,20 @@ class GmcpEmitter(
     }
 
     suspend fun broadcastRoomMobInfo(roomId: RoomId, mobInfos: List<MobInfoEntry>, players: PlayerRegistry) {
-        for (p in players.playersInRoom(roomId)) sendRoomMobInfo(p.sessionId, mobInfos)
+        val payload = mobInfos.map { m ->
+            RoomMobInfoPayload(
+                id = m.id,
+                level = m.level,
+                tier = m.tier,
+                questGiver = m.questGiver,
+                questAvailable = m.questAvailable,
+                questComplete = m.questComplete,
+                shopKeeper = m.shopKeeper,
+                dialogue = m.dialogue,
+                aggressive = m.aggressive,
+            )
+        }
+        broadcastSerialized(players.playersInRoom(roomId), "Room.MobInfo", payload)
     }
 
     /**
@@ -1963,6 +1981,32 @@ class GmcpEmitter(
             return
         }
         outbound.send(OutboundEvent.GmcpData(sessionId, packageName, rawJson))
+    }
+
+    /**
+     * Broadcasts the same [payload] to every recipient in [recipients], serializing
+     * the JSON once regardless of the recipient count. All [broadcast*] helpers in
+     * this class route through here. Per-session [emit] calls would otherwise build
+     * the payload + `writeValueAsString` it once per recipient, which at 1k+ online
+     * sessions in a shared room / world-wide broadcast becomes the dominant
+     * allocation-and-CPU cost of the GMCP flush pass.
+     */
+    private suspend fun <T : Any> broadcastSerialized(
+        recipients: Collection<PlayerState>,
+        packageName: String,
+        payload: T,
+        supportCheck: String = packageName,
+    ) {
+        if (recipients.isEmpty()) return
+        val serialized = json.writeValueAsString(payload)
+        if (serialized.length > MAX_GMCP_PAYLOAD_BYTES) {
+            log.warn { "GMCP payload exceeds ${MAX_GMCP_PAYLOAD_BYTES}B limit for $packageName (${serialized.length}B), skipping" }
+            return
+        }
+        for (p in recipients) {
+            if (!supportsPackage(p.sessionId, supportCheck)) continue
+            outbound.send(OutboundEvent.GmcpData(p.sessionId, packageName, serialized))
+        }
     }
 
     // ---------- private helpers ----------
@@ -2919,9 +2963,12 @@ class GmcpEmitter(
 
     /** Broadcasts `Quest.Global` inactive to all connected players. */
     suspend fun broadcastGlobalQuestInactive(players: PlayerRegistry) {
-        for (p in players.allPlayers()) {
-            sendGlobalQuestInactive(p.sessionId)
-        }
+        broadcastSerialized(
+            players.allPlayers(),
+            "Quest.Global",
+            GlobalQuestInactivePayload(active = false),
+            supportCheck = "Quest",
+        )
     }
 
     private data class GlobalQuestPayload(

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -20,7 +20,9 @@ import dev.ambon.engine.abilities.AbilityId
 import dev.ambon.engine.events.CombatEvent
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.test.TEST_SESSION_ID
+import dev.ambon.test.buildTestPlayerRegistry
 import dev.ambon.test.drainAll
+import dev.ambon.test.loginOrFail
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -180,6 +182,65 @@ class GmcpEmitterTest {
             e.forgetSession(sid)
             e.sendCharVitals(sid, p)
             assertEquals(2, drainGmcp().size, "After forget, identical vitals should emit again")
+        }
+
+    // ── broadcast* helpers: serialize-once, send-N semantics ─────────────
+    //
+    // The broadcast* methods route every recipient through broadcastSerialized,
+    // which builds the payload + writeValueAsString once regardless of recipient
+    // count. These tests assert that a multi-recipient broadcast emits N GmcpData
+    // events with *identical* jsonData — catches both "missed a recipient" and
+    // "somehow diverged the payloads" regressions without needing to introspect
+    // the private helper.
+
+    @Test
+    fun `broadcastRoomUpdateMob emits identical payload to all recipients`() =
+        runTest {
+            val e = emitter("Room.Mobs")
+            val roomId = RoomId("test:room1")
+            val players = buildTestPlayerRegistry(roomId)
+            players.loginOrFail(SessionId(1L), "Alice")
+            players.loginOrFail(SessionId(2L), "Bob")
+            players.loginOrFail(SessionId(3L), "Carol")
+            outbound.drainAll() // discard login-side events
+
+            val mob = MobState(
+                id = MobId("mob-1"),
+                name = "a rat",
+                description = "a rat",
+                hp = 10,
+                maxHp = 20,
+                roomId = roomId,
+            )
+            e.broadcastRoomUpdateMob(roomId, mob, players)
+
+            val events = drainGmcp().filter { it.gmcpPackage == "Room.UpdateMob" }
+            assertEquals(3, events.size, "Expected one GMCP event per room occupant")
+            val payloads = events.map { it.jsonData }.toSet()
+            assertEquals(1, payloads.size, "All recipients should receive byte-identical payload")
+            assertTrue(events[0].jsonData.contains("\"hp\":10"))
+            assertTrue(events[0].jsonData.contains("\"maxHp\":20"))
+        }
+
+    @Test
+    fun `broadcastWorldTime emits identical payload to all online players`() =
+        runTest {
+            val e = emitter("World.Time")
+            val roomId = RoomId("test:room1")
+            val players = buildTestPlayerRegistry(roomId)
+            players.loginOrFail(SessionId(1L), "Alice")
+            players.loginOrFail(SessionId(2L), "Bob")
+            outbound.drainAll()
+
+            e.broadcastWorldTime(
+                GmcpEmitter.WorldTimePayload(period = "noon", hour = 12, minute = 30),
+                players,
+            )
+
+            val events = drainGmcp().filter { it.gmcpPackage == "World.Time" }
+            assertEquals(2, events.size)
+            assertEquals(1, events.map { it.jsonData }.toSet().size, "All recipients share one serialized payload")
+            assertTrue(events[0].jsonData.contains("\"hour\":12"))
         }
 
     // ── Room.Info ──


### PR DESCRIPTION
## Summary

All seven `broadcast*` helpers in `GmcpEmitter` were looping per-recipient through `emit()`, which built the payload object *and* ran `ObjectMapper.writeValueAsString` for **every** session. At 1000+ online players in a shared room or on a world-scoped broadcast (`World.Time`, `World.Events`, `Quest.Global` inactive), this is the dominant allocation-and-CPU cost inside the GMCP flush pass — visible as tick-overrun growth on the 1003-session run even though `Mob System Tick Duration` itself stayed flat.

Refactor: new private helper `broadcastSerialized(recipients, packageName, payload, supportCheck)` that builds the payload + serializes it **once**, then loops the send. Per-session `supportsPackage` filter preserved; payload-size cap runs once on the serialized string.

## Broadcasters refactored

- Room-scoped: `broadcastRoomAddMob`, `broadcastRoomUpdateMob`, `broadcastRoomRemoveMob`, `broadcastRoomItems`, `broadcastRoomMobInfo`
- World-scoped: `broadcastWorldTime`, `broadcastWorldEvents`, `broadcastGlobalQuestInactive`

## Deliberately NOT refactored

- `broadcastGlobalQuest` — payload embeds a per-session `progress` field, so each recipient legitimately needs a distinct serialization. Left as-is.

## Before / after

For N recipients:

| | Before | After |
|---|---|---|
| Payload object builds | N | 1 |
| `writeValueAsString` calls | N | 1 |
| String allocations | N | 1 |
| `supportsPackage` checks | N | N |
| `outbound.send` calls | N | N |

## Test coverage

Added two `GmcpEmitterTest` cases:

- `broadcastRoomUpdateMob emits identical payload to all recipients` — builds a 3-player room, broadcasts, asserts 3 GmcpData events with a single-element set of `jsonData` values.
- `broadcastWorldTime emits identical payload to all online players` — same pattern for the world-scoped path.

These catch both "skipped a recipient" and "payload shape diverged across recipients" regressions without needing to introspect the private helper.

## Expected load-test impact

- Fewer String allocations during GMCP flush → reduced ZGC concurrent-cycle pressure → heap working set should drop slightly.
- World-scoped broadcasts are the biggest win: one `World.Time` fan-out to 1000 players goes from 1000 `writeValueAsString` + 1000 String allocations to 1 of each.
- Tick p99 at peak broadcast bursts should tighten by a few ms.

## Test plan

- [x] `./gradlew ktlintCheck test` passes
- [x] New test assertions green
- [ ] Deploy to demo (Deploy Demo workflow hot-swaps the image via SSM, no CFN change needed for this PR)
- [ ] Re-run 1000-session load test, compare tick p99 + outbound frames/sec against the last ZGC+Postgres baseline