### PR TITLE
Cache PlayerRegistry.allPlayers snapshot, invalidate on mutation

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
@@ -116,6 +116,25 @@ class PlayerRegistry(
     private val sessionByLowerName = mutableMapOf<String, SessionId>()
 
     /**
+     * Immutable snapshot of [players] values, rebuilt every time the map
+     * membership changes. Reads (including [allPlayers]) return this reference
+     * without allocating — `players.values.toList()` per call was a measurable
+     * allocation hotspot at 1k+ online sessions, showing up as GC pressure in
+     * the tick loop's ZGC concurrent-cycle budget.
+     *
+     * Volatile for visibility to off-engine-thread readers (AdminHttpServer
+     * endpoints, metrics scrapes). All writes happen on the engine thread
+     * inside [rebuildAllPlayersSnapshot], which is only called from mutation
+     * paths — no need for a lock since mutations are single-threaded.
+     */
+    @Volatile
+    private var allPlayersSnapshot: List<PlayerState> = emptyList()
+
+    private fun rebuildAllPlayersSnapshot() {
+        allPlayersSnapshot = players.values.toList()
+    }
+
+    /**
      * Async phase 1 of login: look up the player record and verify credentials.
      *
      * Does **not** mutate any in-memory state — safe to call from a background coroutine
@@ -295,6 +314,7 @@ class PlayerRegistry(
         ps.hp = if (boundRecord.hp <= 0) ps.maxHp else boundRecord.hp.coerceIn(1, ps.maxHp)
         ps.mana = boundRecord.mana.coerceIn(0, ps.maxMana)
         players[sessionId] = ps
+        rebuildAllPlayersSnapshot()
         roomMembers.getOrPut(ps.roomId) { mutableSetOf() }.add(sessionId)
         sessionByLowerName[ps.name.lowercase()] = sessionId
         items.ensurePlayer(sessionId)
@@ -318,6 +338,7 @@ class PlayerRegistry(
 
     suspend fun disconnect(sessionId: SessionId) {
         val ps = players.remove(sessionId) ?: return
+        rebuildAllPlayersSnapshot()
 
         // Persist last seen + room for claimed players
         persistIfClaimed(ps)
@@ -352,6 +373,7 @@ class PlayerRegistry(
      */
     fun suspendSession(sessionId: SessionId): PlayerState? {
         val ps = players.remove(sessionId) ?: return null
+        rebuildAllPlayersSnapshot()
         // Keep the player in roomMembers and sessionByLowerName so they
         // remain "visible" during the grace period. The sessionId will be
         // stale but that's fine — outbound messages to it are dropped.
@@ -373,6 +395,7 @@ class PlayerRegistry(
 
         // --- begin atomic map mutations (no suspend points) ---
         players[newSessionId] = resumed
+        rebuildAllPlayersSnapshot()
 
         // Remap room membership, cleaning up empty sets
         roomMembers.removeFromSet(resumed.roomId, oldSessionId)
@@ -392,6 +415,7 @@ class PlayerRegistry(
         ps: PlayerState,
     ) {
         players[sessionId] = ps
+        rebuildAllPlayersSnapshot()
         roomMembers.getOrPut(ps.roomId) { mutableSetOf() }.add(sessionId)
         sessionByLowerName[ps.name.lowercase()] = sessionId
         items.ensurePlayer(sessionId)
@@ -404,6 +428,7 @@ class PlayerRegistry(
      */
     suspend fun removeForHandoff(sessionId: SessionId): PlayerState? {
         val ps = players.remove(sessionId) ?: return null
+        rebuildAllPlayersSnapshot()
 
         // Persist with target room before removing
         persistIfClaimed(ps)
@@ -461,7 +486,7 @@ class PlayerRegistry(
         return true
     }
 
-    fun allPlayers(): List<PlayerState> = players.values.toList()
+    fun allPlayers(): List<PlayerState> = allPlayersSnapshot
 
     fun playersInRoom(roomId: RoomId): List<PlayerState> =
         roomMembers[roomId]
@@ -608,6 +633,7 @@ class PlayerRegistry(
         // --- begin atomic map mutations (no suspend points) ---
         players.remove(oldSid)
         players[newSid] = newPs
+        rebuildAllPlayersSnapshot()
 
         roomMembers.removeFromSet(oldPs.roomId, oldSid)
         roomMembers.getOrPut(newPs.roomId) { mutableSetOf() }.add(newSid)

--- a/src/test/kotlin/dev/ambon/engine/PlayerRegistrySnapshotTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/PlayerRegistrySnapshotTest.kt
@@ -1,0 +1,68 @@
+package dev.ambon.engine
+
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.test.buildTestPlayerRegistry
+import dev.ambon.test.loginOrFail
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Covers the cached-snapshot invariant for [PlayerRegistry.allPlayers].
+ *
+ * At 1k+ sessions, `allPlayers()` was the dominant per-tick allocation
+ * hotspot because every call did `players.values.toList()`. The registry
+ * now caches the snapshot and rebuilds it only on membership change;
+ * these tests pin that behavior so future mutation sites don't silently
+ * regress by forgetting to invalidate.
+ */
+class PlayerRegistrySnapshotTest {
+    private val room = RoomId("test:start")
+
+    @Test
+    fun `allPlayers returns cached reference when membership unchanged`() =
+        runTest {
+            val registry = buildTestPlayerRegistry(room)
+            registry.loginOrFail(SessionId(1L), "Alice")
+
+            val first = registry.allPlayers()
+            val second = registry.allPlayers()
+            assertSame(first, second, "Repeated allPlayers() calls should return the same cached list")
+        }
+
+    @Test
+    fun `allPlayers rebuilds after login`() =
+        runTest {
+            val registry = buildTestPlayerRegistry(room)
+
+            val empty = registry.allPlayers()
+            assertTrue(empty.isEmpty())
+
+            registry.loginOrFail(SessionId(1L), "Alice")
+            val afterLogin = registry.allPlayers()
+            assertNotSame(empty, afterLogin, "Snapshot must be rebuilt on login")
+            assertEquals(1, afterLogin.size)
+            assertEquals("Alice", afterLogin[0].name)
+        }
+
+    @Test
+    fun `allPlayers rebuilds after disconnect`() =
+        runTest {
+            val registry = buildTestPlayerRegistry(room)
+            registry.loginOrFail(SessionId(1L), "Alice")
+            registry.loginOrFail(SessionId(2L), "Bob")
+
+            val twoPlayers = registry.allPlayers()
+            assertEquals(2, twoPlayers.size)
+
+            registry.disconnect(SessionId(1L))
+            val afterDisconnect = registry.allPlayers()
+            assertNotSame(twoPlayers, afterDisconnect, "Snapshot must be rebuilt on disconnect")
+            assertEquals(1, afterDisconnect.size)
+            assertEquals("Bob", afterDisconnect[0].name)
+        }
+}


### PR DESCRIPTION
## Summary

`PlayerRegistry.allPlayers()` was doing `players.values.toList()` on every call — a fresh ~1k-element `ArrayList` per invocation. At 1000 online sessions the engine tick loop alone calls this across ~8 call sites (tick core, regen, hot-reload, scheduler, zone reset, possession check, world-event broadcasts, metrics bind), plus several `AdminHttpServer` endpoints and periodic systems (leaderboard, friends). Net: hundreds of throwaway 1k-element lists per second, pushing ZGC's allocation rate right up to where allocation stalls start showing at the 2GB heap cap.

The snapshot only changes on login / logout / handoff, so cache it. Rebuild at the seven mutation sites in `PlayerRegistry`:

- `bindSession`
- `disconnect`
- `suspendSession`
- `resumeSession`
- `bindFromHandoff`
- `removeForHandoff`
- `takeoverSession`

The cached field is `@Volatile` so off-engine-thread readers (`AdminHttpServer` Ktor handlers, Prometheus metrics scrape) see the latest publication without tearing. All writes stay on the engine thread, so no lock is required.

## Correctness note

Two back-to-back `allPlayers()` calls now return **the same `List` reference**. Callers that relied on getting a fresh snapshot per call are unaffected:

- The list is immutable after publication.
- Any mutation rebuilds it and publishes a new reference.
- The window where a reader has a stale snapshot is bounded by the gap between their read and the next mutation — identical to the old `map.toList()` case where a snapshot taken *before* a concurrent mutation already missed it.

## Expected impact on the 1100-session ceiling

From the last run, the failure mode was: save-flush GC spikes → allocation stalls land on the engine thread → tick overruns → inbound queue backs up → telnet/backpressure disconnects. Cutting the tick loop's allocation rate by hundreds of 1k-element lists per second directly takes pressure off that chain.

Paired with the earlier broadcast-serialize-once change, the tick loop should now hold its budget further into the 1000s of concurrent sessions before the save-flush spike becomes the next thing to fix.

## Test plan

- [x] `./gradlew ktlintCheck test` passes, full suite
- [x] New `PlayerRegistrySnapshotTest` asserts cached reference identity on unchanged membership + snapshot rebuild on login/disconnect
- [ ] Deploy via Deploy Demo hot-swap, re-run load test, compare tick p99 + overruns at 1000–1100 sessions vs prior baseline
- [ ] Watch JVM heap working set — expect a measurable drop in the upper bound since per-tick list allocations are gone