### PR TITLE
Gate mob behavior-tree ticks to zones with players present

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/behavior/BehaviorTreeSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/BehaviorTreeSystem.kt
@@ -40,7 +40,21 @@ class BehaviorTreeSystem(
         val now = clock.millis()
         var actions = 0
 
-        val mobList = mobs.all().filter { it.behaviorTree != null }.toMutableList()
+        // Skip BT evaluation for mobs in zones with no players — idle wandering
+        // and ambient behaviors have no observer, so ticking them is pure waste.
+        // Mobs currently in combat still tick regardless of zone population so
+        // they can make flee / pursue decisions when the player who engaged them
+        // walks into a different zone (combat itself continues via CombatSystem;
+        // this is just the BT-driven side of combat behavior).
+        val activeZones = HashSet<String>()
+        for (p in players.allPlayers()) {
+            activeZones.add(p.roomId.zone)
+        }
+
+        val mobList =
+            mobs.all()
+                .filter { it.behaviorTree != null && (it.roomId.zone in activeZones || isMobInCombat(it.id)) }
+                .toMutableList()
         mobList.shuffle(rng)
 
         for (m in mobList) {

--- a/src/test/kotlin/dev/ambon/engine/behavior/BehaviorTreeSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/behavior/BehaviorTreeSystemTest.kt
@@ -300,6 +300,8 @@ class BehaviorTreeSystemTest {
             val route = listOf(roomB.id, roomC.id, roomA.id)
             val tree = PatrolAction(route)
             val e = env(mobRoom = roomA.id, behaviorTree = tree)
+            // BT now gates on zone-has-player; log a watcher in the mob's zone.
+            e.players.loginOrFail(SessionId(99L), "Watcher")
 
             // Schedule tick (dueAt null → sets future time)
             e.system.tick()
@@ -392,6 +394,7 @@ class BehaviorTreeSystemTest {
         runTest {
             val tree = WanderAction()
             val e = env(behaviorTree = tree)
+            e.players.loginOrFail(SessionId(99L), "Watcher")
 
             e.system.tick() // schedule
             e.clock.advance(200)
@@ -506,6 +509,66 @@ class BehaviorTreeSystemTest {
             )
         }
 
+    @Test
+    fun `BT does not tick mobs in zones with no players`() =
+        runTest {
+            // Mob lives in a zone with no players; player logs in to a different
+            // zone (the world start room, which is zone "zone"). BT tick should
+            // skip the mob entirely — no scheduling, no action execution.
+            val tree = SayAction("I am lonely")
+            val e = env(mobRoom = RoomId("farzone:mob-lair"), behaviorTree = tree)
+            e.players.loginOrFail(SessionId(1L), "Tester")
+            e.outbound.drainAll()
+
+            e.system.tick()
+            e.clock.advance(200)
+            e.system.tick()
+
+            val messages = e.outbound.drainAll()
+            assertFalse(
+                messages.any { ev ->
+                    ev is OutboundEvent.SendText && ev.text.contains("I am lonely")
+                },
+                "Mob in player-less zone should not have executed its BT",
+            )
+        }
+
+    @Test
+    fun `BT resumes ticking mobs when a player enters their zone`() =
+        runTest {
+            // Start with the mob isolated in a player-less zone; BT is quiet.
+            // When a player joins a room in the mob's zone, subsequent ticks
+            // should execute the BT and emit the Say action.
+            val tree = SayAction("About time someone showed up")
+            val mobRoomId = RoomId("zone:a") // same zone as world start room
+            val e = env(mobRoom = mobRoomId, behaviorTree = tree)
+            // No players logged in yet — mob's zone is empty.
+            e.system.tick()
+            e.clock.advance(200)
+            e.system.tick()
+            assertTrue(
+                e.outbound.drainAll().none { ev ->
+                    ev is OutboundEvent.SendText && ev.text.contains("About time")
+                },
+                "Pre-player ticks should be skipped",
+            )
+
+            e.players.loginOrFail(SessionId(1L), "Tester")
+            e.outbound.drainAll()
+
+            e.system.tick()
+            e.clock.advance(200)
+            e.system.tick()
+
+            val messages = e.outbound.drainAll()
+            assertTrue(
+                messages.any { ev ->
+                    ev is OutboundEvent.SendText && ev.text.contains("About time")
+                },
+                "BT should resume once a player is in the mob's zone",
+            )
+        }
+
     // --- CooldownNode tests ---
 
     @Test
@@ -522,6 +585,7 @@ class BehaviorTreeSystemTest {
 
             val tree = CooldownNode(cooldownMs = 1000L, key = "test", child = countingNode)
             val e = env(behaviorTree = tree)
+            e.players.loginOrFail(SessionId(99L), "Watcher")
 
             // Schedule tick (dueAt null → sets future time)
             e.system.tick()


### PR DESCRIPTION
## Summary

`BehaviorTreeSystem.tick()` iterates every mob in the registry on every engine tick, regardless of whether any player is around to observe. Idle wandering, patrols, ambient `say` actions, cooldown evaluations — all ran for mobs in empty zones. Pure waste that scales with total world size, not active playerbase.

Fix: build a `HashSet<String>` of zones-with-players at tick start, filter the mob list to only mobs whose zone is in that set.

```kotlin
val activeZones = HashSet<String>()
for (p in players.allPlayers()) activeZones.add(p.roomId.zone)

val mobList = mobs.all()
    .filter { it.behaviorTree != null && (it.roomId.zone in activeZones || isMobInCombat(it.id)) }
    .toMutableList()
```

## Expected impact

Current demo world (Academy) has one zone so the immediate win is zero — but the load-test profile is already player-dense, not a bottleneck. The real payoff lands when the world grows: Auringold's ~20 zones with players typically concentrated in 3–5 of them means **~75–85% of BT iteration work evaporates** at steady state. Scales linearly with world-size-over-active-zones ratio, which is what the user flagged as the next scaling concern.

## Correctness — the combat exception

Mobs currently in combat still tick regardless of zone population:

```kotlin
.filter { ... (it.roomId.zone in activeZones || isMobInCombat(it.id)) }
```

Reason: if a player engages a mob, then walks to a different zone, the zone they left becomes inactive. Without the `isMobInCombat` carve-out, the mob would stop making BT-driven flee/pursue decisions mid-fight. Combat itself continues via `CombatSystem` (never gated, ticks independently) — this carve-out is just for the BT-driven side (flee-when-low-HP, pursue-target, etc.).

## Test coverage

Three pre-existing tests (`patrol action cycles through waypoints`, `wander action moves mob to random adjacent room`, `cooldown node gates child execution`) exercised BT in isolation without logging in any player. They now log in a `Watcher` session in the mob's zone so the gate allows the mob through.

Two new tests pin the gating itself:

- `BT does not tick mobs in zones with no players` — mob in `farzone`, player in `zone`, assert no `say` output
- `BT resumes ticking mobs when a player enters their zone` — same setup, then log in a player in the mob's zone, assert BT starts firing

## Test plan

- [x] `./gradlew ktlintCheck test` full suite green
- [ ] Deploy via Deploy Demo hot-swap
- [ ] Verify the load-test baseline doesn't regress (expect near-identical numbers since the Academy demo is one zone — this PR is forward-looking for when the full Auringold world is attached)
- [ ] Once Auringold is loaded, re-run and compare: `Mob System Tick Duration` p95/max, engine tick p99 at equivalent session count