### PR TITLE
Clear trainer state on room change to prevent stale panel

### DIFF
--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -329,9 +329,13 @@ export function applyGmcpPackage(
       // Detect actual room change (not just a look/refresh of the same room)
       ctx.setRoom((prev) => {
         if (prev.id !== id && prev.id !== null) {
-          // Moved to a different room — clear dialogue/quest offers
+          // Moved to a different room — clear dialogue/quest offers and trainer data.
+          // Trainer state must be cleared or the panel will render stale data from the
+          // previous trainer (e.g. a single-class WARRIOR trainer) when the user opens
+          // it at a new multi-class trainer before `train list` has fetched fresh data.
           ctx.setDialogue(null);
           ctx.setQuestsAvailable([]);
+          ctx.setTrainer(null);
         }
         return { id, title, description, exits, image, video, music, ambient, station, trainer, mapX, mapY, housing, housingOwner, graphical, terrain, bank, stylist, tavern, dungeon, auction, housingBroker };
       });


### PR DESCRIPTION
## Summary
- A mage visiting Instructor Valence (multi-class trainer) was shown a \"Warrior class is locked, [pay gold]\" panel with no class tabs and no mage abilities.
- Root cause: `Room.Info` handler clears `dialogue` and `questsAvailable` on room change but not `trainer`. If the player had visited any trainer earlier in the session, `state.trainer` retained that stale payload. Since `TrainerAutoLoad` only fires when `state.trainer === null`, opening the panel at the new room rendered the old data instead of refetching.
- Fix: also call `ctx.setTrainer(null)` in the existing room-change branch of `Room.Info`.

Verified server-side emission is correct (a temporary test calling `GmcpEmitter.sendTrainerList` directly for a MAGE at a 5-class trainer produced the expected `classUnlocked: true` on the MAGE entry and `false` on the others).

## Test plan
- [ ] Visit a single-class trainer, run `train list`, then walk to a multi-class trainer and open the panel — should show class tabs with the player's class pre-selected and their abilities listed.
- [ ] Visit the multi-class trainer first — should still work (unchanged path).
- [ ] Walk away from any trainer and reopen the panel at a non-trainer room — should show the \"Loading trainer data…\" state briefly before the server error \"There is no trainer here.\" lands, rather than stale data.