### PR TITLE
Fix quickbar triggering cooldown when cast fails on missing target

### DIFF
--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -282,13 +282,14 @@ function App() {
   const handleCastSkill = (skillId: string, cooldownMs: number) => {
     const skill = state.skills.find((s) => s.id === skillId);
     if (!skill) return;
-    const needsTarget = skill.targetType === "ENEMY" || skill.targetType === "ALLY";
+    const t = skill.targetType.toUpperCase();
+    const needsTarget = t === "ENEMY" || t === "ALLY";
     if (needsTarget && gameStateRef.current.combatTarget?.targetName) {
       completeCast(skillId, cooldownMs, gameStateRef.current.combatTarget.targetName);
       return;
     }
     if (needsTarget) {
-      pendingCastRef.current = { skillId, skillName: skill.name, cooldownMs, targetType: skill.targetType };
+      pendingCastRef.current = { skillId, skillName: skill.name, cooldownMs, targetType: t };
       state.setToast(`Select a target for ${skill.name}`);
       return;
     }


### PR DESCRIPTION
## Summary
- Server lowercases ability `targetType` in `AbilityRegistryLoader.kt:15`, but `App.handleCastSkill` compared against uppercase `"ENEMY"`/`"ALLY"`. The `needsTarget` check was always false, so every quickbar click with no target ran `completeCast` — applying the local cooldown and sending `cast X` with no target, which the server rejected with "Cast X on whom?" while the cooldown sweep stuck on the slot.
- Uppercase `targetType` before comparing, and store the normalized value on `pendingCastRef` so `WorldScene`'s targeting pulse (which also checks uppercase) lights up the mob/ally sprites once the target-select flow is reached.

## Test plan
- [ ] Log in, clear combat target, click a damage spell on the quickbar → toast "Select a target for X" appears, no cooldown sweep on the slot, no `cast X` sent.
- [ ] With a combat target active, click the same spell → cast succeeds and cooldown animates normally.
- [ ] Click a self-targeted spell (e.g. a buff) → fires immediately, cooldown animates.
- [ ] Click an enemy-targeted spell with no combat target, then click a mob on the canvas → targeting pulse highlights mobs (crosshair cursor), then the cast fires against the clicked mob.