### PR TITLE
Make regen tick cap adaptive to player count

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -189,7 +189,12 @@ data class AppConfig(
     }
 
     private fun validateEngineRegen() {
+        engine.regen.cycleTargetMillis.requirePositive("ambonMUD.engine.regen.cycleTargetMillis")
+        engine.regen.minPlayersPerTick.requirePositive("ambonMUD.engine.regen.minPlayersPerTick")
         engine.regen.maxPlayersPerTick.requirePositive("ambonMUD.engine.regen.maxPlayersPerTick")
+        require(engine.regen.maxPlayersPerTick >= engine.regen.minPlayersPerTick) {
+            "ambonMUD.engine.regen.maxPlayersPerTick must be >= minPlayersPerTick"
+        }
         engine.regen.baseIntervalMillis.requirePositive("ambonMUD.engine.regen.baseIntervalMillis")
         engine.regen.minIntervalMillis.requirePositive("ambonMUD.engine.regen.minIntervalMillis")
         engine.regen.regenAmount.requirePositive("ambonMUD.engine.regen.regenAmount")
@@ -1992,7 +1997,9 @@ data class CombatFeedbackConfig(
 )
 
 data class RegenEngineConfig(
-    val maxPlayersPerTick: Int = 50,
+    val cycleTargetMillis: Long = 2_000L,
+    val minPlayersPerTick: Int = 5,
+    val maxPlayersPerTick: Int = 200,
     val baseIntervalMillis: Long = 5_000L,
     val minIntervalMillis: Long = 1_000L,
     val regenAmount: Int = 1,

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -707,6 +707,10 @@ class GameEngine(
             manaBaseIntervalMs = engineConfig.regen.mana.baseIntervalMillis,
             manaMinIntervalMs = engineConfig.regen.mana.minIntervalMillis,
             manaRegenAmount = engineConfig.regen.mana.regenAmount,
+            tickIntervalMs = tickMillis,
+            cycleTargetMs = engineConfig.regen.cycleTargetMillis,
+            minPlayersPerTick = engineConfig.regen.minPlayersPerTick,
+            maxPlayersPerTick = engineConfig.regen.maxPlayersPerTick,
             bindings = engineConfig.stats.bindings,
             metrics = metrics,
             dirtyNotifier = dirtyNotifier,
@@ -1502,7 +1506,7 @@ class GameEngine(
 
                     // Regenerate player HP (time-gated internally)
                     val regenSample = Timer.start()
-                    regenSystem.tick(maxPlayersPerTick = engineConfig.regen.maxPlayersPerTick)
+                    regenSystem.tick()
                     regenSample.stop(metrics.regenTickTimer)
 
                     // Periodic threat table cleanup — sweep stale mob entries every 60s

--- a/src/main/kotlin/dev/ambon/engine/RegenSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/RegenSystem.kt
@@ -18,6 +18,10 @@ class RegenSystem(
     private val manaBaseIntervalMs: Long = 3_000L,
     private val manaMinIntervalMs: Long = 1_000L,
     private val manaRegenAmount: Int = 1,
+    private val tickIntervalMs: Long = 100L,
+    private val cycleTargetMs: Long = 2_000L,
+    private val minPlayersPerTick: Int = 5,
+    private val maxPlayersPerTick: Int = 200,
     private val bindings: StatBindingsConfig = StatBindingsConfig(),
     private val metrics: GameMetrics = GameMetrics.noop(),
     private val dirtyNotifier: DirtyNotifier = DirtyNotifier.NO_OP,
@@ -38,16 +42,20 @@ class RegenSystem(
         lastManaRegenAtMs.remove(sessionId)
     }
 
-    fun tick(maxPlayersPerTick: Int = 50) {
+    fun tick(capOverride: Int? = null) {
         val now = clock.millis()
         var ran = 0
 
         val list = players.allPlayers()
         if (list.isEmpty()) return
+
+        val cap = capOverride ?: adaptiveCap(list.size)
+        if (cap <= 0) return
+
         val start = rng.nextInt(list.size)
 
         for (i in list.indices) {
-            if (ran >= maxPlayersPerTick) break
+            if (ran >= cap) break
             val player = list[(start + i) % list.size]
             ran++
 
@@ -117,5 +125,11 @@ class RegenSystem(
     private fun regenInterval(totalStat: Int, baseMs: Long, msPerPoint: Long, minMs: Long): Long {
         val bonus = (totalStat - PlayerState.BASE_STAT).coerceAtLeast(0).toLong()
         return (baseMs - bonus * msPerPoint).coerceAtLeast(minMs)
+    }
+
+    internal fun adaptiveCap(playerCount: Int): Int {
+        if (playerCount <= 0) return 0
+        val raw = ((playerCount.toLong() * tickIntervalMs + cycleTargetMs - 1) / cycleTargetMs).toInt()
+        return raw.coerceIn(minPlayersPerTick, maxPlayersPerTick)
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -849,7 +849,9 @@ ambonmud:
       buyMultiplier: 1
       sellMultiplier: 0.5
     regen:
-      maxPlayersPerTick: 10
+      cycleTargetMillis: 2000
+      minPlayersPerTick: 5
+      maxPlayersPerTick: 200
       baseIntervalMillis: 4500
       minIntervalMillis: 1000
       regenAmount: 1

--- a/src/test/kotlin/dev/ambon/engine/RegenSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/RegenSystemTest.kt
@@ -154,7 +154,7 @@ class RegenSystemTest {
             clock.advance(200L)
 
             // Limit to 2 players per tick
-            regen.tick(maxPlayersPerTick = 2)
+            regen.tick(capOverride = 2)
 
             val healed = listOf(sid1, sid2, sid3).count { players.get(it)!!.hp > 1 }
             assertTrue(healed <= 2, "Expected at most 2 players healed, got $healed")
@@ -194,13 +194,110 @@ class RegenSystemTest {
 
             // Cap = 10, 11 players total.  The 10 full-HP players consume the cap; sid1 (index 0)
             // is not reached when iteration starts at index 1 (Random(42).nextInt(11) == 1).
-            regen.tick(maxPlayersPerTick = 10)
+            regen.tick(capOverride = 10)
 
             assertEquals(
                 damagedHp,
                 damagedPlayer.hp,
                 "Damaged player must not be healed when cap is consumed by full-HP players",
             )
+        }
+
+    @Test
+    fun `adaptiveCap scales with player count to hit the cycle target`() {
+        val regen =
+            RegenSystem(
+                players = makeRegistry(),
+                items = ItemRegistry(),
+                clock = MutableClock(0L),
+                tickIntervalMs = 100L,
+                cycleTargetMs = 2_000L,
+                minPlayersPerTick = 5,
+                maxPlayersPerTick = 200,
+            )
+        // 100 players * 100ms / 2000ms = 5/tick → cycles in 2s
+        assertEquals(5, regen.adaptiveCap(100))
+        // 500 * 100 / 2000 = 25
+        assertEquals(25, regen.adaptiveCap(500))
+        // 1437 * 100 / 2000 = 71.85 → ceil = 72
+        assertEquals(72, regen.adaptiveCap(1437))
+    }
+
+    @Test
+    fun `adaptiveCap respects floor at low populations`() {
+        val regen =
+            RegenSystem(
+                players = makeRegistry(),
+                items = ItemRegistry(),
+                clock = MutableClock(0L),
+                tickIntervalMs = 100L,
+                cycleTargetMs = 2_000L,
+                minPlayersPerTick = 5,
+                maxPlayersPerTick = 200,
+            )
+        // Raw would be 10 * 100 / 2000 = 0.5 → ceil = 1 → floor lifts to 5
+        assertEquals(5, regen.adaptiveCap(10))
+        // Raw = 1 → floor = 5
+        assertEquals(5, regen.adaptiveCap(1))
+    }
+
+    @Test
+    fun `adaptiveCap respects ceiling at very high populations`() {
+        val regen =
+            RegenSystem(
+                players = makeRegistry(),
+                items = ItemRegistry(),
+                clock = MutableClock(0L),
+                tickIntervalMs = 100L,
+                cycleTargetMs = 2_000L,
+                minPlayersPerTick = 5,
+                maxPlayersPerTick = 200,
+            )
+        // 10000 * 100 / 2000 = 500 → ceiling 200 → cycle degrades to 5s, engine protected
+        assertEquals(200, regen.adaptiveCap(10_000))
+    }
+
+    @Test
+    fun `adaptiveCap returns zero for empty population`() {
+        val regen =
+            RegenSystem(
+                players = makeRegistry(),
+                items = ItemRegistry(),
+                clock = MutableClock(0L),
+            )
+        assertEquals(0, regen.adaptiveCap(0))
+    }
+
+    @Test
+    fun `tick without override uses adaptive cap`() =
+        runTest {
+            val players = makeRegistry()
+            val regen =
+                RegenSystem(
+                    players = players,
+                    items = ItemRegistry(),
+                    clock = MutableClock(0L),
+                    rng = Random(42),
+                    // Zero intervals → any visited, damaged player heals immediately on first tick.
+                    baseIntervalMs = 0L,
+                    minIntervalMs = 0L,
+                    manaBaseIntervalMs = 0L,
+                    manaMinIntervalMs = 0L,
+                    // 5 players * 100ms / 1000ms = 0.5 → ceil 1 → floor lifts to 1
+                    tickIntervalMs = 100L,
+                    cycleTargetMs = 1_000L,
+                    minPlayersPerTick = 1,
+                    maxPlayersPerTick = 200,
+                )
+
+            val sids = (1..5).map { SessionId(it.toLong()) }
+            sids.forEachIndexed { idx, sid -> players.loginOrFail(sid, "Player$idx") }
+            sids.forEach { players.get(it)!!.hp = 1 }
+
+            regen.tick() // adaptive cap = 1
+
+            val healed = sids.count { players.get(it)!!.hp > 1 }
+            assertEquals(1, healed, "Expected adaptive cap of 1 to heal exactly one player")
         }
 
     @Test


### PR DESCRIPTION
## Summary

- Replaces the fixed `engine.regen.maxPlayersPerTick = 10` cap with an adaptive formula driven by a target cycle time: `cap = ceil(playerCount * tickIntervalMs / cycleTargetMillis)`, coerced into `[minPlayersPerTick, maxPlayersPerTick]`.
- Keeps `maxPlayersPerTick` as an absolute ceiling — operators still have a hard knob.
- Removes the pinned `maxPlayersPerTick: 10` from `application.yaml`; the demo now uses the adaptive formula with a 2-second cycle target.

## Why

The existing fixed cap kept per-tick cost bounded but had a hidden correctness cost at scale. In the April 2026 Run 3b load test at 1,437 concurrent sessions, 10 players/tick × 10 TPS = 100/sec, so each player's regen check fired only every ~14s — far slower than the 4.5s `baseIntervalMillis` suggests. The adaptive formula keeps the full-population cycle at roughly `cycleTargetMillis` regardless of player count.

## Behavior at different populations

With the new defaults (`cycleTargetMillis=2000`, `minPlayersPerTick=5`, `maxPlayersPerTick=200`, tick=100ms):

| Players | Cap/tick | Full cycle |
|---------|----------|------------|
| 10      | 5 (floor) | 200ms    |
| 100     | 5        | 2.0s      |
| 500     | 25       | 2.0s      |
| 1,437   | 72       | 2.0s      |
| 10,000  | 200 (ceiling) | 5.0s (graceful degrade) |

## Files changed

- `AppConfig.kt` — `RegenEngineConfig` gains `cycleTargetMillis`, `minPlayersPerTick`, keeps `maxPlayersPerTick`. Validation updated.
- `RegenSystem.kt` — new `adaptiveCap(playerCount)` helper; `tick()` now takes `capOverride: Int?` (for tests) and computes adaptively when null.
- `GameEngine.kt` — wires new config fields through to `RegenSystem` constructor, drops the explicit cap arg at the call site.
- `application.yaml` — new adaptive keys, old pinned override removed.
- `RegenSystemTest.kt` — four new tests covering the formula bounds and adaptive-cap behavior under `tick()`; existing tests updated to the new arg name.

## Test plan

- [x] `./gradlew ktlintCheck` — clean
- [x] `./gradlew test --tests "*Regen*" --tests "*AppConfig*" --tests "*GameEngineTest*"` — green
- [ ] Deploy to demo, confirm regen feels responsive at high player count (expected: full cycle holds at ~2s regardless of population)
- [ ] Verify no Grafana regression in `Regen Tick Duration` p95 — adaptive cap should stay near the old 10/tick cost at small scale, scale up only when needed

## Follow-ups (out of scope)

- `docs/SCALING_STORY.md` still carries one stale "regen has no cap" line in the February 2026 section; will clean up in a small doc PR.
- The remaining regen-tick-duration outliers (~30–40 ms max) are likely dominated by `items.equipmentBonuses()` allocation rather than player-count — worth a separate profiling pass.