### PR TITLE
Coalesce outbound frames: telnet batch write, WebSocket text concat

### DIFF
--- a/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
+++ b/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
@@ -35,6 +35,10 @@ import java.util.concurrent.atomic.AtomicReference
 
 private val log = KotlinLogging.logger {}
 
+// Maximum number of extra frames to drain per write iteration before flushing the text batch.
+// Keeps latency bounded while amortising WebSocket frame overhead across bursts of text output.
+private const val MAX_WS_FRAMES_PER_BATCH = 64
+
 class KtorWebSocketTransport(
     private val port: Int,
     private val inbound: InboundBus,
@@ -217,17 +221,40 @@ private suspend fun DefaultWebSocketServerSession.bridgeWebSocketSession(
 
     val writerJob =
         launch {
+            // Consecutive OutboundFrame.Text entries are concatenated into a single WebSocket
+            // Frame.Text to reduce per-frame header + send-call overhead. GMCP envelopes must
+            // stay isolated — the client's message handler parses each incoming WS text frame
+            // as either a GMCP envelope or plain text, never mixed (see useMudSocket.ts).
+            val pendingText = StringBuilder()
+
+            suspend fun flushPendingText() {
+                if (pendingText.isNotEmpty()) {
+                    send(Frame.Text(pendingText.toString()))
+                    pendingText.setLength(0)
+                }
+            }
+
+            suspend fun process(frame: OutboundFrame) {
+                when (frame) {
+                    is OutboundFrame.Text -> pendingText.append(frame.content)
+                    is OutboundFrame.Gmcp -> {
+                        flushPendingText()
+                        send(Frame.Text("""{"gmcp":"${frame.gmcpPackage}","data":${frame.jsonData}}"""))
+                    }
+                }
+                outboundRouter.onSessionQueueFrameConsumed(sessionId, frame.enqueuedAt)
+            }
+
             try {
                 for (frame in outboundQueue) {
-                    when (frame) {
-                        is OutboundFrame.Text -> send(Frame.Text(frame.content))
-                        is OutboundFrame.Gmcp -> {
-                            val pkg = frame.gmcpPackage
-                            val data = frame.jsonData
-                            send(Frame.Text("""{"gmcp":"$pkg","data":$data}"""))
-                        }
+                    process(frame)
+                    var drained = 0
+                    while (drained < MAX_WS_FRAMES_PER_BATCH) {
+                        val next = outboundQueue.tryReceive().getOrNull() ?: break
+                        process(next)
+                        drained++
                     }
-                    outboundRouter.onSessionQueueFrameConsumed(sessionId, frame.enqueuedAt)
+                    flushPendingText()
                 }
             } catch (_: Throwable) {
                 // best effort

--- a/src/main/kotlin/dev/ambon/transport/NetworkSession.kt
+++ b/src/main/kotlin/dev/ambon/transport/NetworkSession.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
+import java.io.ByteArrayOutputStream
 import java.net.Socket
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantLock
@@ -252,18 +253,23 @@ class NetworkSession(
     private suspend fun writeLoop() {
         try {
             val output = socket.getOutputStream()
+            // Reused across batches; reset() keeps the internal array allocated.
+            val batchBuffer = ByteArrayOutputStream(4096)
             for (frame in outboundQueue) {
-                // Write first frame, then drain any immediately available frames before flushing.
-                var needFlush = writeFrame(output, frame)
+                batchBuffer.reset()
+                appendFrame(batchBuffer, frame)
                 var drained = 0
                 while (drained < MAX_FRAMES_PER_FLUSH) {
                     val next = outboundQueue.tryReceive().getOrNull() ?: break
-                    val wrote = writeFrame(output, next)
-                    if (wrote) needFlush = true
+                    appendFrame(batchBuffer, next)
                     drained++
                 }
-                if (needFlush) {
-                    outputLock.withLock { output.flush() }
+                if (batchBuffer.size() > 0) {
+                    val bytes = batchBuffer.toByteArray()
+                    outputLock.withLock {
+                        output.write(bytes)
+                        output.flush()
+                    }
                 }
             }
         } catch (_: Throwable) {
@@ -274,28 +280,22 @@ class NetworkSession(
     }
 
     /**
-     * Writes a single frame to [output] without flushing.
-     * Returns true if bytes were written (i.e. a flush is needed).
+     * Appends a frame's bytes (if any) into [buffer]. GMCP frames are skipped when the client
+     * has not enabled GMCP — the delivery callback still fires so metrics stay consistent.
      */
-    private fun writeFrame(
-        output: java.io.OutputStream,
+    private fun appendFrame(
+        buffer: ByteArrayOutputStream,
         frame: OutboundFrame,
-    ): Boolean {
+    ) {
         onOutboundFrameWritten(frame.enqueuedAt)
-        return when (frame) {
+        when (frame) {
             is OutboundFrame.Text -> {
-                val bytes = frame.content.toByteArray(Charsets.UTF_8)
-                outputLock.withLock { output.write(bytes) }
-                true
+                buffer.write(frame.content.toByteArray(Charsets.UTF_8))
             }
             is OutboundFrame.Gmcp -> {
                 if (gmcpEnabled) {
                     val payload = "${frame.gmcpPackage} ${frame.jsonData}".toByteArray(Charsets.UTF_8)
-                    val bytes = buildTelnetSubnegotiationBytes(TelnetProtocol.GMCP, payload)
-                    outputLock.withLock { output.write(bytes) }
-                    true
-                } else {
-                    false
+                    buffer.write(buildTelnetSubnegotiationBytes(TelnetProtocol.GMCP, payload))
                 }
             }
         }

--- a/src/test/kotlin/dev/ambon/transport/KtorWebSocketTransportTest.kt
+++ b/src/test/kotlin/dev/ambon/transport/KtorWebSocketTransportTest.kt
@@ -166,6 +166,111 @@ class KtorWebSocketTransportTest {
         assertTrue(isOriginAllowedForHost("http://anything.com", ""))
     }
 
+    @Test
+    fun `consecutive text frames are coalesced into one websocket frame`(): Unit =
+        runBlocking {
+            val inbound = LocalInboundBus()
+            val engineOutbound = LocalOutboundBus()
+            val outboundRouter = OutboundRouter(engineOutbound, this)
+            val routerJob = outboundRouter.start()
+            val sid = SessionId(7)
+
+            testApplication {
+                application {
+                    ambonMUDWebModule(
+                        inbound = inbound,
+                        outboundRouter = outboundRouter,
+                        sessionIdFactory = { sid },
+                    )
+                }
+
+                val wsClient = createClient { install(WebSockets) }
+
+                wsClient.webSocket("/ws") {
+                    // Drain the connection-setup inbound events so we don't race them.
+                    withTimeout(3_000) { inbound.awaitReceive() } // Connected
+                    withTimeout(3_000) { inbound.awaitReceive() } // Core.Supports.Set
+
+                    // Fire three SendText events in rapid succession. The writer should drain
+                    // them into a single WebSocket text frame.
+                    engineOutbound.send(OutboundEvent.SendText(sid, "alpha"))
+                    engineOutbound.send(OutboundEvent.SendText(sid, "beta"))
+                    engineOutbound.send(OutboundEvent.SendText(sid, "gamma"))
+
+                    val received =
+                        withTimeout(3_000) { incoming.receive() }
+                            .let { (it as Frame.Text).readText() }
+
+                    assertTrue(received.contains("alpha"), "missing alpha in: $received")
+                    assertTrue(received.contains("beta"), "missing beta in: $received")
+                    assertTrue(received.contains("gamma"), "missing gamma in: $received")
+                    // All three lines arrived together — if they had been sent as separate
+                    // frames we'd have had to call receive() three times.
+                }
+
+                val disconnected = withTimeout(3_000) { inbound.awaitReceive() }
+                assertTrue(disconnected is InboundEvent.Disconnected)
+            }
+
+            routerJob.cancelAndJoin()
+            inbound.close()
+            engineOutbound.close()
+        }
+
+    @Test
+    fun `gmcp frame stays isolated from surrounding text frames`(): Unit =
+        runBlocking {
+            val inbound = LocalInboundBus()
+            val engineOutbound = LocalOutboundBus()
+            val outboundRouter = OutboundRouter(engineOutbound, this)
+            val routerJob = outboundRouter.start()
+            val sid = SessionId(8)
+
+            testApplication {
+                application {
+                    ambonMUDWebModule(
+                        inbound = inbound,
+                        outboundRouter = outboundRouter,
+                        sessionIdFactory = { sid },
+                    )
+                }
+
+                val wsClient = createClient { install(WebSockets) }
+
+                wsClient.webSocket("/ws") {
+                    withTimeout(3_000) { inbound.awaitReceive() } // Connected
+                    withTimeout(3_000) { inbound.awaitReceive() } // Core.Supports.Set
+
+                    // Text, GMCP, text — GMCP envelope must arrive in its own WS text frame
+                    // so the client's parseGmcp can recognise it.
+                    engineOutbound.send(OutboundEvent.SendText(sid, "before-gmcp"))
+                    engineOutbound.send(
+                        OutboundEvent.GmcpData(sid, "Room.Info", """{"id":"x"}"""),
+                    )
+                    engineOutbound.send(OutboundEvent.SendText(sid, "after-gmcp"))
+
+                    val frames = mutableListOf<String>()
+                    withTimeout(3_000) {
+                        while (frames.size < 3) {
+                            val f = incoming.receive()
+                            frames += (f as Frame.Text).readText()
+                        }
+                    }
+
+                    assertTrue(frames[0].contains("before-gmcp"))
+                    assertEquals("""{"gmcp":"Room.Info","data":{"id":"x"}}""", frames[1])
+                    assertTrue(frames[2].contains("after-gmcp"))
+                }
+
+                val disconnected = withTimeout(3_000) { inbound.awaitReceive() }
+                assertTrue(disconnected is InboundEvent.Disconnected)
+            }
+
+            routerJob.cancelAndJoin()
+            inbound.close()
+            engineOutbound.close()
+        }
+
     private suspend fun InboundBus.awaitReceive(): InboundEvent {
         while (true) {
             tryReceive().getOrNull()?.let { return it }

--- a/src/test/kotlin/dev/ambon/transport/NetworkSessionGmcpBatchTest.kt
+++ b/src/test/kotlin/dev/ambon/transport/NetworkSessionGmcpBatchTest.kt
@@ -168,6 +168,50 @@ class NetworkSessionGmcpBatchTest {
         }
 
     @Test
+    fun `large burst of text frames arrives concatenated in order`(): Unit =
+        runBlocking {
+            val serverSock = ServerSocket(0)
+            val clientSock = Socket("localhost", serverSock.localPort)
+            val sessionSock = serverSock.accept()
+            serverSock.close()
+            try {
+                val inbound = LocalInboundBus()
+                val queue = Channel<OutboundFrame>(capacity = Channel.UNLIMITED)
+                val session =
+                    NetworkSession(
+                        sessionId = SessionId(1),
+                        socket = sessionSock,
+                        inbound = inbound,
+                        outboundQueue = queue,
+                        onDisconnected = {},
+                        scope = this,
+                    )
+                session.start()
+
+                val clientIn = clientSock.getInputStream()
+
+                readNBytes(clientIn, initNegotiationSize)
+
+                // Queue 100 distinct frames — exceeds MAX_FRAMES_PER_FLUSH (64), forcing at
+                // least two batch cycles. Order and content must still be preserved exactly.
+                val expected = StringBuilder()
+                repeat(100) { i ->
+                    val line = "line-$i\r\n"
+                    queue.send(OutboundFrame.Text(line))
+                    expected.append(line)
+                }
+
+                val expectedBytes = expected.toString().toByteArray(Charsets.UTF_8)
+                val received = readNBytes(clientIn, expectedBytes.size)
+
+                assertArrayEquals(expectedBytes, received)
+            } finally {
+                clientSock.close()
+                runCatching { sessionSock.close() }
+            }
+        }
+
+    @Test
     fun `GMCP frame produces no bytes when gmcp is disabled`(): Unit =
         runBlocking {
             val serverSock = ServerSocket(0)


### PR DESCRIPTION
## Summary

Two related optimisations on the outbound write path, each in its own commit so they can be reviewed and (if needed) reverted independently.

### Commit 1 — Telnet: single socket write + flush per batch

The telnet `writeLoop` in `NetworkSession` already drained up to 64 frames per cycle before flushing, but:

- Acquired `outputLock` once **per frame** (N+1 acquires per batch).
- Called `output.write()` once per frame — `SocketOutputStream` is unbuffered at the JDK layer, so each write is a syscall.

Now: all drained bytes accumulate in a reusable `ByteArrayOutputStream`, then a single `write() + flush()` under the lock for the whole batch.

| Per batch (N frames) | Before | After |
|----------------------|--------|-------|
| Lock acquires | N + 1 | 1 |
| `output.write()` syscalls | N | 1 |
| `output.flush()` syscalls | 1 | 1 |

### Commit 2 — WebSocket: concatenate consecutive text frames

The WebSocket writer sent one `Frame.Text` per `OutboundFrame`, paying WebSocket framing overhead (2–14 header bytes + Ktor/Netty send-call trip) for every message.

Now: consecutive `OutboundFrame.Text` entries are concatenated into a `StringBuilder` and sent as a single `Frame.Text`. GMCP envelopes stay isolated — the web client's `useMudSocket.ts` parses each incoming text frame as either a GMCP envelope or plain text, never mixed, so pending text is flushed before every GMCP frame and again at end-of-batch.

## Why

April 2026 Run 3b clocked ~50k outbound frames/sec at 1,437 sessions. With the prior code that was ~50k lock-acquires and ~50k syscalls per second on the telnet side, plus a WebSocket frame header per message on the WS side. Serialize-once (#1013) reduced payload-side allocation pressure; this reduces the syscall/framing-side overhead on both transports.

## Files changed

| File | Change |
|------|--------|
| `NetworkSession.kt` | `writeLoop` batches into a reusable `ByteArrayOutputStream`; `writeFrame` → `appendFrame` (writes to buffer, no I/O). |
| `NetworkSessionGmcpBatchTest.kt` | New integration test queues 100 frames (>`MAX_FRAMES_PER_FLUSH` = 64) and asserts exact byte-for-byte concatenation across multi-batch boundaries. |
| `KtorWebSocketTransport.kt` | Writer accumulates consecutive text frames in a `StringBuilder`; `MAX_WS_FRAMES_PER_BATCH = 64` drain cap matches telnet. GMCP envelopes flush pending text first, then send alone. |
| `KtorWebSocketTransportTest.kt` | Two new integration tests: consecutive `SendText` events arrive in one WS frame; a GMCP frame between two text frames stays in its own WS frame. |

## Test plan

- [x] `./gradlew ktlintCheck` — clean
- [x] `./gradlew test --tests "*Transport*" --tests "*OutboundRouter*" --tests "*WebSocket*"` — green
- [x] `./gradlew integrationTest --tests "*NetworkSessionGmcpBatch*" --tests "*KtorWebSocketTransportTest*"` — green (existing batching tests + 3 new ones)
- [ ] Deploy to demo; expected: lower process CPU at equivalent session count on telnet, and measurably fewer WS frames/sec per user-visible MUD action on the web client
- [ ] Watch `Outbound Frames / sec` (counts `OutboundFrame`, not transport-level frames) for continuity — this metric should be unchanged since it fires at enqueue time, not write time