### PR TITLE
Playtest QoL: dungeon/crafting/housing panel fixes

### DIFF
--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -353,6 +353,18 @@ function App() {
     return () => window.removeEventListener("keydown", handler);
   }, []);
 
+  // Close the dungeon panel when the player actually enters a dungeon — the
+  // catalog-plus-"Resume Run" view confuses users into hammering the re-enter
+  // button. The conditional toolbar button remains for intentional access.
+  const dungeonActive = state.dungeonInfo?.active ?? false;
+  const prevDungeonActiveRef = useRef(dungeonActive);
+  useEffect(() => {
+    if (dungeonActive && !prevDungeonActiveRef.current) {
+      state.setActivePopout((prev) => (prev === "dungeon" ? null : prev));
+    }
+    prevDungeonActiveRef.current = dungeonActive;
+  }, [dungeonActive]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Keyboard digit shortcuts
   useEffect(() => {
     const onKeyDown = (event: globalThis.KeyboardEvent) => {

--- a/web-v3/src/components/panels/CraftingPanel.tsx
+++ b/web-v3/src/components/panels/CraftingPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { CraftingSkill, CraftingRecipe, CraftingNode } from "../../types";
 
 interface CraftingPanelProps {
@@ -25,6 +25,25 @@ export function CraftingPanel({
   onLoadSkills,
 }: CraftingPanelProps) {
   const [activeTab, setActiveTab] = useState<"skills" | "recipes" | "nodes">("skills");
+  const skillsRequestedRef = useRef(false);
+  const recipesRequestedRef = useRef(false);
+  const ready = connected && hasCharacterProfile;
+
+  useEffect(() => {
+    if (!ready) return;
+    if (skills.length === 0 && !skillsRequestedRef.current) {
+      skillsRequestedRef.current = true;
+      onLoadSkills();
+    }
+  }, [ready, skills.length, onLoadSkills]);
+
+  useEffect(() => {
+    if (!ready || activeTab !== "recipes") return;
+    if (recipes.length === 0 && !recipesRequestedRef.current) {
+      recipesRequestedRef.current = true;
+      onRequestRecipes();
+    }
+  }, [ready, activeTab, recipes.length, onRequestRecipes]);
 
   if (!connected) return <p className="empty-note">Connect to view crafting.</p>;
   if (!hasCharacterProfile) return <p className="empty-note">Log in to view crafting.</p>;
@@ -48,7 +67,7 @@ export function CraftingPanel({
           role="tab"
           className={`crafting-tab ${activeTab === "recipes" ? "crafting-tab-active" : ""}`}
           aria-selected={activeTab === "recipes"}
-          onClick={() => { setActiveTab("recipes"); if (recipes.length === 0) onRequestRecipes(); }}
+          onClick={() => setActiveTab("recipes")}
         >
           Recipes
         </button>
@@ -71,10 +90,7 @@ export function CraftingPanel({
           {skills.length === 0 ? (
             <div className="crafting-empty-state">
               <span className="crafting-empty-icon">{"\u2692"}</span>
-              <p className="empty-note">No crafting skills loaded yet.</p>
-              <button type="button" className="crafting-load-btn" onClick={onLoadSkills}>
-                Load Skills
-              </button>
+              <p className="empty-note">Loading professions&hellip;</p>
             </div>
           ) : (
             <ul className="crafting-skill-list">
@@ -115,7 +131,7 @@ export function CraftingPanel({
           {recipes.length === 0 ? (
             <div className="crafting-empty-state">
               <span className="crafting-empty-icon">{"\u2726"}</span>
-              <p className="empty-note">No recipes loaded. Type <code>recipes</code> to browse.</p>
+              <p className="empty-note">Loading recipes&hellip;</p>
             </div>
           ) : (
             <ul className="crafting-recipe-list">

--- a/web-v3/src/components/panels/HousingPanel.tsx
+++ b/web-v3/src/components/panels/HousingPanel.tsx
@@ -106,11 +106,16 @@ export function HousingPanel({
         </div>
       )}
 
-      {room.housingBroker && !inOwnHouse && (
+      {!inOwnHouse && (
         <div className="housing-actions">
-          <button type="button" className="housing-action-btn" onClick={() => onSendCommand("house list")}>
-            Browse Templates
+          <button type="button" className="housing-action-btn" onClick={() => onSendCommand("recall")}>
+            Recall Home
           </button>
+          {room.housingBroker && (
+            <button type="button" className="housing-action-btn" onClick={() => onSendCommand("house list")}>
+              Browse Templates
+            </button>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
Three minor playtest QoL fixes bundled together:

- **Dungeon panel auto-closes on entry** — the catalog-plus-"Resume Run" view was confusing users into clicking "Resume Run" repeatedly after they'd already entered. Panel now closes the moment `dungeonInfo.active` flips true; the conditional Dungeon toolbar button is still there for intentional access.
- **Crafting panel self-loads** — dropped the "Load Skills" button and "Type \`recipes\` to browse" hint. Skills fetch on panel open; recipes fetch the first time the Recipes tab is viewed. Empty states now show loading placeholders.
- **Housing recall button** — when the player owns a house and isn't in it, HousingPanel shows a Recall Home button that fires \`recall\` (which the server routes home for house owners).

## Test plan
- [ ] Click a dungeon portal, pick a difficulty, click Enter — panel closes on entry; toolbar Dungeon button visible; clicking it reopens the panel with Leave Dungeon.
- [ ] Open the Crafting panel fresh — professions load without a button click; switch to Recipes tab and confirm recipes arrive on their own.
- [ ] Open Housing while owning a house — Recall Home button shows; clicking it teleports home; once inside, the button is hidden (replaced by Guests/Templates row).
- [ ] \`bun x tsc --noEmit\` and \`bun run lint\` pass.