### PR TITLE
Fix flaky WebSocket frame-coalesce test

### DIFF
--- a/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
+++ b/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
@@ -29,6 +29,7 @@ import io.ktor.websocket.readText
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
@@ -37,7 +38,56 @@ private val log = KotlinLogging.logger {}
 
 // Maximum number of extra frames to drain per write iteration before flushing the text batch.
 // Keeps latency bounded while amortising WebSocket frame overhead across bursts of text output.
-private const val MAX_WS_FRAMES_PER_BATCH = 64
+internal const val MAX_WS_FRAMES_PER_BATCH = 64
+
+/**
+ * Drain [outboundQueue] into [send], coalescing consecutive [OutboundFrame.Text] entries into
+ * one WebSocket [Frame.Text] per wake-up batch. GMCP envelopes are flushed and sent in their
+ * own frame so the client's parser can recognise them.
+ *
+ * Exits cleanly when the queue is closed; swallows send errors (best-effort).
+ */
+internal suspend fun writeCoalescedOutboundFrames(
+    outboundQueue: ReceiveChannel<OutboundFrame>,
+    send: suspend (Frame) -> Unit,
+    onFrameConsumed: (OutboundFrame) -> Unit,
+    maxBatch: Int = MAX_WS_FRAMES_PER_BATCH,
+) {
+    val pendingText = StringBuilder()
+
+    suspend fun flushPendingText() {
+        if (pendingText.isNotEmpty()) {
+            send(Frame.Text(pendingText.toString()))
+            pendingText.setLength(0)
+        }
+    }
+
+    suspend fun process(frame: OutboundFrame) {
+        when (frame) {
+            is OutboundFrame.Text -> pendingText.append(frame.content)
+            is OutboundFrame.Gmcp -> {
+                flushPendingText()
+                send(Frame.Text("""{"gmcp":"${frame.gmcpPackage}","data":${frame.jsonData}}"""))
+            }
+        }
+        onFrameConsumed(frame)
+    }
+
+    try {
+        for (frame in outboundQueue) {
+            process(frame)
+            var drained = 0
+            while (drained < maxBatch) {
+                val next = outboundQueue.tryReceive().getOrNull() ?: break
+                process(next)
+                drained++
+            }
+            flushPendingText()
+        }
+    } catch (_: Throwable) {
+        // best effort
+    }
+}
 
 class KtorWebSocketTransport(
     private val port: Int,
@@ -222,43 +272,16 @@ private suspend fun DefaultWebSocketServerSession.bridgeWebSocketSession(
     val writerJob =
         launch {
             // Consecutive OutboundFrame.Text entries are concatenated into a single WebSocket
-            // Frame.Text to reduce per-frame header + send-call overhead. GMCP envelopes must
-            // stay isolated — the client's message handler parses each incoming WS text frame
-            // as either a GMCP envelope or plain text, never mixed (see useMudSocket.ts).
-            val pendingText = StringBuilder()
-
-            suspend fun flushPendingText() {
-                if (pendingText.isNotEmpty()) {
-                    send(Frame.Text(pendingText.toString()))
-                    pendingText.setLength(0)
-                }
-            }
-
-            suspend fun process(frame: OutboundFrame) {
-                when (frame) {
-                    is OutboundFrame.Text -> pendingText.append(frame.content)
-                    is OutboundFrame.Gmcp -> {
-                        flushPendingText()
-                        send(Frame.Text("""{"gmcp":"${frame.gmcpPackage}","data":${frame.jsonData}}"""))
-                    }
-                }
-                outboundRouter.onSessionQueueFrameConsumed(sessionId, frame.enqueuedAt)
-            }
-
-            try {
-                for (frame in outboundQueue) {
-                    process(frame)
-                    var drained = 0
-                    while (drained < MAX_WS_FRAMES_PER_BATCH) {
-                        val next = outboundQueue.tryReceive().getOrNull() ?: break
-                        process(next)
-                        drained++
-                    }
-                    flushPendingText()
-                }
-            } catch (_: Throwable) {
-                // best effort
-            }
+            // Frame.Text to reduce per-frame header + send-call overhead. GMCP envelopes stay
+            // isolated — the client's message handler parses each incoming WS text frame as
+            // either a GMCP envelope or plain text, never mixed (see useMudSocket.ts).
+            writeCoalescedOutboundFrames(
+                outboundQueue = outboundQueue,
+                send = { send(it) },
+                onFrameConsumed = { frame ->
+                    outboundRouter.onSessionQueueFrameConsumed(sessionId, frame.enqueuedAt)
+                },
+            )
         }
 
     try {

--- a/src/test/kotlin/dev/ambon/transport/KtorWebSocketTransportTest.kt
+++ b/src/test/kotlin/dev/ambon/transport/KtorWebSocketTransportTest.kt
@@ -167,8 +167,13 @@ class KtorWebSocketTransportTest {
     }
 
     @Test
-    fun `consecutive text frames are coalesced into one websocket frame`(): Unit =
+    fun `consecutive text frames preserve order end-to-end`(): Unit =
         runBlocking {
+            // End-to-end smoke test: the router → queue → writer pipeline delivers every
+            // SendText in the right order. Whether the writer coalesces is scheduling-
+            // dependent (router and writer coroutines run on different dispatchers), so
+            // this test only asserts ordering + completeness. The coalescing contract
+            // itself is verified deterministically in WriteCoalescedOutboundFramesTest.
             val inbound = LocalInboundBus()
             val engineOutbound = LocalOutboundBus()
             val outboundRouter = OutboundRouter(engineOutbound, this)
@@ -187,25 +192,31 @@ class KtorWebSocketTransportTest {
                 val wsClient = createClient { install(WebSockets) }
 
                 wsClient.webSocket("/ws") {
-                    // Drain the connection-setup inbound events so we don't race them.
                     withTimeout(3_000) { inbound.awaitReceive() } // Connected
                     withTimeout(3_000) { inbound.awaitReceive() } // Core.Supports.Set
 
-                    // Fire three SendText events in rapid succession. The writer should drain
-                    // them into a single WebSocket text frame.
                     engineOutbound.send(OutboundEvent.SendText(sid, "alpha"))
                     engineOutbound.send(OutboundEvent.SendText(sid, "beta"))
                     engineOutbound.send(OutboundEvent.SendText(sid, "gamma"))
 
-                    val received =
-                        withTimeout(3_000) { incoming.receive() }
-                            .let { (it as Frame.Text).readText() }
+                    val combined = StringBuilder()
+                    withTimeout(3_000) {
+                        while (!combined.contains("gamma")) {
+                            combined.append((incoming.receive() as Frame.Text).readText())
+                        }
+                    }
 
-                    assertTrue(received.contains("alpha"), "missing alpha in: $received")
-                    assertTrue(received.contains("beta"), "missing beta in: $received")
-                    assertTrue(received.contains("gamma"), "missing gamma in: $received")
-                    // All three lines arrived together — if they had been sent as separate
-                    // frames we'd have had to call receive() three times.
+                    assertTrue(combined.contains("alpha"), "missing alpha in: $combined")
+                    assertTrue(combined.contains("beta"), "missing beta in: $combined")
+                    assertTrue(combined.contains("gamma"), "missing gamma in: $combined")
+                    assertTrue(
+                        combined.indexOf("alpha") < combined.indexOf("beta"),
+                        "alpha must precede beta in: $combined",
+                    )
+                    assertTrue(
+                        combined.indexOf("beta") < combined.indexOf("gamma"),
+                        "beta must precede gamma in: $combined",
+                    )
                 }
 
                 val disconnected = withTimeout(3_000) { inbound.awaitReceive() }

--- a/src/test/kotlin/dev/ambon/transport/WriteCoalescedOutboundFramesTest.kt
+++ b/src/test/kotlin/dev/ambon/transport/WriteCoalescedOutboundFramesTest.kt
@@ -1,0 +1,152 @@
+package dev.ambon.transport
+
+import io.ktor.websocket.Frame
+import io.ktor.websocket.readText
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Deterministic tests for [writeCoalescedOutboundFrames]. Pre-filling the queue before the
+ * writer runs avoids the router/writer scheduling race that makes the end-to-end integration
+ * test flaky for small burst sizes.
+ */
+class WriteCoalescedOutboundFramesTest {
+    @Test
+    fun `consecutive text frames already queued are coalesced into one frame`() =
+        runBlocking {
+            val queue = Channel<OutboundFrame>(capacity = 64)
+            val sent = mutableListOf<Frame>()
+            val consumed = mutableListOf<OutboundFrame>()
+
+            queue.trySend(OutboundFrame.Text("alpha"))
+            queue.trySend(OutboundFrame.Text("beta"))
+            queue.trySend(OutboundFrame.Text("gamma"))
+            queue.close()
+
+            writeCoalescedOutboundFrames(
+                outboundQueue = queue,
+                send = { sent += it },
+                onFrameConsumed = { consumed += it },
+            )
+
+            assertEquals(1, sent.size, "expected one coalesced text frame, got ${sent.map { (it as Frame.Text).readText() }}")
+            assertEquals("alphabetagamma", (sent[0] as Frame.Text).readText())
+            assertEquals(3, consumed.size)
+        }
+
+    @Test
+    fun `gmcp frame flushes pending text and stays isolated`() =
+        runBlocking {
+            val queue = Channel<OutboundFrame>(capacity = 64)
+            val sent = mutableListOf<String>()
+
+            queue.trySend(OutboundFrame.Text("before"))
+            queue.trySend(OutboundFrame.Gmcp("Room.Info", """{"id":"x"}"""))
+            queue.trySend(OutboundFrame.Text("after"))
+            queue.close()
+
+            writeCoalescedOutboundFrames(
+                outboundQueue = queue,
+                send = { sent += (it as Frame.Text).readText() },
+                onFrameConsumed = { },
+            )
+
+            assertEquals(3, sent.size, "expected text/gmcp/text as three distinct frames, got $sent")
+            assertEquals("before", sent[0])
+            assertEquals("""{"gmcp":"Room.Info","data":{"id":"x"}}""", sent[1])
+            assertEquals("after", sent[2])
+        }
+
+    @Test
+    fun `drain bound caps coalesced frame size`() =
+        runBlocking {
+            val queue = Channel<OutboundFrame>(capacity = 100)
+            val sent = mutableListOf<String>()
+            val maxBatch = 4
+
+            // Queue up more frames than a single wake-up batch can drain. With maxBatch=4,
+            // the writer consumes 1 + 4 = 5 frames per iteration, so 11 frames produces
+            // three batches of sizes 5, 5, 1.
+            repeat(11) { queue.trySend(OutboundFrame.Text("x$it")) }
+            queue.close()
+
+            writeCoalescedOutboundFrames(
+                outboundQueue = queue,
+                send = { sent += (it as Frame.Text).readText() },
+                onFrameConsumed = { },
+                maxBatch = maxBatch,
+            )
+
+            assertEquals(3, sent.size, "expected 3 batched frames, got $sent")
+            assertEquals("x0x1x2x3x4", sent[0])
+            assertEquals("x5x6x7x8x9", sent[1])
+            assertEquals("x10", sent[2])
+        }
+
+    @Test
+    fun `empty text string does not produce a frame`() =
+        runBlocking {
+            val queue = Channel<OutboundFrame>(capacity = 4)
+            val sent = mutableListOf<Frame>()
+
+            queue.trySend(OutboundFrame.Text(""))
+            queue.close()
+
+            writeCoalescedOutboundFrames(
+                outboundQueue = queue,
+                send = { sent += it },
+                onFrameConsumed = { },
+            )
+
+            assertTrue(sent.isEmpty(), "empty text should not emit a frame, got $sent")
+        }
+
+    @Test
+    fun `writer exits when queue closes even if send raises`() =
+        runBlocking {
+            val queue = Channel<OutboundFrame>(capacity = 4)
+            queue.trySend(OutboundFrame.Text("boom"))
+            queue.close()
+
+            // Send throws; writer should swallow and return cleanly.
+            writeCoalescedOutboundFrames(
+                outboundQueue = queue,
+                send = { error("simulated transport failure") },
+                onFrameConsumed = { },
+            )
+            // Reaching here without a thrown exception proves the try/catch kept us alive.
+        }
+
+    @Test
+    fun `late arrivals to queue are picked up on next wake`() =
+        runTest {
+            val queue = Channel<OutboundFrame>(capacity = 64)
+            val sent = mutableListOf<String>()
+
+            val writer: Job =
+                launch {
+                    writeCoalescedOutboundFrames(
+                        outboundQueue = queue,
+                        send = { sent += (it as Frame.Text).readText() },
+                        onFrameConsumed = { },
+                    )
+                }
+
+            // First batch
+            queue.send(OutboundFrame.Text("first"))
+            yield()
+            // Second batch (after the writer has parked waiting on receive again)
+            queue.send(OutboundFrame.Text("second"))
+            queue.close()
+            writer.join()
+
+            assertEquals(listOf("first", "second"), sent)
+        }
+}


### PR DESCRIPTION
## Summary
The `consecutive text frames are coalesced into one websocket frame` integration test (added in #1023) has been flaking on main — #1019's CI and both of #1024's CI runs all failed with:

\`\`\`
KtorWebSocketTransportTest > consecutive text frames are coalesced into one websocket frame() FAILED
    org.opentest4j.AssertionFailedError at KtorWebSocketTransportTest.kt:205  // beta assertion
\`\`\`

**Root cause.** The test sends three \`OutboundEvent.SendText\` events and asserts that all three arrive in one \`Frame.Text\`. That holds only when the router coroutine (\`engineOutbound → sink.queue\` in \`OutboundRouter.start()\`) enqueues all three frames *before* the writer coroutine wakes on the first enqueue. They live on different dispatchers, so under unfavourable CI scheduling the writer sees one item, its \`tryReceive()\` drain finds nothing more, and \"alpha\" goes out as its own frame. There's no way to make this deterministic for N=3 without restructuring the production code.

**Fix.**
- Extract the writer's drain + coalesce loop from the anonymous \`launch\` inside \`bridgeWebSocketSession\` into \`writeCoalescedOutboundFrames(queue, send, onFrameConsumed)\`. The ktor bridge now delegates to it — behaviour unchanged.
- Add \`WriteCoalescedOutboundFramesTest\` — a deterministic unit test that pre-fills the channel before the writer runs, proving the coalescing contract: three consecutive texts collapse to one frame, GMCP envelopes flush pending text and stay isolated, \`maxBatch\` bounds each flush, empty texts drop, queue close exits cleanly, late arrivals get picked up on the next wake.
- Rewrite the integration test as \`consecutive text frames preserve order end-to-end\` — drains frames until the last token arrives and asserts all tokens are present in order. Whether the writer coalesces in this test is no longer the assertion.

## Test plan
- [ ] \`./gradlew ktlintCheck test integrationTest\` locally — 5 stress runs of the rewritten integration test all passed (previously flaked routinely).
- [ ] The new \`WriteCoalescedOutboundFramesTest\` exercises the coalescing contract deterministically (6 tests).