### PR TITLE
Streamline container interaction: one-click open + locked hero

### DIFF
--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -230,7 +230,24 @@ function App() {
     canvasCallbacks.openShop = () => openPanel("shop");
     canvasCallbacks.openAuction = () => openPanel("auction");
     canvasCallbacks.openPuzzle = () => openPanel("puzzle");
-    canvasCallbacks.openFeatures = (preferredType?: FeaturePopoutFocus) => openPanel("features", preferredType ?? null);
+    canvasCallbacks.openFeatures = (preferredType?: FeaturePopoutFocus) => {
+      // If the user clicked the canvas chest badge and there is exactly one
+      // container in the room that's closed + unlocked, open it for them so
+      // the panel opens already showing contents (paired with auto-search
+      // inside WorldFeaturesPopout).
+      if (preferredType === "container") {
+        const containers = (gameStateRef.current.roomFeatures ?? []).filter(
+          (f) => f.type === "container",
+        );
+        if (containers.length === 1) {
+          const only = containers[0];
+          if (only.state === "closed" && only.locked !== true) {
+            sendCommand(`open ${only.keyword}`);
+          }
+        }
+      }
+      openPanel("features", preferredType ?? null);
+    };
     canvasCallbacks.openBank = () => openPanel("bank");
     canvasCallbacks.openStylist = () => openPanel("stylist");
     canvasCallbacks.openTrainer = () => openPanel("trainer");

--- a/web-v3/src/components/WorldFeaturesPopout.tsx
+++ b/web-v3/src/components/WorldFeaturesPopout.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { ContainerContents, FeaturePopoutFocus, RoomFeature, RoomFeatureType } from "../types";
 import { DirectionIcon } from "./Icons";
 
@@ -109,6 +109,64 @@ function LeverWidget({
   );
 }
 
+function LockedContainerHero({
+  feature,
+  onCommand,
+}: {
+  feature: RoomFeature;
+  onCommand: (cmd: string) => void;
+}) {
+  return (
+    <article className="feature-card feature-card-container feature-card-hero-locked">
+      <div className="feature-card-hero-lock" aria-hidden="true">
+        <svg viewBox="0 0 64 80" className="feature-card-hero-lock-svg">
+          <path
+            d="M20 34 V24 a12 12 0 0 1 24 0 V34"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="4"
+            strokeLinecap="round"
+          />
+          <rect
+            x="12"
+            y="34"
+            width="40"
+            height="34"
+            rx="5"
+            fill="currentColor"
+            opacity="0.18"
+            stroke="currentColor"
+            strokeWidth="2.5"
+          />
+          <circle cx="32" cy="48" r="4" fill="currentColor" />
+          <path
+            d="M32 52 V58"
+            stroke="currentColor"
+            strokeWidth="3"
+            strokeLinecap="round"
+          />
+        </svg>
+      </div>
+      <div className="feature-card-hero-copy">
+        <span className="feature-card-kind feature-card-kind-container">Container</span>
+        <h4>{feature.name}</h4>
+        <p className="feature-card-hero-subtitle">
+          {feature.keyRequired ? "A key is required to unlock this." : "Locked tight."}
+        </p>
+      </div>
+      <div className="feature-card-hero-actions">
+        <button
+          type="button"
+          className="feature-card-action feature-card-action-primary"
+          onClick={() => onCommand(`unlock ${feature.keyword}`)}
+        >
+          Unlock
+        </button>
+      </div>
+    </article>
+  );
+}
+
 function featureSummary(features: RoomFeature[], type: RoomFeatureType): string {
   const count = features.filter((feature) => feature.type === type).length;
   if (count === 0) return `No ${FEATURE_LABELS[type].plural.toLowerCase()}`;
@@ -138,7 +196,6 @@ function featureActions(feature: RoomFeature): Array<{ label: string; command: s
   if (feature.type === "container") {
     const actions: Array<{ label: string; command: string }> = [];
     if (feature.state === "open") {
-      actions.push({ label: "Search", command: `search ${feature.keyword}` });
       actions.push({ label: "Close", command: `close ${feature.keyword}` });
     } else if (feature.state === "closed") {
       actions.push({ label: "Open", command: `open ${feature.keyword}` });
@@ -185,6 +242,33 @@ export function WorldFeaturesPopout({
   );
 
   const [manualTab, setManualTab] = useState<RoomFeatureType | null>(null);
+
+  // Auto-search containers once they become open so their contents render
+  // without an extra click. A ref tracks which feature ids we've already
+  // requested, scoped to the current "open" session — if a container closes
+  // or disappears, its id is dropped so reopening triggers a fresh search.
+  const autoSearchedRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    const openIds = new Set(
+      roomFeatures
+        .filter((f) => f.type === "container" && f.state === "open")
+        .map((f) => f.id),
+    );
+    for (const id of Array.from(autoSearchedRef.current)) {
+      if (!openIds.has(id)) autoSearchedRef.current.delete(id);
+    }
+    for (const feature of roomFeatures) {
+      if (
+        feature.type === "container" &&
+        feature.state === "open" &&
+        !autoSearchedRef.current.has(feature.id) &&
+        containerContents?.featureId !== feature.id
+      ) {
+        autoSearchedRef.current.add(feature.id);
+        onCommand(`search ${feature.keyword}`);
+      }
+    }
+  }, [roomFeatures, containerContents, onCommand]);
 
   if (roomFeatures.length === 0) {
     return (
@@ -248,6 +332,14 @@ export function WorldFeaturesPopout({
         {visibleFeatures.map((feature) => {
           if (feature.type === "lever") {
             return <LeverWidget key={feature.id} feature={feature} onCommand={onCommand} />;
+          }
+
+          if (
+            feature.type === "container" &&
+            feature.state === "locked" &&
+            visibleFeatures.length === 1
+          ) {
+            return <LockedContainerHero key={feature.id} feature={feature} onCommand={onCommand} />;
           }
 
           const contents = feature.type === "container" && containerContents?.featureId === feature.id

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -3576,6 +3576,85 @@ body {
   font-size: 0.84rem;
 }
 
+/* Hero treatment for a single locked container — bigger, centered, with a
+   prominent lock glyph and a primary Unlock action. */
+.feature-card-hero-locked {
+  grid-column: 1 / -1;
+  justify-self: center;
+  max-width: 420px;
+  width: 100%;
+  gap: 14px;
+  padding: 28px 24px 24px;
+  align-items: center;
+  text-align: center;
+  background:
+    radial-gradient(circle at 50% 0%, rgb(212 178 110 / 18%), transparent 60%),
+    linear-gradient(160deg, rgb(72 68 92 / 94%), rgb(52 50 74 / 92%));
+  border-color: rgb(212 178 110 / 28%);
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 10%),
+    0 12px 32px rgb(10 8 18 / 34%);
+}
+
+.feature-card-hero-lock {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 96px;
+  height: 96px;
+  color: rgb(226 198 134);
+  filter: drop-shadow(0 0 10px rgb(226 198 134 / 24%));
+  animation: hero-lock-breathe 4s var(--ease-in-out-smooth) infinite;
+}
+
+.feature-card-hero-lock-svg {
+  width: 72px;
+  height: 90px;
+}
+
+@keyframes hero-lock-breathe {
+  0%, 100% { transform: scale(1); opacity: 0.92; }
+  50% { transform: scale(1.04); opacity: 1; }
+}
+
+.feature-card-hero-copy {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.feature-card-hero-copy > h4 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.18rem;
+  color: var(--text-primary);
+}
+
+.feature-card-hero-subtitle {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.86rem;
+}
+
+.feature-card-hero-actions {
+  display: flex;
+  justify-content: center;
+  margin-top: 4px;
+}
+
+.feature-card-action-primary {
+  padding: 10px 22px;
+  font-size: 0.9rem;
+  border-color: rgb(226 198 134 / 46%);
+  background: linear-gradient(135deg, rgb(164 136 82 / 70%), rgb(124 102 62 / 64%));
+}
+
+.feature-card-action-primary:hover {
+  border-color: rgb(240 214 150 / 70%);
+  background: linear-gradient(135deg, rgb(188 158 100 / 80%), rgb(142 118 74 / 72%));
+}
+
 .skills-combat-panel {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);


### PR DESCRIPTION
## Summary

Reimagines the container interaction so the UI matches what players actually want to do with a chest. Click a chest on the canvas → if it's unlocked, the panel opens with the contents already visible. If it's locked, you see a big, centered lock card with a single Unlock button.

Three cooperating changes:

- **Auto-search on open** (`WorldFeaturesPopout.tsx`): when any visible container's state is `"open"` and we don't yet have its `containerContents`, fire `search <keyword>` automatically. A ref tracks already-searched feature ids and clears them when the container closes so reopening still refreshes. The explicit Search button is gone.
- **Auto-open unlocked canvas click** (`App.tsx`): in the `openFeatures` canvas callback, if the current room has exactly one container and it's closed + unlocked, send `open <keyword>` before opening the panel. Reads live state from `gameStateRef.current` so the callback stays fresh across renders.
- **Locked-chest hero** (`WorldFeaturesPopout.tsx` + `styles.css`): when the container tab has exactly one container and it's locked, render a centered `LockedContainerHero` card — larger padding, a breathing SVG lock glyph, a gold-tinted primary Unlock action, and copy that notes when a key is required.

## Test plan

- [ ] Enter a room with a single unlocked, closed chest. Click the chest badge — panel opens with items already listed; no Open or Search click required.
- [ ] Close the chest from the panel, then reopen it from the canvas badge. Items appear again without a Search click.
- [ ] Enter a room with a single locked chest. Click the badge — hero card appears with a prominent lock glyph and the Unlock button.
- [ ] Unlock the chest. Contents appear after the auto-search fires on the open transition.
- [ ] Enter a room with multiple containers. Each shows its normal card with Open/Close actions; auto-search still populates contents on transition to open.
- [ ] Verify doors and levers still render and behave unchanged.