### PR TITLE
Refresh sprite catalogue on stylist race change

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -1206,6 +1206,7 @@ class GameEngine(
                 abilitySystem = abilitySystem,
                 markVitalsDirty = ::markVitalsDirty,
                 markStatsDirty = ::markStatsDirty,
+                spriteRegistry = spriteRegistry,
             ),
             WorldInfoHandler(
                 ctx = ctx,

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/StylistHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/StylistHandler.kt
@@ -5,6 +5,7 @@ import dev.ambon.domain.StatMap
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.PlayerProgression
 import dev.ambon.engine.PlayerState
+import dev.ambon.engine.SpriteRegistry
 import dev.ambon.engine.abilities.AbilitySystem
 import dev.ambon.engine.commands.Command
 import dev.ambon.engine.commands.CommandHandler
@@ -19,6 +20,7 @@ class StylistHandler(
     private val abilitySystem: AbilitySystem? = null,
     private val markVitalsDirty: ((SessionId) -> Unit)? = null,
     private val markStatsDirty: ((SessionId) -> Unit)? = null,
+    private val spriteRegistry: SpriteRegistry? = null,
 ) : CommandHandler {
     private val players = ctx.players
     private val world = ctx.world
@@ -125,12 +127,34 @@ class StylistHandler(
             ),
         )
 
+        // If the player had an explicit sprite pinned that's no longer valid for the new race,
+        // drop it so they fall back to auto-resolve for their new race.
+        val spriteReg = spriteRegistry
+        val currentSprite = me.activeSprite
+        if (spriteReg != null && currentSprite != null) {
+            val stillValid = spriteReg.validateSelection(
+                imageId = currentSprite,
+                level = me.level,
+                unlockedAchievementIds = me.unlockedAchievementIds,
+                isStaff = me.isStaff,
+                playerRace = me.race,
+                playerClass = me.playerClass,
+                playerGender = me.gender,
+            )
+            if (stillValid == null) {
+                me.activeSprite = null
+            }
+        }
+
         gmcpEmitter?.sendCharName(sessionId, me)
         if (abilitySystem != null) {
             gmcpEmitter?.sendCharSkills(sessionId, abilitySystem.knownAbilities(sessionId)) { abilityId ->
                 abilitySystem.cooldownRemainingMs(sessionId, abilityId)
             }
         }
+        // Re-emit the sprite catalogue so the stylist / sprite panel shows choices
+        // appropriate to the new race (sprites are race-filtered).
+        gmcpEmitter?.sendCharSprites(sessionId, me)
         emitStylistState(sessionId, me)
     }
 

--- a/src/test/kotlin/dev/ambon/engine/commands/RouterTestHelper.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/RouterTestHelper.kt
@@ -26,6 +26,7 @@ import dev.ambon.engine.PrestigeSystem
 import dev.ambon.engine.PuzzleSystem
 import dev.ambon.engine.RaceRegistry
 import dev.ambon.engine.ShopRegistry
+import dev.ambon.engine.SpriteRegistry
 import dev.ambon.engine.TradeSystem
 import dev.ambon.engine.WorldStateRegistry
 import dev.ambon.engine.commands.handlers.AdminHandler
@@ -106,6 +107,7 @@ internal fun buildTestRouter(
     guildHallSystem: GuildHallSystem? = null,
     gmcpEmitter: GmcpEmitter? = null,
     abilitySystem: dev.ambon.engine.abilities.AbilitySystem? = null,
+    spriteRegistry: SpriteRegistry? = null,
 ): CommandRouter {
     val router = CommandRouter(outbound = outbound, players = players)
     val ctx = EngineContext(
@@ -157,6 +159,7 @@ internal fun buildTestRouter(
                 stylistConfig = it,
                 progression = progression,
                 abilitySystem = abilitySystem,
+                spriteRegistry = spriteRegistry,
             )
         },
         DuelHandler(ctx = ctx, duelSystem = duelSystem, combatSystem = combat),

--- a/src/test/kotlin/dev/ambon/engine/commands/StylistCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/StylistCommandTest.kt
@@ -7,12 +7,16 @@ import dev.ambon.domain.RaceDef
 import dev.ambon.domain.StatMap
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.sprite.SpriteCategory
+import dev.ambon.domain.sprite.SpriteDefinition
+import dev.ambon.domain.sprite.SpriteVariant
 import dev.ambon.domain.world.Room
 import dev.ambon.domain.world.World
 import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.GmcpEmitter
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.RaceRegistry
+import dev.ambon.engine.SpriteRegistry
 import dev.ambon.engine.abilities.AbilityDefinition
 import dev.ambon.engine.abilities.AbilityEffect
 import dev.ambon.engine.abilities.AbilityId
@@ -58,6 +62,47 @@ class StylistCommandTest {
     companion object {
         private val stylistRoom = RoomId("test:stylist")
         private val lobbyRoom = RoomId("test:lobby")
+
+        /**
+         * Builds a sprite registry with one per-race tier sprite for HUMAN and ELF so we can
+         * observe race-filtered output in `Char.Sprites` GMCP after a stylist race swap.
+         */
+        private fun spriteRegistryForRaces(): SpriteRegistry {
+            val registry = SpriteRegistry()
+            registry.register(
+                SpriteDefinition(
+                    id = "human_base_def",
+                    displayName = "Human Base",
+                    category = SpriteCategory.TIER,
+                    sortOrder = 0,
+                    variants = listOf(
+                        SpriteVariant(
+                            imageId = "human_base",
+                            displayName = "Human Base",
+                            race = "HUMAN",
+                            imagePath = "player_sprites/human_base.png",
+                        ),
+                    ),
+                ),
+            )
+            registry.register(
+                SpriteDefinition(
+                    id = "elf_base_def",
+                    displayName = "Elf Base",
+                    category = SpriteCategory.TIER,
+                    sortOrder = 0,
+                    variants = listOf(
+                        SpriteVariant(
+                            imageId = "elf_base",
+                            displayName = "Elf Base",
+                            race = "ELF",
+                            imagePath = "player_sprites/elf_base.png",
+                        ),
+                    ),
+                ),
+            )
+            return registry
+        }
 
         private fun buildRaceRegistry(): RaceRegistry {
             val registry = RaceRegistry()
@@ -402,6 +447,91 @@ class StylistCommandTest {
             assertTrue("elf_grace" in known)
             // learnedAbilityIds itself is untouched.
             assertTrue("shared_trick" in h.players.get(sid)!!.learnedAbilityIds)
+        }
+
+        @Test
+        fun `changerace emits Char_Sprites GMCP so stylist panel shows new race sprites`() = runTest {
+            val world = stylistWorld()
+            val outbound = LocalOutboundBus()
+            val players = buildTestPlayerRegistry(world.startRoom)
+            val spriteRegistry = spriteRegistryForRaces()
+            val gmcpEmitter = GmcpEmitter(
+                outbound = outbound,
+                supportsPackage = { _, _ -> true },
+                spriteRegistry = spriteRegistry,
+            )
+            val h = CommandRouterHarness.create(
+                world = world,
+                players = players,
+                outbound = outbound,
+                stylistConfig = StylistConfig(feeGold = 0),
+                raceRegistry = buildRaceRegistry(),
+                gmcpEmitter = gmcpEmitter,
+                spriteRegistry = spriteRegistry,
+            )
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Alice")
+            val me = h.players.get(sid)!!
+            me.gold = 1000L
+            me.race = "HUMAN"
+            h.drain()
+
+            h.router.handle(sid, Command.Stylist.ChangeRace("ELF"))
+            val events = h.drain()
+
+            val charSprites = events.filterIsInstance<OutboundEvent.GmcpData>()
+                .filter { it.sessionId == sid && it.gmcpPackage == "Char.Sprites" }
+            assertTrue(
+                charSprites.isNotEmpty(),
+                "Char.Sprites GMCP should be emitted after race change so stylist panel refreshes",
+            )
+            val payload = charSprites.last().jsonData
+            assertTrue(
+                "elf_base" in payload,
+                "new race sprite missing in payload: $payload",
+            )
+            assertFalse(
+                "human_base" in payload,
+                "old race sprite still present in payload: $payload",
+            )
+        }
+
+        @Test
+        fun `changerace resets pinned activeSprite when it is no longer valid for new race`() = runTest {
+            val world = stylistWorld()
+            val outbound = LocalOutboundBus()
+            val players = buildTestPlayerRegistry(world.startRoom)
+            val spriteRegistry = spriteRegistryForRaces()
+            val gmcpEmitter = GmcpEmitter(
+                outbound = outbound,
+                supportsPackage = { _, _ -> true },
+                spriteRegistry = spriteRegistry,
+            )
+            val h = CommandRouterHarness.create(
+                world = world,
+                players = players,
+                outbound = outbound,
+                stylistConfig = StylistConfig(feeGold = 0),
+                raceRegistry = buildRaceRegistry(),
+                gmcpEmitter = gmcpEmitter,
+                spriteRegistry = spriteRegistry,
+            )
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Alice")
+            val me = h.players.get(sid)!!
+            me.gold = 1000L
+            me.race = "HUMAN"
+            me.activeSprite = "human_base"
+            h.drain()
+
+            h.router.handle(sid, Command.Stylist.ChangeRace("ELF"))
+            h.drain()
+
+            assertEquals(
+                null,
+                h.players.get(sid)!!.activeSprite,
+                "activeSprite should be cleared when pinned sprite no longer matches new race",
+            )
         }
 
         @Test

--- a/src/test/kotlin/dev/ambon/test/TestFixtures.kt
+++ b/src/test/kotlin/dev/ambon/test/TestFixtures.kt
@@ -252,6 +252,7 @@ class CommandRouterHarness private constructor(
             housingSystem: HousingSystem? = null,
             gmcpEmitter: GmcpEmitter? = null,
             abilitySystem: dev.ambon.engine.abilities.AbilitySystem? = null,
+            spriteRegistry: dev.ambon.engine.SpriteRegistry? = null,
         ): CommandRouterHarness {
             val combat = CombatSystem(players, mobs, items, outbound)
             val router =
@@ -289,6 +290,7 @@ class CommandRouterHarness private constructor(
                     housingSystem = housingSystem,
                     gmcpEmitter = gmcpEmitter,
                     abilitySystem = abilitySystem,
+                    spriteRegistry = spriteRegistry,
                 )
             return CommandRouterHarness(
                 world = world,


### PR DESCRIPTION
## Summary

When a player used the stylist to change race, the stylist/sprite panel kept showing the old race's sprite options until they relogged. Reason: `StylistHandler.handleChangeRace` re-emits `Char.Name` and `Char.Skills` GMCP (for the name banner and ability list) but never re-emitted `Char.Sprites`. Sprite variants are race-filtered via `SpriteRegistry.availableVariants(playerRace = ...)`, so without a refresh the client's panel stayed stale.

### Fix

In `StylistHandler.handleChangeRace`, after race/stats/abilities update:

- If the player had a pinned `activeSprite` that no longer passes `SpriteRegistry.validateSelection` for the new race, clear it so auto-resolve picks a valid one.
- Emit `Char.Sprites` via `GmcpEmitter.sendCharSprites`, re-using the same path the `sprite`/`sprite set`/`sprite default` commands use. The web client already replaces its list on receipt (`applyGmcpPackage.ts` case `"Char.Sprites"`), and the package is in the WebSocket auto-opt-in list, so no transport or client changes were needed.

### Files

- `StylistHandler.kt` — accept `SpriteRegistry?`, clear stale pinned sprite, emit `Char.Sprites` after race change.
- `GameEngine.kt` — pass `spriteRegistry` into `StylistHandler`.
- `RouterTestHelper.kt` / `TestFixtures.kt` — plumb optional `spriteRegistry` through the test harness.
- `StylistCommandTest.kt` — two new tests (see below).

## Test plan

- [x] `./gradlew.bat ktlintCheck`
- [x] `./gradlew.bat test --tests "dev.ambon.engine.commands.StylistCommandTest"`
- New test `changerace emits Char_Sprites GMCP so stylist panel shows new race sprites` — changes race HUMAN -> ELF, asserts `Char.Sprites` GMCP emitted and payload contains `elf_base` (new race) but not `human_base` (old race).
- New test `changerace resets pinned activeSprite when it is no longer valid for new race` — player had `activeSprite = "human_base"`; after `changerace ELF`, `activeSprite` is `null` (falls back to auto for new race).
- Existing stylist tests (skills refresh, ability grant/revoke, stat/HP recompute, fee charging) still pass.

Fixes #1046