### PR TITLE
fix: emit Dungeon.Catalog and Lottery.Info on password login (#1045)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -241,6 +241,12 @@ class GameEngine(
                 markStatsDirty(sid)
                 broadcastServerWho()
                 issueResumeToken(sid)
+                // Emit panels that every session needs up-front. These were
+                // previously only fired on auth-token / resume paths, so a
+                // freshly created character saw empty Dungeon/Lottery panels
+                // until the first relog. See issue #1045.
+                emitDungeonCatalog(sid)
+                players.get(sid)?.let { p -> emitLotteryInfo(sid, p.name) }
             },
             // Only password/create logins need a fresh auth token — the client
             // doesn't have one yet. Auto-relog via Session.Authenticate and
@@ -1849,8 +1855,8 @@ class GameEngine(
             players,
             guildSystem,
         )
-        emitDungeonCatalog(newSessionId)
-        emitLotteryInfo(newSessionId, me.name)
+        // Dungeon catalog + lottery info are now emitted from onAfterLogin above
+        // so they fire on every login path, including password/new-char logins.
         if (me.isStaff) {
             gmcpEmitter.sendStaffWorldInfo(newSessionId, world)
             gmcpEmitter.sendStaffMobTemplates(newSessionId, world)
@@ -1950,8 +1956,8 @@ class GameEngine(
             players,
             guildSystem,
         )
-        emitDungeonCatalog(sessionId)
-        emitLotteryInfo(sessionId, player.name)
+        // Dungeon catalog + lottery info are now emitted from onAfterLogin above
+        // so they fire on every login path, including password/new-char logins.
         if (player.isStaff) {
             gmcpEmitter.sendStaffWorldInfo(sessionId, world)
             gmcpEmitter.sendStaffMobTemplates(sessionId, world)

--- a/src/test/kotlin/dev/ambon/engine/GameEngineLoginFlowTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GameEngineLoginFlowTest.kt
@@ -899,4 +899,120 @@ class GameEngineLoginFlowTest {
 
             h.close()
         }
+
+    /**
+     * Regression for issue #1045: first login after character creation did not
+     * emit Dungeon.Catalog or Lottery.Info, so the panels showed empty-state
+     * copy until the player relogged. Both packages must now fire on the
+     * initial password-creation login path.
+     */
+    @Test
+    fun `first login of newly created character emits dungeon catalog and lottery info`() =
+        runTest {
+            val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)
+            val h = GameEngineHarness.start(scope = this, clock = clock)
+
+            val sid = SessionId(42L)
+            runCurrent()
+
+            h.inbound.send(InboundEvent.Connected(sid))
+            // Opt into the GMCP packages whose emission we want to verify.
+            // The production WebSocket transport auto-sends this message on
+            // connect — see KtorWebSocketTransport.kt.
+            h.inbound.send(
+                InboundEvent.GmcpReceived(
+                    sid,
+                    "Core.Supports.Set",
+                    """["Dungeon 1","Lottery 1"]""",
+                ),
+            )
+            h.inbound.send(InboundEvent.LineReceived(sid, "FreshChar"))
+            h.inbound.send(InboundEvent.LineReceived(sid, "yes"))
+            h.inbound.send(InboundEvent.LineReceived(sid, "password"))
+            h.inbound.send(InboundEvent.LineReceived(sid, "1")) // race
+            h.inbound.send(InboundEvent.LineReceived(sid, "1")) // class
+            advanceTimeBy(h.tickMillis)
+            runCurrent()
+            // Second tick so background auth coroutine can complete and the
+            // resulting finalizeSuccessfulLogin GMCP emits land on outbound.
+            advanceTimeBy(h.tickMillis)
+            runCurrent()
+
+            val outs = h.outbound.drainAll()
+
+            assertTrue(
+                outs.any {
+                    it is OutboundEvent.GmcpData &&
+                        it.sessionId == sid &&
+                        it.gmcpPackage == "Dungeon.Catalog"
+                },
+                "Expected Dungeon.Catalog GMCP on first login of newly created character. got=$outs",
+            )
+            assertTrue(
+                outs.any {
+                    it is OutboundEvent.GmcpData &&
+                        it.sessionId == sid &&
+                        it.gmcpPackage == "Lottery.Info"
+                },
+                "Expected Lottery.Info GMCP on first login of newly created character. got=$outs",
+            )
+
+            h.close()
+        }
+
+    /**
+     * Companion to the #1045 regression above: an existing character logging
+     * back in with a password must also receive both panels. This was already
+     * working via the auth-token resume path, but we previously only wired
+     * Dungeon.Catalog / Lottery.Info into the resume / Session.Authenticate
+     * handlers — not the plain-password finalizeSuccessfulLogin path. Guard
+     * against regressions in either direction.
+     */
+    @Test
+    fun `existing character password login emits dungeon catalog and lottery info`() =
+        runTest {
+            val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)
+            val repo = InMemoryPlayerRepository()
+            repo.createTestPlayer("Alice", TestWorlds.testWorld.startRoom, password = "secret", ansiEnabled = false)
+            val h = GameEngineHarness.start(scope = this, clock = clock, repo = repo)
+
+            val sid = SessionId(7L)
+            runCurrent()
+
+            h.inbound.send(InboundEvent.Connected(sid))
+            h.inbound.send(
+                InboundEvent.GmcpReceived(
+                    sid,
+                    "Core.Supports.Set",
+                    """["Dungeon 1","Lottery 1"]""",
+                ),
+            )
+            h.inbound.send(InboundEvent.LineReceived(sid, "Alice"))
+            h.inbound.send(InboundEvent.LineReceived(sid, "secret"))
+            advanceTimeBy(h.tickMillis)
+            runCurrent()
+            advanceTimeBy(h.tickMillis)
+            runCurrent()
+
+            val outs = h.outbound.drainAll()
+
+            assertTrue(
+                outs.any {
+                    it is OutboundEvent.GmcpData &&
+                        it.sessionId == sid &&
+                        it.gmcpPackage == "Dungeon.Catalog"
+                },
+                "Expected Dungeon.Catalog GMCP on password login of existing character. got=$outs",
+            )
+            assertTrue(
+                outs.any {
+                    it is OutboundEvent.GmcpData &&
+                        it.sessionId == sid &&
+                        it.gmcpPackage == "Lottery.Info"
+                },
+                "Expected Lottery.Info GMCP on password login of existing character. got=$outs",
+            )
+
+            h.close()
+        }
 }


### PR DESCRIPTION
## Summary

- Moved the `Dungeon.Catalog` and `Lottery.Info` GMCP emissions into the shared `onAfterLogin` callback in `LoginFlowHandler`, which runs on every login path (`finalizeSuccessfulLogin`, `handleSessionResume`, `handleSessionAuthenticate`). Previously both packages were only fired from the auth-token and resume handlers, so a newly created character — or any existing character signing in with a plain password — saw empty-state copy in the Dungeon and Lottery panels until their next relog.
- Removed the now-redundant explicit emissions from the resume/auto-relog paths.
- Added two regression tests in `GameEngineLoginFlowTest` covering first login of a newly created character and password login of an existing character.

## Root cause

`emitDungeonCatalog` and `emitLotteryInfo` were only invoked from `GameEngine.handleSessionResume` and `GameEngine.handleSessionAuthenticate`. The plain-password `finalizeSuccessfulLogin` path in `LoginFlowHandler` — which handles both account creation and password logins without a cached auth token — never called them. A full relog happened to work because the client presents its freshly-issued auth token on reconnect and hits `handleSessionAuthenticate`.

## Test plan

- [x] `./gradlew.bat ktlintCheck` (passes)
- [x] `./gradlew.bat test -x buildWeb` (full suite passes)
- [x] New test `first login of newly created character emits dungeon catalog and lottery info` passes
- [x] New test `existing character password login emits dungeon catalog and lottery info` passes
- [ ] Manual: create a brand-new character via the web client and confirm the Dungeon and Lottery panels hydrate on first login with no relog

Fixes #1045