### PR TITLE
Fix bank deposit/withdraw silently no-op

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -937,8 +937,8 @@ object CommandParser {
             parseDepositWithdraw(rest.trim(), isDeposit = false)
         }?.let { return it }
 
-        matchPrefix(line, listOf("bank")) { _ ->
-            Command.Bank.Balance
+        matchPrefix(line, listOf("bank")) { rest ->
+            parseBankSubcommand(rest.trim())
         }?.let { return it }
 
         // stylist: "stylist" lists races + fee, "changerace <id>" applies the swap
@@ -1660,7 +1660,7 @@ object CommandParser {
     private fun parseDepositWithdraw(rest: String, isDeposit: Boolean): Command {
         if (rest.isEmpty()) {
             val verb = if (isDeposit) "deposit" else "withdraw"
-            return Command.Invalid("$verb", "$verb <amount> gold | $verb <item>")
+            return Command.Invalid(verb, "$verb <amount> [gold] | $verb <item>")
         }
         // Check for "<amount> gold" pattern
         val goldMatch = Regex("^(\\d+)\\s+gold$", RegexOption.IGNORE_CASE).find(rest)
@@ -1668,12 +1668,32 @@ object CommandParser {
             val amount = goldMatch.groupValues[1].toLongOrNull() ?: 0L
             return if (isDeposit) Command.Bank.DepositGold(amount) else Command.Bank.WithdrawGold(amount)
         }
-        // Check for "all gold"
-        if (rest.equals("all gold", ignoreCase = true)) {
+        // Bare numeric argument (e.g. "deposit 100") — treat as gold. The web bank
+        // panel sends this form, and it matches common intuition.
+        val bareAmount = rest.toLongOrNull()
+        if (bareAmount != null && bareAmount > 0) {
+            return if (isDeposit) Command.Bank.DepositGold(bareAmount) else Command.Bank.WithdrawGold(bareAmount)
+        }
+        // Check for "all gold" or bare "all"
+        if (rest.equals("all gold", ignoreCase = true) || rest.equals("all", ignoreCase = true)) {
             val amount = Long.MAX_VALUE // sentinel for "all"
             return if (isDeposit) Command.Bank.DepositGold(amount) else Command.Bank.WithdrawGold(amount)
         }
         // Otherwise treat as item keyword
         return if (isDeposit) Command.Bank.DepositItem(rest) else Command.Bank.WithdrawItem(rest)
+    }
+
+    private fun parseBankSubcommand(rest: String): Command {
+        if (rest.isEmpty() || rest.equals("balance", ignoreCase = true)) {
+            return Command.Bank.Balance
+        }
+        val lower = rest.lowercase()
+        return when {
+            lower.startsWith("deposit ") -> parseDepositWithdraw(rest.substring("deposit ".length).trim(), isDeposit = true)
+            lower == "deposit" -> Command.Invalid("bank deposit", "bank deposit <amount> | bank deposit <item>")
+            lower.startsWith("withdraw ") -> parseDepositWithdraw(rest.substring("withdraw ".length).trim(), isDeposit = false)
+            lower == "withdraw" -> Command.Invalid("bank withdraw", "bank withdraw <amount> | bank withdraw <item>")
+            else -> Command.Invalid("bank", "bank [balance] | bank deposit ... | bank withdraw ...")
+        }
     }
 }

--- a/src/test/kotlin/dev/ambon/engine/commands/BankCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/BankCommandTest.kt
@@ -67,8 +67,67 @@ class BankCommandTest {
         }
 
         @Test
+        fun `bank balance parses to Bank Balance`() {
+            assertEquals(Command.Bank.Balance, CommandParser.parse("bank balance"))
+        }
+
+        @Test
+        fun `bank deposit amount parses to DepositGold`() {
+            val result = CommandParser.parse("bank deposit 100")
+            assertTrue(result is Command.Bank.DepositGold, "got=$result")
+            assertEquals(100L, (result as Command.Bank.DepositGold).amount)
+        }
+
+        @Test
+        fun `bank withdraw amount parses to WithdrawGold`() {
+            val result = CommandParser.parse("bank withdraw 25")
+            assertTrue(result is Command.Bank.WithdrawGold, "got=$result")
+            assertEquals(25L, (result as Command.Bank.WithdrawGold).amount)
+        }
+
+        @Test
+        fun `bank deposit item parses to DepositItem`() {
+            val result = CommandParser.parse("bank deposit sword")
+            assertTrue(result is Command.Bank.DepositItem, "got=$result")
+            assertEquals("sword", (result as Command.Bank.DepositItem).keyword)
+        }
+
+        @Test
+        fun `bank withdraw item parses to WithdrawItem`() {
+            val result = CommandParser.parse("bank withdraw sword")
+            assertTrue(result is Command.Bank.WithdrawItem, "got=$result")
+            assertEquals("sword", (result as Command.Bank.WithdrawItem).keyword)
+        }
+
+        @Test
+        fun `deposit bare amount parses to DepositGold`() {
+            val result = CommandParser.parse("deposit 100")
+            assertTrue(result is Command.Bank.DepositGold, "got=$result")
+            assertEquals(100L, (result as Command.Bank.DepositGold).amount)
+        }
+
+        @Test
+        fun `withdraw bare amount parses to WithdrawGold`() {
+            val result = CommandParser.parse("withdraw 75")
+            assertTrue(result is Command.Bank.WithdrawGold, "got=$result")
+            assertEquals(75L, (result as Command.Bank.WithdrawGold).amount)
+        }
+
+        @Test
+        fun `deposit all parses with MAX_VALUE sentinel`() {
+            val result = CommandParser.parse("deposit all")
+            assertTrue(result is Command.Bank.DepositGold, "got=$result")
+            assertEquals(Long.MAX_VALUE, (result as Command.Bank.DepositGold).amount)
+        }
+
+        @Test
         fun `deposit alone returns Invalid`() {
             assertTrue(CommandParser.parse("deposit") is Command.Invalid)
+        }
+
+        @Test
+        fun `bank deposit alone returns Invalid`() {
+            assertTrue(CommandParser.parse("bank deposit") is Command.Invalid)
         }
     }
 
@@ -226,6 +285,46 @@ class BankCommandTest {
             val infos = h.drain().filterIsInstance<OutboundEvent.SendInfo>().map { it.text }
             assertTrue(infos.any { it.contains("200") }, "got=$infos")
             assertTrue(infos.any { it.contains("copper sword") }, "got=$infos")
+        }
+
+        @Test
+        fun `bank deposit from parsed text moves gold end-to-end`() = runTest {
+            // Regression for #1043: the web bank panel sends "bank deposit <amount>"
+            // which previously parsed to Command.Bank.Balance (silently ignoring the args)
+            // instead of depositing.
+            val (h, _) = harness()
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Alice")
+            h.players.get(sid)!!.gold = 500L
+            h.drain()
+
+            val parsed = CommandParser.parse("bank deposit 200")
+            assertTrue(parsed is Command.Bank.DepositGold, "parser returned $parsed")
+            h.router.handle(sid, parsed)
+
+            val infos = h.drain().filterIsInstance<OutboundEvent.SendInfo>().map { it.text }
+            assertTrue(infos.any { it.contains("deposit") && it.contains("200") }, "got=$infos")
+            assertEquals(300L, h.players.get(sid)!!.gold)
+            assertEquals(200L, h.players.get(sid)!!.bankGold)
+        }
+
+        @Test
+        fun `bank withdraw from parsed text moves gold end-to-end`() = runTest {
+            // Regression for #1043: same bug on withdraw.
+            val (h, _) = harness()
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Alice")
+            h.players.get(sid)!!.bankGold = 500L
+            h.drain()
+
+            val parsed = CommandParser.parse("bank withdraw 150")
+            assertTrue(parsed is Command.Bank.WithdrawGold, "parser returned $parsed")
+            h.router.handle(sid, parsed)
+
+            val infos = h.drain().filterIsInstance<OutboundEvent.SendInfo>().map { it.text }
+            assertTrue(infos.any { it.contains("withdraw") && it.contains("150") }, "got=$infos")
+            assertEquals(150L, h.players.get(sid)!!.gold)
+            assertEquals(350L, h.players.get(sid)!!.bankGold)
         }
 
         @Test


### PR DESCRIPTION
## Summary
- The web bank panel sends `bank deposit <amount>` / `bank withdraw <amount>`, but the parser's `bank` matcher ignored the trailing args and always returned `Command.Bank.Balance`, so every deposit/withdraw click silently just re-rendered the balance.
- Add a `parseBankSubcommand` that routes `bank balance`, `bank deposit ...`, and `bank withdraw ...` to the right commands.
- Accept bare numeric args (e.g. `deposit 100`) as gold amounts to match the web panel and common intuition, and allow `deposit all` as a shorthand for `deposit all gold`.

The handler already emits `SendInfo`/`SendError` on every path, so no handler logic changes were needed.

## Test plan
- [x] `./gradlew.bat ktlintCheck` — passes
- [x] `./gradlew.bat test --tests "dev.ambon.engine.commands.BankCommandTest" --tests "dev.ambon.engine.commands.CommandParserTest"` — passes
- [x] New parser tests cover `bank balance`, `bank deposit <n>`, `bank withdraw <n>`, `bank deposit <item>`, `bank withdraw <item>`, bare `deposit <n>`, bare `withdraw <n>`, `deposit all`, and both invalid forms.
- [x] New router regressions parse the exact strings the web bank panel sends (`bank deposit 200`, `bank withdraw 150`) and assert gold moves between wallet and vault end-to-end.

Fixes #1043