### PR TITLE
Fix collection quests not counting already-held items

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
@@ -127,21 +127,61 @@ class QuestSystem(
             return "You lack the standing with $factionName to take this quest."
         }
 
+        val seededObjectives =
+            quest.objectives.map { objDef ->
+                val initial = ObjectiveProgress(current = 0, required = objDef.count)
+                seedInitialProgress(sessionId, objDef, initial) ?: initial
+            }
         val state =
             QuestState(
                 questId = questId,
                 acceptedAtEpochMs = clock.millis(),
-                objectives = quest.objectives.map { ObjectiveProgress(current = 0, required = it.count) },
+                objectives = seededObjectives,
             )
         ps.activeQuests = ps.activeQuests + (questId to state)
         players.persistPlayer(ps.sessionId)
 
         outbound.send(OutboundEvent.SendInfo(sessionId, "Quest accepted: ${quest.name}"))
-        for (obj in quest.objectives) {
+        for ((index, obj) in quest.objectives.withIndex()) {
             outbound.send(OutboundEvent.SendText(sessionId, "  - ${obj.description}"))
+            val prog = seededObjectives[index]
+            if (prog.current > 0) {
+                sendObjectiveProgress(sessionId, obj.description, prog)
+                onQuestObjectiveUpdated?.invoke(sessionId, questId, index, prog.current, prog.required)
+            }
         }
         onQuestListChanged?.invoke(sessionId)
+        // An already-satisfied collect objective (e.g. player already holds the items)
+        // should auto-complete the quest when its completion type allows it.
+        checkAutoComplete(sessionId, ps.activeQuests)
         return null
+    }
+
+    /**
+     * Seeds initial progress for an objective based on current player state at the moment
+     * of quest acceptance. This covers the case where the player already holds items
+     * required by a COLLECT objective — without this, the objective would sit at 0/N
+     * until the next pickup, at which point counting existing inventory would appear
+     * to "jump" progress.
+     *
+     * Returns the seeded [ObjectiveProgress] or null when no seed applies (no-op).
+     */
+    private fun seedInitialProgress(
+        sessionId: SessionId,
+        objDef: QuestObjectiveDef,
+        initial: ObjectiveProgress,
+    ): ObjectiveProgress? {
+        val handler = objectiveHandlers.collectHandler(objDef.type) ?: return null
+        val targetIdRaw = objDef.targetId
+        // Count any inventory items whose id matches the objective target, using the
+        // same loose-suffix semantics the collect handler applies at pickup time.
+        val currentCount =
+            items.inventory(sessionId).count { inv ->
+                val itemId = inv.id.value
+                itemId == targetIdRaw || itemId.endsWith(":${targetIdRaw.substringAfterLast(':')}")
+            }
+        if (currentCount <= 0) return null
+        return handler.advance(objDef, initial, targetIdRaw, currentCount)
     }
 
     /**

--- a/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
@@ -343,6 +343,170 @@ class QuestSystemTest {
         }
 
     @Test
+    fun `acceptQuest seeds collect progress from existing inventory`() =
+        runTest {
+            val c = SystemTestComponents(clockInitialMs = 1_000L)
+            val registry = QuestRegistry()
+            val collectItemId = "zone:shiny_rock"
+            val collectQuestId = "zone:collect_quest"
+            val collectQuest =
+                QuestDef(
+                    id = collectQuestId,
+                    name = "Collect Rocks",
+                    description = "Gather shiny rocks.",
+                    giverMobId = "zone:quest_giver",
+                    objectives =
+                        listOf(
+                            QuestObjectiveDef(
+                                type = "collect",
+                                targetId = collectItemId,
+                                count = 3,
+                                description = "Collect 3 shiny rocks",
+                            ),
+                        ),
+                    rewards = QuestRewards(xp = 50L, gold = 10L),
+                    completionType = "auto",
+                )
+            registry.register(collectQuest)
+            val qs =
+                QuestSystem(
+                    registry = registry,
+                    players = c.players,
+                    items = c.items,
+                    outbound = c.outbound,
+                    clock = c.clock,
+                )
+            val sid = SessionId(10L)
+            c.players.loginOrFail(sid, "Gatherer")
+
+            // Player already holds 2 of the 3 required rocks BEFORE accepting the quest.
+            repeat(2) {
+                val rock = ItemInstance(id = ItemId(collectItemId), item = Item(keyword = "rock", displayName = "a shiny rock"))
+                c.items.addToInventory(sid, rock)
+            }
+
+            val err = qs.acceptQuest(sid, collectQuestId)
+            assertNull(err)
+
+            val ps = c.players.get(sid)!!
+            val prog = ps.activeQuests[collectQuestId]!!.objectives[0]
+            assertEquals(
+                2,
+                prog.current,
+                "Existing inventory should seed collect objective progress to 2/3 on accept",
+            )
+            assertEquals(3, prog.required)
+            assertFalse(prog.isComplete)
+        }
+
+    @Test
+    fun `collect quest completes after one more pickup when 2 of 3 were already held`() =
+        runTest {
+            val c = SystemTestComponents(clockInitialMs = 1_000L)
+            val registry = QuestRegistry()
+            val collectItemId = "zone:shiny_rock"
+            val collectQuestId = "zone:collect_quest"
+            val collectQuest =
+                QuestDef(
+                    id = collectQuestId,
+                    name = "Collect Rocks",
+                    description = "Gather shiny rocks.",
+                    giverMobId = "zone:quest_giver",
+                    objectives =
+                        listOf(
+                            QuestObjectiveDef(
+                                type = "collect",
+                                targetId = collectItemId,
+                                count = 3,
+                                description = "Collect 3 shiny rocks",
+                            ),
+                        ),
+                    rewards = QuestRewards(xp = 50L, gold = 10L),
+                    completionType = "auto",
+                )
+            registry.register(collectQuest)
+            val qs =
+                QuestSystem(
+                    registry = registry,
+                    players = c.players,
+                    items = c.items,
+                    outbound = c.outbound,
+                    clock = c.clock,
+                )
+            val sid = SessionId(11L)
+            c.players.loginOrFail(sid, "Gatherer")
+
+            // Pre-existing inventory: 2 rocks already in bag.
+            repeat(2) {
+                val rock = ItemInstance(id = ItemId(collectItemId), item = Item(keyword = "rock", displayName = "a shiny rock"))
+                c.items.addToInventory(sid, rock)
+            }
+
+            qs.acceptQuest(sid, collectQuestId)
+
+            // Confirm seeded to 2/3.
+            assertEquals(2, c.players.get(sid)!!.activeQuests[collectQuestId]!!.objectives[0].current)
+
+            // Picking up one more rock (delta of 1) should finish the quest at 3/3 — not jump.
+            val thirdRock = ItemInstance(id = ItemId(collectItemId), item = Item(keyword = "rock", displayName = "a shiny rock"))
+            c.items.addToInventory(sid, thirdRock)
+            qs.onItemCollected(sid, thirdRock)
+
+            val ps = c.players.get(sid)!!
+            assertFalse(ps.activeQuests.containsKey(collectQuestId), "Quest should auto-complete")
+            assertTrue(ps.completedQuestIds.contains(collectQuestId))
+        }
+
+    @Test
+    fun `accepting collect quest with full required inventory auto-completes`() =
+        runTest {
+            val c = SystemTestComponents(clockInitialMs = 1_000L)
+            val registry = QuestRegistry()
+            val collectItemId = "zone:shiny_rock"
+            val collectQuestId = "zone:collect_quest"
+            val collectQuest =
+                QuestDef(
+                    id = collectQuestId,
+                    name = "Collect Rocks",
+                    description = "Gather shiny rocks.",
+                    giverMobId = "zone:quest_giver",
+                    objectives =
+                        listOf(
+                            QuestObjectiveDef(
+                                type = "collect",
+                                targetId = collectItemId,
+                                count = 2,
+                                description = "Collect 2 shiny rocks",
+                            ),
+                        ),
+                    rewards = QuestRewards(xp = 50L, gold = 10L),
+                    completionType = "auto",
+                )
+            registry.register(collectQuest)
+            val qs =
+                QuestSystem(
+                    registry = registry,
+                    players = c.players,
+                    items = c.items,
+                    outbound = c.outbound,
+                    clock = c.clock,
+                )
+            val sid = SessionId(12L)
+            c.players.loginOrFail(sid, "Gatherer")
+
+            repeat(2) {
+                val rock = ItemInstance(id = ItemId(collectItemId), item = Item(keyword = "rock", displayName = "a shiny rock"))
+                c.items.addToInventory(sid, rock)
+            }
+
+            qs.acceptQuest(sid, collectQuestId)
+
+            val ps = c.players.get(sid)!!
+            assertFalse(ps.activeQuests.containsKey(collectQuestId), "Quest with all items already held should auto-complete on accept")
+            assertTrue(ps.completedQuestIds.contains(collectQuestId))
+        }
+
+    @Test
     fun `formatQuestLog shows multiple quests on separate lines`() =
         runTest {
             val (_, players, _) = setup()


### PR DESCRIPTION
## Summary
- `QuestSystem.acceptQuest` now seeds each collect objective's progress from the player's current inventory at accept time, so a player who already holds 2/3 of the required items sees 2/3 immediately instead of 0/3.
- If the seeded progress satisfies an auto-complete quest (player already holds all required items), the quest auto-completes on accept.
- Subsequent pickups continue to update progress correctly — the inventory re-scan in `CollectObjectiveHandlerImpl` only ever moves the count forward.

## Root cause
`onItemCollected` re-scans the full inventory rather than incrementing by a pickup delta. Without seeding at accept time, the already-held items were only credited at the next pickup, making progress appear to "jump".

## Test plan
- [x] New test: player holds 2/3 items before accept -> objective shows 2/3 immediately.
- [x] New test: player holds 2/3 before accept, picks up 1 more -> quest auto-completes (3/3 not 5/3).
- [x] New test: player holds full required count -> quest auto-completes on accept.
- [x] `./gradlew.bat ktlintCheck` passes.
- [x] `./gradlew.bat test -x buildWeb` passes (buildWeb skipped; requires bun, unrelated to change).

Fixes #1039