### PR TITLE
Fix stale dungeon panel after boss defeat (#1041)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -2483,6 +2483,8 @@ class GameEngine(
         val inst = dungeonManager.findInstanceByBossMob(mobId)
         if (inst == null || inst.completed) return
         dungeonManager.markComplete(inst)
+        val completionHeadline =
+            "** The dungeon boss has been defeated! The ${inst.template.name} is complete! **"
         for (sid in inst.members) {
             players.get(sid)?.let { it.dungeonsCompleted += 1 }
             achievementSystem.onDungeonCompleted(sid, inst.template.name)
@@ -2490,12 +2492,7 @@ class GameEngine(
             if (inst.members.size >= engineConfig.group.maxSize) {
                 achievementSystem.onDungeonCompletedWithFullParty(sid, inst.template.name)
             }
-            outbound.send(
-                OutboundEvent.SendInfo(
-                    sid,
-                    "** The dungeon boss has been defeated! The ${inst.template.name} is complete! **",
-                ),
-            )
+            outbound.send(OutboundEvent.SendInfo(sid, completionHeadline))
             val lootTable = inst.template.lootTables[inst.difficulty]
             if (lootTable != null) {
                 for (rewardId in lootTable.completionRewards) {
@@ -2510,6 +2507,26 @@ class GameEngine(
             }
             outbound.send(
                 OutboundEvent.SendInfo(sid, "Type 'dungeon leave' to return to the portal."),
+            )
+            // Update dungeon panel state so the UI shows completion instead of the stale
+            // "You enter <name>" message (see issue #1041).
+            gmcpEmitter.sendDungeonInfo(
+                sid,
+                active = true,
+                instanceId = inst.id,
+                name = inst.template.name,
+                difficulty = inst.difficulty.displayName,
+                totalRooms = inst.layout.rooms.size,
+                completed = true,
+                memberCount = inst.members.size,
+            )
+            gmcpEmitter.sendUiFeedback(
+                sessionId = sid,
+                type = "success",
+                message = "${inst.template.name} complete! Type 'dungeon leave' to return to the portal.",
+                code = "COMPLETED",
+                scope = "dungeon",
+                command = "complete",
             )
         }
     }

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -1660,6 +1660,51 @@ class GmcpEmitterTest {
         assertEquals(1, gmcp.size, "Normal-sized payload should be emitted")
     }
 
+    // ── Dungeon.Info ──
+
+    @Test
+    fun `sendDungeonInfo emits completed=true when dungeon boss has been defeated`() =
+        runTest {
+            val e = emitter("Dungeon")
+            e.sendDungeonInfo(
+                sessionId = sid,
+                active = true,
+                instanceId = "abc12345",
+                name = "Test Crypt",
+                difficulty = "Normal",
+                totalRooms = 5,
+                completed = true,
+                memberCount = 2,
+            )
+            val events = drainGmcp()
+            assertEquals(1, events.size)
+            val data = events[0]
+            assertEquals("Dungeon.Info", data.gmcpPackage)
+            assertTrue(data.jsonData.contains("\"active\":true"), "got=${data.jsonData}")
+            assertTrue(data.jsonData.contains("\"completed\":true"), "got=${data.jsonData}")
+            assertTrue(data.jsonData.contains("\"name\":\"Test Crypt\""), "got=${data.jsonData}")
+            assertTrue(data.jsonData.contains("\"instanceId\":\"abc12345\""), "got=${data.jsonData}")
+        }
+
+    @Test
+    fun `sendDungeonInfo emits active=false when leaving dungeon`() =
+        runTest {
+            val e = emitter("Dungeon")
+            e.sendDungeonInfo(sessionId = sid, active = false)
+            val events = drainGmcp()
+            assertEquals(1, events.size)
+            assertEquals("Dungeon.Info", events[0].gmcpPackage)
+            assertTrue(events[0].jsonData.contains("\"active\":false"), "got=${events[0].jsonData}")
+        }
+
+    @Test
+    fun `sendDungeonInfo does nothing when Dungeon package not supported`() =
+        runTest {
+            val e = emitter()
+            e.sendDungeonInfo(sessionId = sid, active = true, completed = true)
+            assertTrue(drainGmcp().isEmpty())
+        }
+
     @Test
     fun `MAX_GMCP_PAYLOAD_BYTES is 64KB`() {
         assertEquals(65_536, GmcpEmitter.MAX_GMCP_PAYLOAD_BYTES)

--- a/src/test/kotlin/dev/ambon/engine/commands/DungeonCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/DungeonCommandTest.kt
@@ -11,7 +11,9 @@ import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.world.MobSpawn
 import dev.ambon.domain.world.Room
 import dev.ambon.domain.world.World
+import dev.ambon.engine.GmcpEmitter
 import dev.ambon.engine.MobRegistry
+import dev.ambon.engine.PlayerProgression
 import dev.ambon.engine.dungeon.DungeonGenerator
 import dev.ambon.engine.dungeon.DungeonManager
 import dev.ambon.engine.dungeon.DungeonRegistry
@@ -259,6 +261,93 @@ class DungeonCommandTest {
             .map { it.text }
 
         assertTrue(texts.any { it.contains("Unknown difficulty") }, "Should reject invalid difficulty. got=$texts")
+    }
+
+    @Test
+    fun `dungeon info gmcp reflects completion after markComplete`() = runTest {
+        val players = buildTestPlayerRegistry(world.startRoom)
+        val outbound = dev.ambon.bus.LocalOutboundBus()
+        val gmcpEmitter = GmcpEmitter(
+            outbound = outbound,
+            supportsPackage = { _, _ -> true },
+            progression = PlayerProgression(),
+        )
+        val h = CommandRouterHarness.create(
+            world = world,
+            players = players,
+            mobs = mobs,
+            outbound = outbound,
+            dungeonManager = manager,
+            dungeonRegistry = registry,
+            gmcpEmitter = gmcpEmitter,
+        )
+        val sid = SessionId(1)
+        h.loginPlayer(sid, "Alice")
+        h.players.get(sid)!!.level = 5
+        h.drain()
+
+        // Enter dungeon — GMCP should say completed=false
+        h.router.handle(sid, Command.DungeonEnter("crypt", null))
+        val enterGmcp = h.drain()
+            .filterIsInstance<OutboundEvent.GmcpData>()
+            .filter { it.gmcpPackage == "Dungeon.Info" }
+        assertTrue(enterGmcp.isNotEmpty(), "Expected a Dungeon.Info emission on enter")
+        assertTrue(
+            enterGmcp.last().jsonData.contains("\"completed\":false"),
+            "Enter payload should have completed=false. got=${enterGmcp.last().jsonData}",
+        )
+
+        // Simulate boss kill by marking the instance complete, then re-enter.
+        val inst = manager.getInstanceForPlayer(sid)!!
+        manager.markComplete(inst)
+
+        // Move player out (as if teleported to portal) so re-entry is triggered.
+        h.players.moveTo(sid, portalRoom)
+
+        h.router.handle(sid, Command.DungeonEnter("crypt", null))
+        val reenterEvents = h.drain()
+        val reenterGmcp = reenterEvents
+            .filterIsInstance<OutboundEvent.GmcpData>()
+            .filter { it.gmcpPackage == "Dungeon.Info" }
+        assertTrue(reenterGmcp.isNotEmpty(), "Expected a Dungeon.Info emission on re-enter")
+        assertTrue(
+            reenterGmcp.last().jsonData.contains("\"completed\":true"),
+            "Re-enter payload after completion should have completed=true. got=${reenterGmcp.last().jsonData}",
+        )
+    }
+
+    @Test
+    fun `dungeon enter emits scoped UI feedback so panel can show current action`() = runTest {
+        val players = buildTestPlayerRegistry(world.startRoom)
+        val outbound = dev.ambon.bus.LocalOutboundBus()
+        val gmcpEmitter = GmcpEmitter(
+            outbound = outbound,
+            supportsPackage = { _, _ -> true },
+            progression = PlayerProgression(),
+        )
+        val h = CommandRouterHarness.create(
+            world = world,
+            players = players,
+            mobs = mobs,
+            outbound = outbound,
+            dungeonManager = manager,
+            dungeonRegistry = registry,
+            gmcpEmitter = gmcpEmitter,
+        )
+        val sid = SessionId(1)
+        h.loginPlayer(sid, "Alice")
+        h.players.get(sid)!!.level = 5
+        h.drain()
+
+        h.router.handle(sid, Command.DungeonEnter("crypt", null))
+        val events = h.drain()
+            .filterIsInstance<OutboundEvent.GmcpData>()
+            .filter { it.gmcpPackage == "UI.Feedback" }
+        val dungeonScoped = events.filter { it.jsonData.contains("\"scope\":\"dungeon\"") }
+        assertTrue(
+            dungeonScoped.any { it.jsonData.contains("\"code\":\"ENTERED\"") },
+            "Expected ENTERED feedback on enter. got=${dungeonScoped.map { it.jsonData }}",
+        )
     }
 
     @Test

--- a/web-v3/src/components/panels/DungeonPanel.tsx
+++ b/web-v3/src/components/panels/DungeonPanel.tsx
@@ -49,11 +49,17 @@ export function DungeonPanel({ dungeonInfo, dungeonCatalog, uiFeedbackFeed, onCo
             <div><dt>Status</dt><dd>{dungeonInfo.completed ? "Boss defeated" : "In progress"}</dd></div>
           </dl>
           <div className="systems-action-row">
-            <button type="button" className="systems-primary-btn" onClick={() => onCommand("dungeon enter resume")}>
-              Resume Run
-            </button>
-            <button type="button" className="systems-secondary-btn" onClick={() => onCommand("dungeon leave")}>
-              Leave Dungeon
+            {!dungeonInfo.completed && (
+              <button type="button" className="systems-primary-btn" onClick={() => onCommand("dungeon enter resume")}>
+                Resume Run
+              </button>
+            )}
+            <button
+              type="button"
+              className={dungeonInfo.completed ? "systems-primary-btn" : "systems-secondary-btn"}
+              onClick={() => onCommand("dungeon leave")}
+            >
+              {dungeonInfo.completed ? "Return to Portal" : "Leave Dungeon"}
             </button>
           </div>
         </article>


### PR DESCRIPTION
## Summary

- **Server:** `GameEngine.checkDungeonBossKilled` now emits a `Dungeon.Info` GMCP update with `completed=true` (plus a `UI.Feedback` success entry scoped to `dungeon` with code `COMPLETED`) for every member the moment the boss dies. Previously the only completion signal was a single `SendInfo` line, so the panel kept showing the stale `You enter <name>` message forever.
- **Client:** `DungeonPanel` hides the `Resume Run` button once the run is complete and promotes the remaining action to `Return to Portal`. The existing "Completed" pill / "Boss defeated" status line already rendered correctly once the server actually delivered `completed=true`.
- **Tests:** Added coverage in `GmcpEmitterTest` for the `completed=true` and `active=false` shapes of `Dungeon.Info`, and in `DungeonCommandTest` for (a) `Dungeon.Info` reflecting `instance.completed` on re-entry and (b) the `ENTERED` scoped feedback entry the panel consumes.

Fixes #1041

## Test plan

- [x] `./gradlew.bat ktlintCheck`
- [x] `./gradlew.bat test -x buildWeb` (full suite green)
- [x] Targeted: `./gradlew.bat test --tests "*DungeonCommandTest*" --tests "*DungeonManagerTest*" --tests "*GmcpEmitterTest*"`
- [x] `web-v3` TypeScript `tsc --noEmit` and `eslint` both clean (local `bun` env is broken on this Windows box; verified via `npm`).
- [ ] Manual: enter a dungeon, kill the boss, confirm panel shows the `Completed` pill, `Boss defeated` status, `COMPLETED` feedback message, and the `Return to Portal` CTA; leaving returns you to the portal and the panel shows the catalog again.