### PR TITLE
Fix Examine modal: centered, on top, shows item stats (#1028)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -1817,6 +1817,13 @@ class GmcpEmitter(
         race: String? = null,
         playerClass: String? = null,
         playerDescription: String? = null,
+        slot: String? = null,
+        damage: Int? = null,
+        armor: Int? = null,
+        basePrice: Int? = null,
+        stats: Map<String, Int>? = null,
+        enchantments: List<String>? = null,
+        consumable: Boolean? = null,
     ) {
         emit(
             sessionId,
@@ -1830,6 +1837,13 @@ class GmcpEmitter(
                 race = race,
                 playerClass = playerClass,
                 playerDescription = playerDescription,
+                slot = slot,
+                damage = damage,
+                armor = armor,
+                basePrice = basePrice,
+                stats = stats,
+                enchantments = enchantments,
+                consumable = consumable,
             ),
             supportCheck = "Room.Info",
         )
@@ -2716,6 +2730,13 @@ class GmcpEmitter(
         val race: String? = null,
         @get:JsonProperty("class") val playerClass: String? = null,
         val playerDescription: String? = null,
+        val slot: String? = null,
+        val damage: Int? = null,
+        val armor: Int? = null,
+        val basePrice: Int? = null,
+        val stats: Map<String, Int>? = null,
+        val enchantments: List<String>? = null,
+        val consumable: Boolean? = null,
     )
 
     // ---------- shop payloads ----------

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
@@ -3,6 +3,7 @@ package dev.ambon.engine.commands.handlers
 import dev.ambon.config.RecallConfig
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.world.LockableState
 import dev.ambon.engine.GuildHallSystem
 import dev.ambon.engine.HouseEntryResult
@@ -343,7 +344,7 @@ class NavigationHandler(
         if (roomItem != null) {
             val desc = roomItem.item.description.ifEmpty { "You see nothing special about ${roomItem.item.displayName}." }
             outbound.send(OutboundEvent.SendText(sessionId, "${roomItem.item.displayName}: $desc"))
-            gmcpEmitter?.sendLookTarget(sessionId, "item", roomItem.item.displayName, desc, image = roomItem.item.image)
+            sendItemLookTarget(sessionId, roomItem, desc)
             return
         }
 
@@ -353,7 +354,7 @@ class NavigationHandler(
         if (invItem != null) {
             val desc = invItem.item.description.ifEmpty { "You see nothing special about ${invItem.item.displayName}." }
             outbound.send(OutboundEvent.SendText(sessionId, "${invItem.item.displayName}: $desc"))
-            gmcpEmitter?.sendLookTarget(sessionId, "item", invItem.item.displayName, desc, image = invItem.item.image)
+            sendItemLookTarget(sessionId, invItem, desc)
             return
         }
 
@@ -363,7 +364,7 @@ class NavigationHandler(
         if (eqItem != null) {
             val desc = eqItem.item.description.ifEmpty { "You see nothing special about ${eqItem.item.displayName}." }
             outbound.send(OutboundEvent.SendText(sessionId, "${eqItem.item.displayName}: $desc"))
-            gmcpEmitter?.sendLookTarget(sessionId, "item", eqItem.item.displayName, desc, image = eqItem.item.image)
+            sendItemLookTarget(sessionId, eqItem, desc)
             return
         }
 
@@ -393,6 +394,29 @@ class NavigationHandler(
         val msg = "You don't see '${cmd.target}' here."
         outbound.send(OutboundEvent.SendError(sessionId, msg))
         gmcpEmitter?.sendUiFeedback(sessionId, "error", msg, code = "TARGET_NOT_FOUND", scope = "navigation", command = "look")
+    }
+
+    private suspend fun sendItemLookTarget(
+        sessionId: SessionId,
+        instance: ItemInstance,
+        description: String,
+    ) {
+        val item = instance.item
+        val stats = item.stats.nonZero().ifEmpty { null }
+        gmcpEmitter?.sendLookTarget(
+            sessionId = sessionId,
+            type = "item",
+            name = item.displayName,
+            description = description,
+            image = item.image,
+            slot = item.slot?.label(),
+            damage = if (item.damage != 0) item.damage else null,
+            armor = if (item.armor != 0) item.armor else null,
+            basePrice = if (item.basePrice > 0) item.basePrice else null,
+            stats = stats,
+            enchantments = instance.enchantments.ifEmpty { null },
+            consumable = if (item.consumable) true else null,
+        )
     }
 
     private suspend fun handleLookDir(

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -35,9 +35,86 @@ import { useCommandHistory } from "./hooks/useCommandHistory";
 import { useMiniMap } from "./hooks/useMiniMap";
 import { useQuickbar } from "./hooks/useQuickbar";
 import { canvasCallbacks, gameStateRef, pendingCastRef } from "./canvas/GameStateBridge";
-import type { ChatChannel, FeaturePopoutFocus, PopoutPanel } from "./types";
+import type { ChatChannel, FeaturePopoutFocus, LookTargetInfo, PopoutPanel } from "./types";
 import { sortExits, titleCaseWords } from "./utils";
 import "./styles.css";
+
+// ── Look-target (Examine) helpers ───────────────────────────────────────────
+function formatItemSlot(slot: string): string {
+  return titleCaseWords(slot.replace(/_/g, " "));
+}
+
+function formatStatLabel(key: string): string {
+  return titleCaseWords(key.replace(/_/g, " "));
+}
+
+function formatStatValue(value: number): string {
+  return value > 0 ? `+${value}` : `${value}`;
+}
+
+function hasItemStatContent(info: LookTargetInfo): boolean {
+  if (info.type !== "item") return false;
+  if (info.damage != null && info.damage !== 0) return true;
+  if (info.armor != null && info.armor !== 0) return true;
+  if (info.basePrice != null && info.basePrice > 0) return true;
+  if (info.slot) return true;
+  if (info.consumable) return true;
+  if (info.stats && Object.values(info.stats).some((v) => v !== 0)) return true;
+  if (info.enchantments && info.enchantments.length > 0) return true;
+  return false;
+}
+
+function renderItemStats(info: LookTargetInfo) {
+  if (!hasItemStatContent(info)) return null;
+  const coreStats: Array<{ label: string; value: string; tone: "damage" | "armor" | "value" | "neutral" }> = [];
+  if (info.damage != null && info.damage !== 0) {
+    coreStats.push({ label: "Damage", value: formatStatValue(info.damage), tone: "damage" });
+  }
+  if (info.armor != null && info.armor !== 0) {
+    coreStats.push({ label: "Armor", value: formatStatValue(info.armor), tone: "armor" });
+  }
+  if (info.basePrice != null && info.basePrice > 0) {
+    coreStats.push({ label: "Value", value: `${info.basePrice}g`, tone: "value" });
+  }
+  if (info.consumable) {
+    coreStats.push({ label: "Type", value: "Consumable", tone: "neutral" });
+  }
+  const statEntries = info.stats
+    ? Object.entries(info.stats).filter(([, v]) => v !== 0)
+    : [];
+
+  return (
+    <div className="look-target-stats" role="group" aria-label="Item details">
+      {coreStats.length > 0 && (
+        <ul className="look-target-stat-grid">
+          {coreStats.map((s) => (
+            <li key={s.label} className={`look-target-stat look-target-stat-${s.tone}`}>
+              <span className="look-target-stat-label">{s.label}</span>
+              <span className="look-target-stat-value">{s.value}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+      {statEntries.length > 0 && (
+        <ul className="look-target-modifier-list">
+          {statEntries.map(([key, value]) => (
+            <li key={key} className={`look-target-modifier ${value > 0 ? "is-positive" : "is-negative"}`}>
+              <span className="look-target-modifier-label">{formatStatLabel(key)}</span>
+              <span className="look-target-modifier-value">{formatStatValue(value)}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+      {info.enchantments && info.enchantments.length > 0 && (
+        <ul className="look-target-enchantments">
+          {info.enchantments.map((e, i) => (
+            <li key={`${e}-${i}`} className="look-target-enchantment">{e}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
 
 function TrainerAutoLoad({ onCommand }: { onCommand: (cmd: string) => void }) {
   const sent = useRef(false);
@@ -351,11 +428,14 @@ function App() {
     };
   }, [state.activePopout, drawMap, startPulse, stopPulse]);
 
-  // Auto-dismiss look target
+  // Close look-target modal on Escape
   useEffect(() => {
     if (!state.lookTarget) return;
-    const t = setTimeout(() => state.setLookTarget(null), 6000);
-    return () => clearTimeout(t);
+    const handler = (e: globalThis.KeyboardEvent) => {
+      if (e.key === "Escape") state.setLookTarget(null);
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
   }, [state.lookTarget]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Ctrl+K (or Cmd+K) opens the command palette
@@ -1104,19 +1184,45 @@ function App() {
 
       {/* Look target card */}
       {state.lookTarget && (
-        <div className="look-target-card" role="dialog" aria-label="Inspect target" onClick={() => state.setLookTarget(null)}>
-          <div className="look-target-header">
-            <span className="look-target-name">{state.lookTarget.name}</span>
-            {state.lookTarget.level != null && (
-              <span className="look-target-meta">
-                Lv {state.lookTarget.level}
-                {state.lookTarget.race && ` ${state.lookTarget.race}`}
-                {state.lookTarget.playerClass && ` ${state.lookTarget.playerClass}`}
-              </span>
+        <div
+          className="look-target-backdrop"
+          role="presentation"
+          onClick={() => state.setLookTarget(null)}
+        >
+          <div
+            className="look-target-card"
+            role="dialog"
+            aria-modal="true"
+            aria-label={`Inspect ${state.lookTarget.name}`}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              type="button"
+              className="look-target-close"
+              aria-label="Close"
+              onClick={() => state.setLookTarget(null)}
+            >
+              &#x2715;
+            </button>
+            <div className="look-target-header">
+              <span className="look-target-name">{state.lookTarget.name}</span>
+              {state.lookTarget.level != null && (
+                <span className="look-target-meta">
+                  Lv {state.lookTarget.level}
+                  {state.lookTarget.race && ` ${state.lookTarget.race}`}
+                  {state.lookTarget.playerClass && ` ${state.lookTarget.playerClass}`}
+                </span>
+              )}
+              {state.lookTarget.type === "item" && state.lookTarget.slot && (
+                <span className="look-target-slot">{formatItemSlot(state.lookTarget.slot)}</span>
+              )}
+            </div>
+            {state.lookTarget.image && <img src={state.lookTarget.image} alt="" className="look-target-image" />}
+            {state.lookTarget.description && (
+              <p className="look-target-desc">{state.lookTarget.description}</p>
             )}
+            {state.lookTarget.type === "item" && renderItemStats(state.lookTarget)}
           </div>
-          <p className="look-target-desc">{state.lookTarget.description}</p>
-          {state.lookTarget.image && <img src={state.lookTarget.image} alt="" className="look-target-image" />}
         </div>
       )}
 

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -489,6 +489,13 @@ export function applyGmcpPackage(
     case "Room.LookTarget": {
       const packet = data as Partial<Record<string, unknown>>;
       const targetType = typeof packet.type === "string" ? packet.type : "item";
+      const stats =
+        packet.stats && typeof packet.stats === "object" && !Array.isArray(packet.stats)
+          ? (packet.stats as Record<string, number>)
+          : null;
+      const enchantments = Array.isArray(packet.enchantments)
+        ? (packet.enchantments as unknown[]).filter((e): e is string => typeof e === "string")
+        : null;
       ctx.setLookTarget({
         type: targetType as LookTargetInfo["type"],
         name: typeof packet.name === "string" ? packet.name : "Unknown",
@@ -498,6 +505,13 @@ export function applyGmcpPackage(
         race: typeof packet.race === "string" ? packet.race : null,
         playerClass: typeof packet.class === "string" ? (packet.class as string) : null,
         receivedAt: Date.now(),
+        slot: typeof packet.slot === "string" ? packet.slot : null,
+        damage: typeof packet.damage === "number" ? packet.damage : null,
+        armor: typeof packet.armor === "number" ? packet.armor : null,
+        basePrice: typeof packet.basePrice === "number" ? packet.basePrice : null,
+        stats,
+        enchantments,
+        consumable: typeof packet.consumable === "boolean" ? packet.consumable : null,
       });
       break;
     }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -96,6 +96,20 @@
   --ease-in-soft: cubic-bezier(0.25, 0.46, 0.45, 0.94);
   --ease-out-soft: cubic-bezier(0.33, 0.66, 0.66, 1);
   --ease-in-out-smooth: cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* ── Layering ─────────────────────────────────────────── */
+  /* Canvas and inline HUD elements. */
+  --z-base: 1;
+  /* Page-level fixed overlays (atmosphere HUDs, toasts). */
+  --z-hud: 80;
+  /* Sidebar popouts and room dialogs. */
+  --z-popout: 100;
+  /* Mobile drawer sheet and its backdrop. */
+  --z-drawer: 120;
+  /* Examine / inspect modals — above drawers but below broadcast/auth. */
+  --z-inspect: 1000;
+  /* Critical system overlays: broadcasts, login, command palette. */
+  --z-critical: 1100;
 }
 
 * {
@@ -7391,57 +7405,287 @@ body {
   border: 0;
 }
 
-.look-target-card {
+/* ── Look-target (Examine) modal ─────────────────────────── */
+.look-target-backdrop {
   position: fixed;
-  top: 80px;
-  right: 20px;
-  z-index: 100;
-  max-width: 320px;
-  padding: var(--space-3) var(--space-4);
-  background: rgb(30 25 40 / 94%);
-  border: 1px solid rgb(120 100 160 / 30%);
-  border-radius: var(--radius-md);
-  backdrop-filter: blur(8px);
-  cursor: pointer;
-  animation: lookTargetFadeIn 200ms ease-out;
+  inset: 0;
+  z-index: var(--z-inspect);
+  display: grid;
+  place-items: center;
+  padding: var(--space-4);
+  background: rgb(14 16 28 / 60%);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  animation: lookTargetBackdropIn 180ms var(--ease-out-soft);
 }
 
-@keyframes lookTargetFadeIn {
-  from { opacity: 0; transform: translateY(-8px); }
-  to { opacity: 1; transform: translateY(0); }
+.look-target-card {
+  position: relative;
+  width: min(420px, 100%);
+  max-height: calc(100dvh - 40px);
+  overflow-y: auto;
+  padding: var(--space-4) var(--space-5);
+  background:
+    linear-gradient(165deg, rgb(48 55 82 / 97%), rgb(38 47 71 / 95%));
+  border: 1px solid rgb(146 136 180 / 30%);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg), var(--shadow-glow);
+  color: var(--text-primary);
+  animation: lookTargetCardIn 220ms var(--ease-out-soft);
+  display: grid;
+  gap: var(--space-3);
+  scrollbar-width: thin;
+  scrollbar-color: rgb(90 82 120 / 70%) transparent;
+}
+
+.look-target-card:focus-visible,
+.look-target-backdrop:focus-visible {
+  outline: 2px solid var(--color-primary-lavender);
+  outline-offset: 2px;
+}
+
+@keyframes lookTargetBackdropIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes lookTargetCardIn {
+  from { opacity: 0; transform: translateY(8px) scale(0.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .look-target-backdrop,
+  .look-target-card {
+    animation: none;
+  }
+}
+
+.look-target-close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--line-soft);
+  border-radius: 999px;
+  background: rgb(40 46 68 / 70%);
+  color: var(--text-primary);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 160ms var(--ease-out-soft), transform 160ms var(--ease-out-soft);
+}
+
+.look-target-close:hover {
+  background: rgb(62 70 104 / 90%);
+}
+
+.look-target-close:active {
+  transform: scale(0.96);
+}
+
+.look-target-close:focus-visible {
+  outline: 2px solid var(--color-primary-lavender);
+  outline-offset: 2px;
 }
 
 .look-target-header {
   display: flex;
+  flex-wrap: wrap;
   align-items: baseline;
   gap: var(--space-2);
-  margin-bottom: var(--space-1);
+  padding-right: var(--space-6);
 }
 
 .look-target-name {
-  font-size: 0.88rem;
+  font-family: var(--font-display);
+  font-size: 1.35rem;
   font-weight: 700;
-  color: var(--color-accent-moonlit-silver);
+  color: var(--text-bright);
+  letter-spacing: 0.01em;
 }
 
 .look-target-meta {
-  font-size: 0.72rem;
+  font-size: 0.82rem;
   color: var(--text-secondary);
+}
+
+.look-target-slot {
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgb(168 151 210 / 16%);
+  border: 1px solid rgb(168 151 210 / 32%);
+  color: var(--color-primary-lavender);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .look-target-desc {
   margin: 0;
-  font-size: 0.78rem;
+  font-size: 0.9rem;
   color: var(--text-primary);
-  line-height: 1.4;
+  line-height: 1.5;
+  font-style: italic;
 }
 
 .look-target-image {
   display: block;
   max-width: 100%;
-  max-height: 120px;
-  margin-top: var(--space-2);
+  max-height: 180px;
+  margin: 0 auto;
+  border-radius: var(--radius-md);
+  background: rgb(24 28 44 / 60%);
+  border: 1px solid var(--line-faint);
+}
+
+.look-target-stats {
+  display: grid;
+  gap: var(--space-3);
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--line-faint);
+}
+
+.look-target-stat-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: var(--space-2);
+}
+
+.look-target-stat {
+  display: grid;
+  gap: 2px;
+  padding: var(--space-2) var(--space-3);
   border-radius: var(--radius-sm);
+  background: rgb(34 41 64 / 80%);
+  border: 1px solid var(--line-faint);
+}
+
+.look-target-stat-label {
+  font-size: 0.68rem;
+  color: var(--text-tertiary);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.look-target-stat-value {
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-bright);
+}
+
+.look-target-stat-damage {
+  border-color: rgb(212 136 138 / 40%);
+}
+
+.look-target-stat-damage .look-target-stat-value {
+  color: var(--color-damage);
+}
+
+.look-target-stat-armor {
+  border-color: rgb(127 182 207 / 36%);
+}
+
+.look-target-stat-armor .look-target-stat-value {
+  color: var(--color-primary-pale-blue);
+}
+
+.look-target-stat-value,
+.look-target-modifier-value {
+  font-variant-numeric: tabular-nums;
+}
+
+.look-target-modifier-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.look-target-modifier {
+  display: inline-flex;
+  gap: 6px;
+  align-items: baseline;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgb(34 41 64 / 70%);
+  border: 1px solid var(--line-faint);
+  font-size: 0.78rem;
+}
+
+.look-target-modifier-label {
+  color: var(--text-secondary);
+  letter-spacing: 0.02em;
+}
+
+.look-target-modifier-value {
+  font-family: var(--font-mono);
+  font-weight: 700;
+}
+
+.look-target-modifier.is-positive {
+  border-color: rgb(138 191 138 / 36%);
+}
+
+.look-target-modifier.is-positive .look-target-modifier-value {
+  color: var(--color-heal);
+}
+
+.look-target-modifier.is-negative {
+  border-color: rgb(232 160 160 / 36%);
+}
+
+.look-target-modifier.is-negative .look-target-modifier-value {
+  color: var(--color-error);
+}
+
+.look-target-enchantments {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.look-target-enchantment {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgb(206 147 216 / 14%);
+  border: 1px solid rgb(206 147 216 / 36%);
+  color: var(--color-accent-violet);
+  font-size: 0.76rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+/* Responsive — tighter layout at narrow widths, roomier on desktop. */
+@media (max-width: 599px) {
+  .look-target-card {
+    padding: var(--space-3) var(--space-4);
+  }
+
+  .look-target-name {
+    font-size: 1.2rem;
+  }
+
+  .look-target-stat-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .look-target-card {
+    width: min(500px, 100%);
+  }
 }
 
 /* ── Possession vignette overlay ── */
@@ -14502,7 +14746,7 @@ html:has(.game-shell),
   position: fixed;
   inset: 0;
   background: rgb(8 10 18 / 0%);
-  z-index: 100;
+  z-index: var(--z-drawer);
   pointer-events: none;
   transition: background 0.3s var(--ease-out-soft);
 }
@@ -14519,7 +14763,7 @@ html:has(.game-shell),
   bottom: 0;
   left: 0;
   right: 0;
-  z-index: 101;
+  z-index: calc(var(--z-drawer) + 1);
   background: linear-gradient(180deg, rgb(43 53 79 / 98%), rgb(34 41 64 / 98%));
   border-top: 1px solid var(--line-soft);
   border-radius: var(--radius-xl) var(--radius-xl) 0 0;

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -696,6 +696,20 @@ export interface LookTargetInfo {
   race?: string | null;
   playerClass?: string | null;
   receivedAt: number;
+  /** Item-only: slot name (e.g. "MAIN_HAND"). */
+  slot?: string | null;
+  /** Item-only: bonus melee damage. */
+  damage?: number | null;
+  /** Item-only: bonus armor. */
+  armor?: number | null;
+  /** Item-only: merchant base price in gold. */
+  basePrice?: number | null;
+  /** Item-only: stat modifiers (e.g. {STR: 2, INT: -1}). */
+  stats?: Record<string, number> | null;
+  /** Item-only: active enchantment names. */
+  enchantments?: string[] | null;
+  /** Item-only: true if usable/consumable. */
+  consumable?: boolean | null;
 }
 
 export interface CombatLogMessage {


### PR DESCRIPTION
## Summary
- Makes the inventory Examine flow usable: the look-target overlay is now a centered modal with a backdrop that renders above the drawer/sidebar (was behind the drawer at z:100 < drawer z:101, and pinned to the top-right corner).
- Surfaces item stats the server already knew about (damage, armor, slot, base gold value, stat modifiers, enchantments, consumable) via a `Room.LookTarget` GMCP payload extension, so players can actually tell gear apart from junk.
- Introduces layering design tokens (`--z-hud`, `--z-popout`, `--z-drawer`, `--z-inspect`, `--z-critical`) instead of scattered magic numbers.

Fixes #1028.

## Test plan
- [x] `./gradlew.bat ktlintCheck`
- [x] `./gradlew.bat test --tests *Navigation* --tests *Gmcp* --tests *Look*`
- [x] `bun run lint` (web-v3)
- [x] `bunx tsc -b` (web-v3)
- [x] `bunx vite build` (web-v3)
- [ ] Manual: click Examine on inventory weapon, armor, consumable, and trash item; verify modal is centered, above drawer, shows damage/armor/value/slot/modifiers/enchantments where applicable, and dismisses on backdrop click, close button, or Escape.
- [ ] Manual: check responsive layouts at 375px, 600px, and 1024px.
- [ ] Manual: verify `prefers-reduced-motion` disables enter animations.

## Notes
- Auto-dismiss timer (6s) is removed — players couldn't read stats in that window. Closing is now explicit (click outside, close button, or Esc).
- The modal now also shows stats when looking at inventory items via the telnet `look <keyword>` command, since it shares the same GMCP feed. Room items still show their description. Players and mobs are unchanged.