### PR TITLE
Fix training panel to surface level-gated skills (#1036)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -664,15 +664,15 @@ class GmcpEmitter(
         val knownIds = abilitySystem.knownAbilityIds(sessionId)
         val classPayloads = trainer.classNames.map { className ->
             val unlocked = player.unlockedClasses.any { it.equals(className, ignoreCase = true) }
-            val abilities = if (unlocked) {
-                abilitySystem.trainableAbilities(className, player.level, knownIds)
+            val entries = if (unlocked) {
+                abilitySystem.trainerPanelAbilities(className, player.level, knownIds)
             } else {
                 emptyList()
             }
             TrainerClassPayload(
                 className = className,
                 classUnlocked = unlocked,
-                abilities = abilities.map { a -> a.toTrainerAbilityPayload() },
+                abilities = entries.map { it.toTrainerAbilityPayload() },
             )
         }
         emit(
@@ -691,21 +691,23 @@ class GmcpEmitter(
         )
     }
 
-    private fun AbilityDefinition.toTrainerAbilityPayload(): TrainerAbilityPayload =
+    private fun AbilitySystem.TrainerPanelEntry.toTrainerAbilityPayload(): TrainerAbilityPayload =
         TrainerAbilityPayload(
-            id = id.value,
-            name = displayName,
-            description = description,
-            skillPointCost = skillPointCost,
-            levelRequired = levelRequired,
-            manaCost = manaCost,
-            cooldownMs = cooldownMs,
-            targetType = targetType,
-            effectType = effect.toEffectType(),
-            image = image,
-            prerequisites = prerequisites.map { it.value },
-            tree = tree,
-            tier = tier,
+            id = ability.id.value,
+            name = ability.displayName,
+            description = ability.description,
+            skillPointCost = ability.skillPointCost,
+            levelRequired = ability.levelRequired,
+            manaCost = ability.manaCost,
+            cooldownMs = ability.cooldownMs,
+            targetType = ability.targetType,
+            effectType = ability.effect.toEffectType(),
+            image = ability.image,
+            prerequisites = ability.prerequisites.map { it.value },
+            tree = ability.tree,
+            tier = ability.tier,
+            locked = locked,
+            lockReason = lockReason,
         )
 
     /** Sends `Char.Classes` with the player's unlocked classes. */
@@ -2227,6 +2229,8 @@ class GmcpEmitter(
         val prerequisites: List<String> = emptyList(),
         val tree: String = "",
         val tier: Int = 0,
+        val locked: Boolean = false,
+        val lockReason: String? = null,
     )
 
     private data class TrainerClassPayload(

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
@@ -686,6 +686,55 @@ class AbilitySystem(
             )
 
     /**
+     * Entry returned by [trainerPanelAbilities]. Includes the underlying ability plus
+     * per-player lock status so the UI can render locked rows with a clear reason.
+     */
+    data class TrainerPanelEntry(
+        val ability: AbilityDefinition,
+        val locked: Boolean,
+        val lockReason: String?,
+    )
+
+    /**
+     * Returns every ability belonging to [className] that the player does not already know,
+     * annotated with lock status. Unlike [trainableAbilities], this does *not* filter out
+     * abilities above the player's current level — those appear with `locked = true` and a
+     * "Requires level N" reason so the training panel can show them as gated rather than
+     * hiding them entirely.
+     */
+    fun trainerPanelAbilities(
+        className: String,
+        level: Int,
+        knownIds: Set<String>,
+    ): List<TrainerPanelEntry> =
+        registry.abilitiesForClass(className)
+            .filter { it.id.value !in knownIds }
+            .map { ability ->
+                val levelMet = ability.levelRequired <= level
+                val prereqMet = registry.isPrerequisiteMet(ability.id, knownIds)
+                val reason = when {
+                    !levelMet -> "Requires level ${ability.levelRequired}"
+                    !prereqMet -> {
+                        val prereqNames = ability.prerequisites.map { pid ->
+                            registry.get(pid)?.displayName ?: pid.value
+                        }
+                        "Requires: ${prereqNames.joinToString(", ")}"
+                    }
+                    else -> null
+                }
+                TrainerPanelEntry(
+                    ability = ability,
+                    locked = !levelMet || !prereqMet,
+                    lockReason = reason,
+                )
+            }
+            .sortedWith(
+                compareBy<TrainerPanelEntry> { it.ability.tier }
+                    .thenBy { it.locked }
+                    .thenBy { it.ability.levelRequired },
+            )
+
+    /**
      * Attempts to learn [abilityId] for the session. Returns null on success, or an error message.
      * Updates the in-memory learned set; caller is responsible for persisting to [PlayerState].
      *

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/TrainerHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/TrainerHandler.kt
@@ -223,24 +223,40 @@ class TrainerHandler(
                 return
             }
 
-            // Search for a matching ability across all unlocked classes this trainer teaches
-            val candidates: List<Pair<String, AbilityDefinition>> = unlockedHere.flatMap { cls ->
-                abilitySystem.trainableAbilities(cls, me.level, abilitySystem.knownAbilityIds(sessionId))
+            // Search for a matching ability across all unlocked classes this trainer teaches.
+            // Include level-locked abilities so we can return a clear "requires level N" error
+            // rather than a confusing "no matching ability" message.
+            val knownIds = abilitySystem.knownAbilityIds(sessionId)
+            val allCandidates: List<Pair<String, AbilityDefinition>> = unlockedHere.flatMap { cls ->
+                abilitySystem.registry.abilitiesForClass(cls)
+                    .filter { it.id.value !in knownIds }
                     .map { cls to it }
             }
-            val target = candidates.firstOrNull { (_, ability) ->
+            val matched = allCandidates.firstOrNull { (_, ability) ->
                 ability.id.value.equals(keyword, ignoreCase = true) ||
                     ability.displayName.equals(keyword, ignoreCase = true)
             }
-                ?: candidates.firstOrNull { (_, ability) ->
+                ?: allCandidates.firstOrNull { (_, ability) ->
                     ability.id.value.startsWith(keyword.lowercase()) ||
                         ability.displayName.lowercase().contains(keyword.lowercase())
                 }
 
-            if (target == null) {
+            if (matched == null) {
                 outbound.send(OutboundEvent.SendError(sessionId, "No trainable ability matching '$keyword' found here."))
                 return
             }
+
+            val matchedAbility = matched.second
+            if (matchedAbility.levelRequired > me.level) {
+                outbound.send(
+                    OutboundEvent.SendError(
+                        sessionId,
+                        "You need to be level ${matchedAbility.levelRequired} to learn ${matchedAbility.displayName}.",
+                    ),
+                )
+                return
+            }
+            val target = matched
 
             val ability = target.second
 

--- a/src/test/kotlin/dev/ambon/engine/abilities/TrainerPanelAbilitiesTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/abilities/TrainerPanelAbilitiesTest.kt
@@ -1,0 +1,160 @@
+package dev.ambon.engine.abilities
+
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.domain.DamageRange
+import dev.ambon.test.AbilityTestFixture
+import dev.ambon.test.MutableClock
+import dev.ambon.test.TEST_ROOM_ID
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Verifies that [AbilitySystem.trainerPanelAbilities] returns abilities with correct lock
+ * status so the Trainer.List GMCP payload can render level-gated skills visibly instead of
+ * hiding them. See https://github.com/jnoecker/AmbonMUD/issues/1036.
+ */
+class TrainerPanelAbilitiesTest {
+    private fun registry(): AbilityRegistry {
+        val r = AbilityRegistry()
+        r.register(
+            AbilityDefinition(
+                id = AbilityId("slash"),
+                displayName = "Slash",
+                description = "A basic slash.",
+                manaCost = 0,
+                cooldownMs = 0,
+                levelRequired = 1,
+                targetType = "enemy",
+                effect = AbilityEffect.DirectDamage(DamageRange(1, 2)),
+                requiredClass = "WARRIOR",
+                skillPointCost = 1,
+            ),
+        )
+        r.register(
+            AbilityDefinition(
+                id = AbilityId("cleave"),
+                displayName = "Cleave",
+                description = "Hit all foes.",
+                manaCost = 5,
+                cooldownMs = 0,
+                levelRequired = 5,
+                targetType = "enemy",
+                effect = AbilityEffect.DirectDamage(DamageRange(2, 4)),
+                requiredClass = "WARRIOR",
+                skillPointCost = 1,
+            ),
+        )
+        r.register(
+            AbilityDefinition(
+                id = AbilityId("whirlwind"),
+                displayName = "Whirlwind",
+                description = "Spin attack.",
+                manaCost = 10,
+                cooldownMs = 0,
+                levelRequired = 10,
+                targetType = "enemy",
+                effect = AbilityEffect.DirectDamage(DamageRange(5, 10)),
+                requiredClass = "WARRIOR",
+                prerequisites = setOf(AbilityId("cleave")),
+                skillPointCost = 2,
+            ),
+        )
+        return r
+    }
+
+    private fun buildSystem(registry: AbilityRegistry): AbilitySystem {
+        val fixture = AbilityTestFixture(
+            roomId = TEST_ROOM_ID,
+            clock = MutableClock(0L),
+            rng = java.util.Random(0),
+            outbound = LocalOutboundBus(),
+        )
+        return fixture.buildAbilitySystem(registry = registry)
+    }
+
+    @Test
+    fun `trainerPanelAbilities includes level-locked abilities with reason`() {
+        val registry = registry()
+        val system = buildSystem(registry)
+
+        val entries = system.trainerPanelAbilities(
+            className = "WARRIOR",
+            level = 3,
+            knownIds = emptySet(),
+        )
+
+        val ids = entries.map { it.ability.id.value }
+        assertTrue(ids.contains("slash"), "slash (level 1) should be listed")
+        assertTrue(ids.contains("cleave"), "cleave (level 5) should be listed even though player is level 3")
+        assertTrue(ids.contains("whirlwind"), "whirlwind (level 10) should be listed")
+
+        val slash = entries.first { it.ability.id.value == "slash" }
+        assertFalse(slash.locked, "slash should be unlocked at level 3")
+        assertNull(slash.lockReason)
+
+        val cleave = entries.first { it.ability.id.value == "cleave" }
+        assertTrue(cleave.locked, "cleave should be locked at level 3")
+        assertEquals("Requires level 5", cleave.lockReason)
+    }
+
+    @Test
+    fun `trainerPanelAbilities flags prerequisite-locked abilities`() {
+        val registry = registry()
+        val system = buildSystem(registry)
+
+        // Player at level 15 has the level for everything but hasn't learned cleave yet
+        val entries = system.trainerPanelAbilities(
+            className = "WARRIOR",
+            level = 15,
+            knownIds = emptySet(),
+        )
+
+        val whirlwind = entries.first { it.ability.id.value == "whirlwind" }
+        assertTrue(whirlwind.locked, "whirlwind should be locked without its prerequisite")
+        assertNotNull(whirlwind.lockReason)
+        assertTrue(
+            whirlwind.lockReason!!.contains("Cleave"),
+            "lock reason should reference prerequisite display name, got: ${whirlwind.lockReason}",
+        )
+    }
+
+    @Test
+    fun `trainerPanelAbilities hides already-known abilities`() {
+        val registry = registry()
+        val system = buildSystem(registry)
+
+        val entries = system.trainerPanelAbilities(
+            className = "WARRIOR",
+            level = 15,
+            knownIds = setOf("slash"),
+        )
+
+        assertTrue(entries.none { it.ability.id.value == "slash" }, "known abilities should not appear")
+    }
+
+    @Test
+    fun `trainerPanelAbilities sorts unlocked before locked within the same tier`() {
+        val registry = registry()
+        val system = buildSystem(registry)
+
+        val entries = system.trainerPanelAbilities(
+            className = "WARRIOR",
+            level = 15,
+            knownIds = emptySet(),
+        )
+
+        val firstLocked = entries.indexOfFirst { it.locked }
+        val lastUnlocked = entries.indexOfLast { !it.locked }
+        if (firstLocked >= 0 && lastUnlocked >= 0) {
+            val summary = entries.map { e -> "${e.ability.id.value}=locked:${e.locked}" }
+            assertTrue(
+                lastUnlocked < firstLocked,
+                "all unlocked entries should sort before the first locked entry, got: $summary",
+            )
+        }
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/commands/TrainerRespecTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/TrainerRespecTest.kt
@@ -512,4 +512,51 @@ class TrainerRespecTest {
             assertEquals(0L, me.gold, "Staff gold should remain unchanged at 0")
         }
     }
+
+    /**
+     * Level-gated abilities should no longer silently produce a confusing "no matching
+     * ability" error — they should surface the specific level requirement. See #1036.
+     */
+    @Nested
+    inner class LearnLockGating {
+        @Test
+        fun `train learn level-locked ability returns clear requires-level error`() = runTest {
+            loginAndSetup(gold = 2000, level = 1)
+            abilitySystem.loadAbilities(SID, emptySet())
+            outbound.drainAll()
+
+            // fireball requires level 2 in the fixture — player is level 1
+            router.handle(SID, Command.Train.Learn("fireball"))
+
+            val events = outbound.drainAll()
+            val errors = events.errorMessages(SID)
+            assertTrue(
+                errors.any { it.contains("level 2") && it.contains("Fireball") },
+                "Expected a clear level-requirement error referencing 'level 2' and 'Fireball', got: $errors",
+            )
+
+            // And the player should not have learned it
+            val me = players.get(SID)!!
+            assertTrue(
+                "fireball" !in me.learnedAbilityIds,
+                "Level-locked ability should not be learned; learned ids: ${me.learnedAbilityIds}",
+            )
+        }
+
+        @Test
+        fun `train learn unknown ability still returns no-matching error`() = runTest {
+            loginAndSetup(gold = 2000, level = 10)
+            abilitySystem.loadAbilities(SID, emptySet())
+            outbound.drainAll()
+
+            router.handle(SID, Command.Train.Learn("nonexistent"))
+
+            val events = outbound.drainAll()
+            val errors = events.errorMessages(SID)
+            assertTrue(
+                errors.any { it.contains("No trainable ability matching") },
+                "Expected no-matching-ability error, got: $errors",
+            )
+        }
+    }
 }

--- a/web-v3/src/components/TrainerPanel.tsx
+++ b/web-v3/src/components/TrainerPanel.tsx
@@ -32,13 +32,26 @@ function AbilityRow({
   onLearn: (id: string) => void;
   canAfford: boolean;
 }) {
+  const isLocked = ability.locked;
+  const canLearn = !isLocked && canAfford;
+  const buttonTitle = isLocked
+    ? ability.lockReason ?? "Requirements not met"
+    : canAfford
+      ? `Learn ${ability.name}`
+      : "Not enough skill points";
+  const rowClass = `trainer-ability-row${isLocked ? " trainer-ability-row-locked" : ""}`;
   return (
-    <div className="trainer-ability-row">
+    <div className={rowClass}>
       <div className="trainer-ability-icon">
         {ability.image ? (
           <img src={ability.image} alt="" className="trainer-ability-img" />
         ) : (
           <div className="trainer-ability-placeholder" />
+        )}
+        {isLocked && (
+          <span className="trainer-ability-lock-overlay" aria-hidden="true">
+            {"🔒"}
+          </span>
         )}
       </div>
       <div className="trainer-ability-info">
@@ -48,17 +61,28 @@ function AbilityRow({
           <span className="trainer-meta-tag">{effectLabel(ability.effectType)}</span>
           <span className="trainer-meta-tag">{ability.manaCost} MP</span>
           <span className="trainer-meta-tag">CD: {cooldownLabel(ability.cooldownMs)}</span>
-          <span className="trainer-meta-tag">Lv {ability.levelRequired}</span>
+          <span className={`trainer-meta-tag${isLocked ? " trainer-meta-tag-lock" : ""}`}>
+            Lv {ability.levelRequired}
+          </span>
+          <span className="trainer-meta-tag">
+            {ability.skillPointCost === 0
+              ? "Auto"
+              : `${ability.skillPointCost} SP`}
+          </span>
         </div>
+        {isLocked && ability.lockReason && (
+          <span className="trainer-ability-lock-reason">{ability.lockReason}</span>
+        )}
       </div>
       <button
         type="button"
-        className={`trainer-learn-btn${canAfford ? "" : " trainer-learn-btn-disabled"}`}
-        disabled={!canAfford}
-        title={canAfford ? `Learn ${ability.name}` : "Not enough skill points"}
+        className={`trainer-learn-btn${canLearn ? "" : " trainer-learn-btn-disabled"}`}
+        disabled={!canLearn}
+        title={buttonTitle}
+        aria-label={isLocked ? `${ability.name} locked — ${ability.lockReason ?? "requirements not met"}` : `Learn ${ability.name}`}
         onClick={() => onLearn(ability.id)}
       >
-        Learn
+        {isLocked ? "Locked" : "Learn"}
       </button>
     </div>
   );

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -1901,12 +1901,15 @@ export function applyGmcpPackage(
                 id: typeof a.id === "string" ? a.id : "",
                 name: typeof a.name === "string" ? a.name : "",
                 description: typeof a.description === "string" ? a.description : "",
+                skillPointCost: safeNumber(a.skillPointCost, 1),
                 levelRequired: safeNumber(a.levelRequired, 1),
                 manaCost: safeNumber(a.manaCost),
                 cooldownMs: safeNumber(a.cooldownMs),
                 targetType: typeof a.targetType === "string" ? a.targetType : "ENEMY",
                 effectType: typeof a.effectType === "string" ? a.effectType : "DIRECT_DAMAGE",
                 image: typeof a.image === "string" ? a.image : null,
+                locked: a.locked === true,
+                lockReason: typeof a.lockReason === "string" ? a.lockReason : null,
               }))
           : [];
       const classes = Array.isArray(packet.classes)

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -8788,6 +8788,47 @@ body {
   opacity: 0.6;
 }
 
+/* Locked ability rows — shown but clearly gated */
+
+.trainer-ability-row-locked {
+  opacity: 0.55;
+  background: rgb(255 255 255 / 2%);
+  border-color: rgb(255 255 255 / 6%);
+}
+
+.trainer-ability-row-locked .trainer-ability-name,
+.trainer-ability-row-locked .trainer-ability-desc {
+  color: var(--text-tertiary);
+}
+
+.trainer-ability-row-locked .trainer-ability-icon {
+  position: relative;
+  filter: grayscale(80%);
+}
+
+.trainer-ability-lock-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  text-shadow: 0 1px 2px rgb(0 0 0 / 60%);
+  pointer-events: none;
+}
+
+.trainer-meta-tag-lock {
+  background: color-mix(in srgb, var(--accent-lavender) 30%, transparent);
+  color: var(--text-secondary);
+}
+
+.trainer-ability-lock-reason {
+  margin-top: 4px;
+  font-size: 0.75rem;
+  font-style: italic;
+  color: var(--text-secondary);
+}
+
 /* Class-locked state */
 
 .trainer-locked {

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -741,12 +741,17 @@ export interface TrainerAbility {
   id: string;
   name: string;
   description: string;
+  skillPointCost: number;
   levelRequired: number;
   manaCost: number;
   cooldownMs: number;
   targetType: string;
   effectType: string;
   image: string | null;
+  /** True when the player cannot currently learn this ability. */
+  locked: boolean;
+  /** Human-readable reason the ability is locked (e.g. "Requires level 10"), or null when unlocked. */
+  lockReason: string | null;
 }
 
 /** One class taught by a trainer. Multi-class trainers emit one entry per class. */


### PR DESCRIPTION
## Summary

The training panel was silently hiding abilities above the player's current level, and attempting to `train learn <skill>` on one produced a confusing "no matching ability" error. Now locked skills are visible with a clear gate.

- **Server**: `AbilitySystem.trainerPanelAbilities()` returns every class ability with `locked` + `lockReason` ("Requires level N" or "Requires: <prereq>"). `Trainer.List` GMCP payload gains `skillPointCost`, `locked`, `lockReason` per ability. `handleTrainLearn` now surfaces "You need to be level N to learn X." for level-gated targets instead of pretending the ability doesn't exist.
- **Client**: `TrainerPanel` renders locked rows grayscale with a lock overlay, "Locked" button, and an italic lock reason. The ability meta row also now shows skill-point cost. New CSS for `.trainer-ability-row-locked`, `.trainer-ability-lock-overlay`, `.trainer-meta-tag-lock`, `.trainer-ability-lock-reason`.

## Test plan

- [x] `./gradlew ktlintCheck` passes
- [x] `./gradlew test` passes (full suite)
- [x] `cd web-v3 && bun run lint` passes
- [x] `cd web-v3 && bun run build` produces artifacts
- [x] New `TrainerPanelAbilitiesTest` covers level-lock, prerequisite-lock, known-ability filtering, and ordering
- [x] New `TrainerRespecTest.LearnLockGating` verifies the clear level-requirement error and that unknown abilities still return the no-matching error
- [ ] Manual: visit a trainer below the required level — higher-level skills should appear dimmed with a lock icon and a "Requires level N" label; the Learn button reads "Locked" and is disabled
- [ ] Manual: try `train learn <level-locked ability>` — receive "You need to be level N to learn X."

Fixes #1036