### PR TITLE
Hide USE button for non-consumables; show effect on consumables

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/items/Item.kt
+++ b/src/main/kotlin/dev/ambon/domain/items/Item.kt
@@ -7,6 +7,18 @@ data class ItemUseEffect(
     val grantXp: Long = 0L,
 ) {
     fun hasEffect(): Boolean = healHp > 0 || grantXp > 0L
+
+    /**
+     * Short human-readable summary of what using the item does, suitable for
+     * surfacing in the web client inventory tooltip. Returns null when the
+     * effect is a no-op.
+     */
+    fun describe(): String? {
+        val parts = mutableListOf<String>()
+        if (healHp > 0) parts.add("Restores $healHp HP")
+        if (grantXp > 0L) parts.add("Grants $grantXp XP")
+        return if (parts.isEmpty()) null else parts.joinToString(", ")
+    }
 }
 
 data class Item(

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -2045,6 +2045,8 @@ class GmcpEmitter(
             video = item.item.video,
             stats = item.item.stats.nonZero().ifEmpty { null },
             enchantments = item.enchantments.ifEmpty { null },
+            consumable = if (item.item.consumable) true else null,
+            useEffect = item.item.onUse?.describe(),
         )
 
     private fun toRoomMobPayload(mob: MobState): RoomMobPayload {
@@ -2149,6 +2151,8 @@ class GmcpEmitter(
         val video: String? = null,
         val stats: Map<String, Int>? = null,
         val enchantments: List<String>? = null,
+        val consumable: Boolean? = null,
+        val useEffect: String? = null,
     )
 
     private data class EquipmentSlotPayload(

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -11,6 +11,7 @@ import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.items.Item
 import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.items.ItemSlot
+import dev.ambon.domain.items.ItemUseEffect
 import dev.ambon.domain.mob.MobState
 import dev.ambon.domain.world.Direction
 import dev.ambon.domain.world.Room
@@ -1349,6 +1350,71 @@ class GmcpEmitterTest {
             e.sendCharItemsList(sid, listOf(priced), emptyMap())
             val data = drainGmcp()[0]
             assertTrue(data.jsonData.contains("\"basePrice\":75"), "Expected basePrice in Char.Items.List. got=${data.jsonData}")
+        }
+
+    @Test
+    fun `consumable flag and useEffect appear in Char Items List`() =
+        runTest {
+            val e = emitter("Char.Items")
+            val potion = ItemInstance(
+                id = ItemId("zone:potion"),
+                item = Item(
+                    keyword = "potion",
+                    displayName = "Healing Potion",
+                    consumable = true,
+                    onUse = ItemUseEffect(healHp = 15, grantXp = 25L),
+                ),
+            )
+            e.sendCharItemsList(sid, listOf(potion), emptyMap())
+            val data = drainGmcp()[0]
+            assertTrue(
+                data.jsonData.contains("\"consumable\":true"),
+                "Expected consumable=true in Char.Items.List. got=${data.jsonData}",
+            )
+            assertTrue(
+                data.jsonData.contains("\"useEffect\":\"Restores 15 HP, Grants 25 XP\""),
+                "Expected useEffect description in Char.Items.List. got=${data.jsonData}",
+            )
+        }
+
+    @Test
+    fun `non-consumable equipment omits consumable and useEffect in Char Items List`() =
+        runTest {
+            val e = emitter("Char.Items")
+            val sword = item()
+            e.sendCharItemsList(sid, listOf(sword), emptyMap())
+            val data = drainGmcp()[0]
+            // consumable/useEffect are serialized as null for non-consumables; never "true" or a value string.
+            assertTrue(
+                !data.jsonData.contains("\"consumable\":true"),
+                "Non-consumable should not have consumable=true. got=${data.jsonData}",
+            )
+            assertTrue(
+                !data.jsonData.contains("\"useEffect\":\""),
+                "Non-consumable should not have a useEffect string. got=${data.jsonData}",
+            )
+        }
+
+    @Test
+    fun `consumable with only healHp produces heal-only description`() =
+        runTest {
+            val e = emitter("Char.Items")
+            val food = ItemInstance(
+                id = ItemId("zone:rations"),
+                item = Item(
+                    keyword = "rations",
+                    displayName = "Traveler's Rations",
+                    consumable = true,
+                    onUse = ItemUseEffect(healHp = 30),
+                ),
+            )
+            e.sendCharItemsList(sid, listOf(food), emptyMap())
+            val data = drainGmcp()[0]
+            assertTrue(data.jsonData.contains("\"consumable\":true"))
+            assertTrue(
+                data.jsonData.contains("\"useEffect\":\"Restores 30 HP\""),
+                "Expected heal-only useEffect. got=${data.jsonData}",
+            )
         }
 
     @Test

--- a/web-v3/src/components/panels/InventoryPanel.tsx
+++ b/web-v3/src/components/panels/InventoryPanel.tsx
@@ -70,6 +70,9 @@ export function InventoryPanel({
           {resolveItemImage(item) && <img src={resolveItemImage(item)!} alt="" className="inventory-item-thumb" />}
           <span className="inventory-item-name">{item.name}</span>
           {item.slot && <span className="inventory-item-slot">{item.slot}</span>}
+          {!item.slot && item.consumable && item.useEffect && (
+            <span className="inventory-item-effect" title={item.useEffect}>{item.useEffect}</span>
+          )}
         </span>
         <span className="inventory-item-actions">
           <button
@@ -80,11 +83,11 @@ export function InventoryPanel({
           >
             Examine
           </button>
-          {!item.slot && (
+          {!item.slot && item.consumable && (
             <button
               type="button"
               className="inventory-action-btn inventory-action-use"
-              title={`Use ${item.name}`}
+              title={item.useEffect ? `Use ${item.name} — ${item.useEffect}` : `Use ${item.name}`}
               disabled={!canManageItems}
               onClick={() => onCommand(`use ${item.keyword}`)}
             >

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -415,6 +415,8 @@ export function applyGmcpPackage(
               video: typeof entry.video === "string" ? entry.video : null,
               stats: entry.stats && typeof entry.stats === "object" ? entry.stats as Record<string, number> : undefined,
               enchantments: Array.isArray(entry.enchantments) ? entry.enchantments.filter((e): e is string => typeof e === "string") : undefined,
+              consumable: typeof entry.consumable === "boolean" ? entry.consumable : undefined,
+              useEffect: typeof entry.useEffect === "string" ? entry.useEffect : undefined,
             }))
         : [];
 
@@ -455,6 +457,8 @@ export function applyGmcpPackage(
           video: typeof packet.video === "string" ? packet.video : null,
           stats: packet.stats && typeof packet.stats === "object" ? packet.stats as Record<string, number> : undefined,
           enchantments: Array.isArray(packet.enchantments) ? (packet.enchantments as unknown[]).filter((e): e is string => typeof e === "string") : undefined,
+          consumable: typeof packet.consumable === "boolean" ? packet.consumable : undefined,
+          useEffect: typeof packet.useEffect === "string" ? packet.useEffect : undefined,
         },
       ]);
       break;

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -6209,6 +6209,19 @@ body {
   flex-shrink: 0;
 }
 
+.inventory-item-effect {
+  font-size: 0.66rem;
+  color: var(--accent-gold, var(--text-secondary));
+  background: rgb(255 255 255 / 6%);
+  padding: 1px 6px;
+  border-radius: 999px;
+  flex-shrink: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 14ch;
+}
+
 .inventory-item-actions {
   display: flex;
   gap: 2px;

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -232,6 +232,8 @@ export interface ItemSummary {
   video?: string | null;
   stats?: Record<string, number>;
   enchantments?: string[];
+  consumable?: boolean;
+  useEffect?: string;
 }
 
 export interface EquipmentSlotDef {


### PR DESCRIPTION
Fixes #1030

## Summary

- The inventory panel was rendering a **USE** button on every item, even swords and armor. It now only appears for items flagged `consumable: true` on the server.
- Consumable items now show a small inline badge (and tooltip) describing what using them will do — e.g. `Restores 15 HP`, `Grants 25 XP`, or `Restores 15 HP, Grants 25 XP` — sourced from the server's existing `ItemUseEffect { healHp, grantXp }` domain model.

## Changes

**Server (`GmcpEmitter` / `Item` / `ItemUseEffect`)**
- `ItemUseEffect.describe()` builds a short, human-readable summary from `healHp` / `grantXp` (returns `null` when the effect is empty).
- `ItemPayload` gains nullable `consumable` and `useEffect` fields; `toItemPayload` populates them from the underlying `Item`.
- Char.Items.List and Char.Items.Add both carry the new fields (they share `toItemPayload`).

**Web client**
- `ItemSummary` gains optional `consumable` / `useEffect`.
- `applyGmcpPackage.ts` maps both fields for `Char.Items.List` and `Char.Items.Add`.
- `InventoryPanel.tsx` only renders the USE button when `item.consumable === true`; tooltip includes the `useEffect` description; a `.inventory-item-effect` badge renders inline next to the item name (uses `--accent-gold` token).

## Test plan

- [x] New `GmcpEmitterTest` cases: consumable+useEffect appear in Char.Items.List; non-consumable gear omits both; heal-only effect produces correct description.
- [x] `./gradlew.bat ktlintCheck test` green.
- [x] `web-v3`: `bun run lint` + `bunx tsc -b` clean.
- [ ] Manual: in the Academy starter zone, verify the USE button only shows on potions/food/rations and that the badge reads "Restores 15 HP" / "Restores 30 HP" / "Restores 20 HP, Grants 25 XP" / "Restores 5 HP, Grants 50 XP" for the four bundled consumables; swords, armor, and quest items show no USE button.