### PR TITLE
Fix combat freeze when one-shotting weak enemies (#1034)

### DIFF
--- a/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
@@ -15,6 +15,7 @@ import dev.ambon.domain.items.ItemSlot
 import dev.ambon.domain.mob.MobState
 import dev.ambon.domain.world.ItemSpawn
 import dev.ambon.domain.world.MobDrop
+import dev.ambon.engine.events.CombatEvent
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.status.StatusEffectDefinition
 import dev.ambon.engine.status.StatusEffectId
@@ -199,6 +200,71 @@ class CombatSystemTest {
             assertNull(fixture.mobs.get(mob.id), "Expected mob to be removed after death")
             assertTrue(fixture.items.itemsInMob(mob.id).isEmpty(), "Expected mob inventory to be cleared")
             assertEquals(1, fixture.items.itemsInRoom(fixture.roomId).size, "Expected dropped item in room")
+        }
+
+    /**
+     * Regression test for GH #1034: one-shotting a very weak enemy (e.g. a
+     * 1-HP crane) must still emit a MeleeHit CombatEvent *before* the Kill
+     * CombatEvent.  The web client relies on seeing the hit first so it can
+     * animate the strike landing before the death animation takes over —
+     * without this ordering the fight visually "freezes" and ends in one
+     * silent frame.  The hit text must also precede the death text.
+     */
+    @Test
+    fun `one-shot kill emits melee hit combat event before kill event`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            val mob =
+                MobState(
+                    MobId("demo:crane"),
+                    "a crane",
+                    fixture.roomId,
+                    hp = 1,
+                    maxHp = 1,
+                    xpReward = 1L,
+                )
+            fixture.mobs.upsert(mob)
+
+            val combat = fixture.buildCombat(rng = Random(1), minDamage = 1, maxDamage = 1)
+
+            val sid = SessionId(42L)
+            fixture.players.loginOrFail(sid, "Slayer")
+
+            val combatEvents = mutableListOf<CombatEvent>()
+            combat.onCombatEvent = { _, event -> combatEvents += event }
+
+            assertNull(combat.startCombat(sid, "crane"))
+            fixture.tickCombat(combat)
+
+            // Server must emit at least a MeleeHit before the Kill so the
+            // client can animate an attack round.
+            val hitIdx = combatEvents.indexOfFirst { it is CombatEvent.MeleeHit }
+            val killIdx = combatEvents.indexOfFirst { it is CombatEvent.Kill }
+            assertTrue(hitIdx >= 0, "Expected a MeleeHit combat event, got: $combatEvents")
+            assertTrue(killIdx >= 0, "Expected a Kill combat event, got: $combatEvents")
+            assertTrue(
+                hitIdx < killIdx,
+                "Expected MeleeHit (idx $hitIdx) to precede Kill (idx $killIdx) in $combatEvents",
+            )
+
+            // The mob should be dead.
+            assertNull(fixture.mobs.get(mob.id))
+
+            // The "You hit ..." text must also precede the "... dies." text in
+            // the outbound stream so telnet clients see the swing land.
+            val texts =
+                fixture.outbound
+                    .drainAll()
+                    .filterIsInstance<OutboundEvent.SendText>()
+                    .map { it.text }
+            val hitTextIdx = texts.indexOfFirst { it.startsWith("You hit ") && it.contains("crane") }
+            val deathTextIdx = texts.indexOfFirst { it == "a crane dies." }
+            assertTrue(hitTextIdx >= 0, "Expected a 'You hit a crane' message in: $texts")
+            assertTrue(deathTextIdx >= 0, "Expected 'a crane dies.' message in: $texts")
+            assertTrue(
+                hitTextIdx < deathTextIdx,
+                "Expected hit text (idx $hitTextIdx) before death text (idx $deathTextIdx) in $texts",
+            )
         }
 
     @Test

--- a/web-v3/src/canvas/systems/CombatAnimator.ts
+++ b/web-v3/src/canvas/systems/CombatAnimator.ts
@@ -1,5 +1,13 @@
 import { Container, Graphics, Text } from "pixi.js";
 import type { CombatEventData } from "../../types";
+import {
+  createKillDeferralState,
+  decideKillTiming,
+  registerDamagingHit,
+  resetKillDeferral,
+  tickKillDeferral,
+  type KillDeferralState,
+} from "./killDeferral";
 
 const FLOAT_SPEED = 50;
 const LIFETIME_MS = 1200;
@@ -79,6 +87,16 @@ const DEATH_ANIM_DURATION_MS = 2400;
 const DEATH_FLASH_FRAC = 0.15; // first 15% = white flash (~360ms)
 const DEATH_DISSOLVE_FRAC = 0.55; // 15–55% = dissolve/shrink (~960ms)
 
+/**
+ * Minimum time a preceding melee/ability hit animation must play before a
+ * kill animation is allowed to start. Without this gap, one-shotting a very
+ * weak enemy (e.g. a 1-HP crane) renders the hit and kill on the same frame
+ * and the kill's white flash visually swallows the strike — combat looks
+ * like it "freezes" and then the mob vanishes. Gating on the forward-lunge
+ * duration guarantees the player sees the blow land first. See GH #1034.
+ */
+const KILL_POSTROLL_DELAY_MS = LUNGE_DURATION_MS;
+
 // Firework / sparkle particles
 const PARTICLE_LIFETIME_MS = 900;
 const PARTICLE_GRAVITY = 80; // pixels/s²
@@ -109,6 +127,11 @@ const EVENT_COLORS: Record<string, string> = {
   death: "#b88faa",
 };
 
+interface KillPayload {
+  enemyX: number;
+  enemyY: number;
+}
+
 export class CombatAnimator {
   readonly container = new Container();
   private floats: FloatingNumber[] = [];
@@ -125,6 +148,11 @@ export class CombatAnimator {
   private slashGraphics = new Graphics();
   private glowGraphics = new Graphics();
   private particleGraphics = new Graphics();
+  /**
+   * Pure state machine governing whether an incoming kill event should be
+   * deferred so a preceding hit animation can land first.  See GH #1034.
+   */
+  private killDeferral: KillDeferralState<KillPayload> = createKillDeferralState();
 
   constructor() {
     this.container.addChild(this.glowGraphics);
@@ -142,28 +170,19 @@ export class CombatAnimator {
     }
 
     if (type === "kill") {
-      // Start multi-phase death animation instead of a brief flash
-      this.deathAnim = {
-        elapsed: 0,
-        duration: DEATH_ANIM_DURATION_MS,
-        phases: { flashEnd: DEATH_FLASH_FRAC, dissolveEnd: DEATH_DISSOLVE_FRAC },
-      };
-      // Remember enemy position for staggered bursts
-      this.deathEnemyPos = { x: enemyX, y: enemyY };
-      // Intense white flash at start
-      this.addFlash("enemy", 0xffffff, DEATH_ANIM_DURATION_MS * DEATH_FLASH_FRAC);
-      // Heavy shake during flash phase
-      this.shakes = this.shakes.filter((s) => s.who !== "enemy");
-      this.shakes.push({ who: "enemy", elapsed: 0 });
-      // Spawn "DEFEATED" text
-      this.spawnFloat("DEFEATED", EVENT_COLORS.kill, enemyX, enemyY - 30);
-      // Multiple slashes at the enemy for dramatic finish
-      this.addSlash(enemyX - 8, enemyY - 8);
-      this.addSlash(enemyX + 8, enemyY + 8);
-      // Initial firework burst from enemy position
-      this.spawnBurst(enemyX, enemyY, BURST_COUNT);
-      this.deathBurstsFired = 1;
-      // "VICTORY" text spawns slightly later — handled by BattleScene
+      // If a damaging hit was just processed (same tick / same frame), defer
+      // the death animation briefly so the player actually sees the strike
+      // land before the white flash + dissolve takes over. Fixes the
+      // "combat freezes" feeling when one-shotting very weak enemies.
+      const decision = decideKillTiming(this.killDeferral, KILL_POSTROLL_DELAY_MS);
+      if (decision.kind === "defer") {
+        this.killDeferral.pending = {
+          remainingMs: decision.remainingMs,
+          payload: { enemyX, enemyY },
+        };
+      } else {
+        this.startKillAnimation(enemyX, enemyY);
+      }
       return;
     }
 
@@ -175,6 +194,10 @@ export class CombatAnimator {
     }
 
     if (event.damage > 0) {
+      // Track when the most recent hit landed so a kill arriving in the same
+      // frame can be deferred (see KILL_POSTROLL_DELAY_MS).
+      registerDamagingHit(this.killDeferral);
+
       const color = EVENT_COLORS[type] ?? EVENT_COLORS.meleeHit;
       const targetX = event.sourceIsPlayer ? enemyX : playerX;
       const targetY = event.sourceIsPlayer ? enemyY : playerY;
@@ -211,6 +234,31 @@ export class CombatAnimator {
     if (event.absorbed > 0) {
       this.spawnFloat(`(${event.absorbed})`, EVENT_COLORS.shieldAbsorb, event.sourceIsPlayer ? enemyX : playerX, (event.sourceIsPlayer ? enemyY : playerY) + 16);
     }
+  }
+
+  /** Kick off the full multi-phase death animation (flash → dissolve → hold). */
+  private startKillAnimation(enemyX: number, enemyY: number) {
+    this.deathAnim = {
+      elapsed: 0,
+      duration: DEATH_ANIM_DURATION_MS,
+      phases: { flashEnd: DEATH_FLASH_FRAC, dissolveEnd: DEATH_DISSOLVE_FRAC },
+    };
+    // Remember enemy position for staggered bursts
+    this.deathEnemyPos = { x: enemyX, y: enemyY };
+    // Intense white flash at start
+    this.addFlash("enemy", 0xffffff, DEATH_ANIM_DURATION_MS * DEATH_FLASH_FRAC);
+    // Heavy shake during flash phase
+    this.shakes = this.shakes.filter((s) => s.who !== "enemy");
+    this.shakes.push({ who: "enemy", elapsed: 0 });
+    // Spawn "DEFEATED" text
+    this.spawnFloat("DEFEATED", EVENT_COLORS.kill, enemyX, enemyY - 30);
+    // Multiple slashes at the enemy for dramatic finish
+    this.addSlash(enemyX - 8, enemyY - 8);
+    this.addSlash(enemyX + 8, enemyY + 8);
+    // Initial firework burst from enemy position
+    this.spawnBurst(enemyX, enemyY, BURST_COUNT);
+    this.deathBurstsFired = 1;
+    // "VICTORY" text spawns slightly later — handled by BattleScene
   }
 
   private spawnFloat(display: string, color: string, x: number, y: number) {
@@ -275,6 +323,13 @@ export class CombatAnimator {
   }
 
   update(deltaMs: number) {
+    // Tick the kill deferral state; if a queued kill's post-roll elapsed,
+    // launch the full death animation now.
+    const ready = tickKillDeferral(this.killDeferral, deltaMs, KILL_POSTROLL_DELAY_MS);
+    if (ready) {
+      this.startKillAnimation(ready.enemyX, ready.enemyY);
+    }
+
     // Update floating numbers
     for (let i = this.floats.length - 1; i >= 0; i--) {
       const f = this.floats[i];
@@ -530,9 +585,13 @@ export class CombatAnimator {
     }
   }
 
-  /** Whether a death animation is currently playing. */
+  /**
+   * Whether a death animation is currently playing OR queued to start.
+   * A queued kill must block scene transitions so the deferred death
+   * animation has a chance to actually render (see KILL_POSTROLL_DELAY_MS).
+   */
   get isDeathAnimating(): boolean {
-    return this.deathAnim !== null;
+    return this.deathAnim !== null || this.killDeferral.pending !== null;
   }
 
   /**
@@ -575,6 +634,7 @@ export class CombatAnimator {
     this.deathAnim = null;
     this.deathEnemyPos = null;
     this.deathBurstsFired = 0;
+    this.killDeferral.pending = null;
   }
 
   clear() {
@@ -592,6 +652,7 @@ export class CombatAnimator {
     this.deathAnim = null;
     this.deathEnemyPos = null;
     this.deathBurstsFired = 0;
+    resetKillDeferral(this.killDeferral);
     this.flashGraphics.clear();
     this.slashGraphics.clear();
     this.glowGraphics.clear();

--- a/web-v3/src/canvas/systems/killDeferral.ts
+++ b/web-v3/src/canvas/systems/killDeferral.ts
@@ -1,0 +1,86 @@
+/**
+ * Pure timing logic for deferring a kill animation when a damaging hit was
+ * just processed in the same frame.  Split out from CombatAnimator so it
+ * has no PixiJS dependency and can be unit-tested directly.  See GH #1034:
+ * one-shotting a 1-HP enemy must still render an attack round.
+ */
+
+export interface KillDeferralState<T> {
+  /**
+   * Time (ms) since the last damaging hit was registered.  Starts at
+   * POSITIVE_INFINITY so the first kill of a new scene is not deferred
+   * unnecessarily.
+   */
+  msSinceLastDamagingHit: number;
+  /**
+   * Kill payload waiting for the post-roll delay to elapse, or null.
+   */
+  pending: { remainingMs: number; payload: T } | null;
+}
+
+/** Initial, empty deferral state. */
+export function createKillDeferralState<T>(): KillDeferralState<T> {
+  return {
+    msSinceLastDamagingHit: Number.POSITIVE_INFINITY,
+    pending: null,
+  };
+}
+
+/** Register a damaging hit at "now". */
+export function registerDamagingHit(state: KillDeferralState<unknown>): void {
+  state.msSinceLastDamagingHit = 0;
+}
+
+/**
+ * Decide what to do with an incoming kill event.  Returns either "start
+ * immediately" (no recent hit) or "defer" with a remaining delay.
+ *
+ * @param state   current deferral state (not mutated)
+ * @param postRollMs minimum ms a preceding hit must play before the kill
+ *                   animation may start
+ */
+export function decideKillTiming(
+  state: Readonly<KillDeferralState<unknown>>,
+  postRollMs: number,
+): { kind: "start" } | { kind: "defer"; remainingMs: number } {
+  if (state.msSinceLastDamagingHit < postRollMs) {
+    return {
+      kind: "defer",
+      remainingMs: postRollMs - state.msSinceLastDamagingHit,
+    };
+  }
+  return { kind: "start" };
+}
+
+/**
+ * Tick the deferral state forward by deltaMs.  Returns a payload iff a
+ * pending kill has finished its post-roll and should now start animating.
+ */
+export function tickKillDeferral<T>(
+  state: KillDeferralState<T>,
+  deltaMs: number,
+  postRollMs: number,
+): T | null {
+  if (state.msSinceLastDamagingHit !== Number.POSITIVE_INFINITY) {
+    state.msSinceLastDamagingHit += deltaMs;
+    if (state.msSinceLastDamagingHit > postRollMs * 2) {
+      state.msSinceLastDamagingHit = Number.POSITIVE_INFINITY;
+    }
+  }
+
+  if (state.pending) {
+    state.pending.remainingMs -= deltaMs;
+    if (state.pending.remainingMs <= 0) {
+      const payload = state.pending.payload;
+      state.pending = null;
+      return payload;
+    }
+  }
+  return null;
+}
+
+/** Reset to initial state. */
+export function resetKillDeferral(state: KillDeferralState<unknown>): void {
+  state.msSinceLastDamagingHit = Number.POSITIVE_INFINITY;
+  state.pending = null;
+}

--- a/web-v3/test/killDeferral.test.ts
+++ b/web-v3/test/killDeferral.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createKillDeferralState,
+  decideKillTiming,
+  registerDamagingHit,
+  resetKillDeferral,
+  tickKillDeferral,
+} from "../src/canvas/systems/killDeferral";
+
+const POSTROLL = 280;
+
+interface Payload {
+  id: string;
+}
+
+describe("killDeferral (GH #1034)", () => {
+  test("kill with no preceding hit starts immediately", () => {
+    const state = createKillDeferralState<Payload>();
+    expect(decideKillTiming(state, POSTROLL).kind).toBe("start");
+  });
+
+  test("kill arriving same-frame as a hit defers for the full post-roll", () => {
+    const state = createKillDeferralState<Payload>();
+    registerDamagingHit(state);
+
+    const decision = decideKillTiming(state, POSTROLL);
+    expect(decision.kind).toBe("defer");
+    if (decision.kind === "defer") {
+      expect(decision.remainingMs).toBe(POSTROLL);
+    }
+  });
+
+  test("kill arriving mid-post-roll defers only the remaining time", () => {
+    const state = createKillDeferralState<Payload>();
+    registerDamagingHit(state);
+    tickKillDeferral(state, 100, POSTROLL); // 100ms has elapsed since the hit
+
+    const decision = decideKillTiming(state, POSTROLL);
+    expect(decision.kind).toBe("defer");
+    if (decision.kind === "defer") {
+      expect(decision.remainingMs).toBe(POSTROLL - 100);
+    }
+  });
+
+  test("kill arriving after post-roll has already elapsed starts immediately", () => {
+    const state = createKillDeferralState<Payload>();
+    registerDamagingHit(state);
+    for (let t = 0; t < POSTROLL + 50; t += 16) {
+      tickKillDeferral(state, 16, POSTROLL);
+    }
+
+    expect(decideKillTiming(state, POSTROLL).kind).toBe("start");
+  });
+
+  test("tickKillDeferral releases a pending kill once its timer expires", () => {
+    const state = createKillDeferralState<Payload>();
+    state.pending = { remainingMs: POSTROLL, payload: { id: "crane" } };
+
+    // First partial tick — still waiting.
+    expect(tickKillDeferral(state, 100, POSTROLL)).toBeNull();
+    expect(state.pending).not.toBeNull();
+
+    // Next tick completes the post-roll — payload released, queue cleared.
+    const ready = tickKillDeferral(state, POSTROLL, POSTROLL);
+    expect(ready).not.toBeNull();
+    expect(ready?.id).toBe("crane");
+    expect(state.pending).toBeNull();
+  });
+
+  test("last-hit timer stops growing unboundedly after 2× post-roll", () => {
+    const state = createKillDeferralState<Payload>();
+    registerDamagingHit(state);
+    for (let i = 0; i < 100; i++) {
+      tickKillDeferral(state, 100, POSTROLL);
+    }
+    // Value must have been clamped back to POSITIVE_INFINITY.
+    expect(state.msSinceLastDamagingHit).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  test("resetKillDeferral clears both fields", () => {
+    const state = createKillDeferralState<Payload>();
+    registerDamagingHit(state);
+    state.pending = { remainingMs: 50, payload: { id: "x" } };
+
+    resetKillDeferral(state);
+
+    expect(state.msSinceLastDamagingHit).toBe(Number.POSITIVE_INFINITY);
+    expect(state.pending).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Attacking a 1-HP enemy rendered the `MeleeHit` and `Kill` combat events on the same frame, so the kill's full-screen white flash and 2.4s dissolve animation immediately took over — visually swallowing the strike and making combat feel like it "froze" and then the mob simply disappeared.
- Server already emits `MeleeHit` before `Kill`; added a regression test that pins this ordering (plus the corresponding `SendText` ordering) in `CombatSystemTest`.
- Client fix: when a `kill` combat event arrives within the forward-lunge window (280ms) of a preceding damaging hit, the `CombatAnimator` now defers the death animation by the remaining lunge time so the player visibly sees the blow land before the white flash. When no hit just preceded the kill (e.g. a spell finisher) the death animation starts immediately, as before.
- The deferral logic is extracted into a pure helper (`killDeferral.ts`) so it can be unit-tested without a PixiJS rendering context. `isDeathAnimating` now also returns true for queued kills, so `SceneManager` does not swap away from `BattleScene` before the deferred death animation plays.

## Test plan

- [x] `./gradlew ktlintCheck`
- [x] `./gradlew test` (full suite)
- [x] New `CombatSystemTest."one-shot kill emits melee hit combat event before kill event"` passes — asserts `MeleeHit` precedes `Kill` in the `onCombatEvent` stream and `"You hit a crane"` precedes `"a crane dies."` in the outbound text stream.
- [x] `cd web-v3 && bun test` — 7 new tests in `killDeferral.test.ts` cover: immediate-start when no preceding hit; full-delay deferral same-frame; partial deferral mid-postroll; no deferral once postroll has elapsed; pending-kill release on tick; clamp of stale last-hit timer; reset.
- [x] `cd web-v3 && bun run lint`
- [x] `cd web-v3 && bunx tsc -b`
- [ ] Manual playtest: attack a 1-HP mob (e.g. crane in Academy) on the web client and confirm the attack round (lunge + slash + damage float) is visible before the death flash/dissolve.

Fixes #1034