### PR TITLE
Make level-up a headline moment (#1037)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -28,7 +28,7 @@ data class CombatSystemConfig(
 
 data class CombatSystemCallbacks(
     val onMobRemoved: suspend (MobId, RoomId) -> Unit = { _, _ -> },
-    val onLevelUp: suspend (SessionId, Int) -> Unit = { _, _ -> },
+    val onLevelUp: suspend (SessionId, LevelUpResult) -> Unit = { _, _ -> },
     val onMobKilledByPlayer: suspend (SessionId, String) -> Unit = { _, _ -> },
     val onRoomItemsChanged: suspend (RoomId) -> Unit = {},
 )
@@ -1288,7 +1288,7 @@ class CombatSystem(
                         player.playerClass,
                     )
                 outbound.send(OutboundEvent.SendText(sid, levelUpMessage))
-                callbacks.onLevelUp(sid, result.newLevel)
+                callbacks.onLevelUp(sid, result)
             }
         }
     }

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -1344,11 +1344,11 @@ class GameEngine(
                         val levelUp = players.grantXp(sid, xp)
                         outbound.send(OutboundEvent.SendText(sid, "You gain $xp XP."))
                         gmcpEmitter.sendCharGain(sid, "xp", xp, "bounty")
-                        if (levelUp != null) {
+                        if (levelUp != null && levelUp.levelsGained > 0) {
                             outbound.send(
                                 OutboundEvent.SendInfo(sid, "Congratulations! You reached level ${levelUp.newLevel}!"),
                             )
-                            onCombatLevelUp(sid, levelUp.newLevel)
+                            onCombatLevelUp(sid, levelUp)
                         }
                     }
                     markVitalsDirty(sid)
@@ -2165,10 +2165,11 @@ class GameEngine(
 
     private suspend fun onCombatLevelUp(
         sessionId: SessionId,
-        level: Int,
+        result: LevelUpResult,
     ) {
         markVitalsDirty(sessionId)
         markStatsDirty(sessionId)
+        val level = result.newLevel
         val p = players.get(sessionId)
         val autoLearned = p?.let { abilitySystem.recomputeKnownAbilities(sessionId, level, it.unlockedClasses) }.orEmpty()
         sendAutoLearnedAbilities(sessionId, autoLearned)
@@ -2189,11 +2190,38 @@ class GameEngine(
             )
         }
         if (p != null) {
+            val hpStat = p.stats[engineConfig.stats.bindings.hpScalingStat]
+            val manaStat = p.stats[engineConfig.stats.bindings.manaScalingStat]
+            val (classHpPerLevel, classManaPerLevel) = progression.resolveClassScaling(p.playerClass)
+            val newMaxHp = progression.maxHpForLevel(level, hpStat, classHpPerLevel)
+            val oldMaxHp = progression.maxHpForLevel(result.previousLevel, hpStat, classHpPerLevel)
+            val newMaxMana = progression.maxManaForLevel(level, manaStat, classManaPerLevel)
+            val oldMaxMana = progression.maxManaForLevel(result.previousLevel, manaStat, classManaPerLevel)
+            val hpGained = (newMaxHp - oldMaxHp).coerceAtLeast(0)
+            val manaGained = (newMaxMana - oldMaxMana).coerceAtLeast(0)
             gmcpEmitter.sendCharName(sessionId, p)
             gmcpEmitter.sendCharSkills(sessionId, abilitySystem.knownAbilities(sessionId)) { abilityId ->
                 abilitySystem.cooldownRemainingMs(sessionId, abilityId)
             }
-            gmcpEmitter.sendCharGain(sessionId, "levelUp", level.toLong(), newLevel = level)
+            gmcpEmitter.sendCharGain(
+                sessionId,
+                "levelUp",
+                level.toLong(),
+                newLevel = level,
+                hpGained = hpGained,
+                manaGained = manaGained,
+            )
+            gmcpEmitter.sendCharLevelUp(
+                sessionId,
+                previousLevel = result.previousLevel,
+                newLevel = level,
+                levelsGained = result.levelsGained.coerceAtLeast(1),
+                hpGained = hpGained,
+                manaGained = manaGained,
+                newAbilities = autoLearned.map { it.displayName },
+                skillPointsAvailable = available,
+                isMilestone = isMilestoneLevel(level),
+            )
             // Notify about new sprites if the player has a custom selection
             if (p.activeSprite != null) {
                 notifyNewSprites(sessionId, p)
@@ -2202,6 +2230,9 @@ class GameEngine(
         }
         achievementSystem.onLevelReached(sessionId, level)
     }
+
+    /** Milestone levels trigger extra flourish on the client level-up banner. */
+    private fun isMilestoneLevel(level: Int): Boolean = level == 10 || level == 25 || level == 50 || level == 100
 
     /** Sends a text hint when a level-up or achievement unlock makes new sprites available. */
     private suspend fun notifyNewSprites(
@@ -2250,9 +2281,18 @@ class GameEngine(
                 ),
             )
         }
-        val afterLevel = players.get(sessionId)?.level ?: beforeLevel
-        if (afterLevel > beforeLevel) {
-            onCombatLevelUp(sessionId, afterLevel)
+        val afterPlayer = players.get(sessionId)
+        val afterLevel = afterPlayer?.level ?: beforeLevel
+        if (afterLevel > beforeLevel && afterPlayer != null) {
+            onCombatLevelUp(
+                sessionId,
+                LevelUpResult(
+                    previousLevel = beforeLevel,
+                    levelsGained = afterLevel - beforeLevel,
+                    newLevel = afterLevel,
+                    xpTotal = afterPlayer.xpTotal,
+                ),
+            )
         }
         gmcpEmitter.sendDailyQuests(sessionId, dqs)
         gmcpEmitter.sendWeeklyQuests(sessionId, dqs)
@@ -2344,7 +2384,7 @@ class GameEngine(
                         "for placing ${ordinalPlace(winner.place)} in the global quest!"
                     outbound.send(OutboundEvent.SendInfo(winner.sessionId, rewardMsg))
                     if (levelResult.levelsGained > 0) {
-                        onCombatLevelUp(winner.sessionId, levelResult.newLevel)
+                        onCombatLevelUp(winner.sessionId, levelResult)
                     }
                 }
                 gmcpEmitter.broadcastGlobalQuestInactive(players)

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -1562,6 +1562,41 @@ class GmcpEmitter(
         )
     }
 
+    // ---------- level-up event ----------
+
+    /**
+     * Emits a dedicated Char.LevelUp event for the client to present a prominent
+     * celebratory overlay. This is distinct from Char.Gain so clients can subscribe
+     * to it independently and keep the existing floating-text popup for smaller
+     * gains. [isMilestone] flags round-number levels (10, 25, 50) for extra flourish.
+     */
+    suspend fun sendCharLevelUp(
+        sessionId: SessionId,
+        previousLevel: Int,
+        newLevel: Int,
+        levelsGained: Int,
+        hpGained: Int,
+        manaGained: Int,
+        newAbilities: List<String> = emptyList(),
+        skillPointsAvailable: Int = 0,
+        isMilestone: Boolean = false,
+    ) {
+        emit(
+            sessionId,
+            "Char.LevelUp",
+            CharLevelUpPayload(
+                previousLevel = previousLevel,
+                newLevel = newLevel,
+                levelsGained = levelsGained,
+                hpGained = hpGained,
+                manaGained = manaGained,
+                newAbilities = newAbilities,
+                skillPointsAvailable = skillPointsAvailable,
+                isMilestone = isMilestone,
+            ),
+        )
+    }
+
     // ---------- room mob info ----------
 
     suspend fun sendRoomMobInfo(
@@ -2645,6 +2680,19 @@ class GmcpEmitter(
         val newLevel: Int? = null,
         val hpGained: Int? = null,
         val manaGained: Int? = null,
+    )
+
+    // ---------- level-up payload ----------
+
+    private data class CharLevelUpPayload(
+        val previousLevel: Int,
+        val newLevel: Int,
+        val levelsGained: Int,
+        val hpGained: Int,
+        val manaGained: Int,
+        val newAbilities: List<String>,
+        val skillPointsAvailable: Int,
+        val isMilestone: Boolean,
     )
 
     // ---------- who payload ----------

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ItemHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ItemHandler.kt
@@ -323,27 +323,40 @@ class ItemHandler(
             if (result.levelsGained <= 0) return
             metrics.onLevelUp()
 
-            val levelUpMessage = progression.buildLevelUpMessage(result, player.stats["CON"], player.stats["INT"], player.playerClass)
+            val hpStatValue = player.stats["CON"]
+            val manaStatValue = player.stats["INT"]
+            val levelUpMessage = progression.buildLevelUpMessage(result, hpStatValue, manaStatValue, player.playerClass)
             outbound.send(OutboundEvent.SendText(sessionId, levelUpMessage))
 
+            val (classHpPerLevel, classManaPerLevel) = progression.resolveClassScaling(player.playerClass)
+            val newMaxHp = progression.maxHpForLevel(result.newLevel, hpStatValue, classHpPerLevel)
+            val oldMaxHp = progression.maxHpForLevel(result.previousLevel, hpStatValue, classHpPerLevel)
+            val hpGained = (newMaxHp - oldMaxHp).coerceAtLeast(0)
+            val newMaxMana = progression.maxManaForLevel(result.newLevel, manaStatValue, classManaPerLevel)
+            val oldMaxMana = progression.maxManaForLevel(result.previousLevel, manaStatValue, classManaPerLevel)
+            val manaGained = (newMaxMana - oldMaxMana).coerceAtLeast(0)
+
+            var autoLearnedNames: List<String> = emptyList()
+            var availablePoints = 0
             if (abilitySystem != null) {
                 val autoLearned = abilitySystem.recomputeKnownAbilities(sessionId, result.newLevel, player.unlockedClasses)
+                autoLearnedNames = autoLearned.map { it.displayName }
                 if (autoLearned.isNotEmpty()) {
                     val names = autoLearned.joinToString { it.displayName }
                     val verb = if (autoLearned.size == 1) "is" else "are"
                     outbound.send(OutboundEvent.SendText(sessionId, "$names $verb now yours automatically."))
                 }
-                val available = abilitySystem.availableSkillPoints(
+                availablePoints = abilitySystem.availableSkillPoints(
                     level = result.newLevel,
                     spentPoints = abilitySystem.spentSkillPoints(player.learnedAbilityIds),
                     interval = skillPointsConfig.interval,
                 )
-                if (available > 0) {
-                    val pointWord = if (available == 1) "skill point" else "skill points"
+                if (availablePoints > 0) {
+                    val pointWord = if (availablePoints == 1) "skill point" else "skill points"
                     outbound.send(
                         OutboundEvent.SendText(
                             sessionId,
-                            "You have $available $pointWord available! Visit a class trainer to learn new abilities.",
+                            "You have $availablePoints $pointWord available! Visit a class trainer to learn new abilities.",
                         ),
                     )
                 }
@@ -351,6 +364,26 @@ class ItemHandler(
                     abilitySystem.cooldownRemainingMs(sessionId, abilityId)
                 }
             }
+
+            gmcpEmitter?.sendCharGain(
+                sessionId,
+                "levelUp",
+                result.newLevel.toLong(),
+                newLevel = result.newLevel,
+                hpGained = hpGained,
+                manaGained = manaGained,
+            )
+            gmcpEmitter?.sendCharLevelUp(
+                sessionId,
+                previousLevel = result.previousLevel,
+                newLevel = result.newLevel,
+                levelsGained = result.levelsGained.coerceAtLeast(1),
+                hpGained = hpGained,
+                manaGained = manaGained,
+                newAbilities = autoLearnedNames,
+                skillPointsAvailable = availablePoints,
+                isMilestone = result.newLevel == 10 || result.newLevel == 25 || result.newLevel == 50 || result.newLevel == 100,
+            )
         }
     }
 

--- a/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
+++ b/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
@@ -263,7 +263,7 @@ private suspend fun DefaultWebSocketServerSession.bridgeWebSocketSession(
         InboundEvent.GmcpReceived(
             sessionId,
             "Core.Supports.Set",
-            """["Char.Vitals 1","Room.Info 1","Zone 1","Char.StatusVars 1","Char.Items 1","Char.Equipment 1","Room.Players 1","Room.Mobs 1","Room.Items 1","Char.Skills 1","Char.Name 1","Char.StatusEffects 1","Char.Achievements 1","Char.Sprites 1","Comm.Channel 1","Guild 1","Group.Info 1","Friends 1","Core.Ping 1","Dialogue 1","Shop 1","Char.Combat 1","Char.Combat.Event 1","Char.Stats 1","Quest 1","Char.Cooldown 1","Char.Gain 1","Room.MobInfo 1","Mail 1","Crafting 1","Login 1","Server 1","UI.Feedback 1","Staff 1","Housing 1","Session 1","Trade 1","Auction 1","Char.Factions 1","Char.Currencies 1","Char.Pet 1","Char.Bank 1","Char.Stylist 1","World 1","Leaderboard 1","Trainer 1","Char.Classes 1","Lottery 1","Duel 1","Dungeon 1","Prestige 1","Puzzle 1"]""",
+            """["Char.Vitals 1","Room.Info 1","Zone 1","Char.StatusVars 1","Char.Items 1","Char.Equipment 1","Room.Players 1","Room.Mobs 1","Room.Items 1","Char.Skills 1","Char.Name 1","Char.StatusEffects 1","Char.Achievements 1","Char.Sprites 1","Comm.Channel 1","Guild 1","Group.Info 1","Friends 1","Core.Ping 1","Dialogue 1","Shop 1","Char.Combat 1","Char.Combat.Event 1","Char.Stats 1","Quest 1","Char.Cooldown 1","Char.Gain 1","Char.LevelUp 1","Room.MobInfo 1","Mail 1","Crafting 1","Login 1","Server 1","UI.Feedback 1","Staff 1","Housing 1","Session 1","Trade 1","Auction 1","Char.Factions 1","Char.Currencies 1","Char.Pet 1","Char.Bank 1","Char.Stylist 1","World 1","Leaderboard 1","Trainer 1","Char.Classes 1","Lottery 1","Duel 1","Dungeon 1","Prestige 1","Puzzle 1"]""",
         ),
     )
     metrics.onWsConnected()

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -1207,6 +1207,70 @@ class GmcpEmitterTest {
             assertTrue(drainGmcp().isEmpty())
         }
 
+    // ── Char.LevelUp ──
+
+    @Test
+    fun `sendCharLevelUp emits level-up JSON with hp mana and abilities`() =
+        runTest {
+            val e = emitter("Char.LevelUp")
+            e.sendCharLevelUp(
+                sid,
+                previousLevel = 4,
+                newLevel = 5,
+                levelsGained = 1,
+                hpGained = 12,
+                manaGained = 6,
+                newAbilities = listOf("Fireball", "Ice Shard"),
+                skillPointsAvailable = 2,
+                isMilestone = false,
+            )
+            val events = drainGmcp()
+            assertEquals(1, events.size)
+            assertEquals("Char.LevelUp", events[0].gmcpPackage)
+            val body = events[0].jsonData
+            assertTrue(body.contains("\"previousLevel\":4"), body)
+            assertTrue(body.contains("\"newLevel\":5"), body)
+            assertTrue(body.contains("\"levelsGained\":1"), body)
+            assertTrue(body.contains("\"hpGained\":12"), body)
+            assertTrue(body.contains("\"manaGained\":6"), body)
+            assertTrue(body.contains("\"newAbilities\":[\"Fireball\",\"Ice Shard\"]"), body)
+            assertTrue(body.contains("\"skillPointsAvailable\":2"), body)
+            assertTrue(body.contains("\"isMilestone\":false"), body)
+        }
+
+    @Test
+    fun `sendCharLevelUp marks milestone levels`() =
+        runTest {
+            val e = emitter("Char.LevelUp")
+            e.sendCharLevelUp(
+                sid,
+                previousLevel = 9,
+                newLevel = 10,
+                levelsGained = 1,
+                hpGained = 20,
+                manaGained = 10,
+                isMilestone = true,
+            )
+            val events = drainGmcp()
+            assertEquals(1, events.size)
+            assertTrue(events[0].jsonData.contains("\"isMilestone\":true"))
+        }
+
+    @Test
+    fun `sendCharLevelUp does nothing when not supported`() =
+        runTest {
+            val e = emitter()
+            e.sendCharLevelUp(
+                sid,
+                previousLevel = 4,
+                newLevel = 5,
+                levelsGained = 1,
+                hpGained = 10,
+                manaGained = 5,
+            )
+            assertTrue(drainGmcp().isEmpty())
+        }
+
     // ── Room.MobInfo ──
 
     @Test

--- a/src/test/kotlin/dev/ambon/test/CombatTestFixture.kt
+++ b/src/test/kotlin/dev/ambon/test/CombatTestFixture.kt
@@ -12,6 +12,7 @@ import dev.ambon.engine.CombatSystemCallbacks
 import dev.ambon.engine.CombatSystemConfig
 import dev.ambon.engine.DirtyNotifier
 import dev.ambon.engine.GroupSystem
+import dev.ambon.engine.LevelUpResult
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PetSystem
 import dev.ambon.engine.PlayerClassRegistry
@@ -50,7 +51,7 @@ class CombatTestFixture(
         onMobRemoved: suspend (MobId, RoomId) -> Unit = { _, _ -> },
         progression: PlayerProgression = PlayerProgression(),
         metrics: GameMetrics = GameMetrics.noop(),
-        onLevelUp: suspend (SessionId, Int) -> Unit = { _, _ -> },
+        onLevelUp: suspend (SessionId, LevelUpResult) -> Unit = { _, _ -> },
         bindings: StatBindingsConfig = StatBindingsConfig(),
         dirtyNotifier: DirtyNotifier = DirtyNotifier.NO_OP,
         statusEffects: StatusEffectSystem? = null,

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -25,6 +25,7 @@ import { LotteryPanel } from "./components/panels/LotteryPanel";
 import { AdminPanel } from "./components/panels/AdminPanel";
 import { WorldAtmosphereHud } from "./components/WorldAtmosphereHud";
 import { HelpContent } from "./components/HelpContent";
+import { LevelUpBanner } from "./components/LevelUpBanner";
 import { LoginModal } from "./canvas/LoginModal";
 import { CharacterPicker } from "./components/CharacterPicker";
 import { CommandPalette } from "./components/CommandPalette";
@@ -1240,6 +1241,12 @@ function App() {
           </div>
         </div>
       )}
+
+      {/* Level-up celebration — headline moment on XP/kill → level threshold */}
+      <LevelUpBanner
+        notification={state.levelUpNotification}
+        onDismiss={() => state.setLevelUpNotification(null)}
+      />
 
       {/* Server broadcast */}
       {state.broadcast && (

--- a/web-v3/src/components/LevelUpBanner.tsx
+++ b/web-v3/src/components/LevelUpBanner.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useState } from "react";
+import type { LevelUpNotification } from "../types";
+
+interface LevelUpBannerProps {
+  notification: LevelUpNotification | null;
+  /** Dismisses the banner (click-to-dismiss or auto-fade). */
+  onDismiss: () => void;
+}
+
+/**
+ * Full-page celebration overlay triggered by a Char.LevelUp GMCP packet.
+ *
+ * Visibility contract:
+ *  - The notification stays rendered (with a pulsing glow) until either the
+ *    player clicks/keys to dismiss OR the auto-fade timer elapses.
+ *  - Milestone levels (10/25/50/100) get a longer auto-fade + extra flourish.
+ *  - Honors `prefers-reduced-motion`: animations collapse to a simple fade
+ *    while the dismiss affordances remain untouched.
+ *
+ * Gameplay is intentionally *not* blocked — the overlay uses pointer-events:
+ * none on the backdrop and only the card itself is interactive, so the player
+ * can keep attacking during a grind.
+ *
+ * The component re-keys on notification.id, which resets all internal state
+ * (including the entering/closing animation state) when a new notification
+ * arrives. That avoids setState-in-effect lint violations.
+ */
+export function LevelUpBanner({ notification, onDismiss }: LevelUpBannerProps) {
+  if (!notification) return null;
+  return (
+    <LevelUpBannerInner
+      key={notification.id}
+      notification={notification}
+      onDismiss={onDismiss}
+    />
+  );
+}
+
+interface InnerProps {
+  notification: LevelUpNotification;
+  onDismiss: () => void;
+}
+
+function LevelUpBannerInner({ notification, onDismiss }: InnerProps) {
+  const [closing, setClosing] = useState(false);
+
+  useEffect(() => {
+    const autoFadeMs = notification.isMilestone ? 7000 : 4500;
+    const fadeTimer = window.setTimeout(() => setClosing(true), autoFadeMs);
+    return () => window.clearTimeout(fadeTimer);
+  }, [notification.isMilestone]);
+
+  useEffect(() => {
+    if (!closing) return;
+    const clearTimer = window.setTimeout(() => onDismiss(), 650);
+    return () => window.clearTimeout(clearTimer);
+  }, [closing, onDismiss]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape" || e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        setClosing(true);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  const dismiss = () => setClosing(true);
+  const animClass = closing ? "level-up-banner-closing" : "level-up-banner-entering";
+  const milestoneClass = notification.isMilestone ? " level-up-banner-milestone" : "";
+  const headline = notification.isMilestone ? "Milestone!" : "Level Up!";
+  const gainedLevels = Math.max(1, notification.levelsGained);
+  const gainedLabel =
+    gainedLevels > 1
+      ? `${notification.previousLevel} → ${notification.newLevel} (+${gainedLevels} levels)`
+      : `${notification.previousLevel} → ${notification.newLevel}`;
+
+  return (
+    <div
+      className={`level-up-banner-overlay ${animClass}${milestoneClass}`}
+      role="presentation"
+      aria-hidden={closing ? "true" : undefined}
+    >
+      <div className="level-up-banner-aura" aria-hidden="true">
+        <div className="level-up-banner-ring level-up-banner-ring-1" />
+        <div className="level-up-banner-ring level-up-banner-ring-2" />
+        <div className="level-up-banner-ring level-up-banner-ring-3" />
+      </div>
+
+      <div
+        className="level-up-banner-card"
+        role="alertdialog"
+        aria-live="assertive"
+        aria-labelledby="level-up-headline"
+        onClick={dismiss}
+      >
+        <div className="level-up-banner-sparkles" aria-hidden="true">
+          <span className="level-up-banner-spark spark-a">{"✨"}</span>
+          <span className="level-up-banner-spark spark-b">{"✨"}</span>
+          <span className="level-up-banner-spark spark-c">{"✨"}</span>
+          <span className="level-up-banner-spark spark-d">{"✨"}</span>
+        </div>
+
+        <p className="level-up-banner-eyebrow">{headline}</p>
+        <h2 id="level-up-headline" className="level-up-banner-level">
+          Level <span className="level-up-banner-number">{notification.newLevel}</span>
+        </h2>
+        <p className="level-up-banner-transition">{gainedLabel}</p>
+
+        <ul className="level-up-banner-rewards" role="list">
+          {notification.hpGained > 0 && (
+            <li className="level-up-banner-reward level-up-banner-reward-hp">
+              <span className="level-up-banner-reward-amount">+{notification.hpGained}</span>
+              <span className="level-up-banner-reward-label">Max HP</span>
+            </li>
+          )}
+          {notification.manaGained > 0 && (
+            <li className="level-up-banner-reward level-up-banner-reward-mana">
+              <span className="level-up-banner-reward-amount">+{notification.manaGained}</span>
+              <span className="level-up-banner-reward-label">Max Mana</span>
+            </li>
+          )}
+          {notification.skillPointsAvailable > 0 && (
+            <li className="level-up-banner-reward level-up-banner-reward-skill">
+              <span className="level-up-banner-reward-amount">
+                {notification.skillPointsAvailable}
+              </span>
+              <span className="level-up-banner-reward-label">
+                Skill point{notification.skillPointsAvailable === 1 ? "" : "s"}
+              </span>
+            </li>
+          )}
+        </ul>
+
+        {notification.newAbilities.length > 0 && (
+          <div className="level-up-banner-abilities">
+            <p className="level-up-banner-abilities-title">New abilities learned</p>
+            <ul className="level-up-banner-abilities-list" role="list">
+              {notification.newAbilities.map((name) => (
+                <li key={name} className="level-up-banner-ability">
+                  {name}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <button
+          type="button"
+          className="level-up-banner-dismiss"
+          aria-label="Dismiss level up notification"
+          onClick={(e) => {
+            e.stopPropagation();
+            dismiss();
+          }}
+        >
+          Continue
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -24,6 +24,7 @@ import type {
   FriendEntry,
   FriendNotification,
   GainEvent,
+  LevelUpNotification,
   GroupInfo,
   GroupMember,
   GuildInfo,
@@ -134,6 +135,7 @@ interface GmcpContext {
   setAutoQuest: Dispatch<SetStateAction<AutoQuest | null>>;
   setGlobalQuest: Dispatch<SetStateAction<GlobalQuest | null>>;
   pushGainEvent: (event: GainEvent) => void;
+  pushLevelUp: (notification: Omit<LevelUpNotification, "id">) => void;
   pushQuestNotification: (notification: QuestNotification) => void;
   setMobInfo: Dispatch<SetStateAction<MobInfo[]>>;
   setRoomFeatures: Dispatch<SetStateAction<RoomFeature[]>>;
@@ -1172,6 +1174,24 @@ export function applyGmcpPackage(
         newLevel: nl,
         hpGained: hpG,
         manaGained: manaG,
+      });
+      break;
+    }
+
+    case "Char.LevelUp": {
+      const packet = data as Partial<Record<string, unknown>>;
+      const abilities = Array.isArray(packet.newAbilities)
+        ? (packet.newAbilities as unknown[]).filter((v): v is string => typeof v === "string")
+        : [];
+      ctx.pushLevelUp({
+        previousLevel: safeNumber(packet.previousLevel, 0),
+        newLevel: safeNumber(packet.newLevel, 0),
+        levelsGained: safeNumber(packet.levelsGained, 1),
+        hpGained: safeNumber(packet.hpGained, 0),
+        manaGained: safeNumber(packet.manaGained, 0),
+        newAbilities: abilities,
+        skillPointsAvailable: safeNumber(packet.skillPointsAvailable, 0),
+        isMilestone: packet.isMilestone === true,
       });
       break;
     }

--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -49,6 +49,7 @@ import type {
   HousingInfo,
   ItemSummary,
   LeaderboardData,
+  LevelUpNotification,
   LoginErrorState,
   LoginPromptState,
   LookTargetInfo,
@@ -183,6 +184,8 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
   const [combatLogMessages, setCombatLogMessages] = useState<CombatLogMessage[]>([]);
   const combatEventsRef = useRef<CombatEventData[]>([]);
   const gainEventsRef = useRef<GainEvent[]>([]);
+  const [levelUpNotification, setLevelUpNotification] = useState<LevelUpNotification | null>(null);
+  const levelUpIdRef = useRef(0);
   const [duelState, setDuelState] = useState<DuelState | null>(null);
   const [duelChallenge, setDuelChallenge] = useState<DuelChallenge | null>(null);
 
@@ -411,6 +414,14 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     canvasEvents.push(event);
   }, []);
 
+  // Server-side Char.LevelUp GMCP → headline celebration overlay. Each new
+  // notification replaces any prior (un-dismissed) banner so rapid multi-level
+  // gains surface the highest level reached rather than stacking pop-ups.
+  const pushLevelUp = useCallback((notification: Omit<LevelUpNotification, "id">) => {
+    levelUpIdRef.current += 1;
+    setLevelUpNotification({ ...notification, id: levelUpIdRef.current });
+  }, []);
+
   const pushQuestNotification = useCallback((notification: QuestNotification) => {
     setQuestNotifications((prev) => {
       const next = [...prev, notification];
@@ -490,6 +501,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
         setAutoQuest,
         setGlobalQuest,
         pushGainEvent,
+        pushLevelUp,
         pushQuestNotification,
         setMobInfo,
         setRoomFeatures,
@@ -545,7 +557,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
         sendGmcp: (p: string, payload: unknown) => { sendGmcpRef.current(p, payload); return true; },
       });
     },
-    [applyCurrencies, applyFactions, pushFriendNotification, pushCombatEvent, pushGainEvent, pushQuestNotification, pushUiFeedback, pushCraftingResult, pushMailNotification, updateMap, loadZoneMap, resumeTokenRef, pendingAuthCharRef, sendGmcpRef],
+    [applyCurrencies, applyFactions, pushFriendNotification, pushCombatEvent, pushGainEvent, pushLevelUp, pushQuestNotification, pushUiFeedback, pushCraftingResult, pushMailNotification, updateMap, loadZoneMap, resumeTokenRef, pendingAuthCharRef, sendGmcpRef],
   );
 
   // ── Reset all HUD state on disconnect ─────────────
@@ -618,6 +630,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     setFactionActivity([]);
     combatEventsRef.current = [];
     gainEventsRef.current = [];
+    setLevelUpNotification(null);
     setCombatLogMessages([]);
     setUiFeedbackFeed([]);
     setActivePopout(null);
@@ -671,6 +684,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     lookTarget, setLookTarget, spriteList,
     // UI
     activePopout, setActivePopout, broadcast, setBroadcast, possessing, toast, setToast, uiFeedbackFeed,
+    levelUpNotification, setLevelUpNotification,
     // Setters needed by App
     setQuestsAvailable,
     // GMCP

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -7845,6 +7845,390 @@ body {
     0 0 0 4px rgb(216 197 232 / 30%);
 }
 
+/* ─────────────────────────────────────────────────────────────
+ * Level-up banner — celebratory overlay for a Char.LevelUp GMCP.
+ *
+ * Surreal Gentle Magic: jewel-tone gradient card with a pulsing
+ * aura ring system, soft gold eyebrow text, and a big lavender-on-gold
+ * level number. Backdrop is non-blocking so the player can keep
+ * playing; only the card is pointer-interactive for click-to-dismiss.
+ * ───────────────────────────────────────────────────────────── */
+
+.level-up-banner-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 250;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.level-up-banner-overlay.level-up-banner-entering {
+  animation: levelUpOverlayFadeIn 320ms var(--ease-out-soft);
+}
+
+.level-up-banner-overlay.level-up-banner-closing {
+  animation: levelUpOverlayFadeOut 600ms var(--ease-out-soft) forwards;
+}
+
+@keyframes levelUpOverlayFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes levelUpOverlayFadeOut {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+.level-up-banner-aura {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.level-up-banner-ring {
+  position: absolute;
+  width: clamp(280px, 60vw, 720px);
+  height: clamp(280px, 60vw, 720px);
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+.level-up-banner-ring-1 {
+  background: radial-gradient(
+    circle,
+    rgb(190 168 115 / 28%) 0%,
+    rgb(168 151 210 / 18%) 45%,
+    transparent 70%
+  );
+  animation: levelUpAuraPulseA 2.4s var(--ease-out-soft) infinite;
+}
+
+.level-up-banner-ring-2 {
+  background: radial-gradient(
+    circle,
+    rgb(168 151 210 / 22%) 0%,
+    rgb(140 174 201 / 14%) 45%,
+    transparent 70%
+  );
+  animation: levelUpAuraPulseB 3.2s var(--ease-out-soft) infinite;
+}
+
+.level-up-banner-ring-3 {
+  border: 1px solid rgb(190 168 115 / 38%);
+  background: transparent;
+  animation: levelUpAuraExpand 2.8s var(--ease-out-soft) infinite;
+}
+
+@keyframes levelUpAuraPulseA {
+  0%, 100% { transform: scale(0.85); opacity: 0.6; }
+  50% { transform: scale(1.1); opacity: 1; }
+}
+
+@keyframes levelUpAuraPulseB {
+  0%, 100% { transform: scale(1.05); opacity: 0.5; }
+  50% { transform: scale(0.9); opacity: 0.85; }
+}
+
+@keyframes levelUpAuraExpand {
+  0% { transform: scale(0.6); opacity: 0.7; }
+  100% { transform: scale(1.35); opacity: 0; }
+}
+
+.level-up-banner-card {
+  position: relative;
+  max-width: min(480px, 92vw);
+  padding: var(--space-6) var(--space-6) var(--space-5);
+  background: linear-gradient(
+    152deg,
+    rgb(48 36 68 / 96%) 0%,
+    rgb(34 27 52 / 96%) 55%,
+    rgb(28 22 44 / 96%) 100%
+  );
+  border: 1px solid rgb(190 168 115 / 48%);
+  border-radius: var(--radius-lg);
+  box-shadow:
+    0 12px 48px rgb(0 0 0 / 55%),
+    0 0 80px rgb(168 151 210 / 22%),
+    inset 0 1px 0 rgb(216 197 232 / 12%);
+  pointer-events: auto;
+  cursor: pointer;
+  text-align: center;
+  backdrop-filter: blur(10px);
+  animation: levelUpCardEnter 520ms var(--ease-out-soft);
+}
+
+.level-up-banner-overlay.level-up-banner-closing .level-up-banner-card {
+  animation: levelUpCardExit 520ms var(--ease-out-soft) forwards;
+}
+
+@keyframes levelUpCardEnter {
+  0% { opacity: 0; transform: translateY(24px) scale(0.88); }
+  60% { opacity: 1; transform: translateY(-4px) scale(1.03); }
+  100% { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+@keyframes levelUpCardExit {
+  0% { opacity: 1; transform: translateY(0) scale(1); }
+  100% { opacity: 0; transform: translateY(-18px) scale(0.94); }
+}
+
+.level-up-banner-milestone .level-up-banner-card {
+  border-color: rgb(212 184 92 / 70%);
+  box-shadow:
+    0 14px 64px rgb(0 0 0 / 60%),
+    0 0 120px rgb(212 184 92 / 30%),
+    0 0 32px rgb(190 168 115 / 36%),
+    inset 0 1px 0 rgb(255 229 128 / 20%);
+}
+
+.level-up-banner-milestone .level-up-banner-ring-1 {
+  background: radial-gradient(
+    circle,
+    rgb(212 184 92 / 40%) 0%,
+    rgb(190 168 115 / 22%) 45%,
+    transparent 70%
+  );
+}
+
+.level-up-banner-sparkles {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  border-radius: var(--radius-lg);
+}
+
+.level-up-banner-spark {
+  position: absolute;
+  font-size: 1.1rem;
+  opacity: 0;
+  animation: levelUpSpark 2.2s var(--ease-out-soft) infinite;
+}
+
+.spark-a { top: 10%; left: 14%; animation-delay: 0ms; }
+.spark-b { top: 22%; right: 10%; animation-delay: 450ms; }
+.spark-c { bottom: 18%; left: 20%; animation-delay: 900ms; }
+.spark-d { bottom: 12%; right: 18%; animation-delay: 1300ms; }
+
+@keyframes levelUpSpark {
+  0%, 100% { opacity: 0; transform: translateY(4px) scale(0.7); }
+  35% { opacity: 1; transform: translateY(-2px) scale(1.1); }
+  65% { opacity: 0.85; transform: translateY(-4px) scale(1); }
+}
+
+.level-up-banner-eyebrow {
+  margin: 0 0 var(--space-2);
+  font-family: var(--font-display, "Cormorant Garamond", serif);
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--color-primary-soft-gold);
+  text-shadow: 0 0 20px rgb(190 168 115 / 60%);
+}
+
+.level-up-banner-level {
+  margin: 0 0 var(--space-2);
+  font-family: var(--font-display, "Cormorant Garamond", serif);
+  font-size: clamp(1.6rem, 3.2vw, 2.1rem);
+  font-weight: 500;
+  color: var(--color-neutral-cloud);
+  letter-spacing: 0.04em;
+}
+
+.level-up-banner-number {
+  display: inline-block;
+  font-size: clamp(3.2rem, 7vw, 4.8rem);
+  font-weight: 700;
+  line-height: 1;
+  padding: 0 var(--space-2);
+  background: linear-gradient(
+    180deg,
+    var(--color-primary-soft-gold) 0%,
+    var(--color-gold-bright, #d4b85c) 50%,
+    var(--color-primary-soft-gold) 100%
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  text-shadow: 0 0 40px rgb(212 184 92 / 40%);
+  animation: levelUpNumberPulse 1.6s var(--ease-out-soft) infinite;
+}
+
+@keyframes levelUpNumberPulse {
+  0%, 100% { transform: scale(1); filter: drop-shadow(0 0 12px rgb(212 184 92 / 40%)); }
+  50% { transform: scale(1.05); filter: drop-shadow(0 0 24px rgb(212 184 92 / 60%)); }
+}
+
+.level-up-banner-transition {
+  margin: 0 0 var(--space-5);
+  font-size: 0.9rem;
+  color: var(--color-neutral-soft-fog);
+  letter-spacing: 0.04em;
+}
+
+.level-up-banner-rewards {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--space-3);
+  list-style: none;
+  margin: 0 0 var(--space-4);
+  padding: 0;
+}
+
+.level-up-banner-reward {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: var(--space-3) var(--space-4);
+  min-width: 92px;
+  background: rgb(28 22 44 / 60%);
+  border: 1px solid rgb(168 151 210 / 28%);
+  border-radius: var(--radius-md);
+}
+
+.level-up-banner-reward-amount {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--color-neutral-cloud);
+}
+
+.level-up-banner-reward-label {
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-neutral-soft-fog);
+}
+
+.level-up-banner-reward-hp {
+  border-color: rgb(158 191 117 / 42%);
+}
+
+.level-up-banner-reward-hp .level-up-banner-reward-amount {
+  color: var(--color-hp-light);
+}
+
+.level-up-banner-reward-mana {
+  border-color: rgb(127 182 207 / 42%);
+}
+
+.level-up-banner-reward-mana .level-up-banner-reward-amount {
+  color: var(--color-mana-light);
+}
+
+.level-up-banner-reward-skill {
+  border-color: rgb(190 168 115 / 52%);
+}
+
+.level-up-banner-reward-skill .level-up-banner-reward-amount {
+  color: var(--color-primary-soft-gold);
+}
+
+.level-up-banner-abilities {
+  margin: 0 0 var(--space-4);
+  padding: var(--space-3);
+  background: rgb(28 22 44 / 50%);
+  border: 1px solid rgb(168 151 210 / 26%);
+  border-radius: var(--radius-md);
+}
+
+.level-up-banner-abilities-title {
+  margin: 0 0 var(--space-2);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-primary-lavender);
+}
+
+.level-up-banner-abilities-list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--space-2);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.level-up-banner-ability {
+  padding: 4px var(--space-3);
+  border: 1px solid rgb(168 151 210 / 46%);
+  border-radius: 999px;
+  background: linear-gradient(140deg, rgb(120 90 170 / 28%), rgb(100 70 150 / 22%));
+  font-size: 0.82rem;
+  color: var(--color-neutral-cloud);
+}
+
+.level-up-banner-dismiss {
+  padding: var(--space-2) var(--space-5);
+  border: 1px solid rgb(190 168 115 / 52%);
+  border-radius: var(--radius-sm);
+  background: linear-gradient(140deg, rgb(190 168 115 / 22%), rgb(168 151 210 / 18%));
+  color: var(--color-neutral-cloud);
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition:
+    background 160ms var(--ease-out-soft),
+    border-color 160ms var(--ease-out-soft),
+    transform 160ms var(--ease-out-soft);
+}
+
+.level-up-banner-dismiss:hover {
+  background: linear-gradient(140deg, rgb(190 168 115 / 34%), rgb(168 151 210 / 28%));
+  border-color: rgb(212 184 92 / 72%);
+  transform: translateY(-1px);
+}
+
+.level-up-banner-dismiss:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px rgb(190 168 115 / 64%),
+    0 0 0 4px rgb(168 151 210 / 36%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .level-up-banner-overlay.level-up-banner-entering,
+  .level-up-banner-overlay.level-up-banner-closing {
+    animation: levelUpOverlayFadeIn 200ms linear;
+  }
+
+  .level-up-banner-overlay.level-up-banner-closing {
+    animation: levelUpOverlayFadeOut 200ms linear forwards;
+  }
+
+  .level-up-banner-card,
+  .level-up-banner-overlay.level-up-banner-closing .level-up-banner-card {
+    animation: none;
+  }
+
+  .level-up-banner-ring-1,
+  .level-up-banner-ring-2,
+  .level-up-banner-ring-3,
+  .level-up-banner-number,
+  .level-up-banner-spark {
+    animation: none;
+  }
+
+  .level-up-banner-ring-3 {
+    opacity: 0.25;
+  }
+
+  .level-up-banner-spark {
+    opacity: 0.7;
+  }
+}
+
 .game-toast {
   position: fixed;
   top: 60px;

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -450,6 +450,19 @@ export interface GainEvent {
   manaGained: number | null;
 }
 
+/** Server-sent celebration data surfaced by the LevelUpBanner overlay. */
+export interface LevelUpNotification {
+  id: number;
+  previousLevel: number;
+  newLevel: number;
+  levelsGained: number;
+  hpGained: number;
+  manaGained: number;
+  newAbilities: string[];
+  skillPointsAvailable: number;
+  isMilestone: boolean;
+}
+
 export interface CraftingSkill {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary

A new character could grind the Academy to level 30 without noticing they had levelled. The only level-up feedback was a small floating text popup on the canvas plus a single "You reached level X!" server line, which got lost in combat noise.

This PR makes the level-up a headline moment with a proper celebratory overlay, while keeping gameplay unblocked and respecting accessibility.

### Server
- New `Char.LevelUp` GMCP carrying `previousLevel`, `newLevel`, `levelsGained`, `hpGained`, `manaGained`, `newAbilities`, `skillPointsAvailable`, and an `isMilestone` flag (true at levels 10/25/50/100).
- Emitted from every path that currently levels a player: combat kill rewards, XP-granting items, daily/weekly quests, global-quest end rewards, and autoQuest turn-ins.
- Existing `Char.Gain` `levelUp` is now correctly populated with HP/mana gains (the fields were previously always null).
- Registered in the WebSocket `Core.Supports.Set` auto-opt-in so the banner works out of the box.
- `GmcpEmitterTest` covers the new payload shape, the milestone flag, and the "not supported → no emit" path.

### Client (`web-v3`)
- New `LevelUpBanner` component renders a full-viewport flourish: pulsing aura rings, a large gradient gold level number, HP / Mana / skill-point reward chips, and the list of newly learned abilities. Milestone levels get an extra gold glow and a longer auto-fade.
- Auto-fade after 4.5s (7s on milestones), dismissible by click, Escape / Enter / Space. Backdrop uses `pointer-events: none` so players can keep attacking mid-banner.
- `prefers-reduced-motion` collapses every animation to a simple opacity fade while keeping the banner readable and dismissible.
- Uses Surreal Gentle Magic CSS tokens (`--color-primary-soft-gold`, `--color-primary-lavender`, `--color-hp-light`, `--color-mana-light`) — no hard-coded colors except alpha wrappers over those tokens.

## Test plan

- [x] `./gradlew.bat ktlintCheck` clean.
- [x] `./gradlew.bat test` passes (new `sendCharLevelUp` tests in `GmcpEmitterTest`).
- [x] `./gradlew.bat integrationTest` passes with `buildWeb` producing the web assets.
- [x] `cd web-v3 && bun run lint` clean.
- [x] `cd web-v3 && bunx tsc -b` clean.
- [x] `cd web-v3 && bun run build` builds without warnings beyond the existing chunk-size notice.
- [ ] Manual smoke test: grind a mob from level 1 → 2 in the Academy; banner appears with +HP/+Mana, auto-fades after ~4.5s, clickable to dismiss.
- [ ] Manual smoke test: reach a milestone level (10) and confirm the gold-ring flourish + extended hold.
- [ ] Manual smoke test: set `prefers-reduced-motion: reduce` in devtools; banner renders as a simple fade with no aura pulses.

Fixes #1037