### PR TITLE
Fix dialogue dismiss: click anywhere to close when ended (#1033)

### DIFF
--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -454,6 +454,27 @@ function App() {
     return () => window.removeEventListener("keydown", handler);
   }, [state.lookTarget]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Close NPC dialogue / quest offers on Escape — but only when the
+  // conversation has reached a state with no further choices (mirrors the
+  // click-to-dismiss behaviour in DialogueOverlay). A mid-conversation Escape
+  // is ignored so players don't accidentally abandon an active choice branch.
+  const dialogue = state.dialogue;
+  const hasQuestsAvailable = state.questsAvailable.length > 0;
+  useEffect(() => {
+    if (!dialogue && !hasQuestsAvailable) return;
+    const hasActiveChoices = dialogue !== null && dialogue.choices.length > 0;
+    if (hasActiveChoices) return;
+    const handler = (e: globalThis.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        const target = e.target as HTMLElement | null;
+        if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA")) return;
+        canvasCallbacks.dismissDialogue?.();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [dialogue, hasQuestsAvailable]);
+
   // Ctrl+K (or Cmd+K) opens the command palette
   useEffect(() => {
     const handler = (e: globalThis.KeyboardEvent) => {

--- a/web-v3/src/canvas/systems/DialogueOverlay.ts
+++ b/web-v3/src/canvas/systems/DialogueOverlay.ts
@@ -30,6 +30,10 @@ const QUEST_SEPARATOR_GAP = 12;
 export class DialogueOverlay {
   readonly container = new Container();
 
+  // Full-canvas hit area that dismisses the dialogue when clicked. Only active
+  // once the conversation has reached a state with no further choices, so
+  // mid-conversation canvas interactions (e.g. choice buttons) are preserved.
+  private fullBg = new Graphics();
   private bg = new Graphics();
   private npcNameText: Text;
   private bodyText: Text;
@@ -54,13 +58,29 @@ export class DialogueOverlay {
       style: { fontFamily: "JetBrains Mono, Cascadia Mono, monospace", fontSize: 12, fill: TEXT_COLOR, wordWrap: true, wordWrapWidth: 300 },
     });
 
-    this.bg.eventMode = "static";
-    this.bg.cursor = "default";
-    this.bg.on("pointerdown", () => {
+    // Full-canvas dismiss backdrop — only enabled when dismissable.
+    this.fullBg.eventMode = "none";
+    this.fullBg.visible = false;
+    this.fullBg.on("pointerdown", () => {
       if (this.isDismissable) {
         canvasCallbacks.dismissDialogue?.();
       }
     });
+
+    this.bg.eventMode = "static";
+    this.bg.cursor = "default";
+    this.bg.on("pointerdown", (event) => {
+      if (this.isDismissable) {
+        canvasCallbacks.dismissDialogue?.();
+      }
+      // Stop propagation so the full-canvas backdrop underneath doesn't also
+      // fire (it would double-dismiss, which is harmless, but explicit is
+      // cleaner). Also prevents clicking the box from bubbling to world hits.
+      event.stopPropagation();
+    });
+    // fullBg must render behind the dialogue box and its choices so those
+    // still receive pointer events.
+    this.container.addChild(this.fullBg);
     this.container.addChild(this.bg);
     this.container.addChild(this.npcNameText);
     this.container.addChild(this.bodyText);
@@ -70,6 +90,15 @@ export class DialogueOverlay {
   resize(width: number, height: number) {
     this.width = width;
     this.height = height;
+    this.redrawFullBg();
+  }
+
+  private redrawFullBg() {
+    this.fullBg.clear();
+    this.fullBg.rect(0, 0, this.width, this.height);
+    // Near-transparent fill so it still registers hits without darkening the
+    // scene behind the dialogue.
+    this.fullBg.fill({ color: 0x000000, alpha: 0.001 });
   }
 
   update() {
@@ -79,6 +108,8 @@ export class DialogueOverlay {
 
     if (!dialogue && !hasQuestOffers) {
       this.container.visible = false;
+      this.fullBg.visible = false;
+      this.fullBg.eventMode = "none";
       this.lastDialogueKey = null;
       return;
     }
@@ -188,9 +219,21 @@ export class DialogueOverlay {
     this.isDismissable = !hasActiveChoices;
     this.bg.cursor = this.isDismissable ? "pointer" : "default";
 
+    // Full-canvas dismiss backdrop is only interactive when dismissable, so
+    // mid-conversation canvas clicks (e.g. picking choices) aren't swallowed.
+    if (this.isDismissable) {
+      this.redrawFullBg();
+      this.fullBg.visible = true;
+      this.fullBg.eventMode = "static";
+      this.fullBg.cursor = "pointer";
+    } else {
+      this.fullBg.visible = false;
+      this.fullBg.eventMode = "none";
+    }
+
     if (this.isDismissable) {
       this.dismissHint = new Text({
-        text: "Click to close",
+        text: "Click anywhere to close",
         style: { fontFamily: "JetBrains Mono, Cascadia Mono, monospace", fontSize: 10, fill: ENDING_COLOR },
       });
       this.dismissHint.anchor.set(0.5, 0);


### PR DESCRIPTION
## Summary
- After a dialogue ends (no remaining choices / ending text or quest-offer state), a transparent full-canvas hit area sits behind the dialogue box and dismisses the dialogue on any canvas click.
- Mid-conversation clicks are left alone so choice buttons and other canvas interactions still work.
- Escape key also dismisses a dialogue/quest-offer once no choices remain (ignored mid-conversation so players don't accidentally drop a branch).
- Existing close paths (clicking the box itself, `Dialogue.End` from server) are preserved.

## Test plan
- [ ] Talk to an NPC that has multiple choices: verify clicking outside the box does NOT dismiss, clicking a numbered choice still works.
- [ ] Advance to a node with no more choices ("The conversation has ended." appears): click anywhere on the canvas (e.g. on an empty floor tile or mob sprite area), dialogue should dismiss and further canvas clicks route normally.
- [ ] Walk up to an NPC offering a quest with no dialogue choices: click anywhere dismisses.
- [ ] Press Escape on the ended dialogue — dialogue closes. Press Escape mid-conversation — no-op.
- [ ] While typing in the chat input, Escape does not fire the dismiss handler.
- [ ] Dialogue box click still closes when over; hint now reads "Click anywhere to close".

Fixes #1033