### PR TITLE
Fix #1029: Onboarding hints for inventory + equip

### DIFF
--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -35,6 +35,7 @@ import { useAudioEngine } from "./hooks/useAudioEngine";
 import { useCommandHistory } from "./hooks/useCommandHistory";
 import { useMiniMap } from "./hooks/useMiniMap";
 import { useQuickbar } from "./hooks/useQuickbar";
+import { useOnboarding } from "./hooks/useOnboarding";
 import { canvasCallbacks, gameStateRef, pendingCastRef } from "./canvas/GameStateBridge";
 import type { ChatChannel, FeaturePopoutFocus, LookTargetInfo, PopoutPanel } from "./types";
 import { sortExits, titleCaseWords } from "./utils";
@@ -519,6 +520,44 @@ function App() {
   };
 
   const hasCharacterProfile = state.character.name !== "-";
+
+  // First-time onboarding hints: pulse the Inventory sidebar button until opened,
+  // then pulse the Equip action on wearable items until one is worn. Persisted
+  // per-character in localStorage so we only nag new players.
+  const onboarding = useOnboarding(hasCharacterProfile ? state.character.name : "");
+  const hasUnequippedWearable = useMemo(
+    () => state.inventory.some((i) => i.slot != null),
+    [state.inventory],
+  );
+  const showInventoryHint =
+    hasCharacterProfile
+    && hasUnequippedWearable
+    && !onboarding.flags.invHintDone
+    && !onboarding.flags.equipHintDone;
+  const showEquipHint =
+    hasCharacterProfile
+    && hasUnequippedWearable
+    && !onboarding.flags.equipHintDone;
+
+  // Opening the inventory drawer counts as acknowledging the sidebar hint.
+  useEffect(() => {
+    if (state.activePopout === "inventory" && !onboarding.flags.invHintDone) {
+      onboarding.markInvHintDone();
+    }
+  }, [state.activePopout, onboarding]);
+
+  // Once the player has no unequipped wearables left, the equip hint is done.
+  useEffect(() => {
+    if (
+      onboarding.flags.invHintDone
+      && !onboarding.flags.equipHintDone
+      && !hasUnequippedWearable
+      && hasCharacterProfile
+    ) {
+      onboarding.markEquipHintDone();
+    }
+  }, [onboarding, hasUnequippedWearable, hasCharacterProfile]);
+
   const displayRace = state.character.race ? titleCaseWords(state.character.race) : "";
   const displayClassName = state.character.className ? titleCaseWords(state.character.className) : "";
   const xpText = state.vitals.xpToNextLevel === null
@@ -613,6 +652,7 @@ function App() {
           resetComposerCompletion();
         }}
         onInputKeyDown={handleInputKeyDown}
+        inventoryHint={showInventoryHint}
       />
 
       <Drawer open={state.activePopout !== null} title={drawerTitle} onClose={closeDrawer}>
@@ -674,6 +714,7 @@ function App() {
             onDropItem={(name) => sendCommand(`drop ${name}`)}
             onGiveItem={(keyword, player) => sendCommand(`give ${keyword} ${player}`)}
             onCommand={sendCommand}
+            equipHint={showEquipHint}
           />
         )}
 

--- a/web-v3/src/components/GameShell.tsx
+++ b/web-v3/src/components/GameShell.tsx
@@ -26,6 +26,7 @@ interface GameShellProps {
   inputValue: string;
   onInputChange: (value: string) => void;
   onInputKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  inventoryHint?: boolean;
   children?: ReactNode;
 }
 
@@ -49,6 +50,7 @@ export function GameShell({
   inputValue,
   onInputChange,
   onInputKeyDown,
+  inventoryHint,
   children,
 }: GameShellProps) {
   const loggedIn = connected && hasCharacterProfile;
@@ -106,6 +108,7 @@ export function GameShell({
         onInputChange={onInputChange}
         onInputKeyDown={onInputKeyDown}
         onHeightChange={setHudBottomInset}
+        inventoryHint={inventoryHint}
       />
 
       {children}

--- a/web-v3/src/components/VitalsBar.tsx
+++ b/web-v3/src/components/VitalsBar.tsx
@@ -75,6 +75,8 @@ interface VitalsBarProps {
   onInputChange: (value: string) => void;
   onInputKeyDown?: (event: KeyboardEvent<HTMLInputElement>) => void;
   onHeightChange?: (height: number) => void;
+  /** Pulse the Inventory panel button to draw first-time player attention. */
+  inventoryHint?: boolean;
 }
 
 interface SkillSlotProps {
@@ -170,6 +172,7 @@ export function VitalsBar({
   onInputChange,
   onInputKeyDown,
   onHeightChange,
+  inventoryHint = false,
 }: VitalsBarProps) {
   const [showPanels, setShowPanels] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -323,18 +326,27 @@ export function VitalsBar({
 
       {/* Panel grid — always rendered; hidden by CSS on mobile unless expanded */}
       <div className={`vbar-panel-grid${showPanels ? " vbar-panel-grid-open" : ""}`}>
-        {PANELS.map(({ panel, label, icon }) => (
-          <button
-            key={panel}
-            type="button"
-            className={`vbar-panel-btn${activePopout === panel ? " vbar-panel-btn-active" : ""}`}
-            onClick={() => { onOpenPanel(panel); setShowPanels(false); }}
-            aria-label={label}
-          >
-            {icon}
-            <span className="vbar-panel-label">{label}</span>
-          </button>
-        ))}
+        {PANELS.map(({ panel, label, icon }) => {
+          const isInventoryHint = inventoryHint && panel === "inventory" && activePopout !== "inventory";
+          const classes = [
+            "vbar-panel-btn",
+            activePopout === panel ? "vbar-panel-btn-active" : "",
+            isInventoryHint ? "vbar-panel-btn-hint" : "",
+          ].filter(Boolean).join(" ");
+          return (
+            <button
+              key={panel}
+              type="button"
+              className={classes}
+              onClick={() => { onOpenPanel(panel); setShowPanels(false); }}
+              aria-label={isInventoryHint ? `${label} (new item)` : label}
+            >
+              {icon}
+              <span className="vbar-panel-label">{label}</span>
+              {isInventoryHint && <span className="vbar-panel-btn-hint-dot" aria-hidden="true" />}
+            </button>
+          );
+        })}
         {dungeonActive && (
           <button
             type="button"

--- a/web-v3/src/components/panels/InventoryPanel.tsx
+++ b/web-v3/src/components/panels/InventoryPanel.tsx
@@ -15,6 +15,8 @@ interface InventoryPanelProps {
   onDropItem: (itemName: string) => void;
   onGiveItem: (itemKeyword: string, playerName: string) => void;
   onCommand: (command: string) => void;
+  /** Pulse the equip action on wearable items as a first-time onboarding cue. */
+  equipHint?: boolean;
 }
 
 function categorize(items: ItemSummary[]): { wearable: ItemSummary[]; other: ItemSummary[] } {
@@ -42,6 +44,7 @@ export function InventoryPanel({
   onDropItem,
   onGiveItem,
   onCommand,
+  equipHint = false,
 }: InventoryPanelProps) {
   const [givePickerItemId, setGivePickerItemId] = useState<string | null>(null);
   const containers = useMemo(
@@ -97,12 +100,13 @@ export function InventoryPanel({
           {item.slot && (
             <button
               type="button"
-              className="inventory-action-btn inventory-action-equip"
-              title={`Wear ${item.name}`}
+              className={`inventory-action-btn inventory-action-equip${equipHint ? " inventory-action-equip-hint" : ""}`}
+              title={equipHint ? `Equip ${item.name}` : `Wear ${item.name}`}
               disabled={!canManageItems}
               onClick={() => onWearItem(item.name)}
             >
               <WearItemIcon className="inventory-action-icon" />
+              {equipHint && <span className="inventory-action-equip-hint-label">Equip</span>}
             </button>
           )}
           {containerContents && (

--- a/web-v3/src/hooks/useOnboarding.ts
+++ b/web-v3/src/hooks/useOnboarding.ts
@@ -1,0 +1,89 @@
+import { useCallback, useState } from "react";
+
+// Per-character, one-time UI hints for first-time players. Stored in localStorage
+// under a single key so we can evolve the schema without adding new keys.
+//
+// Schema:
+//   {
+//     "<characterName>": { invHintDone?: true, equipHintDone?: true }
+//   }
+//
+// A hint is "done" once the user has taken the triggering action (opened the
+// inventory drawer / equipped the item). We only show hints when the character
+// has at least one equipable-but-unequipped item in inventory.
+
+const STORAGE_KEY = "ambonmud_onboarding_v1";
+
+export interface OnboardingFlags {
+  invHintDone?: boolean;
+  equipHintDone?: boolean;
+}
+
+type OnboardingStore = Record<string, OnboardingFlags>;
+
+function readStore(): OnboardingStore {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as OnboardingStore;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeStore(store: OnboardingStore): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+  } catch {
+    /* ignore — localStorage might be unavailable in private mode */
+  }
+}
+
+/**
+ * Onboarding hints for a single character. Pass the empty string ("" / "-") before
+ * a character is selected; hints remain hidden until a real name is provided.
+ */
+export function useOnboarding(characterName: string): {
+  flags: OnboardingFlags;
+  markInvHintDone: () => void;
+  markEquipHintDone: () => void;
+} {
+  const active = characterName.length > 0 && characterName !== "-";
+
+  // Track which character the current `flags` value corresponds to so we can
+  // re-derive (without a setState-in-effect) on character switch.
+  const [entry, setEntry] = useState<{ name: string; flags: OnboardingFlags }>(() => ({
+    name: active ? characterName : "",
+    flags: active ? readStore()[characterName] ?? {} : {},
+  }));
+
+  let flags: OnboardingFlags;
+  if (entry.name !== (active ? characterName : "")) {
+    // Character changed — derive fresh value inline and schedule a sync render.
+    flags = active ? readStore()[characterName] ?? {} : {};
+    setEntry({ name: active ? characterName : "", flags });
+  } else {
+    flags = entry.flags;
+  }
+
+  const setFlag = useCallback(
+    (patch: OnboardingFlags) => {
+      if (!active) return;
+      setEntry((prev) => {
+        const base = prev.name === characterName ? prev.flags : readStore()[characterName] ?? {};
+        const next = { ...base, ...patch };
+        const store = readStore();
+        store[characterName] = next;
+        writeStore(store);
+        return { name: characterName, flags: next };
+      });
+    },
+    [active, characterName],
+  );
+
+  const markInvHintDone = useCallback(() => setFlag({ invHintDone: true }), [setFlag]);
+  const markEquipHintDone = useCallback(() => setFlag({ equipHintDone: true }), [setFlag]);
+
+  return { flags, markInvHintDone, markEquipHintDone };
+}

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -6320,6 +6320,40 @@ body {
   color: var(--color-primary-moss-green);
 }
 
+/* First-time onboarding hint: pulse the Equip action on wearable items until
+   the player actually wears one. Soft-gold border + inline "Equip" label so the
+   action is discoverable at a glance. */
+.inventory-action-equip-hint {
+  border-color: var(--color-primary-soft-gold);
+  color: var(--color-primary-soft-gold);
+  padding-right: 8px;
+  animation: inventory-equip-hint-pulse 1.8s var(--ease-in-out-smooth) infinite;
+}
+
+.inventory-action-equip-hint-label {
+  margin-left: 4px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+@keyframes inventory-equip-hint-pulse {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgb(190 168 115 / 55%);
+  }
+  50% {
+    box-shadow: 0 0 10px 1px rgb(190 168 115 / 55%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .inventory-action-equip-hint {
+    animation: none;
+    box-shadow: 0 0 0 2px rgb(190 168 115 / 55%);
+  }
+}
+
 .inventory-action-examine,
 .inventory-action-use,
 .inventory-action-put {
@@ -15189,6 +15223,7 @@ html:has(.game-shell),
   cursor: pointer;
   transition: transform 0.12s, background 0.15s;
   min-height: 70px;
+  position: relative;
 }
 
 .vbar-panel-btn:active {
@@ -15203,6 +15238,41 @@ html:has(.game-shell),
 .vbar-panel-btn-dungeon {
   background: linear-gradient(135deg, rgb(210 120 140 / 82%), rgb(140 80 110 / 82%));
   border-color: rgb(232 170 190 / 55%);
+}
+
+/* First-time onboarding hint: pulse the Inventory sidebar button until opened.
+   Uses soft-gold tokens so it reads as "attention" without competing with the
+   primary-lavender active state. */
+.vbar-panel-btn-hint {
+  border-color: var(--color-primary-soft-gold);
+  animation: vbar-panel-btn-hint-pulse 2s var(--ease-in-out-smooth) infinite;
+}
+
+@keyframes vbar-panel-btn-hint-pulse {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgb(190 168 115 / 55%);
+  }
+  50% {
+    box-shadow: 0 0 14px 2px rgb(190 168 115 / 55%);
+  }
+}
+
+.vbar-panel-btn-hint-dot {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-primary-soft-gold);
+  box-shadow: 0 0 6px rgb(190 168 115 / 80%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vbar-panel-btn-hint {
+    animation: none;
+    box-shadow: 0 0 0 2px rgb(190 168 115 / 55%);
+  }
 }
 
 .vbar-panel-btn-dungeon:hover {


### PR DESCRIPTION
## Summary

After looting the first item from a chest, nothing told a new player to click **Inventory** and then **Equip**. This PR adds two one-time, per-character visual cues.

- **Sidebar Inventory button** pulses (soft-gold glow + corner dot) whenever the character has an equipable-but-unequipped item in inventory. The glow clears the first time the inventory drawer is opened.
- **Equip action** inside the inventory panel pulses with an inline "Equip" label (instead of just the icon) on wearable items until the player actually wears one. Clears once the wearable list is empty.

State is persisted per-character in `localStorage` under `ambonmud_onboarding_v1` (mirrors the existing `ambonmud_auth_tokens` pattern), so each character gets the nudge exactly once.

Design notes:

- All colours use existing Surreal Gentle Magic tokens (`--color-primary-soft-gold`). No hardcoded colours.
- Both cues honour `prefers-reduced-motion` — they fall back to a static outline instead of a keyframe pulse.
- Hints are scoped narrowly (inventory-grew + equipable flag); this is not a generic tutorial system.

## Test plan

- [ ] New character, loot a wearable from a chest → sidebar Inventory button glows with corner dot.
- [ ] Open Inventory → sidebar glow disappears; Equip button on wearable item pulses with "Equip" label.
- [ ] Click Equip (or type `wear <item>`) → equip pulse disappears after the item leaves inventory.
- [ ] Loot a second wearable on the same character → no hints (already seen).
- [ ] Create a second character on the same browser → hints reappear for that character.
- [ ] Enable "Reduce motion" in OS settings → static gold outline shown instead of pulse animation.
- [ ] `cd web-v3 && npx eslint . && npx tsc -b && npm run build` all pass.

Fixes #1029