### PR TITLE
Fix #1035: Persistent Combat Log panel

### DIFF
--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -23,6 +23,7 @@ import { AuctionPanel } from "./components/panels/AuctionPanel";
 import { DungeonPanel } from "./components/panels/DungeonPanel";
 import { LotteryPanel } from "./components/panels/LotteryPanel";
 import { AdminPanel } from "./components/panels/AdminPanel";
+import { CombatLogPanel } from "./components/panels/CombatLogPanel";
 import { WorldAtmosphereHud } from "./components/WorldAtmosphereHud";
 import { HelpContent } from "./components/HelpContent";
 import { LevelUpBanner } from "./components/LevelUpBanner";
@@ -629,6 +630,7 @@ function App() {
       case "auction": return "Auction House";
       case "dungeon": return "Dungeon";
       case "lottery": return "Lottery";
+      case "combatlog": return "Combat Log";
       case "help": return "Command Reference";
       case "room": return state.room.title !== "-" ? state.room.title : "Room Details";
       case "map": return "World Map";
@@ -925,6 +927,13 @@ function App() {
             lotteryInfo={state.lotteryInfo}
             uiFeedbackFeed={state.uiFeedbackFeed}
             onCommand={sendCommand}
+          />
+        )}
+
+        {drawerPanel === "combatlog" && (
+          <CombatLogPanel
+            messages={state.combatLogMessages}
+            onClearLog={state.clearCombatLog}
           />
         )}
 

--- a/web-v3/src/components/VitalsBar.tsx
+++ b/web-v3/src/components/VitalsBar.tsx
@@ -18,6 +18,7 @@ import {
   SpellbookIcon,
   QuestsTabIcon,
   SkillCastIcon,
+  AttackIcon,
 } from "./Icons";
 
 function skillCategory(skill: SkillSummary): string {
@@ -47,6 +48,7 @@ const PANELS: PanelDef[] = [
   { panel: "inventory", label: "Inventory", icon: <EquipmentIcon className="vbar-icon" /> },
   { panel: "spellbook", label: "Spellbook", icon: <SpellbookIcon className="vbar-icon" /> },
   { panel: "quests", label: "Quests", icon: <QuestsTabIcon className="vbar-icon" /> },
+  { panel: "combatlog", label: "Combat Log", icon: <AttackIcon className="vbar-icon" /> },
   { panel: "chat", label: "Social", icon: <ChatBubbleIcon className="vbar-icon" /> },
   { panel: "crafting", label: "Crafting", icon: <CraftingIcon className="vbar-icon" /> },
   { panel: "auction", label: "Auction", icon: <AuctionIcon className="vbar-icon" /> },

--- a/web-v3/src/components/panels/CombatLogPanel.tsx
+++ b/web-v3/src/components/panels/CombatLogPanel.tsx
@@ -1,0 +1,175 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { CombatLogMessage } from "../../types";
+
+type CombatStyle = CombatLogMessage["style"];
+
+interface CombatLogPanelProps {
+  messages: CombatLogMessage[];
+  onClearLog: () => void;
+}
+
+const FILTER_OPTIONS: { style: CombatStyle; label: string }[] = [
+  { style: "damage", label: "Damage" },
+  { style: "heal", label: "Heal" },
+  { style: "dodge", label: "Dodge" },
+  { style: "kill", label: "Kills" },
+  { style: "xp", label: "XP" },
+  { style: "info", label: "Info" },
+  { style: "error", label: "Errors" },
+];
+
+// How close to the bottom (in px) counts as "stuck to bottom".
+const STICKY_THRESHOLD = 24;
+
+function formatRelativeTime(receivedAt: number, now: number): string {
+  const ageMs = Math.max(0, now - receivedAt);
+  if (ageMs < 5000) return "just now";
+  if (ageMs < 60_000) return `${Math.floor(ageMs / 1000)}s ago`;
+  const minutes = Math.floor(ageMs / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+export function CombatLogPanel({ messages, onClearLog }: CombatLogPanelProps) {
+  const [now, setNow] = useState(() => Date.now());
+  const [hidden, setHidden] = useState<Set<CombatStyle>>(() => new Set());
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  // Start sticky so the newest entries are visible when the panel opens.
+  const stickyRef = useRef<boolean>(true);
+
+  // Tick the clock once per second to keep relative timestamps fresh.
+  useEffect(() => {
+    const interval = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(interval);
+  }, []);
+
+  const toggleStyle = useCallback((style: CombatStyle) => {
+    setHidden((prev) => {
+      const next = new Set(prev);
+      if (next.has(style)) next.delete(style);
+      else next.add(style);
+      return next;
+    });
+  }, []);
+
+  const visible = useMemo(
+    () => messages.filter((m) => !hidden.has(m.style)),
+    [messages, hidden],
+  );
+
+  // Track whether the user is stuck at the bottom so new messages auto-scroll
+  // only when they haven't scrolled up to read something.
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    stickyRef.current = distanceFromBottom <= STICKY_THRESHOLD;
+  }, []);
+
+  // On mount (panel open): scroll to newest.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+    stickyRef.current = true;
+  }, []);
+
+  // When a new entry arrives and user is stuck to bottom, keep following.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    if (stickyRef.current) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [visible.length]);
+
+  const hasMessages = messages.length > 0;
+  const hiddenCount = messages.length - visible.length;
+
+  return (
+    <article className="subpanel combat-log-panel" aria-label="Combat log">
+      <header className="combat-log-panel-header">
+        <div className="combat-log-panel-title">
+          <h3>Combat Log</h3>
+          <span className="combat-log-panel-count">
+            {hasMessages
+              ? `${messages.length} entr${messages.length === 1 ? "y" : "ies"}${hiddenCount > 0 ? ` (${hiddenCount} filtered)` : ""}`
+              : "No activity yet"}
+          </span>
+        </div>
+        <div className="combat-log-panel-actions">
+          <button
+            type="button"
+            className="soft-button combat-log-panel-clear"
+            onClick={onClearLog}
+            disabled={!hasMessages}
+            aria-label="Clear combat log"
+          >
+            Clear
+          </button>
+        </div>
+      </header>
+
+      <div className="combat-log-panel-filters" role="group" aria-label="Combat log filters">
+        {FILTER_OPTIONS.map((opt) => {
+          const active = !hidden.has(opt.style);
+          return (
+            <button
+              key={opt.style}
+              type="button"
+              className={`combat-log-panel-chip combat-log-panel-chip-${opt.style}${active ? " combat-log-panel-chip-on" : ""}`}
+              onClick={() => toggleStyle(opt.style)}
+              aria-pressed={active}
+            >
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {!hasMessages && (
+        <div className="combat-log-panel-empty">
+          <p>Your combat log is empty.</p>
+          <p className="combat-log-panel-empty-hint">
+            Attacks, dodges, heals, kills, and XP gains will appear here as you fight.
+          </p>
+        </div>
+      )}
+
+      {hasMessages && visible.length === 0 && (
+        <div className="combat-log-panel-empty">
+          <p>All entries are hidden by filters.</p>
+        </div>
+      )}
+
+      {visible.length > 0 && (
+        <div
+          ref={scrollRef}
+          className="combat-log-panel-scroll"
+          onScroll={handleScroll}
+          role="log"
+          aria-live="polite"
+          aria-label="Combat log entries"
+        >
+          {visible.map((msg) => (
+            <div
+              key={msg.id}
+              className={`combat-log-panel-row combat-log-panel-row-${msg.style}`}
+            >
+              <time
+                className="combat-log-panel-row-time"
+                dateTime={new Date(msg.receivedAt).toISOString()}
+                title={new Date(msg.receivedAt).toLocaleTimeString()}
+              >
+                {formatRelativeTime(msg.receivedAt, now)}
+              </time>
+              <span className="combat-log-panel-row-text">{msg.text}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </article>
+  );
+}

--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -134,7 +134,7 @@ function combatEventToLogMessage(event: CombatEventData): CombatLogMessage | nul
   }
 }
 
-const MAX_COMBAT_LOG = 20;
+const MAX_COMBAT_LOG = 200;
 const MAX_QUEST_NOTIFICATIONS = 5;
 const MAX_FRIEND_NOTIFICATIONS = 5;
 const MAX_UI_FEEDBACK_FEED = 20;
@@ -298,6 +298,10 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
       const next = [...prev, msg];
       return next.length > MAX_COMBAT_LOG ? next.slice(-MAX_COMBAT_LOG) : next;
     });
+  }, []);
+
+  const clearCombatLog = useCallback(() => {
+    setCombatLogMessages([]);
   }, []);
 
   const pushCombatEvent = useCallback((event: CombatEventData) => {
@@ -692,7 +696,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     // Reset
     resetHud,
     // Push helpers
-    pushCombatLogMessage, pushUiFeedback,
+    pushCombatLogMessage, pushUiFeedback, clearCombatLog,
   };
 }
 

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -12309,6 +12309,227 @@ body {
   }
 }
 
+/* ─── Persistent Combat Log panel (drawer) ────────────────────────────── */
+.combat-log-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 8px);
+  min-height: 0;
+  height: 100%;
+}
+
+.combat-log-panel-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--space-2, 8px);
+  flex-wrap: wrap;
+}
+
+.combat-log-panel-title {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.combat-log-panel-title h3 {
+  margin: 0;
+  font-family: var(--font-display, inherit);
+  font-size: 1.1rem;
+  color: var(--text-heading, var(--color-text));
+}
+
+.combat-log-panel-count {
+  font-size: 0.8rem;
+  color: var(--text-muted, rgb(200 208 224 / 70%));
+}
+
+.combat-log-panel-actions {
+  display: flex;
+  gap: var(--space-1, 4px);
+}
+
+.combat-log-panel-clear[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.combat-log-panel-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.combat-log-panel-chip {
+  border: 1px solid rgb(140 174 201 / 28%);
+  background: rgb(22 27 41 / 55%);
+  color: var(--text-muted, rgb(200 208 224 / 78%));
+  border-radius: var(--radius-sm, 6px);
+  padding: 3px 10px;
+  font-size: 0.78rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+}
+
+.combat-log-panel-chip:hover {
+  background: rgb(38 48 70 / 70%);
+  color: var(--color-text, #e0e0e0);
+}
+
+.combat-log-panel-chip-on {
+  background: rgb(60 80 120 / 60%);
+  color: var(--color-text, #e0e0e0);
+  border-color: rgb(140 174 201 / 50%);
+}
+
+.combat-log-panel-chip-on.combat-log-panel-chip-damage {
+  color: var(--color-damage, #d4888a);
+  border-color: var(--color-damage, #d4888a);
+}
+
+.combat-log-panel-chip-on.combat-log-panel-chip-heal {
+  color: var(--color-heal, #8abf8a);
+  border-color: var(--color-heal, #8abf8a);
+}
+
+.combat-log-panel-chip-on.combat-log-panel-chip-dodge {
+  color: var(--color-dodge, #d9c8a1);
+  border-color: var(--color-dodge, #d9c8a1);
+}
+
+.combat-log-panel-chip-on.combat-log-panel-chip-kill,
+.combat-log-panel-chip-on.combat-log-panel-chip-xp {
+  color: var(--color-xp, #bea873);
+  border-color: var(--color-xp, #bea873);
+}
+
+.combat-log-panel-chip-on.combat-log-panel-chip-info {
+  color: var(--color-info, #8caec9);
+  border-color: var(--color-info, #8caec9);
+}
+
+.combat-log-panel-chip-on.combat-log-panel-chip-error {
+  color: var(--color-error, #e8a0a0);
+  border-color: var(--color-error, #e8a0a0);
+}
+
+.combat-log-panel-empty {
+  text-align: center;
+  padding: var(--space-4, 16px);
+  color: var(--text-muted, rgb(200 208 224 / 70%));
+  border: 1px dashed rgb(140 174 201 / 20%);
+  border-radius: var(--radius-md, 8px);
+  background: rgb(18 22 34 / 35%);
+}
+
+.combat-log-panel-empty p {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.combat-log-panel-empty-hint {
+  margin-top: var(--space-1, 4px) !important;
+  font-size: 0.8rem;
+  opacity: 0.8;
+}
+
+.combat-log-panel-scroll {
+  flex: 1 1 auto;
+  min-height: 200px;
+  max-height: 60vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px 4px;
+  background: rgb(12 14 24 / 35%);
+  border-radius: var(--radius-md, 8px);
+  border: 1px solid rgb(140 174 201 / 14%);
+  scrollbar-width: thin;
+}
+
+.combat-log-panel-scroll::-webkit-scrollbar {
+  width: 8px;
+}
+
+.combat-log-panel-scroll::-webkit-scrollbar-thumb {
+  background: rgb(140 174 201 / 30%);
+  border-radius: 4px;
+}
+
+.combat-log-panel-row {
+  display: grid;
+  grid-template-columns: minmax(64px, auto) minmax(0, 1fr);
+  align-items: baseline;
+  gap: var(--space-2, 8px);
+  padding: 4px 10px;
+  border-radius: var(--radius-sm, 6px);
+  font-size: 0.85rem;
+  line-height: 1.4;
+  background: rgb(18 22 34 / 55%);
+  border-left: 2px solid transparent;
+  color: var(--color-text, #e0e0e0);
+  word-break: break-word;
+}
+
+.combat-log-panel-row-time {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.72rem;
+  color: var(--text-muted, rgb(200 208 224 / 65%));
+  white-space: nowrap;
+}
+
+.combat-log-panel-row-text {
+  min-width: 0;
+}
+
+.combat-log-panel-row-damage {
+  color: var(--color-damage, #d4888a);
+  border-left-color: var(--color-damage, #d4888a);
+}
+
+.combat-log-panel-row-heal {
+  color: var(--color-heal, #8abf8a);
+  border-left-color: var(--color-heal, #8abf8a);
+}
+
+.combat-log-panel-row-error {
+  color: var(--color-error, #e8a0a0);
+  border-left-color: var(--color-error, #e8a0a0);
+  font-weight: 600;
+}
+
+.combat-log-panel-row-info {
+  color: var(--color-info, #8caec9);
+  border-left-color: var(--color-info, #8caec9);
+}
+
+.combat-log-panel-row-kill {
+  color: var(--color-xp, #bea873);
+  border-left-color: var(--color-xp, #bea873);
+  font-weight: 600;
+}
+
+.combat-log-panel-row-dodge {
+  color: var(--color-dodge, #d9c8a1);
+  border-left-color: var(--color-dodge, #d9c8a1);
+  font-style: italic;
+}
+
+.combat-log-panel-row-xp {
+  color: var(--color-xp, #bea873);
+  border-left-color: var(--color-xp, #bea873);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .combat-log-panel-chip {
+    transition: none;
+  }
+}
+
 /* Terminal overlay — appears over canvas when command input is focused */
 .terminal-overlay {
   position: absolute;

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -1,4 +1,4 @@
-export type PopoutPanel = "map" | "inventory" | "equipment" | "room" | "help" | "character" | "chat" | "shop" | "spellbook" | "quests" | "mail" | "crafting" | "housing" | "leaderboard" | "trainer" | "bank" | "stylist" | "auction" | "dungeon" | "lottery" | "puzzle" | "features" | null;
+export type PopoutPanel = "map" | "inventory" | "equipment" | "room" | "help" | "character" | "chat" | "shop" | "spellbook" | "quests" | "mail" | "crafting" | "housing" | "leaderboard" | "trainer" | "bank" | "stylist" | "auction" | "dungeon" | "lottery" | "puzzle" | "features" | "combatlog" | null;
 export type SystemPanelView = "dungeon" | "duel" | "lottery" | "pet" | "prestige" | "currencies" | "factions";
 export type ChatChannel = "say" | "tell" | "gossip" | "shout" | "ooc" | "gtell" | "gchat";
 export type SocialTab = "chat" | "friends" | "guild" | "group" | "who";


### PR DESCRIPTION
## Summary
- Adds a scrollable, persistent Combat Log panel accessible from the sidebar (drawer). Combats in Academy training are over in seconds, and players had no way to review what hit them or what they killed. The existing `CombatLog` HUD is an ephemeral overlay (6s fade, 8 visible); plumbing already fed `combatLogMessages`, but no UI exposed the history.
- Bumps `MAX_COMBAT_LOG` from 20 to 200 entries so review is actually useful, and adds a `clearCombatLog` helper.
- New `CombatLogPanel` component: color-coded rows (damage / heal / dodge / kill / xp / info / error), relative timestamps (`just now`, `1m ago`, …), filter chips, Clear button, empty state, and smart auto-scroll that sticks to bottom only when the user hasn't scrolled up.
- Wires the panel through `PopoutPanel`, `App.tsx` drawer, and a new sidebar entry in `VitalsBar` using `AttackIcon`.
- Styling uses only CSS variables, honors `prefers-reduced-motion`, and keeps color-blind-friendly left-border accents for each event type.

Fixes #1035

## Test plan
- [ ] `cd web-v3 && bun run lint && bunx tsc -b && bun run build` (all pass locally)
- [ ] Launch `./gradlew demo`, log in, enter combat in Academy, open the **Combat Log** sidebar entry and verify entries appear color-coded with timestamps.
- [ ] Scroll up in the panel during ongoing combat — new entries should NOT force-scroll the view.
- [ ] Scroll back to the bottom — new entries should resume auto-scrolling.
- [ ] Click **Clear** — panel empties and shows the empty state.
- [ ] Toggle filter chips (Damage / Heal / Dodge / Kill / XP / Info / Errors) — filtered entries disappear and the count shows "(N filtered)".
- [ ] Close and reopen the panel — history persists (up to 200 entries); log resets on disconnect/logout (existing `resetHud` behavior).
- [ ] Verify panel renders cleanly on mobile (drawer half/full snap) and with `prefers-reduced-motion` enabled.