### PR TITLE
Apply chest hero treatment to locked doors

### DIFF
--- a/web-v3/src/components/WorldFeaturesPopout.tsx
+++ b/web-v3/src/components/WorldFeaturesPopout.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import type { ReactNode } from "react";
 import type { ContainerContents, FeaturePopoutFocus, RoomFeature, RoomFeatureType } from "../types";
 import { DirectionIcon } from "./Icons";
 
@@ -109,15 +110,27 @@ function LeverWidget({
   );
 }
 
-function LockedContainerHero({
+function LockedFeatureHero({
   feature,
+  kindLabel,
+  kindClass,
+  heroVariantClass,
+  subtitle,
+  extraContent,
   onCommand,
 }: {
   feature: RoomFeature;
+  kindLabel: string;
+  kindClass: string;
+  heroVariantClass: string;
+  subtitle: string;
+  extraContent?: ReactNode;
   onCommand: (cmd: string) => void;
 }) {
   return (
-    <article className="feature-card feature-card-container feature-card-hero-locked">
+    <article
+      className={`feature-card feature-card-${feature.type} feature-card-hero-locked ${heroVariantClass}`}
+    >
       <div className="feature-card-hero-lock" aria-hidden="true">
         <svg viewBox="0 0 64 80" className="feature-card-hero-lock-svg">
           <path
@@ -148,11 +161,10 @@ function LockedContainerHero({
         </svg>
       </div>
       <div className="feature-card-hero-copy">
-        <span className="feature-card-kind feature-card-kind-container">Container</span>
+        <span className={`feature-card-kind ${kindClass}`}>{kindLabel}</span>
         <h4>{feature.name}</h4>
-        <p className="feature-card-hero-subtitle">
-          {feature.keyRequired ? "A key is required to unlock this." : "Locked tight."}
-        </p>
+        <p className="feature-card-hero-subtitle">{subtitle}</p>
+        {extraContent}
       </div>
       <div className="feature-card-hero-actions">
         <button
@@ -164,6 +176,60 @@ function LockedContainerHero({
         </button>
       </div>
     </article>
+  );
+}
+
+function LockedContainerHero({
+  feature,
+  onCommand,
+}: {
+  feature: RoomFeature;
+  onCommand: (cmd: string) => void;
+}) {
+  return (
+    <LockedFeatureHero
+      feature={feature}
+      kindLabel="Container"
+      kindClass="feature-card-kind-container"
+      heroVariantClass="feature-card-hero-locked-container"
+      subtitle={feature.keyRequired ? "A key is required to unlock this." : "Locked tight."}
+      onCommand={onCommand}
+    />
+  );
+}
+
+function LockedDoorHero({
+  feature,
+  onCommand,
+}: {
+  feature: RoomFeature;
+  onCommand: (cmd: string) => void;
+}) {
+  const direction = feature.direction ? titleCase(feature.direction) : null;
+  return (
+    <LockedFeatureHero
+      feature={feature}
+      kindLabel="Door"
+      kindClass="feature-card-kind-door"
+      heroVariantClass="feature-card-hero-locked-door"
+      subtitle={
+        feature.keyRequired
+          ? "A key is required to pass through."
+          : "The way is barred."
+      }
+      extraContent={
+        direction ? (
+          <span className="feature-card-hero-direction">
+            <DirectionIcon
+              direction={feature.direction as "north" | "east" | "south" | "west" | "up" | "down"}
+              className="feature-card-direction-icon"
+            />
+            Leads {direction}
+          </span>
+        ) : null
+      }
+      onCommand={onCommand}
+    />
   );
 }
 
@@ -340,6 +406,14 @@ export function WorldFeaturesPopout({
             visibleFeatures.length === 1
           ) {
             return <LockedContainerHero key={feature.id} feature={feature} onCommand={onCommand} />;
+          }
+
+          if (
+            feature.type === "door" &&
+            feature.state === "locked" &&
+            visibleFeatures.length === 1
+          ) {
+            return <LockedDoorHero key={feature.id} feature={feature} onCommand={onCommand} />;
           }
 
           const contents = feature.type === "container" && containerContents?.featureId === feature.id

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -3643,8 +3643,10 @@ body {
   font-size: 0.84rem;
 }
 
-/* Hero treatment for a single locked container — bigger, centered, with a
-   prominent lock glyph and a primary Unlock action. */
+/* Hero treatment for a single locked feature (container or door) — bigger,
+   centered, with a prominent lock glyph and a primary Unlock action. Variant
+   classes re-tint the card (gold for containers, cool blue for doors) while
+   the layout and glyph stay consistent. */
 .feature-card-hero-locked {
   grid-column: 1 / -1;
   justify-self: center;
@@ -3654,13 +3656,23 @@ body {
   padding: 28px 24px 24px;
   align-items: center;
   text-align: center;
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 10%),
+    0 12px 32px rgb(10 8 18 / 34%);
+}
+
+.feature-card-hero-locked-container {
   background:
     radial-gradient(circle at 50% 0%, rgb(212 178 110 / 18%), transparent 60%),
     linear-gradient(160deg, rgb(72 68 92 / 94%), rgb(52 50 74 / 92%));
   border-color: rgb(212 178 110 / 28%);
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 10%),
-    0 12px 32px rgb(10 8 18 / 34%);
+}
+
+.feature-card-hero-locked-door {
+  background:
+    radial-gradient(circle at 50% 0%, rgb(146 184 223 / 20%), transparent 60%),
+    linear-gradient(160deg, rgb(62 73 108 / 94%), rgb(45 56 86 / 92%));
+  border-color: rgb(146 184 223 / 30%);
 }
 
 .feature-card-hero-lock {
@@ -3669,9 +3681,17 @@ body {
   justify-content: center;
   width: 96px;
   height: 96px;
+  animation: hero-lock-breathe 4s var(--ease-in-out-smooth) infinite;
+}
+
+.feature-card-hero-locked-container .feature-card-hero-lock {
   color: rgb(226 198 134);
   filter: drop-shadow(0 0 10px rgb(226 198 134 / 24%));
-  animation: hero-lock-breathe 4s var(--ease-in-out-smooth) infinite;
+}
+
+.feature-card-hero-locked-door .feature-card-hero-lock {
+  color: rgb(189 216 238);
+  filter: drop-shadow(0 0 10px rgb(189 216 238 / 28%));
 }
 
 .feature-card-hero-lock-svg {
@@ -3682,6 +3702,12 @@ body {
 @keyframes hero-lock-breathe {
   0%, 100% { transform: scale(1); opacity: 0.92; }
   50% { transform: scale(1.04); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .feature-card-hero-lock {
+    animation: none;
+  }
 }
 
 .feature-card-hero-copy {
@@ -3704,6 +3730,18 @@ body {
   font-size: 0.86rem;
 }
 
+.feature-card-hero-direction {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgb(10 12 22 / 34%);
+  color: var(--text-primary);
+  font-size: 0.8rem;
+}
+
 .feature-card-hero-actions {
   display: flex;
   justify-content: center;
@@ -3713,13 +3751,26 @@ body {
 .feature-card-action-primary {
   padding: 10px 22px;
   font-size: 0.9rem;
+}
+
+.feature-card-hero-locked-container .feature-card-action-primary {
   border-color: rgb(226 198 134 / 46%);
   background: linear-gradient(135deg, rgb(164 136 82 / 70%), rgb(124 102 62 / 64%));
 }
 
-.feature-card-action-primary:hover {
+.feature-card-hero-locked-container .feature-card-action-primary:hover {
   border-color: rgb(240 214 150 / 70%);
   background: linear-gradient(135deg, rgb(188 158 100 / 80%), rgb(142 118 74 / 72%));
+}
+
+.feature-card-hero-locked-door .feature-card-action-primary {
+  border-color: rgb(156 190 228 / 50%);
+  background: linear-gradient(135deg, rgb(88 120 168 / 72%), rgb(66 92 136 / 66%));
+}
+
+.feature-card-hero-locked-door .feature-card-action-primary:hover {
+  border-color: rgb(186 214 240 / 70%);
+  background: linear-gradient(135deg, rgb(110 144 196 / 82%), rgb(82 112 160 / 74%));
 }
 
 .skills-combat-panel {


### PR DESCRIPTION
## Summary

Doors now get the same one-click / locked-hero polish the containers
got in #1026 and #1051. A single locked door in a room renders a
centered hero card with the breathing lock glyph, a prominent Unlock
action, and a directional badge showing where the door leads.

Changes:

- **Shared hero primitive** (`WorldFeaturesPopout.tsx`): extract
  `LockedFeatureHero` — one layout, one SVG lock glyph, configurable
  kind label + subtitle + tint class.
- **`LockedContainerHero`** routes through the primitive (no visual
  change; still gold-tinted with the "key required" subtitle).
- **`LockedDoorHero`** renders when the active door tab has exactly one
  feature and it's locked. Blue-tinted, with a "Leads <direction>"
  badge below the subtitle when the door has a direction.
- **CSS**: split `.feature-card-hero-locked` into shared layout/shadow
  and two variant classes (`-container`, `-door`) that re-tint the
  background gradient, glyph color/glow, and primary-action button
  gradient. `prefers-reduced-motion` disables the breathing animation.

The one-click unlock-to-open behaviour from #1051 is unchanged — manual
`unlock <door>` already resolves to OPEN on the server, so the hero's
Unlock button walks a player with the key straight through in one step.
Closed-but-unlocked doors keep their existing one-click open path on
the canvas badge.

## Test plan

- [x] `bun run lint` — clean
- [x] `bunx tsc -b` — clean
- [x] `bun run build` — builds successfully
- [ ] Manual: enter a room with a single locked door → hero card
  appears with the breathing lock glyph, the "Leads <dir>" badge, and a
  blue-tinted Unlock button.
- [ ] Manual: click Unlock on a locked door you hold the key for → the
  door opens and you step through in a single action (regression check
  for #1051).
- [ ] Manual: enter a room with a single locked chest → still gets the
  existing gold-tinted container hero (regression check for #1026).
- [ ] Manual: enter a room with multiple doors (at least one locked) →
  each renders as a normal compact card, no hero treatment.
- [ ] Manual: enable `prefers-reduced-motion` → lock glyph stops
  breathing for both container and door variants.

Fixes #1032