### PR TITLE
Fix pet image URL prefix and dismiss broadcast (#1068, #1069)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -1040,7 +1040,11 @@ class CombatSystem(
                 exclude = ownerSid,
             )
             threatTable.removePlayer(petSid)
+            val petRoomId = pet.roomId
             petSystem?.dismissOne(pet.id)
+            // Mirror the mob-death cleanup so the pet disappears from canvas/sidebar
+            // without waiting for a room change. See issue #1069.
+            callbacks.onMobRemoved(pet.id, petRoomId)
         }
     }
 

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -289,7 +289,9 @@ class GameEngine(
             onPlayerLoggedOut = { player, sid ->
                 log.info { "Player logged out: name=${player.name} sessionId=$sid" }
                 puzzleSystem.removeSession(sid)
-                petSystem.onOwnerDisconnect(sid)
+                for (dismissed in petSystem.onOwnerDisconnect(sid)) {
+                    broadcastPetRemoved(dismissed)
+                }
                 tradeSystem.cancelForPlayer(sid)
                 val endedDuel = duelSystem.onPlayerDisconnect(sid)
                 if (endedDuel != null) {
@@ -671,6 +673,7 @@ class GameEngine(
         config = engineConfig.pets,
         mobs = mobs,
         clock = clock,
+        imagesBaseUrl = imagesBaseUrl,
     )
     private val combatSystem =
         CombatSystem(
@@ -1544,6 +1547,9 @@ class GameEngine(
                             ),
                         )
                         emitPetState(expired.ownerSessionId, null)
+                        broadcastPetRemoved(
+                            PetSystem.DismissedPet(expired.petId, expired.roomId, expired.petName),
+                        )
                     }
 
                     // Tick world time — broadcast on period change
@@ -2123,7 +2129,9 @@ class GameEngine(
         }
 
         // Dismiss active pets
-        petSystem.dismissAll(sessionId)
+        for (dismissed in petSystem.dismissAll(sessionId)) {
+            broadcastPetRemoved(dismissed)
+        }
 
         // Clear status effects (stop DOTs ticking on a corpse)
         statusEffectSystem.removeAllFromPlayer(sessionId)
@@ -2404,6 +2412,19 @@ class GameEngine(
         2 -> "2nd"
         3 -> "3rd"
         else -> "${n}th"
+    }
+
+    /**
+     * Broadcasts `Room.RemoveMob` and a refreshed `Room.MobInfo` to every player in the
+     * pet's room so the canvas / sidebar mob list updates immediately when a pet is
+     * dismissed (manual command, duration expiry, owner disconnect, pet death).
+     * Mirrors the summon-side broadcast added in #1067 — see issue #1069.
+     */
+    private suspend fun broadcastPetRemoved(dismissed: PetSystem.DismissedPet) {
+        gmcpEmitter.broadcastRoomRemoveMob(dismissed.roomId, dismissed.petId.value, players)
+        val mobsInRoom = mobs.mobsInRoom(dismissed.roomId)
+        val mobInfoEntries = gmcpEmitter.buildMobInfoEntries(mobsInRoom)
+        gmcpEmitter.broadcastRoomMobInfo(dismissed.roomId, mobInfoEntries, players)
     }
 
     private suspend fun emitPetState(sessionId: SessionId, pet: dev.ambon.domain.mob.MobState?) {

--- a/src/main/kotlin/dev/ambon/engine/PetSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/PetSystem.kt
@@ -28,7 +28,11 @@ class PetSystem(
     private val config: PetConfig,
     private val mobs: MobRegistry,
     private val clock: Clock,
+    imagesBaseUrl: String = "/images/",
 ) {
+    /** Trailing-slash-normalized base for resolving pet template image paths. */
+    private val imagesBase: String = if (imagesBaseUrl.endsWith("/")) imagesBaseUrl else "$imagesBaseUrl/"
+
     /** Tracks expiry time for timed pets. Key = MobId, value = wall-clock ms when the pet expires. */
     private val expiryTimes = mutableMapOf<MobId, Long>()
 
@@ -87,7 +91,7 @@ class PetSystem(
             armor = template.armor,
             xpReward = 0L,
             templateKey = templateKey,
-            image = template.image,
+            image = resolveImage(template.image),
             ownerSessionId = ownerSid,
             ownerName = ownerName,
             spells = petSpells,
@@ -124,7 +128,7 @@ class PetSystem(
             if (now >= expiresAt) {
                 val pet = mobs.get(mobId)
                 if (pet != null) {
-                    expired.add(ExpiredPet(pet.ownerSessionId!!, pet.name))
+                    expired.add(ExpiredPet(pet.ownerSessionId!!, pet.name, mobId, pet.roomId))
                     removePetSession(mobId)
                     mobs.remove(mobId)
                 }
@@ -134,16 +138,21 @@ class PetSystem(
         return expired
     }
 
-    /** Dismisses all pets owned by a player. Returns dismissed pet count. */
-    fun dismissAll(ownerSid: SessionId): Int {
+    /**
+     * Dismisses all pets owned by a player. Returns the dismissed pets so callers can
+     * broadcast `Room.RemoveMob` / refreshed `Room.MobInfo` to the rooms they were in
+     * (issue #1069 — dismissed pet must disappear immediately, not on next room change).
+     */
+    fun dismissAll(ownerSid: SessionId): List<DismissedPet> {
         val pets = getPets(ownerSid)
+        val dismissed = pets.map { DismissedPet(it.id, it.roomId, it.name) }
         for (pet in pets) {
             expiryTimes.remove(pet.id)
             removePetSession(pet.id)
             mobs.remove(pet.id)
             log.debug { "Pet dismissed: ${pet.name} (${pet.id})" }
         }
-        return pets.size
+        return dismissed
     }
 
     /** Moves all pets to follow their owner to a new room. */
@@ -153,10 +162,11 @@ class PetSystem(
         }
     }
 
-    /** Called on owner disconnect — dismisses all pets. */
-    fun onOwnerDisconnect(ownerSid: SessionId) {
-        dismissAll(ownerSid)
-    }
+    /**
+     * Called on owner disconnect — dismisses all pets. Returns the dismissed pets so the
+     * caller can broadcast `Room.RemoveMob` to anyone left in their rooms (issue #1069).
+     */
+    fun onOwnerDisconnect(ownerSid: SessionId): List<DismissedPet> = dismissAll(ownerSid)
 
     fun clear() {
         expiryTimes.clear()
@@ -179,13 +189,15 @@ class PetSystem(
     /** Returns the synthetic SessionId for a pet, or null if the pet has no threat entry. */
     fun getPetSessionId(petId: MobId): SessionId? = petToSession[petId]
 
-    /** Removes a single pet by MobId (e.g. on pet death). */
-    fun dismissOne(petId: MobId) {
-        val pet = mobs.get(petId) ?: return
+    /** Removes a single pet by MobId (e.g. on pet death). Returns the dismissed pet, or null if not found. */
+    fun dismissOne(petId: MobId): DismissedPet? {
+        val pet = mobs.get(petId) ?: return null
+        val dismissed = DismissedPet(pet.id, pet.roomId, pet.name)
         expiryTimes.remove(petId)
         removePetSession(petId)
         mobs.remove(petId)
         log.debug { "Pet dismissed: ${pet.name} ($petId)" }
+        return dismissed
     }
 
     private fun removePetSession(petId: MobId) {
@@ -214,5 +226,26 @@ class PetSystem(
     data class ExpiredPet(
         val ownerSessionId: SessionId,
         val petName: String,
+        val petId: MobId,
+        val roomId: RoomId,
     )
+
+    /** Snapshot of a pet that was just removed — used by callers to broadcast room updates. */
+    data class DismissedPet(
+        val petId: MobId,
+        val roomId: RoomId,
+        val petName: String,
+    )
+
+    /**
+     * Resolve a pet template's image path against the configured CDN/local base, mirroring
+     * how mob images are prefixed in `WorldLoader`. Bare relative paths previously slipped
+     * through and resolved against the MUD host instead of the asset host (issue #1068).
+     * Already-absolute URLs (`http(s)://…`) and explicit roots (`/…`) are returned unchanged.
+     */
+    private fun resolveImage(raw: String?): String? {
+        if (raw == null) return null
+        if (raw.startsWith("http://") || raw.startsWith("https://") || raw.startsWith("/")) return raw
+        return "$imagesBase$raw"
+    }
 }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/PetHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/PetHandler.kt
@@ -14,6 +14,7 @@ class PetHandler(
     private val petSystem: PetSystem,
 ) : CommandHandler {
     private val players = ctx.players
+    private val mobs = ctx.mobs
     private val outbound = ctx.outbound
     private val gmcpEmitter = ctx.gmcpEmitter
 
@@ -68,7 +69,7 @@ class PetHandler(
         }
 
         val petName = pet.name
-        petSystem.dismissAll(sessionId)
+        val dismissed = petSystem.dismissAll(sessionId)
         val message = "You dismiss $petName."
         outbound.send(OutboundEvent.SendInfo(sessionId, message))
         sendScopedFeedback(
@@ -84,6 +85,19 @@ class PetHandler(
         players.withPlayer(sessionId) { me ->
             broadcastToRoom(me.roomId, "$petName vanishes.", players, outbound)
         }
+        // Refresh the room mob list for the dismisser and bystanders so the pet disappears
+        // immediately instead of lingering until next room change. See issue #1069.
+        for (entry in dismissed) {
+            broadcastPetRemoved(entry)
+        }
+    }
+
+    private suspend fun broadcastPetRemoved(dismissed: PetSystem.DismissedPet) {
+        val emitter = gmcpEmitter ?: return
+        emitter.broadcastRoomRemoveMob(dismissed.roomId, dismissed.petId.value, players)
+        val mobsInRoom = mobs.mobsInRoom(dismissed.roomId)
+        val mobInfoEntries = emitter.buildMobInfoEntries(mobsInRoom)
+        emitter.broadcastRoomMobInfo(dismissed.roomId, mobInfoEntries, players)
     }
 
     private suspend fun handlePetName(sessionId: SessionId, cmd: Command.PetName) {

--- a/src/test/kotlin/dev/ambon/engine/PetImageAndDismissTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/PetImageAndDismissTest.kt
@@ -1,0 +1,184 @@
+package dev.ambon.engine
+
+import dev.ambon.config.PetConfig
+import dev.ambon.config.PetTemplateConfig
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.test.AbilityTestFixture
+import dev.ambon.test.MutableClock
+import dev.ambon.test.TEST_ROOM_ID
+import dev.ambon.test.drainAll
+import dev.ambon.test.loginOrFail
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression tests for pet image URL prefix (issue #1068) and pet dismiss visibility
+ * (issue #1069 — companion to #1066 on the removal side).
+ *
+ * Both bugs share the same shape: pet template state was used as-is when summoning,
+ * skipping the asset-URL helper that other mob/item paths run through, and the
+ * removal-side dismiss didn't notify other players in the room.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PetImageAndDismissTest {
+    private val roomId: RoomId = TEST_ROOM_ID
+    private val ownerSid = SessionId(1L)
+    private val bystanderSid = SessionId(2L)
+
+    private val petConfig = PetConfig(
+        definitions = mapOf(
+            "fire_familiar" to PetTemplateConfig(
+                name = "a fire familiar",
+                description = "A small elemental of living flame.",
+                hp = 20,
+                minDamage = 2,
+                maxDamage = 5,
+                armor = 1,
+                image = "pets/fire_familiar.png",
+            ),
+        ),
+    )
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Issue #1068 — pet image must be resolved against the asset host.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `pet image is resolved against the configured asset host (issue 1068)`() {
+        val pets = PetSystem(
+            config = petConfig,
+            mobs = MobRegistry(),
+            clock = MutableClock(0L),
+            imagesBaseUrl = "https://auringold.ambon.dev/img/",
+        )
+
+        val pet = pets.summon(ownerSid, "fire_familiar", roomId, ownerLevel = 1)!!
+
+        assertTrue(
+            pet.image == "https://auringold.ambon.dev/img/pets/fire_familiar.png",
+            "expected prefixed asset URL, got=${pet.image}",
+        )
+    }
+
+    @Test
+    fun `pet image without trailing slash on base still resolves correctly`() {
+        val pets = PetSystem(
+            config = petConfig,
+            mobs = MobRegistry(),
+            clock = MutableClock(0L),
+            imagesBaseUrl = "https://auringold.ambon.dev/img",
+        )
+
+        val pet = pets.summon(ownerSid, "fire_familiar", roomId, ownerLevel = 1)!!
+        assertTrue(
+            pet.image == "https://auringold.ambon.dev/img/pets/fire_familiar.png",
+            "expected normalized URL, got=${pet.image}",
+        )
+    }
+
+    @Test
+    fun `pet image left untouched when template image is null`() {
+        val cfg = PetConfig(definitions = mapOf("no_img" to PetTemplateConfig(name = "a wisp")))
+        val pets = PetSystem(config = cfg, mobs = MobRegistry(), clock = MutableClock(0L), imagesBaseUrl = "https://x/")
+        val pet = pets.summon(ownerSid, "no_img", roomId, ownerLevel = 1)!!
+        assertNull(pet.image)
+    }
+
+    @Test
+    fun `pet image left untouched when template path is already absolute`() {
+        val cfg = PetConfig(
+            definitions = mapOf(
+                "abs" to PetTemplateConfig(name = "a wisp", image = "https://other.cdn.example/p.png"),
+            ),
+        )
+        val pets = PetSystem(config = cfg, mobs = MobRegistry(), clock = MutableClock(0L), imagesBaseUrl = "https://x/")
+        val pet = pets.summon(ownerSid, "abs", roomId, ownerLevel = 1)!!
+        assertTrue(pet.image == "https://other.cdn.example/p.png", "got=${pet.image}")
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Issue #1069 — dismissed pet must broadcast Room.RemoveMob immediately.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `manual dismiss broadcasts Room_RemoveMob to summoner and bystanders (issue 1069)`() = runTest {
+        val fixture = AbilityTestFixture(roomId = roomId)
+        val pets = PetSystem(
+            config = petConfig,
+            mobs = fixture.mobs,
+            clock = fixture.clock,
+            imagesBaseUrl = "https://auringold.ambon.dev/img/",
+        )
+        val gmcp = GmcpEmitter(outbound = fixture.outbound, supportsPackage = { _, _ -> true })
+
+        fixture.players.loginOrFail(ownerSid, "Owner")
+        fixture.players.loginOrFail(bystanderSid, "Bystander")
+        val pet = pets.summon(ownerSid, "fire_familiar", roomId, ownerLevel = 1)!!
+        fixture.outbound.drainAll()
+
+        // Mirror what PetHandler/GameEngine do after dismissAll: broadcast removal
+        // (and refreshed Room.MobInfo) for every dismissed pet.
+        val dismissed = pets.dismissAll(ownerSid)
+        for (entry in dismissed) {
+            gmcp.broadcastRoomRemoveMob(entry.roomId, entry.petId.value, fixture.players)
+            val mobInfo = gmcp.buildMobInfoEntries(fixture.mobs.mobsInRoom(entry.roomId))
+            gmcp.broadcastRoomMobInfo(entry.roomId, mobInfo, fixture.players)
+        }
+
+        val gmcpEvents = fixture.outbound.drainAll().filterIsInstance<OutboundEvent.GmcpData>()
+        val ownerRemove = gmcpEvents.filter { it.sessionId == ownerSid && it.gmcpPackage == "Room.RemoveMob" }
+        val bystanderRemove = gmcpEvents.filter { it.sessionId == bystanderSid && it.gmcpPackage == "Room.RemoveMob" }
+        assertTrue(ownerRemove.isNotEmpty(), "summoner must receive Room.RemoveMob on dismiss")
+        assertTrue(bystanderRemove.isNotEmpty(), "bystander must receive Room.RemoveMob on dismiss")
+        assertTrue(
+            ownerRemove.all { it.jsonData.contains(pet.id.value) },
+            "Room.RemoveMob payload must reference the dismissed pet id — got=${ownerRemove.map { it.jsonData }}",
+        )
+
+        val ownerMobInfo = gmcpEvents.filter { it.sessionId == ownerSid && it.gmcpPackage == "Room.MobInfo" }
+        val bystanderMobInfo = gmcpEvents.filter { it.sessionId == bystanderSid && it.gmcpPackage == "Room.MobInfo" }
+        assertTrue(ownerMobInfo.isNotEmpty(), "summoner must receive companion Room.MobInfo")
+        assertTrue(bystanderMobInfo.isNotEmpty(), "bystander must receive companion Room.MobInfo")
+    }
+
+    @Test
+    fun `duration expiry returns the pet's room so callers can broadcast (issue 1069)`() {
+        val clock = MutableClock(0L)
+        val pets = PetSystem(
+            config = petConfig,
+            mobs = MobRegistry(),
+            clock = clock,
+            imagesBaseUrl = "/images/",
+        )
+        val pet = pets.summon(ownerSid, "fire_familiar", roomId, ownerLevel = 1, durationMs = 5_000L)!!
+
+        clock.advance(5_000L)
+        val expired = pets.tick()
+        assertTrue(expired.size == 1, "expected one expired pet, got=$expired")
+        val ex = expired.single()
+        assertTrue(ex.petId == pet.id, "expired entry must carry the petId for broadcast routing")
+        assertTrue(ex.roomId == roomId, "expired entry must carry the roomId for broadcast routing")
+    }
+
+    @Test
+    fun `onOwnerDisconnect returns dismissed pets so callers can broadcast (issue 1069)`() {
+        val pets = PetSystem(
+            config = petConfig,
+            mobs = MobRegistry(),
+            clock = MutableClock(0L),
+            imagesBaseUrl = "/images/",
+        )
+        val pet = pets.summon(ownerSid, "fire_familiar", roomId, ownerLevel = 1)!!
+
+        val dismissed = pets.onOwnerDisconnect(ownerSid)
+        assertTrue(dismissed.size == 1, "onOwnerDisconnect must return dismissed pets, got=$dismissed")
+        val entry = dismissed.single()
+        assertTrue(entry.petId == pet.id)
+        assertTrue(entry.roomId == roomId)
+    }
+}


### PR DESCRIPTION
## Summary

Two pet-related playtest bugs in one PR (both narrow and isolated).

### #1068 — pet image resolved against MUD host instead of asset host
`PetTemplateConfig.image` was passed straight through to `MobState.image` without running through the asset-URL helper that `WorldLoader` applies to every other mob image. The lore overlay then resolved the bare relative path against `mud.ambon.dev` instead of `auringold.ambon.dev`.

Fix: thread `imagesBaseUrl` into `PetSystem` and prefix `template.image` in `summon()`, mirroring `WorldLoader.imagesBase`. Already-absolute URLs (`http(s)://…`) and explicit roots (`/…`) pass through unchanged. Once `MobState.image` carries the resolved URL, every downstream payload (`Char.Pet`, `Room.Mobs`, `Room.AddMob`, `Room.UpdateMob`) gets the correct host for free.

### #1069 — dismissed pet lingered until the player walked away
Companion to #1066 (summon-side fix in #1067) on the removal side. Engine removed the pet from `MobRegistry` but never broadcast `Room.RemoveMob` or refreshed `Room.MobInfo`, so canvas / sidebar mob list kept showing the pet until the next room change re-emitted `Room.Mobs`.

Fix: `PetSystem.dismissAll` / `dismissOne` / `onOwnerDisconnect` now return `DismissedPet(petId, roomId, name)` snapshots, and `tick()` / `ExpiredPet` carry the same fields. Each dismiss path broadcasts:
- manual `pet dismiss` — `PetHandler.handlePetDismiss`
- duration expiry — `GameEngine` pet-tick block
- owner disconnect — `GameEngine.onPlayerLoggedOut`
- player death — `GameEngine.cleanupOnPlayerDeath`
- pet death in combat — `CombatSystem.executeMobMeleeOnPet` now invokes `callbacks.onMobRemoved`, reusing the `Room.RemoveMob` broadcast `GameEngine` already wires for regular mob deaths

## Test plan

- [x] `./gradlew.bat test -x buildWeb` — full suite green
- [x] `./gradlew.bat ktlintCheck -x buildWeb` — clean
- [x] New `PetImageAndDismissTest`:
  - `summon` produces `https://auringold.ambon.dev/img/…` URL
  - trailing-slash normalization, null pass-through, absolute-URL pass-through
  - end-to-end: summon then `dismissAll` triggers `Room.RemoveMob` + `Room.MobInfo` for owner and bystander
  - duration expiry and `onOwnerDisconnect` return room/petId so the engine wiring can broadcast
- [ ] Manual playtest: cast a pet-summon ability, check the lore overlay image loads from `auringold.ambon.dev`, then `pet dismiss` and confirm the pet sprite disappears from the canvas immediately

Fixes #1068
Fixes #1069