### PR TITLE
Emit combat log events for pet attacks

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -657,6 +657,15 @@ class CombatSystem(
                 outbound.send(
                     OutboundEvent.SendText(sessionId, "${pet.name} hits ${mob.name} for $petDamage damage."),
                 )
+                onCombatEvent(
+                    sessionId,
+                    CombatEvent.PetHit(
+                        petName = pet.name,
+                        targetName = mob.name,
+                        targetId = mob.id.value,
+                        damage = petDamage,
+                    ),
+                )
                 broadcastToRoom(
                     players,
                     outbound,
@@ -1019,6 +1028,14 @@ class CombatSystem(
         dirtyNotifier.mobHpDirty(pet.id)
         outbound.send(
             OutboundEvent.SendText(ownerSid, "${mob.name} hits ${pet.name} for $petDamage damage."),
+        )
+        onCombatEvent(
+            ownerSid,
+            CombatEvent.PetHurt(
+                petName = pet.name,
+                attackerName = mob.name,
+                damage = petDamage,
+            ),
         )
         broadcastToRoom(
             players,

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -927,6 +927,19 @@ class GmcpEmitter(
                 absorbed = event.absorbed,
                 shieldRemaining = event.remaining,
             )
+            is CombatEvent.PetHit -> CombatEventPayload(
+                type = "petHit",
+                petName = event.petName,
+                targetName = event.targetName,
+                targetId = event.targetId,
+                damage = event.damage,
+            )
+            is CombatEvent.PetHurt -> CombatEventPayload(
+                type = "petHurt",
+                petName = event.petName,
+                attackerName = event.attackerName,
+                damage = event.damage,
+            )
         }
         emit(sessionId, "Char.Combat.Event", payload, supportCheck = "Char.Combat.Event")
     }
@@ -2484,6 +2497,7 @@ class GmcpEmitter(
         val attackerName: String? = null,
         val absorbed: Int? = null,
         val shieldRemaining: Int? = null,
+        val petName: String? = null,
     )
 
     // ---------- stats payload ----------

--- a/src/main/kotlin/dev/ambon/engine/events/CombatEvent.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/CombatEvent.kt
@@ -60,4 +60,17 @@ sealed interface CombatEvent {
         val absorbed: Int,
         val remaining: Int,
     ) : CombatEvent
+
+    data class PetHit(
+        val petName: String,
+        val targetName: String,
+        val targetId: String?,
+        val damage: Int,
+    ) : CombatEvent
+
+    data class PetHurt(
+        val petName: String,
+        val attackerName: String,
+        val damage: Int,
+    ) : CombatEvent
 }

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -944,6 +944,7 @@ export function applyGmcpPackage(
         attackerName: typeof packet.attackerName === "string" ? packet.attackerName : null,
         xpGained: safeNumber(packet.xpGained),
         goldGained: safeNumber(packet.goldGained),
+        petName: typeof packet.petName === "string" ? packet.petName : null,
       });
       break;
     }

--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -108,6 +108,10 @@ function combatEventToLogMessage(event: CombatEventData): CombatLogMessage | nul
       return event.sourceIsPlayer
         ? { id, text: `You hit ${event.targetName} for ${event.damage} damage.`, style: "damage", receivedAt: now }
         : { id, text: `${event.targetName} hits you for ${event.damage} damage!`, style: "damage", receivedAt: now };
+    case "petHit":
+      return { id, text: `${event.petName ?? "Your pet"} hits ${event.targetName} for ${event.damage} damage.`, style: "damage", receivedAt: now };
+    case "petHurt":
+      return { id, text: `${event.attackerName} hits ${event.petName ?? "your pet"} for ${event.damage} damage!`, style: "damage", receivedAt: now };
     case "abilityHit":
       return event.sourceIsPlayer
         ? { id, text: `Your ${event.abilityName} hits ${event.targetName} for ${event.damage} damage.`, style: "damage", receivedAt: now }

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -415,6 +415,7 @@ export interface CombatEventData {
   attackerName: string | null;
   xpGained: number;
   goldGained: number;
+  petName: string | null;
 }
 
 export interface StatEntry {


### PR DESCRIPTION
## Summary
- Pet attacks and mob-on-pet hits now emit `CombatEvent.PetHit` / `CombatEvent.PetHurt` alongside the existing `SendText`, so they surface in the web client's combat log overlay (which is driven by `Char.Combat.Event` GMCP packets).
- Adds a `petName` field to the GMCP `Char.Combat.Event` payload and renders both variants in `combatEventToLogMessage`, styled as `damage` so they respect the existing Dmg filter.

## Why
Pets were fully participating in combat (damage, threat, tanking) but the web UI only logged the player's own hits, making it look like pets weren't contributing. This closes that gap without changing combat mechanics.

## Test plan
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew test --tests "*TankPetCombat*" --tests "*CombatSystem*"`
- [x] `bun run lint` in `web-v3/`
- [ ] Manual: summon a ranger pet, engage a mob, confirm pet hits appear in the in-game combat log overlay (and mob-on-pet hits for `bear_guardian`).