### PR TITLE
Add achievement-gated exits

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/world/Room.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/Room.kt
@@ -2,6 +2,12 @@ package dev.ambon.domain.world
 
 import dev.ambon.domain.ids.RoomId
 
+/** Per-character achievement gate on an exit. */
+data class AchievementGate(
+    val achievementId: String,
+    val lockedMessage: String?,
+)
+
 data class Room(
     val id: RoomId,
     val title: String,
@@ -9,6 +15,8 @@ data class Room(
     val exits: Map<Direction, RoomId>,
     /** Directions whose targets are in zones not loaded on this engine (cross-zone stubs). */
     val remoteExits: Set<Direction> = emptySet(),
+    /** Directions whose exits require the player to have unlocked a given achievement. */
+    val achievementGates: Map<Direction, AchievementGate> = emptyMap(),
     /** Stateful features in this room: doors, containers, levers, signs. */
     val features: List<RoomFeature> = emptyList(),
     /** Crafting station available in this room, if any. */

--- a/src/main/kotlin/dev/ambon/domain/world/data/ExitValue.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/ExitValue.kt
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode
  *   n: inner_keep
  * ```
  *
- * Object form with optional door block:
+ * Object form with optional door block and/or achievement gate:
  * ```yaml
  * exits:
  *   n:
@@ -25,11 +25,19 @@ import com.fasterxml.jackson.databind.node.ObjectNode
  *       keyItemId: zone:iron_key
  *       keyConsumed: false
  *       resetWithZone: true
+ *     requiresAchievement: academy_boss_slain
+ *     lockedMessage: "The door is sealed until you prove yourself in the Academy."
  * ```
+ *
+ * `requiresAchievement` is a per-player gate: the exit only resolves for characters
+ * whose `unlockedAchievementIds` contains the given id. `lockedMessage` is the text
+ * shown when a character without the achievement tries to move through it.
  */
 data class ExitValue(
     val to: String,
     val door: DoorFile? = null,
+    val requiresAchievement: String? = null,
+    val lockedMessage: String? = null,
 )
 
 class ExitValueDeserializer : StdDeserializer<ExitValue>(ExitValue::class.java) {
@@ -53,6 +61,15 @@ class ExitValueDeserializer : StdDeserializer<ExitValue>(ExitValue::class.java) 
             } else {
                 null
             }
-        ExitValue(to = to, door = door)
+        val requiresAchievement =
+            node.get("requiresAchievement")?.asText()?.trim()?.takeUnless { it.isEmpty() }
+        val lockedMessage =
+            node.get("lockedMessage")?.asText()?.takeUnless { it.isEmpty() }
+        ExitValue(
+            to = to,
+            door = door,
+            requiresAchievement = requiresAchievement,
+            lockedMessage = lockedMessage,
+        )
     }
 }

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -35,6 +35,7 @@ import dev.ambon.domain.puzzle.PuzzleType
 import dev.ambon.domain.quest.QuestDef
 import dev.ambon.domain.quest.QuestObjectiveDef
 import dev.ambon.domain.quest.QuestRewards
+import dev.ambon.domain.world.AchievementGate
 import dev.ambon.domain.world.Direction
 import dev.ambon.domain.world.ItemSpawn
 import dev.ambon.domain.world.LeverState
@@ -131,6 +132,7 @@ object WorldLoader {
         // Normalize + merge all rooms
         val mergedRooms = LinkedHashMap<RoomId, Room>()
         val allExits = LinkedHashMap<RoomId, Map<Direction, RoomId>>() // staged exits per room
+        val allGates = LinkedHashMap<RoomId, Map<Direction, AchievementGate>>() // staged per-room achievement gates
         val allRoomFeatures = LinkedHashMap<RoomId, MutableList<RoomFeature>>() // staged features per room
         val mergedMobs = LinkedHashMap<MobId, MobSpawn>()
         val mergedItems = LinkedHashMap<ItemId, ItemSpawn>()
@@ -221,12 +223,19 @@ object WorldLoader {
             for ((rawId, rf) in file.rooms) {
                 val fromId = normalizeId(zone, rawId)
                 val featList = allRoomFeatures.getOrPut(fromId) { mutableListOf() }
+                val gatesForRoom = mutableMapOf<Direction, AchievementGate>()
                 val exits: Map<Direction, RoomId> =
                     rf.exits
                         .map { (dirStr, exitValue) ->
                             val dir =
                                 parseDirectionOrNull(dirStr)
                                     ?: throw WorldLoadException("Room ‘${fromId.value}’ has invalid direction ‘$dirStr’")
+                            exitValue.requiresAchievement?.let { achievementId ->
+                                gatesForRoom[dir] = AchievementGate(
+                                    achievementId = achievementId,
+                                    lockedMessage = exitValue.lockedMessage,
+                                )
+                            }
                             val doorFile = exitValue.door
                             if (doorFile != null) {
                                 val doorKeyItemId =
@@ -257,6 +266,9 @@ object WorldLoader {
                         }.toMap()
 
                 allExits[fromId] = exits
+                if (gatesForRoom.isNotEmpty()) {
+                    allGates[fromId] = gatesForRoom
+                }
             }
 
             // Stage non-exit features (containers, levers, signs)
@@ -857,6 +869,7 @@ object WorldLoader {
             mergedRooms[fromId] = room.copy(
                 exits = exits,
                 remoteExits = remoteExits,
+                achievementGates = allGates[fromId] ?: emptyMap(),
                 features = allRoomFeatures[fromId] ?: emptyList(),
                 station = room.station,
             )

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
@@ -104,6 +104,13 @@ class NavigationHandler(
                 }
             }
 
+            val gate = room.achievementGates[cmd.dir]
+            if (gate != null && gate.achievementId !in me.unlockedAchievementIds) {
+                val msg = gate.lockedMessage ?: "The way is sealed to you."
+                outbound.send(OutboundEvent.SendText(sessionId, msg))
+                return
+            }
+
             // Housing exit: resolve dynamic destination
             if (housingSystem != null && housingSystem.isHouseExit(to)) {
                 val origin = housingSystem.resolveHouseExit(sessionId)

--- a/src/test/kotlin/dev/ambon/engine/commands/AchievementGateTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/AchievementGateTest.kt
@@ -1,0 +1,86 @@
+package dev.ambon.engine.commands
+
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.world.Direction
+import dev.ambon.engine.CombatSystem
+import dev.ambon.engine.LoginResult
+import dev.ambon.engine.MobRegistry
+import dev.ambon.engine.WorldStateRegistry
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.drainAll
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AchievementGateTest {
+    private val world = dev.ambon.test.TestWorlds.okAchievementGate
+    private val courtyard: RoomId = world.startRoom
+    private val cottage = RoomId("ok_achievement_gate:cottage")
+
+    @Test
+    fun `gated exit blocks movement without achievement`() =
+        runTest {
+            val h = harness()
+            h.router.handle(h.sid, Command.Move(Direction.NORTH))
+            val outs = h.outbound.drainAll()
+            assertTrue(
+                outs.any {
+                    it is OutboundEvent.SendText &&
+                        it.text.contains("prove yourself", ignoreCase = true)
+                },
+                "Expected locked-message feedback, got: $outs",
+            )
+            assertEquals(courtyard, h.players.get(h.sid)?.roomId)
+        }
+
+    @Test
+    fun `gated exit opens after achievement is unlocked`() =
+        runTest {
+            val h = harness()
+            // Grant the gating achievement to this character.
+            val player = h.players.get(h.sid)!!
+            player.unlockedAchievementIds = player.unlockedAchievementIds + "academy_boss_slain"
+
+            h.router.handle(h.sid, Command.Move(Direction.NORTH))
+            h.outbound.drainAll()
+            assertEquals(cottage, h.players.get(h.sid)?.roomId)
+        }
+
+    private data class Harness(
+        val sid: SessionId,
+        val players: dev.ambon.engine.PlayerRegistry,
+        val router: CommandRouter,
+        val outbound: LocalOutboundBus,
+    )
+
+    private suspend fun harness(): Harness {
+        val items = ItemRegistry()
+        items.loadSpawns(world.itemSpawns)
+        val outbound = LocalOutboundBus()
+        val players = dev.ambon.test.buildTestPlayerRegistry(courtyard, InMemoryPlayerRepository(), items)
+        val mobs = MobRegistry()
+        val worldState = WorldStateRegistry(world)
+        val router =
+            buildTestRouter(
+                world = world,
+                players = players,
+                mobs = mobs,
+                items = items,
+                combat = CombatSystem(players, mobs, items, outbound),
+                outbound = outbound,
+                worldState = worldState,
+            )
+        val sid = SessionId(1)
+        val res = players.login(sid, "Tester", "password")
+        require(res == LoginResult.Ok)
+        outbound.drainAll()
+        return Harness(sid, players, router, outbound)
+    }
+}

--- a/src/test/kotlin/dev/ambon/test/TestFixtures.kt
+++ b/src/test/kotlin/dev/ambon/test/TestFixtures.kt
@@ -65,6 +65,7 @@ object TestWorlds {
     val okSmall: World by lazy { WorldLoader.loadFromResource("world/ok_small.yaml") }
     val okFeatures: World by lazy { WorldLoader.loadFromResource("world/ok_features.yaml") }
     val okPuzzles: World by lazy { WorldLoader.loadFromResource("world/ok_puzzles.yaml") }
+    val okAchievementGate: World by lazy { WorldLoader.loadFromResource("world/ok_achievement_gate.yaml") }
 }
 
 object TestPasswordHasher : PasswordHasher {

--- a/src/test/resources/world/ok_achievement_gate.yaml
+++ b/src/test/resources/world/ok_achievement_gate.yaml
@@ -1,0 +1,17 @@
+zone: ok_achievement_gate
+lifespan: 1
+startRoom: courtyard
+rooms:
+  courtyard:
+    title: "Academy Courtyard"
+    description: "A quiet courtyard. A cottage lies to the north."
+    exits:
+      north:
+        to: cottage
+        requiresAchievement: academy_boss_slain
+        lockedMessage: "The cottage door is sealed until you prove yourself in the Academy."
+  cottage:
+    title: "Aineroia's Cottage"
+    description: "A warm, lived-in cottage."
+    exits:
+      south: courtyard


### PR DESCRIPTION
## Summary
- Extend the room-exit YAML schema with optional `requiresAchievement` and `lockedMessage` fields. When set, that direction only resolves for characters whose `unlockedAchievementIds` contains the given id; otherwise the locked message is shown and the move is blocked.
- Adds `Room.achievementGates: Map<Direction, AchievementGate>`, populated by `WorldLoader`, and the check in `NavigationHandler.handleMove` right after the existing door check.
- Backward compatible — existing string-form and door-only exits are untouched.

## Why
Gives world designers a narrative lever that ties story progression to meaningful milestones (e.g. open Aineroia's Cottage only after the Academy boss is slain) without inventing a shared-world door state or a key-item workaround. Achievements are per-character, so each alt re-runs any gated chain organically.

## Example YAML
```yaml
rooms:
  courtyard:
    title: "Academy Courtyard"
    exits:
      north:
        to: cottage
        requiresAchievement: academy_boss_slain
        lockedMessage: "The cottage door is sealed until you prove yourself in the Academy."
```

## Test plan
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew test --tests "*AchievementGate*" --tests "*WorldLoader*" --tests "*Navigation*" --tests "*CommandRouter*"`
- [ ] Manual: author a gated exit in a live zone, confirm blocked character sees the locked message and the move fails; grant the achievement, confirm the move succeeds.