### PR TITLE
Diminishing XP for over-leveled mob kills (#1047)

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -489,6 +489,14 @@ data class AppConfig(
         require(progression.xp.linearXp >= 0L) { "ambonMUD.progression.xp.linearXp must be >= 0" }
         require(progression.xp.multiplier >= 0.0) { "ambonMUD.progression.xp.multiplier must be >= 0" }
         require(progression.xp.defaultKillXp >= 0L) { "ambonMUD.progression.xp.defaultKillXp must be >= 0" }
+        progression.xp.diminishing.thresholds.forEachIndexed { index, t ->
+            require(t.levelsBelow >= 0) {
+                "ambonMUD.progression.xp.diminishing.thresholds[$index].levelsBelow must be >= 0"
+            }
+            require(t.multiplier in 0.0..1.0) {
+                "ambonMUD.progression.xp.diminishing.thresholds[$index].multiplier must be in [0.0, 1.0]"
+            }
+        }
         require(progression.rewards.hpPerLevel >= 0) { "ambonMUD.progression.rewards.hpPerLevel must be >= 0" }
         require(progression.rewards.manaPerLevel >= 0) { "ambonMUD.progression.rewards.manaPerLevel must be >= 0" }
         require(progression.rewards.baseHp >= 1) { "ambonMUD.progression.rewards.baseHp must be >= 1" }
@@ -1889,6 +1897,27 @@ data class XpCurveConfig(
     val linearXp: Long = 0L,
     val multiplier: Double = 1.0,
     val defaultKillXp: Long = 50L,
+    val diminishing: DiminishingXpConfig = DiminishingXpConfig(),
+)
+
+/**
+ * Per-kill XP diminishing returns based on the gap between the player's level
+ * and the mob's level. When enabled, kills on mobs [DiminishingXpThreshold.levelsBelow]
+ * or more below the player award only [DiminishingXpThreshold.multiplier] of the
+ * normal XP. The highest matching threshold wins.
+ */
+data class DiminishingXpConfig(
+    val enabled: Boolean = true,
+    val thresholds: List<DiminishingXpThreshold> =
+        listOf(
+            DiminishingXpThreshold(levelsBelow = 5, multiplier = 0.5),
+            DiminishingXpThreshold(levelsBelow = 10, multiplier = 0.1),
+        ),
+)
+
+data class DiminishingXpThreshold(
+    val levelsBelow: Int = 0,
+    val multiplier: Double = 1.0,
 )
 
 data class LevelRewardsConfig(

--- a/src/main/kotlin/dev/ambon/domain/mob/MobState.kt
+++ b/src/main/kotlin/dev/ambon/domain/mob/MobState.kt
@@ -39,6 +39,7 @@ data class MobState(
     override val defaultAttack: String? = null,
     /** Threat multiplier for pet combat. 0.0 = no threat generation (default). */
     val threatMultiplier: Double = 0.0,
+    override val level: Int = 1,
 ) : MobTemplate {
     val isPet: Boolean get() = ownerSessionId != null
 }

--- a/src/main/kotlin/dev/ambon/domain/mob/MobTemplate.kt
+++ b/src/main/kotlin/dev/ambon/domain/mob/MobTemplate.kt
@@ -17,6 +17,7 @@ interface MobTemplate {
     val damage: DamageRange
     val armor: Int
     val xpReward: Long
+    val level: Int
     val drops: List<MobDrop>
     val goldMin: Long
     val goldMax: Long

--- a/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
@@ -31,4 +31,5 @@ data class MobSpawn(
     val category: String = "humanoid",
     override val spells: List<MobSpell> = emptyList(),
     override val defaultAttack: String? = null,
+    override val level: Int = 1,
 ) : MobTemplate

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -396,6 +396,7 @@ object WorldLoader {
                         },
                         spells = spells,
                         defaultAttack = mf.defaultAttack,
+                        level = level,
                     )
             }
 

--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -1293,7 +1293,15 @@ class CombatSystem(
             val player = players.get(sid) ?: continue
             val equipStats = items.equipmentBonuses(sid).stats
             val totalBonusStat = player.stats[config.bindings.xpBonusStat] + equipStats[config.bindings.xpBonusStat]
-            val reward = progression.applyCharismaXpBonus(totalBonusStat, perPlayerXp)
+            val diminish = progression.diminishingKillXpMultiplier(player.level, mob.level)
+            val afterDiminish =
+                if (diminish >= 1.0) {
+                    perPlayerXp
+                } else {
+                    (perPlayerXp * diminish).toLong().coerceAtLeast(0L)
+                }
+            if (afterDiminish <= 0L) continue
+            val reward = progression.applyCharismaXpBonus(totalBonusStat, afterDiminish)
 
             val result = players.grantXp(sid, reward, progression) ?: continue
             metrics.onXpAwarded(reward, "kill")

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -1666,7 +1666,7 @@ class GmcpEmitter(
         val mid = mob.id.value
         MobInfoEntry(
             id = mid,
-            level = estimateMobLevel(mob.xpReward),
+            level = if (mob.level > 0) mob.level else estimateMobLevel(mob.xpReward),
             tier = "standard",
             questGiver = mob.questIds.isNotEmpty(),
             questAvailable = mid in questAvailableMobIds,

--- a/src/main/kotlin/dev/ambon/engine/PlayerProgression.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerProgression.kt
@@ -157,6 +157,29 @@ class PlayerProgression(
     fun killXpReward(mob: MobState): Long = scaledXp(mob.xpReward)
 
     /**
+     * Returns the XP multiplier for a kill given the player's level and the
+     * mob's level. When the player out-levels the mob by enough to match a
+     * configured diminishing-returns threshold, the corresponding multiplier is
+     * applied. The threshold with the largest `levelsBelow` that still fits
+     * the gap wins.
+     */
+    fun diminishingKillXpMultiplier(playerLevel: Int, mobLevel: Int): Double {
+        val cfg = config.xp.diminishing
+        if (!cfg.enabled || cfg.thresholds.isEmpty()) return 1.0
+        val gap = playerLevel - mobLevel
+        if (gap <= 0) return 1.0
+        var best: Double? = null
+        var bestLevelsBelow = -1
+        for (t in cfg.thresholds) {
+            if (gap >= t.levelsBelow && t.levelsBelow > bestLevelsBelow) {
+                best = t.multiplier
+                bestLevelsBelow = t.levelsBelow
+            }
+        }
+        return best ?: 1.0
+    }
+
+    /**
      * Applies an XP multiplier based on the configured xpBonusStat (+[bindings.xpBonusPerPoint] per
      * point above [PlayerState.BASE_STAT]) to [baseXp]. Returns [baseXp] unchanged if there is no bonus.
      */

--- a/src/main/kotlin/dev/ambon/engine/ZoneResetHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/ZoneResetHandler.kt
@@ -59,6 +59,7 @@ internal fun spawnToMobState(spawn: MobSpawn, world: World): MobState =
         category = spawn.category,
         spells = spawn.spells,
         defaultAttack = spawn.defaultAttack,
+        level = spawn.level,
     )
 
 /**

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
@@ -182,6 +182,7 @@ class AdminHandler(
                 drops = template.drops,
                 spawnRoomId = me.roomId,
                 image = template.image,
+                level = template.level,
             )
             mobs.upsert(spawned)
             broadcastToRoom(players, outbound, me.roomId, "${template.name} appears.")

--- a/src/main/kotlin/dev/ambon/engine/dungeon/DungeonManager.kt
+++ b/src/main/kotlin/dev/ambon/engine/dungeon/DungeonManager.kt
@@ -226,6 +226,7 @@ class DungeonManager(
                     image = mobSpawn.image,
                     video = mobSpawn.video,
                     category = mobSpawn.category,
+                    level = mobSpawn.level,
                 )
 
                 mobs.upsert(mob)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1921,6 +1921,15 @@ ambonmud:
       linearXp: 0
       multiplier: 1
       defaultKillXp: 10
+      # Diminishing returns when a player over-levels a mob. Largest matching
+      # `levelsBelow` wins. Prevents trivial trash farming from capping out XP.
+      diminishing:
+        enabled: true
+        thresholds:
+          - levelsBelow: 5
+            multiplier: 0.5
+          - levelsBelow: 10
+            multiplier: 0.1
     rewards:
       hpPerLevel: 2
       manaPerLevel: 1

--- a/src/test/kotlin/dev/ambon/engine/PlayerProgressionTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/PlayerProgressionTest.kt
@@ -2,6 +2,8 @@ package dev.ambon.engine
 
 import dev.ambon.config.ClassDefinitionConfig
 import dev.ambon.config.ClassEngineConfig
+import dev.ambon.config.DiminishingXpConfig
+import dev.ambon.config.DiminishingXpThreshold
 import dev.ambon.config.LevelRewardsConfig
 import dev.ambon.config.ProgressionConfig
 import dev.ambon.config.XpCurveConfig
@@ -251,5 +253,50 @@ class PlayerProgressionTest {
         assertEquals(12, player.baseMaxHp)
         assertEquals(12, player.maxHp)
         assertEquals(12, player.hp)
+    }
+
+    @Test
+    fun `diminishing returns applies largest matching threshold`() {
+        val progression =
+            PlayerProgression(
+                ProgressionConfig(
+                    xp = XpCurveConfig(
+                        diminishing = DiminishingXpConfig(
+                            enabled = true,
+                            thresholds = listOf(
+                                DiminishingXpThreshold(levelsBelow = 5, multiplier = 0.5),
+                                DiminishingXpThreshold(levelsBelow = 10, multiplier = 0.1),
+                            ),
+                        ),
+                    ),
+                ),
+            )
+
+        assertEquals(1.0, progression.diminishingKillXpMultiplier(playerLevel = 3, mobLevel = 3))
+        assertEquals(1.0, progression.diminishingKillXpMultiplier(playerLevel = 5, mobLevel = 1))
+        assertEquals(0.5, progression.diminishingKillXpMultiplier(playerLevel = 6, mobLevel = 1))
+        assertEquals(0.5, progression.diminishingKillXpMultiplier(playerLevel = 10, mobLevel = 1))
+        assertEquals(0.1, progression.diminishingKillXpMultiplier(playerLevel = 11, mobLevel = 1))
+        assertEquals(0.1, progression.diminishingKillXpMultiplier(playerLevel = 50, mobLevel = 1))
+        assertEquals(1.0, progression.diminishingKillXpMultiplier(playerLevel = 1, mobLevel = 10))
+    }
+
+    @Test
+    fun `diminishing returns disabled yields full xp`() {
+        val progression =
+            PlayerProgression(
+                ProgressionConfig(
+                    xp = XpCurveConfig(
+                        diminishing = DiminishingXpConfig(
+                            enabled = false,
+                            thresholds = listOf(
+                                DiminishingXpThreshold(levelsBelow = 1, multiplier = 0.0),
+                            ),
+                        ),
+                    ),
+                ),
+            )
+
+        assertEquals(1.0, progression.diminishingKillXpMultiplier(playerLevel = 50, mobLevel = 1))
     }
 }


### PR DESCRIPTION
## Summary
- Adds `progression.xp.diminishing` config — kills on mobs far below the player's level yield reduced XP. Default: -5 levels → 50%, -10 levels → 10%.
- Threads real mob `level` through `MobSpawn` → `MobState` (WorldLoader, ZoneResetHandler, DungeonManager, /spawn admin). `GmcpEmitter` prefers the real level; falls back to the xpReward estimator only for legacy mobs without one.
- Applied per group member in `CombatSystem.grantGroupKillXp`, so each recipient's own level controls the cut.

Closes #1047.

## Test plan
- [x] `./gradlew ktlintCheck test integrationTest` green
- [x] New `PlayerProgressionTest` cases: largest-threshold wins, disabled config yields 1.0