### PR TITLE
Add auto-loot toggle to character panel

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -443,6 +443,7 @@ class GmcpEmitter(
                 level = player.level,
                 sprite = resolveSprite(player),
                 isStaff = player.isStaff,
+                autolootEnabled = player.autolootEnabled,
             ),
         )
     }
@@ -2333,6 +2334,7 @@ class GmcpEmitter(
         val level: Int,
         val sprite: String,
         val isStaff: Boolean,
+        val autolootEnabled: Boolean,
     )
 
     private data class SessionAuthTokenPayload(

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/UiHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/UiHandler.kt
@@ -92,12 +92,12 @@ class UiHandler(
         when (action) {
             AutolootAction.ON -> {
                 players.setAutolootEnabled(sessionId, true)
-                players.get(sessionId)?.let { gmcpEmitter?.sendCharName(sessionId, it) }
+                gmcpEmitter?.sendCharName(sessionId, me)
                 outbound.send(OutboundEvent.SendInfo(sessionId, "Auto-loot enabled."))
             }
             AutolootAction.OFF -> {
                 players.setAutolootEnabled(sessionId, false)
-                players.get(sessionId)?.let { gmcpEmitter?.sendCharName(sessionId, it) }
+                gmcpEmitter?.sendCharName(sessionId, me)
                 outbound.send(OutboundEvent.SendInfo(sessionId, "Auto-loot disabled."))
             }
             AutolootAction.STATUS -> {

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/UiHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/UiHandler.kt
@@ -92,10 +92,12 @@ class UiHandler(
         when (action) {
             AutolootAction.ON -> {
                 players.setAutolootEnabled(sessionId, true)
+                players.get(sessionId)?.let { gmcpEmitter?.sendCharName(sessionId, it) }
                 outbound.send(OutboundEvent.SendInfo(sessionId, "Auto-loot enabled."))
             }
             AutolootAction.OFF -> {
                 players.setAutolootEnabled(sessionId, false)
+                players.get(sessionId)?.let { gmcpEmitter?.sendCharName(sessionId, it) }
                 outbound.send(OutboundEvent.SendInfo(sessionId, "Auto-loot disabled."))
             }
             AutolootAction.STATUS -> {

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -450,16 +450,21 @@ class GmcpEmitterTest {
     // ── Char.Name ──
 
     @Test
-    fun `sendCharName emits name race class level`() =
+    fun `sendCharName emits name race class level and autoloot`() =
         runTest {
             val e = emitter("Char.Name")
-            e.sendCharName(sid, player(name = "Alice", race = "ELF", playerClass = "MAGE", level = 10))
+            e.sendCharName(
+                sid,
+                player(name = "Alice", race = "ELF", playerClass = "MAGE", level = 10)
+                    .copy(autolootEnabled = true),
+            )
             val data = drainGmcp()[0]
             assertEquals("Char.Name", data.gmcpPackage)
             assertTrue(data.jsonData.contains("\"name\":\"Alice\""))
             assertTrue(data.jsonData.contains("\"race\":\"ELF\""))
             assertTrue(data.jsonData.contains("\"class\":\"MAGE\""))
             assertTrue(data.jsonData.contains("\"level\":10"))
+            assertTrue(data.jsonData.contains("\"autolootEnabled\":true"))
         }
 
     // ── Comm.Channel ──

--- a/src/test/kotlin/dev/ambon/engine/commands/AutolootCommandRouterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/AutolootCommandRouterTest.kt
@@ -1,6 +1,8 @@
 package dev.ambon.engine.commands
 
+import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.engine.GmcpEmitter
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.toPlayerRecord
 import dev.ambon.engine.toPlayerState
@@ -114,5 +116,35 @@ class AutolootCommandRouterTest {
 
             val restored = record.toPlayerState(SessionId(6))
             assertEquals(true, restored.autolootEnabled)
+        }
+
+    @Test
+    fun `autoloot toggle emits Char Name GMCP updates for the web client`() =
+        runTest {
+            val outbound = LocalOutboundBus()
+            val gmcpEmitter = GmcpEmitter(outbound = outbound, supportsPackage = { _, pkg -> pkg == "Char.Name" })
+            val h = CommandRouterHarness.create(outbound = outbound, gmcpEmitter = gmcpEmitter)
+            val sid = SessionId(6)
+            h.players.loginOrFail(sid, "Finn")
+
+            h.router.handle(sid, Command.AutolootOn)
+            val enableEvents = h.outbound.drainAll()
+            val enablePacket = enableEvents
+                .filterIsInstance<OutboundEvent.GmcpData>()
+                .lastOrNull { it.gmcpPackage == "Char.Name" }
+            assertTrue(
+                enablePacket?.jsonData?.contains("\"autolootEnabled\":true") == true,
+                "Expected Char.Name GMCP update with autoloot enabled, got=$enableEvents",
+            )
+
+            h.router.handle(sid, Command.AutolootOff)
+            val disableEvents = h.outbound.drainAll()
+            val disablePacket = disableEvents
+                .filterIsInstance<OutboundEvent.GmcpData>()
+                .lastOrNull { it.gmcpPackage == "Char.Name" }
+            assertTrue(
+                disablePacket?.jsonData?.contains("\"autolootEnabled\":false") == true,
+                "Expected Char.Name GMCP update with autoloot disabled, got=$disableEvents",
+            )
         }
 }

--- a/web-v3/src/canvas/GameStateBridge.ts
+++ b/web-v3/src/canvas/GameStateBridge.ts
@@ -115,7 +115,7 @@ export const gameStateRef: { current: GameStateSnapshot } = {
     combatTarget: null,
     inCombat: false,
     effects: [],
-    character: { name: "-", gender: "", race: "", className: "", level: null, sprite: null, isStaff: false },
+    character: { name: "-", gender: "", race: "", className: "", level: null, sprite: null, isStaff: false, autolootEnabled: false },
     mobInfo: [],
     groupInfo: { leader: null, members: [] },
     dialogue: null,

--- a/web-v3/src/components/panels/CharacterPanel.tsx
+++ b/web-v3/src/components/panels/CharacterPanel.tsx
@@ -101,6 +101,7 @@ export function CharacterPanel({
     () => achievements.completed.filter((a) => a.title !== null).map((a) => a.title as string),
     [achievements.completed],
   );
+  const autolootEnabled = character.autolootEnabled;
 
   const CATEGORY_LABELS: Record<string, string> = { general: "Sprites", tier: "Tier Sprites", achievement: "Achievement Sprites", staff: "Staff Sprites" };
   const CATEGORY_ORDER = ["general", "tier", "achievement", "staff"];
@@ -267,6 +268,31 @@ export function CharacterPanel({
                     <option value="enby">Enby</option>
                   </select>
                 </label>
+              </div>
+              <div className="character-utility-strip" role="group" aria-label="Auto-loot setting">
+                <div className="character-utility-copy">
+                  <p className="character-utility-kicker">Field Utility</p>
+                  <p className="character-utility-title">Auto-Loot</p>
+                  <p className="character-utility-description">
+                    {autolootEnabled
+                      ? "Mob drops go straight into your pack after a kill."
+                      : "Drops stay in the room until you pick them up."}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  className={`character-utility-toggle ${autolootEnabled ? "character-utility-toggle-active" : ""}`}
+                  aria-pressed={autolootEnabled}
+                  aria-label={autolootEnabled ? "Disable auto-loot" : "Enable auto-loot"}
+                  title={autolootEnabled ? "Disable auto-loot" : "Enable auto-loot"}
+                  disabled={!connected}
+                  onClick={() => onCommand(autolootEnabled ? "autoloot off" : "autoloot on")}
+                >
+                  <span className="character-utility-toggle-track" aria-hidden="true">
+                    <span className="character-utility-toggle-thumb" />
+                  </span>
+                  <span className="character-utility-toggle-label">{autolootEnabled ? "On" : "Off"}</span>
+                </button>
               </div>
               <div className="description-editor-section">
                 <button

--- a/web-v3/src/constants.ts
+++ b/web-v3/src/constants.ts
@@ -94,6 +94,6 @@ export const DEFAULT_STATUS_VAR_LABELS: StatusVarLabels = {
   xp: "XP",
 };
 
-export const EMPTY_CHAR: CharacterInfo = { name: "-", gender: "", race: "", className: "", level: null, sprite: null, isStaff: false };
+export const EMPTY_CHAR: CharacterInfo = { name: "-", gender: "", race: "", className: "", level: null, sprite: null, isStaff: false, autolootEnabled: false };
 export const EMPTY_ROOM: RoomState = { id: null, title: "-", description: "", exits: {}, mapX: 0, mapY: 0, graphical: false, terrain: "outside" };
 

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -277,6 +277,7 @@ export function applyGmcpPackage(
         level: typeof packet.level === "number" ? packet.level : null,
         sprite: typeof packet.sprite === "string" ? packet.sprite : null,
         isStaff: packet.isStaff === true,
+        autolootEnabled: packet.autolootEnabled === true,
       });
       // Login complete — dismiss modal
       ctx.setLoginPrompt(null);

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -7150,6 +7150,138 @@ body {
   background: rgb(42 44 57 / 40%);
 }
 
+/* ---------- Character utility controls ---------- */
+
+.character-utility-strip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin-top: var(--space-3);
+  padding: 10px 12px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgb(134 146 191 / 18%);
+  background:
+    radial-gradient(circle at top left, rgb(190 168 115 / 12%), transparent 42%),
+    linear-gradient(145deg, rgb(54 64 94 / 82%), rgb(39 48 73 / 90%));
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 10%);
+}
+
+.character-utility-copy {
+  min-width: min(100%, 240px);
+  flex: 1 1 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.character-utility-kicker {
+  margin: 0;
+  font-size: 0.62rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-tertiary);
+}
+
+.character-utility-title {
+  margin: 0;
+  font-size: 0.98rem;
+  font-family: var(--font-display);
+  color: var(--text-bright);
+}
+
+.character-utility-description {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.76rem;
+  line-height: 1.45;
+}
+
+.character-utility-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+  margin-inline-start: auto;
+  padding: 7px 10px 7px 8px;
+  border: 1px solid rgb(128 145 219 / 24%);
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgb(39 47 73 / 95%), rgb(55 65 97 / 92%));
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 0.76rem;
+  font-weight: 800;
+  cursor: pointer;
+  transition:
+    transform 150ms var(--ease-out-soft),
+    border-color 150ms var(--ease-out-soft),
+    box-shadow 150ms var(--ease-out-soft),
+    background-color 150ms var(--ease-out-soft),
+    color 150ms var(--ease-out-soft);
+}
+
+.character-utility-toggle:hover:not(:disabled) {
+  transform: translateY(-1px);
+  border-color: rgb(176 193 255 / 42%);
+  box-shadow: var(--shadow-sm), 0 0 14px rgb(118 133 190 / 20%);
+}
+
+.character-utility-toggle:active:not(:disabled) {
+  transform: scale(0.98);
+}
+
+.character-utility-toggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+}
+
+.character-utility-toggle-active {
+  border-color: rgb(184 216 232 / 34%);
+  background:
+    linear-gradient(135deg, rgb(72 103 82 / 96%), rgb(56 83 75 / 92%)),
+    linear-gradient(0deg, rgb(0 0 0 / 8%), rgb(0 0 0 / 8%));
+  color: rgb(231 255 241 / 96%);
+}
+
+.character-utility-toggle-track {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  width: 42px;
+  height: 24px;
+  padding: 3px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgb(92 87 122 / 96%), rgb(66 78 116 / 94%));
+  box-shadow: inset 0 1px 2px rgb(6 8 14 / 35%);
+}
+
+.character-utility-toggle-active .character-utility-toggle-track {
+  background: linear-gradient(135deg, rgb(129 171 114 / 96%), rgb(83 132 102 / 92%));
+}
+
+.character-utility-toggle-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: linear-gradient(145deg, rgb(241 244 255 / 96%), rgb(196 208 235 / 94%));
+  box-shadow: 0 2px 6px rgb(8 10 18 / 32%);
+  transform: translateX(0);
+  transition: transform 180ms var(--ease-out-soft);
+}
+
+.character-utility-toggle-active .character-utility-toggle-thumb {
+  transform: translateX(18px);
+}
+
+.character-utility-toggle-label {
+  min-width: 2ch;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
 /* -- Description editor ------------------------------------------------- */
 
 .description-editor-section {

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -190,6 +190,7 @@ export interface CharacterInfo {
   level: number | null;
   sprite: string | null;
   isStaff: boolean;
+  autolootEnabled: boolean;
 }
 
 export interface RoomState {

--- a/web-v3/test/characterAutoloot.test.tsx
+++ b/web-v3/test/characterAutoloot.test.tsx
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { CharacterPanel } from "../src/components/panels/CharacterPanel";
+import { DEFAULT_STATUS_VAR_LABELS, EMPTY_CHAR, EMPTY_VITALS } from "../src/constants";
+import { applyGmcpPackage } from "../src/gmcp/applyGmcpPackage";
+import type { CharacterInfo } from "../src/types";
+
+const baseProps = {
+  connected: true,
+  hasCharacterProfile: true,
+  canOpenEquipment: true,
+  character: {
+    ...EMPTY_CHAR,
+    name: "Alice",
+    gender: "female",
+    race: "ELF",
+    className: "MAGE",
+    level: 10,
+    autolootEnabled: false,
+  },
+  displayRace: "Elf",
+  displayClassName: "Mage",
+  vitals: {
+    ...EMPTY_VITALS,
+    hp: 42,
+    maxHp: 50,
+    mana: 27,
+    maxMana: 30,
+    level: 10,
+    xpIntoLevel: 20,
+    xpToNextLevel: 100,
+    gold: 55,
+  },
+  statusVarLabels: DEFAULT_STATUS_VAR_LABELS,
+  xpValue: 20,
+  xpMax: 100,
+  xpText: "20 / 100",
+  effects: [],
+  visibleEffects: [],
+  hiddenEffectsCount: 0,
+  achievements: { completed: [], inProgress: [] },
+  quests: [],
+  questNotifications: [],
+  charStats: null,
+  guildInfo: { name: null, tag: null, rank: null, motd: null, memberCount: 0, maxSize: 50 },
+  groupInfo: { leader: null, members: [] },
+  activeTitle: null,
+  spriteList: { active: null, sprites: [] },
+  currencies: [],
+  factions: [],
+  petState: null,
+  prestigeInfo: null,
+  onDismissQuestNotification: () => {},
+  onAbandonQuest: () => {},
+  onOpenInventory: () => {},
+  onOpenEquipment: () => {},
+  onCommand: () => {},
+  onLogout: () => {},
+};
+
+describe("character auto-loot UI", () => {
+  test("renders the auto-loot control in the off state", () => {
+    const html = renderToStaticMarkup(<CharacterPanel {...baseProps} />);
+
+    expect(html).toContain("Auto-Loot");
+    expect(html).toContain("Drops stay in the room until you pick them up.");
+    expect(html).toContain('aria-pressed="false"');
+    expect(html).toContain(">Off<");
+  });
+
+  test("renders the auto-loot control in the on state", () => {
+    const html = renderToStaticMarkup(
+      <CharacterPanel
+        {...baseProps}
+        character={{ ...baseProps.character, autolootEnabled: true }}
+      />,
+    );
+
+    expect(html).toContain("Mob drops go straight into your pack after a kill.");
+    expect(html).toContain('aria-pressed="true"');
+    expect(html).toContain(">On<");
+  });
+});
+
+describe("Char.Name auto-loot sync", () => {
+  test("stores autolootEnabled from the GMCP payload", () => {
+    let character: CharacterInfo = EMPTY_CHAR;
+    const ctx = {
+      setCharacter: (next: CharacterInfo | ((prev: CharacterInfo) => CharacterInfo)) => {
+        character = typeof next === "function" ? next(character) : next;
+      },
+      setLoginPrompt: () => {},
+      setLoginError: () => {},
+    } as unknown as Parameters<typeof applyGmcpPackage>[2];
+
+    applyGmcpPackage(
+      "Char.Name",
+      {
+        name: "Alice",
+        gender: "female",
+        race: "ELF",
+        class: "MAGE",
+        level: 10,
+        sprite: "/images/alice.webp",
+        isStaff: false,
+        autolootEnabled: true,
+      },
+      ctx,
+    );
+
+    expect(character.autolootEnabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Adds an auto-loot control to the web character panel and wires it to authoritative server state.

## What Changed
- adds an Auto-Loot toggle inside the character panel UI
- extends `Char.Name` GMCP with `autolootEnabled`
- re-emits `Char.Name` when the auto-loot command changes state so the web client stays in sync
- updates web client state/types/defaults to store the new flag
- adds Kotlin and web tests for the GMCP field and panel rendering

## Why
Auto-loot already existed as a command, but the browser client had no native control for it and no authoritative state to render. That left the feature effectively hidden in the web UI.

## Impact
Players using the browser client can now discover and toggle auto-loot directly from the character panel, with the UI reflecting the actual server-side setting.

## Validation
- `bun run lint`
- `bun test`
- `.\gradlew.bat ktlintCheck test`