### PR TITLE
fix inventory panel layout

### DIFF
--- a/web-v3/src/components/PopoutLayer.tsx
+++ b/web-v3/src/components/PopoutLayer.tsx
@@ -41,7 +41,7 @@ export function PopoutLayer({
 
   const isPanelPopout = PANEL_POPOUTS.has(activePopout);
   const dialogClass = isPanelPopout
-    ? "popout-dialog popout-dialog-panel"
+    ? `popout-dialog popout-dialog-panel popout-dialog-panel-${activePopout}`
     : "popout-dialog";
 
   return (

--- a/web-v3/src/components/panels/InventoryPanel.tsx
+++ b/web-v3/src/components/panels/InventoryPanel.tsx
@@ -51,6 +51,7 @@ export function InventoryPanel({
     () => roomFeatures.filter((f) => f.type === "container"),
     [roomFeatures],
   );
+  const activeContainerKeyword = containerContents?.keyword ?? null;
 
   if (!connected || !hasCharacterProfile) {
     return <p className="empty-note">Log in to view inventory.</p>;
@@ -69,18 +70,23 @@ export function InventoryPanel({
   const renderItem = (item: ItemSummary) => (
     <li key={item.id} className="inventory-item">
       <div className="inventory-item-row">
-        <span className="inventory-item-info">
+        <div className="inventory-item-info">
           {resolveItemImage(item) && <img src={resolveItemImage(item)!} alt="" className="inventory-item-thumb" />}
-          <span className="inventory-item-name">{item.name}</span>
-          {item.slot && <span className="inventory-item-slot">{item.slot}</span>}
-          {!item.slot && item.consumable && item.useEffect && (
-            <span className="inventory-item-effect" title={item.useEffect}>{item.useEffect}</span>
-          )}
-        </span>
-        <span className="inventory-item-actions">
+          <div className="inventory-item-copy">
+            <span className="inventory-item-name">{item.name}</span>
+            <div className="inventory-item-meta">
+              {item.slot && <span className="inventory-item-slot">{item.slot}</span>}
+              {!item.slot && item.consumable && item.useEffect && (
+                <span className="inventory-item-effect" title={item.useEffect}>{item.useEffect}</span>
+              )}
+            </div>
+          </div>
+        </div>
+        <div className="inventory-item-actions">
           <button
             type="button"
-            className="inventory-action-btn inventory-action-examine"
+            className="inventory-action-btn inventory-action-btn-pill inventory-action-examine"
+            aria-label={`Examine ${item.name}`}
             title={`Examine ${item.name}`}
             onClick={() => onCommand(`look ${item.keyword}`)}
           >
@@ -89,8 +95,9 @@ export function InventoryPanel({
           {!item.slot && item.consumable && (
             <button
               type="button"
-              className="inventory-action-btn inventory-action-use"
-              title={item.useEffect ? `Use ${item.name} — ${item.useEffect}` : `Use ${item.name}`}
+              className="inventory-action-btn inventory-action-btn-pill inventory-action-use"
+              aria-label={`Use ${item.name}`}
+              title={`Use ${item.name}${item.useEffect ? ` - ${item.useEffect}` : ""}`}
               disabled={!canManageItems}
               onClick={() => onCommand(`use ${item.keyword}`)}
             >
@@ -100,31 +107,34 @@ export function InventoryPanel({
           {item.slot && (
             <button
               type="button"
-              className={`inventory-action-btn inventory-action-equip${equipHint ? " inventory-action-equip-hint" : ""}`}
+              className={`inventory-action-btn inventory-action-btn-pill inventory-action-equip${equipHint ? " inventory-action-equip-hint" : ""}`}
+              aria-label={`Equip ${item.name}`}
               title={equipHint ? `Equip ${item.name}` : `Wear ${item.name}`}
               disabled={!canManageItems}
               onClick={() => onWearItem(item.name)}
             >
               <WearItemIcon className="inventory-action-icon" />
-              {equipHint && <span className="inventory-action-equip-hint-label">Equip</span>}
+              <span>Equip</span>
             </button>
           )}
           {containerContents && (
             <button
               type="button"
-              className="inventory-action-btn inventory-action-put"
-              title={`Put ${item.name} in ${containerContents.name}`}
+              className="inventory-action-btn inventory-action-btn-pill inventory-action-put"
+              aria-label={`Store ${item.name} in ${containerContents.name}`}
+              title={`Store ${item.name} in ${containerContents.name}`}
               disabled={!canManageItems}
               onClick={() => onCommand(`put ${item.keyword} in ${containerContents.keyword}`)}
             >
-              Put in {containerContents.name}
+              Store
             </button>
           )}
           {players.length > 0 && (
             <button
               type="button"
-              className={`inventory-action-btn ${givePickerItemId === item.id ? "inventory-action-btn-active" : ""}`}
+              className={`inventory-action-btn inventory-action-btn-icon${givePickerItemId === item.id ? " inventory-action-btn-active" : ""}`}
               title={`Give ${item.name}`}
+              aria-label={`Give ${item.name}`}
               aria-expanded={givePickerItemId === item.id}
               disabled={!canManageItems}
               onClick={() => setGivePickerItemId(givePickerItemId === item.id ? null : item.id)}
@@ -134,14 +144,15 @@ export function InventoryPanel({
           )}
           <button
             type="button"
-            className="inventory-action-btn"
+            className="inventory-action-btn inventory-action-btn-icon"
             title={`Drop ${item.name}`}
+            aria-label={`Drop ${item.name}`}
             disabled={!canManageItems}
             onClick={() => onDropItem(item.name)}
           >
             <DropItemIcon className="inventory-action-icon" />
           </button>
-        </span>
+        </div>
       </div>
       {givePickerItemId === item.id && (
         <div className="inventory-give-picker" role="listbox" aria-label={`Give ${item.name} to`}>
@@ -167,6 +178,12 @@ export function InventoryPanel({
 
   return (
     <div className="inventory-panel">
+      {containerContents && (
+        <div className="inventory-active-container" role="status" aria-live="polite">
+          <span className="inventory-active-container-label">Storing in</span>
+          <span className="inventory-active-container-name" title={containerContents.name}>{containerContents.name}</span>
+        </div>
+      )}
       {wearable.length > 0 && (
         <section className="inventory-section">
           <h3 className="inventory-section-title">Equipment</h3>
@@ -183,39 +200,45 @@ export function InventoryPanel({
         <section className="inventory-section">
           <h3 className="inventory-section-title">Containers</h3>
           <div className="container-list">
-            {containers.map((c) => (
-              <div key={c.id} className="container-entry">
+            {containers.map((container) => (
+              <div
+                key={container.id}
+                className={`container-entry${activeContainerKeyword === container.keyword ? " container-entry-active" : ""}`}
+              >
                 <div className="container-entry-header">
-                  <span className="container-entry-name">{c.name}</span>
+                  <span className="container-entry-name">{container.name}</span>
                   <button
                     type="button"
-                    className="inventory-action-btn inventory-action-use"
-                    title={`Search ${c.name}`}
+                    className="inventory-action-btn inventory-action-btn-pill inventory-action-use"
+                    title={`Search ${container.name}`}
+                    aria-label={`Search ${container.name}`}
                     disabled={!canManageItems}
-                    onClick={() => onCommand(`search ${c.keyword}`)}
+                    onClick={() => onCommand(`search ${container.keyword}`)}
                   >
                     Search
                   </button>
                 </div>
-                {containerContents && containerContents.keyword === c.keyword && containerContents.items.length > 0 && (
+                {containerContents && containerContents.keyword === container.keyword && containerContents.items.length > 0 && (
                   <ul className="container-items">
                     {containerContents.items.map((ci, idx) => (
                       <li key={`${ci.keyword}-${idx}`} className="container-item">
                         <span className="container-item-name">{ci.name}</span>
                         <button
                           type="button"
-                          className="inventory-action-btn inventory-action-examine"
+                          className="inventory-action-btn inventory-action-btn-pill inventory-action-examine"
                           title={`Examine ${ci.name}`}
+                          aria-label={`Examine ${ci.name}`}
                           onClick={() => onCommand(`look ${ci.keyword}`)}
                         >
                           Examine
                         </button>
                         <button
                           type="button"
-                          className="inventory-action-btn inventory-action-use"
+                          className="inventory-action-btn inventory-action-btn-pill inventory-action-use"
                           title={`Take ${ci.name}`}
+                          aria-label={`Take ${ci.name}`}
                           disabled={!canManageItems}
-                          onClick={() => onCommand(`get ${ci.keyword} from ${c.keyword}`)}
+                          onClick={() => onCommand(`get ${ci.keyword} from ${container.keyword}`)}
                         >
                           Take
                         </button>

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -6234,6 +6234,39 @@ body {
   flex-direction: column;
   gap: var(--space-3);
   padding: var(--space-2) 0;
+  container-type: inline-size;
+}
+
+.inventory-active-container {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  align-self: flex-start;
+  min-width: 0;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid rgb(190 168 115 / 26%);
+  background: linear-gradient(135deg, rgb(190 168 115 / 16%), rgb(168 151 210 / 10%));
+  color: var(--text-secondary);
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 6%);
+}
+
+.inventory-active-container-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-primary-soft-gold);
+}
+
+.inventory-active-container-name {
+  min-width: 0;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .inventory-section {
@@ -6273,11 +6306,11 @@ body {
 }
 
 .inventory-item-row {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  gap: var(--space-2);
-  padding: 6px 8px;
+  gap: var(--space-2) var(--space-3);
+  padding: 8px 10px;
 }
 
 .inventory-item-info {
@@ -6285,6 +6318,21 @@ body {
   align-items: center;
   gap: var(--space-2);
   min-width: 0;
+}
+
+.inventory-item-copy {
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.inventory-item-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-height: 18px;
 }
 
 .inventory-item-thumb {
@@ -6298,6 +6346,7 @@ body {
 
 .inventory-item-name {
   font-size: 0.8rem;
+  font-weight: 600;
   color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
@@ -6328,33 +6377,47 @@ body {
 
 .inventory-item-actions {
   display: flex;
-  gap: 2px;
-  flex-shrink: 0;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 6px;
 }
 
 .inventory-action-btn {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 44px;
-  min-height: 44px;
-  width: 28px;
-  height: 28px;
-  border: 1px solid transparent;
-  border-radius: var(--radius-sm);
-  background: none;
+  gap: 6px;
+  min-width: 36px;
+  min-height: 36px;
+  width: auto;
+  height: auto;
+  padding: 0 10px;
+  border: 1px solid var(--line-faint);
+  border-radius: 999px;
+  background: rgb(255 255 255 / 4%);
   color: var(--text-secondary);
   cursor: pointer;
+  white-space: nowrap;
+  font: inherit;
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1;
+  flex: 0 0 auto;
   transition:
     background 140ms var(--ease-out-soft),
     color 140ms var(--ease-out-soft),
-    border-color 140ms var(--ease-out-soft);
+    border-color 140ms var(--ease-out-soft),
+    transform 140ms var(--ease-out-soft),
+    box-shadow 140ms var(--ease-out-soft);
 }
 
 .inventory-action-btn:hover:not(:disabled) {
-  background: rgb(255 255 255 / 8%);
+  background: rgb(255 255 255 / 10%);
   color: var(--text-primary);
-  border-color: var(--line-faint);
+  border-color: rgb(168 151 210 / 28%);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 12px rgb(8 10 18 / 18%);
 }
 
 .inventory-action-btn:disabled {
@@ -6362,31 +6425,43 @@ body {
   cursor: not-allowed;
 }
 
+.inventory-action-btn-pill {
+  padding-inline: 12px;
+}
+
+.inventory-action-btn-icon {
+  width: 36px;
+  padding: 0;
+  border-radius: 11px;
+}
+
 .inventory-action-btn-active {
   background: rgb(168 151 210 / 20%);
   border-color: rgb(168 151 210 / 40%);
+}
+
+.inventory-action-examine {
+  color: var(--color-accent-moonlit-silver);
+}
+
+.inventory-action-use {
+  color: var(--color-primary-pale-blue);
 }
 
 .inventory-action-equip {
   color: var(--color-primary-moss-green);
 }
 
+.inventory-action-put {
+  color: var(--color-primary-soft-gold);
+}
+
 /* First-time onboarding hint: pulse the Equip action on wearable items until
-   the player actually wears one. Soft-gold border + inline "Equip" label so the
-   action is discoverable at a glance. */
+   the player actually wears one. */
 .inventory-action-equip-hint {
   border-color: var(--color-primary-soft-gold);
   color: var(--color-primary-soft-gold);
-  padding-right: 8px;
   animation: inventory-equip-hint-pulse 1.8s var(--ease-in-out-smooth) infinite;
-}
-
-.inventory-action-equip-hint-label {
-  margin-left: 4px;
-  font-size: 0.68rem;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
 }
 
 @keyframes inventory-equip-hint-pulse {
@@ -6405,21 +6480,10 @@ body {
   }
 }
 
-.inventory-action-examine,
-.inventory-action-use,
-.inventory-action-put {
-  font-size: 0.68rem;
-  font-weight: 600;
-  padding: 2px 6px;
-}
-
-.inventory-action-examine {
-  color: var(--color-accent-moonlit-silver);
-}
-
 .inventory-action-icon {
   width: 16px;
   height: 16px;
+  flex-shrink: 0;
 }
 
 .inventory-give-picker {
@@ -6468,6 +6532,12 @@ body {
   border-radius: var(--radius-md);
   background: rgb(50 58 82 / 30%);
   padding: 6px 8px;
+  transition: border-color 140ms var(--ease-out-soft), background 140ms var(--ease-out-soft);
+}
+
+.container-entry-active {
+  border-color: rgb(190 168 115 / 34%);
+  background: linear-gradient(145deg, rgb(190 168 115 / 10%), rgb(50 58 82 / 38%));
 }
 
 .container-entry-header {
@@ -6512,6 +6582,28 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+@container (max-width: 720px) {
+  .inventory-active-container {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .inventory-item-row {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .inventory-item-actions {
+    justify-content: flex-start;
+  }
+
+  .container-entry-header,
+  .container-item {
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
 }
 
 /* ────────── Equipment Panel (Paper Doll) ────────── */
@@ -9897,6 +9989,11 @@ body {
 .popout-dialog-panel {
   width: min(90vw, 560px);
   max-height: min(80dvh, 640px);
+}
+
+.popout-dialog-panel-inventory {
+  width: min(92vw, 860px);
+  max-height: min(82dvh, 720px);
 }
 
 .popout-panel-content {

--- a/web-v3/test/inventoryPanel.test.tsx
+++ b/web-v3/test/inventoryPanel.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import type { ComponentProps } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { InventoryPanel } from "../src/components/panels/InventoryPanel";
+
+const baseProps: ComponentProps<typeof InventoryPanel> = {
+  connected: true,
+  hasCharacterProfile: true,
+  inventory: [
+    {
+      id: "dreamweave-cowl",
+      name: "a dreamweave cowl",
+      keyword: "dreamweave cowl",
+      slot: "head",
+      consumable: false,
+      useEffect: undefined,
+      image: null,
+    },
+    {
+      id: "memory-drop",
+      name: "a crystallized memory drop",
+      keyword: "memory drop",
+      slot: null,
+      consumable: true,
+      useEffect: "Restores 15 HP",
+      image: null,
+    },
+  ],
+  players: [{ name: "Bramble", level: 4, sprite: null }],
+  canManageItems: true,
+  roomFeatures: [
+    {
+      id: "welcome-chest",
+      name: "a shimmering welcome chest",
+      keyword: "welcome chest",
+      type: "container",
+      state: "open",
+      direction: null,
+      locked: false,
+      keyRequired: false,
+      text: null,
+    },
+  ],
+  containerContents: null,
+  onWearItem: () => {},
+  onDropItem: () => {},
+  onGiveItem: () => {},
+  onCommand: () => {},
+  equipHint: false,
+};
+
+describe("inventory panel", () => {
+  test("uses a shared container banner with compact Store actions", () => {
+    const html = renderToStaticMarkup(
+      <InventoryPanel
+        {...baseProps}
+        containerContents={{
+          featureId: "welcome-chest",
+          name: "a shimmering welcome chest",
+          keyword: "welcome chest",
+          items: [],
+        }}
+      />,
+    );
+
+    expect(html).toContain("Storing in");
+    expect(html).toContain(">Store<");
+    expect(html).not.toContain("Put in a shimmering welcome chest");
+    expect(html).toContain("container-entry-active");
+  });
+
+  test("renders an explicit Equip action for wearable items", () => {
+    const html = renderToStaticMarkup(<InventoryPanel {...baseProps} />);
+
+    expect(html).toContain(">Equip<");
+    expect(html).toContain('aria-label="Equip a dreamweave cowl"');
+  });
+});


### PR DESCRIPTION
## What changed
- rebuilt the inventory item row so item details and actions use a stable two-column layout instead of squeezing everything into one inline rail
- converted text actions into readable pill buttons, kept give/drop as compact icon buttons, and made wearable items show an explicit `Equip` action
- replaced repeated `Put in a shimmering welcome chest` labels with a shared active-container banner plus compact `Store` actions
- widened the inventory popout on desktop and added container-query fallbacks so rows stack cleanly when space gets tight
- added a regression test covering the compact store action and explicit equip affordance

## Why
The recent inventory changes mixed long text labels with controls still styled like tiny icon buttons inside a narrow modal. That caused action overlap, broken wrapping, and poor readability, especially when a container with a long name was open.

## Impact
- inventory actions remain readable and clickable with long container names
- the currently open container is visible once at panel level instead of repeated on every item
- the inventory panel behaves more predictably across desktop and narrower widths

## Root cause
The UI treated text-bearing actions as if they were still 28px icon buttons, while the inventory popout width and row layout did not adapt to the extra content.

## Validation
- `bun run lint`
- `bun test`
- `bun run build`
- `.\gradlew.bat ktlintCheck`
- `.\gradlew.bat test`