### PR TITLE
Route quest XP through diminishing returns

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -1893,25 +1893,25 @@ data class ProgressionConfig(
 
 data class XpCurveConfig(
     val baseXp: Long = 100L,
-    val exponent: Double = 2.0,
-    val linearXp: Long = 0L,
+    val exponent: Double = 2.2,
+    val linearXp: Long = 150L,
     val multiplier: Double = 1.0,
     val defaultKillXp: Long = 50L,
     val diminishing: DiminishingXpConfig = DiminishingXpConfig(),
 )
 
 /**
- * Per-kill XP diminishing returns based on the gap between the player's level
- * and the mob's level. When enabled, kills on mobs [DiminishingXpThreshold.levelsBelow]
- * or more below the player award only [DiminishingXpThreshold.multiplier] of the
- * normal XP. The highest matching threshold wins.
+ * Diminishing returns applied when a player has out-levelled the content
+ * awarding XP. Used by kills (mob level) and by quests/puzzles that declare
+ * an intended player level. The highest matching `levelsBelow` wins.
  */
 data class DiminishingXpConfig(
     val enabled: Boolean = true,
     val thresholds: List<DiminishingXpThreshold> =
         listOf(
-            DiminishingXpThreshold(levelsBelow = 5, multiplier = 0.5),
-            DiminishingXpThreshold(levelsBelow = 10, multiplier = 0.1),
+            DiminishingXpThreshold(levelsBelow = 3, multiplier = 0.5),
+            DiminishingXpThreshold(levelsBelow = 5, multiplier = 0.2),
+            DiminishingXpThreshold(levelsBelow = 8, multiplier = 0.0),
         ),
 )
 

--- a/src/main/kotlin/dev/ambon/domain/quest/QuestDef.kt
+++ b/src/main/kotlin/dev/ambon/domain/quest/QuestDef.kt
@@ -13,6 +13,13 @@ data class QuestDef(
     val completionType: String = "auto",
     /** Optional reputation gate. */
     val requiredReputation: ReputationRequirement? = null,
+    /**
+     * Intended player level for this quest. When set, XP rewards are scaled by
+     * the same diminishing-returns curve used for kills — a player who has
+     * out-levelled the quest receives reduced XP instead of the flat reward.
+     * Null preserves legacy flat-award behaviour.
+     */
+    val level: Int? = null,
 )
 
 data class QuestObjectiveDef(

--- a/src/main/kotlin/dev/ambon/domain/world/data/QuestFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/QuestFile.kt
@@ -9,6 +9,8 @@ data class QuestFile(
     val rewards: QuestRewardsFile = QuestRewardsFile(),
     /** Optional reputation gate. min → giver hints to grind; max → quest disappears when exceeded. */
     val requiredReputation: ReputationRequirementFile? = null,
+    /** Intended player level. Drives XP diminishing returns on completion when set. */
+    val level: Int? = null,
 )
 
 data class QuestObjectiveFile(

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -607,6 +607,7 @@ object WorldLoader {
                         ),
                         completionType = completionType,
                         requiredReputation = questRep,
+                        level = questFile.level,
                     ),
                 )
             }

--- a/src/main/kotlin/dev/ambon/engine/EngineUtil.kt
+++ b/src/main/kotlin/dev/ambon/engine/EngineUtil.kt
@@ -115,6 +115,12 @@ internal fun rollRange(
  * Gold is added to [ps] immediately. XP is granted via [players.grantXp], which
  * also handles persistence. The caller is responsible for persisting when no XP
  * is granted (i.e. when [rewards.xp] == 0 and gold was awarded).
+ *
+ * When [progression] and [sourceLevel] are both supplied, the XP reward is
+ * passed through the same diminishing-returns curve that kills use, so players
+ * who have out-levelled a quest or puzzle receive reduced XP instead of the
+ * flat amount authored in content. Omit either to preserve legacy flat award
+ * behaviour.
  */
 internal suspend fun grantRewards(
     sessionId: SessionId,
@@ -122,13 +128,28 @@ internal suspend fun grantRewards(
     ps: PlayerState,
     players: PlayerRegistry,
     outbound: OutboundBus,
+    progression: PlayerProgression? = null,
+    sourceLevel: Int? = null,
 ) {
     if (rewards.gold > 0) {
         ps.gold += rewards.gold
         outbound.send(OutboundEvent.SendText(sessionId, "You receive ${rewards.gold} gold."))
     }
     if (rewards.xp > 0) {
-        players.grantXp(sessionId, rewards.xp)
-        outbound.send(OutboundEvent.SendText(sessionId, "You gain ${rewards.xp} XP."))
+        val effectiveXp =
+            if (progression != null && sourceLevel != null) {
+                val multiplier = progression.diminishingKillXpMultiplier(ps.level, sourceLevel)
+                if (multiplier >= 1.0) {
+                    rewards.xp
+                } else {
+                    (rewards.xp * multiplier).toLong().coerceAtLeast(0L)
+                }
+            } else {
+                rewards.xp
+            }
+        if (effectiveXp > 0) {
+            players.grantXp(sessionId, effectiveXp)
+            outbound.send(OutboundEvent.SendText(sessionId, "You gain $effectiveXp XP."))
+        }
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -878,6 +878,7 @@ class GameEngine(
             outbound = outbound,
             clock = clock,
             reputationSystem = reputationSystem,
+            progression = progression,
         )
 
     private val dailyQuestSystem: DailyQuestSystem? =

--- a/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
@@ -23,6 +23,7 @@ class QuestSystem(
     private val objectiveHandlers: ObjectiveHandlerRegistry = ObjectiveHandlerRegistry.withDefaults(),
     private val completionHandlers: CompletionHandlerRegistry = CompletionHandlerRegistry.withDefaults(),
     private val reputationSystem: ReputationSystem? = null,
+    private val progression: PlayerProgression? = null,
 ) {
     /** Invoked after a quest is successfully completed; used by AchievementSystem. */
     var onQuestCompleted: (suspend (SessionId, String) -> Unit)? = null
@@ -348,7 +349,7 @@ class QuestSystem(
         onQuestCompletedGmcp?.invoke(sessionId, questId, quest.name)
         onQuestCompleted?.invoke(sessionId, questId)
 
-        grantRewards(sessionId, rewards, ps, players, outbound)
+        grantRewards(sessionId, rewards, ps, players, outbound, progression, quest.level)
         if (rewards.xp == 0L) players.persistPlayer(ps.sessionId)
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1917,19 +1917,23 @@ ambonmud:
     maxLevel: 50
     xp:
       baseXp: 100
-      exponent: 1.8
-      linearXp: 0
+      exponent: 2.2
+      linearXp: 150
       multiplier: 1
       defaultKillXp: 10
-      # Diminishing returns when a player over-levels a mob. Largest matching
-      # `levelsBelow` wins. Prevents trivial trash farming from capping out XP.
+      # Diminishing returns when a player has out-levelled the XP source.
+      # Applies to kills (mob level) and to quests/puzzles that declare an
+      # intended player level. Largest matching `levelsBelow` wins — prevents
+      # trivial trash farming and flat-reward quest ladders from capping XP.
       diminishing:
         enabled: true
         thresholds:
-          - levelsBelow: 5
+          - levelsBelow: 3
             multiplier: 0.5
-          - levelsBelow: 10
-            multiplier: 0.1
+          - levelsBelow: 5
+            multiplier: 0.2
+          - levelsBelow: 8
+            multiplier: 0.0
     rewards:
       hpPerLevel: 2
       manaPerLevel: 1

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -33,7 +33,13 @@ class GmcpEmitterTest {
     private val sid = TEST_SESSION_ID
     private val outbound = LocalOutboundBus()
 
-    private val progression = PlayerProgression()
+    private val progression =
+        PlayerProgression(
+            dev.ambon.config.ProgressionConfig(
+                maxLevel = 50,
+                xp = dev.ambon.config.XpCurveConfig(baseXp = 100L, exponent = 2.0, linearXp = 0L),
+            ),
+        )
 
     private val defaultSlotRegistry = EquipmentSlotRegistry(EquipmentConfig())
 

--- a/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
@@ -47,10 +47,13 @@ class QuestSystemTest {
             completionType = "auto",
         )
 
-    private fun setup(): Triple<QuestSystem, PlayerRegistry, LocalOutboundBus> {
+    private fun setup(
+        quest: QuestDef = killQuest,
+        progression: PlayerProgression? = null,
+    ): Triple<QuestSystem, PlayerRegistry, LocalOutboundBus> {
         val c = SystemTestComponents(clockInitialMs = 1_000L)
         val registry = QuestRegistry()
-        registry.register(killQuest)
+        registry.register(quest)
         val questSystem =
             QuestSystem(
                 registry = registry,
@@ -58,6 +61,7 @@ class QuestSystemTest {
                 items = c.items,
                 outbound = c.outbound,
                 clock = c.clock,
+                progression = progression,
             )
         return Triple(questSystem, c.players, c.outbound)
     }
@@ -126,6 +130,52 @@ class QuestSystemTest {
                 events.filterIsInstance<OutboundEvent.SendText>().map { it.text } +
                     events.filterIsInstance<OutboundEvent.SendInfo>().map { it.text }
             assertTrue(texts.any { it.contains("complete", ignoreCase = true) })
+        }
+
+    @Test
+    fun `quest XP diminishes when player is far above quest level`() =
+        runTest {
+            val progression = PlayerProgression()
+            val leveledQuest = killQuest.copy(level = 1, rewards = QuestRewards(xp = 1000L, gold = 0L))
+            val (qs, players, outbound) = setup(leveledQuest, progression)
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Hero")
+            players.setLevel(sid, 10)
+            val xpAtLevel10 = players.get(sid)!!.xpTotal
+            qs.acceptQuest(sid, questId)
+            outbound.drainAll()
+
+            repeat(3) { qs.onMobKilled(sid, mobTemplateKey) }
+
+            val ps = players.get(sid)!!
+            assertTrue(
+                ps.completedQuestIds.contains(questId),
+                "Quest should complete regardless of XP diminishing",
+            )
+            val xpGained = ps.xpTotal - xpAtLevel10
+            assertTrue(
+                xpGained < 1000L,
+                "Overleveled quest XP should be reduced (got $xpGained, expected << 1000)",
+            )
+        }
+
+    @Test
+    fun `quest XP ignores diminishing when level is not declared`() =
+        runTest {
+            val progression = PlayerProgression()
+            val (qs, players, outbound) = setup(progression = progression)
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Hero")
+            players.setLevel(sid, 20)
+            val xpAtLevel20 = players.get(sid)!!.xpTotal
+            qs.acceptQuest(sid, questId)
+            outbound.drainAll()
+
+            repeat(3) { qs.onMobKilled(sid, mobTemplateKey) }
+
+            val ps = players.get(sid)!!
+            val xpGained = ps.xpTotal - xpAtLevel20
+            assertEquals(100L, xpGained, "Quest with no level should award the full flat reward")
         }
 
     @Test


### PR DESCRIPTION
## Summary

Quests, puzzles, and achievements previously called `grantXp` directly, bypassing the diminishing-returns curve that combat kills already respect. A zone author could stack flat-reward quests and ladder a player through a third of the level range with two or three turn-ins — the symptom behind the recent Academy pacing complaint.

- Add optional `level` to `QuestFile` + `QuestDef`, wired through `WorldLoader`.
- Extend `EngineUtil.grantRewards` with optional `progression` and `sourceLevel` parameters; when both are supplied, the XP reward is passed through `diminishingKillXpMultiplier` before award. Achievements (no inherent level) keep legacy flat behaviour.
- `QuestSystem` now receives `PlayerProgression` and passes `quest.level` to `grantRewards`.
- Tighten default `XpCurveConfig` (exponent 2.0 → 2.2, linearXp 0 → 150) and `DiminishingXpConfig` (new thresholds 3/0.5, 5/0.2, 8/0.0). Mirror in `application.yaml` so the live Ambon tune matches the new defaults.
- `GmcpEmitterTest`'s progression fixture is pinned to the legacy curve so the JSON-shape assertions stay decoupled from default-curve arithmetic.
- New `QuestSystemTest` cases cover both the diminished and undeclared-level paths.

## Test plan
- [x] `./gradlew ktlintCheck test -x buildWeb` — 1951 tests, all passing.
- [ ] Run an Academy playthrough on the live server to confirm pacing feels right before retuning zone content further.
- [ ] Retune per-zone reward numbers once the curve settles (Arcanum tuning wizard is getting a matching PR).