### PR TITLE
Add MobRole to gate combat by role

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/mob/MobRole.kt
+++ b/src/main/kotlin/dev/ambon/domain/mob/MobRole.kt
@@ -1,0 +1,45 @@
+package dev.ambon.domain.mob
+
+/**
+ * Classifies what a mob is *for*, independent of how tough it is. Gates
+ * which behaviours a mob exposes — combatants can be attacked and award XP,
+ * vendors/quest-givers/dialog mobs surface their social affordances but
+ * refuse combat, and props are examine-only set dressing.
+ */
+enum class MobRole {
+    /** Can be attacked, fights back via behaviour tree, awards XP and drops. */
+    COMBAT,
+
+    /** Shopkeeper. Has a shop; cannot be attacked. */
+    VENDOR,
+
+    /** Offers and accepts quests. Cannot be attacked. */
+    QUEST_GIVER,
+
+    /** Conversational NPC — dialog trees only, no combat. */
+    DIALOG,
+
+    /** Examine-only flavour entity (statues, totems, etc.). No interaction beyond look. */
+    PROP,
+    ;
+
+    /** True when this role participates in the combat system. */
+    val isCombatant: Boolean
+        get() = this == COMBAT
+
+    companion object {
+        /**
+         * Parses a role string from world YAML, case-insensitive. Returns [COMBAT]
+         * when [raw] is null or blank so legacy mob definitions retain their
+         * previous behaviour without explicit opt-in.
+         */
+        fun parse(raw: String?): MobRole {
+            if (raw.isNullOrBlank()) return COMBAT
+            val normalized = raw.trim().uppercase().replace('-', '_').replace(' ', '_')
+            return entries.firstOrNull { it.name == normalized }
+                ?: throw IllegalArgumentException(
+                    "Unknown mob role '$raw' (expected one of ${entries.joinToString { it.name.lowercase() }})",
+                )
+        }
+    }
+}

--- a/src/main/kotlin/dev/ambon/domain/mob/MobState.kt
+++ b/src/main/kotlin/dev/ambon/domain/mob/MobState.kt
@@ -40,6 +40,7 @@ data class MobState(
     /** Threat multiplier for pet combat. 0.0 = no threat generation (default). */
     val threatMultiplier: Double = 0.0,
     override val level: Int = 1,
+    override val role: MobRole = MobRole.COMBAT,
 ) : MobTemplate {
     val isPet: Boolean get() = ownerSessionId != null
 }

--- a/src/main/kotlin/dev/ambon/domain/mob/MobTemplate.kt
+++ b/src/main/kotlin/dev/ambon/domain/mob/MobTemplate.kt
@@ -30,4 +30,7 @@ interface MobTemplate {
 
     /** Spell id that replaces the mob's default melee attack. */
     val defaultAttack: String?
+
+    /** Classifies what this mob is *for*; gates combat and interaction affordances. */
+    val role: MobRole
 }

--- a/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
@@ -3,6 +3,7 @@ package dev.ambon.domain.world
 import dev.ambon.domain.DamageRange
 import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.mob.MobRole
 import dev.ambon.domain.mob.MobSpell
 import dev.ambon.domain.mob.MobTemplate
 import dev.ambon.engine.behavior.BtNode
@@ -32,4 +33,5 @@ data class MobSpawn(
     override val spells: List<MobSpell> = emptyList(),
     override val defaultAttack: String? = null,
     override val level: Int = 1,
+    override val role: MobRole = MobRole.COMBAT,
 ) : MobTemplate

--- a/src/main/kotlin/dev/ambon/domain/world/data/MobFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/MobFile.kt
@@ -4,6 +4,12 @@ data class MobFile(
     val name: String,
     val description: String = "",
     val room: String,
+    /**
+     * What this mob is for: combat, vendor, quest_giver, dialog, or prop.
+     * Non-combat roles refuse attack commands and skip combat-stat computation.
+     * Null/missing defaults to combat to preserve legacy behaviour.
+     */
+    val role: String? = null,
     val tier: String? = null,
     val level: Int? = null,
     val hp: Int? = null,

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -397,6 +397,11 @@ object WorldLoader {
                         spells = spells,
                         defaultAttack = mf.defaultAttack,
                         level = level,
+                        role = try {
+                            dev.ambon.domain.mob.MobRole.parse(mf.role)
+                        } catch (e: IllegalArgumentException) {
+                            throw WorldLoadException("Mob '${mobId.value}': ${e.message}")
+                        },
                     )
             }
 

--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -147,6 +147,15 @@ class CombatSystem(
         if (matches.isEmpty()) return "You don't see '$keyword' here."
 
         val mob = matches.first()
+        if (!mob.role.isCombatant) {
+            return when (mob.role) {
+                dev.ambon.domain.mob.MobRole.VENDOR -> "${mob.name} isn't interested in fighting — try the shop instead."
+                dev.ambon.domain.mob.MobRole.QUEST_GIVER -> "${mob.name} has no quarrel with you. Maybe they have work to offer?"
+                dev.ambon.domain.mob.MobRole.DIALOG -> "${mob.name} has no interest in fighting you."
+                dev.ambon.domain.mob.MobRole.PROP -> "${mob.name} is not something you can attack."
+                dev.ambon.domain.mob.MobRole.COMBAT -> error("unreachable")
+            }
+        }
 
         val now = clock.millis()
         registerCombatant(sessionId, mob.id, player, now)
@@ -449,6 +458,7 @@ class CombatSystem(
         val player = players.get(sessionId) ?: return false
         val mob = mobs.get(mobId) ?: return false
 
+        if (!mob.role.isCombatant) return false
         if (playerTarget.containsKey(sessionId)) return false
         if (player.roomId != mob.roomId) return false
 

--- a/src/main/kotlin/dev/ambon/engine/ZoneResetHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/ZoneResetHandler.kt
@@ -60,6 +60,7 @@ internal fun spawnToMobState(spawn: MobSpawn, world: World): MobState =
         spells = spawn.spells,
         defaultAttack = spawn.defaultAttack,
         level = spawn.level,
+        role = spawn.role,
     )
 
 /**

--- a/src/test/kotlin/dev/ambon/engine/MobRoleTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/MobRoleTest.kt
@@ -1,0 +1,164 @@
+package dev.ambon.engine
+
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.mob.MobRole
+import dev.ambon.domain.mob.MobState
+import dev.ambon.test.CombatTestFixture
+import dev.ambon.test.loginOrFail
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.Random
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MobRoleTest {
+    @Test
+    fun `parse accepts lowercase role names`() {
+        assertEquals(MobRole.COMBAT, MobRole.parse("combat"))
+        assertEquals(MobRole.VENDOR, MobRole.parse("VENDOR"))
+        assertEquals(MobRole.QUEST_GIVER, MobRole.parse("quest_giver"))
+        assertEquals(MobRole.QUEST_GIVER, MobRole.parse("quest-giver"))
+        assertEquals(MobRole.DIALOG, MobRole.parse("Dialog"))
+        assertEquals(MobRole.PROP, MobRole.parse("prop"))
+    }
+
+    @Test
+    fun `parse defaults to combat when role is null or blank`() {
+        assertEquals(MobRole.COMBAT, MobRole.parse(null))
+        assertEquals(MobRole.COMBAT, MobRole.parse(""))
+        assertEquals(MobRole.COMBAT, MobRole.parse("   "))
+    }
+
+    @Test
+    fun `parse rejects unknown role names`() {
+        assertThrows(IllegalArgumentException::class.java) { MobRole.parse("boss") }
+    }
+
+    @Test
+    fun `isCombatant is true only for COMBAT`() {
+        assertTrue(MobRole.COMBAT.isCombatant)
+        assertFalse(MobRole.VENDOR.isCombatant)
+        assertFalse(MobRole.QUEST_GIVER.isCombatant)
+        assertFalse(MobRole.DIALOG.isCombatant)
+        assertFalse(MobRole.PROP.isCombatant)
+    }
+
+    @Test
+    fun `startCombat refuses a vendor mob`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            fixture.mobs.upsert(
+                MobState(
+                    id = MobId("town:shopkeep"),
+                    name = "Quartermaster Quill",
+                    roomId = fixture.roomId,
+                    hp = 10,
+                    maxHp = 10,
+                    role = MobRole.VENDOR,
+                ),
+            )
+            val combat = fixture.buildCombat(rng = Random(1))
+            val sid = SessionId(1L)
+            fixture.players.loginOrFail(sid, "Hero")
+
+            val err = combat.startCombat(sid, "quill")
+            assertNotNull(err)
+            assertTrue(err!!.contains("shop", ignoreCase = true))
+        }
+
+    @Test
+    fun `startCombat refuses a quest giver mob`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            fixture.mobs.upsert(
+                MobState(
+                    id = MobId("town:loremaster"),
+                    name = "Elder Oak",
+                    roomId = fixture.roomId,
+                    hp = 10,
+                    maxHp = 10,
+                    role = MobRole.QUEST_GIVER,
+                ),
+            )
+            val combat = fixture.buildCombat(rng = Random(1))
+            val sid = SessionId(1L)
+            fixture.players.loginOrFail(sid, "Hero")
+
+            val err = combat.startCombat(sid, "oak")
+            assertNotNull(err)
+            assertTrue(err!!.contains("quarrel", ignoreCase = true) || err.contains("work", ignoreCase = true))
+        }
+
+    @Test
+    fun `startCombat refuses a prop`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            fixture.mobs.upsert(
+                MobState(
+                    id = MobId("town:statue"),
+                    name = "a weathered statue",
+                    roomId = fixture.roomId,
+                    hp = 1,
+                    maxHp = 1,
+                    role = MobRole.PROP,
+                ),
+            )
+            val combat = fixture.buildCombat(rng = Random(1))
+            val sid = SessionId(1L)
+            fixture.players.loginOrFail(sid, "Hero")
+
+            val err = combat.startCombat(sid, "statue")
+            assertNotNull(err)
+            assertTrue(err!!.contains("not something you can attack", ignoreCase = true))
+        }
+
+    @Test
+    fun `startCombat accepts a combat mob`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            fixture.mobs.upsert(
+                MobState(
+                    id = MobId("demo:rat"),
+                    name = "a rat",
+                    roomId = fixture.roomId,
+                    hp = 10,
+                    maxHp = 10,
+                    role = MobRole.COMBAT,
+                ),
+            )
+            val combat = fixture.buildCombat(rng = Random(1))
+            val sid = SessionId(1L)
+            fixture.players.loginOrFail(sid, "Hero")
+
+            assertNull(combat.startCombat(sid, "rat"))
+        }
+
+    @Test
+    fun `startMobCombat refuses to initiate for a non-combat mob`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            val mobId = MobId("town:shopkeep")
+            fixture.mobs.upsert(
+                MobState(
+                    id = mobId,
+                    name = "Quartermaster Quill",
+                    roomId = fixture.roomId,
+                    hp = 10,
+                    maxHp = 10,
+                    role = MobRole.VENDOR,
+                ),
+            )
+            val combat = fixture.buildCombat(rng = Random(1))
+            val sid = SessionId(1L)
+            fixture.players.loginOrFail(sid, "Hero")
+
+            assertFalse(combat.startMobCombat(mobId, sid))
+        }
+}


### PR DESCRIPTION
## Summary

First phase of the tier-based content model — authors declare *what a mob is for* and the engine enforces the implied interaction boundaries. Today the only way to stop a shopkeeper from being killed is to pile on HP and zero out XP; going forward `role: vendor` means the engine refuses the attack outright.

- New `MobRole` enum (`COMBAT | VENDOR | QUEST_GIVER | DIALOG | PROP`) with case-insensitive YAML parsing. Null/blank defaults to `COMBAT`, so every existing zone file retains its current behaviour with zero changes.
- `role` threaded through `MobTemplate` → `MobFile` / `MobSpawn` / `MobState` → `WorldLoader` → `spawnToMobState`.
- `CombatSystem.startCombat` refuses non-COMBAT targets with a role-appropriate refusal message (`"Quartermaster Quill isn't interested in fighting — try the shop instead."`).
- `CombatSystem.startMobCombat` also short-circuits when the mob isn't a combatant, so an aggressive-behaviour script can't accidentally start combat on a social NPC.
- `look <npc>` continues to work for every role — flavour text doesn't care about attackability.

## Sequencing

This is Phase 1 of a four-phase plan agreed with @jnoecker:

1. **Mob role** — this PR.
2. Mob tier-driven stat computation (authored numbers become overrides).
3. Quest difficulty tiers (author picks trivial/easy/standard/hard/epic; engine computes XP).
4. Zone-level scaling (`scaling: static | bounded | player`).

Each phase ships as a paired MUD + Arcanum PR.

## Test plan
- [x] `./gradlew ktlintCheck test -x buildWeb` — 1959 tests pass, ktlint clean
- [x] New `MobRoleTest`: parse semantics, `isCombatant`, attack refusal for each non-combat role, attack accepted for COMBAT, `startMobCombat` short-circuit
- [ ] Manual: flip Quartermaster Quill to `role: vendor` in Auringold, verify shop still opens and `kill quill` produces the refusal message