### PR TITLE
Compute quest XP from difficulty tier

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -501,6 +501,13 @@ data class AppConfig(
         require(progression.rewards.manaPerLevel >= 0) { "ambonMUD.progression.rewards.manaPerLevel must be >= 0" }
         require(progression.rewards.baseHp >= 1) { "ambonMUD.progression.rewards.baseHp must be >= 1" }
         require(progression.rewards.baseMana >= 0) { "ambonMUD.progression.rewards.baseMana must be >= 0" }
+        require(progression.quests.baseline.baseXp >= 0L) { "ambonMUD.progression.quests.baseline.baseXp must be >= 0" }
+        require(progression.quests.baseline.xpPerLevel >= 0L) { "ambonMUD.progression.quests.baseline.xpPerLevel must be >= 0" }
+        for ((difficulty, multiplier) in progression.quests.tiers) {
+            require(multiplier >= 0.0) {
+                "ambonMUD.progression.quests.tiers[$difficulty] must be >= 0 (got $multiplier)"
+            }
+        }
     }
 
     private fun validateTransport() {
@@ -1889,7 +1896,56 @@ data class ProgressionConfig(
     val maxLevel: Int = 50,
     val xp: XpCurveConfig = XpCurveConfig(),
     val rewards: LevelRewardsConfig = LevelRewardsConfig(),
+    val quests: QuestXpConfig = QuestXpConfig(),
 )
+
+/**
+ * Engine-computed XP for quests. Quests with an explicit `rewards.xp` authored
+ * in the YAML keep that value as an override; quests that declare only a
+ * `difficulty` (and optional `level`) get
+ *   `(baseline.baseXp + baseline.xpPerLevel * (level - 1)) * tiers[difficulty]`
+ * at completion time, with diminishing returns layered on top as usual.
+ */
+data class QuestXpConfig(
+    val baseline: QuestBaselineConfig = QuestBaselineConfig(),
+    val tiers: Map<QuestDifficulty, Double> =
+        mapOf(
+            QuestDifficulty.TRIVIAL to 0.25,
+            QuestDifficulty.EASY to 0.5,
+            QuestDifficulty.STANDARD to 1.0,
+            QuestDifficulty.HARD to 1.75,
+            QuestDifficulty.EPIC to 3.0,
+        ),
+)
+
+data class QuestBaselineConfig(
+    val baseXp: Long = 50L,
+    val xpPerLevel: Long = 20L,
+)
+
+enum class QuestDifficulty {
+    TRIVIAL,
+    EASY,
+    STANDARD,
+    HARD,
+    EPIC,
+    ;
+
+    companion object {
+        /**
+         * Parses a difficulty string from world YAML. Null/blank returns null
+         * (quest has no tier — XP comes from the authored `rewards.xp` alone).
+         */
+        fun parse(raw: String?): QuestDifficulty? {
+            if (raw.isNullOrBlank()) return null
+            val normalized = raw.trim().uppercase()
+            return entries.firstOrNull { it.name == normalized }
+                ?: throw IllegalArgumentException(
+                    "Unknown quest difficulty '$raw' (expected one of ${entries.joinToString { it.name.lowercase() }})",
+                )
+        }
+    }
+}
 
 data class XpCurveConfig(
     val baseXp: Long = 100L,

--- a/src/main/kotlin/dev/ambon/domain/quest/QuestDef.kt
+++ b/src/main/kotlin/dev/ambon/domain/quest/QuestDef.kt
@@ -1,5 +1,6 @@
 package dev.ambon.domain.quest
 
+import dev.ambon.config.QuestDifficulty
 import dev.ambon.domain.Rewards
 import dev.ambon.domain.world.ReputationRequirement
 
@@ -20,6 +21,13 @@ data class QuestDef(
      * Null preserves legacy flat-award behaviour.
      */
     val level: Int? = null,
+    /**
+     * Engine-driven difficulty tier. When non-null and `rewards.xp == 0`, the
+     * engine computes XP from the progression config's quest baseline and the
+     * tier's multiplier. An explicit positive `rewards.xp` always wins as an
+     * override.
+     */
+    val difficulty: QuestDifficulty? = null,
 )
 
 data class QuestObjectiveDef(

--- a/src/main/kotlin/dev/ambon/domain/world/data/QuestFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/QuestFile.kt
@@ -11,6 +11,12 @@ data class QuestFile(
     val requiredReputation: ReputationRequirementFile? = null,
     /** Intended player level. Drives XP diminishing returns on completion when set. */
     val level: Int? = null,
+    /**
+     * Engine-driven difficulty tier. Omit or leave blank to use the authored
+     * `rewards.xp` as-is; set `trivial|easy|standard|hard|epic` to let the
+     * engine compute XP from quest level × tier multiplier.
+     */
+    val difficulty: String? = null,
 )
 
 data class QuestObjectiveFile(

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -613,6 +613,11 @@ object WorldLoader {
                         completionType = completionType,
                         requiredReputation = questRep,
                         level = questFile.level,
+                        difficulty = try {
+                            dev.ambon.config.QuestDifficulty.parse(questFile.difficulty)
+                        } catch (e: IllegalArgumentException) {
+                            throw WorldLoadException("Quest '$questId': ${e.message}")
+                        },
                     ),
                 )
             }

--- a/src/main/kotlin/dev/ambon/engine/PlayerProgression.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerProgression.kt
@@ -1,6 +1,7 @@
 package dev.ambon.engine
 
 import dev.ambon.config.ProgressionConfig
+import dev.ambon.config.QuestDifficulty
 import dev.ambon.config.StatBindingsConfig
 import dev.ambon.domain.mob.MobState
 import kotlin.math.pow
@@ -155,6 +156,23 @@ class PlayerProgression(
     fun defaultKillXpReward(): Long = scaledXp(config.xp.defaultKillXp)
 
     fun killXpReward(mob: MobState): Long = scaledXp(mob.xpReward)
+
+    /**
+     * Computes the engine-authored XP reward for a quest based on its tier and
+     * intended level. `(baseline.baseXp + baseline.xpPerLevel * (level - 1))`
+     * scaled by the tier multiplier; the result is clamped to non-negative.
+     * Returns 0 when [difficulty] is null (no tier declared) or when the
+     * tier has no configured multiplier.
+     */
+    fun computeQuestXp(difficulty: QuestDifficulty?, level: Int): Long {
+        if (difficulty == null) return 0L
+        val multiplier = config.quests.tiers[difficulty] ?: return 0L
+        val steps = (level.coerceAtLeast(1) - 1).toLong()
+        val baseline = config.quests.baseline.baseXp + config.quests.baseline.xpPerLevel * steps
+        val scaled = baseline.toDouble() * multiplier
+        if (!scaled.isFinite()) return Long.MAX_VALUE
+        return scaled.roundToLong().coerceAtLeast(0L)
+    }
 
     /**
      * Returns the XP multiplier for a kill given the player's level and the

--- a/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
@@ -349,8 +349,17 @@ class QuestSystem(
         onQuestCompletedGmcp?.invoke(sessionId, questId, quest.name)
         onQuestCompleted?.invoke(sessionId, questId)
 
-        grantRewards(sessionId, rewards, ps, players, outbound, progression, quest.level)
-        if (rewards.xp == 0L) players.persistPlayer(ps.sessionId)
+        val effectiveRewards =
+            if (rewards.xp == 0L && quest.difficulty != null && progression != null) {
+                val effectiveLevel = quest.level ?: ps.level
+                val computed = progression.computeQuestXp(quest.difficulty, effectiveLevel)
+                if (computed > 0L) rewards.copy(xp = computed) else rewards
+            } else {
+                rewards
+            }
+
+        grantRewards(sessionId, effectiveRewards, ps, players, outbound, progression, quest.level)
+        if (effectiveRewards.xp == 0L) players.persistPlayer(ps.sessionId)
     }
 
     private suspend fun sendObjectiveProgress(

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1941,6 +1941,20 @@ ambonmud:
       fullManaOnLevelUp: true
       baseHp: 10
       baseMana: 10
+    # Engine-computed XP for quests. Authors pick a difficulty tier (or leave
+    # `rewards.xp` authored for an explicit override) and the engine produces
+    #   (baseXp + xpPerLevel * (level - 1)) * tiers[difficulty]
+    # at completion time. Diminishing returns still applies on top.
+    quests:
+      baseline:
+        baseXp: 50
+        xpPerLevel: 20
+      tiers:
+        TRIVIAL: 0.25
+        EASY: 0.5
+        STANDARD: 1.0
+        HARD: 1.75
+        EPIC: 3.0
   transport:
     telnet:
       maxLineLen: 1024

--- a/src/test/kotlin/dev/ambon/engine/PlayerProgressionTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/PlayerProgressionTest.kt
@@ -6,6 +6,9 @@ import dev.ambon.config.DiminishingXpConfig
 import dev.ambon.config.DiminishingXpThreshold
 import dev.ambon.config.LevelRewardsConfig
 import dev.ambon.config.ProgressionConfig
+import dev.ambon.config.QuestBaselineConfig
+import dev.ambon.config.QuestDifficulty
+import dev.ambon.config.QuestXpConfig
 import dev.ambon.config.XpCurveConfig
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
@@ -298,5 +301,66 @@ class PlayerProgressionTest {
             )
 
         assertEquals(1.0, progression.diminishingKillXpMultiplier(playerLevel = 50, mobLevel = 1))
+    }
+
+    @Test
+    fun `computeQuestXp returns zero when no difficulty is declared`() {
+        val progression = PlayerProgression()
+        assertEquals(0L, progression.computeQuestXp(null, level = 5))
+    }
+
+    @Test
+    fun `computeQuestXp scales baseline by tier multiplier at the quest's level`() {
+        val progression =
+            PlayerProgression(
+                ProgressionConfig(
+                    quests = QuestXpConfig(
+                        baseline = QuestBaselineConfig(baseXp = 50L, xpPerLevel = 20L),
+                        tiers = mapOf(
+                            QuestDifficulty.TRIVIAL to 0.25,
+                            QuestDifficulty.EASY to 0.5,
+                            QuestDifficulty.STANDARD to 1.0,
+                            QuestDifficulty.HARD to 1.75,
+                            QuestDifficulty.EPIC to 3.0,
+                        ),
+                    ),
+                ),
+            )
+
+        // Level 1: baseline = 50
+        assertEquals(13L, progression.computeQuestXp(QuestDifficulty.TRIVIAL, level = 1))
+        assertEquals(50L, progression.computeQuestXp(QuestDifficulty.STANDARD, level = 1))
+        assertEquals(150L, progression.computeQuestXp(QuestDifficulty.EPIC, level = 1))
+
+        // Level 5: baseline = 50 + 20*4 = 130
+        assertEquals(33L, progression.computeQuestXp(QuestDifficulty.TRIVIAL, level = 5))
+        assertEquals(130L, progression.computeQuestXp(QuestDifficulty.STANDARD, level = 5))
+        assertEquals(228L, progression.computeQuestXp(QuestDifficulty.HARD, level = 5))
+
+        // Level 10: baseline = 50 + 20*9 = 230
+        assertEquals(690L, progression.computeQuestXp(QuestDifficulty.EPIC, level = 10))
+    }
+
+    @Test
+    fun `computeQuestXp clamps level 0 or below to level 1 baseline`() {
+        val progression = PlayerProgression()
+        val atOne = progression.computeQuestXp(QuestDifficulty.STANDARD, level = 1)
+        val atZero = progression.computeQuestXp(QuestDifficulty.STANDARD, level = 0)
+        val atNegative = progression.computeQuestXp(QuestDifficulty.STANDARD, level = -5)
+        assertEquals(atOne, atZero)
+        assertEquals(atOne, atNegative)
+    }
+
+    @Test
+    fun `computeQuestXp returns zero when the tier lacks a multiplier`() {
+        val progression =
+            PlayerProgression(
+                ProgressionConfig(
+                    quests = QuestXpConfig(
+                        tiers = mapOf(QuestDifficulty.STANDARD to 1.0),
+                    ),
+                ),
+            )
+        assertEquals(0L, progression.computeQuestXp(QuestDifficulty.EPIC, level = 5))
     }
 }

--- a/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
@@ -3,6 +3,7 @@ package dev.ambon.engine
 import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.config.FactionConfig
 import dev.ambon.config.FactionDefinition
+import dev.ambon.config.QuestDifficulty
 import dev.ambon.domain.ids.ItemId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.items.Item
@@ -157,6 +158,58 @@ class QuestSystemTest {
                 xpGained < 1000L,
                 "Overleveled quest XP should be reduced (got $xpGained, expected << 1000)",
             )
+        }
+
+    @Test
+    fun `quest XP is computed from difficulty when rewards xp is zero`() =
+        runTest {
+            val progression = PlayerProgression()
+            val tieredQuest =
+                killQuest.copy(
+                    level = 3,
+                    difficulty = QuestDifficulty.STANDARD,
+                    rewards = QuestRewards(xp = 0L, gold = 0L),
+                )
+            val (qs, players, outbound) = setup(tieredQuest, progression)
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Hero")
+            players.setLevel(sid, 3)
+            val xpBefore = players.get(sid)!!.xpTotal
+            qs.acceptQuest(sid, questId)
+            outbound.drainAll()
+
+            repeat(3) { qs.onMobKilled(sid, mobTemplateKey) }
+
+            val ps = players.get(sid)!!
+            assertTrue(ps.completedQuestIds.contains(questId))
+            val xpGained = ps.xpTotal - xpBefore
+            // STANDARD × (50 + 20*2) = 90 at level 3
+            assertEquals(90L, xpGained, "Quest XP should be computed from difficulty baseline")
+        }
+
+    @Test
+    fun `authored quest XP overrides computed difficulty XP`() =
+        runTest {
+            val progression = PlayerProgression()
+            val tieredQuest =
+                killQuest.copy(
+                    level = 3,
+                    difficulty = QuestDifficulty.EPIC,
+                    rewards = QuestRewards(xp = 42L, gold = 0L),
+                )
+            val (qs, players, outbound) = setup(tieredQuest, progression)
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Hero")
+            players.setLevel(sid, 3)
+            val xpBefore = players.get(sid)!!.xpTotal
+            qs.acceptQuest(sid, questId)
+            outbound.drainAll()
+
+            repeat(3) { qs.onMobKilled(sid, mobTemplateKey) }
+
+            val ps = players.get(sid)!!
+            val xpGained = ps.xpTotal - xpBefore
+            assertEquals(42L, xpGained, "Authored rewards.xp should win over the tier")
         }
 
     @Test


### PR DESCRIPTION
## Summary

Phase 3 of the tier-based content model. Authors pick a quest difficulty (`trivial | easy | standard | hard | epic`) and the engine computes XP from a configurable baseline at completion time. An explicit `rewards.xp` still wins as an override so every existing quest in every existing zone keeps its current numbers.

- **`QuestDifficulty`** enum with case-insensitive YAML parsing. Null stays null — legacy quests behave exactly as today.
- **`QuestXpConfig` + `QuestBaselineConfig`** mounted on `ProgressionConfig`. Defaults: `baseXp: 50, xpPerLevel: 20`, tier multipliers `0.25 / 0.5 / 1.0 / 1.75 / 3.0`. `application.yaml` mirrors them so the live Ambon tune ships with the new config populated.
- `QuestDef.difficulty` + `QuestFile.difficulty`; `WorldLoader` parses and propagates with a quest-id-tagged error message on typos.
- **`PlayerProgression.computeQuestXp(difficulty, level)`** — `(baseline.baseXp + baseline.xpPerLevel × (level - 1)) × tiers[difficulty]`, clamped to non-negative, level coerced to ≥1, non-finite results clamped to `Long.MAX_VALUE`.
- **`QuestSystem.completeQuest`**: computed value is used when `rewards.xp == 0` AND a difficulty is set; authored value wins when `rewards.xp > 0`. Diminishing returns still applies on top via the existing `grantRewards` path.
- Config validation added for baseXp ≥ 0, xpPerLevel ≥ 0, and all tier multipliers ≥ 0.

## Migration

Zero. Every quest today has `rewards.xp > 0`, so the override branch wins and behaviour is unchanged. Authors opt into tier-computed XP quest-by-quest as they flip `difficulty: standard` and remove the hand-tuned number.

## Phase of the plan

3 of 4:

1. ✅ Mob role
2. ✅ Mob tier-driven stats
3. **Quest difficulty tiers** — this PR
4. Zone-level scaling (`scaling: static | bounded | player`)

## Test plan
- [x] `./gradlew ktlintCheck test -x buildWeb` — all tests pass, ktlint clean
- New `PlayerProgressionTest` cases: baseline arithmetic at levels 1/5/10, TRIVIAL/STANDARD/HARD/EPIC multipliers, level-clamping at ≤0, missing-multiplier handling
- New `QuestSystemTest` cases: computed XP at level 3 (STANDARD → 90), authored override beats difficulty (epic quest awards the authored 42)
- [ ] Manual: flip Auringold Academy's "Grand Tour" to `difficulty: standard` with `rewards.xp: 0`, verify player at level 1 gains 50 XP instead of the authored 150