### PR TITLE
Add ZoneScaling for bounded / player-sync content

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
@@ -1,5 +1,6 @@
 package dev.ambon.domain.world
 
+import dev.ambon.config.MobTierConfig
 import dev.ambon.domain.DamageRange
 import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
@@ -8,6 +9,21 @@ import dev.ambon.domain.mob.MobSpell
 import dev.ambon.domain.mob.MobTemplate
 import dev.ambon.engine.behavior.BtNode
 import dev.ambon.engine.dialogue.DialogueTree
+
+/**
+ * Authored stat overrides that won at load time. Preserved on [MobSpawn] so
+ * that spawn-time rescaling (for zones with non-STATIC scaling) can replay
+ * the tier × level math while still honouring the author's explicit values.
+ */
+data class MobStatOverrides(
+    val hp: Int? = null,
+    val minDamage: Int? = null,
+    val maxDamage: Int? = null,
+    val armor: Int? = null,
+    val xpReward: Long? = null,
+    val goldMin: Long? = null,
+    val goldMax: Long? = null,
+)
 
 data class MobSpawn(
     override val id: MobId,
@@ -34,4 +50,13 @@ data class MobSpawn(
     override val defaultAttack: String? = null,
     override val level: Int = 1,
     override val role: MobRole = MobRole.COMBAT,
+    /**
+     * The tier config used to resolve stats at load time. Preserved so
+     * spawn-time rescaling can replay the formulas at a different level
+     * without re-reading config. Null means "don't rescale this mob even in
+     * scaling zones" — typically because no tier was available at load.
+     */
+    val tier: MobTierConfig? = null,
+    /** Which stats the author explicitly set. Overrides stay fixed even when scaling shifts level. */
+    val overrides: MobStatOverrides = MobStatOverrides(),
 ) : MobTemplate

--- a/src/main/kotlin/dev/ambon/domain/world/ResolvedMobStats.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/ResolvedMobStats.kt
@@ -1,0 +1,41 @@
+package dev.ambon.domain.world
+
+import dev.ambon.config.MobTierConfig
+import dev.ambon.domain.DamageRange
+
+/** Fully-resolved combat stats for a mob at a specific level. */
+data class ResolvedMobStats(
+    val hp: Int,
+    val damage: DamageRange,
+    val armor: Int,
+    val xpReward: Long,
+    val goldMin: Long,
+    val goldMax: Long,
+)
+
+/**
+ * Resolves a mob's combat stats from (tier, level, author overrides).
+ * Mirrors the baking that `WorldLoader` does at load time so spawn-time
+ * rescaling for [ZoneScaling] can replay the same math at a different
+ * level without re-reading world YAML.
+ *
+ * Authored overrides always win; only tier-derived fields change with level.
+ */
+fun resolveMobStats(
+    tier: MobTierConfig,
+    level: Int,
+    overrides: MobStatOverrides = MobStatOverrides(),
+): ResolvedMobStats {
+    val normalized = level.coerceAtLeast(1)
+    val steps = normalized - 1
+    val minDamage = overrides.minDamage ?: (tier.baseMinDamage + steps * tier.damagePerLevel)
+    val maxDamage = overrides.maxDamage ?: (tier.baseMaxDamage + steps * tier.damagePerLevel)
+    return ResolvedMobStats(
+        hp = overrides.hp ?: (tier.baseHp + steps * tier.hpPerLevel),
+        damage = DamageRange(minDamage, maxDamage),
+        armor = overrides.armor ?: tier.baseArmor,
+        xpReward = overrides.xpReward ?: (tier.baseXpReward + steps.toLong() * tier.xpRewardPerLevel),
+        goldMin = overrides.goldMin ?: (tier.baseGoldMin + steps.toLong() * tier.goldPerLevel),
+        goldMax = overrides.goldMax ?: (tier.baseGoldMax + steps.toLong() * tier.goldPerLevel),
+    )
+}

--- a/src/main/kotlin/dev/ambon/domain/world/World.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/World.kt
@@ -16,6 +16,7 @@ class World(
     zoneLifespansMinutes: Map<String, Long> = emptyMap(),
     pvpZones: Set<String> = emptySet(),
     zoneStartRooms: Map<String, RoomId> = emptyMap(),
+    zoneScaling: Map<String, ZoneScaling> = emptyMap(),
     shopDefinitions: List<ShopDefinition> = emptyList(),
     trainerDefinitions: List<TrainerDefinition> = emptyList(),
     questDefinitions: List<QuestDef> = emptyList(),
@@ -50,6 +51,12 @@ class World(
 
     /** Returns the start room for a zone, if known. */
     fun zoneStartRoom(zoneId: String): RoomId? = _zoneStartRooms[zoneId]
+
+    private val _zoneScaling = zoneScaling.toMutableMap()
+    val zoneScaling: Map<String, ZoneScaling> get() = _zoneScaling
+
+    /** Returns the scaling config for a zone. Falls back to STATIC when unset. */
+    fun zoneScaling(zoneId: String): ZoneScaling = _zoneScaling[zoneId] ?: ZoneScaling()
 
     private val _shopDefinitions = shopDefinitions.toMutableList()
     val shopDefinitions: List<ShopDefinition> get() = _shopDefinitions
@@ -127,6 +134,9 @@ class World(
         source.zoneStartRoom(zone)?.let { _zoneStartRooms[zone] = it }
             ?: _zoneStartRooms.remove(zone)
 
+        source._zoneScaling[zone]?.let { _zoneScaling[zone] = it }
+            ?: _zoneScaling.remove(zone)
+
         return oldRoomIds - newRooms.keys
     }
 
@@ -155,6 +165,9 @@ class World(
 
         _zoneStartRooms.clear()
         _zoneStartRooms.putAll(source._zoneStartRooms)
+
+        _zoneScaling.clear()
+        _zoneScaling.putAll(source._zoneScaling)
 
         _shopDefinitions.clear()
         _shopDefinitions.addAll(source.shopDefinitions)

--- a/src/main/kotlin/dev/ambon/domain/world/ZoneScaling.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/ZoneScaling.kt
@@ -1,0 +1,79 @@
+package dev.ambon.domain.world
+
+/**
+ * Controls how a zone resolves mob and quest levels at runtime.
+ *
+ * - [STATIC] — mobs and quests use their authored `level` fields as-is. Current
+ *   behaviour; the default for zones that don't declare scaling.
+ * - [BOUNDED] — mobs and quests scale to the level of the highest-level player
+ *   in the zone, clamped to the zone's `levelRange`. Players below the floor
+ *   get floor-level content; players above the ceiling get ceiling-level
+ *   content. Keeps progression gates intact while letting mixed-level parties
+ *   play the same zone.
+ * - [PLAYER] — mobs and quests scale directly to the reference player's level
+ *   with no bounds. Intended for tutorial zones, endgame social hubs, or any
+ *   content that should always match the player.
+ */
+enum class ScalingMode {
+    STATIC,
+    BOUNDED,
+    PLAYER,
+    ;
+
+    companion object {
+        /**
+         * Parses a mode string from world YAML. Null/blank returns [STATIC]
+         * so zones without explicit scaling keep their authored levels.
+         */
+        fun parse(raw: String?): ScalingMode {
+            if (raw.isNullOrBlank()) return STATIC
+            val normalized = raw.trim().uppercase()
+            return entries.firstOrNull { it.name == normalized }
+                ?: throw IllegalArgumentException(
+                    "Unknown scaling mode '$raw' (expected one of ${entries.joinToString { it.name.lowercase() }})",
+                )
+        }
+    }
+}
+
+/**
+ * Per-zone scaling configuration. Immutable; parsed once at world load and
+ * consulted by spawn/completion paths at runtime.
+ */
+data class ZoneScaling(
+    val mode: ScalingMode = ScalingMode.STATIC,
+    /** Inclusive min/max bounds for [ScalingMode.BOUNDED]. Required when mode is BOUNDED; ignored otherwise. */
+    val levelRange: IntRange? = null,
+) {
+    /**
+     * Computes the effective level to use for content in this zone given a
+     * reference player level (typically the highest-level player in the zone
+     * when a mob respawns or a quest turns in) and the authored level on the
+     * content itself.
+     *
+     * - [ScalingMode.STATIC]: returns [authoredLevel] when set, else [referencePlayerLevel].
+     * - [ScalingMode.BOUNDED]: clamps [referencePlayerLevel] to [levelRange];
+     *   falls back to [authoredLevel] or `range.first` when no reference is given.
+     * - [ScalingMode.PLAYER]: returns [referencePlayerLevel]; falls back to
+     *   [authoredLevel] or 1.
+     *
+     * The returned level is always at least 1.
+     */
+    fun resolveLevel(referencePlayerLevel: Int?, authoredLevel: Int?): Int {
+        val resolved = when (mode) {
+            ScalingMode.STATIC -> authoredLevel ?: referencePlayerLevel ?: 1
+            ScalingMode.BOUNDED -> {
+                val range = levelRange
+                if (range == null) {
+                    authoredLevel ?: referencePlayerLevel ?: 1
+                } else if (referencePlayerLevel != null) {
+                    referencePlayerLevel.coerceIn(range)
+                } else {
+                    authoredLevel?.coerceIn(range) ?: range.first
+                }
+            }
+            ScalingMode.PLAYER -> referencePlayerLevel ?: authoredLevel ?: 1
+        }
+        return resolved.coerceAtLeast(1)
+    }
+}

--- a/src/main/kotlin/dev/ambon/domain/world/data/WorldFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/WorldFile.kt
@@ -12,6 +12,8 @@ data class WorldFile(
     val terrain: String? = null,
     /** Controlling faction for this region. Inherited by mobs that don't set their own. */
     val faction: String? = null,
+    /** Dynamic level-scaling configuration. Null/missing = STATIC (use authored levels). */
+    val scaling: ZoneScalingFile? = null,
     val image: ZoneImageDefaults? = null,
     val audio: ZoneAudioDefaults? = null,
     val rooms: Map<String, RoomFile>,
@@ -24,6 +26,12 @@ data class WorldFile(
     val recipes: Map<String, RecipeFile> = emptyMap(),
     val dungeon: DungeonFile? = null,
     val puzzles: Map<String, PuzzleFile> = emptyMap(),
+)
+
+data class ZoneScalingFile(
+    val mode: String = "static",
+    /** Inclusive [min, max] bounds. Required for BOUNDED mode. */
+    val levelRange: List<Int>? = null,
 )
 
 data class TrainerFile(

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -42,17 +42,21 @@ import dev.ambon.domain.world.LeverState
 import dev.ambon.domain.world.LockableState
 import dev.ambon.domain.world.MobDrop
 import dev.ambon.domain.world.MobSpawn
+import dev.ambon.domain.world.MobStatOverrides
 import dev.ambon.domain.world.ReputationRequirement
 import dev.ambon.domain.world.Room
 import dev.ambon.domain.world.RoomFeature
+import dev.ambon.domain.world.ScalingMode
 import dev.ambon.domain.world.ShopDefinition
 import dev.ambon.domain.world.TrainerDefinition
 import dev.ambon.domain.world.World
+import dev.ambon.domain.world.ZoneScaling
 import dev.ambon.domain.world.data.ExitValue
 import dev.ambon.domain.world.data.ExitValueDeserializer
 import dev.ambon.domain.world.data.FeatureFile
 import dev.ambon.domain.world.data.ReputationRequirementFile
 import dev.ambon.domain.world.data.WorldFile
+import dev.ambon.domain.world.resolveMobStats
 import dev.ambon.engine.behavior.BehaviorTemplates
 import dev.ambon.engine.behavior.BehaviorTreeLoader
 import dev.ambon.engine.behavior.BtNode
@@ -146,6 +150,7 @@ object WorldLoader {
         val zoneLifespansMinutes = LinkedHashMap<String, Long?>()
         val pvpZones = mutableSetOf<String>()
         val zoneStartRooms = LinkedHashMap<String, RoomId>()
+        val zoneScalings = LinkedHashMap<String, ZoneScaling>()
 
         // startRoomOverride wins; otherwise fall back to first file’s declared startRoom.
         val worldStart = startRoomOverride ?: normalizeId(files.first().zone, files.first().startRoom)
@@ -185,6 +190,36 @@ object WorldLoader {
                 }
             }
             if (file.pvpEnabled) pvpZones.add(zone)
+
+            file.scaling?.let { scalingFile ->
+                val mode = try {
+                    ScalingMode.parse(scalingFile.mode)
+                } catch (e: IllegalArgumentException) {
+                    throw WorldLoadException("Zone '$zone' scaling: ${e.message}")
+                }
+                val range: IntRange? = scalingFile.levelRange?.let { values ->
+                    when {
+                        values.size != 2 ->
+                            throw WorldLoadException(
+                                "Zone '$zone' scaling.levelRange must be exactly [min, max] (got ${values.size} values)",
+                            )
+                        values[0] < 1 || values[1] < values[0] ->
+                            throw WorldLoadException(
+                                "Zone '$zone' scaling.levelRange must be [min >= 1, max >= min] (got $values)",
+                            )
+                        else -> values[0]..values[1]
+                    }
+                }
+                if (mode == ScalingMode.BOUNDED && range == null) {
+                    throw WorldLoadException("Zone '$zone' scaling.mode = bounded requires a levelRange")
+                }
+                val parsed = ZoneScaling(mode, range)
+                val existing = zoneScalings[zone]
+                if (existing != null && existing != parsed) {
+                    throw WorldLoadException("Zone '$zone' declares conflicting scaling configs across files")
+                }
+                zoneScalings[zone] = parsed
+            }
 
             // First pass per file: create room shells, detect collisions
             for ((rawId, rf) in file.rooms) {
@@ -303,15 +338,24 @@ object WorldLoader {
 
                 val level = mf.level ?: 1
                 requireAtLeast(level, 1, "Mob '${mobId.value}'", "level")
-                val steps = level - 1
 
-                val resolvedHp = mf.hp ?: (tier.baseHp + steps * tier.hpPerLevel)
-                val resolvedMinDamage = mf.minDamage ?: (tier.baseMinDamage + steps * tier.damagePerLevel)
-                val resolvedMaxDamage = mf.maxDamage ?: (tier.baseMaxDamage + steps * tier.damagePerLevel)
-                val resolvedArmor = mf.armor ?: tier.baseArmor
-                val resolvedXpReward = mf.xpReward ?: (tier.baseXpReward + steps.toLong() * tier.xpRewardPerLevel)
-                val resolvedGoldMin = mf.goldMin ?: (tier.baseGoldMin + steps.toLong() * tier.goldPerLevel)
-                val resolvedGoldMax = mf.goldMax ?: (tier.baseGoldMax + steps.toLong() * tier.goldPerLevel)
+                val overrides = MobStatOverrides(
+                    hp = mf.hp,
+                    minDamage = mf.minDamage,
+                    maxDamage = mf.maxDamage,
+                    armor = mf.armor,
+                    xpReward = mf.xpReward,
+                    goldMin = mf.goldMin,
+                    goldMax = mf.goldMax,
+                )
+                val resolved = resolveMobStats(tier, level, overrides)
+                val resolvedHp = resolved.hp
+                val resolvedMinDamage = resolved.damage.min
+                val resolvedMaxDamage = resolved.damage.max
+                val resolvedArmor = resolved.armor
+                val resolvedXpReward = resolved.xpReward
+                val resolvedGoldMin = resolved.goldMin
+                val resolvedGoldMax = resolved.goldMax
                 val drops =
                     mf.drops.mapIndexed { index, drop ->
                         val rawItemId = requireNonBlank(drop.itemId) {
@@ -402,6 +446,8 @@ object WorldLoader {
                         } catch (e: IllegalArgumentException) {
                             throw WorldLoadException("Mob '${mobId.value}': ${e.message}")
                         },
+                        tier = tier,
+                        overrides = overrides,
                     )
             }
 
@@ -1027,6 +1073,7 @@ object WorldLoader {
                     .toMap(),
             pvpZones = pvpZones.toSet(),
             zoneStartRooms = zoneStartRooms.toMap(),
+            zoneScaling = zoneScalings.toMap(),
             shopDefinitions = mergedShops.toList(),
             trainerDefinitions = mergedTrainers.toList(),
             questDefinitions = mergedQuests.toList(),

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -879,6 +879,7 @@ class GameEngine(
             clock = clock,
             reputationSystem = reputationSystem,
             progression = progression,
+            world = world,
         )
 
     private val dailyQuestSystem: DailyQuestSystem? =
@@ -2167,7 +2168,8 @@ class GameEngine(
             scheduler.scheduleIn(respawnMs) {
                 if (mobs.get(spawn.id) != null) return@scheduleIn
                 if (world.rooms[spawn.roomId] == null) return@scheduleIn
-                val respawned = spawnToMobState(spawn, world)
+                val referenceLevel = highestPlayerLevelInZone(players, spawn.roomId.zone)
+                val respawned = spawnToMobState(spawn, world, referenceLevel)
                 mobs.upsert(respawned)
                 mobSystem.onMobSpawned(spawn.id)
                 behaviorTreeSystem.onMobSpawned(spawn.id)

--- a/src/main/kotlin/dev/ambon/engine/HotReloadManager.kt
+++ b/src/main/kotlin/dev/ambon/engine/HotReloadManager.kt
@@ -167,7 +167,8 @@ class HotReloadManager(
         var newMobSpawns = 0
         for (spawn in world.mobSpawns) {
             if (mobs.get(spawn.id) == null) {
-                val mobState = spawnToMobState(spawn, world)
+                val referenceLevel = highestPlayerLevelInZone(players, spawn.roomId.zone)
+                val mobState = spawnToMobState(spawn, world, referenceLevel)
                 mobs.upsert(mobState)
                 mobSystem.onMobSpawned(spawn.id)
                 behaviorTreeSystem.onMobSpawned(spawn.id)

--- a/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
@@ -2,12 +2,15 @@ package dev.ambon.engine
 
 import dev.ambon.bus.OutboundBus
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.ids.idZone
 import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.quest.ObjectiveProgress
 import dev.ambon.domain.quest.QuestDef
 import dev.ambon.domain.quest.QuestObjectiveDef
 import dev.ambon.domain.quest.QuestRewards
 import dev.ambon.domain.quest.QuestState
+import dev.ambon.domain.world.ScalingMode
+import dev.ambon.domain.world.World
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.engine.quest.CompletionHandlerRegistry
@@ -24,6 +27,7 @@ class QuestSystem(
     private val completionHandlers: CompletionHandlerRegistry = CompletionHandlerRegistry.withDefaults(),
     private val reputationSystem: ReputationSystem? = null,
     private val progression: PlayerProgression? = null,
+    private val world: World? = null,
 ) {
     /** Invoked after a quest is successfully completed; used by AchievementSystem. */
     var onQuestCompleted: (suspend (SessionId, String) -> Unit)? = null
@@ -349,16 +353,30 @@ class QuestSystem(
         onQuestCompletedGmcp?.invoke(sessionId, questId, quest.name)
         onQuestCompleted?.invoke(sessionId, questId)
 
+        // Zone scaling (phase 4): if the quest's zone declares non-STATIC scaling,
+        // the "effective level" for XP computation and diminishing tracks the
+        // player's current level instead of the authored quest level.
+        val zoneScaling = world?.zoneScaling(idZone(quest.id))
+        val effectiveLevel = when {
+            zoneScaling == null -> quest.level ?: ps.level
+            zoneScaling.mode == ScalingMode.STATIC -> quest.level ?: ps.level
+            else -> zoneScaling.resolveLevel(ps.level, quest.level)
+        }
+
         val effectiveRewards =
             if (rewards.xp == 0L && quest.difficulty != null && progression != null) {
-                val effectiveLevel = quest.level ?: ps.level
                 val computed = progression.computeQuestXp(quest.difficulty, effectiveLevel)
                 if (computed > 0L) rewards.copy(xp = computed) else rewards
             } else {
                 rewards
             }
 
-        grantRewards(sessionId, effectiveRewards, ps, players, outbound, progression, quest.level)
+        // Diminishing applies in STATIC zones only. In BOUNDED / PLAYER zones
+        // the content is already scaled to the player, so charging an additional
+        // over-level penalty contradicts the zone's explicit opt-in to scaling.
+        val sourceLevelForDiminishing =
+            if (zoneScaling != null && zoneScaling.mode != ScalingMode.STATIC) null else quest.level
+        grantRewards(sessionId, effectiveRewards, ps, players, outbound, progression, sourceLevelForDiminishing)
         if (effectiveRewards.xp == 0L) players.persistPlayer(ps.sessionId)
     }
 

--- a/src/main/kotlin/dev/ambon/engine/ZoneResetHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/ZoneResetHandler.kt
@@ -6,7 +6,9 @@ import dev.ambon.domain.ids.idZone
 import dev.ambon.domain.mob.MobState
 import dev.ambon.domain.world.MobSpawn
 import dev.ambon.domain.world.RoomFeature
+import dev.ambon.domain.world.ScalingMode
 import dev.ambon.domain.world.World
+import dev.ambon.domain.world.resolveMobStats
 import dev.ambon.engine.behavior.BehaviorTreeSystem
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
@@ -32,21 +34,51 @@ internal fun computeDistanceMap(start: RoomId, world: World): Map<RoomId, Int> {
     return distances
 }
 
-/** Converts a [MobSpawn] definition into a live [MobState] instance. */
-internal fun spawnToMobState(spawn: MobSpawn, world: World): MobState =
-    MobState(
+/**
+ * Converts a [MobSpawn] definition into a live [MobState] instance.
+ *
+ * When [referencePlayerLevel] is supplied and the mob's zone uses a non-STATIC
+ * scaling mode, the spawn level and tier-derived stats are recomputed for that
+ * player level. Authored overrides still win. Pass null (or nothing) to use
+ * the authored spawn level — the normal path for zones without scaling.
+ */
+internal fun spawnToMobState(
+    spawn: MobSpawn,
+    world: World,
+    referencePlayerLevel: Int? = null,
+): MobState {
+    val zone = idZone(spawn.id.value)
+    val scaling = world.zoneScaling(zone)
+
+    val shouldRescale = scaling.mode != ScalingMode.STATIC && spawn.tier != null
+    val effectiveLevel = if (shouldRescale) scaling.resolveLevel(referencePlayerLevel, spawn.level) else spawn.level
+    val resolved =
+        if (shouldRescale && effectiveLevel != spawn.level && spawn.tier != null) {
+            resolveMobStats(spawn.tier, effectiveLevel, spawn.overrides)
+        } else {
+            null
+        }
+
+    val maxHp = resolved?.hp ?: spawn.maxHp
+    val damage = resolved?.damage ?: spawn.damage
+    val armor = resolved?.armor ?: spawn.armor
+    val xpReward = resolved?.xpReward ?: spawn.xpReward
+    val goldMin = resolved?.goldMin ?: spawn.goldMin
+    val goldMax = resolved?.goldMax ?: spawn.goldMax
+
+    return MobState(
         id = spawn.id,
         name = spawn.name,
         description = spawn.description,
         roomId = spawn.roomId,
-        hp = spawn.maxHp,
-        maxHp = spawn.maxHp,
-        damage = spawn.damage,
-        armor = spawn.armor,
-        xpReward = spawn.xpReward,
+        hp = maxHp,
+        maxHp = maxHp,
+        damage = damage,
+        armor = armor,
+        xpReward = xpReward,
         drops = spawn.drops,
-        goldMin = spawn.goldMin,
-        goldMax = spawn.goldMax,
+        goldMin = goldMin,
+        goldMax = goldMax,
         dialogue = spawn.dialogue,
         behaviorTree = spawn.behaviorTree,
         aggressive = spawn.aggressive,
@@ -59,9 +91,20 @@ internal fun spawnToMobState(spawn: MobSpawn, world: World): MobState =
         category = spawn.category,
         spells = spawn.spells,
         defaultAttack = spawn.defaultAttack,
-        level = spawn.level,
+        level = effectiveLevel,
         role = spawn.role,
     )
+}
+
+/**
+ * Returns the highest-level player currently in any room of [zone], or null
+ * if nobody's there. Used as the reference-player input to spawn-time scaling.
+ */
+internal fun highestPlayerLevelInZone(players: PlayerRegistry, zone: String): Int? =
+    players
+        .allPlayers()
+        .filter { it.roomId.zone == zone }
+        .maxOfOrNull { it.level }
 
 /**
  * Handles periodic zone resets: tracks per-zone lifespan timers, removes stale mobs/items,
@@ -172,8 +215,9 @@ internal class ZoneResetHandler(
             mobRemovalCoordinator.removeMobExternally(mobId)
         }
 
+        val referenceLevel = highestPlayerLevelInZone(players, zone)
         for (spawn in zoneMobSpawns) {
-            mobs.upsert(spawnToMobState(spawn, world))
+            mobs.upsert(spawnToMobState(spawn, world, referenceLevel))
             mobSystem.onMobSpawned(spawn.id)
             behaviorTreeSystem.onMobSpawned(spawn.id)
         }

--- a/src/test/kotlin/dev/ambon/domain/world/MobStatResolverTest.kt
+++ b/src/test/kotlin/dev/ambon/domain/world/MobStatResolverTest.kt
@@ -1,0 +1,59 @@
+package dev.ambon.domain.world
+
+import dev.ambon.config.MobTierConfig
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class MobStatResolverTest {
+    private val standardTier = MobTierConfig(
+        baseHp = 20,
+        hpPerLevel = 5,
+        baseMinDamage = 2,
+        baseMaxDamage = 4,
+        damagePerLevel = 2,
+        baseArmor = 1,
+        baseXpReward = 30,
+        xpRewardPerLevel = 10,
+        baseGoldMin = 3,
+        baseGoldMax = 8,
+        goldPerLevel = 2,
+    )
+
+    @Test
+    fun `resolves tier stats at level 1`() {
+        val stats = resolveMobStats(standardTier, level = 1)
+        assertEquals(20, stats.hp)
+        assertEquals(2, stats.damage.min)
+        assertEquals(4, stats.damage.max)
+        assertEquals(1, stats.armor)
+        assertEquals(30L, stats.xpReward)
+        assertEquals(3L, stats.goldMin)
+        assertEquals(8L, stats.goldMax)
+    }
+
+    @Test
+    fun `scales with level using (level - 1) steps`() {
+        val stats = resolveMobStats(standardTier, level = 5)
+        // 4 steps of growth
+        assertEquals(20 + 4 * 5, stats.hp)
+        assertEquals(2 + 4 * 2, stats.damage.min)
+        assertEquals(4 + 4 * 2, stats.damage.max)
+        assertEquals(30L + 4L * 10, stats.xpReward)
+    }
+
+    @Test
+    fun `overrides win over tier math`() {
+        val overrides = MobStatOverrides(hp = 999, xpReward = 5L)
+        val stats = resolveMobStats(standardTier, level = 5, overrides)
+        assertEquals(999, stats.hp)
+        assertEquals(5L, stats.xpReward)
+        // Non-overridden fields still scale with level
+        assertEquals(2 + 4 * 2, stats.damage.min)
+    }
+
+    @Test
+    fun `level is clamped to 1 floor`() {
+        val stats = resolveMobStats(standardTier, level = 0)
+        assertEquals(20, stats.hp)
+    }
+}

--- a/src/test/kotlin/dev/ambon/domain/world/ZoneScalingTest.kt
+++ b/src/test/kotlin/dev/ambon/domain/world/ZoneScalingTest.kt
@@ -1,0 +1,73 @@
+package dev.ambon.domain.world
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class ZoneScalingTest {
+    @Test
+    fun `parse accepts lowercase and defaults to static`() {
+        assertEquals(ScalingMode.STATIC, ScalingMode.parse(null))
+        assertEquals(ScalingMode.STATIC, ScalingMode.parse(""))
+        assertEquals(ScalingMode.STATIC, ScalingMode.parse("static"))
+        assertEquals(ScalingMode.BOUNDED, ScalingMode.parse("BOUNDED"))
+        assertEquals(ScalingMode.PLAYER, ScalingMode.parse("Player"))
+    }
+
+    @Test
+    fun `parse rejects unknown modes`() {
+        assertThrows(IllegalArgumentException::class.java) { ScalingMode.parse("dynamic") }
+    }
+
+    @Test
+    fun `static returns authored level when set`() {
+        val s = ZoneScaling(ScalingMode.STATIC)
+        assertEquals(5, s.resolveLevel(referencePlayerLevel = 30, authoredLevel = 5))
+    }
+
+    @Test
+    fun `static falls back to reference level when author omitted`() {
+        val s = ZoneScaling(ScalingMode.STATIC)
+        assertEquals(12, s.resolveLevel(referencePlayerLevel = 12, authoredLevel = null))
+    }
+
+    @Test
+    fun `bounded clamps reference level to levelRange`() {
+        val s = ZoneScaling(ScalingMode.BOUNDED, levelRange = 3..8)
+        assertEquals(3, s.resolveLevel(referencePlayerLevel = 1, authoredLevel = null))
+        assertEquals(5, s.resolveLevel(referencePlayerLevel = 5, authoredLevel = null))
+        assertEquals(8, s.resolveLevel(referencePlayerLevel = 30, authoredLevel = null))
+    }
+
+    @Test
+    fun `bounded falls back to range min when no reference`() {
+        val s = ZoneScaling(ScalingMode.BOUNDED, levelRange = 3..8)
+        assertEquals(3, s.resolveLevel(referencePlayerLevel = null, authoredLevel = null))
+    }
+
+    @Test
+    fun `bounded clamps authored fallback to range too`() {
+        val s = ZoneScaling(ScalingMode.BOUNDED, levelRange = 3..8)
+        assertEquals(8, s.resolveLevel(referencePlayerLevel = null, authoredLevel = 50))
+        assertEquals(3, s.resolveLevel(referencePlayerLevel = null, authoredLevel = 1))
+    }
+
+    @Test
+    fun `player mode ignores authored level in favour of reference`() {
+        val s = ZoneScaling(ScalingMode.PLAYER)
+        assertEquals(20, s.resolveLevel(referencePlayerLevel = 20, authoredLevel = 3))
+    }
+
+    @Test
+    fun `player mode falls back to authored then 1 when no reference`() {
+        val s = ZoneScaling(ScalingMode.PLAYER)
+        assertEquals(3, s.resolveLevel(referencePlayerLevel = null, authoredLevel = 3))
+        assertEquals(1, s.resolveLevel(referencePlayerLevel = null, authoredLevel = null))
+    }
+
+    @Test
+    fun `resolveLevel never returns below 1`() {
+        val s = ZoneScaling(ScalingMode.PLAYER)
+        assertEquals(1, s.resolveLevel(referencePlayerLevel = -5, authoredLevel = null))
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
@@ -51,6 +51,7 @@ class QuestSystemTest {
     private fun setup(
         quest: QuestDef = killQuest,
         progression: PlayerProgression? = null,
+        world: dev.ambon.domain.world.World? = null,
     ): Triple<QuestSystem, PlayerRegistry, LocalOutboundBus> {
         val c = SystemTestComponents(clockInitialMs = 1_000L)
         val registry = QuestRegistry()
@@ -63,6 +64,7 @@ class QuestSystemTest {
                 outbound = c.outbound,
                 clock = c.clock,
                 progression = progression,
+                world = world,
             )
         return Triple(questSystem, c.players, c.outbound)
     }
@@ -185,6 +187,77 @@ class QuestSystemTest {
             val xpGained = ps.xpTotal - xpBefore
             // STANDARD × (50 + 20*2) = 90 at level 3
             assertEquals(90L, xpGained, "Quest XP should be computed from difficulty baseline")
+        }
+
+    @Test
+    fun `quest XP scales to player level when zone is PLAYER-scaled`() =
+        runTest {
+            val progression = PlayerProgression()
+            val tieredQuest =
+                killQuest.copy(
+                    level = 1, // authored at level 1
+                    difficulty = dev.ambon.config.QuestDifficulty.STANDARD,
+                    rewards = QuestRewards(xp = 0L, gold = 0L),
+                )
+            val world = dev.ambon.domain.world.World(
+                rooms = emptyMap(),
+                startRoom = dev.ambon.domain.ids.RoomId("zone:start"),
+                zoneScaling = mapOf(
+                    "zone" to dev.ambon.domain.world.ZoneScaling(
+                        mode = dev.ambon.domain.world.ScalingMode.PLAYER,
+                    ),
+                ),
+            )
+            val (qs, players, outbound) = setup(tieredQuest, progression, world)
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Hero")
+            players.setLevel(sid, 10)
+            val xpBefore = players.get(sid)!!.xpTotal
+            qs.acceptQuest(sid, questId)
+            outbound.drainAll()
+
+            repeat(3) { qs.onMobKilled(sid, mobTemplateKey) }
+
+            val ps = players.get(sid)!!
+            val xpGained = ps.xpTotal - xpBefore
+            // STANDARD at level 10 = (50 + 20*9) = 230 (scaled to player, not authored level 1)
+            assertEquals(230L, xpGained)
+        }
+
+    @Test
+    fun `quest XP clamps to zone bounds when BOUNDED-scaled`() =
+        runTest {
+            val progression = PlayerProgression()
+            val tieredQuest =
+                killQuest.copy(
+                    level = 3, // authored — irrelevant in bounded mode
+                    difficulty = dev.ambon.config.QuestDifficulty.STANDARD,
+                    rewards = QuestRewards(xp = 0L, gold = 0L),
+                )
+            val world = dev.ambon.domain.world.World(
+                rooms = emptyMap(),
+                startRoom = dev.ambon.domain.ids.RoomId("zone:start"),
+                zoneScaling = mapOf(
+                    "zone" to dev.ambon.domain.world.ZoneScaling(
+                        mode = dev.ambon.domain.world.ScalingMode.BOUNDED,
+                        levelRange = 3..8,
+                    ),
+                ),
+            )
+            val (qs, players, outbound) = setup(tieredQuest, progression, world)
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Hero")
+            players.setLevel(sid, 30) // overleveled → clamp to 8
+            val xpBefore = players.get(sid)!!.xpTotal
+            qs.acceptQuest(sid, questId)
+            outbound.drainAll()
+
+            repeat(3) { qs.onMobKilled(sid, mobTemplateKey) }
+
+            val ps = players.get(sid)!!
+            val xpGained = ps.xpTotal - xpBefore
+            // STANDARD at clamped level 8 = (50 + 20*7) = 190
+            assertEquals(190L, xpGained)
         }
 
     @Test


### PR DESCRIPTION
## Summary

Phase 4 (final) of the tier-based content model. Zones declare a scaling mode and the engine resolves effective mob and quest levels at spawn + completion time. `STATIC` remains the default, so every current zone loads and runs identically.

### New data model

- `ScalingMode` enum: `STATIC | BOUNDED | PLAYER`
- `ZoneScaling(mode, levelRange?)` with `resolveLevel(referencePlayerLevel, authoredLevel)`:
  - **STATIC** — authored level when set, else reference, else 1
  - **BOUNDED** — clamp reference to `levelRange`; fall back to `range.first` when no reference; reject at load if `levelRange` is missing
  - **PLAYER** — reference level; fall back to authored, then 1
- Result always clamped to ≥ 1.

### Wiring

- `WorldFile.scaling` field parses `{ mode: static|bounded|player, levelRange: [min, max] }`. `WorldLoader` validates the range (`min >= 1`, `max >= min`), detects conflicting declarations across multi-file zones, and mounts into `World.zoneScaling(zone)`.
- Extracted `resolveMobStats(tier, level, overrides)` — the tier × level math that previously lived inline in `WorldLoader`. `MobSpawn` now carries the tier config and authored-override record (`MobStatOverrides`) so spawn-time rescaling can replay the formulas at a new level without re-reading config.
- `spawnToMobState(spawn, world, referencePlayerLevel?)` recomputes mob level + stats when the zone is non-STATIC and a reference player level is provided. Authored overrides still win. All four call sites pass `highestPlayerLevelInZone()`:
  - `GameEngine` init-spawn (players is empty at boot → null → bounded falls back to `range.first`)
  - `GameEngine` respawn after kill
  - `HotReloadManager` new-mob spawn after reload
  - `ZoneResetHandler` periodic zone reset
- `QuestSystem` takes an optional `World` and routes completion XP through zone scaling when non-STATIC. Diminishing is **disabled in scaling zones** — the content is already scaled to the player, so charging an additional over-level penalty contradicts the zone's explicit opt-in. STATIC zones keep the existing diminishing behaviour.

### Migration

Zero. No zone in any current world declares scaling, so `World.zoneScaling(zone)` returns the default `STATIC` for everyone and every existing code path runs byte-for-byte as before.

## Phase of the plan

4 of 4:

1. ✅ Mob role
2. ✅ Mob tier-driven stats
3. ✅ Quest difficulty tiers
4. **Zone-level scaling** — this PR

## Test plan
- [x] `./gradlew ktlintCheck test -x buildWeb` — all tests pass, ktlint clean
- New `ZoneScalingTest`: parse defaults + enum coverage, STATIC/BOUNDED/PLAYER level resolution, BOUNDED clamp + range fallbacks, clamp-to-1 floor
- New `MobStatResolverTest`: tier math at level 1 and scaled, authored overrides win, level clamping
- New `QuestSystemTest` cases: `PLAYER`-scaled zone awards player-level XP (level 1 quest at player level 10 pays 230 STANDARD XP), `BOUNDED`-scaled zone clamps to range max (player 30 in 3-8 zone pays 190 XP at effective level 8 with diminishing disabled)
- [ ] Manual: flip one Auringold zone to `scaling: { mode: bounded, levelRange: [3, 8] }`, verify mob levels + quest XP match band bounds regardless of player level
- [ ] Manual: verify STATIC zones still produce identical mob stats to main (spot-check a few mob HP values)