### PR TITLE
Lower combat base damage roll from 1d150 to 1d4

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -789,7 +789,7 @@ ambonmud:
       maxCombatsPerTick: 20
       tickMillis: 2000
       minDamage: 1
-      maxDamage: 150
+      maxDamage: 4
       feedback:
         enabled: false
         roomBroadcastEnabled: false


### PR DESCRIPTION
## Summary
- `engine.combat.maxDamage` in `application.yaml` was set to 150, which `CombatSystem.kt:600` uses as the base roll for every melee swing before weapon and STR bonuses are added.
- Combined with shop weapons around `damage: 4` and early-game mobs in the 5–20 HP range, this made every swing a likely one-shot and drowned out class, gear, and stat tuning.
- Lowers the override to match the code default in `AppConfig.kt` (`maxDamage: 4`), restoring the intended dynamic where `weaponAttack + strBonus` dominates the roll.

Fixes #1093. World-content tuning (mob HP bands, Academy shop gear) looks reasonable and is being reviewed separately on the Arcanum side.

## Test plan
- [x] `./gradlew ktlintCheck test` passes
- [ ] Manual Academy playthrough: level-1 unarmed vs. wandering_wisp (7 HP) takes more than 1 swing on average
- [ ] Iron sword from the armory meaningfully improves damage output over unarmed