### PR TITLE
Sanctum respawn + depart command for PvE death

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -186,6 +186,25 @@ data class AppConfig(
         require(!engine.combat.feedback.roomBroadcastEnabled || engine.combat.feedback.enabled) {
             "ambonMUD.engine.combat.feedback.roomBroadcastEnabled requires feedback.enabled=true"
         }
+        validateDeath()
+    }
+
+    private fun validateDeath() {
+        val d = engine.death
+        require(d.respawnHpFraction in 0.05..1.0) {
+            "ambonMUD.engine.death.respawnHpFraction must be in [0.05, 1.0] (got ${d.respawnHpFraction})"
+        }
+        require(d.respawnManaFraction in 0.0..1.0) {
+            "ambonMUD.engine.death.respawnManaFraction must be in [0.0, 1.0] (got ${d.respawnManaFraction})"
+        }
+        require(d.xpPenaltyFraction in 0.0..0.5) {
+            "ambonMUD.engine.death.xpPenaltyFraction must be in [0.0, 0.5] (got ${d.xpPenaltyFraction})"
+        }
+        d.sanctumRoom?.let { sr ->
+            require(sr.contains(':')) {
+                "ambonMUD.engine.death.sanctumRoom must be in 'zone:room' format, got '$sr'"
+            }
+        }
     }
 
     private fun validateEngineRegen() {
@@ -1513,6 +1532,34 @@ data class EngineConfig(
     val globalQuests: GlobalQuestsConfig = GlobalQuestsConfig(),
     val lottery: LotteryConfig = LotteryConfig(),
     val gambling: GamblingConfig = GamblingConfig(),
+    val death: DeathConfig = DeathConfig(),
+)
+
+/**
+ * Configuration for what happens when a player dies in PvE.
+ *
+ * On death, the player is moved to [sanctumRoom] (falling back to the zone's startRoom, then world
+ * startRoom if unset/missing), restored to [respawnHpFraction] of max HP, and their last death
+ * zone is recorded so a follow-up `depart` command can return them to that zone's start room.
+ */
+data class DeathConfig(
+    /** Fully-qualified "zone:room" ID of the sanctum players respawn in. Null = zone startRoom fallback. */
+    val sanctumRoom: String? = null,
+    /** Fraction of maxHp restored on respawn (0.2 = 20%). Clamped to [0.05, 1.0]. */
+    val respawnHpFraction: Double = 0.2,
+    /** Fraction of maxMana restored on respawn (0.2 = 20%). Clamped to [0.0, 1.0]. */
+    val respawnManaFraction: Double = 0.2,
+    /** Fraction of current xpTotal deducted on death. 0 = no penalty. Clamped to [0.0, 0.5]. */
+    val xpPenaltyFraction: Double = 0.0,
+    val messages: DeathMessagesConfig = DeathMessagesConfig(),
+)
+
+data class DeathMessagesConfig(
+    val arriveSanctum: String = "The world fades... and you awaken in the sanctum, your body mending.",
+    val departNoSanctum: String = "You can only depart from the sanctum.",
+    val departNoDeath: String = "You have nowhere to return to.",
+    val departBegin: String = "You step through the spirit gate and return to the world.",
+    val departUnreachable: String = "The spirit gate flickers, but nothing happens.",
 )
 
 data class NavigationConfig(

--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -1,6 +1,7 @@
 package dev.ambon.engine
 
 import dev.ambon.bus.OutboundBus
+import dev.ambon.config.DeathConfig
 import dev.ambon.config.StatBindingsConfig
 import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
@@ -105,6 +106,12 @@ class CombatSystem(
 
     /** Zone start room lookup, wired by GameEngine after construction. */
     var zoneStartRoomLookup: (String) -> RoomId? = { _ -> null }
+
+    /** Sanctum room lookup for PvE death respawn, wired by GameEngine after construction. */
+    var sanctumRoomLookup: () -> RoomId? = { null }
+
+    /** Death behavior config, wired by GameEngine after construction. */
+    var deathConfig: DeathConfig = DeathConfig()
 
     fun isInCombat(sessionId: SessionId): Boolean =
         playerTarget.containsKey(sessionId) || pvpTarget.containsKey(sessionId)
@@ -1098,11 +1105,35 @@ class CombatSystem(
             CombatEvent.Death(killerName = killerName, killerIsPlayer = killerIsPlayer),
         )
         outbound.send(OutboundEvent.SendText(sessionId, deathMessage))
-        outbound.send(OutboundEvent.SendText(sessionId, "You are safe now — rest and your wounds will mend."))
         broadcastToRoom(players, outbound, roomId, roomMessage, exclude = sessionId)
 
         // Clean up cross-system state that should not persist through death
         onPlayerDeath(sessionId)
+
+        val player = players.get(sessionId)
+        if (player != null) {
+            // Remember where the spirit gate should send them back to.
+            player.lastDeathZone = roomId.zone
+
+            // Resolve respawn room: sanctum → zone start → world start (whatever is in roomId now, as a last resort).
+            val respawnRoom = sanctumRoomLookup()
+                ?: zoneStartRoomLookup(roomId.zone)
+                ?: player.roomId
+            player.roomId = respawnRoom
+
+            // Restore a fraction of HP/mana. Leaves the player vulnerable so they have to rest in the sanctum.
+            player.hp = ((player.maxHp * deathConfig.respawnHpFraction).toInt()).coerceAtLeast(1)
+            player.mana = ((player.maxMana * deathConfig.respawnManaFraction).toInt()).coerceAtLeast(0)
+
+            // Optional XP penalty (0 by default — tutorial stays forgiving).
+            if (deathConfig.xpPenaltyFraction > 0.0) {
+                val penalty = (player.xpTotal * deathConfig.xpPenaltyFraction).toLong()
+                player.xpTotal = (player.xpTotal - penalty).coerceAtLeast(0L)
+            }
+
+            dirtyNotifier.playerVitalsDirty(sessionId)
+            outbound.send(OutboundEvent.SendText(sessionId, deathConfig.messages.arriveSanctum))
+        }
 
         outbound.send(OutboundEvent.SendPrompt(sessionId))
     }

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -929,6 +929,10 @@ class GameEngine(
         combatSystem.onPlayerDeath = { sid -> cleanupOnPlayerDeath(sid) }
         combatSystem.onPvpKill = { sid -> notifyDailyQuest(sid, "pvpKill") }
         combatSystem.zoneStartRoomLookup = { zoneId -> world.zoneStartRoom(zoneId) }
+        combatSystem.deathConfig = engineConfig.death
+        combatSystem.sanctumRoomLookup = {
+            engineConfig.death.sanctumRoom?.let { RoomId(it) }?.takeIf { world.rooms.containsKey(it) }
+        }
         combatSystem.onPvpKill = { killerSid ->
             val killer = players.get(killerSid)
             if (killer != null && currencySystem.honorPerPvpKill > 0) {
@@ -1136,6 +1140,7 @@ class GameEngine(
                 dialogueSystem = dialogueSystem,
                 onCrossZoneMove = crossZoneMove,
                 recallConfig = engineConfig.navigation.recall,
+                deathConfig = engineConfig.death,
                 housingSystem = housingSystem,
                 guildHallSystem = guildHallSystem,
                 onPlayerMoved = { sid, roomId -> petSystem.followOwner(sid, roomId) },

--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -56,6 +56,8 @@ data class PlayerState(
     var guildRank: String? = null,
     var guildTag: String? = null,
     var recallRoomId: RoomId? = null,
+    /** Zone ID (e.g. "academy") of the player's last death. Drives `depart` from the sanctum. */
+    var lastDeathZone: String? = null,
     var friendsList: MutableSet<String> = mutableSetOf(),
     var bankGold: Long = 0L,
     var bankItems: MutableList<dev.ambon.domain.items.ItemInstance> = mutableListOf(),
@@ -228,6 +230,7 @@ fun PlayerRecord.toPlayerState(sessionId: SessionId): PlayerState =
         inbox = inbox.toMutableList(),
         guildId = guildId,
         recallRoomId = recallRoomId,
+        lastDeathZone = lastDeathZone,
         craftingSkills = craftingSkills.map { (key, state) ->
             key.lowercase() to state
         }.toMap().toMutableMap(),
@@ -288,6 +291,7 @@ fun PlayerState.toPlayerRecord(lastSeenEpochMs: Long): PlayerRecord {
         inbox = inbox.toList(),
         guildId = guildId,
         recallRoomId = recallRoomId,
+        lastDeathZone = lastDeathZone,
         craftingSkills = craftingSkills.toMap(),
         discoveredRecipes = discoveredRecipes.toSet(),
         craftingSpecialization = craftingSpecialization,

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -224,6 +224,9 @@ sealed interface Command {
 
     data object Recall : Command
 
+    /** Leaves the sanctum after death, returning to the zone where the player last died. */
+    data object Depart : Command
+
     data class Petition(
         val keyword: String,
     ) : Command
@@ -1591,6 +1594,7 @@ object CommandParser {
             "exits", "ex" -> Command.Exits
             "flee" -> Command.Flee
             "recall" -> Command.Recall
+            "depart" -> Command.Depart
             "score", "sc" -> Command.Score
             "spells", "abilities", "skills" -> Command.Spells
             "effects", "buffs", "debuffs" -> Command.Effects

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
@@ -1,5 +1,6 @@
 package dev.ambon.engine.commands.handlers
 
+import dev.ambon.config.DeathConfig
 import dev.ambon.config.RecallConfig
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
@@ -26,6 +27,7 @@ class NavigationHandler(
     private val onCrossZoneMove: (suspend (SessionId, RoomId) -> Unit)? = null,
     private val clock: Clock = Clock.systemUTC(),
     private val recallConfig: RecallConfig = RecallConfig(),
+    private val deathConfig: DeathConfig = DeathConfig(),
     private val housingSystem: HousingSystem? = null,
     private val guildHallSystem: GuildHallSystem? = null,
     private val onPlayerMoved: (suspend (SessionId, RoomId) -> Unit)? = null,
@@ -62,6 +64,7 @@ class NavigationHandler(
         router.on<Command.LookDir> { sid, cmd -> handleLookDir(sid, cmd) }
         router.on<Command.LookAt> { sid, cmd -> handleLookAt(sid, cmd) }
         router.on<Command.Recall> { sid, _ -> handleRecall(sid) }
+        router.on<Command.Depart> { sid, _ -> handleDepart(sid) }
         router.on<Command.Petition> { sid, cmd -> handlePetition(sid, cmd) }
     }
 
@@ -277,6 +280,51 @@ class NavigationHandler(
         )
         onPlayerMoved?.invoke(sessionId, target)
         outbound.send(OutboundEvent.SendText(sessionId, msgs.arrival))
+        ctx.sendLook(sessionId)
+    }
+
+    private suspend fun handleDepart(sessionId: SessionId) {
+        val msgs = deathConfig.messages
+        val me = players.get(sessionId) ?: return
+
+        // Only available from the configured sanctum room.
+        val sanctumRoomId = deathConfig.sanctumRoom?.let { RoomId(it) }
+        if (sanctumRoomId == null || me.roomId != sanctumRoomId) {
+            outbound.send(OutboundEvent.SendError(sessionId, msgs.departNoSanctum))
+            return
+        }
+
+        val deathZone = me.lastDeathZone
+        if (deathZone == null) {
+            outbound.send(OutboundEvent.SendError(sessionId, msgs.departNoDeath))
+            return
+        }
+
+        val target = world.zoneStartRoom(deathZone) ?: world.startRoom
+        if (!world.rooms.containsKey(target)) {
+            if (attemptCrossZoneMove(sessionId, target, onCrossZoneMove, router::suppressAutoPrompt)) {
+                me.lastDeathZone = null
+                return
+            }
+            outbound.send(OutboundEvent.SendError(sessionId, msgs.departUnreachable))
+            return
+        }
+
+        outbound.send(OutboundEvent.SendText(sessionId, msgs.departBegin))
+        val from = me.roomId
+        movePlayerWithNotify(
+            sessionId,
+            from,
+            target,
+            "steps through the spirit gate and fades from view.",
+            "emerges from a shimmering spirit gate.",
+            players,
+            outbound,
+            gmcpEmitter,
+            dialogueSystem,
+        )
+        me.lastDeathZone = null
+        onPlayerMoved?.invoke(sessionId, target)
         ctx.sendLook(sessionId)
     }
 

--- a/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
@@ -52,6 +52,8 @@ data class PlayerRecord(
     val inbox: List<MailMessage> = emptyList(),
     val guildId: String? = null,
     val recallRoomId: RoomId? = null,
+    /** Zone ID (e.g. "academy") of the player's last death. Spirit-gate return target. */
+    val lastDeathZone: String? = null,
     val craftingSkills: Map<String, CraftingSkillState> = emptyMap(),
     val discoveredRecipes: Set<String> = emptySet(),
     val craftingSpecialization: String? = null,

--- a/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
@@ -55,6 +55,7 @@ object PlayersTable : Table("players") {
     val mailInbox = text("mail_inbox").default("[]")
     val guildId = varchar("guild_id", 64).nullable()
     val recallRoomId = varchar("recall_room_id", 128).nullable()
+    val lastDeathZone = varchar("last_death_zone", 64).nullable()
     val craftingSkills = text("crafting_skills").default("{}")
     val discoveredRecipes = text("discovered_recipes").default("[]")
     val craftingSpecialization = varchar("crafting_specialization", 64).nullable()
@@ -112,6 +113,7 @@ object PlayersTable : Table("players") {
             inbox = safeReadJson(row[mailInbox], mailInboxType, emptyList()),
             guildId = row[guildId],
             recallRoomId = row[recallRoomId]?.let { RoomId(it) },
+            lastDeathZone = row[lastDeathZone],
             craftingSkills = safeReadJson(row[craftingSkills], craftingSkillsType, emptyMap()),
             discoveredRecipes = safeReadJson(row[discoveredRecipes], discoveredRecipesType, emptySet()),
             craftingSpecialization = row[craftingSpecialization],
@@ -168,6 +170,7 @@ object PlayersTable : Table("players") {
         statement[mailInbox] = jsonMapper.writeValueAsString(record.inbox)
         statement[guildId] = record.guildId
         statement[recallRoomId] = record.recallRoomId?.value
+        statement[lastDeathZone] = record.lastDeathZone
         statement[craftingSkills] = jsonMapper.writeValueAsString(record.craftingSkills)
         statement[discoveredRecipes] = jsonMapper.writeValueAsString(record.discoveredRecipes)
         statement[craftingSpecialization] = record.craftingSpecialization

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -793,6 +793,11 @@ ambonmud:
       feedback:
         enabled: false
         roomBroadcastEnabled: false
+    death:
+      sanctumRoom: academy:sanctum
+      respawnHpFraction: 0.2
+      respawnManaFraction: 0.2
+      xpPenaltyFraction: 0.0
     mob:
       minActionDelayMillis: 2000
       maxActionDelayMillis: 5000

--- a/src/main/resources/db/migration/V36__add_last_death_zone.sql
+++ b/src/main/resources/db/migration/V36__add_last_death_zone.sql
@@ -1,0 +1,1 @@
+ALTER TABLE players ADD COLUMN last_death_zone VARCHAR(64);

--- a/src/main/resources/world/academy.yaml
+++ b/src/main/resources/world/academy.yaml
@@ -348,6 +348,17 @@ rooms:
     exits:
       s: common_room
     image: fe897d386ee1ff382d9b4a5d268504b10a5c9cc765c4addc3f6c0d47212b3342.jpg
+  sanctum:
+    title: The Sanctum
+    description: >-
+      A quiet chamber suffused with silver light, warm despite the stillness of the air. A shallow reflecting pool
+      murmurs in the centre of the room, its surface scattered with floating candles that refuse to gutter. Pale
+      draperies hang from unseen supports, stirring gently as though in a breeze you cannot feel. The world beyond
+      seems very far away here — a place to catch your breath between lives.
+
+
+      A carved stone pedestal near the pool bears a simple instruction: "When you are ready, depart — the spirit
+      gate will return you to the world where you fell."
   mob_templates:
     title: Template Chamber
     description: An internal room used to stage dungeon mob templates. Players cannot reach this room.

--- a/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
@@ -1,5 +1,6 @@
 package dev.ambon.engine
 
+import dev.ambon.config.DeathConfig
 import dev.ambon.config.LevelRewardsConfig
 import dev.ambon.config.ProgressionConfig
 import dev.ambon.config.StatBindingsConfig
@@ -611,7 +612,7 @@ class CombatSystemTest {
         }
 
     @Test
-    fun `player slain by mob shows death summary and safe respawn message`() =
+    fun `player slain by mob shows death summary and sanctum arrival message`() =
         runTest {
             val fixture = CombatTestFixture()
             // mob hits hard enough to one-shot the player
@@ -648,8 +649,8 @@ class CombatSystemTest {
                 "Expected death summary message, got: $messages",
             )
             assertTrue(
-                messages.any { it.contains("You are safe now") },
-                "Expected safe respawn message, got: $messages",
+                messages.any { it.contains("awaken in the sanctum") },
+                "Expected sanctum arrival message, got: $messages",
             )
         }
 
@@ -693,7 +694,7 @@ class CombatSystemTest {
         }
 
     @Test
-    fun `player at zero hp shows collapse message and safe respawn`() =
+    fun `player at zero hp shows collapse message and sanctum arrival`() =
         runTest {
             val fixture = CombatTestFixture()
             val mob = MobState(MobId("demo:rat"), "a rat", fixture.roomId, hp = 100, maxHp = 100)
@@ -722,8 +723,8 @@ class CombatSystemTest {
                 "Expected collapse message, got: $messages",
             )
             assertTrue(
-                messages.any { it.contains("You are safe now") },
-                "Expected safe respawn message, got: $messages",
+                messages.any { it.contains("awaken in the sanctum") },
+                "Expected sanctum arrival message, got: $messages",
             )
         }
 
@@ -1129,5 +1130,108 @@ class CombatSystemTest {
             val inv = fixture.items.inventory(sid)
             assertEquals(1, inv.size)
             assertEquals("demo:fang", inv.first().id.value)
+        }
+
+    @Test
+    fun `player death moves to sanctum and records death zone`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            val mob =
+                MobState(
+                    MobId("demo:ogre"),
+                    "an ogre",
+                    fixture.roomId,
+                    hp = 100,
+                    maxHp = 100,
+                    damage = DamageRange(50, 50),
+                )
+            fixture.mobs.upsert(mob)
+
+            val combat = fixture.buildCombat(rng = Random(1), minDamage = 1, maxDamage = 1)
+            val sanctum = dev.ambon.domain.ids.RoomId("limbo:sanctum")
+            combat.sanctumRoomLookup = { sanctum }
+            combat.deathConfig = DeathConfig(
+                sanctumRoom = sanctum.value,
+                respawnHpFraction = 0.2,
+                respawnManaFraction = 0.5,
+            )
+
+            val sid = SessionId(42L)
+            fixture.players.loginOrFail(sid, "Doomed")
+            val player = fixture.players.get(sid)!!
+            player.maxHp = 50
+            player.maxMana = 40
+            val originalZone = player.roomId.zone
+
+            combat.startCombat(sid, "ogre")
+            fixture.outbound.drainAll()
+            fixture.tickCombat(combat)
+
+            assertEquals(sanctum, player.roomId, "Expected player to respawn in sanctum")
+            assertEquals(originalZone, player.lastDeathZone, "Expected lastDeathZone recorded from pre-death room")
+            assertEquals(10, player.hp, "Expected 20% of 50 maxHp = 10")
+            assertEquals(20, player.mana, "Expected 50% of 40 maxMana = 20")
+        }
+
+    @Test
+    fun `player death falls back to zone start when no sanctum configured`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            val mob =
+                MobState(
+                    MobId("demo:ogre"),
+                    "an ogre",
+                    fixture.roomId,
+                    hp = 100,
+                    maxHp = 100,
+                    damage = DamageRange(50, 50),
+                )
+            fixture.mobs.upsert(mob)
+
+            val combat = fixture.buildCombat(rng = Random(1), minDamage = 1, maxDamage = 1)
+            val zoneStart = dev.ambon.domain.ids.RoomId("zone:start")
+            combat.zoneStartRoomLookup = { if (it == "zone") zoneStart else null }
+            // No sanctum configured — falls back to zone start.
+
+            val sid = SessionId(43L)
+            fixture.players.loginOrFail(sid, "Fallbacked")
+            val player = fixture.players.get(sid)!!
+
+            combat.startCombat(sid, "ogre")
+            fixture.outbound.drainAll()
+            fixture.tickCombat(combat)
+
+            assertEquals(zoneStart, player.roomId, "Expected fallback to zone start room")
+            assertEquals("zone", player.lastDeathZone)
+        }
+
+    @Test
+    fun `player death applies xp penalty when configured`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            val mob =
+                MobState(
+                    MobId("demo:ogre"),
+                    "an ogre",
+                    fixture.roomId,
+                    hp = 100,
+                    maxHp = 100,
+                    damage = DamageRange(50, 50),
+                )
+            fixture.mobs.upsert(mob)
+
+            val combat = fixture.buildCombat(rng = Random(1), minDamage = 1, maxDamage = 1)
+            combat.deathConfig = DeathConfig(xpPenaltyFraction = 0.1)
+
+            val sid = SessionId(44L)
+            fixture.players.loginOrFail(sid, "Penalised")
+            val player = fixture.players.get(sid)!!
+            player.xpTotal = 1000L
+
+            combat.startCombat(sid, "ogre")
+            fixture.outbound.drainAll()
+            fixture.tickCombat(combat)
+
+            assertEquals(900L, player.xpTotal, "Expected 10% xp penalty (1000 -> 900)")
         }
 }

--- a/src/test/kotlin/dev/ambon/engine/commands/DepartCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/DepartCommandTest.kt
@@ -1,0 +1,88 @@
+package dev.ambon.engine.commands
+
+import dev.ambon.config.DeathConfig
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.test.CommandRouterHarness
+import dev.ambon.test.MutableClock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DepartCommandTest {
+    private val hub = RoomId("test_zone:hub")
+    private val outpost = RoomId("test_zone:outpost")
+
+    @Test
+    fun `depart from sanctum returns to last death zone start`() =
+        runTest {
+            val h = CommandRouterHarness.create(
+                clock = MutableClock(0L),
+                deathConfig = DeathConfig(sanctumRoom = outpost.value),
+            )
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Hero")
+
+            // Simulate having died in test_zone and been respawned in the sanctum (outpost).
+            h.players.moveTo(sid, outpost)
+            val player = h.players.get(sid)!!
+            player.lastDeathZone = "test_zone"
+            h.drain()
+
+            h.router.handle(sid, Command.Depart)
+            h.drain()
+
+            assertEquals(hub, h.players.get(sid)!!.roomId, "Expected to land at test_zone start (hub)")
+            assertNull(h.players.get(sid)!!.lastDeathZone, "lastDeathZone should be cleared after successful depart")
+        }
+
+    @Test
+    fun `depart outside sanctum errors`() =
+        runTest {
+            val h = CommandRouterHarness.create(
+                clock = MutableClock(0L),
+                deathConfig = DeathConfig(sanctumRoom = outpost.value),
+            )
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Hero")
+            // Player is in hub, not in the sanctum (outpost).
+            h.players.get(sid)!!.lastDeathZone = "test_zone"
+            h.drain()
+
+            h.router.handle(sid, Command.Depart)
+            val outs = h.drain()
+
+            assertTrue(
+                outs.any { it is OutboundEvent.SendError && it.text.contains("sanctum") },
+                "Expected sanctum-required error. got=$outs",
+            )
+            assertEquals(hub, h.players.get(sid)!!.roomId, "Player should not move")
+        }
+
+    @Test
+    fun `depart with no recorded death errors`() =
+        runTest {
+            val h = CommandRouterHarness.create(
+                clock = MutableClock(0L),
+                deathConfig = DeathConfig(sanctumRoom = outpost.value),
+            )
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Hero")
+            // Player is in sanctum but has no recorded death zone (fresh character).
+            h.players.moveTo(sid, outpost)
+            h.drain()
+
+            h.router.handle(sid, Command.Depart)
+            val outs = h.drain()
+
+            assertTrue(
+                outs.any { it is OutboundEvent.SendError && it.text.contains("nowhere to return") },
+                "Expected 'nowhere to return' error. got=$outs",
+            )
+        }
+}

--- a/src/test/kotlin/dev/ambon/engine/commands/RouterTestHelper.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/RouterTestHelper.kt
@@ -108,6 +108,7 @@ internal fun buildTestRouter(
     gmcpEmitter: GmcpEmitter? = null,
     abilitySystem: dev.ambon.engine.abilities.AbilitySystem? = null,
     spriteRegistry: SpriteRegistry? = null,
+    deathConfig: dev.ambon.config.DeathConfig = dev.ambon.config.DeathConfig(),
 ): CommandRouter {
     val router = CommandRouter(outbound = outbound, players = players)
     val ctx = EngineContext(
@@ -139,7 +140,13 @@ internal fun buildTestRouter(
             engineId = engineId,
             onRemoteWho = onRemoteWho,
         ),
-        NavigationHandler(ctx = ctx, onCrossZoneMove = onCrossZoneMove, clock = clock, puzzleSystem = puzzleSystem),
+        NavigationHandler(
+            ctx = ctx,
+            onCrossZoneMove = onCrossZoneMove,
+            clock = clock,
+            deathConfig = deathConfig,
+            puzzleSystem = puzzleSystem,
+        ),
         CombatHandler(ctx = ctx),
         ProgressionHandler(ctx = ctx, progression = progression, groupSystem = groupSystem),
         ItemHandler(ctx = ctx),

--- a/src/test/kotlin/dev/ambon/test/TestFixtures.kt
+++ b/src/test/kotlin/dev/ambon/test/TestFixtures.kt
@@ -254,6 +254,7 @@ class CommandRouterHarness private constructor(
             gmcpEmitter: GmcpEmitter? = null,
             abilitySystem: dev.ambon.engine.abilities.AbilitySystem? = null,
             spriteRegistry: dev.ambon.engine.SpriteRegistry? = null,
+            deathConfig: dev.ambon.config.DeathConfig = dev.ambon.config.DeathConfig(),
         ): CommandRouterHarness {
             val combat = CombatSystem(players, mobs, items, outbound)
             val router =
@@ -292,6 +293,7 @@ class CommandRouterHarness private constructor(
                     gmcpEmitter = gmcpEmitter,
                     abilitySystem = abilitySystem,
                     spriteRegistry = spriteRegistry,
+                    deathConfig = deathConfig,
                 )
             return CommandRouterHarness(
                 world = world,


### PR DESCRIPTION
## Summary
- On PvE death the player is now moved to a configurable sanctum room (falls back to the zone's startRoom, then world startRoom), restored to 20% maxHp/maxMana, and has their death zone recorded. Gear is retained in full.
- New `depart` command (available only inside the sanctum) walks the player back through a spirit gate to the zone where they died. `lastDeathZone` clears on a successful return.
- New `DeathConfig` block (sanctum room, respawn fractions, optional xp penalty — default 0) wired into `engine.death`. Per-zone overrides and personal/house-owned sanctums are future work.
- Ships a placeholder Sanctum room in `academy.yaml` so the default demo instance has somewhere to respawn. Auringold content will need its own sanctum room authored on the Arcanum side.

Replaces the previous behaviour where slain players were left standing at 0 HP in the room they died in with only a "You are safe now" message, relying on reconnect-time HP restoration to function.

Closes #1086.

## Test plan
- [x] `./gradlew ktlintCheck test` (1989 tests)
- [x] `./gradlew integrationTest`
- [x] New unit tests:
  - Player death moves to sanctum and records death zone
  - Death falls back to zone start when no sanctum is configured
  - XP penalty applied when configured
  - `depart` from sanctum returns to last death zone's start
  - `depart` outside sanctum errors
  - `depart` without a recorded death errors
- [ ] Manual playthrough: die in the Academy, confirm arrival at `academy:sanctum`, use `depart`, confirm return to `academy:academy_gates`
- [ ] Deploy-side: confirm Auringold content gets its own `deathSanctum` or the config is pointed at `auringold:realm_of_dead` before ramping

## Follow-ups (future PRs)
- Per-zone sanctum override in zone YAML (`deathSanctum`).
- Personal sanctums via housing: wardrobe + potion vault; `bind` to choose global vs personal.
- Decide whether PvP should also route through the sanctum (currently still uses its existing arena-local respawn).