### PR TITLE
Close dialogue on aggro; open crafting panel on station click

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -66,6 +66,10 @@ class CombatSystem(
     /** Callback when a player kills another player in PvP; wired by GameEngine. */
     var onPvpKill: suspend (killerSid: SessionId) -> Unit = { _ -> }
 
+    /** Callback when a player enters combat (attacker or victim); wired by GameEngine.
+     *  Used to close dialogue overlays so the player isn't trapped in conversation. */
+    var onPlayerEnteredCombat: suspend (SessionId) -> Unit = { _ -> }
+
     // Per-mob combat state (tracks tick timing)
     private data class MobCombatState(
         val mobId: MobId,
@@ -166,6 +170,7 @@ class CombatSystem(
 
         val now = clock.millis()
         registerCombatant(sessionId, mob.id, player, now)
+        onPlayerEnteredCombat(sessionId)
 
         outbound.send(OutboundEvent.SendText(sessionId, "You attack ${mob.name}."))
         broadcastToRoom(players, outbound, roomId, "${player.name} attacks ${mob.name}.", exclude = sessionId)
@@ -263,6 +268,7 @@ class CombatSystem(
         )
         dirtyNotifier.playerVitalsDirty(attackerSid)
         dirtyNotifier.playerCombatDirty(attackerSid)
+        onPlayerEnteredCombat(attackerSid)
 
         // If the target is not already fighting back, auto-engage them
         if (pvpTarget[targetSid] == null && playerTarget[targetSid] == null) {
@@ -274,6 +280,7 @@ class CombatSystem(
             )
             dirtyNotifier.playerVitalsDirty(targetSid)
             dirtyNotifier.playerCombatDirty(targetSid)
+            onPlayerEnteredCombat(targetSid)
         }
 
         outbound.send(OutboundEvent.SendText(attackerSid, "You attack ${'$'}{target.name}!"))
@@ -471,6 +478,7 @@ class CombatSystem(
 
         val now = clock.millis()
         registerCombatant(sessionId, mobId, player, now)
+        onPlayerEnteredCombat(sessionId)
 
         outbound.send(OutboundEvent.SendText(sessionId, "${mob.name} attacks you!"))
         broadcastToRoom(players, outbound, player.roomId, "${mob.name} attacks ${player.name}.", exclude = sessionId)

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -924,6 +924,7 @@ class GameEngine(
     init {
         // Late-wire combat event / gain callbacks (avoids circular type inference with gmcpEmitter)
         combatSystem.onCombatEvent = { sid, event -> gmcpEmitter.sendCombatEvent(sid, event) }
+        combatSystem.onPlayerEnteredCombat = { sid -> dialogueSystem.endConversation(sid) }
         combatSystem.onXpGained = { sid, amount, source -> gmcpEmitter.sendCharGain(sid, "xp", amount, source) }
         combatSystem.onGoldGained = { sid, amount, source -> gmcpEmitter.sendCharGain(sid, "gold", amount, source) }
         combatSystem.onPlayerDeath = { sid -> cleanupOnPlayerDeath(sid) }

--- a/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
@@ -1234,4 +1234,61 @@ class CombatSystemTest {
 
             assertEquals(900L, player.xpTotal, "Expected 10% xp penalty (1000 -> 900)")
         }
+
+    @Test
+    fun `onPlayerEnteredCombat fires when mob aggros a player`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            val mob =
+                MobState(
+                    MobId("demo:wolf"),
+                    "a wolf",
+                    fixture.roomId,
+                    hp = 20,
+                    maxHp = 20,
+                )
+            fixture.mobs.upsert(mob)
+
+            val combat = fixture.buildCombat(rng = Random(1))
+
+            val entered = mutableListOf<SessionId>()
+            combat.onPlayerEnteredCombat = { sid -> entered.add(sid) }
+
+            val sid = SessionId(50L)
+            fixture.players.loginOrFail(sid, "Chatter")
+
+            val started = combat.startMobCombat(mob.id, sid)
+            assertTrue(started, "Expected startMobCombat to succeed")
+            assertEquals(
+                listOf(sid),
+                entered,
+                "Expected onPlayerEnteredCombat to fire exactly once for the aggro victim",
+            )
+        }
+
+    @Test
+    fun `onPlayerEnteredCombat fires when player initiates combat`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            val mob =
+                MobState(
+                    MobId("demo:rat"),
+                    "a rat",
+                    fixture.roomId,
+                    hp = 10,
+                    maxHp = 10,
+                )
+            fixture.mobs.upsert(mob)
+
+            val combat = fixture.buildCombat(rng = Random(1))
+
+            val entered = mutableListOf<SessionId>()
+            combat.onPlayerEnteredCombat = { sid -> entered.add(sid) }
+
+            val sid = SessionId(51L)
+            fixture.players.loginOrFail(sid, "Striker")
+
+            assertNull(combat.startCombat(sid, "rat"))
+            assertEquals(listOf(sid), entered)
+        }
 }

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -346,6 +346,7 @@ function App() {
     canvasCallbacks.openBank = () => openPanel("bank");
     canvasCallbacks.openStylist = () => openPanel("stylist");
     canvasCallbacks.openTrainer = () => openPanel("trainer");
+    canvasCallbacks.openCrafting = () => openPanel("crafting");
     canvasCallbacks.openDungeon = () => openPanel("dungeon");
     canvasCallbacks.openLottery = () => openPanel("lottery");
     canvasCallbacks.openHousing = () => openPanel("housing");
@@ -364,6 +365,7 @@ function App() {
       canvasCallbacks.openBank = null;
       canvasCallbacks.openStylist = null;
       canvasCallbacks.openTrainer = null;
+      canvasCallbacks.openCrafting = null;
       canvasCallbacks.openDungeon = null;
       canvasCallbacks.openLottery = null;
       canvasCallbacks.openHousing = null;

--- a/web-v3/src/canvas/GameStateBridge.ts
+++ b/web-v3/src/canvas/GameStateBridge.ts
@@ -67,6 +67,7 @@ export const canvasCallbacks: {
   openBank: (() => void) | null;
   openStylist: (() => void) | null;
   openTrainer: (() => void) | null;
+  openCrafting: (() => void) | null;
   openDungeon: (() => void) | null;
   openLottery: (() => void) | null;
   openHousing: (() => void) | null;
@@ -87,6 +88,7 @@ export const canvasCallbacks: {
   openBank: null,
   openStylist: null,
   openTrainer: null,
+  openCrafting: null,
   openDungeon: null,
   openLottery: null,
   openHousing: null,

--- a/web-v3/src/canvas/scenes/WorldScene.ts
+++ b/web-v3/src/canvas/scenes/WorldScene.ts
@@ -407,7 +407,7 @@ export class WorldScene {
     this.stationBadge.eventMode = "static";
     this.stationBadge.cursor = "pointer";
     this.stationBadge.on("pointerdown", () => {
-      canvasCallbacks.sendCommand?.("recipes");
+      canvasCallbacks.openCrafting?.();
     });
     this.stationBadge.on("pointerover", () => {
       if (this.stationSprite) this.stationSprite.alpha = 1;


### PR DESCRIPTION
## Summary
- Fixes #1081 — when a mob aggros a player, the open dialogue is now force-closed so the player isn't trapped in conversation with a hostile in the room.
- Fixes #1082 — clicking the station badge in the web canvas opens the Crafting drawer panel instead of silently firing a `recipes` command with no visible UI.

## Changes
- `CombatSystem` exposes `onPlayerEnteredCombat` and fires it from `startCombat`, `startMobCombat`, and `startPvpCombat` (both attacker and auto-engaged victim).
- `GameEngine` wires `combatSystem.onPlayerEnteredCombat = { sid -> dialogueSystem.endConversation(sid) }`.
- New canvas callback `openCrafting` mirrors `openTrainer`/`openStylist`; `WorldScene` station pointerdown calls it instead of `sendCommand("recipes")`.

## Test plan
- [x] `./gradlew ktlintCheck test` — green
- [x] New tests in `CombatSystemTest` verify `onPlayerEnteredCombat` fires for mob-aggro and player-initiated combat
- [x] `bun run build` — clean
- [ ] Manual: start dialogue with an NPC, have a mob aggro, confirm the overlay dismisses and combat commands work
- [ ] Manual: click the alchemy table station badge, confirm the Crafting drawer opens