### PR TITLE
Surface gather cooldown and craft errors in the crafting panel

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -1157,6 +1157,19 @@ class GmcpEmitter(
         emit(sessionId, "Crafting.Nodes", nodes, supportCheck = "Crafting")
     }
 
+    suspend fun sendCraftingCooldown(
+        sessionId: SessionId,
+        type: String,
+        untilMs: Long,
+    ) {
+        emit(
+            sessionId,
+            "Crafting.Cooldown",
+            CraftingCooldownPayload(type = type, untilMs = untilMs),
+            supportCheck = "Crafting",
+        )
+    }
+
     suspend fun sendCraftingResult(
         sessionId: SessionId,
         type: String,
@@ -2626,6 +2639,11 @@ class GmcpEmitter(
         val skill: String,
         val skillRequired: Int,
         val image: String? = null,
+    )
+
+    private data class CraftingCooldownPayload(
+        val type: String,
+        val untilMs: Long,
     )
 
     private data class CraftingResultPayload(

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/CraftingHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/CraftingHandler.kt
@@ -47,21 +47,35 @@ class CraftingHandler(
             val result = cs.gather(me, cmd.keyword, me.roomId, items)
             when (result) {
                 is Either.Left -> when (val err = result.value) {
-                    is GatherError.NoNodeFound -> outbound.send(
-                        OutboundEvent.SendError(
-                            sessionId,
-                            "There is nothing to gather here matching '${cmd.keyword}'.",
-                        ),
+                    is GatherError.NoNodeFound -> sendGatherError(
+                        sessionId,
+                        "There is nothing to gather here matching '${cmd.keyword}'.",
+                        code = "no_node",
                     )
-                    is GatherError.SkillTooLow -> sendSkillTooLow(sessionId, err.required, err.current)
-                    is GatherError.NodeDepleted -> outbound.send(
-                        OutboundEvent.SendError(
+                    is GatherError.SkillTooLow -> {
+                        sendSkillTooLow(sessionId, err.required, err.current)
+                        gmcpEmitter?.sendUiFeedback(
                             sessionId,
-                            "That resource is depleted. It will respawn in ${err.respawnInSeconds}s.",
-                        ),
+                            type = "error",
+                            message = "Your skill is too low (need ${err.required}, have ${err.current}).",
+                            code = "skill_too_low",
+                            scope = "crafting",
+                        )
+                    }
+                    is GatherError.NodeDepleted -> sendGatherError(
+                        sessionId,
+                        "That resource is depleted. It will respawn in ${err.respawnInSeconds}s.",
+                        code = "node_depleted",
                     )
-                    is GatherError.OnCooldown ->
-                        outbound.send(OutboundEvent.SendError(sessionId, "You must wait before gathering again."))
+                    is GatherError.OnCooldown -> {
+                        val seconds = ((err.remainingMs + 999) / 1000).coerceAtLeast(1)
+                        sendGatherError(
+                            sessionId,
+                            "You must wait ${seconds}s before gathering again.",
+                            code = "on_cooldown",
+                        )
+                        gmcpEmitter?.sendCraftingCooldown(sessionId, "gather", me.gatherCooldownUntilMs)
+                    }
                 }
                 is Either.Right -> {
                     val r = result.value
@@ -99,6 +113,7 @@ class CraftingHandler(
                         quantity = totalQuantity,
                         rareFind = r.rareItemsGathered.isNotEmpty(),
                     )
+                    gmcpEmitter?.sendCraftingCooldown(sessionId, "gather", me.gatherCooldownUntilMs)
                     onItemGathered?.invoke(sessionId, r.node.skill)
                     notifyNewDiscoveries(sessionId, me, cs)
                     emitCraftingSkills(sessionId, me)
@@ -114,32 +129,49 @@ class CraftingHandler(
             val result = cs.craft(me, cmd.recipeKeyword, me.roomId, items, room?.station)
             when (result) {
                 is Either.Left -> when (val err = result.value) {
-                    is CraftError.RecipeNotFound -> outbound.send(
-                        OutboundEvent.SendError(
-                            sessionId,
-                            "Unknown recipe '${cmd.recipeKeyword}'. Type 'recipes' to see available recipes.",
-                        ),
+                    is CraftError.RecipeNotFound -> sendCraftError(
+                        sessionId,
+                        "Unknown recipe '${cmd.recipeKeyword}'. Type 'recipes' to see available recipes.",
+                        code = "recipe_not_found",
                     )
-                    is CraftError.NotDiscovered -> outbound.send(
-                        OutboundEvent.SendError(
-                            sessionId,
-                            "You haven't discovered that recipe yet. Keep leveling your skills!",
-                        ),
+                    is CraftError.NotDiscovered -> sendCraftError(
+                        sessionId,
+                        "You haven't discovered that recipe yet. Keep leveling your skills!",
+                        code = "not_discovered",
                     )
-                    is CraftError.SkillTooLow -> sendSkillTooLow(sessionId, err.required, err.current)
-                    is CraftError.LevelTooLow -> outbound.send(
-                        OutboundEvent.SendError(
+                    is CraftError.SkillTooLow -> {
+                        sendSkillTooLow(sessionId, err.required, err.current)
+                        gmcpEmitter?.sendUiFeedback(
                             sessionId,
-                            "You need to be level ${err.required} to craft this (you are level ${err.current}).",
-                        ),
+                            type = "error",
+                            message = "Your skill is too low (need ${err.required}, have ${err.current}).",
+                            code = "skill_too_low",
+                            scope = "crafting",
+                        )
+                    }
+                    is CraftError.LevelTooLow -> sendCraftError(
+                        sessionId,
+                        "You need to be level ${err.required} to craft this (you are level ${err.current}).",
+                        code = "level_too_low",
                     )
                     is CraftError.MissingMaterials -> {
                         outbound.send(OutboundEvent.SendError(sessionId, "You are missing materials:"))
+                        val missingSummary = err.missing.joinToString(", ") { (itemId, qty) ->
+                            val name = items.getTemplate(itemId)?.displayName ?: itemId.value
+                            "$name x$qty"
+                        }
                         for ((itemId, qty) in err.missing) {
                             val template = items.getTemplate(itemId)
                             val name = template?.displayName ?: itemId.value
                             outbound.send(OutboundEvent.SendError(sessionId, "  - $name x$qty"))
                         }
+                        gmcpEmitter?.sendUiFeedback(
+                            sessionId,
+                            type = "error",
+                            message = "Missing materials: $missingSummary",
+                            code = "missing_materials",
+                            scope = "crafting",
+                        )
                     }
                 }
                 is Either.Right -> {
@@ -387,6 +419,16 @@ class CraftingHandler(
 
     private suspend fun sendSkillTooLow(sessionId: SessionId, required: Int, current: Int) {
         outbound.send(OutboundEvent.SendError(sessionId, "Your skill is too low (need $required, have $current)."))
+    }
+
+    private suspend fun sendGatherError(sessionId: SessionId, message: String, code: String) {
+        outbound.send(OutboundEvent.SendError(sessionId, message))
+        gmcpEmitter?.sendUiFeedback(sessionId, type = "error", message = message, code = code, scope = "crafting")
+    }
+
+    private suspend fun sendCraftError(sessionId: SessionId, message: String, code: String) {
+        outbound.send(OutboundEvent.SendError(sessionId, message))
+        gmcpEmitter?.sendUiFeedback(sessionId, type = "error", message = message, code = code, scope = "crafting")
     }
 
     private suspend fun sendCraftingXp(

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -857,6 +857,8 @@ function App() {
             skills={state.craftingSkills}
             recipes={state.craftingRecipes}
             nodes={state.craftingNodes}
+            gatherCooldownUntilMs={state.gatherCooldownUntilMs}
+            uiFeedbackFeed={state.uiFeedbackFeed}
             onGather={(keyword) => sendCommand(`gather ${keyword}`)}
             onCraft={(recipeKeyword) => sendCommand(`craft ${recipeKeyword}`)}
             onRequestRecipes={() => sendCommand("recipes")}

--- a/web-v3/src/components/panels/CraftingPanel.tsx
+++ b/web-v3/src/components/panels/CraftingPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import type { CraftingSkill, CraftingRecipe, CraftingNode } from "../../types";
+import type { CraftingSkill, CraftingRecipe, CraftingNode, UiFeedbackEntry } from "../../types";
 
 interface CraftingPanelProps {
   connected: boolean;
@@ -7,6 +7,8 @@ interface CraftingPanelProps {
   skills: CraftingSkill[];
   recipes: CraftingRecipe[];
   nodes: CraftingNode[];
+  gatherCooldownUntilMs: number;
+  uiFeedbackFeed: UiFeedbackEntry[];
   onGather: (keyword: string) => void;
   onCraft: (recipeKeyword: string) => void;
   onRequestRecipes: () => void;
@@ -19,6 +21,8 @@ export function CraftingPanel({
   skills,
   recipes,
   nodes,
+  gatherCooldownUntilMs,
+  uiFeedbackFeed,
   onGather,
   onCraft,
   onRequestRecipes,
@@ -28,6 +32,24 @@ export function CraftingPanel({
   const skillsRequestedRef = useRef(false);
   const recipesRequestedRef = useRef(false);
   const ready = connected && hasCharacterProfile;
+
+  const [now, setNow] = useState(() => Date.now());
+  const gatherRemainingMs = Math.max(0, gatherCooldownUntilMs - now);
+  const gatherOnCooldown = gatherRemainingMs > 0;
+
+  useEffect(() => {
+    if (!gatherOnCooldown) return;
+    const id = window.setInterval(() => setNow(Date.now()), 250);
+    return () => window.clearInterval(id);
+  }, [gatherOnCooldown]);
+
+  const gatherCountdownLabel = gatherOnCooldown
+    ? `Ready in ${Math.ceil(gatherRemainingMs / 1000)}s`
+    : "Gather";
+
+  const latestCraftingFeedback = uiFeedbackFeed
+    .filter((entry) => entry.scope === "crafting")
+    .slice(-1)[0];
 
   useEffect(() => {
     if (!ready) return;
@@ -52,6 +74,16 @@ export function CraftingPanel({
 
   return (
     <div className="crafting-panel">
+      {latestCraftingFeedback && (
+        <div
+          key={latestCraftingFeedback.id}
+          className={`crafting-feedback crafting-feedback-${latestCraftingFeedback.type}`}
+          role="status"
+          aria-live="polite"
+        >
+          {latestCraftingFeedback.message}
+        </div>
+      )}
       <div className="crafting-tab-bar" role="tablist">
         <button
           type="button"
@@ -191,11 +223,12 @@ export function CraftingPanel({
                     </div>
                     <button
                       type="button"
-                      className="crafting-gather-button"
-                      disabled={!canGather}
+                      className={`crafting-gather-button${gatherOnCooldown ? " crafting-gather-button-cooldown" : ""}`}
+                      disabled={!canGather || gatherOnCooldown}
                       onClick={() => onGather(n.name)}
+                      title={gatherOnCooldown ? gatherCountdownLabel : undefined}
                     >
-                      Gather
+                      {gatherOnCooldown ? gatherCountdownLabel : "Gather"}
                     </button>
                   </li>
                 );

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -159,6 +159,7 @@ interface GmcpContext {
   setCraftingSkills: Dispatch<SetStateAction<CraftingSkill[]>>;
   setCraftingRecipes: Dispatch<SetStateAction<CraftingRecipe[]>>;
   setCraftingNodes: Dispatch<SetStateAction<CraftingNode[]>>;
+  setGatherCooldownUntilMs: Dispatch<SetStateAction<number>>;
   pushCraftingResult: (result?: CraftingResult) => void;
   setMailInbox: Dispatch<SetStateAction<MailEntry[] | null>>;
   setMailMessage: Dispatch<SetStateAction<MailMessage | null>>;
@@ -1564,6 +1565,16 @@ export function applyGmcpPackage(
             image: typeof e.image === "string" ? e.image : null,
           })),
       );
+      break;
+    }
+
+    case "Crafting.Cooldown": {
+      const packet = data as Partial<Record<string, unknown>>;
+      const type = typeof packet.type === "string" ? packet.type : "";
+      const untilMs = safeNumber(packet.untilMs, 0);
+      if (type === "gather") {
+        ctx.setGatherCooldownUntilMs(untilMs);
+      }
       break;
     }
 

--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -243,6 +243,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
   const [craftingSkills, setCraftingSkills] = useState<CraftingSkill[]>([]);
   const [craftingRecipes, setCraftingRecipes] = useState<CraftingRecipe[]>([]);
   const [craftingNodes, setCraftingNodes] = useState<CraftingNode[]>([]);
+  const [gatherCooldownUntilMs, setGatherCooldownUntilMs] = useState<number>(0);
 
   // ── World ─────────────────────────────────────────
   const [dialogue, setDialogue] = useState<DialogueState | null>(null);
@@ -532,6 +533,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
         setCraftingSkills,
         setCraftingRecipes,
         setCraftingNodes,
+        setGatherCooldownUntilMs,
         pushCraftingResult,
         setMailInbox,
         setMailMessage,
@@ -613,6 +615,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     setCraftingSkills([]);
     setCraftingRecipes([]);
     setCraftingNodes([]);
+    setGatherCooldownUntilMs(0);
     setMailInbox(null);
     setMailMessage(null);
     setLoginPrompt(null);
@@ -674,7 +677,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     // Economy
     shop, puzzle, auctionListings, currencies, currencyActivity, bankState, stylistState, lotteryInfo,
     // Crafting
-    craftingSkills, craftingRecipes, craftingNodes,
+    craftingSkills, craftingRecipes, craftingNodes, gatherCooldownUntilMs,
     // World
     dialogue, setDialogue, zoneInstances, worldTime, worldWeather, worldEvents, zoneEnvironment, factions, factionActivity, dungeonInfo, dungeonCatalog,
     // Housing & pets

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -5176,6 +5176,53 @@ body {
   pointer-events: none;
 }
 
+.crafting-gather-button-cooldown:disabled {
+  opacity: 0.78;
+  background: color-mix(in srgb, var(--color-accent-lavender) 28%, var(--surface-2));
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.01em;
+}
+
+.crafting-feedback {
+  margin-bottom: var(--space-2);
+  padding: 8px 12px;
+  border-radius: var(--radius-md, 8px);
+  font-size: 0.82rem;
+  line-height: 1.35;
+  border: 1px solid transparent;
+  animation: crafting-feedback-in 160ms ease-out;
+}
+
+.crafting-feedback-error {
+  background: color-mix(in srgb, var(--color-danger, #d06a6a) 14%, var(--surface-1));
+  border-color: color-mix(in srgb, var(--color-danger, #d06a6a) 48%, transparent);
+  color: var(--color-danger, #d06a6a);
+}
+
+.crafting-feedback-info {
+  background: color-mix(in srgb, var(--color-pale-blue, #7aa8c8) 14%, var(--surface-1));
+  border-color: color-mix(in srgb, var(--color-pale-blue, #7aa8c8) 40%, transparent);
+  color: var(--text-primary);
+}
+
+.crafting-feedback-success {
+  background: color-mix(in srgb, var(--color-moss-green, #6a9d7a) 16%, var(--surface-1));
+  border-color: color-mix(in srgb, var(--color-moss-green, #6a9d7a) 48%, transparent);
+  color: var(--text-primary);
+}
+
+@keyframes crafting-feedback-in {
+  from { opacity: 0; transform: translateY(-2px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .crafting-feedback {
+    animation: none;
+  }
+}
+
 .crafting-recipe-meta {
   display: flex;
   gap: var(--space-2);


### PR DESCRIPTION
## Summary
- Gather cooldown now tells the player how long to wait and emits a new `Crafting.Cooldown` GMCP ({ type, untilMs }) on both success and cooldown rejection.
- Gather/craft error paths (missing materials, skill too low, level too low, unknown recipe, not discovered, no node, depleted node, on-cooldown) also emit `UI.Feedback` with `scope=crafting` and a stable machine-readable `code`.
- Web CraftingPanel consumes the cooldown package to disable Gather buttons and render a live "Ready in Xs" countdown, and shows the latest `scope=crafting` feedback entry as an inline banner so panel-click results are visible instead of buried in scrollback.
- No craft cooldown system was introduced (none exists today) — the pattern is now available if one is later.

Fixes #1085

## Test plan
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew test --tests "*CraftingSystemTest*" --tests "*CommandRouter*"`
- [x] `bun run lint` (web-v3)
- [x] `bun run build` (web-v3)
- [ ] Manual: click an ore node on cooldown — button dims and shows countdown; error line includes seconds.
- [ ] Manual: click a craft recipe with missing materials — inline banner shows "Missing materials: ..." with a red tone.
- [ ] Manual: cooldown clears after the gather window expires and Gather re-enables.