### PR TITLE
Persist lastRespecAtMs so respec cooldown survives logout

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -63,7 +63,7 @@ data class PlayerState(
     var bankItems: MutableList<dev.ambon.domain.items.ItemInstance> = mutableListOf(),
     /** Epoch-ms timestamp after which recall is available again. Runtime-only; not persisted. */
     var recallCooldownUntilMs: Long = 0L,
-    /** Epoch-ms of last stat respec. Runtime-only; not persisted (cooldown resets on logout). */
+    /** Epoch-ms of the last stat/ability respec. Persisted so the cooldown survives logout. */
     var lastRespecAtMs: Long = 0L,
     var craftingSkills: MutableMap<String, CraftingSkillState> = mutableMapOf(),
     var discoveredRecipes: MutableSet<String> = mutableSetOf(),
@@ -259,6 +259,7 @@ fun PlayerRecord.toPlayerState(sessionId: SessionId): PlayerState =
         authTokenHash = authTokenHash,
         authTokenIssuedAt = authTokenIssuedAt,
         autolootEnabled = autolootEnabled,
+        lastRespecAtMs = lastRespecAtMs,
     )
 
 /** Converts this runtime state to a [PlayerRecord] for persistence. */
@@ -315,6 +316,7 @@ fun PlayerState.toPlayerRecord(lastSeenEpochMs: Long): PlayerRecord {
         authTokenHash = authTokenHash,
         authTokenIssuedAt = authTokenIssuedAt,
         autolootEnabled = autolootEnabled,
+        lastRespecAtMs = lastRespecAtMs,
     )
 }
 

--- a/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
@@ -94,6 +94,8 @@ data class PlayerRecord(
     val description: String = "",
     /** When true, items dropped by mobs the player kills are auto-looted into inventory. */
     val autolootEnabled: Boolean = false,
+    /** Epoch-ms of the last stat/ability respec. 0 means never respec'd. */
+    val lastRespecAtMs: Long = 0L,
 ) {
     /**
      * Applies legacy migration fixes after deserialization.

--- a/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
@@ -81,6 +81,7 @@ object PlayersTable : Table("players") {
     val screenReaderEnabled = bool("screen_reader_enabled").default(false)
     val description = text("description").default("")
     val autolootEnabled = bool("autoloot_enabled").default(false)
+    val lastRespecAtMs = long("last_respec_at_ms").default(0L)
 
     override val primaryKey = PrimaryKey(id)
 
@@ -139,6 +140,7 @@ object PlayersTable : Table("players") {
             screenReaderEnabled = row[screenReaderEnabled],
             description = row[description],
             autolootEnabled = row[autolootEnabled],
+            lastRespecAtMs = row[lastRespecAtMs],
         ).migrateDefaults()
 
     /** Writes all [PlayerRecord] fields into an insert or upsert [statement]. */
@@ -196,5 +198,6 @@ object PlayersTable : Table("players") {
         statement[screenReaderEnabled] = record.screenReaderEnabled
         statement[description] = record.description
         statement[autolootEnabled] = record.autolootEnabled
+        statement[lastRespecAtMs] = record.lastRespecAtMs
     }
 }

--- a/src/main/resources/db/migration/V37__add_last_respec_at_ms.sql
+++ b/src/main/resources/db/migration/V37__add_last_respec_at_ms.sql
@@ -1,0 +1,1 @@
+ALTER TABLE players ADD COLUMN last_respec_at_ms BIGINT NOT NULL DEFAULT 0;


### PR DESCRIPTION
## Summary
`PlayerState.lastRespecAtMs` was runtime-only, so the respec cooldown checked in `TrainerHandler` (src/main/kotlin/dev/ambon/engine/commands/handlers/TrainerHandler.kt:400) could be bypassed by logging out and back in — the field reset to `0L` on reload.

This wires the field through the persistence boundary per the CLAUDE.md playbook:
- `PlayerRecord` gains `lastRespecAtMs: Long = 0L`
- `PlayersTable` gains `last_respec_at_ms BIGINT NOT NULL DEFAULT 0` with read/write mappings
- `toPlayerState()` / `toPlayerRecord()` carry it across the boundary
- Flyway migration `V37__add_last_respec_at_ms.sql` adds the column with a `0` default
- `PlayerState` comment updated from "runtime-only; not persisted" to reflect the new behavior

Noted during work on a downstream project (Arcanum); fix lives here in AmbonMUD.

## Test plan
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew test --tests "*Trainer*" --tests "*Persist*" --tests "*PlayerRepository*" --tests "*PlayersTable*"`
- [ ] Manual: respec once, log out, log back in, attempt respec — should still be blocked by cooldown with correct remaining time.