### PR TITLE
Redesign inventory/equipment panels with item categorization

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/items/Item.kt
+++ b/src/main/kotlin/dev/ambon/domain/items/Item.kt
@@ -36,4 +36,22 @@ data class Item(
     val basePrice: Int = 0,
     val image: String? = null,
     val video: String? = null,
-)
+    val itemType: ItemType? = null,
+    val questItem: Boolean = false,
+) {
+    /**
+     * Effective item type for categorization. Uses [itemType] when set,
+     * otherwise infers from slot/consumable/basePrice. Quest items always
+     * resolve to [ItemType.QUEST] regardless of declared type.
+     */
+    fun resolvedType(): ItemType {
+        if (questItem) return ItemType.QUEST
+        itemType?.let { return it }
+        return when {
+            slot != null -> ItemType.EQUIPMENT
+            consumable -> ItemType.CONSUMABLE
+            basePrice > 0 -> ItemType.TREASURE
+            else -> ItemType.MISC
+        }
+    }
+}

--- a/src/main/kotlin/dev/ambon/domain/items/ItemType.kt
+++ b/src/main/kotlin/dev/ambon/domain/items/ItemType.kt
@@ -1,0 +1,27 @@
+package dev.ambon.domain.items
+
+/**
+ * Broad categorization used by the client to group inventory items and by
+ * the server to gate certain actions (quest items cannot be dropped, sold,
+ * given, or stored in containers).
+ *
+ * When an item does not declare [Item.itemType] explicitly, a value is
+ * inferred via [Item.resolvedType] from the item's other properties.
+ */
+enum class ItemType {
+    EQUIPMENT,
+    CONSUMABLE,
+    QUEST,
+    TREASURE,
+    MISC,
+    ;
+
+    fun label(): String = name.lowercase()
+
+    companion object {
+        fun parse(raw: String): ItemType? {
+            val value = raw.trim().uppercase().ifEmpty { return null }
+            return entries.firstOrNull { it.name == value }
+        }
+    }
+}

--- a/src/main/kotlin/dev/ambon/domain/world/data/ItemFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/ItemFile.kt
@@ -19,4 +19,6 @@ data class ItemFile(
     val basePrice: Int = 0,
     val image: String? = null,
     val video: String? = null,
+    val itemType: String? = null,
+    val questItem: Boolean = false,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -27,6 +27,7 @@ import dev.ambon.domain.ids.qualifyId
 import dev.ambon.domain.items.Item
 import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.items.ItemSlot
+import dev.ambon.domain.items.ItemType
 import dev.ambon.domain.mob.MobSpell
 import dev.ambon.domain.puzzle.PuzzleDef
 import dev.ambon.domain.puzzle.PuzzleReward
@@ -502,6 +503,18 @@ object WorldLoader {
                 val basePrice = itemFile.basePrice
                 requireAtLeast(basePrice, 0, itemCtx, "basePrice")
 
+                val itemTypeRaw = itemFile.itemType?.trim()
+                if (itemTypeRaw != null && itemTypeRaw.isEmpty()) {
+                    throw WorldLoadException("Item '${itemId.value}' itemType cannot be blank")
+                }
+                val itemType = itemTypeRaw?.let { raw ->
+                    ItemType.parse(raw)
+                        ?: throw WorldLoadException(
+                            "Item '${itemId.value}' itemType '$raw' is not a known type. " +
+                                "Valid values: ${ItemType.entries.joinToString(", ") { it.label() }}",
+                        )
+                }
+
                 val roomRaw = itemFile.room?.trim()?.takeUnless { it.isEmpty() }
                 val mobRaw = itemFile.mob?.trim()?.takeUnless { it.isEmpty() }
                 if (roomRaw != null && mobRaw != null) {
@@ -540,6 +553,8 @@ object WorldLoader {
                                         basePrice = basePrice,
                                         image = (itemFile.image ?: imageDefaults?.item)?.let { "$imagesBase$it" },
                                         video = itemFile.video?.let { "$videosBase$it" },
+                                        itemType = itemType,
+                                        questItem = itemFile.questItem,
                                     ),
                             ),
                         roomId = roomId,

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -2109,7 +2109,25 @@ class GmcpEmitter(
             enchantments = item.enchantments.ifEmpty { null },
             consumable = if (item.item.consumable) true else null,
             useEffect = item.item.onUse?.describe(),
+            itemType = item.item.resolvedType().label(),
+            questItem = if (item.item.questItem) true else null,
+            stackKey = computeStackKey(item),
         )
+
+    /**
+     * Grouping key used by the web client to visually collapse identical instances
+     * into a single row with a count. Two instances share a stackKey only when their
+     * item definition, enchantments, and remaining charges all match.
+     */
+    private fun computeStackKey(item: ItemInstance): String {
+        val enchants = if (item.enchantments.isEmpty()) {
+            ""
+        } else {
+            item.enchantments.sorted().joinToString(",")
+        }
+        val charges = item.item.charges?.toString() ?: ""
+        return "${item.item.keyword}|$enchants|$charges"
+    }
 
     private fun toRoomMobPayload(mob: MobState): RoomMobPayload {
         val effects = getMobEffects(mob.id)
@@ -2215,6 +2233,9 @@ class GmcpEmitter(
         val enchantments: List<String>? = null,
         val consumable: Boolean? = null,
         val useEffect: String? = null,
+        val itemType: String,
+        val questItem: Boolean? = null,
+        val stackKey: String,
     )
 
     private data class EquipmentSlotPayload(

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/AuctionHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/AuctionHandler.kt
@@ -104,6 +104,12 @@ class AuctionHandler(
         }
 
         players.withPlayer(sessionId) { me ->
+            val carried = items.peekInventoryItem(sessionId, cmd.itemKeyword)
+            if (carried != null && carried.item.questItem) {
+                val message = "You can't auction ${carried.item.displayName} — it's a quest item."
+                sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, message, "auction", code = "QUEST_ITEM", command = "sell")
+                return
+            }
             val listing = auction.postListing(sessionId, me.name, cmd.itemKeyword, cmd.price)
             if (listing == null) {
                 val message = "You aren't carrying '${cmd.itemKeyword}'."

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ItemHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ItemHandler.kt
@@ -205,6 +205,16 @@ class ItemHandler(
                     return
                 }
             }
+            val carried = items.peekInventoryItem(me.sessionId, cmd.keyword)
+            if (carried != null && carried.item.questItem) {
+                outbound.send(
+                    OutboundEvent.SendError(
+                        sessionId,
+                        "You can't drop ${carried.item.displayName} — it's a quest item.",
+                    ),
+                )
+                return
+            }
             val moved = items.dropToRoom(me.sessionId, roomId, cmd.keyword)
             if (moved == null) {
                 outbound.send(OutboundEvent.SendError(sessionId, "You aren't carrying '${cmd.keyword}'."))
@@ -288,6 +298,16 @@ class ItemHandler(
             }
             players.withPlayer(targetSid) { target ->
                 if (!requireSameRoom(sessionId, me, target, outbound)) return
+                val owned = items.peekOwnedItem(me.sessionId, cmd.keyword)
+                if (owned != null && owned.item.questItem) {
+                    outbound.send(
+                        OutboundEvent.SendError(
+                            sessionId,
+                            "You can't give away ${owned.item.displayName} — it's a quest item.",
+                        ),
+                    )
+                    return
+                }
                 when (val result = items.giveToPlayer(me.sessionId, targetSid, cmd.keyword)) {
                     is ItemRegistry.GiveResult.Given -> {
                         if (result.location == ItemRegistry.HeldItemLocation.EQUIPPED) {

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ShopHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ShopHandler.kt
@@ -172,6 +172,15 @@ class ShopHandler(
                 outbound.send(OutboundEvent.SendError(sessionId, "You don't have '$keyword'."))
                 return
             }
+            if (invItem.item.questItem) {
+                outbound.send(
+                    OutboundEvent.SendError(
+                        sessionId,
+                        "You can't sell ${invItem.item.displayName} — it's a quest item.",
+                    ),
+                )
+                return
+            }
             val sellPrice = (invItem.item.basePrice * economyConfig.sellMultiplier).roundToInt().toLong()
             if (sellPrice <= 0L) {
                 outbound.send(OutboundEvent.SendError(sessionId, "${invItem.item.displayName} is worthless."))

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/TradeHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/TradeHandler.kt
@@ -82,6 +82,16 @@ class TradeHandler(
             return
         }
 
+        val carried = items.peekInventoryItem(sessionId, cmd.itemKeyword)
+        if (carried != null && carried.item.questItem) {
+            outbound.send(
+                OutboundEvent.SendError(
+                    sessionId,
+                    "You can't trade ${carried.item.displayName} — it's a quest item.",
+                ),
+            )
+            return
+        }
         val result = ts.offerItem(sessionId, cmd.itemKeyword)
         if (result == null) {
             outbound.send(OutboundEvent.SendError(sessionId, "You aren't carrying '${cmd.itemKeyword}'."))

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldFeaturesHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldFeaturesHandler.kt
@@ -167,6 +167,16 @@ class WorldFeaturesHandler(
         containerKeyword: String,
     ): Unit = withPlayerAndRoom(sessionId, players, world) { me, room ->
         val feature = requireOpenContainer(sessionId, room, containerKeyword, worldState, outbound) ?: return
+        val carried = items.peekInventoryItem(sessionId, itemKeyword)
+        if (carried != null && carried.item.questItem) {
+            outbound.send(
+                OutboundEvent.SendError(
+                    sessionId,
+                    "You can't stash ${carried.item.displayName} — it's a quest item.",
+                ),
+            )
+            return
+        }
         val item = items.removeFromInventory(sessionId, itemKeyword)
         if (item == null) {
             outbound.send(OutboundEvent.SendError(sessionId, "You don't have any '$itemKeyword'."))

--- a/src/main/kotlin/dev/ambon/engine/items/ItemRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/items/ItemRegistry.kt
@@ -501,6 +501,28 @@ class ItemRegistry {
         return instance
     }
 
+    /**
+     * Look up (without removing) an item owned by [sessionId] (inventory or equipped)
+     * matching [keyword]. Used by handlers to pre-validate actions (e.g. quest-item guards).
+     */
+    fun peekOwnedItem(
+        sessionId: SessionId,
+        keyword: String,
+    ): ItemInstance? = findOwnedItemMatch(sessionId, keyword)?.item
+
+    /**
+     * Look up (without removing) an item in [sessionId]'s inventory only (not equipped)
+     * matching [keyword]. Used by handlers that apply only to carried items.
+     */
+    fun peekInventoryItem(
+        sessionId: SessionId,
+        keyword: String,
+    ): ItemInstance? {
+        val inv = inventoryItems[sessionId] ?: return null
+        val idx = findMatchingItemIndex(inv, keyword)
+        return if (idx >= 0) inv[idx] else null
+    }
+
     private fun findOwnedItemMatch(
         sessionId: SessionId,
         keyword: String,

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterItemsTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterItemsTest.kt
@@ -126,6 +126,43 @@ class CommandRouterItemsTest {
         }
 
     @Test
+    fun `drop is blocked for quest items`() =
+        runTest {
+            val h = CommandRouterHarness.create()
+
+            val sid = SessionId(41L)
+            h.loginPlayer(sid, "QuestHolder")
+
+            h.items.setRoomItems(
+                h.world.startRoom,
+                listOf(
+                    ItemInstance(
+                        ItemId("test:relic"),
+                        Item(
+                            keyword = "relic",
+                            displayName = "the Lost Relic",
+                            questItem = true,
+                        ),
+                    ),
+                ),
+            )
+            h.items.takeFromRoom(sid, h.world.startRoom, "relic")
+            assertEquals(1, h.items.inventory(sid).size)
+
+            h.router.handle(sid, Command.Drop("relic"))
+
+            // Quest item stays in inventory; room still empty
+            assertEquals(1, h.items.inventory(sid).size)
+            assertEquals(0, h.items.itemsInRoom(h.world.startRoom).size)
+
+            val outs = h.drain()
+            assertTrue(
+                outs.any { it is OutboundEvent.SendError && it.text.contains("quest item") },
+                "Expected quest-item error. got=$outs",
+            )
+        }
+
+    @Test
     fun `wear moves item from inventory to equipment slot`() =
         runTest {
             val h = CommandRouterHarness.create()

--- a/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.items.ItemSlot
+import dev.ambon.domain.items.ItemType
 import dev.ambon.domain.world.Direction
 import dev.ambon.domain.world.WorldFactory
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -142,6 +143,52 @@ class WorldLoaderTest {
         assertEquals(3, sword.instance.item.damage)
         assertEquals(0, sword.instance.item.armor)
         assertEquals(1, sword.instance.item.stats["CON"])
+    }
+
+    @Test
+    fun `loads declared item types and quest-item flag`() {
+        val world = WorldLoader.loadFromResource("world/ok_item_types.yaml")
+        val items = world.itemSpawns.associateBy { it.instance.id.value }
+
+        val relic = items.getValue("ok_item_types:relic").instance.item
+        assertEquals(ItemType.QUEST, relic.itemType)
+        assertTrue(relic.questItem)
+        assertEquals(ItemType.QUEST, relic.resolvedType())
+
+        // Inferred: has basePrice, no slot/consumable -> TREASURE
+        val trinket = items.getValue("ok_item_types:trinket").instance.item
+        assertNull(trinket.itemType)
+        assertFalse(trinket.questItem)
+        assertEquals(ItemType.TREASURE, trinket.resolvedType())
+
+        // Inferred: nothing special -> MISC
+        val plain = items.getValue("ok_item_types:plain").instance.item
+        assertEquals(ItemType.MISC, plain.resolvedType())
+
+        // Inferred from slot -> EQUIPMENT
+        val blade = items.getValue("ok_item_types:blade").instance.item
+        assertEquals(ItemType.EQUIPMENT, blade.resolvedType())
+
+        // Inferred from consumable flag -> CONSUMABLE
+        val elixir = items.getValue("ok_item_types:elixir").instance.item
+        assertEquals(ItemType.CONSUMABLE, elixir.resolvedType())
+
+        // questItem=true always resolves to QUEST regardless of slot
+        val signet = items.getValue("ok_item_types:marked_gear").instance.item
+        assertTrue(signet.questItem)
+        assertEquals(ItemType.QUEST, signet.resolvedType())
+    }
+
+    @Test
+    fun `rejects unknown itemType value`() {
+        val ex =
+            assertThrows(WorldLoadException::class.java) {
+                WorldLoader.loadFromResource("world/bad_item_type.yaml")
+            }
+        assertTrue(
+            ex.message!!.contains("itemType", ignoreCase = true),
+            "Got: ${ex.message}",
+        )
     }
 
     @Test

--- a/src/test/resources/world/bad_item_type.yaml
+++ b/src/test/resources/world/bad_item_type.yaml
@@ -1,0 +1,10 @@
+zone: bad_item_type
+startRoom: a
+rooms:
+  a:
+    title: "Room A"
+    description: "Start."
+items:
+  broken:
+    displayName: "a broken item"
+    itemType: "nonsense"

--- a/src/test/resources/world/ok_item_types.yaml
+++ b/src/test/resources/world/ok_item_types.yaml
@@ -1,0 +1,31 @@
+zone: ok_item_types
+startRoom: a
+rooms:
+  a:
+    title: "Room A"
+    description: "Start."
+items:
+  relic:
+    displayName: "the Lost Relic"
+    description: "A holy artifact."
+    itemType: quest
+    questItem: true
+    basePrice: 500
+  trinket:
+    displayName: "a shiny trinket"
+    basePrice: 10
+  plain:
+    displayName: "a plain rock"
+  blade:
+    displayName: "a short blade"
+    slot: weapon
+    damage: 3
+  elixir:
+    displayName: "an elixir"
+    consumable: true
+    onUse:
+      healHp: 10
+  marked_gear:
+    displayName: "a signet ring"
+    slot: neck
+    questItem: true

--- a/web-v3/src/components/panels/EquipmentPanel.tsx
+++ b/web-v3/src/components/panels/EquipmentPanel.tsx
@@ -13,6 +13,44 @@ interface EquipmentPanelProps {
   onRemoveItem: (slot: string) => void;
 }
 
+function renderItemBonuses(item: ItemSummary) {
+  const badges: { key: string; label: string; tone: string }[] = [];
+  if ((item.damage ?? 0) > 0) {
+    badges.push({ key: "dmg", label: `+${item.damage} dmg`, tone: "damage" });
+  }
+  if ((item.armor ?? 0) > 0) {
+    badges.push({ key: "arm", label: `+${item.armor} arm`, tone: "armor" });
+  }
+  if (item.stats) {
+    for (const [stat, value] of Object.entries(item.stats)) {
+      if (value !== 0) {
+        badges.push({
+          key: `stat-${stat}`,
+          label: `${value > 0 ? "+" : ""}${value} ${stat}`,
+          tone: "stat",
+        });
+      }
+    }
+  }
+  if (item.enchantments && item.enchantments.length > 0) {
+    badges.push({
+      key: "enchant",
+      label: item.enchantments.join(", "),
+      tone: "enchant",
+    });
+  }
+  if (badges.length === 0) return null;
+  return (
+    <div className="paperdoll-list-badges">
+      {badges.map((b) => (
+        <span key={b.key} className={`paperdoll-list-badge paperdoll-list-badge-${b.tone}`}>
+          {b.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
 export function EquipmentPanel({
   connected,
   hasCharacterProfile,
@@ -90,6 +128,7 @@ export function EquipmentPanel({
                       {item ? item.name : "\u2014"}
                     </span>
                   </div>
+                  {item && renderItemBonuses(item)}
                   {isSelected && item && (
                     <div className="paperdoll-list-actions">
                       <button

--- a/web-v3/src/components/panels/InventoryPanel.tsx
+++ b/web-v3/src/components/panels/InventoryPanel.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import type { ContainerContents, ItemSummary, RoomFeature, RoomPlayer } from "../../types";
+import type { ContainerContents, ItemSummary, ItemType, RoomFeature, RoomPlayer } from "../../types";
 import { DropItemIcon, GiveItemIcon, WearItemIcon } from "../Icons";
 import { resolveItemImage } from "../../imageDefaults";
 
@@ -19,17 +19,87 @@ interface InventoryPanelProps {
   equipHint?: boolean;
 }
 
-function categorize(items: ItemSummary[]): { wearable: ItemSummary[]; other: ItemSummary[] } {
-  const wearable: ItemSummary[] = [];
-  const other: ItemSummary[] = [];
+interface ItemStack {
+  /** Server stackKey, or a synthetic per-instance key for older servers. */
+  key: string;
+  /** First instance in the group — used for display name, keyword, and image. */
+  lead: ItemSummary;
+  /** All instances sharing the stackKey (count = instances.length). */
+  instances: ItemSummary[];
+}
+
+type SectionKey = "equipment" | "consumable" | "quest" | "treasure" | "misc";
+
+interface Section {
+  key: SectionKey;
+  title: string;
+  hint: string | null;
+  stacks: ItemStack[];
+}
+
+function resolveItemType(item: ItemSummary): ItemType {
+  if (item.itemType) return item.itemType;
+  if (item.questItem) return "quest";
+  if (item.slot) return "equipment";
+  if (item.consumable) return "consumable";
+  if ((item.basePrice ?? 0) > 0) return "treasure";
+  return "misc";
+}
+
+function groupAndCategorize(items: ItemSummary[]): Section[] {
+  const buckets: Record<SectionKey, Map<string, ItemStack>> = {
+    equipment: new Map(),
+    consumable: new Map(),
+    quest: new Map(),
+    treasure: new Map(),
+    misc: new Map(),
+  };
+
   for (const item of items) {
-    if (item.slot) {
-      wearable.push(item);
+    const type = resolveItemType(item);
+    // Fall back to a unique per-instance key when the server did not provide one:
+    // that means every instance renders as its own stack of 1 (safe degrade).
+    const key = item.stackKey ?? `__instance__:${item.id}`;
+    const bucket = buckets[type];
+    const existing = bucket.get(key);
+    if (existing) {
+      existing.instances.push(item);
     } else {
-      other.push(item);
+      bucket.set(key, { key, lead: item, instances: [item] });
     }
   }
-  return { wearable, other };
+
+  const order: { key: SectionKey; title: string; hint: string | null }[] = [
+    { key: "equipment", title: "Equipment", hint: null },
+    { key: "consumable", title: "Consumables", hint: null },
+    { key: "quest", title: "Quest Items", hint: "Soulbound — cannot be dropped or sold." },
+    { key: "treasure", title: "Valuables", hint: "Sell to a shopkeeper for gold." },
+    { key: "misc", title: "Other", hint: null },
+  ];
+
+  return order
+    .map(({ key, title, hint }) => ({
+      key,
+      title,
+      hint,
+      stacks: Array.from(buckets[key].values()),
+    }))
+    .filter((section) => section.stacks.length > 0);
+}
+
+function categoryChipLabel(type: ItemType): string {
+  switch (type) {
+    case "equipment":
+      return "Gear";
+    case "consumable":
+      return "Use";
+    case "quest":
+      return "Quest";
+    case "treasure":
+      return "Sell";
+    case "misc":
+      return "Misc";
+  }
 }
 
 export function InventoryPanel({
@@ -46,12 +116,13 @@ export function InventoryPanel({
   onCommand,
   equipHint = false,
 }: InventoryPanelProps) {
-  const [givePickerItemId, setGivePickerItemId] = useState<string | null>(null);
+  const [givePickerStackKey, setGivePickerStackKey] = useState<string | null>(null);
   const containers = useMemo(
     () => roomFeatures.filter((f) => f.type === "container"),
     [roomFeatures],
   );
   const activeContainerKeyword = containerContents?.keyword ?? null;
+  const sections = useMemo(() => groupAndCategorize(inventory), [inventory]);
 
   if (!connected || !hasCharacterProfile) {
     return <p className="empty-note">Log in to view inventory.</p>;
@@ -65,116 +136,159 @@ export function InventoryPanel({
     );
   }
 
-  const { wearable, other } = categorize(inventory);
+  const renderStack = (stack: ItemStack, type: ItemType) => {
+    const item = stack.lead;
+    const count = stack.instances.length;
+    const isQuest = type === "quest" || !!item.questItem;
+    const isVendorFodder = type === "treasure" && !item.slot && !item.consumable;
+    const image = resolveItemImage(item);
 
-  const renderItem = (item: ItemSummary) => (
-    <li key={item.id} className="inventory-item">
-      <div className="inventory-item-row">
-        <div className="inventory-item-info">
-          {resolveItemImage(item) && <img src={resolveItemImage(item)!} alt="" className="inventory-item-thumb" />}
-          <div className="inventory-item-copy">
-            <span className="inventory-item-name">{item.name}</span>
-            <div className="inventory-item-meta">
-              {item.slot && <span className="inventory-item-slot">{item.slot}</span>}
-              {!item.slot && item.consumable && item.useEffect && (
-                <span className="inventory-item-effect" title={item.useEffect}>{item.useEffect}</span>
+    const rowClasses = [
+      "inventory-item-row",
+      `inventory-item-row-${type}`,
+      isQuest ? "inventory-item-row-quest" : "",
+      isVendorFodder ? "inventory-item-row-vendor" : "",
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    return (
+      <li key={stack.key} className="inventory-item">
+        <div className={rowClasses}>
+          <div className="inventory-item-info">
+            <div className="inventory-item-thumb-wrap">
+              {image && <img src={image} alt="" className="inventory-item-thumb" />}
+              {count > 1 && (
+                <span className="inventory-stack-count" aria-label={`${count} in stack`}>
+                  ×{count}
+                </span>
               )}
             </div>
+            <div className="inventory-item-copy">
+              <span className="inventory-item-name">{item.name}</span>
+              <div className="inventory-item-meta">
+                <span className={`inventory-item-chip inventory-item-chip-${type}`}>
+                  {categoryChipLabel(type)}
+                </span>
+                {item.slot && <span className="inventory-item-slot">{item.slot}</span>}
+                {!item.slot && item.consumable && item.useEffect && (
+                  <span className="inventory-item-effect" title={item.useEffect}>
+                    {item.useEffect}
+                  </span>
+                )}
+                {isVendorFodder && (item.basePrice ?? 0) > 0 && (
+                  <span className="inventory-item-price" title="Vendor price">
+                    {item.basePrice}g
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+          <div className="inventory-item-actions">
+            <button
+              type="button"
+              className="inventory-action-btn inventory-action-btn-pill inventory-action-examine"
+              aria-label={`Examine ${item.name}`}
+              title={`Examine ${item.name}`}
+              onClick={() => onCommand(`look ${item.keyword}`)}
+            >
+              Examine
+            </button>
+            {!item.slot && item.consumable && (
+              <button
+                type="button"
+                className="inventory-action-btn inventory-action-btn-pill inventory-action-use"
+                aria-label={`Use ${item.name}`}
+                title={`Use ${item.name}${item.useEffect ? ` - ${item.useEffect}` : ""}`}
+                disabled={!canManageItems}
+                onClick={() => onCommand(`use ${item.keyword}`)}
+              >
+                Use
+              </button>
+            )}
+            {item.slot && (
+              <button
+                type="button"
+                className={`inventory-action-btn inventory-action-btn-pill inventory-action-equip${equipHint ? " inventory-action-equip-hint" : ""}`}
+                aria-label={`Equip ${item.name}`}
+                title={equipHint ? `Equip ${item.name}` : `Wear ${item.name}`}
+                disabled={!canManageItems}
+                onClick={() => onWearItem(item.name)}
+              >
+                <WearItemIcon className="inventory-action-icon" />
+                <span>Equip</span>
+              </button>
+            )}
+            {containerContents && !isQuest && (
+              <button
+                type="button"
+                className="inventory-action-btn inventory-action-btn-pill inventory-action-put"
+                aria-label={`Store ${item.name} in ${containerContents.name}`}
+                title={`Store ${item.name} in ${containerContents.name}`}
+                disabled={!canManageItems}
+                onClick={() => onCommand(`put ${item.keyword} in ${containerContents.keyword}`)}
+              >
+                Store
+              </button>
+            )}
+            {players.length > 0 && !isQuest && (
+              <button
+                type="button"
+                className={`inventory-action-btn inventory-action-btn-icon${givePickerStackKey === stack.key ? " inventory-action-btn-active" : ""}`}
+                title={`Give ${item.name}`}
+                aria-label={`Give ${item.name}`}
+                aria-expanded={givePickerStackKey === stack.key}
+                disabled={!canManageItems}
+                onClick={() => setGivePickerStackKey(givePickerStackKey === stack.key ? null : stack.key)}
+              >
+                <GiveItemIcon className="inventory-action-icon" />
+              </button>
+            )}
+            {!isQuest && (
+              <button
+                type="button"
+                className="inventory-action-btn inventory-action-btn-icon"
+                title={count > 1 ? `Drop one ${item.name}` : `Drop ${item.name}`}
+                aria-label={count > 1 ? `Drop one ${item.name}` : `Drop ${item.name}`}
+                disabled={!canManageItems}
+                onClick={() => onDropItem(item.name)}
+              >
+                <DropItemIcon className="inventory-action-icon" />
+              </button>
+            )}
+            {isQuest && (
+              <span
+                className="inventory-item-soulbound"
+                title="Quest items cannot be dropped, given, sold, or traded."
+                aria-label="Soulbound"
+              >
+                Soulbound
+              </span>
+            )}
           </div>
         </div>
-        <div className="inventory-item-actions">
-          <button
-            type="button"
-            className="inventory-action-btn inventory-action-btn-pill inventory-action-examine"
-            aria-label={`Examine ${item.name}`}
-            title={`Examine ${item.name}`}
-            onClick={() => onCommand(`look ${item.keyword}`)}
-          >
-            Examine
-          </button>
-          {!item.slot && item.consumable && (
-            <button
-              type="button"
-              className="inventory-action-btn inventory-action-btn-pill inventory-action-use"
-              aria-label={`Use ${item.name}`}
-              title={`Use ${item.name}${item.useEffect ? ` - ${item.useEffect}` : ""}`}
-              disabled={!canManageItems}
-              onClick={() => onCommand(`use ${item.keyword}`)}
-            >
-              Use
-            </button>
-          )}
-          {item.slot && (
-            <button
-              type="button"
-              className={`inventory-action-btn inventory-action-btn-pill inventory-action-equip${equipHint ? " inventory-action-equip-hint" : ""}`}
-              aria-label={`Equip ${item.name}`}
-              title={equipHint ? `Equip ${item.name}` : `Wear ${item.name}`}
-              disabled={!canManageItems}
-              onClick={() => onWearItem(item.name)}
-            >
-              <WearItemIcon className="inventory-action-icon" />
-              <span>Equip</span>
-            </button>
-          )}
-          {containerContents && (
-            <button
-              type="button"
-              className="inventory-action-btn inventory-action-btn-pill inventory-action-put"
-              aria-label={`Store ${item.name} in ${containerContents.name}`}
-              title={`Store ${item.name} in ${containerContents.name}`}
-              disabled={!canManageItems}
-              onClick={() => onCommand(`put ${item.keyword} in ${containerContents.keyword}`)}
-            >
-              Store
-            </button>
-          )}
-          {players.length > 0 && (
-            <button
-              type="button"
-              className={`inventory-action-btn inventory-action-btn-icon${givePickerItemId === item.id ? " inventory-action-btn-active" : ""}`}
-              title={`Give ${item.name}`}
-              aria-label={`Give ${item.name}`}
-              aria-expanded={givePickerItemId === item.id}
-              disabled={!canManageItems}
-              onClick={() => setGivePickerItemId(givePickerItemId === item.id ? null : item.id)}
-            >
-              <GiveItemIcon className="inventory-action-icon" />
-            </button>
-          )}
-          <button
-            type="button"
-            className="inventory-action-btn inventory-action-btn-icon"
-            title={`Drop ${item.name}`}
-            aria-label={`Drop ${item.name}`}
-            disabled={!canManageItems}
-            onClick={() => onDropItem(item.name)}
-          >
-            <DropItemIcon className="inventory-action-icon" />
-          </button>
-        </div>
-      </div>
-      {givePickerItemId === item.id && (
-        <div className="inventory-give-picker" role="listbox" aria-label={`Give ${item.name} to`}>
-          <span className="inventory-give-label">Give to:</span>
-          {players.map((player) => (
-            <button
-              key={player.name}
-              type="button"
-              role="option"
-              className="inventory-give-option"
-              onClick={() => {
-                onGiveItem(item.keyword, player.name);
-                setGivePickerItemId(null);
-              }}
-            >
-              {player.name}
-            </button>
-          ))}
-        </div>
-      )}
-    </li>
-  );
+        {givePickerStackKey === stack.key && (
+          <div className="inventory-give-picker" role="listbox" aria-label={`Give ${item.name} to`}>
+            <span className="inventory-give-label">Give to:</span>
+            {players.map((player) => (
+              <button
+                key={player.name}
+                type="button"
+                role="option"
+                className="inventory-give-option"
+                onClick={() => {
+                  onGiveItem(item.keyword, player.name);
+                  setGivePickerStackKey(null);
+                }}
+              >
+                {player.name}
+              </button>
+            ))}
+          </div>
+        )}
+      </li>
+    );
+  };
 
   return (
     <div className="inventory-panel">
@@ -184,21 +298,25 @@ export function InventoryPanel({
           <span className="inventory-active-container-name" title={containerContents.name}>{containerContents.name}</span>
         </div>
       )}
-      {wearable.length > 0 && (
-        <section className="inventory-section">
-          <h3 className="inventory-section-title">Equipment</h3>
-          <ul className="inventory-list">{wearable.map(renderItem)}</ul>
+      {sections.map((section) => (
+        <section key={section.key} className={`inventory-section inventory-section-${section.key}`}>
+          <div className="inventory-section-header">
+            <h3 className="inventory-section-title">{section.title}</h3>
+            <span className="inventory-section-count" aria-label={`${section.stacks.length} stacks`}>
+              {section.stacks.length}
+            </span>
+          </div>
+          {section.hint && <p className="inventory-section-hint">{section.hint}</p>}
+          <ul className="inventory-list">
+            {section.stacks.map((stack) => renderStack(stack, section.key))}
+          </ul>
         </section>
-      )}
-      {other.length > 0 && (
-        <section className="inventory-section">
-          <h3 className="inventory-section-title">Items</h3>
-          <ul className="inventory-list">{other.map(renderItem)}</ul>
-        </section>
-      )}
+      ))}
       {containers.length > 0 && (
-        <section className="inventory-section">
-          <h3 className="inventory-section-title">Containers</h3>
+        <section className="inventory-section inventory-section-containers">
+          <div className="inventory-section-header">
+            <h3 className="inventory-section-title">Containers</h3>
+          </div>
           <div className="container-list">
             {containers.map((container) => (
               <div

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -6322,14 +6322,67 @@ body {
   gap: var(--space-2);
 }
 
+.inventory-section-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-1);
+}
+
 .inventory-section-title {
   font-family: var(--font-display);
   font-size: 0.92rem;
   font-weight: 600;
   color: var(--text-heading);
   margin: 0;
-  padding: 0 var(--space-1);
   letter-spacing: 0.02em;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.inventory-section-count {
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--text-disabled);
+  background: rgb(255 255 255 / 6%);
+  border-radius: 999px;
+  padding: 1px 8px;
+  flex-shrink: 0;
+}
+
+.inventory-section-hint {
+  margin: 0 var(--space-1);
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+  font-style: italic;
+  line-height: 1.3;
+}
+
+/* Per-section accent stripe on the left edge of the section header. */
+.inventory-section-equipment .inventory-section-title {
+  border-left: 3px solid var(--color-primary-moss-green);
+  padding-left: 8px;
+}
+
+.inventory-section-consumable .inventory-section-title {
+  border-left: 3px solid var(--color-primary-pale-blue);
+  padding-left: 8px;
+}
+
+.inventory-section-quest .inventory-section-title {
+  border-left: 3px solid var(--color-primary-soft-gold);
+  padding-left: 8px;
+}
+
+.inventory-section-treasure .inventory-section-title {
+  border-left: 3px solid var(--color-primary-dusty-rose, #c08a9a);
+  padding-left: 8px;
+}
+
+.inventory-section-misc .inventory-section-title {
+  border-left: 3px solid var(--color-accent-lavender, #a897d2);
+  padding-left: 8px;
 }
 
 .inventory-list {
@@ -6382,6 +6435,13 @@ body {
   min-height: 18px;
 }
 
+.inventory-item-thumb-wrap {
+  position: relative;
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+}
+
 .inventory-item-thumb {
   width: 28px;
   height: 28px;
@@ -6389,6 +6449,26 @@ body {
   object-fit: cover;
   flex-shrink: 0;
   border: 1px solid var(--line-faint);
+  display: block;
+}
+
+.inventory-stack-count {
+  position: absolute;
+  right: -4px;
+  bottom: -4px;
+  min-width: 18px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  background: var(--color-primary-soft-gold, #bea873);
+  color: #1a1411;
+  font-size: 0.66rem;
+  font-weight: 800;
+  line-height: 16px;
+  text-align: center;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 35%);
+  border: 1px solid rgb(0 0 0 / 25%);
+  pointer-events: none;
 }
 
 .inventory-item-name {
@@ -6420,6 +6500,87 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 14ch;
+}
+
+.inventory-item-price {
+  font-size: 0.66rem;
+  color: var(--color-primary-soft-gold);
+  background: rgb(190 168 115 / 12%);
+  padding: 1px 6px;
+  border-radius: 999px;
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Category chip: the leftmost badge in the meta row, color-matched to the
+   section accent. Keeps items visually tagged even when sections scroll. */
+.inventory-item-chip {
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 1px 7px;
+  border-radius: 999px;
+  flex-shrink: 0;
+  border: 1px solid transparent;
+}
+
+.inventory-item-chip-equipment {
+  background: rgb(132 168 122 / 16%);
+  color: var(--color-primary-moss-green);
+  border-color: rgb(132 168 122 / 32%);
+}
+
+.inventory-item-chip-consumable {
+  background: rgb(130 164 199 / 16%);
+  color: var(--color-primary-pale-blue);
+  border-color: rgb(130 164 199 / 32%);
+}
+
+.inventory-item-chip-quest {
+  background: rgb(190 168 115 / 20%);
+  color: var(--color-primary-soft-gold);
+  border-color: rgb(190 168 115 / 40%);
+}
+
+.inventory-item-chip-treasure {
+  background: rgb(192 138 154 / 16%);
+  color: var(--color-primary-dusty-rose, #c08a9a);
+  border-color: rgb(192 138 154 / 32%);
+}
+
+.inventory-item-chip-misc {
+  background: rgb(168 151 210 / 14%);
+  color: var(--color-accent-lavender, #a897d2);
+  border-color: rgb(168 151 210 / 28%);
+}
+
+/* Quest items get a warm left edge to reinforce "soulbound." */
+.inventory-item-row-quest {
+  border-left: 3px solid var(--color-primary-soft-gold);
+  padding-left: 7px;
+}
+
+/* Vendor fodder: dim the row slightly so useful items pop. */
+.inventory-item-row-vendor {
+  opacity: 0.78;
+}
+
+.inventory-item-row-vendor:hover {
+  opacity: 1;
+}
+
+.inventory-item-soulbound {
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: 999px;
+  color: var(--color-primary-soft-gold);
+  background: rgb(190 168 115 / 14%);
+  border: 1px solid rgb(190 168 115 / 32%);
+  cursor: help;
 }
 
 .inventory-item-actions {
@@ -6812,6 +6973,54 @@ body {
 .paperdoll-list-name-empty {
   color: var(--text-disabled);
   font-style: italic;
+}
+
+/* Equipped-item bonus badges — mirror the inventory meta row style so both
+   panels share the same visual vocabulary. */
+.paperdoll-list-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.paperdoll-list-badge {
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 1px 6px;
+  border-radius: 999px;
+  flex-shrink: 0;
+  border: 1px solid transparent;
+}
+
+.paperdoll-list-badge-damage {
+  color: var(--color-primary-dusty-rose, #c08a9a);
+  background: rgb(192 138 154 / 12%);
+  border-color: rgb(192 138 154 / 28%);
+}
+
+.paperdoll-list-badge-armor {
+  color: var(--color-primary-moss-green);
+  background: rgb(132 168 122 / 12%);
+  border-color: rgb(132 168 122 / 28%);
+}
+
+.paperdoll-list-badge-stat {
+  color: var(--color-primary-pale-blue);
+  background: rgb(130 164 199 / 12%);
+  border-color: rgb(130 164 199 / 28%);
+  font-variant-numeric: tabular-nums;
+}
+
+.paperdoll-list-badge-enchant {
+  color: var(--color-primary-soft-gold);
+  background: rgb(190 168 115 / 14%);
+  border-color: rgb(190 168 115 / 32%);
+  max-width: 18ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .paperdoll-list-actions {

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -223,6 +223,14 @@ export interface RoomState {
 /** User layout preference: auto follows zone flag, text/canvas force a mode. */
 export type LayoutMode = "auto" | "text" | "canvas";
 
+/** Broad server-assigned item category, lowercased. */
+export type ItemType =
+  | "equipment"
+  | "consumable"
+  | "quest"
+  | "treasure"
+  | "misc";
+
 export interface ItemSummary {
   id: string;
   name: string;
@@ -239,6 +247,12 @@ export interface ItemSummary {
   enchantments?: string[];
   consumable?: boolean;
   useEffect?: string;
+  /** Server-resolved category. Falls back to "misc" if missing for older servers. */
+  itemType?: ItemType;
+  /** True when the item is soulbound — cannot be dropped, sold, traded, given. */
+  questItem?: boolean;
+  /** Grouping key used to visually collapse identical instances into a stack. */
+  stackKey?: string;
 }
 
 export interface EquipmentSlotDef {


### PR DESCRIPTION
## Summary
- Adds explicit `ItemType` (equipment / consumable / quest / treasure / misc) plus a `questItem` flag to the domain model, with safe inference from existing fields and YAML parsing + validation in `WorldLoader`.
- Blocks `drop`, `give`, `sell`, `auction sell`, `trade offer`, and `put <item> in <container>` for quest items with a user-facing error.
- Extends GMCP `ItemPayload` with `itemType`, `questItem`, and a server-computed `stackKey` (keyword + enchantments + charges) so clients can collapse identical instances.
- Rewrites the web-v3 inventory panel into category-accented sections (Equipment, Consumables, Quest Items, Valuables, Other) with stack counts, category chips, dimmed vendor fodder, and a Soulbound badge that hides destructive actions on quest items.
- Equipment panel now shows `+dmg` / `+armor` / stat / enchantment badges in the slot list so both panels share the same visual vocabulary.

Closes https://github.com/jnoecker/AmbonMUD/issues/1031.

## Test plan
- [x] `./gradlew ktlintCheck` passes
- [x] `./gradlew test --rerun-tasks` passes (includes new `loads declared item types and quest-item flag`, `rejects unknown itemType value`, and `drop is blocked for quest items` tests)
- [x] `bun run lint` + `bun run build` in `web-v3/` pass
- [ ] Manually verify inventory panel in `./gradlew demo`: sections render, `×N` stacks appear for duplicate potions, quest items show Soulbound pill and hide drop/give, vendor fodder is dimmed
- [ ] Manually verify equipment panel: badges appear for equipped gear with stats/damage/armor