### PR TITLE
Auto-swap equipped item when wearing into a filled slot

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ItemHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ItemHandler.kt
@@ -119,17 +119,20 @@ class ItemHandler(
                     )
                     afterEquipChange(sessionId, combat, items, gmcpEmitter, markStatsDirty)
                 }
+                is ItemRegistry.EquipResult.Swapped -> {
+                    outbound.send(
+                        OutboundEvent.SendInfo(
+                            sessionId,
+                            "You remove ${result.previousItem.item.displayName} and wear " +
+                                "${result.item.item.displayName} on your ${result.slot.label()}.",
+                        ),
+                    )
+                    afterEquipChange(sessionId, combat, items, gmcpEmitter, markStatsDirty)
+                }
                 is ItemRegistry.EquipResult.NotFound ->
                     outbound.send(OutboundEvent.SendError(sessionId, "You aren't carrying '${cmd.keyword}'."))
                 is ItemRegistry.EquipResult.NotWearable ->
                     outbound.send(OutboundEvent.SendError(sessionId, "${result.item.item.displayName} cannot be worn."))
-                is ItemRegistry.EquipResult.SlotOccupied ->
-                    outbound.send(
-                        OutboundEvent.SendError(
-                            sessionId,
-                            "You are already wearing ${result.item.item.displayName} on your ${result.slot.label()}.",
-                        ),
-                    )
             }
         }
     }

--- a/src/main/kotlin/dev/ambon/engine/items/ItemRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/items/ItemRegistry.kt
@@ -24,14 +24,21 @@ class ItemRegistry {
             val slot: ItemSlot,
         ) : EquipResult
 
+        /**
+         * Returned when the target slot was already filled and the registry
+         * automatically unequipped [previousItem] to make room for [item].
+         * The previous item is moved back into the inventory as part of the
+         * same atomic operation.
+         */
+        data class Swapped(
+            val item: ItemInstance,
+            val previousItem: ItemInstance,
+            val slot: ItemSlot,
+        ) : EquipResult
+
         data object NotFound : EquipResult
 
         data class NotWearable(
-            val item: ItemInstance,
-        ) : EquipResult
-
-        data class SlotOccupied(
-            val slot: ItemSlot,
             val item: ItemInstance,
         ) : EquipResult
     }
@@ -331,8 +338,10 @@ class ItemRegistry {
     ): EquipResult {
         val inv = inventoryItems[sessionId] ?: return EquipResult.NotFound
         var firstNonWearable: ItemInstance? = null
-        var firstOccupied: EquipResult.SlotOccupied? = null
+        var firstOccupiedIdx: Int = -1
 
+        // Pass 1: prefer a matching item whose target slot is empty. Only if no
+        // such item exists do we fall through to auto-swap.
         for ((idx, instance) in inv.withIndex()) {
             if (!mode.matches(instance.item, keyword)) continue
 
@@ -345,9 +354,7 @@ class ItemRegistry {
             val equipped = equippedItems.getOrPut(sessionId) { mutableMapOf() }
             val existing = equipped[slot]
             if (existing != null) {
-                if (firstOccupied == null) {
-                    firstOccupied = EquipResult.SlotOccupied(slot, existing)
-                }
+                if (firstOccupiedIdx < 0) firstOccupiedIdx = idx
                 continue
             }
 
@@ -358,7 +365,20 @@ class ItemRegistry {
             return EquipResult.Equipped(instance, slot)
         }
 
-        firstOccupied?.let { return it }
+        // Pass 2: no free slot among matches — auto-swap with the first occupied.
+        if (firstOccupiedIdx >= 0) {
+            val instance = inv[firstOccupiedIdx]
+            val slot = instance.item.slot!!
+            val equipped = equippedItems.getOrPut(sessionId) { mutableMapOf() }
+            val previous = equipped.getValue(slot)
+
+            inv.removeAt(firstOccupiedIdx)
+            equipped[slot] = instance
+            inventoryItems.getOrPut(sessionId) { mutableListOf() }.add(previous)
+
+            return EquipResult.Swapped(item = instance, previousItem = previous, slot = slot)
+        }
+
         firstNonWearable?.let { return EquipResult.NotWearable(it) }
         return EquipResult.NotFound
     }

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterItemsTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterItemsTest.kt
@@ -198,6 +198,54 @@ class CommandRouterItemsTest {
         }
 
     @Test
+    fun `wear into a filled slot auto-swaps with the currently equipped item`() =
+        runTest {
+            val h = CommandRouterHarness.create()
+
+            val sid = SessionId(55L)
+            h.loginPlayer(sid, "Swapper")
+
+            h.items.setRoomItems(
+                h.world.startRoom,
+                listOf(
+                    ItemInstance(
+                        ItemId("test:cap-old"),
+                        Item(keyword = "cap", displayName = "a threadbare cap", slot = ItemSlot.HEAD, armor = 1),
+                    ),
+                    ItemInstance(
+                        ItemId("test:helm"),
+                        Item(keyword = "helm", displayName = "a steel helm", slot = ItemSlot.HEAD, armor = 4),
+                    ),
+                ),
+            )
+            h.items.takeFromRoom(sid, h.world.startRoom, "cap")
+            h.items.takeFromRoom(sid, h.world.startRoom, "helm")
+            h.router.handle(sid, Command.Wear("cap"))
+            assertEquals("test:cap-old", h.items.equipment(sid).getValue(ItemSlot.HEAD).id.value)
+            assertEquals(1, h.items.inventory(sid).size)
+            h.drain()
+
+            h.router.handle(sid, Command.Wear("helm"))
+
+            val equipped = h.items.equipment(sid)
+            assertEquals("test:helm", equipped.getValue(ItemSlot.HEAD).id.value)
+
+            val inv = h.items.inventory(sid)
+            assertEquals(1, inv.size, "previous helm should be back in inventory")
+            assertEquals("test:cap-old", inv[0].id.value)
+
+            val outs = h.drain()
+            assertTrue(
+                outs.any {
+                    it is OutboundEvent.SendInfo &&
+                        it.text.contains("You remove a threadbare cap") &&
+                        it.text.contains("wear a steel helm")
+                },
+                "Expected swap message naming both items. got=$outs",
+            )
+        }
+
+    @Test
     fun `remove moves item from equipment slot back to inventory`() =
         runTest {
             val h = CommandRouterHarness.create()


### PR DESCRIPTION
## Summary
- Replaces `EquipResult.SlotOccupied` with `EquipResult.Swapped(item, previousItem, slot)`. When the target slot is already filled, `ItemRegistry.equipFromInventory` atomically unequips the existing item back into inventory and equips the new one.
- The matcher still prefers a matching inventory item whose slot is empty — auto-swap only kicks in when every matching candidate would collide, so duplicate-keyword items with different slot requirements still behave sensibly.
- `handleWear` surfaces "You remove X and wear Y on your <slot>." so the player sees both sides of the swap rather than a silent-looking error.

Closes https://github.com/jnoecker/AmbonMUD/issues/1083. Pairs well with the new inventory panel from https://github.com/jnoecker/AmbonMUD/pull/1103: the "Equip" button is now one-click regardless of whether the slot is already filled.

## Test plan
- [x] `./gradlew ktlintCheck` passes
- [x] `./gradlew test --rerun-tasks` passes (new `wear into a filled slot auto-swaps with the currently equipped item` test; existing wear/remove tests unchanged)
- [ ] Manually in `./gradlew demo`: equip cap, then `wear helm` — helm ends up equipped, cap lands back in inventory, single combined message appears
- [ ] Manually in inventory panel: click Equip on a second head item while one is equipped — no error, both the paperdoll and inventory reflect the swap