### PR TITLE
Fire level-up banner for quest/puzzle XP and hook autoloot into collection quests

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/AchievementSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/AchievementSystem.kt
@@ -20,7 +20,11 @@ class AchievementSystem(
     private val gmcpEmitter: GmcpEmitter? = null,
     private val categoryRegistry: AchievementCategoryRegistry? = null,
     private val spriteRegistry: SpriteRegistry? = null,
+    private val progression: PlayerProgression? = null,
 ) {
+    /** Invoked when an achievement reward grants enough XP to level the player up. */
+    var onLevelUp: (suspend (SessionId, LevelUpResult) -> Unit)? = null
+
     /**
      * Called when a player kills a mob. Increments KILL criteria matching [templateKey]
      * (or any mob when targetId is blank).
@@ -295,7 +299,15 @@ class AchievementSystem(
         )
 
         // Grant rewards
-        grantRewards(sessionId, def.rewards, ps, players, outbound)
+        grantRewards(
+            sessionId,
+            def.rewards,
+            ps,
+            players,
+            outbound,
+            progression,
+            onLevelUp = { result -> onLevelUp?.invoke(sessionId, result) },
+        )
         if (def.rewards.title != null) {
             outbound.send(
                 OutboundEvent.SendText(

--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -70,6 +70,10 @@ class CombatSystem(
      *  Used to close dialogue overlays so the player isn't trapped in conversation. */
     var onPlayerEnteredCombat: suspend (SessionId) -> Unit = { _ -> }
 
+    /** Callback fired for each item transferred into a killer's inventory via auto-loot;
+     *  wired by GameEngine to emit GMCP inventory updates and advance collection quests. */
+    var onItemAutoLooted: suspend (SessionId, dev.ambon.domain.items.ItemInstance) -> Unit = { _, _ -> }
+
     // Per-mob combat state (tracks tick timing)
     private data class MobCombatState(
         val mobId: MobId,
@@ -1409,6 +1413,7 @@ class CombatSystem(
             // elsewhere can't accidentally grab an unrelated item.
             val taken = items.takeFromRoomByInstance(killerSessionId, roomId, candidate) ?: continue
             looted += taken
+            onItemAutoLooted(killerSessionId, taken)
         }
         if (looted.isEmpty()) return
 

--- a/src/main/kotlin/dev/ambon/engine/EngineUtil.kt
+++ b/src/main/kotlin/dev/ambon/engine/EngineUtil.kt
@@ -130,6 +130,7 @@ internal suspend fun grantRewards(
     outbound: OutboundBus,
     progression: PlayerProgression? = null,
     sourceLevel: Int? = null,
+    onLevelUp: suspend (LevelUpResult) -> Unit = {},
 ) {
     if (rewards.gold > 0) {
         ps.gold += rewards.gold
@@ -148,8 +149,24 @@ internal suspend fun grantRewards(
                 rewards.xp
             }
         if (effectiveXp > 0) {
-            players.grantXp(sessionId, effectiveXp)
+            val result = players.grantXp(sessionId, effectiveXp, progression)
             outbound.send(OutboundEvent.SendText(sessionId, "You gain $effectiveXp XP."))
+            if (result != null && result.levelsGained > 0) {
+                if (progression != null) {
+                    val message = progression.buildLevelUpMessage(
+                        result,
+                        ps.stats[progression.bindings.hpScalingStat],
+                        ps.stats[progression.bindings.manaScalingStat],
+                        ps.playerClass,
+                    )
+                    outbound.send(OutboundEvent.SendText(sessionId, message))
+                } else {
+                    outbound.send(
+                        OutboundEvent.SendText(sessionId, "You reached level ${result.newLevel}!"),
+                    )
+                }
+                onLevelUp(result)
+            }
         }
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -919,6 +919,7 @@ class GameEngine(
             gmcpEmitter = gmcpEmitter,
             categoryRegistry = achievementCategoryRegistry,
             spriteRegistry = spriteRegistry,
+            progression = progression,
         )
 
     init {
@@ -991,6 +992,12 @@ class GameEngine(
         questSystem.onQuestCompletedGmcp = { sid, questId, questName ->
             gmcpEmitter.sendQuestComplete(sid, questId, questName)
             sendQuestListGmcp(sid)
+        }
+        questSystem.onLevelUp = ::onCombatLevelUp
+        achievementSystem.onLevelUp = ::onCombatLevelUp
+        combatSystem.onItemAutoLooted = { sid, item ->
+            gmcpEmitter.sendCharItemsAdd(sid, item)
+            questSystem.onItemCollected(sid, item)
         }
         guildSystem?.onGuildCreated = { sid -> achievementSystem.onGuildCreated(sid) }
     }
@@ -1132,7 +1139,12 @@ class GameEngine(
             },
         )
 
-        val puzzleHandlerInstance = PuzzleHandler(ctx = ctx, puzzleSystem = puzzleSystem)
+        val puzzleHandlerInstance = PuzzleHandler(
+            ctx = ctx,
+            puzzleSystem = puzzleSystem,
+            progression = progression,
+            onLevelUp = ::onCombatLevelUp,
+        )
 
         listOf(
             NavigationHandler(

--- a/src/main/kotlin/dev/ambon/engine/PlayerProgression.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerProgression.kt
@@ -17,7 +17,7 @@ data class LevelUpResult(
 class PlayerProgression(
     private val config: ProgressionConfig = ProgressionConfig(),
     private val classRegistry: PlayerClassRegistry? = null,
-    private val bindings: StatBindingsConfig = StatBindingsConfig(),
+    val bindings: StatBindingsConfig = StatBindingsConfig(),
 ) {
     val maxLevel: Int
         get() = config.maxLevel

--- a/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
@@ -37,6 +37,9 @@ class QuestSystem(
     var onQuestObjectiveUpdated: (suspend (SessionId, String, Int, Int, Int) -> Unit)? = null
     var onQuestCompletedGmcp: (suspend (SessionId, String, String) -> Unit)? = null
 
+    /** Invoked when a quest reward grants enough XP to level the player up. */
+    var onLevelUp: (suspend (SessionId, LevelUpResult) -> Unit)? = null
+
     /**
      * Returns quests offered by this mob that the player can accept.
      *
@@ -376,7 +379,16 @@ class QuestSystem(
         // over-level penalty contradicts the zone's explicit opt-in to scaling.
         val sourceLevelForDiminishing =
             if (zoneScaling != null && zoneScaling.mode != ScalingMode.STATIC) null else quest.level
-        grantRewards(sessionId, effectiveRewards, ps, players, outbound, progression, sourceLevelForDiminishing)
+        grantRewards(
+            sessionId,
+            effectiveRewards,
+            ps,
+            players,
+            outbound,
+            progression,
+            sourceLevelForDiminishing,
+            onLevelUp = { result -> onLevelUp?.invoke(sessionId, result) },
+        )
         if (effectiveRewards.xp == 0L) players.persistPlayer(ps.sessionId)
     }
 

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/PuzzleHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/PuzzleHandler.kt
@@ -6,6 +6,8 @@ import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.puzzle.PuzzleReward
 import dev.ambon.domain.world.LockableState
 import dev.ambon.domain.world.RoomFeature
+import dev.ambon.engine.LevelUpResult
+import dev.ambon.engine.PlayerProgression
 import dev.ambon.engine.PuzzleResult
 import dev.ambon.engine.PuzzleSystem
 import dev.ambon.engine.commands.Command
@@ -22,6 +24,8 @@ import dev.ambon.engine.events.OutboundEvent
 class PuzzleHandler(
     private val ctx: EngineContext,
     private val puzzleSystem: PuzzleSystem?,
+    private val progression: PlayerProgression? = null,
+    private val onLevelUp: (suspend (SessionId, LevelUpResult) -> Unit)? = null,
 ) : CommandHandler {
     private val world = ctx.world
     private val players = ctx.players
@@ -169,8 +173,24 @@ class PuzzleHandler(
                 outbound.send(OutboundEvent.SendText(sessionId, "You receive ${reward.amount} gold."))
             }
             is PuzzleReward.GiveXp -> {
-                players.grantXp(sessionId, reward.amount)
+                val result = players.grantXp(sessionId, reward.amount, progression)
                 outbound.send(OutboundEvent.SendText(sessionId, "You gain ${reward.amount} XP."))
+                if (result != null && result.levelsGained > 0) {
+                    if (progression != null) {
+                        val message = progression.buildLevelUpMessage(
+                            result,
+                            me.stats[progression.bindings.hpScalingStat],
+                            me.stats[progression.bindings.manaScalingStat],
+                            me.playerClass,
+                        )
+                        outbound.send(OutboundEvent.SendText(sessionId, message))
+                    } else {
+                        outbound.send(
+                            OutboundEvent.SendText(sessionId, "You reached level ${result.newLevel}!"),
+                        )
+                    }
+                    onLevelUp?.invoke(sessionId, result)
+                }
             }
         }
     }

--- a/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
@@ -1089,6 +1089,36 @@ class CombatSystemTest {
         }
 
     @Test
+    fun `autoloot fires onItemAutoLooted callback for each picked-up item`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            val mob = MobState(MobId("demo:rat"), "a rat", fixture.roomId, hp = 1, maxHp = 1)
+            fixture.mobs.upsert(mob)
+            fixture.items.addMobItem(
+                mob.id,
+                ItemInstance(ItemId("demo:tail"), Item(keyword = "tail", displayName = "a rat tail")),
+            )
+            fixture.items.addMobItem(
+                mob.id,
+                ItemInstance(ItemId("demo:ear"), Item(keyword = "ear", displayName = "a rat ear")),
+            )
+
+            val combat = fixture.buildCombat(rng = Random(2))
+            val looted = mutableListOf<ItemInstance>()
+            combat.onItemAutoLooted = { _, item -> looted += item }
+
+            val sid = SessionId(201L)
+            fixture.players.loginOrFail(sid, "Collector")
+            fixture.players.setAutolootEnabled(sid, true)
+
+            assertNull(combat.startCombat(sid, "rat"))
+            fixture.tickCombat(combat)
+
+            val ids = looted.map { it.id.value }.toSet()
+            assertEquals(setOf("demo:tail", "demo:ear"), ids, "Expected both items to fire the callback")
+        }
+
+    @Test
     fun `autoloot also picks up rolled loot-table drops`() =
         runTest {
             val fixture = CombatTestFixture()

--- a/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
@@ -732,4 +732,30 @@ class QuestSystemTest {
             // Each quest name must appear on its own line (preceded by a newline + indent)
             assertTrue(log.contains("\n  Bonus Quest"), "Bonus Quest must start on its own line")
         }
+
+    @Test
+    fun `quest completion XP that levels up invokes onLevelUp callback`() =
+        runTest {
+            val progression = PlayerProgression()
+            // A huge XP reward guarantees a level-up from level 1.
+            val fatQuest = killQuest.copy(rewards = QuestRewards(xp = 10_000L, gold = 0L))
+            val (qs, players, _) = setup(fatQuest, progression)
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Hero")
+
+            var captured: LevelUpResult? = null
+            qs.onLevelUp = { _, result -> captured = result }
+
+            qs.acceptQuest(sid, questId)
+            repeat(3) { qs.onMobKilled(sid, mobTemplateKey) }
+
+            assertTrue(
+                players.get(sid)!!.completedQuestIds.contains(questId),
+                "Quest should complete",
+            )
+            val result = captured
+            assertNotNull(result, "onLevelUp should fire when quest XP causes a level-up")
+            assertTrue(result!!.levelsGained > 0)
+            assertTrue(result.newLevel > result.previousLevel)
+        }
 }


### PR DESCRIPTION
## Summary

Two related bugs where non-combat XP paths and auto-loot bypassed the hooks that combat kills and manual `get` rely on:

- **Level-up banner missing from quest/puzzle/achievement XP.** Only combat kills, XP-granting items, bounty quests, and daily/weekly quests routed through `onCombatLevelUp` (which emits `Char.LevelUp` GMCP). Main quest completion (`QuestSystem` → `grantRewards` → raw `players.grantXp`), achievement rewards, and puzzle XP leveled the player up silently — no "You reached level X" text and no banner.
- **Auto-loot didn't advance collection quests.** `CombatSystem.applyAutolootForKiller` called `takeFromRoomByInstance` and emitted a loot message but never called `questSystem.onItemCollected` or `gmcpEmitter.sendCharItemsAdd`, unlike the manual `get` handler.

## Changes

- `grantRewards` (EngineUtil) now captures the `LevelUpResult`, emits the level-up message, and invokes a new optional `onLevelUp` callback.
- `QuestSystem` and `AchievementSystem` expose an `onLevelUp` property wired by `GameEngine` to `onCombatLevelUp`.
- `PuzzleHandler` captures the `LevelUpResult` from its raw `grantXp` call and routes it to `onCombatLevelUp`.
- New `CombatSystem.onItemAutoLooted` callback fires per item; `GameEngine` wires it to `gmcpEmitter.sendCharItemsAdd` + `questSystem.onItemCollected`, matching manual pickup.
- Made `PlayerProgression.bindings` public so `grantRewards` can build the stat-aware level-up message.

## Test plan

- [x] `./gradlew ktlintCheck` passes
- [x] `./gradlew test` passes
- [x] New test: `CombatSystemTest` — `autoloot fires onItemAutoLooted callback for each picked-up item`
- [x] New test: `QuestSystemTest` — `quest completion XP that levels up invokes onLevelUp callback`
- [ ] Manual: accept a low-level quest on a near-level character, complete it, confirm the web client banner animates
- [ ] Manual: enable autoloot, kill a mob carrying a quest-item, confirm the COLLECT objective advances without a manual `get`