### PR TITLE
Refresh room view on player respawn so the web client updates after death

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -63,6 +63,11 @@ class CombatSystem(
     /** Callback for player death cleanup; wired by GameEngine after construction. */
     var onPlayerDeath: suspend (SessionId) -> Unit = { _ -> }
 
+    /** Callback fired after a dead player has been moved to their respawn room; wired by GameEngine.
+     *  Used to push a fresh room look (Room.Info, map, players, mobs, items) so the web client
+     *  doesn't keep rendering the location where the player died. */
+    var onPlayerRespawned: suspend (SessionId) -> Unit = { _ -> }
+
     /** Callback when a player kills another player in PvP; wired by GameEngine. */
     var onPvpKill: suspend (killerSid: SessionId) -> Unit = { _ -> }
 
@@ -1145,6 +1150,7 @@ class CombatSystem(
 
             dirtyNotifier.playerVitalsDirty(sessionId)
             outbound.send(OutboundEvent.SendText(sessionId, deathConfig.messages.arriveSanctum))
+            onPlayerRespawned(sessionId)
         }
 
         outbound.send(OutboundEvent.SendPrompt(sessionId))

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -57,6 +57,7 @@ import dev.ambon.engine.commands.handlers.TrainerHandler
 import dev.ambon.engine.commands.handlers.UiHandler
 import dev.ambon.engine.commands.handlers.WorldFeaturesHandler
 import dev.ambon.engine.commands.handlers.WorldInfoHandler
+import dev.ambon.engine.commands.handlers.sendLook
 import dev.ambon.engine.crafting.CraftingRegistry
 import dev.ambon.engine.crafting.CraftingSystem
 import dev.ambon.engine.crafting.EnchantSystem
@@ -1114,6 +1115,10 @@ class GameEngine(
             bankConfig = engineConfig.bank,
             stylistConfig = engineConfig.stylist,
         )
+
+        // Push a fresh room look when a dead player respawns, so the web client
+        // stops showing the room they died in.
+        combatSystem.onPlayerRespawned = { sid -> ctx.sendLook(sid) }
 
         communicationHandler = CommunicationHandler(
             ctx = ctx,

--- a/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
@@ -1204,6 +1204,46 @@ class CombatSystemTest {
         }
 
     @Test
+    fun `player death fires onPlayerRespawned so the web client re-renders the new room`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            val mob =
+                MobState(
+                    MobId("demo:ogre"),
+                    "an ogre",
+                    fixture.roomId,
+                    hp = 100,
+                    maxHp = 100,
+                    damage = DamageRange(50, 50),
+                )
+            fixture.mobs.upsert(mob)
+
+            val combat = fixture.buildCombat(rng = Random(1), minDamage = 1, maxDamage = 1)
+            val sanctum = dev.ambon.domain.ids.RoomId("limbo:sanctum")
+            combat.sanctumRoomLookup = { sanctum }
+            combat.deathConfig = DeathConfig(sanctumRoom = sanctum.value)
+
+            val respawned = mutableListOf<Pair<SessionId, dev.ambon.domain.ids.RoomId>>()
+            combat.onPlayerRespawned = { sid ->
+                val p = fixture.players.get(sid)!!
+                respawned += sid to p.roomId
+            }
+
+            val sid = SessionId(44L)
+            fixture.players.loginOrFail(sid, "Reborn")
+
+            combat.startCombat(sid, "ogre")
+            fixture.outbound.drainAll()
+            fixture.tickCombat(combat)
+
+            assertEquals(
+                listOf(sid to sanctum),
+                respawned,
+                "Expected onPlayerRespawned to fire exactly once with the sanctum room set",
+            )
+        }
+
+    @Test
     fun `player death falls back to zone start when no sanctum configured`() =
         runTest {
             val fixture = CombatTestFixture()


### PR DESCRIPTION
## Summary
- `CombatSystem.handlePlayerDeath()` moved the player's `roomId` to the sanctum (or zone start) and restored vitals, but never pushed a fresh room view. The web client kept rendering the room where the player died — stale background, description, and minimap.
- Added an `onPlayerRespawned` callback on `CombatSystem`, fired at the end of `handlePlayerDeath()` after the player has been moved.
- Wired the callback in `GameEngine` to call `ctx.sendLook(sessionId)`, which emits `Room.Info`, `Room.Players`, `Room.Mobs`, `Room.Items`, and the zone map on zone change — the same path normal movement uses.

## Test plan
- [x] `./gradlew ktlintCheck` passes
- [x] `./gradlew test --tests "dev.ambon.engine.CombatSystemTest"` passes, including the new `player death fires onPlayerRespawned so the web client re-renders the new room` regression test
- [ ] Manual: die in the web client and confirm the sanctum's background, description, and minimap appear instead of the old room