### PR TITLE
Hide quest panel tabs when server disables the feature (#1084)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -548,6 +548,14 @@ class GameEngine(
                 }
             },
             environmentConfig = engineConfig.environment,
+            featureFlags = {
+                ServerFeaturesPayload(
+                    dailyQuests = engineConfig.dailyQuests.enabled,
+                    weeklyQuests = engineConfig.dailyQuests.enabled,
+                    globalQuests = engineConfig.globalQuests.enabled,
+                    autoQuests = engineConfig.autoQuests.enabled,
+                )
+            },
         )
 
     fun markVitalsDirty(sessionId: SessionId) {

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -57,6 +57,18 @@ data class PrestigePerkPayload(
     val earned: Boolean,
 )
 
+/**
+ * Advertises which optional gameplay features are enabled server-side so web clients
+ * can hide UI tabs/panels for features that are disabled. Emitted on login as
+ * `Server.Features`.
+ */
+data class ServerFeaturesPayload(
+    val dailyQuests: Boolean = false,
+    val weeklyQuests: Boolean = false,
+    val globalQuests: Boolean = false,
+    val autoQuests: Boolean = false,
+)
+
 class GmcpEmitter(
     private val outbound: OutboundBus,
     private val supportsPackage: (SessionId, String) -> Boolean,
@@ -77,6 +89,7 @@ class GmcpEmitter(
     private val prestigeNextCost: (Int) -> Long? = { null },
     private val prestigePerkPayloads: (currentRank: Int, maxRank: Int) -> List<PrestigePerkPayload> = { _, _ -> emptyList() },
     private val environmentConfig: dev.ambon.config.EnvironmentConfig = dev.ambon.config.EnvironmentConfig(),
+    private val featureFlags: () -> ServerFeaturesPayload = { ServerFeaturesPayload() },
 ) {
     private val json = jacksonObjectMapper()
     private val imagesBase = if (imagesBaseUrl.endsWith("/")) imagesBaseUrl else "$imagesBaseUrl/"
@@ -585,6 +598,11 @@ class GmcpEmitter(
         emit(sessionId, "Server.Commands", ServerCommandsPayload(commands = commands))
     }
 
+    /** Sends optional-feature availability flags as `Server.Features`. */
+    suspend fun sendServerFeatures(sessionId: SessionId) {
+        emit(sessionId, "Server.Features", featureFlags())
+    }
+
     /** Sends emote presets as `Server.EmotePresets`. */
     suspend fun sendServerEmotePresets(sessionId: SessionId) {
         if (emotePresets.isEmpty()) return
@@ -746,6 +764,7 @@ class GmcpEmitter(
     ) {
         sendServerAssets(sessionId)
         sendServerCommands(sessionId, player.isStaff)
+        sendServerFeatures(sessionId)
         sendServerEmotePresets(sessionId)
         sendCharStatusVars(sessionId)
         sendCharVitals(sessionId, player)

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -1534,6 +1534,33 @@ class GmcpEmitterTest {
             assertTrue(drainGmcp().isEmpty())
         }
 
+    // ── Server.Features ──
+
+    @Test
+    fun `sendServerFeatures emits flag payload reflecting provider`() =
+        runTest {
+            val e = GmcpEmitter(
+                outbound = outbound,
+                supportsPackage = { _, _ -> true },
+                featureFlags = {
+                    ServerFeaturesPayload(
+                        dailyQuests = true,
+                        weeklyQuests = true,
+                        globalQuests = false,
+                        autoQuests = false,
+                    )
+                },
+            )
+            e.sendServerFeatures(sid)
+            val data = drainGmcp()
+            assertEquals(1, data.size)
+            assertEquals("Server.Features", data[0].gmcpPackage)
+            val json = data[0].jsonData
+            assertTrue(json.contains("\"dailyQuests\":true"), "dailyQuests=true expected; got=$json")
+            assertTrue(json.contains("\"globalQuests\":false"), "globalQuests=false expected; got=$json")
+            assertTrue(json.contains("\"autoQuests\":false"), "autoQuests=false expected; got=$json")
+        }
+
     // ── Server.Commands ──
 
     @Test

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -877,6 +877,7 @@ function App() {
             weeklyQuests={state.weeklyQuests}
             autoQuest={state.autoQuest}
             globalQuest={state.globalQuest}
+            features={state.serverFeatures}
             onDismissQuestNotification={(id) => state.setQuestNotifications((prev) => prev.filter((n) => n.id !== id))}
             onAbandonQuest={(name) => sendCommand(`quest abandon ${name}`)}
             onAcceptQuest={(name) => sendCommand(`accept ${name}`)}

--- a/web-v3/src/components/panels/QuestPanel.tsx
+++ b/web-v3/src/components/panels/QuestPanel.tsx
@@ -7,6 +7,7 @@ import type {
   DailyQuestEntry,
   AutoQuest,
   GlobalQuest,
+  ServerFeatures,
 } from "../../types";
 
 type QuestTab = "active" | "available" | "daily" | "weekly" | "bounty" | "global";
@@ -21,6 +22,7 @@ interface QuestPanelProps {
   weeklyQuests: DailyQuestEntry[];
   autoQuest: AutoQuest | null;
   globalQuest: GlobalQuest | null;
+  features: ServerFeatures;
   onDismissQuestNotification: (id: string) => void;
   onAbandonQuest: (questName: string) => void;
   onAcceptQuest: (questName: string) => void;
@@ -59,6 +61,7 @@ export function QuestPanel({
   weeklyQuests,
   autoQuest,
   globalQuest,
+  features,
   onDismissQuestNotification,
   onAbandonQuest,
   onAcceptQuest,
@@ -74,18 +77,23 @@ export function QuestPanel({
     return () => clearInterval(interval);
   }, [globalQuest?.active, globalQuest?.endsAtMs]);
 
-  if (!connected) {
-    return <p className="empty-note">Connect to view quests.</p>;
-  }
-
   const tabs: Array<{ id: QuestTab; label: string; badge?: number }> = [
     { id: "active", label: "Active", badge: quests.length > 0 ? quests.length : undefined },
     ...(questsAvailable.length > 0 ? [{ id: "available" as QuestTab, label: "Available", badge: questsAvailable.length }] : []),
-    { id: "daily", label: "Daily", badge: dailyQuests ? dailyQuests.quests.filter((q) => !q.completed).length : undefined },
-    { id: "weekly", label: "Weekly", badge: weeklyQuests.filter((q) => !q.completed).length > 0 ? weeklyQuests.filter((q) => !q.completed).length : undefined },
-    { id: "bounty", label: "Bounty" },
-    { id: "global", label: "Global" },
+    ...(features.dailyQuests ? [{ id: "daily" as QuestTab, label: "Daily", badge: dailyQuests ? dailyQuests.quests.filter((q) => !q.completed).length : undefined }] : []),
+    ...(features.weeklyQuests ? [{ id: "weekly" as QuestTab, label: "Weekly", badge: weeklyQuests.filter((q) => !q.completed).length > 0 ? weeklyQuests.filter((q) => !q.completed).length : undefined }] : []),
+    ...(features.autoQuests ? [{ id: "bounty" as QuestTab, label: "Bounty" }] : []),
+    ...(features.globalQuests ? [{ id: "global" as QuestTab, label: "Global" }] : []),
   ];
+
+  // If the active tab was disabled server-side, fall back to the first visible tab.
+  const effectiveTab: QuestTab = tabs.some((t) => t.id === activeTab)
+    ? activeTab
+    : (tabs[0]?.id ?? "active");
+
+  if (!connected) {
+    return <p className="empty-note">Connect to view quests.</p>;
+  }
 
   return (
     <div className="quest-panel">
@@ -125,8 +133,8 @@ export function QuestPanel({
             key={tab.id}
             type="button"
             role="tab"
-            className={`quest-tab ${activeTab === tab.id ? "quest-tab-active" : ""}`}
-            aria-selected={activeTab === tab.id}
+            className={`quest-tab ${effectiveTab === tab.id ? "quest-tab-active" : ""}`}
+            aria-selected={effectiveTab === tab.id}
             onClick={() => setActiveTab(tab.id)}
           >
             {tab.label}
@@ -140,7 +148,7 @@ export function QuestPanel({
       </div>
 
       {/* Active quests tab */}
-      {activeTab === "active" && (
+      {effectiveTab === "active" && (
         <section
           className="quest-panel-section"
           role="tabpanel"
@@ -253,7 +261,7 @@ export function QuestPanel({
       )}
 
       {/* Available quests tab */}
-      {activeTab === "available" && questsAvailable.length > 0 && (
+      {effectiveTab === "available" && questsAvailable.length > 0 && (
         <section
           className="quest-panel-section"
           role="tabpanel"
@@ -301,7 +309,7 @@ export function QuestPanel({
       )}
 
       {/* Daily quests tab */}
-      {activeTab === "daily" && (
+      {effectiveTab === "daily" && features.dailyQuests && (
         <section
           className="quest-panel-section"
           role="tabpanel"
@@ -338,7 +346,7 @@ export function QuestPanel({
       )}
 
       {/* Weekly quests tab */}
-      {activeTab === "weekly" && (
+      {effectiveTab === "weekly" && features.weeklyQuests && (
         <section
           className="quest-panel-section"
           role="tabpanel"
@@ -367,7 +375,7 @@ export function QuestPanel({
       )}
 
       {/* Bounty (auto-quest) tab */}
-      {activeTab === "bounty" && (
+      {effectiveTab === "bounty" && features.autoQuests && (
         <section
           className="quest-panel-section"
           role="tabpanel"
@@ -434,7 +442,7 @@ export function QuestPanel({
       )}
 
       {/* Global quest tab */}
-      {activeTab === "global" && (
+      {effectiveTab === "global" && features.globalQuests && (
         <section
           className="quest-panel-section"
           role="tabpanel"

--- a/web-v3/src/constants.ts
+++ b/web-v3/src/constants.ts
@@ -2,6 +2,7 @@ import type {
   ChatChannel,
   CharacterInfo,
   RoomState,
+  ServerFeatures,
   StatusVarLabels,
   TabCycle,
   Vitals,
@@ -95,5 +96,11 @@ export const DEFAULT_STATUS_VAR_LABELS: StatusVarLabels = {
 };
 
 export const EMPTY_CHAR: CharacterInfo = { name: "-", gender: "", race: "", className: "", level: null, sprite: null, isStaff: false, autolootEnabled: false };
+export const DEFAULT_SERVER_FEATURES: ServerFeatures = {
+  dailyQuests: false,
+  weeklyQuests: false,
+  globalQuests: false,
+  autoQuests: false,
+};
 export const EMPTY_ROOM: RoomState = { id: null, title: "-", description: "", exits: {}, mapX: 0, mapY: 0, graphical: false, terrain: "outside" };
 

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -12,6 +12,7 @@ import type {
   CombatTarget,
   CommandEntry,
   EmotePreset,
+  ServerFeatures,
   CompletedAchievement,
   ContainerContents,
   CraftingNode,
@@ -150,6 +151,7 @@ interface GmcpContext {
   setServerAssets: Dispatch<SetStateAction<Record<string, string>>>;
   setServerCommands: Dispatch<SetStateAction<CommandEntry[]>>;
   setEmotePresets: Dispatch<SetStateAction<EmotePreset[]>>;
+  setServerFeatures: Dispatch<SetStateAction<ServerFeatures>>;
   pushUiFeedback: (feedback: UiFeedback) => void;
   setStaffWorldInfo: Dispatch<SetStateAction<StaffWorldZone[]>>;
   setStaffMobTemplates: Dispatch<SetStateAction<StaffMobZone[]>>;
@@ -1357,6 +1359,17 @@ export function applyGmcpPackage(
       const sender = typeof packet.sender === "string" ? packet.sender : "System";
       const message = typeof packet.message === "string" ? packet.message : "";
       if (message.length > 0) ctx.pushBroadcast(sender, message);
+      break;
+    }
+
+    case "Server.Features": {
+      const packet = data as Partial<Record<string, unknown>>;
+      ctx.setServerFeatures({
+        dailyQuests: packet.dailyQuests === true,
+        weeklyQuests: packet.weeklyQuests === true,
+        globalQuests: packet.globalQuests === true,
+        autoQuests: packet.autoQuests === true,
+      });
       break;
     }
 

--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -3,6 +3,7 @@ import type { SetStateAction } from "react";
 import { applyGmcpPackage } from "../gmcp/applyGmcpPackage";
 import { canvasEvents } from "../canvas/CanvasEventBus";
 import {
+  DEFAULT_SERVER_FEATURES,
   DEFAULT_STATUS_VAR_LABELS,
   EMPTY_CHAR,
   EMPTY_ROOM,
@@ -72,6 +73,7 @@ import type {
   RoomPlayer,
   RoomState,
   PuzzleState,
+  ServerFeatures,
   ShopState,
   SkillSummary,
   SpriteList,
@@ -283,6 +285,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
   const [serverAssets, setServerAssets] = useState<Record<string, string>>({});
   const [serverCommands, setServerCommands] = useState<CommandEntry[]>([]);
   const [emotePresets, setEmotePresets] = useState<EmotePreset[]>([]);
+  const [serverFeatures, setServerFeatures] = useState<ServerFeatures>(DEFAULT_SERVER_FEATURES);
   const [staffWorldInfo, setStaffWorldInfo] = useState<StaffWorldZone[]>([]);
   const [staffMobTemplates, setStaffMobTemplates] = useState<StaffMobZone[]>([]);
   const [lookTarget, setLookTarget] = useState<LookTargetInfo | null>(null);
@@ -524,6 +527,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
         setServerAssets,
         setServerCommands,
         setEmotePresets,
+        setServerFeatures,
         pushUiFeedback,
         setStaffWorldInfo,
         setStaffMobTemplates,
@@ -651,6 +655,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     setStaffMobTemplates([]);
     setServerCommands([]);
     setEmotePresets([]);
+    setServerFeatures(DEFAULT_SERVER_FEATURES);
     resetMap();
   }, [resetMap]);
 
@@ -691,7 +696,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     // Login / connection
     loginPrompt, loginError, reconnecting, setReconnecting, savedCharacters, setSavedCharacters,
     // Staff / meta
-    serverAssets, serverCommands, emotePresets, staffWorldInfo, staffMobTemplates,
+    serverAssets, serverCommands, emotePresets, serverFeatures, staffWorldInfo, staffMobTemplates,
     lookTarget, setLookTarget, spriteList,
     // UI
     activePopout, setActivePopout, broadcast, setBroadcast, possessing, toast, setToast, uiFeedbackFeed,

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -666,6 +666,17 @@ export interface EmotePreset {
   action: string;
 }
 
+/**
+ * Optional server-side feature flags sent via `Server.Features`. When a flag is
+ * false the client should hide the corresponding UI entry (tab, panel, button).
+ */
+export interface ServerFeatures {
+  dailyQuests: boolean;
+  weeklyQuests: boolean;
+  globalQuests: boolean;
+  autoQuests: boolean;
+}
+
 export interface StaffWorldRoom {
   id: string;
   title: string;


### PR DESCRIPTION
## Summary
- Adds a `Server.Features` GMCP package that advertises which optional gameplay features are enabled server-side (daily/weekly/global quests, auto/bounty quests).
- Emits it from `sendFullCharacterSync` alongside the other `Server.*` handshake packages.
- The web `QuestPanel` now omits tabs for disabled features and falls back to the first visible tab if the current selection goes away.

Fixes https://github.com/jnoecker/AmbonMUD/issues/1084.

## Test plan
- [x] `./gradlew ktlintCheck test`
- [x] `bun run lint` and `bun run build` in `web-v3`
- [x] New unit test `sendServerFeatures emits flag payload reflecting provider`
- [ ] Manual: boot with `ambonMUD.engine.dailyQuests.enabled=false` + `globalQuests.enabled=false` and confirm the Daily/Weekly/Global tabs do not appear in the web client