### PR TITLE
Require players to turn quests in at the giver NPC

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -1674,6 +1674,12 @@ data class CommandsConfig(
             "quest_log" to CommandMetadata("quest log/list", "View active quests", "quests"),
             "quest_info" to CommandMetadata("quest info <name>", "Quest details", "quests", requiresTarget = true),
             "quest_abandon" to CommandMetadata("quest abandon <name>", "Abandon a quest", "quests", requiresTarget = true),
+            "quest_turnin" to CommandMetadata(
+                "quest turnin <name>",
+                "Turn in a completed quest to its giver NPC",
+                "quests",
+                requiresTarget = true,
+            ),
             "accept" to CommandMetadata("accept <quest>", "Accept a quest from an NPC", "quests", requiresTarget = true),
             "bounty" to CommandMetadata("bounty / quest auto", "Request an auto-generated bounty quest", "quests"),
             "bounty_info" to CommandMetadata("bounty info / quest auto info", "View active bounty progress", "quests"),

--- a/src/main/kotlin/dev/ambon/domain/quest/QuestDef.kt
+++ b/src/main/kotlin/dev/ambon/domain/quest/QuestDef.kt
@@ -11,7 +11,7 @@ data class QuestDef(
     val giverMobId: String,
     val objectives: List<QuestObjectiveDef>,
     val rewards: QuestRewards,
-    val completionType: String = "auto",
+    val completionType: String = "npc_turn_in",
     /** Optional reputation gate. */
     val requiredReputation: ReputationRequirement? = null,
     /**

--- a/src/main/kotlin/dev/ambon/domain/world/data/QuestFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/QuestFile.kt
@@ -4,7 +4,7 @@ data class QuestFile(
     val name: String = "",
     val description: String = "",
     val giver: String = "",
-    val completionType: String = "AUTO",
+    val completionType: String = "NPC_TURN_IN",
     val objectives: List<QuestObjectiveFile> = emptyList(),
     val rewards: QuestRewardsFile = QuestRewardsFile(),
     /** Optional reputation gate. min → giver hints to grind; max → quest disappears when exceeded. */

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -632,7 +632,7 @@ object WorldLoader {
                 val giver = requireNonBlank(questFile.giver) {
                     "Quest '$questId' giver cannot be blank"
                 }
-                val completionType = questFile.completionType.trim().lowercase().ifEmpty { "auto" }
+                val completionType = questFile.completionType.trim().lowercase().ifEmpty { "npc_turn_in" }
                 requireNotEmpty(questFile.objectives, "Quest '$questId'", "objective")
                 val objectives =
                     questFile.objectives.mapIndexed { index, obj ->

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -2107,6 +2107,8 @@ class GameEngine(
                         targetRoomIds = resolveObjectiveRoomIds(objDef.targetId),
                     )
                 },
+                readyToTurnIn = questSystem.isReadyToTurnIn(def, state),
+                giverMobId = def.giverMobId,
             )
         }
         gmcpEmitter.sendQuestList(sessionId, entries)

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -1019,6 +1019,8 @@ class GmcpEmitter(
                         targetRoomIds = o.targetRoomIds,
                     )
                 },
+                readyToTurnIn = q.readyToTurnIn,
+                giverMobId = q.giverMobId,
             )
         }
         emit(sessionId, "Quest.List", payload)
@@ -2580,6 +2582,8 @@ class GmcpEmitter(
         val name: String,
         val description: String,
         val objectives: List<QuestObjectivePayload>,
+        val readyToTurnIn: Boolean,
+        val giverMobId: String,
     )
 
     private data class QuestObjectivePayload(
@@ -3353,6 +3357,8 @@ data class QuestListEntry(
     val name: String,
     val description: String,
     val objectives: List<QuestObjectiveEntry>,
+    val readyToTurnIn: Boolean = false,
+    val giverMobId: String = "",
 )
 
 data class QuestObjectiveEntry(

--- a/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
@@ -95,6 +95,16 @@ class QuestSystem(
         return rep.getStanding(ps, req.faction) > max
     }
 
+    /**
+     * Whether [quest] with [state] is ready to be turned in at its giver NPC:
+     * all objectives complete and the completion handler requires NPC turn-in.
+     */
+    fun isReadyToTurnIn(quest: QuestDef, state: QuestState): Boolean {
+        val handler = completionHandlers.get(quest.completionType) ?: return false
+        if (!handler.requiresNpcTurnIn) return false
+        return state.objectives.all { it.isComplete }
+    }
+
     /** Returns mob IDs that offer quests the player can accept. */
     fun questAvailableMobIds(sessionId: SessionId, mobIds: Collection<String>): Set<String> {
         val ps = players.get(sessionId) ?: return emptySet()
@@ -190,6 +200,37 @@ class QuestSystem(
             }
         if (currentCount <= 0) return null
         return handler.advance(objDef, initial, targetIdRaw, currentCount)
+    }
+
+    /**
+     * Turn in a quest to its quest-giver NPC. Returns an error string, or null on success.
+     *
+     * Validates that the quest exists, is active, all objectives are complete, the
+     * completion handler requires NPC turn-in, and the quest-giver mob is present
+     * in [mobIdsInRoom] (i.e. in the player's current room).
+     */
+    suspend fun turnInQuest(
+        sessionId: SessionId,
+        nameHint: String,
+        mobIdsInRoom: Collection<String>,
+    ): String? {
+        val ps = players.get(sessionId) ?: return ERR_NOT_CONNECTED
+        val questId = findActiveQuestId(ps.activeQuests, nameHint)
+            ?: return "No active quest matching '$nameHint'."
+        val quest = registry.get(questId) ?: return "Quest data not found."
+        val state = ps.activeQuests[questId] ?: return "Quest not active."
+        val handler = completionHandlers.get(quest.completionType)
+        if (handler == null || !handler.requiresNpcTurnIn) {
+            return "That quest does not require a turn-in."
+        }
+        if (!state.objectives.all { it.isComplete }) {
+            return "You haven't finished that quest yet."
+        }
+        if (quest.giverMobId !in mobIdsInRoom) {
+            return "The quest-giver isn't here. Return to them to turn this in."
+        }
+        completeQuest(sessionId, questId, quest.rewards)
+        return null
     }
 
     /**

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -387,6 +387,10 @@ sealed interface Command {
         val nameHint: String,
     ) : Command
 
+    data class QuestTurnIn(
+        val nameHint: String,
+    ) : Command
+
     data object DailyQuests : Command
 
     data object WeeklyQuests : Command
@@ -1397,6 +1401,10 @@ object CommandParser {
                 "abandon" -> {
                     val hint = parts.getOrNull(1)?.trim() ?: ""
                     if (hint.isEmpty()) Command.Invalid(line, "quest abandon <quest-name>") else Command.QuestAbandon(hint)
+                }
+                "turnin", "complete", "finish" -> {
+                    val hint = parts.getOrNull(1)?.trim() ?: ""
+                    if (hint.isEmpty()) Command.Invalid(line, "quest turnin <quest-name>") else Command.QuestTurnIn(hint)
                 }
                 "auto", "request" -> {
                     val sub = parts.getOrNull(1)?.trim()?.lowercase() ?: ""

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestHandler.kt
@@ -39,6 +39,7 @@ class DialogueQuestHandler(
         router.on<Command.QuestInfo> { sid, cmd -> handleQuestInfo(sid, cmd) }
         router.on<Command.QuestAbandon> { sid, cmd -> handleQuestAbandon(sid, cmd) }
         router.on<Command.QuestAccept> { sid, cmd -> handleQuestAccept(sid, cmd) }
+        router.on<Command.QuestTurnIn> { sid, cmd -> handleQuestTurnIn(sid, cmd) }
         router.on<Command.AchievementList> { sid, _ -> handleAchievementList(sid) }
         router.on<Command.TitleSet> { sid, cmd -> handleTitleSet(sid, cmd) }
         router.on<Command.TitleClear> { sid, _ -> handleTitleClear(sid) }
@@ -57,6 +58,17 @@ class DialogueQuestHandler(
         if (questSystem != null && me != null) {
             val mob = mobs.findInRoomByKeyword(me.roomId, cmd.target.trim()).firstOrNull()
             if (mob != null) {
+                val readyForTurnIn = me.activeQuests
+                    .mapNotNull { (qid, state) ->
+                        val def = questRegistry.get(qid) ?: return@mapNotNull null
+                        if (def.giverMobId != mob.id.value) return@mapNotNull null
+                        if (!questSystem.isReadyToTurnIn(def, state)) return@mapNotNull null
+                        def
+                    }
+                for (quest in readyForTurnIn) {
+                    outbound.send(OutboundEvent.SendText(sessionId, "[Quest] ${quest.name} — ready to turn in."))
+                    outbound.send(OutboundEvent.SendText(sessionId, "  Type 'quest turnin ${quest.name}' to complete."))
+                }
                 val available = questSystem.availableQuests(sessionId, mob.id.value)
                 for (quest in available) {
                     outbound.send(OutboundEvent.SendText(sessionId, "[Quest] ${quest.name} — ${quest.description}"))
@@ -200,6 +212,16 @@ class DialogueQuestHandler(
                 outbound.sendIfError(sessionId, qs.acceptQuest(sessionId, matchingQuest.id))
             }
         }
+    }
+
+    private suspend fun handleQuestTurnIn(
+        sessionId: SessionId,
+        cmd: Command.QuestTurnIn,
+    ) {
+        val qs = requireSystemOrNull(sessionId, questSystem, "Quests", outbound) ?: return
+        val me = players.get(sessionId) ?: return
+        val roomMobIds = mobs.mobsInRoom(me.roomId).map { it.id.value }
+        outbound.sendIfError(sessionId, qs.turnInQuest(sessionId, cmd.nameHint, roomMobIds))
     }
 
     private suspend fun handleAchievementList(sessionId: SessionId) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1031,6 +1031,10 @@ ambonmud:
           usage: quest abandon <name>
           category: quests
           staff: false
+        quest_turnin:
+          usage: quest turnin <name>
+          category: quests
+          staff: false
         accept:
           usage: accept <quest>
           category: quests

--- a/src/test/kotlin/dev/ambon/engine/MultiSystemIntegrationTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/MultiSystemIntegrationTest.kt
@@ -343,6 +343,7 @@ class MultiSystemIntegrationTest {
                 ),
             ),
             rewards = QuestRewards(xp = 100, gold = 50),
+            completionType = "auto",
         )
         val questRegistry = QuestRegistry()
         questRegistry.register(questDef)

--- a/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
@@ -758,4 +758,73 @@ class QuestSystemTest {
             assertTrue(result!!.levelsGained > 0)
             assertTrue(result.newLevel > result.previousLevel)
         }
+
+    @Test
+    fun `turn-in quest does not auto-complete and requires NPC in room`() =
+        runTest {
+            val turnInQuest = killQuest.copy(completionType = "npc_turn_in")
+            val (qs, players, _) = setup(turnInQuest)
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Hero")
+
+            qs.acceptQuest(sid, questId)
+            repeat(3) { qs.onMobKilled(sid, mobTemplateKey) }
+
+            val ps = players.get(sid)!!
+            assertTrue(ps.activeQuests.containsKey(questId), "Quest should remain active pending turn-in")
+            assertFalse(ps.completedQuestIds.contains(questId), "Quest must not auto-complete")
+
+            val wrongRoomErr = qs.turnInQuest(sid, "Kill Quest", emptyList())
+            assertNotNull(wrongRoomErr, "Turn-in without giver in room should fail")
+
+            val ok = qs.turnInQuest(sid, "Kill Quest", listOf("zone:quest_giver"))
+            assertNull(ok, "Turn-in with giver in room should succeed")
+            assertTrue(players.get(sid)!!.completedQuestIds.contains(questId))
+        }
+
+    @Test
+    fun `turn-in rejects when objectives are incomplete`() =
+        runTest {
+            val turnInQuest = killQuest.copy(completionType = "npc_turn_in")
+            val (qs, players, _) = setup(turnInQuest)
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Hero")
+
+            qs.acceptQuest(sid, questId)
+            qs.onMobKilled(sid, mobTemplateKey) // only 1/3
+
+            val err = qs.turnInQuest(sid, "Kill Quest", listOf("zone:quest_giver"))
+            assertNotNull(err, "Turn-in with unfinished objectives should fail")
+            assertFalse(players.get(sid)!!.completedQuestIds.contains(questId))
+        }
+
+    @Test
+    fun `turn-in rejects quests whose completion type is auto`() =
+        runTest {
+            val (qs, players, _) = setup() // killQuest with completionType = "auto"
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Hero")
+
+            qs.acceptQuest(sid, questId)
+            // Quest auto-completes — turnInQuest should report no matching active quest.
+            val err = qs.turnInQuest(sid, "Kill Quest", listOf("zone:quest_giver"))
+            assertNotNull(err)
+        }
+
+    @Test
+    fun `isReadyToTurnIn reflects completion handler and objectives`() =
+        runTest {
+            val turnInQuest = killQuest.copy(completionType = "npc_turn_in")
+            val (qs, players, _) = setup(turnInQuest)
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Hero")
+
+            qs.acceptQuest(sid, questId)
+            val stateInProgress = players.get(sid)!!.activeQuests[questId]!!
+            assertFalse(qs.isReadyToTurnIn(turnInQuest, stateInProgress))
+
+            repeat(3) { qs.onMobKilled(sid, mobTemplateKey) }
+            val stateReady = players.get(sid)!!.activeQuests[questId]!!
+            assertTrue(qs.isReadyToTurnIn(turnInQuest, stateReady))
+        }
 }

--- a/src/test/kotlin/dev/ambon/engine/WebClientParityTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/WebClientParityTest.kt
@@ -91,6 +91,7 @@ class WebClientParityTest {
             "QuestLog" to "quest_log",
             "QuestInfo" to "quest_info",
             "QuestAbandon" to "quest_abandon",
+            "QuestTurnIn" to "quest_turnin",
             "QuestAuto" to "bounty",
             "QuestAutoInfo" to "bounty_info",
             "QuestAutoAbandon" to "bounty_abandon",

--- a/web-v3/src/components/panels/QuestPanel.tsx
+++ b/web-v3/src/components/panels/QuestPanel.tsx
@@ -172,6 +172,7 @@ export function QuestPanel({
                   (o) => o.current >= o.required,
                 ).length;
                 const allDone = completedObjectives === totalObjectives;
+                const readyToTurnIn = quest.readyToTurnIn === true;
                 const overallProgress = totalObjectives > 0
                   ? quest.objectives.reduce((sum, o) => sum + Math.min(o.current, o.required), 0) /
                     quest.objectives.reduce((sum, o) => sum + o.required, 0)
@@ -179,7 +180,7 @@ export function QuestPanel({
                 return (
                   <li
                     key={quest.id}
-                    className={`quest-item ${isExpanded ? "quest-item-expanded" : ""} ${allDone ? "quest-item-complete" : ""}`}
+                    className={`quest-item ${isExpanded ? "quest-item-expanded" : ""} ${allDone ? "quest-item-complete" : ""} ${readyToTurnIn ? "quest-item-ready" : ""}`}
                   >
                     <button
                       type="button"
@@ -189,6 +190,9 @@ export function QuestPanel({
                     >
                       <span className="quest-item-icon">{allDone ? "\u2713" : "\u2726"}</span>
                       <span className="quest-item-name">{quest.name}</span>
+                      {readyToTurnIn && (
+                        <span className="quest-item-ready-badge">Ready to turn in</span>
+                      )}
                       <span className="quest-item-progress-badge">
                         {completedObjectives}/{totalObjectives}
                       </span>
@@ -242,6 +246,15 @@ export function QuestPanel({
                           })}
                         </ul>
                         <div className="quest-item-actions">
+                          {readyToTurnIn && (
+                            <button
+                              type="button"
+                              className="quest-turnin-button"
+                              onClick={() => onCommand(`quest turnin ${quest.name}`)}
+                            >
+                              Turn In Quest
+                            </button>
+                          )}
                           <button
                             type="button"
                             className="quest-abandon-button"

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -998,6 +998,8 @@ export function applyGmcpPackage(
                   }),
                 }))
             : [],
+          readyToTurnIn: entry.readyToTurnIn === true,
+          giverMobId: typeof entry.giverMobId === "string" ? entry.giverMobId : "",
         }));
       ctx.setQuests(parsedQuests);
       // Remove newly-active quests from available offers so accept buttons disappear

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -4885,6 +4885,7 @@ body {
   margin-top: var(--space-2);
   display: flex;
   justify-content: flex-end;
+  gap: 6px;
 }
 
 .quest-abandon-button {
@@ -4904,6 +4905,52 @@ body {
 .quest-abandon-button:hover {
   background: rgb(184 143 170 / 24%);
   border-color: rgb(184 143 170 / 56%);
+}
+
+.quest-turnin-button {
+  border: 1px solid rgb(214 184 110 / 70%);
+  border-radius: 6px;
+  background: linear-gradient(90deg, rgb(214 184 110 / 22%), rgb(214 184 110 / 32%));
+  color: var(--color-primary-soft-gold);
+  font-size: 0.74rem;
+  font-weight: 700;
+  padding: 4px 14px;
+  cursor: pointer;
+  box-shadow: 0 0 8px rgb(214 184 110 / 28%);
+  transition:
+    background 150ms var(--ease-out-soft),
+    border-color 150ms var(--ease-out-soft),
+    box-shadow 150ms var(--ease-out-soft);
+}
+
+.quest-turnin-button:hover {
+  background: linear-gradient(90deg, rgb(214 184 110 / 34%), rgb(214 184 110 / 44%));
+  border-color: rgb(214 184 110 / 90%);
+  box-shadow: 0 0 14px rgb(214 184 110 / 42%);
+}
+
+.quest-item-ready {
+  box-shadow: 0 0 12px rgb(214 184 110 / 30%);
+  border-color: rgb(214 184 110 / 50%);
+}
+
+.quest-item-ready .quest-item-icon {
+  color: var(--color-primary-soft-gold);
+}
+
+.quest-item-ready-badge {
+  margin-left: auto;
+  margin-right: 6px;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-primary-soft-gold);
+  background: rgb(214 184 110 / 14%);
+  border: 1px solid rgb(214 184 110 / 50%);
+  border-radius: 999px;
+  padding: 2px 8px;
+  white-space: nowrap;
 }
 
 @keyframes questNotifSlide {

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -461,6 +461,8 @@ export interface QuestEntry {
   name: string;
   description: string;
   objectives: QuestObjective[];
+  readyToTurnIn?: boolean;
+  giverMobId?: string;
 }
 
 export interface GainEvent {


### PR DESCRIPTION
## Summary
- Flip the default quest completion type from `auto` to `npc_turn_in`. Finished quests now stay in the log as "Ready to turn in" until the player returns to the quest-giver.
- Add `quest turnin <name>` command (aliases: `complete`, `finish`) that validates objectives are done and the giver mob is in the player's current room before granting rewards.
- Extend `Quest.List` GMCP with `readyToTurnIn` and `giverMobId`; the web drawer lights up ready quests and shows a "Turn In Quest" button.
- Talking to an NPC who holds a completable quest now also prompts the player to turn it in (parallel to the existing accept prompt).

## Test plan
- [x] `./gradlew ktlintCheck test` green
- [x] `bun run lint` and `bun run build` green in `web-v3/`
- [x] New `QuestSystemTest` cases cover happy-path turn-in, wrong-room rejection, unfinished-objective rejection, and `isReadyToTurnIn` transitions
- [x] `WebClientParityTest` updated for the new command
- [ ] Manually verify: accept Academy `grand_tour`, complete objectives, return to Headmaster Aldric, click "Turn In Quest" in the drawer, confirm rewards granted
- [ ] Manually verify: try to turn in from the wrong room and get the "quest-giver isn't here" error

## Notes
- `completionType: auto` remains available for any quest that should keep the old behaviour — `MultiSystemIntegrationTest` pins it explicitly to preserve coverage of the auto-complete chain.
- All bundled Academy quests (`grand_tour`, `creature_roundup`) now require turn-in, which is the desired behaviour.