### PR TITLE
Fix readyToTurnIn flag on the kill that completes a quest

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -995,14 +995,7 @@ class GameEngine(
             }
         }
         questSystem.onQuestListChanged = { sid -> sendQuestListGmcp(sid) }
-        questSystem.onQuestObjectiveUpdated = { sid, questId, objIndex, current, required ->
-            val def = questRegistry.get(questId)
-            val state = players.get(sid)?.activeQuests?.get(questId)
-            val readyToTurnIn = if (def != null && state != null) {
-                questSystem.isReadyToTurnIn(def, state)
-            } else {
-                false
-            }
+        questSystem.onQuestObjectiveUpdated = { sid, questId, objIndex, current, required, readyToTurnIn ->
             gmcpEmitter.sendQuestUpdate(sid, questId, objIndex, current, required, readyToTurnIn)
         }
         questSystem.onQuestCompletedGmcp = { sid, questId, questName ->

--- a/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
@@ -34,7 +34,7 @@ class QuestSystem(
 
     /** Invoked to emit quest GMCP; set by GameEngine during wiring. */
     var onQuestListChanged: (suspend (SessionId) -> Unit)? = null
-    var onQuestObjectiveUpdated: (suspend (SessionId, String, Int, Int, Int) -> Unit)? = null
+    var onQuestObjectiveUpdated: (suspend (SessionId, String, Int, Int, Int, Boolean) -> Unit)? = null
     var onQuestCompletedGmcp: (suspend (SessionId, String, String) -> Unit)? = null
 
     /** Invoked when a quest reward grants enough XP to level the player up. */
@@ -160,12 +160,22 @@ class QuestSystem(
         players.persistPlayer(ps.sessionId)
 
         outbound.send(OutboundEvent.SendInfo(sessionId, "Quest accepted: ${quest.name}"))
+        val acceptHandler = completionHandlers.get(quest.completionType)
+        val acceptReadyToTurnIn =
+            acceptHandler?.requiresNpcTurnIn == true && seededObjectives.all { it.isComplete }
         for ((index, obj) in quest.objectives.withIndex()) {
             outbound.send(OutboundEvent.SendText(sessionId, "  - ${obj.description}"))
             val prog = seededObjectives[index]
             if (prog.current > 0) {
                 sendObjectiveProgress(sessionId, obj.description, prog)
-                onQuestObjectiveUpdated?.invoke(sessionId, questId, index, prog.current, prog.required)
+                onQuestObjectiveUpdated?.invoke(
+                    sessionId,
+                    questId,
+                    index,
+                    prog.current,
+                    prog.required,
+                    acceptReadyToTurnIn,
+                )
             }
         }
         onQuestListChanged?.invoke(sessionId)
@@ -295,6 +305,7 @@ class QuestSystem(
             val quest = registry.get(questId) ?: continue
             val newObjectives = state.objectives.toMutableList()
             var questChanged = false
+            val handler = completionHandlers.get(quest.completionType)
 
             for ((index, objDef) in quest.objectives.withIndex()) {
                 val prog = newObjectives[index]
@@ -303,7 +314,16 @@ class QuestSystem(
                 newObjectives[index] = updated
                 questChanged = true
                 sendObjectiveProgress(sessionId, objDef.description, updated)
-                onQuestObjectiveUpdated?.invoke(sessionId, questId, index, updated.current, updated.required)
+                val readyToTurnIn =
+                    handler?.requiresNpcTurnIn == true && newObjectives.all { it.isComplete }
+                onQuestObjectiveUpdated?.invoke(
+                    sessionId,
+                    questId,
+                    index,
+                    updated.current,
+                    updated.required,
+                    readyToTurnIn,
+                )
             }
 
             if (questChanged) {

--- a/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
@@ -112,6 +112,37 @@ class QuestSystemTest {
         }
 
     @Test
+    fun `objective update flips readyToTurnIn true on the final kill of an npc_turn_in quest`() =
+        runTest {
+            val turnInQuestId = "zone:turnin_quest"
+            val turnInQuest = killQuest.copy(id = turnInQuestId, completionType = "npc_turn_in")
+            val (qs, players, _) = setup(turnInQuest)
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Hero")
+
+            data class Update(
+                val current: Int,
+                val ready: Boolean,
+            )
+            val updates = mutableListOf<Update>()
+            qs.onQuestObjectiveUpdated = { _, _, _, current, _, ready ->
+                updates.add(Update(current, ready))
+            }
+
+            qs.acceptQuest(sid, turnInQuestId)
+            repeat(3) { qs.onMobKilled(sid, mobTemplateKey) }
+
+            assertEquals(listOf(1, 2, 3), updates.map { it.current })
+            assertEquals(
+                listOf(false, false, true),
+                updates.map { it.ready },
+                "readyToTurnIn must flip on the kill that completes the final objective",
+            )
+            val ps = players.get(sid)!!
+            assertTrue(ps.activeQuests.containsKey(turnInQuestId), "npc_turn_in quest stays active until turned in")
+        }
+
+    @Test
     fun `quest auto-completes and grants rewards when all objectives done`() =
         runTest {
             val (qs, players, outbound) = setup()


### PR DESCRIPTION
## Summary
- The `Quest.Update` emitted on the final kill of an `npc_turn_in` quest carried `readyToTurnIn=false`, so the QuestPanel never showed the **Turn In Quest** button and the NPC popout's lookup found no ready quest and fell back to opening dialogue.
- `QuestSystem.advanceObjectives()` invoked `onQuestObjectiveUpdated` *before* reassigning `ps.activeQuests` with the new objective progress. `GameEngine`'s callback then re-queried player state to compute `readyToTurnIn` and read the stale objectives — the just-completed objective still showed N-1/N.
- Compute `readyToTurnIn` inside `QuestSystem` from the freshly-mutated `newObjectives` list and pass it through the callback; `GameEngine` just forwards the flag. Same path used for `acceptQuest` in case a seeded objective is already complete at accept time.

## Test plan
- [x] New `QuestSystemTest` regression: final kill of an `npc_turn_in` quest emits `readyToTurnIn=true` and the quest stays active until turned in.
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew test --tests "*QuestSystem*" --tests "*GmcpEmitter*" --tests "*MultiSystemIntegration*"`
- [ ] Manual: complete a quest in the web client; verify the Turn In button appears in the quest panel the moment the final objective ticks over, and the NPC popout's "Turn In Quest" action sends `quest turnin <name>` instead of `talk <name>`.