### PR TITLE
Auto-push daily/weekly/global quest state on login (#1091)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -248,6 +248,21 @@ class GameEngine(
                 // until the first relog. See issue #1045.
                 emitDungeonCatalog(sid)
                 players.get(sid)?.let { p -> emitLotteryInfo(sid, p.name) }
+                // Push daily/weekly/global quest state so the client doesn't
+                // need a manual refresh button. See issue #1091.
+                dailyQuestSystem?.let { dqs ->
+                    dqs.checkReset(sid)
+                    gmcpEmitter.sendDailyQuests(sid, dqs)
+                    gmcpEmitter.sendWeeklyQuests(sid, dqs)
+                }
+                globalQuestSystem?.let { sys ->
+                    val status = sys.getStatus()
+                    if (status != null) {
+                        gmcpEmitter.sendGlobalQuest(sid, status, sys.getPlayerProgress(sid) ?: 0)
+                    } else {
+                        gmcpEmitter.sendGlobalQuestInactive(sid)
+                    }
+                }
             },
             // Only password/create logins need a fresh auth token — the client
             // doesn't have one yet. Auto-relog via Session.Authenticate and

--- a/web-v3/src/components/panels/QuestPanel.tsx
+++ b/web-v3/src/components/panels/QuestPanel.tsx
@@ -345,14 +345,7 @@ export function QuestPanel({
           ) : (
             <div className="quest-empty-state">
               <span className="quest-empty-icon">{"\u2726"}</span>
-              <p className="empty-note">No daily quests loaded.</p>
-              <button
-                type="button"
-                className="quest-load-button"
-                onClick={() => onCommand("daily")}
-              >
-                Load Daily Quests
-              </button>
+              <p className="empty-note">No daily quests are available right now.</p>
             </div>
           )}
         </section>
@@ -374,14 +367,7 @@ export function QuestPanel({
           ) : (
             <div className="quest-empty-state">
               <span className="quest-empty-icon">{"\u2726"}</span>
-              <p className="empty-note">No weekly quests loaded.</p>
-              <button
-                type="button"
-                className="quest-load-button"
-                onClick={() => onCommand("weekly")}
-              >
-                Load Weekly Quests
-              </button>
+              <p className="empty-note">No weekly quests are available right now.</p>
             </div>
           )}
         </section>
@@ -511,14 +497,7 @@ export function QuestPanel({
           ) : (
             <div className="quest-empty-state">
               <span className="quest-empty-icon">{"\u2604"}</span>
-              <p className="empty-note">No global quest active.</p>
-              <button
-                type="button"
-                className="quest-load-button"
-                onClick={() => onCommand("globalquest")}
-              >
-                Check Status
-              </button>
+              <p className="empty-note">No global quest is active right now.</p>
             </div>
           )}
         </section>


### PR DESCRIPTION
## Summary
Closes https://github.com/jnoecker/AmbonMUD/issues/1091.

- Emit `Quest.Daily`, `Quest.Weekly`, and `Quest.Global` GMCP packages from `GameEngine.onAfterLogin`, alongside the existing `Quest.List` push — so daily/weekly/global boards are populated without requiring the player to run `daily` / `weekly` / `globalquest`.
- Remove the manual "Load Daily Quests", "Load Weekly Quests", and "Check Status" refresh buttons from `QuestPanel.tsx`; empty-state copy now reads naturally ("No daily quests are available right now.").
- The "Request Bounty" button on the bounty tab is preserved — it requests a new bounty rather than refreshing state.

## Test plan
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew compileKotlin`
- [x] `./gradlew test --tests "*DailyQuest*" --tests "*GlobalQuest*" --tests "*LoginFlow*" --tests "*LoginHandler*"`
- [x] `bun run lint` (web-v3)
- [ ] Manual: log in, verify daily/weekly/global tabs populate automatically with no refresh button visible.