### PR TITLE
Prestige panel: explain system and surface earned bonuses (#1096)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -3278,6 +3278,7 @@ class GmcpEmitter(
         val maxRank: Int,
         val availableXp: Long,
         val nextRankCost: Long?,
+        val requiredLevel: Int,
         val perks: List<PrestigePerkPayload>,
     )
 
@@ -3288,6 +3289,7 @@ class GmcpEmitter(
         maxRank: Int,
         availableXp: Long,
         nextRankCost: Long?,
+        requiredLevel: Int,
         perks: List<PrestigePerkPayload>,
     ) {
         emit(
@@ -3299,6 +3301,7 @@ class GmcpEmitter(
                 maxRank = maxRank,
                 availableXp = availableXp,
                 nextRankCost = nextRankCost,
+                requiredLevel = requiredLevel,
                 perks = perks,
             ),
             supportCheck = "Prestige",
@@ -3312,6 +3315,7 @@ class GmcpEmitter(
         val enabled = prestigeEnabled()
         val currentRank = player.prestigeLevel
         val maxRank = if (enabled) prestigeMaxRank() else 0
+        val requiredLevel = progression?.maxLevel ?: 0
         val availableXp =
             if (enabled && (progression == null || player.level >= progression.maxLevel)) {
                 prestigeAvailableXp(player) ?: 0L
@@ -3337,6 +3341,7 @@ class GmcpEmitter(
             maxRank = maxRank,
             availableXp = availableXp,
             nextRankCost = nextRankCost,
+            requiredLevel = requiredLevel,
             perks = perks,
         )
     }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/PrestigeHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/PrestigeHandler.kt
@@ -185,6 +185,7 @@ class PrestigeHandler(
                 maxRank = maxRank,
                 availableXp = available,
                 nextRankCost = nextCost,
+                requiredLevel = maxLevel,
                 perks = gmcpEmitter.buildPrestigePerkPayloads(currentRank, maxRank) { prestigeSystem.perkForRank(it) },
             )
             sendScopedFeedback(

--- a/web-v3/src/components/panels/SystemsPanel.tsx
+++ b/web-v3/src/components/panels/SystemsPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { CURRENCY_METADATA, FACTION_METADATA, FACTION_TIERS, LOTTERY_SETTINGS, PRESTIGE_MAX_LEVEL } from "../../featureMetadata";
+import { CURRENCY_METADATA, FACTION_METADATA, FACTION_TIERS, LOTTERY_SETTINGS } from "../../featureMetadata";
 import type { CurrencyActivity, CurrencyBalance, DuelChallenge, DuelState, DungeonCatalogEntry, DungeonInfo, FactionActivity, FactionStanding, LotteryInfo, PetState, PrestigeInfo, RoomPlayer, SystemPanelView, UiFeedbackEntry, Vitals } from "../../types";
 
 interface SystemsPanelProps {
@@ -49,6 +49,17 @@ function feedbackScopeForView(view: SystemPanelView): string {
     case "prestige": return "prestige";
     case "currencies": return "currencies";
     case "factions": return "factions";
+    default: return "";
+  }
+}
+
+function formatPrestigePerkType(type: string): string {
+  switch (type) {
+    case "STAT_BONUS": return "Stat Bonus";
+    case "SKILL_POINT": return "Skill Point";
+    case "MAX_HP": return "Max HP";
+    case "MAX_MANA": return "Max Mana";
+    case "TITLE": return "Title";
     default: return "";
   }
 }
@@ -111,9 +122,14 @@ export function SystemsPanel({
     [nearbyPlayers],
   );
 
+  const prestigeRequiredLevel = prestigeInfo?.requiredLevel ?? 0;
+  const prestigePerksConfigured = (prestigeInfo?.perks.length ?? 0) > 0;
   const canPrestige = Boolean(
     prestigeInfo?.enabled &&
-      vitals.level === PRESTIGE_MAX_LEVEL &&
+      prestigePerksConfigured &&
+      prestigeRequiredLevel > 0 &&
+      (vitals.level ?? 0) >= prestigeRequiredLevel &&
+      prestigeInfo.currentRank < prestigeInfo.maxRank &&
       prestigeInfo.nextRankCost != null &&
       prestigeInfo.availableXp >= prestigeInfo.nextRankCost,
   );
@@ -519,12 +535,52 @@ export function SystemsPanel({
           </section>
         )}
 
-        {activeView === "prestige" && (
-          <section className="systems-section">
-            <h3 className="systems-title">Prestige</h3>
+        {activeView === "prestige" && (() => {
+          const requirementLabel = prestigeRequiredLevel > 0 ? `Level ${prestigeRequiredLevel}` : "Max level";
+          const earnedPerks = prestigeInfo?.perks.filter((perk) => perk.earned) ?? [];
+          return (
+            <section className="systems-section">
+              <h3 className="systems-title">Prestige</h3>
 
-            {prestigeInfo ? (
-              prestigeInfo.enabled ? (
+              {!prestigeInfo ? (
+                <p className="empty-note">Prestige data is not available right now.</p>
+              ) : !prestigeInfo.enabled ? (
+                <article className="systems-card">
+                  <div className="systems-card-header">
+                    <div>
+                      <p className="systems-card-label">Unavailable</p>
+                      <h4>Prestige is disabled</h4>
+                    </div>
+                  </div>
+                  <p className="systems-card-copy">Prestige is currently disabled on this server.</p>
+                </article>
+              ) : !prestigePerksConfigured ? (
+                <article className="systems-card">
+                  <div className="systems-card-header">
+                    <div>
+                      <p className="systems-card-label">Coming Soon</p>
+                      <h4>Prestige perks are still being designed</h4>
+                    </div>
+                    <span className="systems-pill">Preview</span>
+                  </div>
+                  <p className="systems-card-copy">
+                    Prestige is the endgame system that lets max-level characters trade surplus
+                    experience for permanent perks &mdash; stat boosts, extra skill points, increased
+                    HP and mana, and unique titles. The framework is live, but the per-rank perks
+                    for this realm haven&rsquo;t been published yet.
+                  </p>
+                  <dl className="systems-stat-grid">
+                    <div><dt>Requirement</dt><dd>{requirementLabel}</dd></div>
+                    <div><dt>Current Level</dt><dd>{vitals.level ?? "-"}</dd></div>
+                    <div><dt>Planned Max Rank</dt><dd>{prestigeInfo.maxRank > 0 ? prestigeInfo.maxRank : "—"}</dd></div>
+                    <div><dt>Status</dt><dd>Awaiting perk data</dd></div>
+                  </dl>
+                  <p className="systems-card-copy">
+                    Surplus XP earned past the level cap is preserved on your character and will
+                    convert into prestige once perks go live.
+                  </p>
+                </article>
+              ) : (
                 <article className="systems-card">
                   <div className="systems-card-header">
                     <div>
@@ -535,19 +591,23 @@ export function SystemsPanel({
                       {prestigeInfo.currentRank >= prestigeInfo.maxRank ? "Max rank" : `Cap ${prestigeInfo.maxRank}`}
                     </span>
                   </div>
+                  <p className="systems-card-copy">
+                    Spend surplus experience earned past the level cap to take a prestige rank.
+                    Each rank grants a permanent perk and is preserved across deaths and respecs.
+                  </p>
                   <dl className="systems-stat-grid">
                     <div><dt>Available XP</dt><dd>{prestigeInfo.availableXp.toLocaleString()}</dd></div>
                     <div><dt>Next Rank Cost</dt><dd>{prestigeInfo.nextRankCost?.toLocaleString() ?? "Maxed"}</dd></div>
                     <div><dt>Current Level</dt><dd>{vitals.level ?? "-"}</dd></div>
-                    <div><dt>Requirement</dt><dd>Level {PRESTIGE_MAX_LEVEL}</dd></div>
+                    <div><dt>Requirement</dt><dd>{requirementLabel}</dd></div>
                   </dl>
                   <div className="systems-callout">
                     {prestigeInfo.currentRank >= prestigeInfo.maxRank
                       ? "You have reached the maximum prestige rank."
-                      : vitals.level !== PRESTIGE_MAX_LEVEL
-                        ? `Reach level ${PRESTIGE_MAX_LEVEL} to prestige again.`
+                      : prestigeRequiredLevel > 0 && (vitals.level ?? 0) < prestigeRequiredLevel
+                        ? `Reach level ${prestigeRequiredLevel} to prestige.`
                         : prestigeInfo.nextRankCost != null && prestigeInfo.availableXp < prestigeInfo.nextRankCost
-                          ? "You need more prestige XP before you can advance."
+                          ? "You need more surplus XP before you can advance."
                           : "You are eligible to take the next prestige rank."}
                   </div>
                   <div className="systems-action-row">
@@ -563,31 +623,39 @@ export function SystemsPanel({
                       Prestige Up
                     </button>
                   </div>
-                  <div className="systems-perk-list">
-                    {prestigeInfo.perks.map((perk) => (
-                      <div key={perk.rank} className={`systems-perk-card ${perk.earned ? "systems-perk-card-earned" : ""}`}>
-                        <span className="systems-perk-rank">{perk.earned ? "Done" : `Rank ${perk.rank}`}</span>
-                        <span className="systems-perk-desc">{perk.description}</span>
-                      </div>
-                    ))}
-                  </div>
-                </article>
-              ) : (
-                <article className="systems-card">
-                  <div className="systems-card-header">
-                    <div>
-                      <p className="systems-card-label">Unavailable</p>
-                      <h4>Prestige is disabled</h4>
+                  {earnedPerks.length > 0 && (
+                    <div className="systems-perk-summary">
+                      <p className="systems-card-label">Bonuses Earned</p>
+                      <ul className="systems-bullet-list">
+                        {earnedPerks.map((perk) => (
+                          <li key={`earned-${perk.rank}`}>
+                            <strong>Rank {perk.rank}:</strong> {perk.description}
+                          </li>
+                        ))}
+                      </ul>
                     </div>
+                  )}
+                  <div className="systems-perk-list">
+                    {prestigeInfo.perks.map((perk) => {
+                      const typeLabel = formatPrestigePerkType(perk.type);
+                      const rankLabel = perk.earned
+                        ? `Rank ${perk.rank} · Earned`
+                        : typeLabel
+                          ? `Rank ${perk.rank} · ${typeLabel}`
+                          : `Rank ${perk.rank}`;
+                      return (
+                        <div key={perk.rank} className={`systems-perk-card ${perk.earned ? "systems-perk-card-earned" : ""}`}>
+                          <span className="systems-perk-rank">{rankLabel}</span>
+                          <span className="systems-perk-desc">{perk.description}</span>
+                        </div>
+                      );
+                    })}
                   </div>
-                  <p className="systems-card-copy">Prestige is currently disabled on this server.</p>
                 </article>
-              )
-            ) : (
-              <p className="empty-note">Prestige data is not available right now.</p>
-            )}
-          </section>
-        )}
+              )}
+            </section>
+          );
+        })()}
 
         {activeView === "currencies" && (
           <section className="systems-section">

--- a/web-v3/src/featureMetadata.ts
+++ b/web-v3/src/featureMetadata.ts
@@ -1,5 +1,3 @@
-export const PRESTIGE_MAX_LEVEL = 50;
-
 export const LOTTERY_SETTINGS = {
   ticketCost: 100,
   maxTicketsPerPlayer: 10,

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -2130,6 +2130,7 @@ export function applyGmcpPackage(
         : [];
       ctx.setPrestigeInfo({
         enabled: packet.enabled === true,
+        requiredLevel: safeNumber(packet.requiredLevel, 0),
         currentRank: safeNumber(packet.currentRank, 0),
         maxRank: safeNumber(packet.maxRank, 0),
         availableXp: safeNumber(packet.availableXp, 0),

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -12926,6 +12926,19 @@ body {
   gap: 0.35rem;
 }
 
+.systems-perk-summary {
+  display: grid;
+  gap: 0.5rem;
+  padding: 0.85rem 0.95rem;
+  border-radius: 14px;
+  background: rgb(105 199 150 / 8%);
+  border: 1px solid rgb(105 199 150 / 22%);
+}
+
+.systems-perk-summary strong {
+  color: var(--text-primary);
+}
+
 .systems-meter {
   display: flex;
   align-items: center;

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -982,6 +982,7 @@ export interface PrestigePerk {
 
 export interface PrestigeInfo {
   enabled: boolean;
+  requiredLevel: number;
   currentRank: number;
   maxRank: number;
   availableXp: number;


### PR DESCRIPTION
## Summary
- Adds a "coming soon" preview state for the Prestige panel when the system is enabled but no perks are configured (the current production state), explaining what prestige will do, requirement level, planned max rank, and that surplus XP is preserved
- When perks are configured, adds an intro sentence, a "Bonuses Earned" callout listing earned perks, and per-rank type labels (Stat Bonus / Skill Point / Max HP / Max Mana / Title)
- Server now sends `requiredLevel` in `Prestige.Info` from `progression.maxLevel` so the client no longer hard-codes level 50

Fixes https://github.com/jnoecker/AmbonMUD/issues/1096

## Test plan
- [x] `./gradlew test --tests "*Prestige*" --tests "*GmcpEmitter*"`
- [x] `./gradlew ktlintCheck`
- [x] `bun test` (web-v3)
- [x] `bun run build` (web-v3)
- [ ] Manual: open Prestige panel on a server with no perks configured — verify "Coming Soon" copy
- [ ] Manual: open Prestige panel on a server with perks configured — verify earned bonuses callout and per-rank type labels