### PR TITLE
Quest popout: refresh indicators on turn-in, skip dialogue on accept

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -1020,13 +1020,17 @@ class GameEngine(
                 }
             }
         }
-        questSystem.onQuestListChanged = { sid -> sendQuestListGmcp(sid) }
+        questSystem.onQuestListChanged = { sid ->
+            sendQuestListGmcp(sid)
+            refreshRoomMobInfoForPlayer(sid)
+        }
         questSystem.onQuestObjectiveUpdated = { sid, questId, objIndex, current, required, readyToTurnIn ->
             gmcpEmitter.sendQuestUpdate(sid, questId, objIndex, current, required, readyToTurnIn)
         }
         questSystem.onQuestCompletedGmcp = { sid, questId, questName ->
             gmcpEmitter.sendQuestComplete(sid, questId, questName)
             sendQuestListGmcp(sid)
+            refreshRoomMobInfoForPlayer(sid)
         }
         questSystem.onLevelUp = ::onCombatLevelUp
         achievementSystem.onLevelUp = ::onCombatLevelUp
@@ -2138,6 +2142,28 @@ class GameEngine(
             )
         }
         gmcpEmitter.sendQuestList(sessionId, entries)
+    }
+
+    /**
+     * Re-emits `Room.MobInfo` for the player's current room. Called when a quest event
+     * may have flipped a mob's `questAvailable` / `questComplete` flag — the canvas
+     * indicators and popout actions key off these flags and otherwise stay stale until
+     * the player leaves and re-enters the room.
+     */
+    private suspend fun refreshRoomMobInfoForPlayer(sessionId: SessionId) {
+        val ps = players.get(sessionId) ?: return
+        val mobsInRoom = mobs.mobsInRoom(ps.roomId)
+        val mobIds = mobsInRoom.map { it.id.value }
+        val questAvailable = questSystem.questAvailableMobIds(sessionId, mobIds)
+        val questComplete = questSystem.questCompleteMobIds(sessionId, mobIds)
+        gmcpEmitter.sendRoomMobInfo(
+            sessionId,
+            gmcpEmitter.buildMobInfoEntries(
+                mobsInRoom,
+                questAvailableMobIds = questAvailable,
+                questCompleteMobIds = questComplete,
+            ),
+        )
     }
 
     /**

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -373,6 +373,8 @@ sealed interface Command {
         val optionNumber: Int,
     ) : Command
 
+    data object DialogueEnd : Command
+
     data object QuestLog : Command
 
     data class QuestInfo(
@@ -1195,6 +1197,9 @@ object CommandParser {
 
         // talk
         requiredArg(line, listOf("talk"), "talk <npc>", { Command.Talk(it) })?.let { return it }
+
+        // bye / goodbye — end the active dialogue conversation
+        matchPrefix(line, listOf("bye", "goodbye")) { Command.DialogueEnd }?.let { return it }
 
         // cast / c
         matchPrefix(line, listOf("cast", "c")) { rest ->

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestHandler.kt
@@ -35,6 +35,7 @@ class DialogueQuestHandler(
     override fun register(router: CommandRouter) {
         router.on<Command.Talk> { sid, cmd -> handleTalk(sid, cmd) }
         router.on<Command.DialogueChoice> { sid, cmd -> handleDialogueChoice(sid, cmd) }
+        router.on<Command.DialogueEnd> { sid, _ -> handleDialogueEnd(sid) }
         router.on<Command.QuestLog> { sid, _ -> handleQuestLog(sid) }
         router.on<Command.QuestInfo> { sid, cmd -> handleQuestInfo(sid, cmd) }
         router.on<Command.QuestAbandon> { sid, cmd -> handleQuestAbandon(sid, cmd) }
@@ -119,6 +120,10 @@ class DialogueQuestHandler(
         }
     }
 
+    private suspend fun handleDialogueEnd(sessionId: SessionId) {
+        dialogueSystem?.endConversation(sessionId)
+    }
+
     private suspend fun handleDialogueAction(
         sessionId: SessionId,
         action: String,
@@ -194,13 +199,23 @@ class DialogueQuestHandler(
         players.withPlayer(sessionId) { me ->
             val nameHintLower = cmd.nameHint.trim().lowercase()
             val roomMobIds = mobs.mobsInRoom(me.roomId).map { it.id.value }.toSet()
-            val matchingQuest =
+            // First try matching the hint against quest names/ids.
+            var matchingQuest =
                 questRegistry
                     .all()
                     .filter { quest ->
                         quest.name.lowercase().contains(nameHintLower) ||
                             quest.id.substringAfterLast(':').lowercase().contains(nameHintLower)
                     }.firstOrNull { quest -> quest.giverMobId in roomMobIds }
+            // Fall back to matching the hint against a room mob — pick the first
+            // quest that mob currently offers the player. This lets clients invoke
+            // `accept <mob>` straight from a popout without first opening dialogue.
+            if (matchingQuest == null) {
+                val mobMatch = mobs.findInRoomByKeyword(me.roomId, cmd.nameHint.trim()).firstOrNull()
+                if (mobMatch != null) {
+                    matchingQuest = qs.availableQuests(sessionId, mobMatch.id.value).firstOrNull()
+                }
+            }
             if (matchingQuest == null) {
                 outbound.send(
                     OutboundEvent.SendError(

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -354,7 +354,13 @@ function App() {
     canvasCallbacks.openMap = () => openPanel("map");
     canvasCallbacks.openRoom = () => openPanel("room");
     canvasCallbacks.openQuests = () => openPanel("quests");
-    canvasCallbacks.dismissDialogue = () => { state.setDialogue(null); state.setQuestsAvailable([]); };
+    canvasCallbacks.dismissDialogue = () => {
+      // Tell the server to drop dialogue state too — otherwise the next "1"-style
+      // input would still resolve to a DialogueChoice on the server.
+      if (gameStateRef.current.dialogue) sendCommand("bye");
+      state.setDialogue(null);
+      state.setQuestsAvailable([]);
+    };
     canvasCallbacks.openVideo = (url: string) => setVideoUrl(url);
     canvasCallbacks.prefillCommand = (text: string) => prefillInput(text);
     return () => {

--- a/web-v3/src/canvas/systems/DialogueOverlay.ts
+++ b/web-v3/src/canvas/systems/DialogueOverlay.ts
@@ -180,7 +180,10 @@ export class DialogueOverlay {
         const idx = choice.index;
         choiceText.on("pointerover", () => { choiceText.style.fill = CHOICE_HOVER_COLOR; });
         choiceText.on("pointerout", () => { choiceText.style.fill = CHOICE_COLOR; });
-        choiceText.on("pointerdown", () => {
+        choiceText.on("pointerdown", (event) => {
+          // Stop propagation so the always-on dismiss backdrop doesn't fire and
+          // close the dialogue when the user is actually picking a choice.
+          event.stopPropagation();
           canvasCallbacks.sendCommand?.(`${idx}`);
         });
 
@@ -214,32 +217,24 @@ export class DialogueOverlay {
       contentHeight -= QUEST_CARD_GAP;
     }
 
-    // Dismissable when no active dialogue choices remain
-    const hasActiveChoices = dialogue !== null && dialogue.choices.length > 0;
-    this.isDismissable = !hasActiveChoices;
-    this.bg.cursor = this.isDismissable ? "pointer" : "default";
+    // The overlay is always dismissable: clicking outside the choices ends the
+    // conversation rather than forcing the user to click through every node.
+    // Choice texts call stopPropagation, so picking a choice doesn't double as
+    // a dismiss.
+    this.isDismissable = true;
+    this.bg.cursor = "pointer";
+    this.redrawFullBg();
+    this.fullBg.visible = true;
+    this.fullBg.eventMode = "static";
+    this.fullBg.cursor = "pointer";
 
-    // Full-canvas dismiss backdrop is only interactive when dismissable, so
-    // mid-conversation canvas clicks (e.g. picking choices) aren't swallowed.
-    if (this.isDismissable) {
-      this.redrawFullBg();
-      this.fullBg.visible = true;
-      this.fullBg.eventMode = "static";
-      this.fullBg.cursor = "pointer";
-    } else {
-      this.fullBg.visible = false;
-      this.fullBg.eventMode = "none";
-    }
-
-    if (this.isDismissable) {
-      this.dismissHint = new Text({
-        text: "Click anywhere to close",
-        style: { fontFamily: "JetBrains Mono, Cascadia Mono, monospace", fontSize: 10, fill: ENDING_COLOR },
-      });
-      this.dismissHint.anchor.set(0.5, 0);
-      this.container.addChild(this.dismissHint);
-      contentHeight += 16;
-    }
+    this.dismissHint = new Text({
+      text: "Click anywhere to close",
+      style: { fontFamily: "JetBrains Mono, Cascadia Mono, monospace", fontSize: 10, fill: ENDING_COLOR },
+    });
+    this.dismissHint.anchor.set(0.5, 0);
+    this.container.addChild(this.dismissHint);
+    contentHeight += 16;
 
     contentHeight += BOX_PADDING;
 

--- a/web-v3/src/canvas/systems/EntityPopout.ts
+++ b/web-v3/src/canvas/systems/EntityPopout.ts
@@ -91,7 +91,9 @@ export class EntityPopout {
       const turnInCommand = readyQuest ? `quest turnin ${readyQuest.name}` : `talk ${name}`;
       actions.push({ label: "\u2605 Turn In Quest", command: turnInCommand, color: 0xf0c674 });
     } else if (info?.questAvailable) {
-      actions.push({ label: "\u2605 Accept Quest", command: `talk ${name}`, color: 0x5a8a6a });
+      // Server resolves `accept <mob>` to the first available quest from that mob,
+      // so we skip opening the dialogue panel just to click an Accept button inside.
+      actions.push({ label: "\u2605 Accept Quest", command: `accept ${name}`, color: 0x5a8a6a });
     } else if (info?.questGiver) {
       // Quest giver with no active quest — still show talk with quest styling
       actions.push({ label: "\u2605 Quests", command: `talk ${name}`, color: 0x8a9a6a });


### PR DESCRIPTION
## Summary

Fixes two quest-flow rough edges in the web client:

- **Stale indicators after turn-in.** The canvas `?` indicator above quest-giver mobs and the "Turn In Quest" action on the mob popout would persist after a successful turn-in, only clearing when the player left and re-entered the room. The server now re-emits `Room.MobInfo` after quest accept / abandon / turn-in / complete via a new `refreshRoomMobInfoForPlayer` helper hooked into the existing `onQuestListChanged` and `onQuestCompletedGmcp` callbacks.
- **Forced dialogue click-through on accept.** Clicking "Accept Quest" on a mob popout used to send `talk <mob>`, which opened the dialogue panel and required the user to click through it just to dismiss. The popout now sends `accept <mob>` directly, and the server's `handleQuestAccept` falls back to matching the hint against a room mob and accepting that mob's first available quest when no quest name matches.
- **Dialogue panel always dismissable.** Previously the overlay was only dismissable once a dialogue node had no remaining choices. It's now always dismissable; choice clicks `stopPropagation` so picking a choice doesn't double as a dismiss. `dismissDialogue` sends a new `bye` command so the server tears down conversation state — otherwise a later `1` keypress would still resolve to a stale `DialogueChoice`.

## Test plan

- [ ] Accept a quest from a mob popout — no dialogue panel opens, quest log updates, mob's `?` indicator stays as expected.
- [ ] Turn in a quest at the giver — popout's "Turn In Quest" action and the `?` indicator clear immediately without leaving the room.
- [ ] Open a dialogue panel and click outside the choices mid-conversation — overlay closes and a follow-up `1` does not re-trigger the conversation.
- [ ] `accept <quest-name>` still works when name matches a registered quest (existing behavior).
- [ ] `./gradlew ktlintCheck test` passes; `bun run lint` and `tsc --noEmit` clean.