### PR TITLE
Bump Kotlin daemon heap to 4g for cold Docker compile

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 kotlin.code.style=official
-org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError -Dkotlinx.coroutines.io.parallelism=256
+org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dkotlinx.coroutines.io.parallelism=256
 org.gradle.caching=true
 org.gradle.configuration-cache=true
-kotlin.daemon.jvmargs=-Xmx2g
+kotlin.daemon.jvmargs=-Xmx4g
 kotlin.compiler.execution.strategy=in-process
 # Reclaim stale daemon processes after 10 minutes of idle (default is 3 hours).
 # Prevents file locks from accumulating when tests hang and leave zombie daemons.


### PR DESCRIPTION
## Summary

The Docker `compileKotlin` step in CI is failing with `java.lang.OutOfMemoryError: GC overhead limit exceeded` (see the `docker` job on the `b493f5be` build). Local builds don't hit it because the Kotlin daemon stays warm and compiles incrementally; CI's cold, non-incremental compile of the full source tree doesn't fit in the previous 2g cap.

Raises both `kotlin.daemon.jvmargs` and `org.gradle.jvmargs` from `-Xmx2g` to `-Xmx4g`.

## Test plan

- [ ] CI's `docker` job passes (which is the regression we're fixing).
- [ ] Local `./gradlew test` continues to pass with the larger heap (no functional change, just headroom).