### PR TITLE
Web client: Depart button at the death sanctum

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -571,6 +571,9 @@ class GameEngine(
                     autoQuests = engineConfig.autoQuests.enabled,
                 )
             },
+            sanctumRoomId = {
+                engineConfig.death.sanctumRoom?.let { RoomId(it) }?.takeIf { world.rooms.containsKey(it) }
+            },
         )
 
     fun markVitalsDirty(sessionId: SessionId) {

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -90,6 +90,7 @@ class GmcpEmitter(
     private val prestigePerkPayloads: (currentRank: Int, maxRank: Int) -> List<PrestigePerkPayload> = { _, _ -> emptyList() },
     private val environmentConfig: dev.ambon.config.EnvironmentConfig = dev.ambon.config.EnvironmentConfig(),
     private val featureFlags: () -> ServerFeaturesPayload = { ServerFeaturesPayload() },
+    private val sanctumRoomId: () -> RoomId? = { null },
 ) {
     private val json = jacksonObjectMapper()
     private val imagesBase = if (imagesBaseUrl.endsWith("/")) imagesBaseUrl else "$imagesBaseUrl/"
@@ -191,7 +192,9 @@ class GmcpEmitter(
         housingOwner: String? = null,
         pvpEnabled: Boolean = false,
         trainerName: String? = null,
+        lastDeathZone: String? = null,
     ) {
+        val canDepart = lastDeathZone != null && sanctumRoomId() == room.id
         emit(
             sessionId,
             "Room.Info",
@@ -220,6 +223,7 @@ class GmcpEmitter(
                 dungeon = room.dungeon,
                 auction = room.auction,
                 housingBroker = room.housingBroker,
+                canDepart = canDepart,
             ),
         )
     }
@@ -2245,6 +2249,7 @@ class GmcpEmitter(
         val dungeon: Boolean = false,
         val auction: Boolean = false,
         val housingBroker: Boolean = false,
+        val canDepart: Boolean = false,
     )
 
     private data class ItemPayload(

--- a/src/main/kotlin/dev/ambon/engine/HotReloadManager.kt
+++ b/src/main/kotlin/dev/ambon/engine/HotReloadManager.kt
@@ -196,6 +196,7 @@ class HotReloadManager(
                 room,
                 pvpEnabled = world.isZonePvpEnabled(room.id.zone),
                 trainerName = trainerRegistry.trainerInRoom(room.id)?.name,
+                lastDeathZone = player.lastDeathZone,
             )
             gmcpEmitter.sendRoomMobs(player.sessionId, mobs.mobsInRoom(player.roomId))
             gmcpEmitter.sendRoomItems(player.sessionId, items.itemsInRoom(player.roomId))

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -351,6 +351,7 @@ internal suspend fun sendLook(
         housingOwner = housingOwner,
         pvpEnabled = isPvpZone,
         trainerName = trainerHere?.name,
+        lastDeathZone = me.lastDeathZone,
     )
     gmcpEmitter?.sendRoomPlayers(sessionId, rawRoomPlayers)
     gmcpEmitter?.sendRoomMobs(sessionId, rawRoomMobs)

--- a/src/main/kotlin/dev/ambon/engine/events/GmcpEventHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/GmcpEventHandler.kt
@@ -69,6 +69,7 @@ class GmcpEventHandler(
                     room,
                     pvpEnabled = world.isZonePvpEnabled(room.id.zone),
                     trainerName = trainerRegistry?.trainerInRoom(room.id)?.name,
+                    lastDeathZone = player.lastDeathZone,
                 )
                 gmcpEmitter.sendZoneEnvironment(
                     sid,

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -267,6 +267,68 @@ class GmcpEmitterTest {
         }
 
     @Test
+    fun `sendRoomInfo emits canDepart=true when at sanctum with lastDeathZone`() =
+        runTest {
+            val sanctum = RoomId("hub:sanctum")
+            val packages = setOf("Room.Info")
+            val e =
+                GmcpEmitter(
+                    outbound = outbound,
+                    supportsPackage = { _, pkg ->
+                        packages.any { s -> pkg == s || pkg.startsWith("$s.") }
+                    },
+                    progression = progression,
+                    equipmentSlotRegistry = defaultSlotRegistry,
+                    sanctumRoomId = { sanctum },
+                )
+            val sanctumRoom = Room(id = sanctum, title = "Sanctum", description = "Quiet.", exits = emptyMap())
+            e.sendRoomInfo(sid, sanctumRoom, lastDeathZone = "forest")
+            val data = drainGmcp().single()
+            assertTrue(data.jsonData.contains("\"canDepart\":true"))
+        }
+
+    @Test
+    fun `sendRoomInfo emits canDepart=false when at sanctum but no death recorded`() =
+        runTest {
+            val sanctum = RoomId("hub:sanctum")
+            val packages = setOf("Room.Info")
+            val e =
+                GmcpEmitter(
+                    outbound = outbound,
+                    supportsPackage = { _, pkg ->
+                        packages.any { s -> pkg == s || pkg.startsWith("$s.") }
+                    },
+                    progression = progression,
+                    equipmentSlotRegistry = defaultSlotRegistry,
+                    sanctumRoomId = { sanctum },
+                )
+            val sanctumRoom = Room(id = sanctum, title = "Sanctum", description = "Quiet.", exits = emptyMap())
+            e.sendRoomInfo(sid, sanctumRoom, lastDeathZone = null)
+            val data = drainGmcp().single()
+            assertTrue(data.jsonData.contains("\"canDepart\":false"))
+        }
+
+    @Test
+    fun `sendRoomInfo emits canDepart=false when not at sanctum even with lastDeathZone`() =
+        runTest {
+            val sanctum = RoomId("hub:sanctum")
+            val packages = setOf("Room.Info")
+            val e =
+                GmcpEmitter(
+                    outbound = outbound,
+                    supportsPackage = { _, pkg ->
+                        packages.any { s -> pkg == s || pkg.startsWith("$s.") }
+                    },
+                    progression = progression,
+                    equipmentSlotRegistry = defaultSlotRegistry,
+                    sanctumRoomId = { sanctum },
+                )
+            e.sendRoomInfo(sid, room(), lastDeathZone = "forest")
+            val data = drainGmcp().single()
+            assertTrue(data.jsonData.contains("\"canDepart\":false"))
+        }
+
+    @Test
     fun `sendRoomInfo JSON-escapes special characters`() =
         runTest {
             val e = emitter("Room.Info")

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -1008,6 +1008,19 @@ function App() {
                 </>
               )}
             </div>
+            {state.room.canDepart && (
+              <div className="room-popout-depart">
+                <button
+                  type="button"
+                  className="room-depart-btn"
+                  title="Return to where you fell"
+                  aria-label="Depart from the sanctum"
+                  onClick={() => sendCommand("depart")}
+                >
+                  Depart through the spirit gate
+                </button>
+              </div>
+            )}
             {(state.room.station || state.craftingNodes.length > 0) && (
               <div className="room-resources-section">
                 {state.room.station && (

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -331,6 +331,7 @@ export function applyGmcpPackage(
       const dungeon = packet.dungeon === true;
       const auction = packet.auction === true;
       const housingBroker = packet.housingBroker === true;
+      const canDepart = packet.canDepart === true;
 
       // Detect actual room change (not just a look/refresh of the same room)
       ctx.setRoom((prev) => {
@@ -343,7 +344,7 @@ export function applyGmcpPackage(
           ctx.setQuestsAvailable([]);
           ctx.setTrainer(null);
         }
-        return { id, title, description, exits, image, video, music, ambient, station, trainer, mapX, mapY, housing, housingOwner, graphical, terrain, bank, stylist, tavern, dungeon, auction, housingBroker };
+        return { id, title, description, exits, image, video, music, ambient, station, trainer, mapX, mapY, housing, housingOwner, graphical, terrain, bank, stylist, tavern, dungeon, auction, housingBroker, canDepart };
       });
 
       if (id) {

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -9514,6 +9514,45 @@ body {
     0 0 0 4px rgb(216 197 232 / 30%);
 }
 
+.room-popout-depart {
+  margin-top: var(--space-3);
+  display: flex;
+  justify-content: center;
+}
+
+.room-depart-btn {
+  padding: 10px 20px;
+  border: 1px solid color-mix(in srgb, var(--color-accent-lavender, #a897d2) 60%, transparent);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--color-accent-lavender, #a897d2) 22%, var(--bg-surface));
+  color: var(--text-bright);
+  font-family: var(--font-body);
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  box-shadow: 0 0 18px color-mix(in srgb, var(--color-accent-lavender, #a897d2) 35%, transparent);
+  transition:
+    background 200ms var(--ease-out-soft),
+    border-color 200ms var(--ease-out-soft),
+    box-shadow 200ms var(--ease-out-soft),
+    transform 200ms var(--ease-out-soft);
+}
+
+.room-depart-btn:hover {
+  background: color-mix(in srgb, var(--color-accent-lavender, #a897d2) 38%, var(--bg-surface));
+  border-color: var(--color-accent-lavender, #a897d2);
+  box-shadow: 0 0 26px color-mix(in srgb, var(--color-accent-lavender, #a897d2) 55%, transparent);
+  transform: translateY(-1px);
+}
+
+.room-depart-btn:focus-visible {
+  outline: 2px solid transparent;
+  box-shadow:
+    0 0 0 2px color-mix(in srgb, var(--color-accent-lavender, #a897d2) 75%, transparent),
+    0 0 24px color-mix(in srgb, var(--color-accent-lavender, #a897d2) 55%, transparent);
+}
+
 /* Room resources section (gathering nodes + crafting stations) */
 
 .room-resources-section {

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -218,6 +218,8 @@ export interface RoomState {
   dungeon?: boolean;
   auction?: boolean;
   housingBroker?: boolean;
+  /** True when this is the death sanctum and the player has somewhere to depart back to. */
+  canDepart?: boolean;
 }
 
 /** User layout preference: auto follows zone flag, text/canvas force a mode. */


### PR DESCRIPTION
## Summary

The `depart` command was already implemented server-side (`NavigationHandler.kt:286-329`), but the web client had no UI affordance — a player who died had to know to type `depart` into the input box. This PR adds a visible button.

- Added `canDepart` to the `Room.Info` GMCP payload. It is `true` when the player is at the configured sanctum room **and** has a `lastDeathZone` recorded.
- Wired `sanctumRoomId` lookup into `GmcpEmitter` and updated the three `sendRoomInfo` callers (`HandlerHelpers.sendLook`, `GmcpEventHandler` Core.Supports.Set sync, `HotReloadManager` refresh) to pass `lastDeathZone`.
- Web client extracts `canDepart` from the packet, threads it through `RoomState`, and renders a "Depart through the spirit gate" button in the room popout when true.
- Three new `GmcpEmitterTest` cases covering the on/off/wrong-room conditions.

## Test plan

- [x] `./gradlew ktlintCheck` clean
- [x] `./gradlew test` clean (full suite)
- [x] `bun run lint` and `bun run build` clean in `web-v3/`
- [ ] Manual: die in-game on web client, verify button appears at sanctum and disappears after departing