### PR TITLE
Decouple talk from quest offers; add GMCP-driven offer surface

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -1080,9 +1080,28 @@ class GmcpEmitter(
                 description = q.description,
                 giverMobId = q.giverMobId,
                 objectives = q.objectives.map { o ->
-                    QuestAvailableObjectivePayload(description = o.description, count = o.count)
+                    QuestAvailableObjectivePayload(
+                        description = o.description,
+                        count = o.count,
+                        current = o.current,
+                    )
                 },
-                rewards = QuestAvailableRewardsPayload(xp = q.rewardXp, gold = q.rewardGold),
+                rewards = QuestAvailableRewardsPayload(
+                    xp = q.rewardXp,
+                    gold = q.rewardGold,
+                    currencies = q.rewardCurrencies,
+                ),
+                levelRequired = q.levelRequired,
+                reputationRequired = q.reputationRequired?.let { rep ->
+                    QuestReputationPayload(
+                        faction = rep.faction,
+                        factionName = rep.factionName,
+                        min = rep.min,
+                        max = rep.max,
+                    )
+                },
+                readyToTurnIn = q.readyToTurnIn,
+                lockedReason = q.lockedReason,
             )
         }
         emit(sessionId, "Quest.Available", payload, supportCheck = "Quest")
@@ -2625,16 +2644,29 @@ class GmcpEmitter(
         val giverMobId: String,
         val objectives: List<QuestAvailableObjectivePayload>,
         val rewards: QuestAvailableRewardsPayload,
+        val levelRequired: Int?,
+        val reputationRequired: QuestReputationPayload?,
+        val readyToTurnIn: Boolean,
+        val lockedReason: String?,
     )
 
     private data class QuestAvailableObjectivePayload(
         val description: String,
         val count: Int,
+        val current: Int,
     )
 
     private data class QuestAvailableRewardsPayload(
         val xp: Long,
         val gold: Long,
+        val currencies: Map<String, Long>,
+    )
+
+    private data class QuestReputationPayload(
+        val faction: String,
+        val factionName: String,
+        val min: Int?,
+        val max: Int?,
     )
 
     // ---------- daily / weekly quest payloads ----------
@@ -3394,11 +3426,24 @@ data class QuestAvailableEntry(
     val objectives: List<QuestAvailableObjectiveSummary>,
     val rewardXp: Long,
     val rewardGold: Long,
+    val rewardCurrencies: Map<String, Long> = emptyMap(),
+    val levelRequired: Int? = null,
+    val reputationRequired: ReputationRequirementSummary? = null,
+    val readyToTurnIn: Boolean = false,
+    val lockedReason: String? = null,
 )
 
 data class QuestAvailableObjectiveSummary(
     val description: String,
     val count: Int,
+    val current: Int = 0,
+)
+
+data class ReputationRequirementSummary(
+    val faction: String,
+    val factionName: String,
+    val min: Int? = null,
+    val max: Int? = null,
 )
 
 data class MobInfoEntry(

--- a/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
@@ -105,6 +105,82 @@ class QuestSystem(
         return state.objectives.all { it.isComplete }
     }
 
+    /**
+     * Builds the full Quest.Available payload for a single NPC: quests this mob
+     * offers that are acceptable now, quests it offers that are blocked by a
+     * reputation gate (with a [QuestAvailableEntry.lockedReason] explaining
+     * why), and active quests already accepted from this mob whose objectives
+     * are complete and ready to turn in here.
+     *
+     * Pass an empty result to the client to dismiss any open quest panel.
+     */
+    fun questOffersFor(
+        sessionId: SessionId,
+        mobId: String,
+    ): List<QuestAvailableEntry> {
+        val ps = players.get(sessionId) ?: return emptyList()
+        val entries = mutableListOf<QuestAvailableEntry>()
+        for (quest in registry.questsForMob(mobId)) {
+            if (ps.completedQuestIds.contains(quest.id)) continue
+            if (exceedsRepMax(ps, quest)) continue // disappears entirely
+            val activeState = ps.activeQuests[quest.id]
+            if (activeState != null) {
+                if (isReadyToTurnIn(quest, activeState)) {
+                    entries.add(buildEntry(quest, ps, activeState, lockedReason = null))
+                }
+                continue
+            }
+            val locked = lockedReasonFor(ps, quest)
+            entries.add(buildEntry(quest, ps, state = null, lockedReason = locked))
+        }
+        return entries
+    }
+
+    private fun lockedReasonFor(ps: PlayerState, quest: QuestDef): String? {
+        if (belowRepMin(ps, quest)) {
+            val req = quest.requiredReputation!!
+            val name = reputationSystem?.getFaction(req.faction)?.name ?: req.faction
+            return "Requires standing with $name."
+        }
+        return null
+    }
+
+    private fun buildEntry(
+        quest: QuestDef,
+        ps: PlayerState,
+        state: QuestState?,
+        lockedReason: String?,
+    ): QuestAvailableEntry {
+        val rep = quest.requiredReputation?.let { req ->
+            ReputationRequirementSummary(
+                faction = req.faction,
+                factionName = reputationSystem?.getFaction(req.faction)?.name ?: req.faction,
+                min = req.min,
+                max = req.max,
+            )
+        }
+        return QuestAvailableEntry(
+            id = quest.id,
+            name = quest.name,
+            description = quest.description,
+            giverMobId = quest.giverMobId,
+            objectives = quest.objectives.mapIndexed { index, obj ->
+                QuestAvailableObjectiveSummary(
+                    description = obj.description,
+                    count = obj.count,
+                    current = state?.objectives?.getOrNull(index)?.current ?: 0,
+                )
+            },
+            rewardXp = quest.rewards.xp,
+            rewardGold = quest.rewards.gold,
+            rewardCurrencies = quest.rewards.currencies,
+            levelRequired = quest.level,
+            reputationRequired = rep,
+            readyToTurnIn = state != null && isReadyToTurnIn(quest, state),
+            lockedReason = lockedReason,
+        )
+    }
+
     /** Returns mob IDs that offer quests the player can accept. */
     fun questAvailableMobIds(sessionId: SessionId, mobIds: Collection<String>): Set<String> {
         val ps = players.get(sessionId) ?: return emptySet()
@@ -229,6 +305,31 @@ class QuestSystem(
             ?: return "No active quest matching '$nameHint'."
         val quest = registry.get(questId) ?: return "Quest data not found."
         val state = ps.activeQuests[questId] ?: return "Quest not active."
+        val handler = completionHandlers.get(quest.completionType)
+        if (handler == null || !handler.requiresNpcTurnIn) {
+            return "That quest does not require a turn-in."
+        }
+        if (!state.objectives.all { it.isComplete }) {
+            return "You haven't finished that quest yet."
+        }
+        if (quest.giverMobId !in mobIdsInRoom) {
+            return "The quest-giver isn't here. Return to them to turn this in."
+        }
+        completeQuest(sessionId, questId, quest.rewards)
+        return null
+    }
+
+    /**
+     * Turn in a quest by id. Returns an error string, or null on success.
+     */
+    suspend fun turnInQuestById(
+        sessionId: SessionId,
+        questId: String,
+        mobIdsInRoom: Collection<String>,
+    ): String? {
+        val ps = players.get(sessionId) ?: return ERR_NOT_CONNECTED
+        val quest = registry.get(questId) ?: return "Unknown quest '$questId'."
+        val state = ps.activeQuests[questId] ?: return "You haven't accepted that quest."
         val handler = completionHandlers.get(quest.completionType)
         if (handler == null || !handler.requiresNpcTurnIn) {
             return "That quest does not require a turn-in."

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -389,8 +389,20 @@ sealed interface Command {
         val nameHint: String,
     ) : Command
 
+    data class QuestAcceptById(
+        val questId: String,
+    ) : Command
+
     data class QuestTurnIn(
         val nameHint: String,
+    ) : Command
+
+    data class QuestTurnInById(
+        val questId: String,
+    ) : Command
+
+    data class QuestOffers(
+        val mobKeyword: String,
     ) : Command
 
     data object DailyQuests : Command
@@ -1373,8 +1385,17 @@ object CommandParser {
             Command.Phase(rest.trim().ifEmpty { null })
         }?.let { return it }
 
-        // accept: "accept <quest-name>" (for accepting quests offered by NPCs)
-        requiredArg(line, listOf("accept"), "accept <quest>", { Command.QuestAccept(it) })?.let { return it }
+        // accept: "accept <quest-name>" (for accepting quests offered by NPCs).
+        // "accept #<quest-id>" routes to the by-id variant — used by the web client
+        // to disambiguate against quests with the same name.
+        requiredArg(line, listOf("accept"), "accept <quest>") { rest ->
+            if (rest.startsWith("#")) {
+                val id = rest.removePrefix("#").trim()
+                if (id.isEmpty()) Command.Invalid(line, "accept #<quest-id>") else Command.QuestAcceptById(id)
+            } else {
+                Command.QuestAccept(rest)
+            }
+        }?.let { return it }
 
         // daily/weekly quest board
         matchPrefix(line, listOf("daily", "dailies")) { Command.DailyQuests }?.let { return it }
@@ -1390,7 +1411,12 @@ object CommandParser {
             }
         }?.let { return it }
 
+        // qoffers: "qoffers <mob>" — request the quest offer panel for an NPC
+        // (web client uses this when the player taps the Quest button on a mob).
+        requiredArg(line, listOf("qoffers"), "qoffers <mob>") { Command.QuestOffers(it) }?.let { return it }
+
         // quest subcommands: "quest log", "quest info <name>", "quest abandon <name>",
+        // "quest offers <mob>", "quest turnin <name|#id>",
         // "quest auto" / "quest auto info" / "quest auto abandon",
         // "quest request" as alias for "quest auto"
         // also "quests" as alias for "quest log"
@@ -1409,7 +1435,22 @@ object CommandParser {
                 }
                 "turnin", "complete", "finish" -> {
                     val hint = parts.getOrNull(1)?.trim() ?: ""
-                    if (hint.isEmpty()) Command.Invalid(line, "quest turnin <quest-name>") else Command.QuestTurnIn(hint)
+                    when {
+                        hint.isEmpty() -> Command.Invalid(line, "quest turnin <quest-name>")
+                        hint.startsWith("#") -> {
+                            val id = hint.removePrefix("#").trim()
+                            if (id.isEmpty()) {
+                                Command.Invalid(line, "quest turnin #<quest-id>")
+                            } else {
+                                Command.QuestTurnInById(id)
+                            }
+                        }
+                        else -> Command.QuestTurnIn(hint)
+                    }
+                }
+                "offers", "offering", "offer" -> {
+                    val hint = parts.getOrNull(1)?.trim() ?: ""
+                    if (hint.isEmpty()) Command.Invalid(line, "quest offers <mob>") else Command.QuestOffers(hint)
                 }
                 "auto", "request" -> {
                     val sub = parts.getOrNull(1)?.trim()?.lowercase() ?: ""

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestHandler.kt
@@ -5,8 +5,6 @@ import dev.ambon.engine.AchievementRegistry
 import dev.ambon.engine.AchievementSystem
 import dev.ambon.engine.HouseEntryResult
 import dev.ambon.engine.HousingSystem
-import dev.ambon.engine.QuestAvailableEntry
-import dev.ambon.engine.QuestAvailableObjectiveSummary
 import dev.ambon.engine.QuestRegistry
 import dev.ambon.engine.QuestSystem
 import dev.ambon.engine.commands.Command
@@ -28,7 +26,6 @@ class DialogueQuestHandler(
 ) : CommandHandler {
     private val players = ctx.players
     private val mobs = ctx.mobs
-    private val world = ctx.world
     private val outbound = ctx.outbound
     private val gmcpEmitter = ctx.gmcpEmitter
 
@@ -40,7 +37,10 @@ class DialogueQuestHandler(
         router.on<Command.QuestInfo> { sid, cmd -> handleQuestInfo(sid, cmd) }
         router.on<Command.QuestAbandon> { sid, cmd -> handleQuestAbandon(sid, cmd) }
         router.on<Command.QuestAccept> { sid, cmd -> handleQuestAccept(sid, cmd) }
+        router.on<Command.QuestAcceptById> { sid, cmd -> handleQuestAcceptById(sid, cmd) }
         router.on<Command.QuestTurnIn> { sid, cmd -> handleQuestTurnIn(sid, cmd) }
+        router.on<Command.QuestTurnInById> { sid, cmd -> handleQuestTurnInById(sid, cmd) }
+        router.on<Command.QuestOffers> { sid, cmd -> handleQuestOffers(sid, cmd) }
         router.on<Command.AchievementList> { sid, _ -> handleAchievementList(sid) }
         router.on<Command.TitleSet> { sid, cmd -> handleTitleSet(sid, cmd) }
         router.on<Command.TitleClear> { sid, _ -> handleTitleClear(sid) }
@@ -50,60 +50,40 @@ class DialogueQuestHandler(
         sessionId: SessionId,
         cmd: Command.Talk,
     ) {
-        val me = players.get(sessionId)
         if (dialogueSystem == null) {
             outbound.send(OutboundEvent.SendError(sessionId, "Nobody here wants to talk."))
             return
         }
         outbound.sendIfError(sessionId, dialogueSystem.startConversation(sessionId, cmd.target))
-        if (questSystem != null && me != null) {
-            val mob = mobs.findInRoomByKeyword(me.roomId, cmd.target.trim()).firstOrNull()
-            if (mob != null) {
-                val readyForTurnIn = me.activeQuests
-                    .mapNotNull { (qid, state) ->
-                        val def = questRegistry.get(qid) ?: return@mapNotNull null
-                        if (def.giverMobId != mob.id.value) return@mapNotNull null
-                        if (!questSystem.isReadyToTurnIn(def, state)) return@mapNotNull null
-                        def
-                    }
-                for (quest in readyForTurnIn) {
-                    outbound.send(OutboundEvent.SendText(sessionId, "[Quest] ${quest.name} — ready to turn in."))
-                    outbound.send(OutboundEvent.SendText(sessionId, "  Type 'quest turnin ${quest.name}' to complete."))
-                }
-                val available = questSystem.availableQuests(sessionId, mob.id.value)
-                for (quest in available) {
-                    outbound.send(OutboundEvent.SendText(sessionId, "[Quest] ${quest.name} — ${quest.description}"))
-                    outbound.send(OutboundEvent.SendText(sessionId, "  Type 'accept ${quest.name}' to accept."))
-                }
-                for (quest in questSystem.hintedQuests(sessionId, mob.id.value)) {
-                    outbound.send(
-                        OutboundEvent.SendText(
-                            sessionId,
-                            "[Quest] ${quest.name} — your standing is too low to take this on yet.",
-                        ),
-                    )
-                }
-                gmcpEmitter?.sendQuestAvailable(
-                    sessionId,
-                    available.map { quest ->
-                        QuestAvailableEntry(
-                            id = quest.id,
-                            name = quest.name,
-                            description = quest.description,
-                            giverMobId = quest.giverMobId,
-                            objectives = quest.objectives.map { obj ->
-                                QuestAvailableObjectiveSummary(
-                                    description = obj.description,
-                                    count = obj.count,
-                                )
-                            },
-                            rewardXp = quest.rewards.xp,
-                            rewardGold = quest.rewards.gold,
-                        )
-                    },
-                )
-            }
+    }
+
+    private suspend fun handleQuestOffers(
+        sessionId: SessionId,
+        cmd: Command.QuestOffers,
+    ) {
+        val qs = requireSystemOrNull(sessionId, questSystem, "Quests", outbound) ?: return
+        val me = players.get(sessionId) ?: return
+        val mob = mobs.findInRoomByKeyword(me.roomId, cmd.mobKeyword.trim()).firstOrNull()
+        if (mob == null) {
+            outbound.send(OutboundEvent.SendError(sessionId, "You don't see anyone like that here."))
+            return
         }
+        val offers = qs.questOffersFor(sessionId, mob.id.value)
+        if (offers.isEmpty()) {
+            outbound.send(OutboundEvent.SendInfo(sessionId, "${mob.name} has no quests for you."))
+            // Still emit so the client can dismiss any open panel.
+            gmcpEmitter?.sendQuestAvailable(sessionId, emptyList())
+            return
+        }
+        for (entry in offers) {
+            val tag = when {
+                entry.readyToTurnIn -> "ready to turn in"
+                entry.lockedReason != null -> entry.lockedReason
+                else -> entry.description
+            }
+            outbound.send(OutboundEvent.SendText(sessionId, "[Quest] ${entry.name} — $tag"))
+        }
+        gmcpEmitter?.sendQuestAvailable(sessionId, offers)
     }
 
     private suspend fun handleDialogueChoice(
@@ -199,23 +179,13 @@ class DialogueQuestHandler(
         players.withPlayer(sessionId) { me ->
             val nameHintLower = cmd.nameHint.trim().lowercase()
             val roomMobIds = mobs.mobsInRoom(me.roomId).map { it.id.value }.toSet()
-            // First try matching the hint against quest names/ids.
-            var matchingQuest =
+            val matchingQuest =
                 questRegistry
                     .all()
                     .filter { quest ->
                         quest.name.lowercase().contains(nameHintLower) ||
                             quest.id.substringAfterLast(':').lowercase().contains(nameHintLower)
                     }.firstOrNull { quest -> quest.giverMobId in roomMobIds }
-            // Fall back to matching the hint against a room mob — pick the first
-            // quest that mob currently offers the player. This lets clients invoke
-            // `accept <mob>` straight from a popout without first opening dialogue.
-            if (matchingQuest == null) {
-                val mobMatch = mobs.findInRoomByKeyword(me.roomId, cmd.nameHint.trim()).firstOrNull()
-                if (mobMatch != null) {
-                    matchingQuest = qs.availableQuests(sessionId, mobMatch.id.value).firstOrNull()
-                }
-            }
             if (matchingQuest == null) {
                 outbound.send(
                     OutboundEvent.SendError(
@@ -229,6 +199,25 @@ class DialogueQuestHandler(
         }
     }
 
+    private suspend fun handleQuestAcceptById(
+        sessionId: SessionId,
+        cmd: Command.QuestAcceptById,
+    ) {
+        val qs = requireSystemOrNull(sessionId, questSystem, "Quests", outbound) ?: return
+        val me = players.get(sessionId) ?: return
+        val quest = questRegistry.get(cmd.questId)
+        if (quest == null) {
+            outbound.send(OutboundEvent.SendError(sessionId, "Unknown quest '${cmd.questId}'."))
+            return
+        }
+        val roomMobIds = mobs.mobsInRoom(me.roomId).map { it.id.value }.toSet()
+        if (quest.giverMobId !in roomMobIds) {
+            outbound.send(OutboundEvent.SendError(sessionId, "The quest-giver isn't here."))
+            return
+        }
+        outbound.sendIfError(sessionId, qs.acceptQuest(sessionId, cmd.questId))
+    }
+
     private suspend fun handleQuestTurnIn(
         sessionId: SessionId,
         cmd: Command.QuestTurnIn,
@@ -237,6 +226,16 @@ class DialogueQuestHandler(
         val me = players.get(sessionId) ?: return
         val roomMobIds = mobs.mobsInRoom(me.roomId).map { it.id.value }
         outbound.sendIfError(sessionId, qs.turnInQuest(sessionId, cmd.nameHint, roomMobIds))
+    }
+
+    private suspend fun handleQuestTurnInById(
+        sessionId: SessionId,
+        cmd: Command.QuestTurnInById,
+    ) {
+        val qs = requireSystemOrNull(sessionId, questSystem, "Quests", outbound) ?: return
+        val me = players.get(sessionId) ?: return
+        val roomMobIds = mobs.mobsInRoom(me.roomId).map { it.id.value }
+        outbound.sendIfError(sessionId, qs.turnInQuestById(sessionId, cmd.questId, roomMobIds))
     }
 
     private suspend fun handleAchievementList(sessionId: SessionId) {

--- a/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
@@ -843,6 +843,88 @@ class QuestSystemTest {
         }
 
     @Test
+    fun `turnInQuestById turns in by id with giver in room`() =
+        runTest {
+            val turnInQuest = killQuest.copy(completionType = "npc_turn_in")
+            val (qs, players, _) = setup(turnInQuest)
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Hero")
+
+            qs.acceptQuest(sid, questId)
+            repeat(3) { qs.onMobKilled(sid, mobTemplateKey) }
+
+            val notHere = qs.turnInQuestById(sid, questId, emptyList())
+            assertNotNull(notHere)
+
+            val ok = qs.turnInQuestById(sid, questId, listOf("zone:quest_giver"))
+            assertNull(ok)
+            assertTrue(players.get(sid)!!.completedQuestIds.contains(questId))
+        }
+
+    @Test
+    fun `turnInQuestById rejects unknown quest id`() =
+        runTest {
+            val (qs, players, _) = setup()
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Hero")
+            val err = qs.turnInQuestById(sid, "zone:does_not_exist", listOf("zone:quest_giver"))
+            assertNotNull(err)
+        }
+
+    @Test
+    fun `questOffersFor returns acceptable quests with full reward and gate metadata`() =
+        runTest {
+            val turnInQuest = killQuest.copy(completionType = "npc_turn_in", level = 5)
+            val (qs, players, _) = setup(turnInQuest)
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Hero")
+
+            val offers = qs.questOffersFor(sid, "zone:quest_giver")
+            assertEquals(1, offers.size)
+            val entry = offers.single()
+            assertEquals(questId, entry.id)
+            assertEquals(100L, entry.rewardXp)
+            assertEquals(20L, entry.rewardGold)
+            assertEquals(5, entry.levelRequired)
+            assertNull(entry.lockedReason)
+            assertFalse(entry.readyToTurnIn)
+        }
+
+    @Test
+    fun `questOffersFor surfaces ready-to-turn-in active quests`() =
+        runTest {
+            val turnInQuest = killQuest.copy(completionType = "npc_turn_in")
+            val (qs, players, _) = setup(turnInQuest)
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Hero")
+
+            qs.acceptQuest(sid, questId)
+            repeat(3) { qs.onMobKilled(sid, mobTemplateKey) }
+
+            val offers = qs.questOffersFor(sid, "zone:quest_giver")
+            assertEquals(1, offers.size)
+            val entry = offers.single()
+            assertTrue(entry.readyToTurnIn, "expected readyToTurnIn=true once objectives complete")
+            assertEquals(3, entry.objectives.single().current)
+        }
+
+    @Test
+    fun `questOffersFor hides completed quests`() =
+        runTest {
+            val turnInQuest = killQuest.copy(completionType = "npc_turn_in")
+            val (qs, players, _) = setup(turnInQuest)
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Hero")
+
+            qs.acceptQuest(sid, questId)
+            repeat(3) { qs.onMobKilled(sid, mobTemplateKey) }
+            qs.turnInQuestById(sid, questId, listOf("zone:quest_giver"))
+
+            val offers = qs.questOffersFor(sid, "zone:quest_giver")
+            assertTrue(offers.isEmpty(), "expected no offers after completion")
+        }
+
+    @Test
     fun `isReadyToTurnIn reflects completion handler and objectives`() =
         runTest {
             val turnInQuest = killQuest.copy(completionType = "npc_turn_in")

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
@@ -935,6 +935,50 @@ class CommandParserTest {
         assertEquals(Command.WeeklyQuests, CommandParser.parse("weekly"))
     }
 
+    // ── Quest accept / turn-in / offers ──────────────────────────────────
+
+    @Test
+    fun `accept by name hint parses to QuestAccept`() {
+        assertEquals(Command.QuestAccept("grand tour"), CommandParser.parse("accept grand tour"))
+    }
+
+    @Test
+    fun `accept hash id parses to QuestAcceptById`() {
+        assertEquals(
+            Command.QuestAcceptById("academy:grand_tour"),
+            CommandParser.parse("accept #academy:grand_tour"),
+        )
+    }
+
+    @Test
+    fun `accept blank hash is invalid`() {
+        val cmd = CommandParser.parse("accept #")
+        assertTrue(cmd is Command.Invalid, "expected Invalid, got $cmd")
+    }
+
+    @Test
+    fun `quest turnin by name hint parses to QuestTurnIn`() {
+        assertEquals(Command.QuestTurnIn("grand tour"), CommandParser.parse("quest turnin grand tour"))
+    }
+
+    @Test
+    fun `quest turnin hash id parses to QuestTurnInById`() {
+        assertEquals(
+            Command.QuestTurnInById("academy:grand_tour"),
+            CommandParser.parse("quest turnin #academy:grand_tour"),
+        )
+    }
+
+    @Test
+    fun `quest offers parses to QuestOffers`() {
+        assertEquals(Command.QuestOffers("aldric"), CommandParser.parse("quest offers aldric"))
+    }
+
+    @Test
+    fun `qoffers alias parses to QuestOffers`() {
+        assertEquals(Command.QuestOffers("aldric"), CommandParser.parse("qoffers aldric"))
+    }
+
     // ── Auto-quest / bounty commands ─────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

First of three PRs that fully separate dialogue from quest interactions in the web client. Today, `talk <npc>` emits both `Dialogue.Node` and `Quest.Available` side-by-side, and the dialogue overlay renders quest cards inline — coupling that forced the recent `accept <mob>` mob-keyword fallback as a workaround. This PR cuts the server-side coupling and gives the client a dedicated, richer GMCP surface to drive a separate quest offer panel.

- **Talk emits dialogue only.** `DialogueQuestHandler.handleTalk` no longer surfaces quest text or `Quest.Available`.
- **New `quest offers <mob>` / `qoffers <mob>` command.** Returns `Quest.Available` for that NPC, including acceptable quests, quests gated by reputation (with `lockedReason`), and active quests already accepted from this mob that are now ready to turn in.
- **Id-keyed accept/turn-in.** `accept #<questId>` (`QuestAcceptById`) and `quest turnin #<questId>` (`QuestTurnInById`) skip name matching — the web client uses these. The mob-keyword fallback added in `a7da1af2` is removed; no longer needed.
- **`Quest.Available` payload gains:** `levelRequired`, `reputationRequired{faction, factionName, min, max}`, `readyToTurnIn`, `lockedReason`, full `rewards{xp, gold, currencies}`, and per-objective `current` progress.
- `MobInfoEntry.dialogue` already existed; no canvas changes here.

The web-client UX split (PR 2) and dialogue-flag gating + flexible turn-in NPC (PR 3) follow.

## Test plan

- [x] `./gradlew ktlintCheck`
- [x] `./gradlew test` (full unit suite)
- [x] New parser tests cover `accept`/`accept #id`, `quest turnin`/`quest turnin #id`, `quest offers`, `qoffers`, blank `accept #`.
- [x] New `QuestSystem` tests cover `turnInQuestById` (happy + unknown-id), and `questOffersFor` (acceptable, ready-to-turn-in, hidden-when-completed).
- [ ] Manual: telnet `talk <npc>` shows dialogue only; `qoffers <npc>` lists offers with new fields; `accept #<id>` and `quest turnin #<id>` route correctly.