### PR TITLE
Web: split Talk and Quest into separate UX flows

### DIFF
--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -11,6 +11,7 @@ import { ChatPanel } from "./components/panels/ChatPanel";
 import { CharacterPanel } from "./components/panels/CharacterPanel";
 import { SpellbookPanel } from "./components/SpellbookPanel";
 import { QuestPanel } from "./components/panels/QuestPanel";
+import { QuestOfferPanel } from "./components/panels/QuestOfferPanel";
 import { InventoryPanel } from "./components/panels/InventoryPanel";
 import { EquipmentPanel } from "./components/panels/EquipmentPanel";
 import { MailPanel } from "./components/panels/MailPanel";
@@ -359,7 +360,10 @@ function App() {
       // input would still resolve to a DialogueChoice on the server.
       if (gameStateRef.current.dialogue) sendCommand("bye");
       state.setDialogue(null);
-      state.setQuestsAvailable([]);
+    };
+    canvasCallbacks.openQuestOffers = (mobKeyword: string) => {
+      sendCommand(`qoffers ${mobKeyword}`);
+      openPanel("questOffers");
     };
     canvasCallbacks.openVideo = (url: string) => setVideoUrl(url);
     canvasCallbacks.prefillCommand = (text: string) => prefillInput(text);
@@ -380,6 +384,7 @@ function App() {
       canvasCallbacks.openRoom = null;
       canvasCallbacks.openQuests = null;
       canvasCallbacks.dismissDialogue = null;
+      canvasCallbacks.openQuestOffers = null;
       canvasCallbacks.openVideo = null;
       canvasCallbacks.prefillCommand = null;
     };
@@ -625,6 +630,7 @@ function App() {
       case "equipment": return "Equipment";
       case "spellbook": return "Spellbook";
       case "quests": return "Quests";
+      case "questOffers": return "Quest Offers";
       case "chat": return "Social";
       case "shop": return state.shop?.name ?? "Shop";
       case "puzzle": return "Puzzle";
@@ -889,6 +895,15 @@ function App() {
             onAbandonQuest={(name) => sendCommand(`quest abandon ${name}`)}
             onAcceptQuest={(name) => sendCommand(`accept ${name}`)}
             onCommand={sendCommand}
+          />
+        )}
+
+        {drawerPanel === "questOffers" && (
+          <QuestOfferPanel
+            connected={connected}
+            questsAvailable={state.questsAvailable}
+            onAcceptQuest={(questId) => sendCommand(`accept #${questId}`)}
+            onTurnInQuest={(questId) => sendCommand(`quest turnin #${questId}`)}
           />
         )}
 

--- a/web-v3/src/canvas/GameStateBridge.ts
+++ b/web-v3/src/canvas/GameStateBridge.ts
@@ -79,6 +79,7 @@ export const canvasCallbacks: {
   onTargetSelected: ((targetName: string) => void) | null;
   openVideo: ((videoUrl: string) => void) | null;
   dismissDialogue: (() => void) | null;
+  openQuestOffers: ((mobKeyword: string) => void) | null;
   loadZoneMap: ((zone: string, rooms: Array<{ id: string; x: number; y: number; exits: Record<string, string> }>) => void) | null;
 } = {
   sendCommand: null,
@@ -100,6 +101,7 @@ export const canvasCallbacks: {
   onTargetSelected: null,
   openVideo: null,
   dismissDialogue: null,
+  openQuestOffers: null,
   loadZoneMap: null,
 };
 

--- a/web-v3/src/canvas/systems/DialogueOverlay.ts
+++ b/web-v3/src/canvas/systems/DialogueOverlay.ts
@@ -1,6 +1,6 @@
 import { Container, Graphics, Text } from "pixi.js";
 import { gameStateRef, canvasCallbacks } from "../GameStateBridge";
-import type { DialogueState, QuestAvailable } from "../../types";
+import type { DialogueState } from "../../types";
 
 const BOX_PADDING = 16;
 const CHOICE_HEIGHT = 28;
@@ -11,21 +11,6 @@ const TEXT_COLOR = "#d8dcef";
 const CHOICE_COLOR = "#b9aed8";
 const CHOICE_HOVER_COLOR = "#d8dcef";
 const ENDING_COLOR = "#6f7da1";
-
-// Quest card colors
-const QUEST_CARD_BG = 0x1a2235;
-const QUEST_CARD_BORDER = 0x5a8a6a;
-const QUEST_TITLE_COLOR = "#8abeb7";
-const QUEST_DESC_COLOR = "#a0a8c0";
-const QUEST_OBJ_COLOR = "#9098b0";
-const QUEST_REWARD_COLOR = "#f0c674";
-const QUEST_ACCEPT_BG = 0x2a5a3a;
-const QUEST_ACCEPT_HOVER_BG = 0x3a7a4a;
-const QUEST_ACCEPT_TEXT_COLOR = "#d8dcef";
-
-const QUEST_CARD_PADDING = 10;
-const QUEST_CARD_GAP = 10;
-const QUEST_SEPARATOR_GAP = 12;
 
 export class DialogueOverlay {
   readonly container = new Container();
@@ -39,7 +24,6 @@ export class DialogueOverlay {
   private bodyText: Text;
   private choiceTexts: Text[] = [];
   private endingText: Text | null = null;
-  private questElements: Container[] = [];
 
   private dismissHint: Text | null = null;
   private lastDialogueKey: string | null = null;
@@ -104,9 +88,8 @@ export class DialogueOverlay {
   update() {
     const state = gameStateRef.current;
     const dialogue = state.dialogue;
-    const hasQuestOffers = state.questsAvailable.length > 0;
 
-    if (!dialogue && !hasQuestOffers) {
+    if (!dialogue) {
       this.container.visible = false;
       this.fullBg.visible = false;
       this.fullBg.eventMode = "none";
@@ -116,18 +99,14 @@ export class DialogueOverlay {
 
     this.container.visible = true;
 
-    const questIds = state.questsAvailable.map((q) => q.id).join(",");
-    const dialogueKey = dialogue
-      ? `${dialogue.mobName}:${dialogue.text}:${dialogue.choices.map((c) => c.text).join("|")}`
-      : "no-dialogue";
-    const key = `${dialogueKey}:q=${questIds}`;
+    const key = `${dialogue.mobName}:${dialogue.text}:${dialogue.choices.map((c) => c.text).join("|")}`;
     if (key === this.lastDialogueKey) return;
     this.lastDialogueKey = key;
 
-    this.rebuild(dialogue, state.questsAvailable);
+    this.rebuild(dialogue);
   }
 
-  private rebuild(dialogue: DialogueState | null, questsAvailable: QuestAvailable[]) {
+  private rebuild(dialogue: DialogueState) {
     // Clear old choices
     for (const choice of this.choiceTexts) {
       this.container.removeChild(choice);
@@ -147,28 +126,19 @@ export class DialogueOverlay {
       this.dismissHint = null;
     }
 
-    // Clear old quest elements
-    for (const el of this.questElements) {
-      this.container.removeChild(el);
-      el.destroy({ children: true });
-    }
-    this.questElements = [];
-
     // Box dimensions
     const boxWidth = Math.min(440, this.width - 40);
     const innerWidth = boxWidth - BOX_PADDING * 2;
     this.bodyText.style.wordWrapWidth = innerWidth;
 
-    this.npcNameText.text = dialogue?.mobName ?? "";
-    this.bodyText.text = dialogue?.text ?? "";
+    this.npcNameText.text = dialogue.mobName;
+    this.bodyText.text = dialogue.text;
 
     // Calculate content height
     let contentHeight = BOX_PADDING;
-    if (dialogue) {
-      contentHeight += this.npcNameText.height + 8 + this.bodyText.height + 12;
-    }
+    contentHeight += this.npcNameText.height + 8 + this.bodyText.height + 12;
 
-    if (dialogue && dialogue.choices.length > 0) {
+    if (dialogue.choices.length > 0) {
       for (const choice of dialogue.choices) {
         const choiceText = new Text({
           text: `${choice.index}. ${choice.text}`,
@@ -191,30 +161,13 @@ export class DialogueOverlay {
         this.container.addChild(choiceText);
         contentHeight += CHOICE_HEIGHT;
       }
-    } else if (dialogue) {
-      // Show ending text only when dialogue existed but had no choices
+    } else {
       this.endingText = new Text({
-        text: questsAvailable.length > 0 ? "" : "The conversation has ended.",
+        text: "The conversation has ended.",
         style: { fontFamily: "JetBrains Mono, Cascadia Mono, monospace", fontSize: 11, fill: ENDING_COLOR, fontStyle: "italic" },
       });
       this.container.addChild(this.endingText);
-      if (!questsAvailable.length) contentHeight += 20;
-    }
-
-    // Build quest offer cards
-    const questCardMeasurements: { container: Container; height: number }[] = [];
-    if (questsAvailable.length > 0) {
-      contentHeight += QUEST_SEPARATOR_GAP;
-
-      for (const quest of questsAvailable) {
-        const { container: questCard, height: cardHeight } = this.buildQuestCard(quest, innerWidth);
-        questCardMeasurements.push({ container: questCard, height: cardHeight });
-        this.questElements.push(questCard);
-        this.container.addChild(questCard);
-        contentHeight += cardHeight + QUEST_CARD_GAP;
-      }
-      // Remove the trailing gap
-      contentHeight -= QUEST_CARD_GAP;
+      contentHeight += 20;
     }
 
     // The overlay is always dismissable: clicking outside the choices ends the
@@ -249,15 +202,13 @@ export class DialogueOverlay {
     this.bg.stroke({ color: BOX_BORDER, alpha: 0.6, width: 1 });
 
     let y = boxY + BOX_PADDING;
-    if (dialogue) {
-      this.npcNameText.x = boxX + BOX_PADDING;
-      this.npcNameText.y = y;
-      y += this.npcNameText.height + 8;
+    this.npcNameText.x = boxX + BOX_PADDING;
+    this.npcNameText.y = y;
+    y += this.npcNameText.height + 8;
 
-      this.bodyText.x = boxX + BOX_PADDING;
-      this.bodyText.y = y;
-      y += this.bodyText.height + 12;
-    }
+    this.bodyText.x = boxX + BOX_PADDING;
+    this.bodyText.y = y;
+    y += this.bodyText.height + 12;
 
     for (const choiceText of this.choiceTexts) {
       choiceText.x = boxX + BOX_PADDING + 8;
@@ -271,146 +222,11 @@ export class DialogueOverlay {
       y += 20;
     }
 
-    // Position quest cards
-    if (questCardMeasurements.length > 0) {
-      y += QUEST_SEPARATOR_GAP;
-      for (const { container: questCard } of questCardMeasurements) {
-        questCard.x = boxX + BOX_PADDING;
-        questCard.y = y;
-        y += questCard.height + QUEST_CARD_GAP;
-      }
-    }
-
     // Position dismiss hint centered at bottom of box
     if (this.dismissHint) {
       this.dismissHint.x = boxX + boxWidth / 2;
       this.dismissHint.y = y + 2;
     }
-  }
-
-  private buildQuestCard(quest: QuestAvailable, maxWidth: number): { container: Container; height: number } {
-    const card = new Container();
-    card.eventMode = "static";
-    const cardInnerWidth = maxWidth;
-
-    const titleText = new Text({
-      text: `\u2726 ${quest.name}`,
-      style: { fontFamily: "JetBrains Mono, Cascadia Mono, monospace", fontSize: 12, fill: QUEST_TITLE_COLOR, fontWeight: "bold" },
-    });
-    titleText.x = QUEST_CARD_PADDING;
-    titleText.y = QUEST_CARD_PADDING;
-
-    const descText = new Text({
-      text: quest.description,
-      style: {
-        fontFamily: "JetBrains Mono, Cascadia Mono, monospace",
-        fontSize: 10,
-        fill: QUEST_DESC_COLOR,
-        wordWrap: true,
-        wordWrapWidth: cardInnerWidth - QUEST_CARD_PADDING * 2,
-      },
-    });
-    descText.x = QUEST_CARD_PADDING;
-    descText.y = titleText.y + titleText.height + 4;
-
-    let yPos = descText.y + descText.height + 6;
-
-    // Objectives
-    const objTexts: Text[] = [];
-    for (const obj of quest.objectives) {
-      const objText = new Text({
-        text: `  \u25CB ${obj.description} (0/${obj.count})`,
-        style: { fontFamily: "JetBrains Mono, Cascadia Mono, monospace", fontSize: 10, fill: QUEST_OBJ_COLOR },
-      });
-      objText.x = QUEST_CARD_PADDING;
-      objText.y = yPos;
-      objTexts.push(objText);
-      yPos += objText.height + 2;
-    }
-
-    // Rewards line
-    const rewardParts: string[] = [];
-    if (quest.rewards.xp > 0) rewardParts.push(`${quest.rewards.xp} XP`);
-    if (quest.rewards.gold > 0) rewardParts.push(`${quest.rewards.gold} Gold`);
-
-    let rewardText: Text | null = null;
-    if (rewardParts.length > 0) {
-      yPos += 2;
-      rewardText = new Text({
-        text: `Rewards: ${rewardParts.join(", ")}`,
-        style: { fontFamily: "JetBrains Mono, Cascadia Mono, monospace", fontSize: 10, fill: QUEST_REWARD_COLOR },
-      });
-      rewardText.x = QUEST_CARD_PADDING;
-      rewardText.y = yPos;
-      yPos += rewardText.height + 6;
-    } else {
-      yPos += 4;
-    }
-
-    // Accept button
-    const btnHeight = 24;
-    const btnWidth = Math.min(120, cardInnerWidth - QUEST_CARD_PADDING * 2);
-    const btnX = QUEST_CARD_PADDING;
-    const btnY = yPos;
-
-    const btnContainer = new Container();
-    btnContainer.eventMode = "static";
-    btnContainer.cursor = "pointer";
-
-    const btnBg = new Graphics();
-    btnBg.roundRect(0, 0, btnWidth, btnHeight, 4);
-    btnBg.fill({ color: QUEST_ACCEPT_BG });
-    btnBg.roundRect(0, 0, btnWidth, btnHeight, 4);
-    btnBg.stroke({ color: QUEST_CARD_BORDER, alpha: 0.5, width: 1 });
-
-    const btnText = new Text({
-      text: "Accept Quest",
-      style: { fontFamily: "JetBrains Mono, Cascadia Mono, monospace", fontSize: 11, fill: QUEST_ACCEPT_TEXT_COLOR, fontWeight: "bold" },
-    });
-    btnText.x = (btnWidth - btnText.width) / 2;
-    btnText.y = (btnHeight - btnText.height) / 2;
-
-    btnContainer.addChild(btnBg);
-    btnContainer.addChild(btnText);
-    btnContainer.x = btnX;
-    btnContainer.y = btnY;
-
-    btnContainer.on("pointerover", () => {
-      btnBg.clear();
-      btnBg.roundRect(0, 0, btnWidth, btnHeight, 4);
-      btnBg.fill({ color: QUEST_ACCEPT_HOVER_BG });
-      btnBg.roundRect(0, 0, btnWidth, btnHeight, 4);
-      btnBg.stroke({ color: QUEST_CARD_BORDER, alpha: 0.8, width: 1 });
-    });
-    btnContainer.on("pointerout", () => {
-      btnBg.clear();
-      btnBg.roundRect(0, 0, btnWidth, btnHeight, 4);
-      btnBg.fill({ color: QUEST_ACCEPT_BG });
-      btnBg.roundRect(0, 0, btnWidth, btnHeight, 4);
-      btnBg.stroke({ color: QUEST_CARD_BORDER, alpha: 0.5, width: 1 });
-    });
-    btnContainer.on("pointerdown", () => {
-      canvasCallbacks.sendCommand?.(`accept ${quest.name}`);
-    });
-
-    yPos += btnHeight + QUEST_CARD_PADDING;
-    const cardHeight = yPos;
-
-    // Card background
-    const cardBg = new Graphics();
-    cardBg.roundRect(0, 0, cardInnerWidth, cardHeight, 4);
-    cardBg.fill({ color: QUEST_CARD_BG, alpha: 0.9 });
-    cardBg.roundRect(0, 0, cardInnerWidth, cardHeight, 4);
-    cardBg.stroke({ color: QUEST_CARD_BORDER, alpha: 0.4, width: 1 });
-
-    card.addChild(cardBg);
-    card.addChild(titleText);
-    card.addChild(descText);
-    for (const objText of objTexts) card.addChild(objText);
-    if (rewardText) card.addChild(rewardText);
-    card.addChild(btnContainer);
-
-    return { container: card, height: cardHeight };
   }
 
   destroy() {

--- a/web-v3/src/canvas/systems/EntityPopout.ts
+++ b/web-v3/src/canvas/systems/EntityPopout.ts
@@ -1,5 +1,5 @@
 import { Container, Graphics, Text, Sprite, Texture, Assets, Rectangle } from "pixi.js";
-import { canvasCallbacks, gameStateRef } from "../GameStateBridge";
+import { canvasCallbacks } from "../GameStateBridge";
 
 const POPOUT_WIDTH = 240;
 const POPOUT_PADDING = 12;
@@ -81,27 +81,19 @@ export class EntityPopout {
     const isNpc = info?.shopKeeper || info?.questGiver || info?.dialogue;
     const isAggressive = info?.aggressive === true;
 
-    // Primary interaction first based on mob role
+    // Quest button: opens the per-NPC offer panel via the `__quest_offers__:`
+    // marker (handled below). The panel surfaces both available and
+    // ready-to-turn-in quests; the label/color reflect whichever state is
+    // more urgent (turn-ins outrank fresh offers).
     if (info?.questComplete) {
-      const readyQuest = info?.id
-        ? gameStateRef.current.quests.find(
-            (q) => q.giverMobId === info.id && q.readyToTurnIn === true,
-          )
-        : undefined;
-      const turnInCommand = readyQuest ? `quest turnin ${readyQuest.name}` : `talk ${name}`;
-      actions.push({ label: "\u2605 Turn In Quest", command: turnInCommand, color: 0xf0c674 });
+      actions.push({ label: "\u2605 Turn In Quest", command: `__quest_offers__:${name}`, color: 0xf0c674 });
     } else if (info?.questAvailable) {
-      // Server resolves `accept <mob>` to the first available quest from that mob,
-      // so we skip opening the dialogue panel just to click an Accept button inside.
-      actions.push({ label: "\u2605 Accept Quest", command: `accept ${name}`, color: 0x5a8a6a });
-    } else if (info?.questGiver) {
-      // Quest giver with no active quest — still show talk with quest styling
-      actions.push({ label: "\u2605 Quests", command: `talk ${name}`, color: 0x8a9a6a });
+      actions.push({ label: "\u2605 Quest", command: `__quest_offers__:${name}`, color: 0x5a8a6a });
     }
-    if (info?.shopKeeper) actions.push({ label: "Browse Shop", command: `__shop__:list`, color: 0x81a2be });
-    if (info?.dialogue && !info?.questComplete && !info?.questAvailable && !info?.questGiver) {
+    if (info?.dialogue) {
       actions.push({ label: "Talk", command: `talk ${name}`, color: 0xb9aed8 });
     }
+    if (info?.shopKeeper) actions.push({ label: "Browse Shop", command: `__shop__:list`, color: 0x81a2be });
 
     // Attack — prominent for aggressive/combat mobs, available for all
     if (isAggressive || !isNpc) {
@@ -285,6 +277,8 @@ export class EntityPopout {
         } else if (cmd.startsWith("__shop__:")) {
           canvasCallbacks.sendCommand?.(cmd.slice("__shop__:".length));
           canvasCallbacks.openShop?.();
+        } else if (cmd.startsWith("__quest_offers__:")) {
+          canvasCallbacks.openQuestOffers?.(cmd.slice("__quest_offers__:".length));
         } else {
           canvasCallbacks.sendCommand?.(cmd);
         }

--- a/web-v3/src/components/panels/QuestOfferPanel.tsx
+++ b/web-v3/src/components/panels/QuestOfferPanel.tsx
@@ -1,0 +1,154 @@
+import type { QuestAvailable } from "../../types";
+
+interface QuestOfferPanelProps {
+  connected: boolean;
+  questsAvailable: QuestAvailable[];
+  onAcceptQuest: (questId: string) => void;
+  onTurnInQuest: (questId: string) => void;
+}
+
+export function QuestOfferPanel({
+  connected,
+  questsAvailable,
+  onAcceptQuest,
+  onTurnInQuest,
+}: QuestOfferPanelProps) {
+  if (!connected) {
+    return <p className="empty-note">Connect to view quests.</p>;
+  }
+  if (questsAvailable.length === 0) {
+    return (
+      <div className="quest-offer-empty">
+        <span className="quest-empty-icon">{"✦"}</span>
+        <p className="empty-note">No quests on offer here.</p>
+      </div>
+    );
+  }
+
+  const ready = questsAvailable.filter((q) => q.readyToTurnIn);
+  const offered = questsAvailable.filter((q) => !q.readyToTurnIn);
+
+  return (
+    <div className="quest-offer-panel">
+      {ready.length > 0 && (
+        <section className="quest-offer-section" aria-label="Ready to Turn In">
+          <h3 className="quest-offer-section-title">Ready to Turn In</h3>
+          <ul className="quest-available-list">
+            {ready.map((quest) => (
+              <QuestOfferCard
+                key={quest.id}
+                quest={quest}
+                onAccept={onAcceptQuest}
+                onTurnIn={onTurnInQuest}
+              />
+            ))}
+          </ul>
+        </section>
+      )}
+      {offered.length > 0 && (
+        <section className="quest-offer-section" aria-label="Offered">
+          {ready.length > 0 && <h3 className="quest-offer-section-title">Offered</h3>}
+          <ul className="quest-available-list">
+            {offered.map((quest) => (
+              <QuestOfferCard
+                key={quest.id}
+                quest={quest}
+                onAccept={onAcceptQuest}
+                onTurnIn={onTurnInQuest}
+              />
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function QuestOfferCard({
+  quest,
+  onAccept,
+  onTurnIn,
+}: {
+  quest: QuestAvailable;
+  onAccept: (questId: string) => void;
+  onTurnIn: (questId: string) => void;
+}) {
+  const locked = quest.lockedReason !== null;
+  const currencyEntries = Object.entries(quest.rewards.currencies);
+  const hasRewards =
+    quest.rewards.xp > 0 || quest.rewards.gold > 0 || currencyEntries.length > 0;
+
+  return (
+    <li className="quest-available-card">
+      <div className="quest-available-header">
+        <span className="quest-available-icon">{"✦"}</span>
+        <span className="quest-available-name">{quest.name}</span>
+      </div>
+      <p className="quest-available-description">{quest.description}</p>
+      <ul className="quest-available-objectives">
+        {quest.objectives.map((obj, idx) => (
+          <li key={idx} className="quest-available-objective">
+            <span className="quest-available-obj-icon">{"○"}</span>
+            <span>{obj.description}</span>
+            <span className="quest-available-obj-count">
+              {obj.current}/{obj.count}
+            </span>
+          </li>
+        ))}
+      </ul>
+      {hasRewards && (
+        <div className="quest-available-rewards">
+          <span className="quest-available-rewards-label">Rewards:</span>
+          {quest.rewards.xp > 0 && (
+            <span className="quest-reward-xp">{quest.rewards.xp} XP</span>
+          )}
+          {quest.rewards.gold > 0 && (
+            <span className="quest-reward-gold">{quest.rewards.gold} Gold</span>
+          )}
+          {currencyEntries.map(([id, amount]) => (
+            <span key={id} className="quest-reward-gold">
+              {amount} {id}
+            </span>
+          ))}
+        </div>
+      )}
+      {(quest.levelRequired !== null || quest.reputationRequired !== null) && (
+        <div className="quest-offer-requirements">
+          {quest.levelRequired !== null && (
+            <span className="quest-offer-requirement">
+              Level {quest.levelRequired}
+            </span>
+          )}
+          {quest.reputationRequired !== null && (
+            <span className="quest-offer-requirement">
+              {quest.reputationRequired.factionName}
+              {quest.reputationRequired.min !== null && ` ≥ ${quest.reputationRequired.min}`}
+              {quest.reputationRequired.max !== null && ` ≤ ${quest.reputationRequired.max}`}
+            </span>
+          )}
+        </div>
+      )}
+      {locked && (
+        <p className="quest-offer-locked">{quest.lockedReason}</p>
+      )}
+      {quest.readyToTurnIn ? (
+        <button
+          type="button"
+          className="quest-accept-button quest-turnin-button"
+          onClick={() => onTurnIn(quest.id)}
+        >
+          Turn In
+        </button>
+      ) : (
+        <button
+          type="button"
+          className="quest-accept-button"
+          onClick={() => onAccept(quest.id)}
+          disabled={locked}
+        >
+          Accept Quest
+        </button>
+      )}
+    </li>
+  );
+}

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -1065,11 +1065,22 @@ export function applyGmcpPackage(
                   .map((o) => ({
                     description: typeof o.description === "string" ? o.description : "",
                     count: safeNumber(o.count),
+                    current: safeNumber(o.current),
                   }))
               : [];
             const rewards = typeof e.rewards === "object" && e.rewards !== null
               ? e.rewards as Record<string, unknown>
               : {};
+            const currenciesRaw = typeof rewards.currencies === "object" && rewards.currencies !== null
+              ? rewards.currencies as Record<string, unknown>
+              : {};
+            const currencies: Record<string, number> = {};
+            for (const [k, v] of Object.entries(currenciesRaw)) {
+              currencies[k] = safeNumber(v);
+            }
+            const rep = typeof e.reputationRequired === "object" && e.reputationRequired !== null
+              ? e.reputationRequired as Record<string, unknown>
+              : null;
             return {
               id: typeof e.id === "string" ? e.id : "",
               name: typeof e.name === "string" ? e.name : "",
@@ -1079,7 +1090,19 @@ export function applyGmcpPackage(
               rewards: {
                 xp: safeNumber(rewards.xp),
                 gold: safeNumber(rewards.gold),
+                currencies,
               },
+              levelRequired: typeof e.levelRequired === "number" ? e.levelRequired : null,
+              reputationRequired: rep
+                ? {
+                    faction: typeof rep.faction === "string" ? rep.faction : "",
+                    factionName: typeof rep.factionName === "string" ? rep.factionName : "",
+                    min: typeof rep.min === "number" ? rep.min : null,
+                    max: typeof rep.max === "number" ? rep.max : null,
+                  }
+                : null,
+              readyToTurnIn: e.readyToTurnIn === true,
+              lockedReason: typeof e.lockedReason === "string" ? e.lockedReason : null,
             };
           }),
       );

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -6176,6 +6176,84 @@ body {
   transform: scale(0.97);
 }
 
+.quest-accept-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+/* Turn-in variant of the accept button — gold glow instead of moss-green */
+.quest-turnin-button {
+  border-color: rgb(240 198 116 / 50%);
+  background: linear-gradient(140deg, rgb(160 130 70 / 55%), rgb(140 110 55 / 45%));
+  color: var(--color-primary-soft-gold);
+}
+
+.quest-turnin-button:hover {
+  background: linear-gradient(140deg, rgb(190 160 90 / 65%), rgb(170 140 75 / 55%));
+  border-color: rgb(240 198 116 / 75%);
+  box-shadow: 0 0 14px rgb(240 198 116 / 30%);
+}
+
+/* ── Quest offer panel (per-NPC popout) ── */
+.quest-offer-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-2) 0;
+}
+
+.quest-offer-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.quest-offer-section-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 0.86rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.quest-offer-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-6) var(--space-4);
+}
+
+.quest-offer-requirements {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+  font-size: 0.72rem;
+}
+
+.quest-offer-requirement {
+  padding: 2px 8px;
+  border: 1px solid rgb(141 169 123 / 25%);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  background: rgb(141 169 123 / 8%);
+}
+
+.quest-offer-locked {
+  margin: 0 0 var(--space-2);
+  padding: 6px 10px;
+  border-left: 2px solid rgb(212 136 138 / 60%);
+  background: rgb(212 136 138 / 10%);
+  font-size: 0.74rem;
+  color: var(--text-secondary);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
 /* Quest notification icon */
 .quest-notification-icon {
   flex-shrink: 0;

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -1,4 +1,4 @@
-export type PopoutPanel = "map" | "inventory" | "equipment" | "room" | "help" | "character" | "chat" | "shop" | "spellbook" | "quests" | "mail" | "crafting" | "housing" | "leaderboard" | "trainer" | "bank" | "stylist" | "auction" | "dungeon" | "lottery" | "puzzle" | "features" | "combatlog" | null;
+export type PopoutPanel = "map" | "inventory" | "equipment" | "room" | "help" | "character" | "chat" | "shop" | "spellbook" | "quests" | "questOffers" | "mail" | "crafting" | "housing" | "leaderboard" | "trainer" | "bank" | "stylist" | "auction" | "dungeon" | "lottery" | "puzzle" | "features" | "combatlog" | null;
 export type SystemPanelView = "dungeon" | "duel" | "lottery" | "pet" | "prestige" | "currencies" | "factions";
 export type ChatChannel = "say" | "tell" | "gossip" | "shout" | "ooc" | "gtell" | "gchat";
 export type SocialTab = "chat" | "friends" | "guild" | "group" | "who";
@@ -581,11 +581,20 @@ export interface QuestNotification {
 export interface QuestAvailableObjective {
   description: string;
   count: number;
+  current: number;
 }
 
 export interface QuestAvailableRewards {
   xp: number;
   gold: number;
+  currencies: Record<string, number>;
+}
+
+export interface QuestAvailableReputation {
+  faction: string;
+  factionName: string;
+  min: number | null;
+  max: number | null;
 }
 
 export interface QuestAvailable {
@@ -595,6 +604,10 @@ export interface QuestAvailable {
   giverMobId: string;
   objectives: QuestAvailableObjective[];
   rewards: QuestAvailableRewards;
+  levelRequired: number | null;
+  reputationRequired: QuestAvailableReputation | null;
+  readyToTurnIn: boolean;
+  lockedReason: string | null;
 }
 
 export interface ZoneInstanceItem {


### PR DESCRIPTION
## Summary

Second of three PRs splitting dialogue from quests in the web client. Builds on the server-side decoupling that landed in #1118 (`qoffers <mob>`, id-keyed accept/turn-in, richer `Quest.Available` payload).

- **DialogueOverlay** is now pure dialogue. Quest cards and the inline Accept button are removed (file shrinks ~150 lines).
- **EntityPopout** shows Talk when `info.dialogue` is true and Quest when `info.questAvailable || info.questComplete`. Both can show simultaneously. The Quest button uses a new `__quest_offers__:<mob>` marker that sends `qoffers <mob>` and opens the new panel.
- **`QuestOfferPanel`** (new) — full-width popout for the per-NPC offer flow:
  - Renders both **available** quests and **ready to turn in** quests in one place.
  - Per-objective `current/required` progress, xp/gold/currency rewards, level and reputation gates rendered as chips, `lockedReason` text on disabled cards.
  - Accept sends `accept #<questId>`; Turn In sends `quest turnin #<questId>` — both use the id-keyed paths from #1118.
- **`QuestAvailable` type** widened to carry the new server fields (`levelRequired`, `reputationRequired`, `readyToTurnIn`, `lockedReason`, `rewards.currencies`, per-objective `current`).
- **CSS** adds the `quest-offer-*` classes plus a gold-tinted `.quest-turnin-button` variant of the existing accept-button.

The legacy questGiver-only "Quests" button (which secretly sent `talk`) is gone — the dedicated Quest button is the canonical path.

## Test plan

- [x] `bun run lint` (web-v3)
- [x] `bun run build` (web-v3 — full tsc + vite)
- [x] `./gradlew buildWeb`
- [x] `./gradlew ktlintCheck`
- [ ] Manual: in-game, click an NPC with both dialogue and a quest — both Talk and Quest buttons appear. Talk opens the dialogue tree only. Quest opens the new panel with full quest detail.
- [ ] Manual: accept and turn in a quest from the panel; verify Quest.List/Quest.Available update correctly.
- [ ] Manual: an NPC with only dialogue shows Talk only; an NPC with only a quest shows Quest only.

PR 3 (dialogue-flag gating + flexible turn-in NPC) follows.