### PR TITLE
Dialogue-flag quest gating + flexible turn-in NPC

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/quest/QuestDef.kt
+++ b/src/main/kotlin/dev/ambon/domain/quest/QuestDef.kt
@@ -28,6 +28,19 @@ data class QuestDef(
      * override.
      */
     val difficulty: QuestDifficulty? = null,
+    /**
+     * Optional dialogue-flag gate. When set, the quest is hidden from
+     * `quest offers` and the canvas Quest indicator until the player has the
+     * named flag in [PlayerState.dialogueFlags]. Flags are added by dialogue
+     * choice actions of the form `unlock_flag:<name>`.
+     */
+    val requiresDialogueFlag: String? = null,
+    /**
+     * Optional override for the NPC that accepts turn-ins. Defaults to
+     * [giverMobId] when null, so most quests remain "give and turn in to the
+     * same NPC".
+     */
+    val turnInMobId: String? = null,
 )
 
 data class QuestObjectiveDef(

--- a/src/main/kotlin/dev/ambon/domain/world/data/QuestFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/QuestFile.kt
@@ -17,6 +17,19 @@ data class QuestFile(
      * engine compute XP from quest level × tier multiplier.
      */
     val difficulty: String? = null,
+    /**
+     * Optional dialogue-flag gate. When set, the quest is hidden from the
+     * Quest button and `qoffers` until the player has the named flag in
+     * their dialogueFlags set. Flags are added by dialogue choice actions
+     * of the form `unlock_flag:<name>`.
+     */
+    val requiresDialogueFlag: String? = null,
+    /**
+     * Optional override for the NPC that accepts turn-ins. Bare mob keyword
+     * (e.g. `headmaster_aldric`); the loader qualifies it with the zone id.
+     * Defaults to [giver] when null.
+     */
+    val turnInMob: String? = null,
 )
 
 data class QuestObjectiveFile(

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -679,6 +679,8 @@ object WorldLoader {
                         } catch (e: IllegalArgumentException) {
                             throw WorldLoadException("Quest '$questId': ${e.message}")
                         },
+                        requiresDialogueFlag = questFile.requiresDialogueFlag?.trim()?.takeIf { it.isNotEmpty() },
+                        turnInMobId = questFile.turnInMob?.trim()?.takeIf { it.isNotEmpty() }?.let { qualifyId(zone, it) },
                     ),
                 )
             }

--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -46,6 +46,12 @@ data class PlayerState(
     val passwordHash: String = "",
     var activeQuests: Map<String, QuestState> = emptyMap(),
     var completedQuestIds: Set<String> = emptySet(),
+    /**
+     * Persisted dialogue-flag set. Set entries are added by dialogue choice
+     * actions (see `unlock_flag:<name>` in DialogueQuestHandler) and consumed
+     * by [QuestSystem] to gate quests behind prior conversations.
+     */
+    var dialogueFlags: MutableSet<String> = mutableSetOf(),
     var unlockedAchievementIds: Set<String> = emptySet(),
     var achievementProgress: Map<String, AchievementState> = emptyMap(),
     var activeTitle: String? = null,
@@ -224,6 +230,7 @@ fun PlayerRecord.toPlayerState(sessionId: SessionId): PlayerState =
         passwordHash = passwordHash,
         activeQuests = activeQuests,
         completedQuestIds = completedQuestIds,
+        dialogueFlags = dialogueFlags.toMutableSet(),
         unlockedAchievementIds = unlockedAchievementIds,
         achievementProgress = achievementProgress,
         activeTitle = activeTitle,
@@ -286,6 +293,7 @@ fun PlayerState.toPlayerRecord(lastSeenEpochMs: Long): PlayerRecord {
         gold = gold,
         activeQuests = activeQuests,
         completedQuestIds = completedQuestIds,
+        dialogueFlags = dialogueFlags.toSet(),
         unlockedAchievementIds = unlockedAchievementIds,
         achievementProgress = achievementProgress,
         activeTitle = activeTitle,

--- a/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
@@ -78,8 +78,17 @@ class QuestSystem(
         if (ps.activeQuests.containsKey(quest.id) || ps.completedQuestIds.contains(quest.id)) return false
         if (exceedsRepMax(ps, quest)) return false
         if (belowRepMin(ps, quest)) return false
+        if (missingDialogueFlag(ps, quest)) return false
         return true
     }
+
+    private fun missingDialogueFlag(ps: PlayerState, quest: QuestDef): Boolean {
+        val flag = quest.requiresDialogueFlag ?: return false
+        return flag !in ps.dialogueFlags
+    }
+
+    private fun resolvedTurnInMobId(quest: QuestDef): String =
+        quest.turnInMobId ?: quest.giverMobId
 
     private fun belowRepMin(ps: PlayerState, quest: QuestDef): Boolean {
         val req = quest.requiredReputation ?: return false
@@ -120,18 +129,35 @@ class QuestSystem(
     ): List<QuestAvailableEntry> {
         val ps = players.get(sessionId) ?: return emptyList()
         val entries = mutableListOf<QuestAvailableEntry>()
+        val seen = mutableSetOf<String>()
         for (quest in registry.questsForMob(mobId)) {
             if (ps.completedQuestIds.contains(quest.id)) continue
             if (exceedsRepMax(ps, quest)) continue // disappears entirely
             val activeState = ps.activeQuests[quest.id]
             if (activeState != null) {
-                if (isReadyToTurnIn(quest, activeState)) {
+                // Only show ready-to-turn-in here when this mob is the resolved
+                // turn-in NPC (which is the giver by default).
+                if (isReadyToTurnIn(quest, activeState) && resolvedTurnInMobId(quest) == mobId) {
                     entries.add(buildEntry(quest, ps, activeState, lockedReason = null))
+                    seen.add(quest.id)
                 }
                 continue
             }
+            // Hide quests gated by an unmet dialogue flag — they shouldn't
+            // tease themselves at all (the dialogue is the gateway).
+            if (missingDialogueFlag(ps, quest)) continue
             val locked = lockedReasonFor(ps, quest)
             entries.add(buildEntry(quest, ps, state = null, lockedReason = locked))
+            seen.add(quest.id)
+        }
+        // Active quests whose turn-in NPC is THIS mob but whose giver is
+        // someone else — still surface them here so the player can hand in.
+        for ((questId, activeState) in ps.activeQuests) {
+            if (questId in seen) continue
+            val quest = registry.get(questId) ?: continue
+            if (resolvedTurnInMobId(quest) != mobId) continue
+            if (!isReadyToTurnIn(quest, activeState)) continue
+            entries.add(buildEntry(quest, ps, activeState, lockedReason = null))
         }
         return entries
     }
@@ -189,16 +215,24 @@ class QuestSystem(
         }
     }
 
-    /** Returns mob IDs that have a turn-in quest whose objectives the player has completed. */
+    /**
+     * Returns mob IDs that are the resolved turn-in NPC for a quest the player
+     * has completed objectives for. Honors [QuestDef.turnInMobId] when set, so
+     * the indicator follows the override NPC rather than the giver.
+     */
     fun questCompleteMobIds(sessionId: SessionId, mobIds: Collection<String>): Set<String> {
         val ps = players.get(sessionId) ?: return emptySet()
-        return mobIds.filterTo(mutableSetOf()) { mobId ->
-            registry.questsForMob(mobId).any { quest ->
-                val handler = completionHandlers.get(quest.completionType)
-                handler?.requiresNpcTurnIn == true &&
-                    ps.activeQuests[quest.id]?.objectives?.all { it.isComplete } == true
-            }
+        val mobIdSet = mobIds.toSet()
+        val result = mutableSetOf<String>()
+        for ((questId, state) in ps.activeQuests) {
+            val quest = registry.get(questId) ?: continue
+            val handler = completionHandlers.get(quest.completionType) ?: continue
+            if (!handler.requiresNpcTurnIn) continue
+            if (!state.objectives.all { it.isComplete }) continue
+            val turnIn = resolvedTurnInMobId(quest)
+            if (turnIn in mobIdSet) result.add(turnIn)
         }
+        return result
     }
 
     /**
@@ -219,6 +253,9 @@ class QuestSystem(
             val req = quest.requiredReputation!!
             val factionName = reputationSystem?.getFaction(req.faction)?.name ?: req.faction
             return "You lack the standing with $factionName to take this quest."
+        }
+        if (missingDialogueFlag(ps, quest)) {
+            return "That quest isn't available to you yet."
         }
 
         val seededObjectives =
@@ -312,7 +349,7 @@ class QuestSystem(
         if (!state.objectives.all { it.isComplete }) {
             return "You haven't finished that quest yet."
         }
-        if (quest.giverMobId !in mobIdsInRoom) {
+        if (resolvedTurnInMobId(quest) !in mobIdsInRoom) {
             return "The quest-giver isn't here. Return to them to turn this in."
         }
         completeQuest(sessionId, questId, quest.rewards)
@@ -337,7 +374,7 @@ class QuestSystem(
         if (!state.objectives.all { it.isComplete }) {
             return "You haven't finished that quest yet."
         }
-        if (quest.giverMobId !in mobIdsInRoom) {
+        if (resolvedTurnInMobId(quest) !in mobIdsInRoom) {
             return "The quest-giver isn't here. Return to them to turn this in."
         }
         completeQuest(sessionId, questId, quest.rewards)

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestHandler.kt
@@ -108,6 +108,10 @@ class DialogueQuestHandler(
         sessionId: SessionId,
         action: String,
     ) {
+        if (action.startsWith("unlock_flag:")) {
+            handleUnlockFlag(sessionId, action.removePrefix("unlock_flag:").trim())
+            return
+        }
         when (action) {
             "set_recall" -> {
                 val me = players.get(sessionId) ?: return
@@ -147,6 +151,17 @@ class DialogueQuestHandler(
                     }
                 }
             }
+        }
+    }
+
+    private suspend fun handleUnlockFlag(sessionId: SessionId, flag: String) {
+        if (flag.isEmpty()) return
+        val me = players.get(sessionId) ?: return
+        if (me.dialogueFlags.add(flag)) {
+            players.persistPlayer(sessionId)
+            // A gated quest may now be acceptable — reuse the existing quest-list
+            // change hook so the canvas refreshes its quest indicators on this NPC.
+            questSystem?.onQuestListChanged?.invoke(sessionId)
         }
     }
 

--- a/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
@@ -96,6 +96,8 @@ data class PlayerRecord(
     val autolootEnabled: Boolean = false,
     /** Epoch-ms of the last stat/ability respec. 0 means never respec'd. */
     val lastRespecAtMs: Long = 0L,
+    /** Persisted dialogue-flag set used to gate quests behind prior conversations. */
+    val dialogueFlags: Set<String> = emptySet(),
 ) {
     /**
      * Applies legacy migration fixes after deserialization.

--- a/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
@@ -14,6 +14,7 @@ import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
 private val statsType = object : TypeReference<Map<String, Int>>() {}
 private val activeQuestsType = object : TypeReference<Map<String, QuestState>>() {}
 private val completedQuestIdsType = object : TypeReference<Set<String>>() {}
+private val dialogueFlagsType = object : TypeReference<Set<String>>() {}
 private val unlockedAchievementIdsType = object : TypeReference<Set<String>>() {}
 private val achievementProgressType = object : TypeReference<Map<String, AchievementState>>() {}
 private val mailInboxType = object : TypeReference<List<MailMessage>>() {}
@@ -82,6 +83,7 @@ object PlayersTable : Table("players") {
     val description = text("description").default("")
     val autolootEnabled = bool("autoloot_enabled").default(false)
     val lastRespecAtMs = long("last_respec_at_ms").default(0L)
+    val dialogueFlags = text("dialogue_flags").default("[]")
 
     override val primaryKey = PrimaryKey(id)
 
@@ -141,6 +143,7 @@ object PlayersTable : Table("players") {
             description = row[description],
             autolootEnabled = row[autolootEnabled],
             lastRespecAtMs = row[lastRespecAtMs],
+            dialogueFlags = safeReadJson(row[dialogueFlags], dialogueFlagsType, emptySet()),
         ).migrateDefaults()
 
     /** Writes all [PlayerRecord] fields into an insert or upsert [statement]. */
@@ -199,5 +202,6 @@ object PlayersTable : Table("players") {
         statement[description] = record.description
         statement[autolootEnabled] = record.autolootEnabled
         statement[lastRespecAtMs] = record.lastRespecAtMs
+        statement[dialogueFlags] = jsonMapper.writeValueAsString(record.dialogueFlags)
     }
 }

--- a/src/main/resources/db/migration/V38__add_dialogue_flags.sql
+++ b/src/main/resources/db/migration/V38__add_dialogue_flags.sql
@@ -1,0 +1,1 @@
+ALTER TABLE players ADD COLUMN dialogue_flags TEXT NOT NULL DEFAULT '[]';

--- a/src/main/resources/world/academy.yaml
+++ b/src/main/resources/world/academy.yaml
@@ -441,6 +441,8 @@ mobs:
     xpReward: 0
     goldMin: 0
     goldMax: 0
+    quests:
+      - scholars_research
     dialogue:
       root:
         text: A slender woman in spectacles and ink-stained robes looks up from a heavy tome, brushing a strand of auburn hair
@@ -454,7 +456,20 @@ mobs:
             next: learn_here
           - text: What's south of here?
             next: directions
+          - text: I overheard you mention research. What are you working on?
+            next: research_inquiry
           - text: Goodbye, Scholar.
+            next: farewell
+      research_inquiry:
+        text: 'Elara hesitates, then leans forward, lowering her voice. "Perceptive of you. I am studying the resonance patterns
+          in Arcane Fragments — they may be more than mere magical residue. I need a sample to compare against my notes,
+          but the Headmaster keeps the archive key. Would you fetch one for me, then bring your findings to him? He
+          should hear of this directly."'
+        action: unlock_flag:scholar_research
+        choices:
+          - text: Of course, I'd be happy to help.
+            next: farewell
+          - text: I'll think about it.
             next: farewell
       about_self:
         text: I was once a wandering sage, traveling from library to library in search of lost knowledge. I spent years
@@ -1162,6 +1177,22 @@ quests:
     rewards:
       xp: 150
       gold: 75
+  scholars_research:
+    name: Scholar's Research
+    description: Scholar Elara has asked you to bring an Arcane Fragment to Headmaster Aldric so he can compare it against her
+      research notes. Collect a fragment from any of the Academy's creatures, then deliver your findings to the Headmaster
+      at the gates.
+    giver: scholar_elara
+    turnInMob: headmaster_aldric
+    requiresDialogueFlag: scholar_research
+    objectives:
+      - type: collect
+        targetKey: arcane_fragment
+        count: 1
+        description: Collect an Arcane Fragment for Elara's research
+    rewards:
+      xp: 75
+      gold: 30
   creature_roundup:
     name: Creature Roundup
     description: Groundskeeper Thorne needs help managing the rowdier creatures in the Proving Grounds. Defeat them in

--- a/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
@@ -940,4 +940,114 @@ class QuestSystemTest {
             val stateReady = players.get(sid)!!.activeQuests[questId]!!
             assertTrue(qs.isReadyToTurnIn(turnInQuest, stateReady))
         }
+
+    // ── Dialogue-flag gating ───────────────────────────────────────────────
+
+    @Test
+    fun `gated quest is hidden from offers and rejects accept until flag set`() =
+        runTest {
+            val gated = killQuest.copy(requiresDialogueFlag = "elara_secret")
+            val (qs, players, _) = setup(gated)
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Hero")
+
+            assertTrue(
+                qs.questOffersFor(sid, "zone:quest_giver").isEmpty(),
+                "Gated quest should be hidden from offers before flag is set",
+            )
+            val rejected = qs.acceptQuest(sid, questId)
+            assertNotNull(rejected, "Accept should fail when dialogue flag is missing")
+
+            players.get(sid)!!.dialogueFlags.add("elara_secret")
+
+            val offers = qs.questOffersFor(sid, "zone:quest_giver")
+            assertEquals(1, offers.size, "Quest should appear once flag is unlocked")
+            val ok = qs.acceptQuest(sid, questId)
+            assertNull(ok, "Accept should succeed once dialogue flag is set")
+        }
+
+    @Test
+    fun `gated quest does not surface canvas indicator until flag set`() =
+        runTest {
+            val gated = killQuest.copy(requiresDialogueFlag = "elara_secret")
+            val (qs, players, _) = setup(gated)
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Hero")
+
+            assertTrue(qs.questAvailableMobIds(sid, listOf("zone:quest_giver")).isEmpty())
+
+            players.get(sid)!!.dialogueFlags.add("elara_secret")
+            assertEquals(
+                setOf("zone:quest_giver"),
+                qs.questAvailableMobIds(sid, listOf("zone:quest_giver")),
+                "Canvas indicator should appear once dialogue flag is set",
+            )
+        }
+
+    // ── Turn-in mob override ───────────────────────────────────────────────
+
+    @Test
+    fun `turnInQuest routes to turnInMobId override when set`() =
+        runTest {
+            val routed = killQuest.copy(
+                completionType = "npc_turn_in",
+                turnInMobId = "zone:other_npc",
+            )
+            val (qs, players, _) = setup(routed)
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Hero")
+
+            qs.acceptQuest(sid, questId)
+            repeat(3) { qs.onMobKilled(sid, mobTemplateKey) }
+
+            // Giver alone is no longer enough — the override mob must be present.
+            val giverOnly = qs.turnInQuest(sid, "Kill Quest", listOf("zone:quest_giver"))
+            assertNotNull(giverOnly, "Turn-in at the giver should be rejected when override is set")
+
+            val ok = qs.turnInQuest(sid, "Kill Quest", listOf("zone:other_npc"))
+            assertNull(ok, "Turn-in at the override mob should succeed")
+            assertTrue(players.get(sid)!!.completedQuestIds.contains(questId))
+        }
+
+    @Test
+    fun `questCompleteMobIds points at the override mob`() =
+        runTest {
+            val routed = killQuest.copy(
+                completionType = "npc_turn_in",
+                turnInMobId = "zone:other_npc",
+            )
+            val (qs, players, _) = setup(routed)
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Hero")
+
+            qs.acceptQuest(sid, questId)
+            repeat(3) { qs.onMobKilled(sid, mobTemplateKey) }
+
+            val complete = qs.questCompleteMobIds(sid, listOf("zone:quest_giver", "zone:other_npc"))
+            assertEquals(setOf("zone:other_npc"), complete)
+        }
+
+    @Test
+    fun `questOffersFor surfaces ready turn-in at override NPC`() =
+        runTest {
+            val routed = killQuest.copy(
+                completionType = "npc_turn_in",
+                turnInMobId = "zone:other_npc",
+            )
+            val (qs, players, _) = setup(routed)
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Hero")
+
+            qs.acceptQuest(sid, questId)
+            repeat(3) { qs.onMobKilled(sid, mobTemplateKey) }
+
+            // Giver no longer offers it (active quest, turn-in is elsewhere).
+            val giverOffers = qs.questOffersFor(sid, "zone:quest_giver")
+            assertTrue(giverOffers.isEmpty(), "Giver should not show ready turn-in for override quests")
+
+            // Override NPC surfaces it.
+            val overrideOffers = qs.questOffersFor(sid, "zone:other_npc")
+            assertEquals(1, overrideOffers.size)
+            assertTrue(overrideOffers.single().readyToTurnIn)
+        }
 }

--- a/src/test/kotlin/dev/ambon/persistence/PersistenceFieldCoverageTest.kt
+++ b/src/test/kotlin/dev/ambon/persistence/PersistenceFieldCoverageTest.kt
@@ -141,6 +141,7 @@ class PersistenceFieldCoverageTest {
                 authTokenHash = "sha256:deadbeef",
                 authTokenIssuedAt = 1_700_000_000_000L,
                 autolootEnabled = true,
+                dialogueFlags = setOf("scholar_research", "innkeeper_intro"),
             )
 
         @BeforeAll


### PR DESCRIPTION
## Summary

Third (and final) PR in the quest/dialogue rework. Adds two related authoring tools that let dialogue and quests cross-reference each other without coupling their UX.

- **`QuestDef.requiresDialogueFlag`** — when set, the quest is hidden from \`qoffers\`, the canvas Quest indicator (\`questAvailableMobIds\`), and \`accept\` until the player has the named flag in their dialogueFlags set. Flags are added by dialogue choice actions of the form \`unlock_flag:<name>\`. Flags are **global strings**, so a quest can sit behind a conversation with a *different* NPC (e.g. talk to the librarian, then the headmaster offers the quest).
- **`QuestDef.turnInMobId`** — overrides the default "turn in to the giver" rule. The Quest button's complete indicator and \`qoffers\` follow the resolved turn-in NPC. Defaults to \`giverMobId\` so existing quests are unaffected.

### Persistence
New \`dialogue_flags\` text column on \`players\`, JSON-serialized like the other \`Set<String>\` fields. V38 migration. PlayerState/PlayerRecord mappings + \`PersistenceFieldCoverageTest\` fixture updated.

### Smoke-test content
Scholar Elara now offers **scholars_research** — a 1-fragment quest gated behind a new dialogue choice (\`unlock_flag:scholar_research\`) and turned in to Headmaster Aldric. Exercises both features end-to-end in the live Academy zone.

### Engine wiring
- \`DialogueQuestHandler.handleDialogueAction\` recognizes the \`unlock_flag:\` prefix, adds to the player's flags, persists, and pings \`onQuestListChanged\` so the canvas Quest indicator refreshes immediately on the same NPC if the unlock made a gated quest acceptable.
- \`QuestSystem.questOffersFor\` now scans active quests so a turn-in-elsewhere quest still surfaces on the override NPC.
- \`QuestSystem.questCompleteMobIds\` and both \`turnInQuest\`/\`turnInQuestById\` paths use the resolved turn-in mob.

## Test plan

- [x] \`./gradlew ktlintCheck test\`
- [x] \`./gradlew integrationTest\` (PersistenceFieldCoverageTest covers Postgres + YAML + Redis round-trip with the new field)
- [x] New \`QuestSystemTest\` cases:
  - Gated quest hidden from offers + accept until flag set, appears after.
  - Canvas indicator (\`questAvailableMobIds\`) hidden until flag set.
  - \`turnInQuest\` rejects giver, accepts override mob.
  - \`questCompleteMobIds\` returns the override mob.
  - \`questOffersFor\` surfaces ready turn-in at the override NPC, not the giver.
- [ ] Manual: in-game, \`talk scholar elara\` → choose the research line → quest now appears on Elara, turn in at Aldric works.