### PR TITLE
Quest turn-in: refresh popout/panel + reward summary toast

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -1029,9 +1029,21 @@ class GameEngine(
         }
         questSystem.onQuestObjectiveUpdated = { sid, questId, objIndex, current, required, readyToTurnIn ->
             gmcpEmitter.sendQuestUpdate(sid, questId, objIndex, current, required, readyToTurnIn)
+            // When the final objective ticks over to complete, the resolved
+            // turn-in NPC's `questComplete` flag flips — refresh so the popout
+            // and canvas indicator pick it up without a room exit/enter.
+            if (readyToTurnIn) refreshRoomMobInfoForPlayer(sid)
         }
-        questSystem.onQuestCompletedGmcp = { sid, questId, questName ->
-            gmcpEmitter.sendQuestComplete(sid, questId, questName)
+        questSystem.onQuestCompletedGmcp = { sid, summary ->
+            gmcpEmitter.sendQuestComplete(
+                sid,
+                summary.questId,
+                summary.questName,
+                summary.questDescription,
+                summary.rewardXp,
+                summary.rewardGold,
+                summary.rewardCurrencies,
+            )
             sendQuestListGmcp(sid)
             refreshRoomMobInfoForPlayer(sid)
         }

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -1056,11 +1056,24 @@ class GmcpEmitter(
         sessionId: SessionId,
         questId: String,
         questName: String,
+        questDescription: String,
+        rewardXp: Long,
+        rewardGold: Long,
+        rewardCurrencies: Map<String, Long>,
     ) {
         emit(
             sessionId,
             "Quest.Complete",
-            QuestCompletePayload(questId = questId, questName = questName),
+            QuestCompletePayload(
+                questId = questId,
+                questName = questName,
+                questDescription = questDescription,
+                rewards = QuestAvailableRewardsPayload(
+                    xp = rewardXp,
+                    gold = rewardGold,
+                    currencies = rewardCurrencies,
+                ),
+            ),
             supportCheck = "Quest",
         )
     }
@@ -2635,6 +2648,8 @@ class GmcpEmitter(
     private data class QuestCompletePayload(
         val questId: String,
         val questName: String,
+        val questDescription: String,
+        val rewards: QuestAvailableRewardsPayload,
     )
 
     private data class QuestAvailablePayload(
@@ -3444,6 +3459,15 @@ data class ReputationRequirementSummary(
     val factionName: String,
     val min: Int? = null,
     val max: Int? = null,
+)
+
+data class QuestCompletionSummary(
+    val questId: String,
+    val questName: String,
+    val questDescription: String,
+    val rewardXp: Long,
+    val rewardGold: Long,
+    val rewardCurrencies: Map<String, Long>,
 )
 
 data class MobInfoEntry(

--- a/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
@@ -35,7 +35,7 @@ class QuestSystem(
     /** Invoked to emit quest GMCP; set by GameEngine during wiring. */
     var onQuestListChanged: (suspend (SessionId) -> Unit)? = null
     var onQuestObjectiveUpdated: (suspend (SessionId, String, Int, Int, Int, Boolean) -> Unit)? = null
-    var onQuestCompletedGmcp: (suspend (SessionId, String, String) -> Unit)? = null
+    var onQuestCompletedGmcp: (suspend (SessionId, QuestCompletionSummary) -> Unit)? = null
 
     /** Invoked when a quest reward grants enough XP to level the player up. */
     var onLevelUp: (suspend (SessionId, LevelUpResult) -> Unit)? = null
@@ -551,13 +551,9 @@ class QuestSystem(
         ps.activeQuests = ps.activeQuests - questId
         ps.completedQuestIds = ps.completedQuestIds + questId
 
-        outbound.send(OutboundEvent.SendInfo(sessionId, "Quest complete: ${quest.name}!"))
-        onQuestCompletedGmcp?.invoke(sessionId, questId, quest.name)
-        onQuestCompleted?.invoke(sessionId, questId)
-
-        // Zone scaling (phase 4): if the quest's zone declares non-STATIC scaling,
-        // the "effective level" for XP computation and diminishing tracks the
-        // player's current level instead of the authored quest level.
+        // Compute effective rewards up front so the GMCP completion payload
+        // (and the client's reward popup) can show the values the player
+        // actually receives — including any zone-scaled XP override.
         val zoneScaling = world?.zoneScaling(idZone(quest.id))
         val effectiveLevel = when {
             zoneScaling == null -> quest.level ?: ps.level
@@ -572,6 +568,20 @@ class QuestSystem(
             } else {
                 rewards
             }
+
+        outbound.send(OutboundEvent.SendInfo(sessionId, "Quest complete: ${quest.name}!"))
+        onQuestCompletedGmcp?.invoke(
+            sessionId,
+            QuestCompletionSummary(
+                questId = questId,
+                questName = quest.name,
+                questDescription = quest.description,
+                rewardXp = effectiveRewards.xp,
+                rewardGold = effectiveRewards.gold,
+                rewardCurrencies = effectiveRewards.currencies,
+            ),
+        )
+        onQuestCompleted?.invoke(sessionId, questId)
 
         // Diminishing applies in STATIC zones only. In BOUNDED / PLAYER zones
         // the content is already scaled to the player, so charging an additional

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestHandler.kt
@@ -1,6 +1,7 @@
 package dev.ambon.engine.commands.handlers
 
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.quest.QuestDef
 import dev.ambon.engine.AchievementRegistry
 import dev.ambon.engine.AchievementSystem
 import dev.ambon.engine.HouseEntryResult
@@ -240,7 +241,20 @@ class DialogueQuestHandler(
         val qs = requireSystemOrNull(sessionId, questSystem, "Quests", outbound) ?: return
         val me = players.get(sessionId) ?: return
         val roomMobIds = mobs.mobsInRoom(me.roomId).map { it.id.value }
-        outbound.sendIfError(sessionId, qs.turnInQuest(sessionId, cmd.nameHint, roomMobIds))
+        // Resolve the quest from the hint up front so we can refresh offers
+        // for the right NPC after a successful turn-in.
+        val matched = me.activeQuests.keys
+            .mapNotNull(questRegistry::get)
+            .firstOrNull { quest ->
+                val lower = cmd.nameHint.trim().lowercase()
+                quest.name.lowercase().contains(lower) || quest.id.lowercase().contains(lower)
+            }
+        val err = qs.turnInQuest(sessionId, cmd.nameHint, roomMobIds)
+        if (err != null) {
+            outbound.send(OutboundEvent.SendError(sessionId, err))
+            return
+        }
+        refreshOffersAfterTurnIn(sessionId, qs, matched, roomMobIds)
     }
 
     private suspend fun handleQuestTurnInById(
@@ -250,7 +264,30 @@ class DialogueQuestHandler(
         val qs = requireSystemOrNull(sessionId, questSystem, "Quests", outbound) ?: return
         val me = players.get(sessionId) ?: return
         val roomMobIds = mobs.mobsInRoom(me.roomId).map { it.id.value }
-        outbound.sendIfError(sessionId, qs.turnInQuestById(sessionId, cmd.questId, roomMobIds))
+        val quest = questRegistry.get(cmd.questId)
+        val err = qs.turnInQuestById(sessionId, cmd.questId, roomMobIds)
+        if (err != null) {
+            outbound.send(OutboundEvent.SendError(sessionId, err))
+            return
+        }
+        refreshOffersAfterTurnIn(sessionId, qs, quest, roomMobIds)
+    }
+
+    /**
+     * Re-emit `Quest.Available` for the resolved turn-in NPC after a successful
+     * turn-in so an open QuestOfferPanel reflects the post-turn-in state
+     * (otherwise it keeps showing the now-completed quest with its Turn In
+     * button).
+     */
+    private suspend fun refreshOffersAfterTurnIn(
+        sessionId: SessionId,
+        qs: QuestSystem,
+        quest: QuestDef?,
+        roomMobIds: Collection<String>,
+    ) {
+        val turnInMobId = (quest?.turnInMobId ?: quest?.giverMobId) ?: return
+        if (turnInMobId !in roomMobIds) return
+        gmcpEmitter?.sendQuestAvailable(sessionId, qs.questOffersFor(sessionId, turnInMobId))
     }
 
     private suspend fun handleAchievementList(sessionId: SessionId) {

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -1205,12 +1205,24 @@ class GmcpEmitterTest {
     fun `sendQuestComplete emits correct JSON`() =
         runTest {
             val e = emitter("Quest")
-            e.sendQuestComplete(sid, "slay_goblins", "Goblin Menace")
+            e.sendQuestComplete(
+                sid,
+                "slay_goblins",
+                "Goblin Menace",
+                "Slay 5 goblins for the captain.",
+                rewardXp = 250L,
+                rewardGold = 30L,
+                rewardCurrencies = mapOf("honor" to 5L),
+            )
             val events = drainGmcp()
             assertEquals(1, events.size)
             assertEquals("Quest.Complete", events[0].gmcpPackage)
             assertTrue(events[0].jsonData.contains("\"questId\":\"slay_goblins\""))
             assertTrue(events[0].jsonData.contains("\"questName\":\"Goblin Menace\""))
+            assertTrue(events[0].jsonData.contains("\"questDescription\":\"Slay 5 goblins for the captain.\""))
+            assertTrue(events[0].jsonData.contains("\"xp\":250"))
+            assertTrue(events[0].jsonData.contains("\"gold\":30"))
+            assertTrue(events[0].jsonData.contains("\"honor\":5"))
         }
 
     @Test
@@ -1219,7 +1231,7 @@ class GmcpEmitterTest {
             val e = emitter()
             e.sendQuestList(sid, emptyList())
             e.sendQuestUpdate(sid, "q", 0, 1, 5, readyToTurnIn = false)
-            e.sendQuestComplete(sid, "q", "Q")
+            e.sendQuestComplete(sid, "q", "Q", "", 0L, 0L, emptyMap())
             assertTrue(drainGmcp().isEmpty())
         }
 

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -28,6 +28,7 @@ import { CombatLogPanel } from "./components/panels/CombatLogPanel";
 import { WorldAtmosphereHud } from "./components/WorldAtmosphereHud";
 import { HelpContent } from "./components/HelpContent";
 import { LevelUpBanner } from "./components/LevelUpBanner";
+import { QuestCompleteToast } from "./components/QuestCompleteToast";
 import { LoginModal } from "./canvas/LoginModal";
 import { CharacterPicker } from "./components/CharacterPicker";
 import { CommandPalette } from "./components/CommandPalette";
@@ -1358,6 +1359,14 @@ function App() {
       <LevelUpBanner
         notification={state.levelUpNotification}
         onDismiss={() => state.setLevelUpNotification(null)}
+      />
+
+      {/* Quest turn-in summary toast — shows quest name + rewards. */}
+      <QuestCompleteToast
+        notifications={state.questNotifications}
+        onDismiss={(id) =>
+          state.setQuestNotifications((prev) => prev.filter((n) => n.id !== id))
+        }
       />
 
       {/* Server broadcast */}

--- a/web-v3/src/components/QuestCompleteToast.tsx
+++ b/web-v3/src/components/QuestCompleteToast.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useMemo, useState } from "react";
+import type { QuestNotification } from "../types";
+
+interface QuestCompleteToastProps {
+  notifications: QuestNotification[];
+  onDismiss: (id: string) => void;
+}
+
+/**
+ * Top-right toast surfaced when a Quest.Complete GMCP packet arrives.
+ *
+ * Picks up the most recent unhandled "complete"-type QuestNotification, shows
+ * quest name + description + rewards for ~5s, then fades. Click anywhere on
+ * the toast to dismiss early. Stays out of the way of gameplay.
+ */
+export function QuestCompleteToast({ notifications, onDismiss }: QuestCompleteToastProps) {
+  const current = useMemo(
+    () => notifications.find((n) => n.event === "complete") ?? null,
+    [notifications],
+  );
+  if (!current) return null;
+  return (
+    <QuestCompleteToastInner
+      key={current.id}
+      notification={current}
+      onDismiss={() => onDismiss(current.id)}
+    />
+  );
+}
+
+interface InnerProps {
+  notification: QuestNotification;
+  onDismiss: () => void;
+}
+
+function QuestCompleteToastInner({ notification, onDismiss }: InnerProps) {
+  const [closing, setClosing] = useState(false);
+
+  useEffect(() => {
+    const fade = window.setTimeout(() => setClosing(true), 5000);
+    return () => window.clearTimeout(fade);
+  }, []);
+
+  useEffect(() => {
+    if (!closing) return;
+    const clear = window.setTimeout(() => onDismiss(), 350);
+    return () => window.clearTimeout(clear);
+  }, [closing, onDismiss]);
+
+  const rewards = notification.rewards;
+  const currencyEntries = rewards ? Object.entries(rewards.currencies) : [];
+  const hasRewards = !!rewards && (rewards.xp > 0 || rewards.gold > 0 || currencyEntries.length > 0);
+
+  return (
+    <div
+      className={`quest-complete-toast${closing ? " quest-complete-toast-closing" : ""}`}
+      role="status"
+      aria-live="polite"
+      onClick={() => setClosing(true)}
+    >
+      <div className="quest-complete-toast-header">
+        <span className="quest-complete-toast-icon" aria-hidden="true">{"✨"}</span>
+        <div className="quest-complete-toast-titles">
+          <span className="quest-complete-toast-eyebrow">Quest Complete</span>
+          <span className="quest-complete-toast-name">{notification.questName}</span>
+        </div>
+      </div>
+      {notification.questDescription && (
+        <p className="quest-complete-toast-desc">{notification.questDescription}</p>
+      )}
+      {hasRewards && (
+        <ul className="quest-complete-toast-rewards" role="list">
+          {rewards!.xp > 0 && (
+            <li className="quest-complete-toast-reward quest-complete-toast-reward-xp">
+              <span className="quest-complete-toast-reward-amount">+{rewards!.xp}</span>
+              <span className="quest-complete-toast-reward-label">XP</span>
+            </li>
+          )}
+          {rewards!.gold > 0 && (
+            <li className="quest-complete-toast-reward quest-complete-toast-reward-gold">
+              <span className="quest-complete-toast-reward-amount">+{rewards!.gold}</span>
+              <span className="quest-complete-toast-reward-label">Gold</span>
+            </li>
+          )}
+          {currencyEntries.map(([id, amount]) => (
+            <li key={id} className="quest-complete-toast-reward quest-complete-toast-reward-currency">
+              <span className="quest-complete-toast-reward-amount">+{amount}</span>
+              <span className="quest-complete-toast-reward-label">{id}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -1039,13 +1039,34 @@ export function applyGmcpPackage(
       const questId = typeof packet.questId === "string" ? packet.questId : null;
       if (!questId) break;
       const questName = typeof packet.questName === "string" ? packet.questName : "Quest";
+      const questDescription = typeof packet.questDescription === "string" ? packet.questDescription : "";
+      const rewardsRaw = typeof packet.rewards === "object" && packet.rewards !== null
+        ? packet.rewards as Record<string, unknown>
+        : {};
+      const currenciesRaw = typeof rewardsRaw.currencies === "object" && rewardsRaw.currencies !== null
+        ? rewardsRaw.currencies as Record<string, unknown>
+        : {};
+      const currencies: Record<string, number> = {};
+      for (const [k, v] of Object.entries(currenciesRaw)) {
+        currencies[k] = safeNumber(v);
+      }
       ctx.setQuests((prev) => prev.filter((q) => q.id !== questId));
+      // Drop the completed quest from any open offer panel so its Turn In
+      // card disappears the moment Quest.Complete arrives, even before the
+      // server's follow-up Quest.Available re-emit lands.
+      ctx.setQuestsAvailable((prev) => prev.filter((q) => q.id !== questId));
       ctx.pushQuestNotification({
         id: `${Date.now()}-${Math.random()}`,
         questId,
         questName,
         event: "complete",
         receivedAt: Date.now(),
+        questDescription,
+        rewards: {
+          xp: safeNumber(rewardsRaw.xp),
+          gold: safeNumber(rewardsRaw.gold),
+          currencies,
+        },
       });
       break;
     }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -16668,3 +16668,162 @@ html:has(.game-shell),
 .terminal-primary {
   display: none !important;
 }
+
+/* ─────────────────────────────────────────────────────────────
+ * Quest-complete toast — top-right summary on Quest.Complete.
+ *
+ * Smaller, non-blocking sibling to the level-up banner: jewel-tone
+ * card slides in from the right, fades out after ~5s. Click to
+ * dismiss. Stays out of canvas/input flow with a fixed position.
+ * ───────────────────────────────────────────────────────────── */
+
+.quest-complete-toast {
+  position: fixed;
+  top: calc(var(--space-4, 16px) + 56px);
+  right: var(--space-4, 16px);
+  z-index: 240;
+  width: min(320px, calc(100vw - 32px));
+  padding: 14px 16px;
+  background: linear-gradient(
+    155deg,
+    color-mix(in srgb, var(--c-soft-gold, #f0c674) 18%, var(--c-surface-raised, #1e2340)) 0%,
+    var(--c-surface-raised, #1e2340) 60%,
+    color-mix(in srgb, var(--c-accent-lavender, #b294bb) 14%, var(--c-surface-raised, #1e2340)) 100%
+  );
+  border: 1px solid color-mix(in srgb, var(--c-soft-gold, #f0c674) 45%, transparent);
+  border-radius: 14px;
+  box-shadow:
+    0 18px 48px rgba(0, 0, 0, 0.45),
+    0 0 0 1px color-mix(in srgb, var(--c-soft-gold, #f0c674) 22%, transparent),
+    0 0 32px color-mix(in srgb, var(--c-soft-gold, #f0c674) 28%, transparent);
+  color: var(--c-text-primary, #d8dcef);
+  cursor: pointer;
+  animation: questCompleteToastIn 380ms var(--ease-out-soft, cubic-bezier(0.22, 1, 0.36, 1));
+  backdrop-filter: blur(8px);
+}
+
+.quest-complete-toast.quest-complete-toast-closing {
+  animation: questCompleteToastOut 320ms var(--ease-out-soft, cubic-bezier(0.22, 1, 0.36, 1)) forwards;
+}
+
+@keyframes questCompleteToastIn {
+  from {
+    opacity: 0;
+    transform: translateX(24px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+}
+
+@keyframes questCompleteToastOut {
+  from {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(16px) scale(0.97);
+  }
+}
+
+.quest-complete-toast-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.quest-complete-toast-icon {
+  font-size: 22px;
+  filter: drop-shadow(0 0 6px color-mix(in srgb, var(--c-soft-gold, #f0c674) 60%, transparent));
+}
+
+.quest-complete-toast-titles {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.quest-complete-toast-eyebrow {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: color-mix(in srgb, var(--c-soft-gold, #f0c674) 70%, var(--c-text-secondary, #8890b0));
+  font-weight: 600;
+}
+
+.quest-complete-toast-name {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--c-text-primary, #d8dcef);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.quest-complete-toast-desc {
+  margin: 0 0 10px 0;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--c-text-secondary, #8890b0);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.quest-complete-toast-rewards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.quest-complete-toast-reward {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  background: color-mix(in srgb, var(--c-surface-base, #131630) 60%, transparent);
+  border: 1px solid color-mix(in srgb, var(--c-text-secondary, #8890b0) 25%, transparent);
+}
+
+.quest-complete-toast-reward-amount {
+  font-weight: 700;
+}
+
+.quest-complete-toast-reward-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--c-text-secondary, #8890b0);
+}
+
+.quest-complete-toast-reward-xp {
+  border-color: color-mix(in srgb, var(--c-accent-lavender, #b294bb) 45%, transparent);
+  color: color-mix(in srgb, var(--c-accent-lavender, #b294bb) 80%, var(--c-text-primary, #d8dcef));
+}
+
+.quest-complete-toast-reward-gold {
+  border-color: color-mix(in srgb, var(--c-soft-gold, #f0c674) 55%, transparent);
+  color: color-mix(in srgb, var(--c-soft-gold, #f0c674) 90%, var(--c-text-primary, #d8dcef));
+}
+
+.quest-complete-toast-reward-currency {
+  border-color: color-mix(in srgb, var(--c-pale-blue, #81a2be) 45%, transparent);
+  color: color-mix(in srgb, var(--c-pale-blue, #81a2be) 85%, var(--c-text-primary, #d8dcef));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .quest-complete-toast,
+  .quest-complete-toast.quest-complete-toast-closing {
+    animation-duration: 80ms;
+  }
+}

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -576,6 +576,13 @@ export interface QuestNotification {
   questName: string;
   event: "complete" | "update";
   receivedAt: number;
+  // Populated for "complete" events; null/empty for "update".
+  questDescription?: string;
+  rewards?: {
+    xp: number;
+    gold: number;
+    currencies: Record<string, number>;
+  };
 }
 
 export interface QuestAvailableObjective {


### PR DESCRIPTION
## Summary

Three quest-flow bug fixes plus a reward popup, building on the talk/quest split landed in #1118–#1120.

**Bugs fixed**

- *Popout doesn't refresh when you finish the quest in the room.* `QuestSystem.advanceObjectives` was firing `onQuestObjectiveUpdated` (→ `Quest.Update`) but not refreshing room mob info. The questgiver's `questComplete` flag stayed false until the player left and re-entered the room, so the popout button stayed "★ Quest" instead of "★ Turn In Quest" and the canvas `?` indicator was stale. `GameEngine` now calls `refreshRoomMobInfoForPlayer` when `readyToTurnIn` flips true.
- *QuestOfferPanel keeps showing "Turn In" after click.* `qoffers <mob>` populates `state.questsAvailable`; after `quest turnin #<id>` succeeded, the server fired `Quest.Complete` + `Quest.List` + `Room.MobInfo` but never re-emitted `Quest.Available`, so the panel rendered the same Turn In card. `DialogueQuestHandler` (both `handleQuestTurnIn` and `handleQuestTurnInById`) now re-emits `Quest.Available` for the resolved turn-in NPC after a successful turn-in.

**New: turn-in reward toast**

- `QuestSystem.completeQuest` now computes effective rewards (post zone-scaling) before invoking `onQuestCompletedGmcp`, and passes a new `QuestCompletionSummary` carrying name, description, xp, gold, and currencies.
- `GmcpEmitter.sendQuestComplete` + `QuestCompletePayload` widened with `questDescription` and full `rewards`. `GmcpEmitterTest` updated.
- Web: `applyGmcpPackage` parses the new fields and also drops the completed quest from `questsAvailable` immediately so the panel reacts even before the server's follow-up re-emit lands.
- New `QuestCompleteToast` component renders a top-right summary card for ~5 s with quest name, description, and XP / Gold / currency chips. Click to dismiss; honors `prefers-reduced-motion`.

## Test plan

- [x] `./gradlew ktlintCheck`
- [x] `./gradlew test` (full suite, incl. updated `GmcpEmitterTest.sendQuestComplete emits correct JSON`)
- [x] `bun run lint` (web-v3)
- [x] `bunx tsc --noEmit` (web-v3)
- [x] `bun run build` (web-v3, full vite build)
- [ ] Manual: kill the last objective mob in the same room as the questgiver — popout immediately offers "★ Turn In Quest" without leaving the room.
- [ ] Manual: click Turn In on the QuestOfferPanel — the card disappears (no stale Turn In button), and a top-right toast appears showing rewards. Toast auto-fades after 5 s; click to dismiss early.
- [ ] Manual: turn in a quest with secondary currency rewards — toast lists XP, Gold, and the currency chip.
- [ ] Manual: turn in a quest at an override `turnInMobId` (e.g. Scholar Elara → Headmaster Aldric) — panel refreshes correctly at Aldric.