### PR TITLE
Mob template/spawn split: enable multi-spawn trash mobs

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/mob/MobState.kt
+++ b/src/main/kotlin/dev/ambon/domain/mob/MobState.kt
@@ -11,7 +11,7 @@ import dev.ambon.engine.dialogue.DialogueTree
 data class MobState(
     override val id: MobId,
     override var name: String,
-    override var roomId: RoomId,
+    var roomId: RoomId,
     override val description: String = "",
     var hp: Int = 10,
     override var maxHp: Int = 10,

--- a/src/main/kotlin/dev/ambon/domain/mob/MobTemplate.kt
+++ b/src/main/kotlin/dev/ambon/domain/mob/MobTemplate.kt
@@ -2,16 +2,14 @@ package dev.ambon.domain.mob
 
 import dev.ambon.domain.DamageRange
 import dev.ambon.domain.ids.MobId
-import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.world.MobDrop
 import dev.ambon.engine.behavior.BtNode
 import dev.ambon.engine.dialogue.DialogueTree
 
-/** Fields shared between the config-time [dev.ambon.domain.world.MobSpawn] and the live [MobState]. */
+/** Fields shared between the config-time [dev.ambon.domain.world.MobTemplateDef] and the live [MobState]. */
 interface MobTemplate {
     val id: MobId
     val name: String
-    val roomId: RoomId
     val description: String
     val maxHp: Int
     val damage: DamageRange

--- a/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
@@ -11,7 +11,7 @@ import dev.ambon.engine.behavior.BtNode
 import dev.ambon.engine.dialogue.DialogueTree
 
 /**
- * Authored stat overrides that won at load time. Preserved on [MobSpawn] so
+ * Authored stat overrides that won at load time. Preserved on [MobTemplateDef] so
  * that spawn-time rescaling (for zones with non-STATIC scaling) can replay
  * the tier × level math while still honouring the author's explicit values.
  */
@@ -25,10 +25,14 @@ data class MobStatOverrides(
     val goldMax: Long? = null,
 )
 
-data class MobSpawn(
+/**
+ * The static, room-independent definition of a mob: stats, drops, dialogue,
+ * behavior, quests, etc. One [MobTemplateDef] is built per `mobs:` entry in the
+ * world YAML and is referenced by zero or more [MobSpawn] placement records.
+ */
+data class MobTemplateDef(
     override val id: MobId,
     override val name: String,
-    override val roomId: RoomId,
     override val description: String = "",
     override val maxHp: Int = 10,
     override val damage: DamageRange = DamageRange(1, 4),
@@ -60,3 +64,23 @@ data class MobSpawn(
     /** Which stats the author explicitly set. Overrides stay fixed even when scaling shifts level. */
     val overrides: MobStatOverrides = MobStatOverrides(),
 ) : MobTemplate
+
+/**
+ * A placement record: one runtime instance of a [MobTemplateDef] in a specific room.
+ * The loader emits one [MobSpawn] per copy declared in the YAML (a `count: 3` entry
+ * produces three [MobSpawn]s sharing the same [templateId] but with distinct [id]s).
+ *
+ * - [id] is the runtime mob id (also the [dev.ambon.domain.mob.MobState.id] when alive).
+ *   For a template with a single global instance this equals [templateId]; otherwise
+ *   it has the form `<templateId>#<instanceIndex>`.
+ * - [templateId] always equals the parent [MobTemplateDef.id], regardless of
+ *   instance count.
+ * - [instanceIndex] is the 0-based ordinal within the template's spawn list, stable
+ *   across reloads as long as the YAML order is unchanged.
+ */
+data class MobSpawn(
+    val id: MobId,
+    val templateId: MobId,
+    val roomId: RoomId,
+    val instanceIndex: Int = 0,
+)

--- a/src/main/kotlin/dev/ambon/domain/world/World.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/World.kt
@@ -3,6 +3,7 @@ package dev.ambon.domain.world
 import dev.ambon.domain.crafting.GatheringNodeDef
 import dev.ambon.domain.crafting.RecipeDef
 import dev.ambon.domain.dungeon.DungeonTemplateDef
+import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.idZone
 import dev.ambon.domain.puzzle.PuzzleDef
@@ -11,6 +12,7 @@ import dev.ambon.domain.quest.QuestDef
 class World(
     rooms: Map<RoomId, Room>,
     startRoom: RoomId,
+    mobTemplates: Map<MobId, MobTemplateDef> = emptyMap(),
     mobSpawns: List<MobSpawn> = emptyList(),
     itemSpawns: List<ItemSpawn> = emptyList(),
     zoneLifespansMinutes: Map<String, Long> = emptyMap(),
@@ -30,6 +32,12 @@ class World(
 
     var startRoom: RoomId = startRoom
         private set
+
+    private val _mobTemplates = LinkedHashMap(mobTemplates)
+    val mobTemplates: Map<MobId, MobTemplateDef> get() = _mobTemplates
+
+    /** Returns the template for [id], or null if unknown. */
+    fun mobTemplate(id: MobId): MobTemplateDef? = _mobTemplates[id]
 
     private val _mobSpawns = mobSpawns.toMutableList()
     val mobSpawns: List<MobSpawn> get() = _mobSpawns
@@ -102,6 +110,12 @@ class World(
         val newRooms = source.rooms.filter { it.key.zone == zone }
         _rooms.putAll(newRooms)
 
+        val templateKeysToRemove = _mobTemplates.keys.filter { idZone(it.value) == zone }
+        for (key in templateKeysToRemove) _mobTemplates.remove(key)
+        for ((key, value) in source.mobTemplates) {
+            if (idZone(key.value) == zone) _mobTemplates[key] = value
+        }
+
         _mobSpawns.removeAll { idZone(it.id.value) == zone }
         _mobSpawns.addAll(source.mobSpawns.filter { idZone(it.id.value) == zone })
 
@@ -150,6 +164,9 @@ class World(
         _rooms.clear()
         _rooms.putAll(source.rooms)
         startRoom = source.startRoom
+
+        _mobTemplates.clear()
+        _mobTemplates.putAll(source.mobTemplates)
 
         _mobSpawns.clear()
         _mobSpawns.addAll(source.mobSpawns)

--- a/src/main/kotlin/dev/ambon/domain/world/data/MobFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/MobFile.kt
@@ -3,7 +3,17 @@ package dev.ambon.domain.world.data
 data class MobFile(
     val name: String,
     val description: String = "",
-    val room: String,
+    /**
+     * Legacy single-room shorthand. Equivalent to `spawns: [{ room: <value> }]`.
+     * Prefer [spawns] for new content; this field is preserved so old YAML keeps loading.
+     */
+    val room: String? = null,
+    /**
+     * Spawn placements for this mob template. Each entry creates [MobSpawnFile.count]
+     * runtime instances in the named room. When empty, [room] is used as a fallback
+     * (one instance in that room).
+     */
+    val spawns: List<MobSpawnFile> = emptyList(),
     /**
      * What this mob is for: combat, vendor, quest_giver, dialog, or prop.
      * Non-combat roles refuse attack commands and skip combat-stat computation.

--- a/src/main/kotlin/dev/ambon/domain/world/data/MobSpawnFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/MobSpawnFile.kt
@@ -1,0 +1,11 @@
+package dev.ambon.domain.world.data
+
+/**
+ * One placement entry for a mob template. The loader expands a [MobSpawnFile]
+ * into [count] runtime [dev.ambon.domain.world.MobSpawn] records, all sharing
+ * the same template stats but each with a distinct instance id.
+ */
+data class MobSpawnFile(
+    val room: String,
+    val count: Int = 1,
+)

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -991,6 +991,32 @@ object WorldLoader {
             }
         }
 
+        // Validate quest-giver and turn-in NPCs are unique (single placement, count == 1).
+        // Multi-spawn quest givers would force the engine to pick one arbitrarily for HUD pins
+        // and dialogue routing, so we reject them at load.
+        val placementCounts: Map<MobId, Int> =
+            mergedSpawns
+                .groupingBy { it.templateId }
+                .eachCount()
+        for (quest in mergedQuests) {
+            requireUniqueQuestNpc(
+                quest = quest,
+                role = "giverMobId",
+                rawId = quest.giverMobId,
+                templates = mergedTemplates,
+                placementCounts = placementCounts,
+            )
+            quest.turnInMobId?.let { turnIn ->
+                requireUniqueQuestNpc(
+                    quest = quest,
+                    role = "turnInMobId",
+                    rawId = turnIn,
+                    templates = mergedTemplates,
+                    placementCounts = placementCounts,
+                )
+            }
+        }
+
         // Validate shop references after merge
         for (shop in mergedShops) {
             if (!mergedRooms.containsKey(shop.roomId)) {
@@ -1183,6 +1209,36 @@ object WorldLoader {
     ): MobId {
         val s = requireNonBlank(raw) { "Mob id cannot be blank" }
         return MobId(qualifyId(zone, s))
+    }
+
+    /**
+     * Enforces the "quest-giver / turn-in NPCs are unique" invariant. Rejects:
+     * - missing template (typo or unloaded zone),
+     * - templates with anything other than exactly one placement.
+     *
+     * Called after spawns are expanded and quests are merged, so [placementCounts]
+     * reflects the final post-load picture.
+     */
+    private fun requireUniqueQuestNpc(
+        quest: QuestDef,
+        role: String,
+        rawId: String,
+        templates: Map<MobId, MobTemplateDef>,
+        placementCounts: Map<MobId, Int>,
+    ) {
+        val mobId = MobId(rawId)
+        if (mobId !in templates) {
+            throw WorldLoadException(
+                "Quest '${quest.id}' $role '$rawId' references unknown mob template.",
+            )
+        }
+        val count = placementCounts[mobId] ?: 0
+        if (count != 1) {
+            throw WorldLoadException(
+                "Quest '${quest.id}' $role '$rawId' must have exactly one spawn " +
+                    "(found $count). Quest-giver and turn-in NPCs must be unique.",
+            )
+        }
     }
 
     /**

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -44,6 +44,7 @@ import dev.ambon.domain.world.LockableState
 import dev.ambon.domain.world.MobDrop
 import dev.ambon.domain.world.MobSpawn
 import dev.ambon.domain.world.MobStatOverrides
+import dev.ambon.domain.world.MobTemplateDef
 import dev.ambon.domain.world.ReputationRequirement
 import dev.ambon.domain.world.Room
 import dev.ambon.domain.world.RoomFeature
@@ -55,6 +56,8 @@ import dev.ambon.domain.world.ZoneScaling
 import dev.ambon.domain.world.data.ExitValue
 import dev.ambon.domain.world.data.ExitValueDeserializer
 import dev.ambon.domain.world.data.FeatureFile
+import dev.ambon.domain.world.data.MobFile
+import dev.ambon.domain.world.data.MobSpawnFile
 import dev.ambon.domain.world.data.ReputationRequirementFile
 import dev.ambon.domain.world.data.WorldFile
 import dev.ambon.domain.world.resolveMobStats
@@ -139,7 +142,8 @@ object WorldLoader {
         val allExits = LinkedHashMap<RoomId, Map<Direction, RoomId>>() // staged exits per room
         val allGates = LinkedHashMap<RoomId, Map<Direction, AchievementGate>>() // staged per-room achievement gates
         val allRoomFeatures = LinkedHashMap<RoomId, MutableList<RoomFeature>>() // staged features per room
-        val mergedMobs = LinkedHashMap<MobId, MobSpawn>()
+        val mergedTemplates = LinkedHashMap<MobId, MobTemplateDef>()
+        val mergedSpawns = mutableListOf<MobSpawn>()
         val mergedItems = LinkedHashMap<ItemId, ItemSpawn>()
         val mergedShops = mutableListOf<ShopDefinition>()
         val mergedTrainers = mutableListOf<TrainerDefinition>()
@@ -320,10 +324,11 @@ object WorldLoader {
             // Stage mobs (normalized), validate uniqueness
             for ((rawId, mf) in file.mobs) {
                 val mobId = normalizeMobId(zone, rawId)
-                if (mergedMobs.containsKey(mobId)) {
+                if (mergedTemplates.containsKey(mobId)) {
                     throw WorldLoadException("Duplicate mob id '${mobId.value}' across zone files")
                 }
-                val roomId = normalizeTarget(zone, mf.room)
+
+                val placementSources = resolveMobPlacements(mobId, mf)
 
                 val tierName = mf.tier?.trim()?.lowercase()
                 val tier =
@@ -415,12 +420,11 @@ object WorldLoader {
                     )
                 }
 
-                mergedMobs[mobId] =
-                    MobSpawn(
+                mergedTemplates[mobId] =
+                    MobTemplateDef(
                         id = mobId,
                         name = mf.name,
                         description = mf.description,
-                        roomId = roomId,
                         maxHp = resolvedHp,
                         damage = DamageRange(resolvedMinDamage, resolvedMaxDamage),
                         armor = resolvedArmor,
@@ -450,6 +454,8 @@ object WorldLoader {
                         tier = tier,
                         overrides = overrides,
                     )
+
+                expandPlacements(mobId, placementSources, zone, mergedSpawns)
             }
 
             // Stage items (normalized), validate uniqueness
@@ -956,10 +962,10 @@ object WorldLoader {
         }
 
         // Validate mob starting rooms exist after merge
-        for ((mobId, mob) in mergedMobs) {
-            if (!mergedRooms.containsKey(mob.roomId)) {
+        for (spawn in mergedSpawns) {
+            if (!mergedRooms.containsKey(spawn.roomId)) {
                 throw WorldLoadException(
-                    "Mob '${mobId.value}' starts in missing room '${mob.roomId.value}'",
+                    "Mob '${spawn.id.value}' starts in missing room '${spawn.roomId.value}'",
                 )
             }
         }
@@ -975,8 +981,8 @@ object WorldLoader {
         }
 
         // Validate mob drop item references exist after merge
-        for ((mobId, mob) in mergedMobs) {
-            for ((index, drop) in mob.drops.withIndex()) {
+        for ((mobId, template) in mergedTemplates) {
+            for ((index, drop) in template.drops.withIndex()) {
                 if (!mergedItems.containsKey(drop.itemId)) {
                     throw WorldLoadException(
                         "Mob '${mobId.value}' drop #${index + 1} references missing item '${drop.itemId.value}'",
@@ -1082,7 +1088,11 @@ object WorldLoader {
         return World(
             rooms = coordRooms.toMutableMap(),
             startRoom = worldStart,
-            mobSpawns = mergedMobs.values.sortedBy { it.id.value },
+            mobTemplates =
+                mergedTemplates.entries
+                    .sortedBy { it.key.value }
+                    .associate { (id, def) -> id to def },
+            mobSpawns = mergedSpawns.sortedWith(compareBy({ it.templateId.value }, { it.instanceIndex })),
             itemSpawns = mergedItems.values.sortedBy { it.instance.id.value },
             zoneLifespansMinutes =
                 zoneLifespansMinutes.entries
@@ -1173,6 +1183,84 @@ object WorldLoader {
     ): MobId {
         val s = requireNonBlank(raw) { "Mob id cannot be blank" }
         return MobId(qualifyId(zone, s))
+    }
+
+    /**
+     * Resolves the spawn list for a mob entry. Prefers the explicit `spawns:`
+     * list; falls back to the legacy `room:` shorthand (one placement) and
+     * logs a one-time deprecation note. Throws if neither is present.
+     */
+    private fun resolveMobPlacements(
+        mobId: MobId,
+        mf: MobFile,
+    ): List<MobSpawnFile> {
+        if (mf.spawns.isNotEmpty()) {
+            if (mf.room != null) {
+                throw WorldLoadException(
+                    "Mob '${mobId.value}' declares both 'room' and 'spawns' — " +
+                        "use 'spawns' only.",
+                )
+            }
+            return mf.spawns
+        }
+        val shorthand = mf.room
+            ?: throw WorldLoadException(
+                "Mob '${mobId.value}' has no spawns and no 'room' shorthand.",
+            )
+        logger.debug(
+            "Mob '{}' uses legacy 'room:' shorthand; migrate to 'spawns: [{{ room: {} }}]'.",
+            mobId.value,
+            shorthand,
+        )
+        return listOf(MobSpawnFile(room = shorthand))
+    }
+
+    /**
+     * Expands [placements] into runtime [MobSpawn] records, appending them to
+     * [out]. Single-instance templates keep an id equal to [templateId];
+     * multi-instance templates get `<templateId>#<n>` ids. Validates `count`
+     * and that each room reference normalizes.
+     */
+    private fun expandPlacements(
+        templateId: MobId,
+        placements: List<MobSpawnFile>,
+        zone: String,
+        out: MutableList<MobSpawn>,
+    ) {
+        val totalInstances = placements.sumOf { it.count }
+        if (totalInstances < 1) {
+            throw WorldLoadException(
+                "Mob '${templateId.value}' must have at least one spawn instance " +
+                    "(found total count $totalInstances).",
+            )
+        }
+        var index = 0
+        for ((placementIndex, placement) in placements.withIndex()) {
+            if (placement.count < 1) {
+                throw WorldLoadException(
+                    "Mob '${templateId.value}' spawn entry #${placementIndex + 1} " +
+                        "must have count >= 1 (got ${placement.count}).",
+                )
+            }
+            val roomId = normalizeTarget(zone, placement.room)
+            repeat(placement.count) {
+                val instanceId =
+                    if (totalInstances == 1) {
+                        templateId
+                    } else {
+                        MobId("${templateId.value}#$index")
+                    }
+                out.add(
+                    MobSpawn(
+                        id = instanceId,
+                        templateId = templateId,
+                        roomId = roomId,
+                        instanceIndex = index,
+                    ),
+                )
+                index++
+            }
+        }
     }
 
     private fun normalizeItemId(

--- a/src/main/kotlin/dev/ambon/engine/AutoQuestSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/AutoQuestSystem.kt
@@ -66,11 +66,14 @@ class AutoQuestSystem(
             ?: return Result.failure(AutoQuestError("Player not found."))
 
         val playerZone = player.roomId.zone
-        val candidates = world.mobSpawns.filter { spawn ->
-            idZone(spawn.id.value) == playerZone &&
-                spawn.dialogue == null &&
-                spawn.xpReward > 0
-        }
+        val candidates = world.mobSpawns
+            .asSequence()
+            .filter { idZone(it.id.value) == playerZone }
+            .map { it.templateId }
+            .distinct()
+            .mapNotNull { world.mobTemplate(it) }
+            .filter { it.dialogue == null && it.xpReward > 0 }
+            .toList()
         if (candidates.isEmpty()) {
             return Result.failure(AutoQuestError("No suitable targets found in this area."))
         }

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -2187,7 +2187,7 @@ class GameEngine(
      */
     private fun resolveObjectiveRoomIds(targetId: String): List<String> {
         val mobRooms = world.mobSpawns
-            .filter { it.id.value == targetId }
+            .filter { it.templateId.value == targetId }
             .map { it.roomId.value }
         if (mobRooms.isNotEmpty()) return mobRooms
 
@@ -2266,8 +2266,9 @@ class GameEngine(
         mobRemovalCoordinator.onCombatKillCleanup(mobId)
         gmcpEmitter.broadcastRoomRemoveMob(roomId, mobId.value, players)
         val spawn = world.mobSpawns.find { it.id == mobId }
-        val respawnMs = spawn?.respawnSeconds?.let { it * 1_000L }
-        if (spawn != null && respawnMs != null) {
+        val template = spawn?.let { world.mobTemplate(it.templateId) }
+        val respawnMs = template?.respawnSeconds?.let { it * 1_000L }
+        if (spawn != null && template != null && respawnMs != null) {
             scheduler.scheduleIn(respawnMs) {
                 if (mobs.get(spawn.id) != null) return@scheduleIn
                 if (world.rooms[spawn.roomId] == null) return@scheduleIn
@@ -2277,7 +2278,7 @@ class GameEngine(
                 mobSystem.onMobSpawned(spawn.id)
                 behaviorTreeSystem.onMobSpawned(spawn.id)
                 for (p in players.playersInRoom(spawn.roomId)) {
-                    outbound.send(OutboundEvent.SendText(p.sessionId, "${spawn.name} appears."))
+                    outbound.send(OutboundEvent.SendText(p.sessionId, "${respawned.name} appears."))
                     gmcpEmitter.sendRoomAddMob(p.sessionId, respawned)
                 }
             }
@@ -2445,13 +2446,13 @@ class GameEngine(
         globalQuestSystem?.onEvent(sessionId, GlobalQuestObjectiveType.KILL)
 
         // Faction reputation changes on mob kill
-        val mobSpawn = world.mobSpawns.firstOrNull { it.id.value == templateKey }
-        if (mobSpawn?.faction != null) {
+        val mobTemplate = world.mobTemplate(dev.ambon.domain.ids.MobId(templateKey))
+        if (mobTemplate?.faction != null) {
             val player = players.get(sessionId)
             if (player != null) {
                 // Level proxy: maxHp/10, capped at 20 to prevent extreme swings from bosses
-                val levelProxy = (mobSpawn.maxHp / 10).coerceAtMost(20)
-                val changes = reputationSystem.onMobKilled(player, mobSpawn.faction, levelProxy)
+                val levelProxy = (mobTemplate.maxHp / 10).coerceAtMost(20)
+                val changes = reputationSystem.onMobKilled(player, mobTemplate.faction, levelProxy)
                 for (change in changes) {
                     val factionName = reputationSystem.getFaction(change.factionId)?.name ?: change.factionId
                     val sign = if (change.amount > 0) "+" else ""

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -2045,14 +2045,14 @@ class GmcpEmitter(
      * Sends mob template listing to staff players for the spawn browser.
      */
     suspend fun sendStaffMobTemplates(sessionId: SessionId, world: World) {
-        val grouped = world.mobSpawns.groupBy { it.id.value.substringBefore(':') }
-        val zones = grouped.entries.sortedBy { it.key }.map { (zone, mobs) ->
+        val grouped = world.mobTemplates.values.groupBy { it.id.value.substringBefore(':') }
+        val zones = grouped.entries.sortedBy { it.key }.map { (zone, templates) ->
             StaffMobZonePayload(
                 zone = zone,
-                mobs = mobs.sortedBy { it.id.value }.map { mob ->
+                mobs = templates.sortedBy { it.id.value }.map { tpl ->
                     StaffMobTemplatePayload(
-                        id = mob.id.value,
-                        name = mob.name,
+                        id = tpl.id.value,
+                        name = tpl.name,
                     )
                 },
             )

--- a/src/main/kotlin/dev/ambon/engine/HotReloadManager.kt
+++ b/src/main/kotlin/dev/ambon/engine/HotReloadManager.kt
@@ -176,7 +176,7 @@ class HotReloadManager(
 
                 // Notify players in the room.
                 for (p in players.playersInRoom(spawn.roomId)) {
-                    outbound.send(OutboundEvent.SendText(p.sessionId, "${spawn.name} appears."))
+                    outbound.send(OutboundEvent.SendText(p.sessionId, "${mobState.name} appears."))
                     gmcpEmitter.sendRoomAddMob(p.sessionId, mobState)
                 }
             }

--- a/src/main/kotlin/dev/ambon/engine/ZoneResetHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/ZoneResetHandler.kt
@@ -35,64 +35,71 @@ internal fun computeDistanceMap(start: RoomId, world: World): Map<RoomId, Int> {
 }
 
 /**
- * Converts a [MobSpawn] definition into a live [MobState] instance.
+ * Converts a [MobSpawn] placement into a live [MobState] instance, reading
+ * stats from the matching [dev.ambon.domain.world.MobTemplateDef].
  *
  * When [referencePlayerLevel] is supplied and the mob's zone uses a non-STATIC
- * scaling mode, the spawn level and tier-derived stats are recomputed for that
- * player level. Authored overrides still win. Pass null (or nothing) to use
- * the authored spawn level — the normal path for zones without scaling.
+ * scaling mode, the template level and tier-derived stats are recomputed for
+ * that player level. Authored overrides still win. Pass null (or nothing) to
+ * use the authored level — the normal path for zones without scaling.
+ *
+ * Throws [IllegalStateException] if [spawn]'s template id is unknown to [world];
+ * the loader's invariant is that every spawn has a corresponding template.
  */
 internal fun spawnToMobState(
     spawn: MobSpawn,
     world: World,
     referencePlayerLevel: Int? = null,
 ): MobState {
+    val template = world.mobTemplate(spawn.templateId)
+        ?: error("No template '${spawn.templateId.value}' for spawn '${spawn.id.value}'")
     val zone = idZone(spawn.id.value)
     val scaling = world.zoneScaling(zone)
 
-    val shouldRescale = scaling.mode != ScalingMode.STATIC && spawn.tier != null
-    val effectiveLevel = if (shouldRescale) scaling.resolveLevel(referencePlayerLevel, spawn.level) else spawn.level
+    val shouldRescale = scaling.mode != ScalingMode.STATIC && template.tier != null
+    val effectiveLevel =
+        if (shouldRescale) scaling.resolveLevel(referencePlayerLevel, template.level) else template.level
     val resolved =
-        if (shouldRescale && effectiveLevel != spawn.level && spawn.tier != null) {
-            resolveMobStats(spawn.tier, effectiveLevel, spawn.overrides)
+        if (shouldRescale && effectiveLevel != template.level && template.tier != null) {
+            resolveMobStats(template.tier, effectiveLevel, template.overrides)
         } else {
             null
         }
 
-    val maxHp = resolved?.hp ?: spawn.maxHp
-    val damage = resolved?.damage ?: spawn.damage
-    val armor = resolved?.armor ?: spawn.armor
-    val xpReward = resolved?.xpReward ?: spawn.xpReward
-    val goldMin = resolved?.goldMin ?: spawn.goldMin
-    val goldMax = resolved?.goldMax ?: spawn.goldMax
+    val maxHp = resolved?.hp ?: template.maxHp
+    val damage = resolved?.damage ?: template.damage
+    val armor = resolved?.armor ?: template.armor
+    val xpReward = resolved?.xpReward ?: template.xpReward
+    val goldMin = resolved?.goldMin ?: template.goldMin
+    val goldMax = resolved?.goldMax ?: template.goldMax
 
     return MobState(
         id = spawn.id,
-        name = spawn.name,
-        description = spawn.description,
+        name = template.name,
+        description = template.description,
         roomId = spawn.roomId,
         hp = maxHp,
         maxHp = maxHp,
         damage = damage,
         armor = armor,
         xpReward = xpReward,
-        drops = spawn.drops,
+        drops = template.drops,
         goldMin = goldMin,
         goldMax = goldMax,
-        dialogue = spawn.dialogue,
-        behaviorTree = spawn.behaviorTree,
-        aggressive = spawn.aggressive,
-        templateKey = spawn.id.value,
+        dialogue = template.dialogue,
+        behaviorTree = template.behaviorTree,
+        aggressive = template.aggressive,
+        templateKey = spawn.templateId.value,
         spawnRoomId = spawn.roomId,
         spawnDistanceMap = computeDistanceMap(spawn.roomId, world),
-        questIds = spawn.questIds,
-        image = spawn.image,
-        video = spawn.video,
-        category = spawn.category,
-        spells = spawn.spells,
-        defaultAttack = spawn.defaultAttack,
+        questIds = template.questIds,
+        image = template.image,
+        video = template.video,
+        category = template.category,
+        spells = template.spells,
+        defaultAttack = template.defaultAttack,
         level = effectiveLevel,
-        role = spawn.role,
+        role = template.role,
     )
 }
 

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
@@ -933,13 +933,13 @@ class AdminHandler(
         }
     }
 
-    private fun findMobTemplate(arg: String): dev.ambon.domain.world.MobSpawn? {
+    private fun findMobTemplate(arg: String): dev.ambon.domain.world.MobTemplateDef? {
         val trimmed = arg.trim()
         return if (':' in trimmed) {
-            world.mobSpawns.firstOrNull { it.id.value.equals(trimmed, ignoreCase = true) }
+            world.mobTemplates.values.firstOrNull { it.id.value.equals(trimmed, ignoreCase = true) }
         } else {
             val lowerLocal = trimmed.lowercase()
-            world.mobSpawns.firstOrNull {
+            world.mobTemplates.values.firstOrNull {
                 it.id.value.substringAfter(':', it.id.value).lowercase() == lowerLocal
             }
         }

--- a/src/main/kotlin/dev/ambon/engine/dungeon/DungeonManager.kt
+++ b/src/main/kotlin/dev/ambon/engine/dungeon/DungeonManager.kt
@@ -7,7 +7,6 @@ import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.mob.MobState
-import dev.ambon.domain.world.MobSpawn
 import dev.ambon.domain.world.Room
 import dev.ambon.domain.world.World
 import dev.ambon.engine.MobRegistry
@@ -184,11 +183,11 @@ class DungeonManager(
         for (room in instance.layout.rooms) {
             val roomId = instance.roomIds[room.index] ?: continue
             for (mobTemplateId in room.mobIds) {
-                // Find the mob spawn from the world's mob spawns (same zone as the template)
+                // Find the mob template from the world (same zone as the dungeon template)
                 val templateZone = template.id.substringBefore(':')
                 val fullMobId = if (':' in mobTemplateId) mobTemplateId else "$templateZone:$mobTemplateId"
-                val mobSpawn = world.mobSpawns.firstOrNull { it.id.value == fullMobId }
-                if (mobSpawn == null) {
+                val mobTemplate = world.mobTemplate(MobId(fullMobId))
+                if (mobTemplate == null) {
                     log.warn { "Dungeon mob template not found: $fullMobId" }
                     continue
                 }
@@ -197,36 +196,36 @@ class DungeonManager(
                 val uniqueId = MobId("${instance.roomIds.values.first().zone}:${mobTemplateId}_${UUID.randomUUID().toString().take(6)}")
 
                 // Scale stats based on difficulty and party level
-                val scaledHp = (mobSpawn.maxHp * diff.hpMultiplier * levelScaleFactor(levelScale, mobSpawn)).roundToInt()
-                val scaledMinDmg = (mobSpawn.damage.min * diff.damageMultiplier * levelScaleFactor(levelScale, mobSpawn)).roundToInt()
-                val scaledMaxDmg = (mobSpawn.damage.max * diff.damageMultiplier * levelScaleFactor(levelScale, mobSpawn)).roundToInt()
-                val scaledXp = (mobSpawn.xpReward * diff.xpMultiplier).toLong()
+                val scaledHp = (mobTemplate.maxHp * diff.hpMultiplier * levelScaleFactor(levelScale)).roundToInt()
+                val scaledMinDmg = (mobTemplate.damage.min * diff.damageMultiplier * levelScaleFactor(levelScale)).roundToInt()
+                val scaledMaxDmg = (mobTemplate.damage.max * diff.damageMultiplier * levelScaleFactor(levelScale)).roundToInt()
+                val scaledXp = (mobTemplate.xpReward * diff.xpMultiplier).toLong()
 
                 val mob = MobState(
                     id = uniqueId,
-                    name = mobSpawn.name,
-                    description = mobSpawn.description,
+                    name = mobTemplate.name,
+                    description = mobTemplate.description,
                     roomId = roomId,
                     hp = scaledHp,
                     maxHp = scaledHp,
                     damage = DamageRange(scaledMinDmg.coerceAtLeast(1), scaledMaxDmg.coerceAtLeast(1)),
-                    armor = mobSpawn.armor,
+                    armor = mobTemplate.armor,
                     xpReward = scaledXp,
-                    drops = mobSpawn.drops.map { drop ->
+                    drops = mobTemplate.drops.map { drop ->
                         drop.copy(chance = (drop.chance * diff.dropRateMultiplier).coerceAtMost(1.0))
                     },
-                    goldMin = mobSpawn.goldMin,
-                    goldMax = mobSpawn.goldMax,
-                    dialogue = mobSpawn.dialogue,
-                    behaviorTree = mobSpawn.behaviorTree,
+                    goldMin = mobTemplate.goldMin,
+                    goldMax = mobTemplate.goldMax,
+                    dialogue = mobTemplate.dialogue,
+                    behaviorTree = mobTemplate.behaviorTree,
                     aggressive = true,
                     templateKey = fullMobId,
                     spawnRoomId = roomId,
-                    questIds = mobSpawn.questIds,
-                    image = mobSpawn.image,
-                    video = mobSpawn.video,
-                    category = mobSpawn.category,
-                    level = mobSpawn.level,
+                    questIds = mobTemplate.questIds,
+                    image = mobTemplate.image,
+                    video = mobTemplate.video,
+                    category = mobTemplate.category,
+                    level = mobTemplate.level,
                 )
 
                 mobs.upsert(mob)
@@ -236,7 +235,7 @@ class DungeonManager(
     }
 
     /** Level scale factor: scales mob stats relative to party level vs mob's base. */
-    private fun levelScaleFactor(partyLevel: Int, spawn: MobSpawn): Double {
+    private fun levelScaleFactor(partyLevel: Int): Double {
         // Simple linear scaling: each party level adds ~10% to base stats
         return (1.0 + (partyLevel - 1) * 0.1).coerceAtLeast(0.5)
     }

--- a/src/main/resources/world/academy.yaml
+++ b/src/main/resources/world/academy.yaml
@@ -372,7 +372,8 @@ image:
 mobs:
   headmaster_aldric:
     name: Headmaster Aldric
-    room: academy_gates
+    spawns:
+      - room: academy_gates
     tier: standard
     level: 10
     hp: 999
@@ -432,7 +433,8 @@ mobs:
     image: d7d20725e259a579a098ea0856dae504e860588448e9d570dc079405ad7dc20b.png
   scholar_elara:
     name: Scholar Elara
-    room: scholars_study
+    spawns:
+      - room: scholars_study
     tier: standard
     level: 8
     hp: 999
@@ -514,7 +516,8 @@ mobs:
     image: 306a50931d50ea68df08991427009fe9ce847aea2f311164f4a9cab0902aa073.png
   quartermaster_bren:
     name: Quartermaster Bren
-    room: armory
+    spawns:
+      - room: armory
     tier: standard
     level: 5
     hp: 999
@@ -549,7 +552,8 @@ mobs:
     image: a6bffb59957c7b9cb75c0a0b9a007938e9eb8b0403f87d32a2db7fa28d6e2a0b.png
   instructor_valence:
     name: Instructor Valence
-    room: training_yard
+    spawns:
+      - room: training_yard
     tier: elite
     level: 10
     hp: 999
@@ -604,7 +608,8 @@ mobs:
     image: be956281462401c1276572bedc906f3f6123987a2d9e77038516e2ae8e507eff.png
   groundskeeper_thorne:
     name: Groundskeeper Thorne
-    room: proving_grounds
+    spawns:
+      - room: proving_grounds
     tier: standard
     level: 5
     hp: 999
@@ -652,7 +657,8 @@ mobs:
     image: 955cf818c472c71960e9a18f0f6e5d630f2be0013d72e01dd4df69ec53005753.png
   puzzlewright:
     name: the Puzzlewright
-    room: riddle_tower
+    spawns:
+      - room: riddle_tower
     tier: standard
     level: 5
     hp: 999
@@ -693,7 +699,8 @@ mobs:
     image: 3ca017584a1614014ea4a44816817e01c6149df064c69735810d02fa743b88e6.png
   artificer_wren:
     name: Artificer Wren
-    room: workshop
+    spawns:
+      - room: workshop
     tier: weak
     level: 3
     hp: 999
@@ -739,7 +746,8 @@ mobs:
     image: d8c66057ee7f9319bbea2805098819ce55a0a5e92cac9746fd08716586314915.png
   stylist_maren:
     name: Stylist Maren
-    room: stylist_parlor
+    spawns:
+      - room: stylist_parlor
     tier: standard
     level: 5
     hp: 999
@@ -776,7 +784,8 @@ mobs:
     image: ea957fdba05f4f57ac0b18eacc94e38ccb7b7f90379ebc2658e97fdd21587820.png
   wandering_wisp:
     name: a wandering wisp
-    room: grand_hall
+    spawns:
+      - room: grand_hall
     tier: weak
     level: 1
     category: elemental
@@ -791,7 +800,8 @@ mobs:
     image: f4c862a089a6bd9cd51e5b8cfd270bf80d8f7b87aac173eb08052a97900004fe.png
   flickering_sprite:
     name: a flickering sprite
-    room: proving_grounds
+    spawns:
+      - room: proving_grounds
     tier: weak
     level: 1
     category: elemental
@@ -806,7 +816,8 @@ mobs:
     image: a407dc506680b2d9adc8ed94f6f7d2c8fe7baa05c4249f51f76ecd694b34b644.png
   shadow_slime:
     name: a shadow slime
-    room: proving_grounds
+    spawns:
+      - room: proving_grounds
     tier: standard
     category: aberration
     level: 2
@@ -825,7 +836,8 @@ mobs:
     image: 9d8a328931a9dbc5bfefb57be108843ad8bc6397f17cd35ac9b790186f5946ed.png
   cave_imp:
     name: a cave imp
-    room: proving_grounds
+    spawns:
+      - room: proving_grounds
     tier: standard
     level: 3
     category: aberration
@@ -853,7 +865,8 @@ mobs:
     image: 464c16c78618268629211ba659c6178806e107b48b130c0446b7fc314845fb04.png
   dread_warden:
     name: the Dread Warden
-    room: throne_room
+    spawns:
+      - room: throne_room
     tier: boss
     level: 7
     category: undead
@@ -901,7 +914,8 @@ mobs:
     image: 6c55e1b65347264558f0932d5d3a361f2f085f40d7941a2fa676a4a18c8998aa.png
   skeleton_warrior:
     name: a skeleton warrior
-    room: mob_templates
+    spawns:
+      - room: mob_templates
     tier: standard
     level: 3
     category: undead
@@ -913,7 +927,8 @@ mobs:
     image: 6f739c926beacfcfa7efab140c0e788f20e468b207d4f2c59d13a4e34d4c3522.png
   wraith:
     name: a wraith
-    room: mob_templates
+    spawns:
+      - room: mob_templates
     tier: elite
     level: 5
     category: undead
@@ -945,7 +960,8 @@ mobs:
     image: c5146681f495e8675a1d63e8ff92cd4a9e34a9964cdfdaf9472bbb7918cc0bfe.png
   fallen_champion:
     name: the Fallen Champion
-    room: mob_templates
+    spawns:
+      - room: mob_templates
     tier: boss
     level: 8
     category: undead

--- a/src/test/kotlin/dev/ambon/domain/world/WorldMutationTest.kt
+++ b/src/test/kotlin/dev/ambon/domain/world/WorldMutationTest.kt
@@ -46,26 +46,30 @@ class WorldMutationTest {
 
     @Test
     fun `replaceAll updates mob spawns`() {
+        val ratId = MobId("zone1:rat")
+        val wolfId = MobId("zone1:wolf")
         val world = World(
             rooms = mapOf(roomA to Room(roomA, "A", "desc", emptyMap())),
             startRoom = roomA,
-            mobSpawns = listOf(
-                MobSpawn(MobId("zone1:rat"), "rat", roomA, damage = DamageRange(1, 2)),
+            mobTemplates = mapOf(
+                ratId to MobTemplateDef(ratId, "rat", damage = DamageRange(1, 2)),
             ),
+            mobSpawns = listOf(MobSpawn(ratId, ratId, roomA)),
         )
 
         val newWorld = World(
             rooms = mapOf(roomA to Room(roomA, "A", "desc", emptyMap())),
             startRoom = roomA,
-            mobSpawns = listOf(
-                MobSpawn(MobId("zone1:wolf"), "wolf", roomA, damage = DamageRange(3, 5)),
+            mobTemplates = mapOf(
+                wolfId to MobTemplateDef(wolfId, "wolf", damage = DamageRange(3, 5)),
             ),
+            mobSpawns = listOf(MobSpawn(wolfId, wolfId, roomA)),
         )
 
         world.replaceAll(newWorld)
 
         assertEquals(1, world.mobSpawns.size)
-        assertEquals("wolf", world.mobSpawns[0].name)
+        assertEquals("wolf", world.mobTemplate(world.mobSpawns[0].templateId)!!.name)
     }
 
     @Test
@@ -91,15 +95,21 @@ class WorldMutationTest {
 
     @Test
     fun `mergeZone replaces only target zone`() {
+        val ratId = MobId("zone1:rat")
+        val wolfId = MobId("zone2:wolf")
         val world = World(
             rooms = mapOf(
                 roomA to Room(roomA, "A", "desc", emptyMap()),
                 roomC to Room(roomC, "C", "desc", emptyMap()),
             ),
             startRoom = roomA,
+            mobTemplates = mapOf(
+                ratId to MobTemplateDef(ratId, "rat", damage = DamageRange(1, 2)),
+                wolfId to MobTemplateDef(wolfId, "wolf", damage = DamageRange(3, 5)),
+            ),
             mobSpawns = listOf(
-                MobSpawn(MobId("zone1:rat"), "rat", roomA, damage = DamageRange(1, 2)),
-                MobSpawn(MobId("zone2:wolf"), "wolf", roomC, damage = DamageRange(3, 5)),
+                MobSpawn(ratId, ratId, roomA),
+                MobSpawn(wolfId, wolfId, roomC),
             ),
         )
 
@@ -109,9 +119,10 @@ class WorldMutationTest {
                 roomB to Room(roomB, "B new", "new room", emptyMap()),
             ),
             startRoom = roomA,
-            mobSpawns = listOf(
-                MobSpawn(MobId("zone1:rat"), "big rat", roomA, maxHp = 20, damage = DamageRange(2, 4)),
+            mobTemplates = mapOf(
+                ratId to MobTemplateDef(ratId, "big rat", maxHp = 20, damage = DamageRange(2, 4)),
             ),
+            mobSpawns = listOf(MobSpawn(ratId, ratId, roomA)),
         )
 
         val removed = world.mergeZone("zone1", sourceWorld)
@@ -125,8 +136,9 @@ class WorldMutationTest {
         assertTrue(removed.isEmpty())
         // zone1 mobs updated, zone2 mobs untouched
         assertEquals(2, world.mobSpawns.size)
-        assertTrue(world.mobSpawns.any { it.name == "big rat" })
-        assertTrue(world.mobSpawns.any { it.name == "wolf" })
+        val names = world.mobSpawns.mapNotNull { world.mobTemplate(it.templateId)?.name }.toSet()
+        assertTrue("big rat" in names)
+        assertTrue("wolf" in names)
     }
 
     @Test

--- a/src/test/kotlin/dev/ambon/engine/AutoQuestSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/AutoQuestSystemTest.kt
@@ -6,6 +6,7 @@ import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.world.MobSpawn
+import dev.ambon.domain.world.MobTemplateDef
 import dev.ambon.domain.world.Room
 import dev.ambon.domain.world.World
 import dev.ambon.engine.dialogue.DialogueNode
@@ -30,13 +31,18 @@ class AutoQuestSystemTest {
     private val mobTemplateId = "$testZone:goblin"
     private val sid = SessionId(1L)
 
-    private val testMobSpawn = MobSpawn(
+    private val testMobTemplate = MobTemplateDef(
         id = MobId(mobTemplateId),
         name = "Goblin",
-        roomId = testRoomId,
         maxHp = 20,
         damage = DamageRange(1, 4),
         xpReward = 30L,
+    )
+
+    private val testMobSpawn = MobSpawn(
+        id = MobId(mobTemplateId),
+        templateId = MobId(mobTemplateId),
+        roomId = testRoomId,
     )
 
     private val defaultConfig = AutoQuestsConfig(
@@ -59,6 +65,7 @@ class AutoQuestSystemTest {
         val world = World(
             rooms = mapOf(testRoomId to Room(testRoomId, "Town Square", "A busy square.", emptyMap())),
             startRoom = testRoomId,
+            mobTemplates = mapOf(testMobTemplate.id to testMobTemplate),
             mobSpawns = listOf(testMobSpawn),
         )
         val system = AutoQuestSystem(
@@ -304,10 +311,10 @@ class AutoQuestSystemTest {
     @Test
     fun `mobs with dialogue are excluded from candidates`() = runTest {
         val c = SystemTestComponents(roomId = testRoomId, clockInitialMs = 1_000L)
-        val dialogueMob = MobSpawn(
-            id = MobId("$testZone:innkeeper"),
+        val innkeeperId = MobId("$testZone:innkeeper")
+        val dialogueTemplate = MobTemplateDef(
+            id = innkeeperId,
             name = "Innkeeper",
-            roomId = testRoomId,
             maxHp = 100,
             xpReward = 0L,
             dialogue = DialogueTree(
@@ -320,9 +327,11 @@ class AutoQuestSystemTest {
                 ),
             ),
         )
+        val dialogueMob = MobSpawn(innkeeperId, innkeeperId, testRoomId)
         val world = World(
             rooms = mapOf(testRoomId to Room(testRoomId, "Town Square", "A busy square.", emptyMap())),
             startRoom = testRoomId,
+            mobTemplates = mapOf(innkeeperId to dialogueTemplate),
             mobSpawns = listOf(dialogueMob),
         )
         val system = AutoQuestSystem(

--- a/src/test/kotlin/dev/ambon/engine/HotReloadManagerTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/HotReloadManagerTest.kt
@@ -17,6 +17,7 @@ import dev.ambon.domain.quest.QuestRewards
 import dev.ambon.domain.world.Direction
 import dev.ambon.domain.world.ItemSpawn
 import dev.ambon.domain.world.MobSpawn
+import dev.ambon.domain.world.MobTemplateDef
 import dev.ambon.domain.world.Room
 import dev.ambon.domain.world.ShopDefinition
 import dev.ambon.domain.world.World
@@ -46,8 +47,16 @@ class HotReloadManagerTest {
             roomB to Room(roomB, "Room B", "desc", mapOf(Direction.SOUTH to roomA)),
         ),
         startRoom = roomA,
+        mobTemplates = mapOf(
+            MobId("zone1:rat") to MobTemplateDef(
+                id = MobId("zone1:rat"),
+                name = "a rat",
+                maxHp = 10,
+                damage = DamageRange(1, 2),
+            ),
+        ),
         mobSpawns = listOf(
-            MobSpawn(MobId("zone1:rat"), "a rat", roomA, maxHp = 10, damage = DamageRange(1, 2)),
+            MobSpawn(MobId("zone1:rat"), MobId("zone1:rat"), roomA),
         ),
         itemSpawns = listOf(
             ItemSpawn(ItemInstance(ItemId("zone1:sword"), Item("sword", "a sword")), roomA),
@@ -100,21 +109,23 @@ class HotReloadManagerTest {
             roomC to Room(roomC, "Room C", "zone2 room", emptyMap()),
         ),
         startRoom = roomA,
-        mobSpawns = listOf(
-            MobSpawn(
-                MobId("zone1:rat"),
-                "a big rat",
-                roomA,
+        mobTemplates = mapOf(
+            MobId("zone1:rat") to MobTemplateDef(
+                id = MobId("zone1:rat"),
+                name = "a big rat",
                 maxHp = 20,
                 damage = DamageRange(2, 4),
             ),
-            MobSpawn(
-                MobId("zone2:wolf"),
-                "a wolf",
-                roomC,
+            MobId("zone2:wolf") to MobTemplateDef(
+                id = MobId("zone2:wolf"),
+                name = "a wolf",
                 maxHp = 30,
                 damage = DamageRange(3, 5),
             ),
+        ),
+        mobSpawns = listOf(
+            MobSpawn(MobId("zone1:rat"), MobId("zone1:rat"), roomA),
+            MobSpawn(MobId("zone2:wolf"), MobId("zone2:wolf"), roomC),
         ),
         itemSpawns = listOf(
             ItemSpawn(ItemInstance(ItemId("zone1:sword"), Item("sword", "a sword", damage = 5)), roomA),

--- a/src/test/kotlin/dev/ambon/engine/MobRespawnTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/MobRespawnTest.kt
@@ -6,6 +6,7 @@ import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.mob.MobState
 import dev.ambon.domain.world.MobSpawn
+import dev.ambon.domain.world.MobTemplateDef
 import dev.ambon.domain.world.Room
 import dev.ambon.domain.world.World
 import dev.ambon.engine.events.OutboundEvent
@@ -41,27 +42,28 @@ class MobRespawnTest {
         { id, _ ->
             mobSystem.onMobRemoved(id)
             val spawn = world.mobSpawns.find { it.id == id }
-            val respawnMs = spawn?.respawnSeconds?.let { it * 1_000L }
-            if (spawn != null && respawnMs != null) {
+            val template = spawn?.let { world.mobTemplate(it.templateId) }
+            val respawnMs = template?.respawnSeconds?.let { it * 1_000L }
+            if (spawn != null && template != null && respawnMs != null) {
                 scheduler.scheduleIn(respawnMs) {
                     if (mobs.get(spawn.id) != null) return@scheduleIn
                     if (world.rooms[spawn.roomId] == null) return@scheduleIn
                     mobs.upsert(
                         MobState(
                             id = spawn.id,
-                            name = spawn.name,
+                            name = template.name,
                             roomId = spawn.roomId,
-                            hp = spawn.maxHp,
-                            maxHp = spawn.maxHp,
-                            damage = spawn.damage,
-                            armor = spawn.armor,
-                            xpReward = spawn.xpReward,
-                            drops = spawn.drops,
+                            hp = template.maxHp,
+                            maxHp = template.maxHp,
+                            damage = template.damage,
+                            armor = template.armor,
+                            xpReward = template.xpReward,
+                            drops = template.drops,
                         ),
                     )
                     mobSystem.onMobSpawned(spawn.id)
                     for (p in players.playersInRoom(spawn.roomId)) {
-                        outbound.send(OutboundEvent.SendText(p.sessionId, "${spawn.name} appears."))
+                        outbound.send(OutboundEvent.SendText(p.sessionId, "${template.name} appears."))
                     }
                 }
             }
@@ -71,8 +73,14 @@ class MobRespawnTest {
     fun `mob with respawnSeconds respawns in origin room after delay`() =
         runTest {
             val room = Room(roomId, "A Room", "A room.", emptyMap())
-            val spawn = MobSpawn(id = mobId, name = "a rat", roomId = roomId, respawnSeconds = 60L)
-            val world = World(mapOf(roomId to room), roomId, mobSpawns = listOf(spawn))
+            val template = MobTemplateDef(id = mobId, name = "a rat", respawnSeconds = 60L)
+            val spawn = MobSpawn(id = mobId, templateId = mobId, roomId = roomId)
+            val world = World(
+                mapOf(roomId to room),
+                roomId,
+                mobTemplates = mapOf(mobId to template),
+                mobSpawns = listOf(spawn),
+            )
 
             val mobs = MobRegistry()
             val outbound = LocalOutboundBus()
@@ -101,15 +109,21 @@ class MobRespawnTest {
             val respawned = mobs.get(mobId)
             assertNotNull(respawned, "Mob should have respawned")
             assertEquals(roomId, respawned!!.roomId)
-            assertEquals(spawn.maxHp, respawned.hp)
+            assertEquals(template.maxHp, respawned.hp)
         }
 
     @Test
     fun `respawn is skipped when mob is already in registry at fire time`() =
         runTest {
             val room = Room(roomId, "A Room", "A room.", emptyMap())
-            val spawn = MobSpawn(id = mobId, name = "a rat", roomId = roomId, respawnSeconds = 60L)
-            val world = World(mapOf(roomId to room), roomId, mobSpawns = listOf(spawn))
+            val template = MobTemplateDef(id = mobId, name = "a rat", respawnSeconds = 60L)
+            val spawn = MobSpawn(id = mobId, templateId = mobId, roomId = roomId)
+            val world = World(
+                mapOf(roomId to room),
+                roomId,
+                mobTemplates = mapOf(mobId to template),
+                mobSpawns = listOf(spawn),
+            )
 
             val mobs = MobRegistry()
             val outbound = LocalOutboundBus()
@@ -141,10 +155,16 @@ class MobRespawnTest {
     fun `respawn is skipped when origin room no longer exists`() =
         runTest {
             val missingRoomId = RoomId("zone:missing")
-            val spawn = MobSpawn(id = mobId, name = "a rat", roomId = missingRoomId, respawnSeconds = 30L)
+            val template = MobTemplateDef(id = mobId, name = "a rat", respawnSeconds = 30L)
+            val spawn = MobSpawn(id = mobId, templateId = mobId, roomId = missingRoomId)
             // World does NOT contain the mob's origin room
             val anchorRoom = Room(roomId, "A Room", "A room.", emptyMap())
-            val world = World(mapOf(roomId to anchorRoom), roomId, mobSpawns = listOf(spawn))
+            val world = World(
+                mapOf(roomId to anchorRoom),
+                roomId,
+                mobTemplates = mapOf(mobId to template),
+                mobSpawns = listOf(spawn),
+            )
 
             val mobs = MobRegistry()
             val outbound = LocalOutboundBus()
@@ -167,8 +187,14 @@ class MobRespawnTest {
     fun `mob without respawnSeconds does not schedule a respawn`() =
         runTest {
             val room = Room(roomId, "A Room", "A room.", emptyMap())
-            val spawn = MobSpawn(id = mobId, name = "a rat", roomId = roomId) // respawnSeconds = null
-            val world = World(mapOf(roomId to room), roomId, mobSpawns = listOf(spawn))
+            val template = MobTemplateDef(id = mobId, name = "a rat") // respawnSeconds = null
+            val spawn = MobSpawn(id = mobId, templateId = mobId, roomId = roomId)
+            val world = World(
+                mapOf(roomId to room),
+                roomId,
+                mobTemplates = mapOf(mobId to template),
+                mobSpawns = listOf(spawn),
+            )
 
             val mobs = MobRegistry()
             val outbound = LocalOutboundBus()
@@ -190,8 +216,14 @@ class MobRespawnTest {
     fun `arrival message is sent to players in origin room when mob respawns`() =
         runTest {
             val room = Room(roomId, "A Room", "A room.", emptyMap())
-            val spawn = MobSpawn(id = mobId, name = "a rat", roomId = roomId, respawnSeconds = 10L)
-            val world = World(mapOf(roomId to room), roomId, mobSpawns = listOf(spawn))
+            val template = MobTemplateDef(id = mobId, name = "a rat", respawnSeconds = 10L)
+            val spawn = MobSpawn(id = mobId, templateId = mobId, roomId = roomId)
+            val world = World(
+                mapOf(roomId to room),
+                roomId,
+                mobTemplates = mapOf(mobId to template),
+                mobSpawns = listOf(spawn),
+            )
 
             val mobs = MobRegistry()
             val outbound = LocalOutboundBus()

--- a/src/test/kotlin/dev/ambon/engine/MobSpellCombatTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/MobSpellCombatTest.kt
@@ -260,7 +260,7 @@ class MobSpellCombatTest {
     @Test
     fun `WorldLoader loads mob spells from YAML`() {
         val world = WorldLoader.loadFromResource("world/ok_mob_spells.yaml")
-        val shadowMage = world.mobSpawns.first { it.name == "a shadow mage" }
+        val shadowMage = world.mobTemplates.values.first { it.name == "a shadow mage" }
 
         assertEquals(2, shadowMage.spells.size)
         assertEquals("shadow_bolt", shadowMage.defaultAttack)
@@ -290,7 +290,7 @@ class MobSpellCombatTest {
     @Test
     fun `mob with no spells loads cleanly`() {
         val world = WorldLoader.loadFromResource("world/ok_mob_spells.yaml")
-        val dummy = world.mobSpawns.first { it.name == "a training dummy" }
+        val dummy = world.mobTemplates.values.first { it.name == "a training dummy" }
         assertTrue(dummy.spells.isEmpty())
         assertNull(dummy.defaultAttack)
     }

--- a/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
@@ -98,6 +98,38 @@ class QuestSystemTest {
         }
 
     @Test
+    fun `kill objective counts any placement of the same template`() =
+        runTest {
+            // Load a world where one goblin template has 3 placements and the
+            // quest is `kill goblin x3`. Killing each placement must advance
+            // the same objective — the contract that lets multi-spawn trash
+            // mobs satisfy quests.
+            val world = dev.ambon.domain.world.load.WorldLoader.loadFromResource(
+                "world/ok_multi_spawn_kill.yaml",
+            )
+            val loadedQuest = world.questDefinitions.single { it.id == "ok_kill:goblin_hunt" }
+                .copy(completionType = "auto")
+            val (qs, players, _) = setup(loadedQuest)
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Hero")
+            qs.acceptQuest(sid, "ok_kill:goblin_hunt")
+
+            // Each placement carries templateKey = "ok_kill:goblin"; the
+            // engine forwards that key into onMobKilled (see CombatSystem).
+            val placements = world.mobSpawns.filter { it.templateId.value == "ok_kill:goblin" }
+            assertEquals(3, placements.size)
+            for (placement in placements) {
+                qs.onMobKilled(sid, placement.templateId.value)
+            }
+
+            val ps = players.get(sid)!!
+            assertTrue(
+                ps.completedQuestIds.contains("ok_kill:goblin_hunt"),
+                "Quest should auto-complete after killing all 3 distinct goblin placements",
+            )
+        }
+
+    @Test
     fun `onMobKilled increments kill objective`() =
         runTest {
             val (qs, players, _) = setup()

--- a/src/test/kotlin/dev/ambon/engine/behavior/BehaviorYamlParsingTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/behavior/BehaviorYamlParsingTest.kt
@@ -13,15 +13,15 @@ class BehaviorYamlParsingTest {
     fun `valid behavior YAML loads successfully`() {
         val world = WorldLoader.loadFromResource("world/ok_behavior.yaml")
 
-        val guard = world.mobSpawns.find { it.id.value == "behavior_test:guard" }
+        val guard = world.mobTemplates.values.find { it.id.value == "behavior_test:guard" }
         assertNotNull(guard, "guard mob should exist")
         assertNotNull(guard!!.behaviorTree, "guard should have a behavior tree")
 
-        val sentry = world.mobSpawns.find { it.id.value == "behavior_test:sentry" }
+        val sentry = world.mobTemplates.values.find { it.id.value == "behavior_test:sentry" }
         assertNotNull(sentry, "sentry mob should exist")
         assertNotNull(sentry!!.behaviorTree, "sentry should have a behavior tree")
 
-        val rat = world.mobSpawns.find { it.id.value == "behavior_test:rat" }
+        val rat = world.mobTemplates.values.find { it.id.value == "behavior_test:rat" }
         assertNotNull(rat, "rat mob should exist")
         assertNotNull(rat!!.behaviorTree, "rat should have a behavior tree")
     }
@@ -29,7 +29,7 @@ class BehaviorYamlParsingTest {
     @Test
     fun `mob without behavior has null behaviorTree`() {
         val world = WorldLoader.loadFromResource("world/ok_dialogue.yaml")
-        for (mob in world.mobSpawns) {
+        for (mob in world.mobTemplates.values) {
             assertNull(mob.behaviorTree, "mob ${mob.id.value} should not have a behavior tree")
         }
     }

--- a/src/test/kotlin/dev/ambon/engine/commands/DungeonCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/DungeonCommandTest.kt
@@ -9,6 +9,7 @@ import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.world.MobSpawn
+import dev.ambon.domain.world.MobTemplateDef
 import dev.ambon.domain.world.Room
 import dev.ambon.domain.world.World
 import dev.ambon.engine.GmcpEmitter
@@ -50,23 +51,27 @@ class DungeonCommandTest {
         ),
     )
 
-    private val skeletonSpawn = MobSpawn(
-        id = MobId("test:test_skeleton"),
+    private val skeletonId = MobId("test:test_skeleton")
+    private val bossId = MobId("test:test_boss")
+
+    private val skeletonTemplate = MobTemplateDef(
+        id = skeletonId,
         name = "a skeleton",
-        roomId = portalRoom,
         maxHp = 20,
         damage = DamageRange(2, 4),
         xpReward = 30L,
     )
 
-    private val bossSpawn = MobSpawn(
-        id = MobId("test:test_boss"),
+    private val bossTemplate = MobTemplateDef(
+        id = bossId,
         name = "the Boss",
-        roomId = portalRoom,
         maxHp = 100,
         damage = DamageRange(8, 15),
         xpReward = 200L,
     )
+
+    private val skeletonSpawn = MobSpawn(skeletonId, skeletonId, portalRoom)
+    private val bossSpawn = MobSpawn(bossId, bossId, portalRoom)
 
     private lateinit var world: World
     private lateinit var mobs: MobRegistry
@@ -78,6 +83,7 @@ class DungeonCommandTest {
         world = World(
             rooms = mapOf(portalRoom to Room(portalRoom, "Portal Room", "A room with a dungeon portal.", emptyMap())),
             startRoom = portalRoom,
+            mobTemplates = mapOf(skeletonId to skeletonTemplate, bossId to bossTemplate),
             mobSpawns = listOf(skeletonSpawn, bossSpawn),
         )
         mobs = MobRegistry()

--- a/src/test/kotlin/dev/ambon/engine/dungeon/DungeonManagerTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/dungeon/DungeonManagerTest.kt
@@ -12,6 +12,7 @@ import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.world.MobSpawn
+import dev.ambon.domain.world.MobTemplateDef
 import dev.ambon.domain.world.Room
 import dev.ambon.domain.world.World
 import dev.ambon.engine.MobRegistry
@@ -54,23 +55,27 @@ class DungeonManagerTest {
         ),
     )
 
-    private val skeletonSpawn = MobSpawn(
-        id = MobId("test:crypt_skeleton"),
+    private val skeletonId = MobId("test:crypt_skeleton")
+    private val bossId = MobId("test:crypt_lord")
+
+    private val skeletonTemplate = MobTemplateDef(
+        id = skeletonId,
         name = "a skeleton",
-        roomId = portalRoomId,
         maxHp = 20,
         damage = DamageRange(2, 4),
         xpReward = 30L,
     )
 
-    private val bossSpawn = MobSpawn(
-        id = MobId("test:crypt_lord"),
+    private val bossTemplate = MobTemplateDef(
+        id = bossId,
         name = "the Crypt Lord",
-        roomId = portalRoomId,
         maxHp = 100,
         damage = DamageRange(8, 15),
         xpReward = 200L,
     )
+
+    private val skeletonSpawn = MobSpawn(skeletonId, skeletonId, portalRoomId)
+    private val bossSpawn = MobSpawn(bossId, bossId, portalRoomId)
 
     private lateinit var world: World
     private lateinit var mobs: MobRegistry
@@ -82,6 +87,7 @@ class DungeonManagerTest {
         world = World(
             rooms = mapOf(portalRoomId to Room(portalRoomId, "Portal", "A portal room.", emptyMap())),
             startRoom = portalRoomId,
+            mobTemplates = mapOf(skeletonId to skeletonTemplate, bossId to bossTemplate),
             mobSpawns = listOf(skeletonSpawn, bossSpawn),
         )
         mobs = MobRegistry()

--- a/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
@@ -79,10 +79,11 @@ class WorldLoaderTest {
     fun `loads mobs from a zone file`() {
         val world = dev.ambon.test.TestWorlds.okSmall
 
-        val mob = world.mobSpawns.single()
+        val spawn = world.mobSpawns.single()
+        val mob = world.mobTemplate(spawn.templateId)!!
         assertEquals("ok_small:rat", mob.id.value)
         assertEquals("a small rat", mob.name)
-        assertEquals(RoomId("ok_small:b"), mob.roomId)
+        assertEquals(RoomId("ok_small:b"), spawn.roomId)
         assertEquals(10, mob.maxHp)
         assertEquals(1, mob.damage.min)
         assertEquals(4, mob.damage.max)
@@ -96,6 +97,79 @@ class WorldLoaderTest {
                 .itemId.value,
         )
         assertEquals(1.0, mob.drops.single().chance)
+    }
+
+    @Test
+    fun `legacy room shorthand produces a single placement with template id`() {
+        val world = dev.ambon.test.TestWorlds.okSmall
+        val rat = world.mobTemplates.values.single { it.id.value == "ok_small:rat" }
+        val placements = world.mobSpawns.filter { it.templateId == rat.id }
+
+        assertEquals(1, placements.size)
+        // Single global instance — placement id matches the template id (no suffix).
+        assertEquals(rat.id, placements[0].id)
+        assertEquals(0, placements[0].instanceIndex)
+        assertEquals(RoomId("ok_small:b"), placements[0].roomId)
+    }
+
+    @Test
+    fun `spawns list with multiple entries produces one placement per copy`() {
+        val world = WorldLoader.loadFromResource("world/ok_mob_multi_spawn.yaml")
+        val placementsByTemplate =
+            world.mobSpawns.groupBy { it.templateId.value }
+
+        // Single-spawn unique NPC keeps a bare id.
+        val unique = placementsByTemplate.getValue("ok_multi:unique_npc")
+        assertEquals(1, unique.size)
+        assertEquals("ok_multi:unique_npc", unique[0].id.value)
+        assertEquals(0, unique[0].instanceIndex)
+
+        // Two rooms, one each → two placements with stable #0/#1 ids.
+        val twoRooms = placementsByTemplate.getValue("ok_multi:trash_two_rooms")
+        assertEquals(2, twoRooms.size)
+        assertEquals(listOf("ok_multi:trash_two_rooms#0", "ok_multi:trash_two_rooms#1"), twoRooms.map { it.id.value })
+        assertEquals(setOf(RoomId("ok_multi:a"), RoomId("ok_multi:b")), twoRooms.map { it.roomId }.toSet())
+
+        // count: 3 → three placements in the same room.
+        val ratCount = placementsByTemplate.getValue("ok_multi:trash_count")
+        assertEquals(3, ratCount.size)
+        assertEquals(listOf(0, 1, 2), ratCount.map { it.instanceIndex })
+        assertTrue(ratCount.all { it.roomId == RoomId("ok_multi:b") })
+
+        // Mixed: count 2 in room a, then 1 in room b → three placements indexed 0,1,2.
+        val slimes = placementsByTemplate.getValue("ok_multi:trash_mixed")
+        assertEquals(3, slimes.size)
+        assertEquals(listOf(0, 1, 2), slimes.map { it.instanceIndex })
+        assertEquals(
+            listOf(RoomId("ok_multi:a"), RoomId("ok_multi:a"), RoomId("ok_multi:b")),
+            slimes.map { it.roomId },
+        )
+    }
+
+    @Test
+    fun `template fields are reachable from every placement of the same template`() {
+        val world = WorldLoader.loadFromResource("world/ok_mob_multi_spawn.yaml")
+        val ratPlacements = world.mobSpawns.filter { it.templateId.value == "ok_multi:trash_count" }
+        val templates = ratPlacements.map { world.mobTemplate(it.templateId)!! }
+        // All three placements resolve to the same template instance — name/stats are shared.
+        assertTrue(templates.all { it.name == "a rat" })
+        assertEquals(1, templates.distinctBy { it.id }.size)
+    }
+
+    @Test
+    fun `fails when mob declares both room and spawns`() {
+        val ex = assertThrows(WorldLoadException::class.java) {
+            WorldLoader.loadFromResource("world/bad_mob_room_and_spawns.yaml")
+        }
+        assertTrue(ex.message!!.contains("both 'room' and 'spawns'"), "Got: ${ex.message}")
+    }
+
+    @Test
+    fun `fails when spawn entry has count zero`() {
+        val ex = assertThrows(WorldLoadException::class.java) {
+            WorldLoader.loadFromResource("world/bad_mob_spawn_count_zero.yaml")
+        }
+        assertTrue(ex.message!!.contains("count"), "Got: ${ex.message}")
     }
 
     @Test
@@ -331,7 +405,7 @@ class WorldLoaderTest {
     @Test
     fun `loads mob without tier or level uses standard defaults`() {
         val world = WorldLoader.loadFromResource("world/ok_mob_stats.yaml")
-        val mobs = world.mobSpawns.associateBy { it.id.value }
+        val mobs = world.mobTemplates.mapKeys { it.key.value }
 
         val rat = mobs.getValue("ok_mob_stats:rat")
         assertEquals(10, rat.maxHp)
@@ -344,7 +418,7 @@ class WorldLoaderTest {
     @Test
     fun `loads mob with tier and level applies tier formula`() {
         val world = WorldLoader.loadFromResource("world/ok_mob_stats.yaml")
-        val mobs = world.mobSpawns.associateBy { it.id.value }
+        val mobs = world.mobTemplates.mapKeys { it.key.value }
 
         // standard tier, level=3: steps=2
         // hp = 10 + 2*3 = 16
@@ -363,7 +437,7 @@ class WorldLoaderTest {
     @Test
     fun `loads mob with explicit stat overrides`() {
         val world = WorldLoader.loadFromResource("world/ok_mob_stats.yaml")
-        val mobs = world.mobSpawns.associateBy { it.id.value }
+        val mobs = world.mobTemplates.mapKeys { it.key.value }
 
         val mob = mobs.getValue("ok_mob_stats:override_mob")
         assertEquals(99, mob.maxHp)
@@ -376,7 +450,7 @@ class WorldLoaderTest {
     @Test
     fun `loads mob with boss tier applies boss defaults`() {
         val world = WorldLoader.loadFromResource("world/ok_mob_stats.yaml")
-        val mobs = world.mobSpawns.associateBy { it.id.value }
+        val mobs = world.mobTemplates.mapKeys { it.key.value }
 
         val boss = mobs.getValue("ok_mob_stats:boss_mob")
         assertEquals(50, boss.maxHp)
@@ -434,7 +508,7 @@ class WorldLoaderTest {
     @Test
     fun `loads mob with respawnSeconds`() {
         val world = WorldLoader.loadFromResource("world/ok_mob_respawn.yaml")
-        val mobs = world.mobSpawns.associateBy { it.id.value }
+        val mobs = world.mobTemplates.mapKeys { it.key.value }
 
         val rat = mobs.getValue("ok_mob_respawn:rat")
         assertEquals(60L, rat.respawnSeconds)
@@ -692,7 +766,7 @@ class WorldLoaderTest {
         @Test
         fun `loads mob gold range from tier defaults`() {
             val world = WorldLoader.loadFromResource("world/ok_mob_stats.yaml")
-            val mobs = world.mobSpawns.associateBy { it.id.value }
+            val mobs = world.mobTemplates.mapKeys { it.key.value }
 
             // Standard tier level 1: goldMin=2, goldMax=8
             val rat = mobs.getValue("ok_mob_stats:rat")
@@ -732,7 +806,7 @@ class WorldLoaderTest {
     @Test
     fun `zone faction propagates to mobs that lack their own`() {
         val world = WorldLoader.loadFromResource("world/ok_faction_gates.yaml")
-        val mobs = world.mobSpawns.associateBy { it.id.value }
+        val mobs = world.mobTemplates.mapKeys { it.key.value }
         assertEquals("royal_court", mobs.getValue("ok_faction_gates:inheritor").faction)
         assertEquals("rebel_cell", mobs.getValue("ok_faction_gates:dissenter").faction)
     }
@@ -776,7 +850,7 @@ class WorldLoaderTest {
     @Test
     fun `loads mob with dialogue tree`() {
         val world = WorldLoader.loadFromResource("world/ok_dialogue.yaml")
-        val mob = world.mobSpawns.single()
+        val mob = world.mobTemplates.values.single()
         val dialogue = mob.dialogue
         assertTrue(dialogue != null, "Dialogue should be loaded")
         assertEquals("root", dialogue!!.rootNodeId)
@@ -844,7 +918,7 @@ class WorldLoaderTest {
         val cave = world.rooms.getValue(RoomId("ok_images:cave"))
         assertNull(cave.image)
 
-        val mob = world.mobSpawns.single()
+        val mob = world.mobTemplates.values.single()
         assertEquals("/images/mobs/wolf.png", mob.image)
 
         val items = world.itemSpawns.associateBy { it.instance.id.value }
@@ -867,7 +941,7 @@ class WorldLoaderTest {
         assertEquals("/images/alley/custom.png", alley.image)
 
         // Mob without explicit image gets zone default
-        val mobs = world.mobSpawns.associateBy { it.id.value }
+        val mobs = world.mobTemplates.mapKeys { it.key.value }
         assertEquals("/images/defaults/mob.png", mobs.getValue("ok_image_defaults:guard").image)
 
         // Mob with explicit image keeps its own

--- a/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
@@ -173,6 +173,40 @@ class WorldLoaderTest {
     }
 
     @Test
+    fun `fails when quest giver has multiple spawn instances`() {
+        val ex = assertThrows(WorldLoadException::class.java) {
+            WorldLoader.loadFromResource("world/bad_quest_giver_multi_spawn.yaml")
+        }
+        assertTrue(ex.message!!.contains("giverMobId"), "Got: ${ex.message}")
+        assertTrue(ex.message!!.contains("exactly one spawn"), "Got: ${ex.message}")
+    }
+
+    @Test
+    fun `multi-spawn placements share one templateKey for kill objectives`() {
+        val world = WorldLoader.loadFromResource("world/ok_multi_spawn_kill.yaml")
+        val goblinPlacements = world.mobSpawns.filter { it.templateId.value == "ok_kill:goblin" }
+        assertEquals(3, goblinPlacements.size)
+
+        // Every placement resolves to the same template id, which is what
+        // QuestSystem.onMobKilled and AchievementSystem.onMobKilled match on.
+        assertEquals(setOf("ok_kill:goblin"), goblinPlacements.map { it.templateId.value }.toSet())
+
+        val quest = world.questDefinitions.single { it.id == "ok_kill:goblin_hunt" }
+        val kill = quest.objectives.single { it.type == "kill" }
+        assertEquals("ok_kill:goblin", kill.targetId)
+        assertEquals(3, kill.count)
+    }
+
+    @Test
+    fun `fails when quest turn-in NPC has multiple placements`() {
+        val ex = assertThrows(WorldLoadException::class.java) {
+            WorldLoader.loadFromResource("world/bad_quest_turn_in_multi_room.yaml")
+        }
+        assertTrue(ex.message!!.contains("turnInMobId"), "Got: ${ex.message}")
+        assertTrue(ex.message!!.contains("exactly one spawn"), "Got: ${ex.message}")
+    }
+
+    @Test
     fun `loads zone lifespan minutes`() {
         val world = dev.ambon.test.TestWorlds.okSmall
 

--- a/src/test/resources/world/bad_mob_room_and_spawns.yaml
+++ b/src/test/resources/world/bad_mob_room_and_spawns.yaml
@@ -1,0 +1,13 @@
+zone: bad_dual
+startRoom: a
+mobs:
+  conflicted:
+    name: "a confused mob"
+    room: a
+    spawns:
+      - room: a
+rooms:
+  a:
+    title: "Room A"
+    description: "Only room."
+    exits: {}

--- a/src/test/resources/world/bad_mob_spawn_count_zero.yaml
+++ b/src/test/resources/world/bad_mob_spawn_count_zero.yaml
@@ -1,0 +1,13 @@
+zone: bad_count
+startRoom: a
+mobs:
+  zero_count:
+    name: "a phantom"
+    spawns:
+      - room: a
+        count: 0
+rooms:
+  a:
+    title: "Room A"
+    description: "Only room."
+    exits: {}

--- a/src/test/resources/world/bad_quest_giver_multi_spawn.yaml
+++ b/src/test/resources/world/bad_quest_giver_multi_spawn.yaml
@@ -1,0 +1,26 @@
+zone: bad_giver
+startRoom: square
+mobs:
+  giver:
+    name: "a quest giver"
+    spawns:
+      - room: square
+        count: 2
+  target:
+    name: "a target"
+    spawns:
+      - room: square
+quests:
+  bad_giver_quest:
+    name: "Bad Giver"
+    giver: giver
+    objectives:
+      - type: kill
+        targetKey: target
+        count: 1
+        description: "Kill the target."
+rooms:
+  square:
+    title: "Square"
+    description: "A square."
+    exits: {}

--- a/src/test/resources/world/bad_quest_turn_in_multi_room.yaml
+++ b/src/test/resources/world/bad_quest_turn_in_multi_room.yaml
@@ -1,0 +1,37 @@
+zone: bad_turnin
+startRoom: a
+mobs:
+  giver:
+    name: "the giver"
+    spawns:
+      - room: a
+  receiver:
+    name: "the receiver"
+    spawns:
+      - room: a
+      - room: b
+  target:
+    name: "a target"
+    spawns:
+      - room: a
+quests:
+  ambiguous_turn_in:
+    name: "Ambiguous Turn-In"
+    giver: giver
+    turnInMob: receiver
+    objectives:
+      - type: kill
+        targetKey: target
+        count: 1
+        description: "Kill the target."
+rooms:
+  a:
+    title: "Room A"
+    description: "First room."
+    exits:
+      north: b
+  b:
+    title: "Room B"
+    description: "Second room."
+    exits:
+      south: a

--- a/src/test/resources/world/ok_mob_multi_spawn.yaml
+++ b/src/test/resources/world/ok_mob_multi_spawn.yaml
@@ -1,0 +1,34 @@
+zone: ok_multi
+startRoom: a
+mobs:
+  unique_npc:
+    name: "Headmaster"
+    spawns:
+      - room: a
+  trash_two_rooms:
+    name: "a goblin"
+    spawns:
+      - room: a
+      - room: b
+  trash_count:
+    name: "a rat"
+    spawns:
+      - room: b
+        count: 3
+  trash_mixed:
+    name: "a slime"
+    spawns:
+      - room: a
+        count: 2
+      - room: b
+rooms:
+  a:
+    title: "Room A"
+    description: "The first room."
+    exits:
+      north: b
+  b:
+    title: "Room B"
+    description: "The second room."
+    exits:
+      south: a

--- a/src/test/resources/world/ok_multi_spawn_kill.yaml
+++ b/src/test/resources/world/ok_multi_spawn_kill.yaml
@@ -1,0 +1,26 @@
+zone: ok_kill
+startRoom: square
+mobs:
+  giver:
+    name: "the quest giver"
+    spawns:
+      - room: square
+  goblin:
+    name: "a goblin"
+    spawns:
+      - room: square
+        count: 3
+quests:
+  goblin_hunt:
+    name: "Goblin Hunt"
+    giver: giver
+    objectives:
+      - type: kill
+        targetKey: goblin
+        count: 3
+        description: "Kill three goblins."
+rooms:
+  square:
+    title: "Square"
+    description: "A square teeming with goblins."
+    exits: {}


### PR DESCRIPTION
## Summary

Splits mob YAML and runtime model into **template** (stats/dialogue/drops) and **placement** (room location). One template can now have multiple spawns, in the same room or across rooms — the standard Diku/Circle pattern for trash mobs that quests need to satisfy.

```yaml
mobs:
  goblin:
    name: a goblin
    tier: standard
    drops: [...]
    spawns:
      - room: cave_a
        count: 2     # two goblins in cave_a
      - room: cave_b # one in cave_b
```

The legacy `room: foo` shorthand still loads (deprecation logged).

## Three commits

1. **Split mob template from spawn placement** — the bulk of the change. New `MobTemplateDef` + lean `MobSpawn` placement record, `World.mobTemplates` map, loader expands counts into stable-id placements (`<templateId>` for single, `<templateId>#<n>` for multi). Quest objective room-pinning matches by `templateId` so multi-spawn mobs pin all their rooms. All call sites swept (GameEngine, GmcpEmitter, HotReloadManager, AdminHandler, DungeonManager, AutoQuestSystem).
2. **Enforce single-placement contract for quest-giver and turn-in NPCs** — hard error at load if a `giverMobId` or `turnInMobId` references a template with anything other than exactly one placement. Includes an integration test that drives `QuestSystem.onMobKilled` across three goblin placements to verify multi-spawn trash mobs satisfy `kill goblin x3`.
3. **Migrate academy.yaml** — rewrites the 16 bundled tutorial mobs to the new shape. Production R2 zones get migrated when Arcanum republishes them.

## Open questions resolved during planning

- **Quest-giver uniqueness**: hard error.
- **Per-spawn `respawnSeconds` override**: no.
- **Per-spawn level override**: no.
- **Stable instance index across YAML edits**: yes — reordering swaps `#0`/`#1`, acceptable since zone reset re-binds.

## Follow-up (not in this PR)

Arcanum (creator-side) needs schema + editor updates before authors can produce multi-spawn entries through the UI. Tracked separately.

## Test plan

- [x] `./gradlew ktlintCheck test` green
- [x] WorldLoader fixtures cover shorthand, `count: N` expansion, multi-room, count=0 rejection, both/`room`+`spawns` rejection, quest-giver and turn-in uniqueness rejection
- [x] QuestSystem integration test: 3 placements × kill objective `count: 3` → quest auto-completes