### PR TITLE
Wrap race/class picker cards on narrow viewports

### DIFF
--- a/web-v3/src/canvas/LoginModal.tsx
+++ b/web-v3/src/canvas/LoginModal.tsx
@@ -171,7 +171,7 @@ function RaceCardGrid({ races, error, onSelect }: RaceCardGridProps) {
       <p className="login-step-label">Choose your race</p>
       {error && <p className="login-error">{error}</p>}
 
-      <div className="char-card-grid char-card-grid--cols6">
+      <div className="char-card-grid">
         {races.map((r, i) => (
           <button
             key={r.id}

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -13751,14 +13751,11 @@ body {
 }
 
 .char-card-grid {
-  display: grid;
-  grid-template-columns: repeat(5, 110px);
+  display: flex;
+  flex-wrap: wrap;
   gap: 10px;
   justify-content: center;
-}
-
-.char-card-grid--cols6 {
-  grid-template-columns: repeat(6, 110px);
+  width: 100%;
 }
 
 .char-card {
@@ -13772,6 +13769,29 @@ body {
   cursor: pointer;
   padding: 0;
   transition: border-color 0.15s, box-shadow 0.2s, transform 0.15s;
+  flex: 0 0 auto;
+}
+
+@media (max-width: 600px) {
+  .char-card {
+    width: 86px;
+  }
+
+  .char-card-label {
+    font-size: 0.72rem;
+    padding: 14px 2px 4px;
+  }
+}
+
+@media (max-width: 380px) {
+  .char-card {
+    width: 72px;
+  }
+
+  .char-card-label {
+    font-size: 0.66rem;
+    padding: 12px 2px 3px;
+  }
 }
 
 .char-card:hover {


### PR DESCRIPTION
## Summary
- The new-character race/class picker used a fixed-column CSS grid (`repeat(5, 110px)` / `repeat(6, 110px)`), so the row of portraits overflowed the modal on phones and at lower desktop widths and got clipped.
- Switched `.char-card-grid` to flex-wrap so cards reflow onto multiple rows when they don't fit, and added breakpoints at 600px and 380px that shrink card width (110 -> 86 -> 72) and label sizing for phones.
- Removed the now-unused `char-card-grid--cols6` modifier from the race grid since wrapping handles any card count uniformly.

## Test plan
- [ ] `./gradlew demo`, open the login flow, pick a name that doesn't exist, advance to race selection
- [ ] Verify all 6 race cards fit in one row at desktop width
- [ ] Resize the browser narrow (or use devtools mobile emulation at ~375px) and verify cards wrap to multiple rows instead of clipping
- [ ] Verify class picker also wraps cleanly
- [ ] `cd web-v3 && bun run lint`