### PR TITLE
feat(items): add healMana to consumable onUse

### DIFF
--- a/docs/WORLD_YAML_SPEC.md
+++ b/docs/WORLD_YAML_SPEC.md
@@ -245,10 +245,11 @@ video: <string, optional - relative path under /videos/, shown in context menu>
 
 ```yaml
 healHp: <integer, optional, default 0, must be >= 0>
+healMana: <integer, optional, default 0, must be >= 0>
 grantXp: <long, optional, default 0, must be >= 0>
 ```
 
-If `onUse` is present, at least one effect must be positive (`healHp > 0` or `grantXp > 0`).
+If `onUse` is present, at least one effect must be positive (`healHp > 0`, `healMana > 0`, or `grantXp > 0`).
 
 Charge/consumption notes:
 - If `charges` is set, one charge is spent per use.
@@ -556,7 +557,7 @@ For each file your tool emits:
 4. Restrict exit direction keys to the allowed set.
 5. Use only non-negative integers for `lifespan`, `damage`, `armor`, `constitution`.
 6. For every item, use `room` or omit placement entirely (unplaced). Do not use `mob`.
-7. If `onUse` is present, include at least one positive effect (`healHp` or `grantXp`).
+7. If `onUse` is present, include at least one positive effect (`healHp`, `healMana`, or `grantXp`).
 8. If `charges` is present, it must be > 0.
 9. Ensure all local/qualified references resolve in the merged set of files.
 10. Ensure normalized room/mob/item IDs are globally unique across files.

--- a/src/main/kotlin/dev/ambon/domain/items/Item.kt
+++ b/src/main/kotlin/dev/ambon/domain/items/Item.kt
@@ -4,9 +4,10 @@ import dev.ambon.domain.StatMap
 
 data class ItemUseEffect(
     val healHp: Int = 0,
+    val healMana: Int = 0,
     val grantXp: Long = 0L,
 ) {
-    fun hasEffect(): Boolean = healHp > 0 || grantXp > 0L
+    fun hasEffect(): Boolean = healHp > 0 || healMana > 0 || grantXp > 0L
 
     /**
      * Short human-readable summary of what using the item does, suitable for
@@ -16,6 +17,7 @@ data class ItemUseEffect(
     fun describe(): String? {
         val parts = mutableListOf<String>()
         if (healHp > 0) parts.add("Restores $healHp HP")
+        if (healMana > 0) parts.add("Restores $healMana mana")
         if (grantXp > 0L) parts.add("Grants $grantXp XP")
         return if (parts.isEmpty()) null else parts.joinToString(", ")
     }

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -498,6 +498,7 @@ object WorldLoader {
                 val onUse =
                     itemFile.onUse?.also { effect ->
                         requireAtLeast(effect.healHp, 0, itemCtx, "onUse.healHp")
+                        requireAtLeast(effect.healMana, 0, itemCtx, "onUse.healMana")
                         requireAtLeast(effect.grantXp, 0L, itemCtx, "onUse.grantXp")
                         if (!effect.hasEffect()) {
                             throw WorldLoadException(

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ItemHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ItemHandler.kt
@@ -17,6 +17,7 @@ import dev.ambon.engine.commands.on
 import dev.ambon.engine.dialogue.DialogueSystem
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.healHp
+import dev.ambon.engine.healMana
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.metrics.GameMetrics
 
@@ -256,6 +257,17 @@ class ItemHandler(
                             markVitalsDirty(sessionId)
                         } else {
                             outbound.send(OutboundEvent.SendInfo(sessionId, "You are already at full health."))
+                        }
+                    }
+                    if (effect.healMana > 0) {
+                        val previousMana = me.mana
+                        me.healMana(effect.healMana)
+                        val restored = (me.mana - previousMana).coerceAtLeast(0)
+                        if (restored > 0) {
+                            outbound.send(OutboundEvent.SendInfo(sessionId, "You recover $restored mana."))
+                            markVitalsDirty(sessionId)
+                        } else {
+                            outbound.send(OutboundEvent.SendInfo(sessionId, "Your mana is already full."))
                         }
                     }
                     if (effect.grantXp > 0L) {


### PR DESCRIPTION
## Summary

- Add `healMana: Int = 0` field to `ItemUseEffect`, parallel to existing `healHp`.
- `ItemHandler` applies it via `PlayerState.healMana(...)`, clamps to maxMana, and sends "You recover N mana." (or "Your mana is already full.").
- `WorldLoader` validates `healMana >= 0`.
- `hasEffect()` and `describe()` recognize the new field, so the inventory tooltip shows "Restores N mana".
- YAML spec doc updated.

No content changes — existing potions are unaffected.

## Test plan

- [x] `./gradlew ktlintCheck`
- [x] `./gradlew test --tests "*ItemRegistry*" --tests "*WorldLoader*" --tests "*CommandRouterItems*" --tests "*GmcpEmitterTest*"`