### PR TITLE
feat(pets): image field on pet skills for quickbar icons

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -879,6 +879,8 @@ data class PetSpellConfig(
     val weight: Int = 1,
     /** Flat threat added to the pet's threat entry on the target (for tank-pet taunt skills). */
     val threatBonus: Double = 0.0,
+    /** Optional asset filename used as the quickbar / spellbook icon for this skill. */
+    val image: String? = null,
 )
 
 data class PetConfig(

--- a/src/main/kotlin/dev/ambon/domain/mob/MobSpell.kt
+++ b/src/main/kotlin/dev/ambon/domain/mob/MobSpell.kt
@@ -27,4 +27,9 @@ data class MobSpell(
      * a bear's roar that need to grab aggro without dealing damage. Ignored for non-pet mobs.
      */
     val threatBonus: Double = 0.0,
+    /**
+     * Optional asset filename used as the quickbar / spellbook icon. Only surfaced for pet
+     * skills today (via Char.Pet.Skills GMCP); mob spells ignore it.
+     */
+    val image: String? = null,
 )

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -2584,7 +2584,7 @@ class GameEngine(
                 cooldownMs = spell.cooldownMs,
                 cooldownRemainingMs = combatSystem.petSkillCooldownRemainingMs(pet.id, spell.id, now),
                 effectType = mapPetSkillEffectType(spell),
-                image = null,
+                image = spell.image,
                 petName = pet.name,
             )
         }

--- a/src/main/kotlin/dev/ambon/engine/PetSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/PetSystem.kt
@@ -224,6 +224,7 @@ class PetSystem(
             cooldownMs = sc.cooldownMs,
             weight = sc.weight,
             threatBonus = sc.threatBonus,
+            image = sc.image,
         )
 
     /** Per-owner timestamp of the most recent manual `pet <skill>` trigger. */

--- a/src/main/kotlin/dev/ambon/engine/PetSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/PetSystem.kt
@@ -224,7 +224,7 @@ class PetSystem(
             cooldownMs = sc.cooldownMs,
             weight = sc.weight,
             threatBonus = sc.threatBonus,
-            image = sc.image,
+            image = resolveImage(sc.image),
         )
 
     /** Per-owner timestamp of the most recent manual `pet <skill>` trigger. */

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/PetHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/PetHandler.kt
@@ -172,7 +172,7 @@ class PetHandler(
                     spell.statusEffectId != null -> "APPLY_STATUS"
                     else -> "DIRECT_DAMAGE"
                 },
-                image = null,
+                image = spell.image,
                 petName = pet.name,
             )
         }


### PR DESCRIPTION
## Summary

- Adds optional `image: String? = null` to `PetSpellConfig` (and its engine mirror `MobSpell`) so each pet skill can carry its own quickbar / spellbook icon.
- `PetSystem.toMobSpell` forwards the field through to runtime.
- Both `Char.Pet.Skills` GMCP emitters (`GameEngine.emitPetSkills`, `PetHandler.emitPetSkillsForActive`) now publish `spell.image` instead of hard-coded `null`.

The web client (spellbook + action bar) already renders `skill.image`, so this is the only piece that was missing — once a pet skill has an `image:` in `application.yaml`, it'll show up automatically in both surfaces. Existing pet skills with no `image:` stay on the fallback `SkillCastIcon`.

### Pet skills in the web client (for reference)

- **Spellbook drawer** — pet skills appear alongside class abilities with a gold "Pet" badge and gold-tinted card border.
- **Quickbar** — drag from spellbook; renders with a paw-print corner marker. Click fires `pet <id>`.

## Test plan

- [x] `./gradlew ktlintCheck`
- [x] `./gradlew test --tests "*PetSkill*" --tests "*PetSystem*" --tests "*PetCommand*"`