### PR TITLE
feat(abilities): per-archetype combat visuals on web client

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -2245,11 +2245,19 @@ data class AbilityDefinitionConfig(
     val prerequisites: List<String> = emptyList(),
     val tree: String = "",
     val tier: Int = 0,
+    val visual: AbilityVisualConfig = AbilityVisualConfig(),
 ) {
     init {
         require(skillPointCost >= 0) { "skillPointCost must be >= 0, got $skillPointCost" }
     }
 }
+
+data class AbilityVisualConfig(
+    val archetype: String = "",
+    val projectileImage: String = "",
+    val color: String = "",
+    val accentColor: String = "",
+)
 
 data class AbilityEffectConfig(
     val type: String = "DIRECT_DAMAGE",

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -440,6 +440,12 @@ class GmcpEmitter(
                     prerequisites = a.prerequisites.map { it.value },
                     tree = a.tree,
                     tier = a.tier,
+                    visual = SkillVisualPayload(
+                        archetype = a.visual.archetype.name,
+                        projectileImage = a.visual.projectileImage,
+                        color = a.visual.color,
+                        accentColor = a.visual.accentColor,
+                    ),
                 )
             },
         )
@@ -963,6 +969,15 @@ class GmcpEmitter(
                 petName = event.petName,
                 attackerName = event.attackerName,
                 damage = event.damage,
+            )
+            is CombatEvent.AbilityCast -> CombatEventPayload(
+                type = "abilityCast",
+                abilityId = event.abilityId,
+                abilityName = event.abilityName,
+                targetName = event.targetName,
+                targetId = event.targetId,
+                targetIsPlayer = event.targetIsPlayer,
+                sourceIsPlayer = event.sourceIsPlayer,
             )
         }
         emit(sessionId, "Char.Combat.Event", payload, supportCheck = "Char.Combat.Event")
@@ -2399,6 +2414,14 @@ class GmcpEmitter(
         val prerequisites: List<String> = emptyList(),
         val tree: String = "",
         val tier: Int = 0,
+        val visual: SkillVisualPayload? = null,
+    )
+
+    private data class SkillVisualPayload(
+        val archetype: String,
+        val projectileImage: String? = null,
+        val color: String? = null,
+        val accentColor: String? = null,
     )
 
     private data class TrainerAbilityPayload(
@@ -2619,6 +2642,7 @@ class GmcpEmitter(
         val absorbed: Int? = null,
         val shieldRemaining: Int? = null,
         val petName: String? = null,
+        val targetIsPlayer: Boolean? = null,
     )
 
     // ---------- stats payload ----------

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -915,6 +915,7 @@ class GmcpEmitter(
             )
             is CombatEvent.Heal -> CombatEventPayload(
                 type = "heal",
+                abilityId = event.abilityId,
                 abilityName = event.abilityName,
                 targetName = event.targetName,
                 healing = event.amount,

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilityDefinition.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilityDefinition.kt
@@ -49,6 +49,34 @@ fun AbilityEffect.toEffectType(): String = when (this) {
     is AbilityEffect.SummonPet -> "SUMMON_PET"
 }
 
+/**
+ * High-level visual archetype that tells the web client how to render the
+ * cast moment in the combat scene. Authors may set this explicitly in the
+ * ability YAML (`visual.archetype`); otherwise it is auto-derived from the
+ * effect type, target type, and class.
+ */
+enum class AbilityVisualArchetype {
+    RANGED_PROJECTILE,
+    MELEE_STRIKE,
+    HEAL_AURA,
+    BUFF_AURA,
+    DEBUFF_AURA,
+    AREA_BURST,
+    SUMMON_POOF,
+}
+
+/**
+ * Per-ability visual customization sent to the web client via Char.Skills GMCP.
+ * `projectileImage` overrides the default (which is the ability `image`).
+ * Colors are hex strings ("#c8a8f0") consumed verbatim by Pixi tints.
+ */
+data class AbilityVisual(
+    val archetype: AbilityVisualArchetype,
+    val projectileImage: String? = null,
+    val color: String? = null,
+    val accentColor: String? = null,
+)
+
 data class AbilityDefinition(
     val id: AbilityId,
     val displayName: String,
@@ -64,8 +92,48 @@ data class AbilityDefinition(
     val tree: String = "",
     val tier: Int = 0,
     val skillPointCost: Int = 1,
+    val visual: AbilityVisual = deriveDefaultVisual(effect, targetType, requiredClass),
 ) {
     init {
         require(skillPointCost >= 0) { "skillPointCost must be >= 0, got $skillPointCost" }
     }
+}
+
+/**
+ * Auto-derive a sensible archetype when authors do not specify `visual` in YAML.
+ * - DIRECT_DAMAGE: WARRIOR/ROGUE get MELEE_STRIKE; others (or unspecified) RANGED_PROJECTILE.
+ * - DIRECT_HEAL: HEAL_AURA.
+ * - APPLY_STATUS: ENEMY → DEBUFF_AURA; SELF/ALLY/GROUP → BUFF_AURA.
+ * - AREA_DAMAGE: AREA_BURST.
+ * - TAUNT: BUFF_AURA on the caster.
+ * - SUMMON_PET: SUMMON_POOF.
+ */
+fun deriveDefaultVisual(
+    effect: AbilityEffect,
+    targetType: String,
+    requiredClass: String?,
+): AbilityVisual {
+    val tt = targetType.uppercase()
+    val cls = requiredClass?.uppercase()
+    val archetype = when (effect) {
+        is AbilityEffect.DirectDamage -> {
+            if (cls == "WARRIOR" || cls == "ROGUE") {
+                AbilityVisualArchetype.MELEE_STRIKE
+            } else {
+                AbilityVisualArchetype.RANGED_PROJECTILE
+            }
+        }
+        is AbilityEffect.DirectHeal -> AbilityVisualArchetype.HEAL_AURA
+        is AbilityEffect.ApplyStatus -> {
+            if (tt == "ENEMY" || tt == "ALL_ENEMIES") {
+                AbilityVisualArchetype.DEBUFF_AURA
+            } else {
+                AbilityVisualArchetype.BUFF_AURA
+            }
+        }
+        is AbilityEffect.AreaDamage -> AbilityVisualArchetype.AREA_BURST
+        is AbilityEffect.Taunt -> AbilityVisualArchetype.BUFF_AURA
+        is AbilityEffect.SummonPet -> AbilityVisualArchetype.SUMMON_POOF
+    }
+    return AbilityVisual(archetype = archetype)
 }

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilityRegistryLoader.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilityRegistryLoader.kt
@@ -1,6 +1,7 @@
 package dev.ambon.engine.abilities
 
 import dev.ambon.config.AbilityEngineConfig
+import dev.ambon.config.AbilityVisualConfig
 import dev.ambon.domain.DamageRange
 import dev.ambon.engine.status.StatusEffectId
 
@@ -50,6 +51,8 @@ object AbilityRegistryLoader {
             val requiredClass = defConfig.requiredClass.ifBlank { null }
             val prerequisites = defConfig.prerequisites.map { AbilityId(it) }.toSet()
             val tree = defConfig.tree.ifBlank { "" }
+            val resolvedImage = defConfig.image.ifBlank { null }?.let { "$imagesBase$it" }
+            val visual = resolveVisual(defConfig.visual, effect, targetType, requiredClass, imagesBase)
             registry.register(
                 AbilityDefinition(
                     id = AbilityId(key),
@@ -62,14 +65,39 @@ object AbilityRegistryLoader {
                     targetType = targetType,
                     effect = effect,
                     requiredClass = requiredClass,
-                    image = defConfig.image.ifBlank { null }?.let { "$imagesBase$it" },
+                    image = resolvedImage,
                     prerequisites = prerequisites,
                     tree = tree,
                     tier = defConfig.tier,
+                    visual = visual,
                 ),
             )
         }
         validateNoPrerequisiteCycles(registry)
+    }
+
+    /**
+     * Resolves the [AbilityVisual] for an ability. An empty [AbilityVisualConfig.archetype]
+     * delegates to [deriveDefaultVisual]; any non-blank field overrides the derived value.
+     * The `projectileImage` is resolved against [imagesBase] just like the spellbook icon.
+     */
+    private fun resolveVisual(
+        config: AbilityVisualConfig,
+        effect: AbilityEffect,
+        targetType: String,
+        requiredClass: String?,
+        imagesBase: String,
+    ): AbilityVisual {
+        val archetype = config.archetype.trim()
+            .takeIf { it.isNotEmpty() }
+            ?.let { runCatching { AbilityVisualArchetype.valueOf(it.uppercase()) }.getOrNull() }
+            ?: deriveDefaultVisual(effect, targetType, requiredClass).archetype
+        return AbilityVisual(
+            archetype = archetype,
+            projectileImage = config.projectileImage.ifBlank { null }?.let { "$imagesBase$it" },
+            color = config.color.ifBlank { null },
+            accentColor = config.accentColor.ifBlank { null },
+        )
     }
 
     /**

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
@@ -178,6 +178,7 @@ class AbilitySystem(
                         "You taunt ${mob.name}! It turns to face you.",
                     ),
                 )
+                emitAbilityCast(sessionId, ability, mob.name, mob.id.value, targetIsPlayer = false)
             }
             is AbilityEffect.ApplyStatus -> {
                 val sys =
@@ -191,6 +192,7 @@ class AbilitySystem(
                         "Your ${ability.displayName} afflicts ${mob.name}!",
                     ),
                 )
+                emitAbilityCast(sessionId, ability, mob.name, mob.id.value, targetIsPlayer = false)
             }
             else -> return "Spell misconfigured (unexpected effect for enemy target)."
         }
@@ -248,10 +250,12 @@ class AbilitySystem(
                         "You are empowered by ${ability.displayName}!",
                     ),
                 )
+                emitAbilityCast(sessionId, ability, player.name, null, targetIsPlayer = true)
             }
             is AbilityEffect.SummonPet -> {
                 deductManaAndCooldown(sessionId, player, ability, now)
                 onSummonPet(sessionId, effect.petTemplateKey, effect.durationMs)
+                emitAbilityCast(sessionId, ability, player.name, null, targetIsPlayer = true)
             }
             else -> return "Spell misconfigured (unexpected effect for self target)."
         }
@@ -365,6 +369,7 @@ class AbilitySystem(
                         ),
                     )
                 }
+                emitAbilityCast(sessionId, ability, target.name, null, targetIsPlayer = (targetSid == sessionId))
             }
             else -> return "Spell misconfigured (unexpected effect for ally target)."
         }
@@ -427,6 +432,7 @@ class AbilitySystem(
                 deductManaAndCooldown(sessionId, player, ability, now)
                 for (m in targetMobs) {
                     sys.applyToMob(m.id, effect.statusEffectId, sessionId)
+                    emitAbilityCast(sessionId, ability, m.name, m.id.value, targetIsPlayer = false)
                 }
                 outbound.send(
                     OutboundEvent.SendText(
@@ -509,6 +515,7 @@ class AbilitySystem(
                 for (targetSid in groupMembers) {
                     sys.applyToPlayer(targetSid, effect.statusEffectId, sessionId)
                     dirtyNotifier.playerStatusDirty(targetSid)
+                    val targetPlayer = players.get(targetSid)
                     if (targetSid == sessionId) {
                         outbound.send(
                             OutboundEvent.SendText(
@@ -516,12 +523,11 @@ class AbilitySystem(
                                 "You are empowered by ${ability.displayName}!",
                             ),
                         )
-                    } else {
-                        val target = players.get(targetSid) ?: continue
+                    } else if (targetPlayer != null) {
                         outbound.send(
                             OutboundEvent.SendText(
                                 sessionId,
-                                "Your ${ability.displayName} empowers ${target.name}!",
+                                "Your ${ability.displayName} empowers ${targetPlayer.name}!",
                             ),
                         )
                         outbound.send(
@@ -531,6 +537,13 @@ class AbilitySystem(
                             ),
                         )
                     }
+                    emitAbilityCast(
+                        sessionId,
+                        ability,
+                        targetPlayer?.name ?: player.name,
+                        null,
+                        targetIsPlayer = (targetSid == sessionId),
+                    )
                 }
             }
             else -> return "Spell misconfigured (unexpected effect for all_allies target)."
@@ -584,6 +597,26 @@ class AbilitySystem(
         if (mob.hp <= 0) {
             combat.handleSpellKill(sessionId, mob)
         }
+    }
+
+    private suspend fun emitAbilityCast(
+        sessionId: SessionId,
+        ability: AbilityDefinition,
+        targetName: String?,
+        targetId: String?,
+        targetIsPlayer: Boolean,
+    ) {
+        onCombatEvent(
+            sessionId,
+            CombatEvent.AbilityCast(
+                abilityId = ability.id.value,
+                abilityName = ability.displayName,
+                targetName = targetName,
+                targetId = targetId,
+                targetIsPlayer = targetIsPlayer,
+                sourceIsPlayer = true,
+            ),
+        )
     }
 
     private suspend fun deductManaAndCooldown(

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
@@ -227,6 +227,7 @@ class AbilitySystem(
                             targetName = player.name,
                             amount = healed,
                             sourceIsPlayer = true,
+                            abilityId = ability.id.value,
                         ),
                     )
                 }
@@ -316,6 +317,7 @@ class AbilitySystem(
                             targetName = target.name,
                             amount = healed,
                             sourceIsPlayer = true,
+                            abilityId = ability.id.value,
                         ),
                     )
                 }
@@ -481,6 +483,7 @@ class AbilitySystem(
                                 targetName = target.name,
                                 amount = healed,
                                 sourceIsPlayer = true,
+                                abilityId = ability.id.value,
                             ),
                         )
                     }

--- a/src/main/kotlin/dev/ambon/engine/events/CombatEvent.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/CombatEvent.kt
@@ -22,6 +22,7 @@ sealed interface CombatEvent {
         val targetName: String,
         val amount: Int,
         val sourceIsPlayer: Boolean,
+        val abilityId: String? = null,
     ) : CombatEvent
 
     data class Dodge(

--- a/src/main/kotlin/dev/ambon/engine/events/CombatEvent.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/CombatEvent.kt
@@ -73,4 +73,23 @@ sealed interface CombatEvent {
         val attackerName: String,
         val damage: Int,
     ) : CombatEvent
+
+    /**
+     * Cast notification for non-damaging, non-healing abilities (buffs,
+     * debuffs, taunts, summons). Damage and heal abilities already emit
+     * [AbilityHit] / [Heal], so this fills the gap for pure-status casts
+     * that previously produced no canvas-visible event.
+     *
+     * [targetIsPlayer] is true when the visible target is the local player
+     * (self-buffs, ally heals/buffs cast on you). When false the target is
+     * an enemy (debuffs) or the caster themselves on a remote screen.
+     */
+    data class AbilityCast(
+        val abilityId: String,
+        val abilityName: String,
+        val targetName: String?,
+        val targetId: String?,
+        val targetIsPlayer: Boolean,
+        val sourceIsPlayer: Boolean,
+    ) : CombatEvent
 }

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -1150,6 +1150,25 @@ class GmcpEmitterTest {
         }
 
     @Test
+    fun `sendCombatEvent emits abilityId for heal events`() =
+        runTest {
+            val e = emitter("Char.Combat")
+            e.sendCombatEvent(
+                sid,
+                CombatEvent.Heal(
+                    abilityName = "Heal",
+                    targetName = "Alice",
+                    amount = 12,
+                    sourceIsPlayer = true,
+                    abilityId = "heal",
+                ),
+            )
+            val data = drainGmcp()[0]
+            assertTrue(data.jsonData.contains("\"type\":\"heal\""))
+            assertTrue(data.jsonData.contains("\"abilityId\":\"heal\""))
+        }
+
+    @Test
     fun `sendCombatEvent matches prefix Char-Combat-Event`() =
         runTest {
             val e = emitter("Char.Combat")

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -515,6 +515,16 @@ class GmcpEmitterTest {
             assertTrue(drainGmcp().isEmpty())
         }
 
+    @Test
+    fun `sendCharSkills includes visual archetype block`() =
+        runTest {
+            val e = emitter("Char.Skills")
+            e.sendCharSkills(sid, listOf(ability())) { 0L }
+            val data = drainGmcp()[0]
+            // DIRECT_DAMAGE with no class derives RANGED_PROJECTILE
+            assertTrue(data.jsonData.contains("\"visual\":{\"archetype\":\"RANGED_PROJECTILE\""))
+        }
+
     // ── Char.Name ──
 
     @Test
@@ -1115,6 +1125,28 @@ class GmcpEmitterTest {
             val e = emitter()
             e.sendCombatEvent(sid, CombatEvent.MeleeHit("Goblin", "mob-1", 10, sourceIsPlayer = true))
             assertTrue(drainGmcp().isEmpty())
+        }
+
+    @Test
+    fun `sendCombatEvent emits abilityCast JSON for buff or debuff`() =
+        runTest {
+            val e = emitter("Char.Combat")
+            e.sendCombatEvent(
+                sid,
+                CombatEvent.AbilityCast(
+                    abilityId = "blessing",
+                    abilityName = "Blessing",
+                    targetName = "Alice",
+                    targetId = null,
+                    targetIsPlayer = true,
+                    sourceIsPlayer = true,
+                ),
+            )
+            val data = drainGmcp()[0]
+            assertEquals("Char.Combat.Event", data.gmcpPackage)
+            assertTrue(data.jsonData.contains("\"type\":\"abilityCast\""))
+            assertTrue(data.jsonData.contains("\"abilityId\":\"blessing\""))
+            assertTrue(data.jsonData.contains("\"targetIsPlayer\":true"))
         }
 
     @Test

--- a/src/test/kotlin/dev/ambon/engine/abilities/AbilityVisualLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/abilities/AbilityVisualLoaderTest.kt
@@ -1,0 +1,158 @@
+package dev.ambon.engine.abilities
+
+import dev.ambon.config.AbilityDefinitionConfig
+import dev.ambon.config.AbilityEffectConfig
+import dev.ambon.config.AbilityEngineConfig
+import dev.ambon.config.AbilityVisualConfig
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class AbilityVisualLoaderTest {
+    private fun load(key: String, def: AbilityDefinitionConfig): AbilityDefinition {
+        val registry = AbilityRegistry()
+        AbilityRegistryLoader.load(
+            AbilityEngineConfig(definitions = mapOf(key to def)),
+            registry,
+            imagesBaseUrl = "/img/",
+        )
+        return registry.all().first()
+    }
+
+    @Test
+    fun `direct damage warrior derives MELEE_STRIKE`() {
+        val a = load(
+            "power_strike",
+            AbilityDefinitionConfig(
+                displayName = "Power Strike",
+                targetType = "ENEMY",
+                requiredClass = "WARRIOR",
+                effect = AbilityEffectConfig(type = "DIRECT_DAMAGE", minDamage = 5, maxDamage = 10),
+            ),
+        )
+        assertEquals(AbilityVisualArchetype.MELEE_STRIKE, a.visual.archetype)
+    }
+
+    @Test
+    fun `direct damage mage derives RANGED_PROJECTILE`() {
+        val a = load(
+            "arcane_bolt",
+            AbilityDefinitionConfig(
+                targetType = "ENEMY",
+                requiredClass = "MAGE",
+                effect = AbilityEffectConfig(type = "DIRECT_DAMAGE", minDamage = 5, maxDamage = 10),
+            ),
+        )
+        assertEquals(AbilityVisualArchetype.RANGED_PROJECTILE, a.visual.archetype)
+    }
+
+    @Test
+    fun `apply status on enemy derives DEBUFF_AURA`() {
+        val a = load(
+            "hex",
+            AbilityDefinitionConfig(
+                targetType = "ENEMY",
+                requiredClass = "MAGE",
+                effect = AbilityEffectConfig(type = "APPLY_STATUS", statusEffectId = "hex_debuff"),
+            ),
+        )
+        assertEquals(AbilityVisualArchetype.DEBUFF_AURA, a.visual.archetype)
+    }
+
+    @Test
+    fun `apply status on self derives BUFF_AURA`() {
+        val a = load(
+            "blessing",
+            AbilityDefinitionConfig(
+                targetType = "SELF",
+                requiredClass = "CLERIC",
+                effect = AbilityEffectConfig(type = "APPLY_STATUS", statusEffectId = "blessing_buff"),
+            ),
+        )
+        assertEquals(AbilityVisualArchetype.BUFF_AURA, a.visual.archetype)
+    }
+
+    @Test
+    fun `direct heal derives HEAL_AURA`() {
+        val a = load(
+            "heal",
+            AbilityDefinitionConfig(
+                targetType = "SELF",
+                requiredClass = "CLERIC",
+                effect = AbilityEffectConfig(type = "DIRECT_HEAL", minHeal = 10, maxHeal = 20),
+            ),
+        )
+        assertEquals(AbilityVisualArchetype.HEAL_AURA, a.visual.archetype)
+    }
+
+    @Test
+    fun `summon pet derives SUMMON_POOF`() {
+        val a = load(
+            "summon_wolf",
+            AbilityDefinitionConfig(
+                targetType = "SELF",
+                requiredClass = "RANGER",
+                effect = AbilityEffectConfig(type = "SUMMON_PET", petTemplateKey = "wolf"),
+            ),
+        )
+        assertEquals(AbilityVisualArchetype.SUMMON_POOF, a.visual.archetype)
+    }
+
+    @Test
+    fun `area damage derives AREA_BURST`() {
+        val a = load(
+            "cleave",
+            AbilityDefinitionConfig(
+                targetType = "ENEMY",
+                requiredClass = "WARRIOR",
+                effect = AbilityEffectConfig(type = "AREA_DAMAGE", minDamage = 5, maxDamage = 10),
+            ),
+        )
+        assertEquals(AbilityVisualArchetype.AREA_BURST, a.visual.archetype)
+    }
+
+    @Test
+    fun `explicit archetype overrides auto-derived`() {
+        val a = load(
+            "shadow_step",
+            AbilityDefinitionConfig(
+                targetType = "ENEMY",
+                requiredClass = "ROGUE",
+                effect = AbilityEffectConfig(type = "DIRECT_DAMAGE", minDamage = 5, maxDamage = 10),
+                visual = AbilityVisualConfig(archetype = "RANGED_PROJECTILE"),
+            ),
+        )
+        // Default for rogue+DIRECT_DAMAGE would be MELEE_STRIKE — explicit override wins.
+        assertEquals(AbilityVisualArchetype.RANGED_PROJECTILE, a.visual.archetype)
+    }
+
+    @Test
+    fun `projectile image is resolved against images base`() {
+        val a = load(
+            "ice_lance",
+            AbilityDefinitionConfig(
+                targetType = "ENEMY",
+                requiredClass = "MAGE",
+                effect = AbilityEffectConfig(type = "DIRECT_DAMAGE", minDamage = 5, maxDamage = 10),
+                visual = AbilityVisualConfig(projectileImage = "ice.png", color = "#88ccff"),
+            ),
+        )
+        assertEquals("/img/ice.png", a.visual.projectileImage)
+        assertEquals("#88ccff", a.visual.color)
+        assertNull(a.visual.accentColor)
+    }
+
+    @Test
+    fun `unknown archetype string falls back to derived default`() {
+        val a = load(
+            "weird",
+            AbilityDefinitionConfig(
+                targetType = "ENEMY",
+                requiredClass = "MAGE",
+                effect = AbilityEffectConfig(type = "DIRECT_DAMAGE", minDamage = 5, maxDamage = 10),
+                visual = AbilityVisualConfig(archetype = "NOT_A_REAL_ARCHETYPE"),
+            ),
+        )
+        assertEquals(AbilityVisualArchetype.RANGED_PROJECTILE, a.visual.archetype)
+    }
+}

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -310,6 +310,9 @@ function App() {
       worldTime: state.worldTime,
       worldWeather: state.worldWeather,
       zoneEnvironment: state.zoneEnvironment,
+      skillsById: new Map(
+        [...state.skills, ...state.petSkills].map((s) => [s.id, s]),
+      ),
     };
   });
 

--- a/web-v3/src/canvas/GameStateBridge.ts
+++ b/web-v3/src/canvas/GameStateBridge.ts
@@ -16,6 +16,7 @@ import type {
   RoomItem,
   RoomState,
   ShopState,
+  SkillSummary,
   StatusEffect,
   StylistState,
   Vitals,
@@ -50,6 +51,8 @@ export interface GameStateSnapshot {
   worldTime: WorldTime | null;
   worldWeather: WorldWeather | null;
   zoneEnvironment: ZoneEnvironment | null;
+  /** Player + pet skills indexed by id for fast per-ability visual lookup. */
+  skillsById: Map<string, SkillSummary>;
 }
 
 export interface PendingCast {
@@ -138,5 +141,6 @@ export const gameStateRef: { current: GameStateSnapshot } = {
     worldTime: null,
     worldWeather: null,
     zoneEnvironment: null,
+    skillsById: new Map(),
   },
 };

--- a/web-v3/src/canvas/scenes/BattleScene.ts
+++ b/web-v3/src/canvas/scenes/BattleScene.ts
@@ -1,6 +1,7 @@
 import { Container, Graphics, Sprite, Text, Texture, Assets } from "pixi.js";
 import { gameStateRef, canvasCallbacks } from "../GameStateBridge";
 import { canvasEvents } from "../CanvasEventBus";
+import { AbilityVisualSystem } from "../systems/AbilityVisualSystem";
 import { CombatAnimator } from "../systems/CombatAnimator";
 import { GainPopupSystem } from "../systems/GainPopup";
 import { StatusEffectDisplay } from "../systems/StatusEffectDisplay";
@@ -52,6 +53,7 @@ export class BattleScene {
   private combatAnimator: CombatAnimator;
   private gainPopups: GainPopupSystem;
   private spellProjectiles = new SpellProjectileSystem();
+  private abilityVisuals = new AbilityVisualSystem();
   private statusEffects = new StatusEffectDisplay();
   private enemyStatusEffects = new StatusEffectDisplay();
   private uiGraphics = new Graphics();
@@ -123,6 +125,7 @@ export class BattleScene {
     this.container.addChild(this.enemyStatusEffects.container);
     this.container.addChild(this.combatAnimator.container);
     this.container.addChild(this.spellProjectiles.graphics);
+    this.container.addChild(this.abilityVisuals.container);
     this.container.addChild(this.gainPopups.container);
 
     this.fleeBtn = this.buildActionButton("Flee", 0xd4888a, 0x4a1a1a, () => {
@@ -162,6 +165,7 @@ export class BattleScene {
     this.container.alpha = 0;
     this.combatAnimator.clear();
     this.spellProjectiles.clear();
+    this.abilityVisuals.clear();
     this.gainPopups.clear();
     this.removeVictoryText();
     // Reset tracking so update() re-creates everything
@@ -252,9 +256,35 @@ export class BattleScene {
     const enemyPos = this.getEnemyPosition();
 
     for (const event of combat) {
-      // Try to spawn a spell projectile — abilities get a visible arcing projectile
-      this.spellProjectiles.trySpawn(event, playerPos.x, playerPos.y, enemyPos.x, enemyPos.y);
-      this.combatAnimator.processEvent(event, playerPos.x, playerPos.y, enemyPos.x, enemyPos.y);
+      // Per-ability archetype dispatch — looks up the skill's visual from the
+      // bridge state and routes to the AbilityVisualSystem. When an archetype
+      // consumes the event we skip the generic SpellProjectile/red slash so
+      // the per-archetype animation is the only visible effect.
+      const skill = event.abilityId ? gameStateRef.current.skillsById.get(event.abilityId) : null;
+      const route = this.abilityVisuals.processEvent(
+        event,
+        skill?.visual?.archetype ?? null,
+        skill?.visual ?? null,
+        skill?.image ?? null,
+        playerPos.x, playerPos.y,
+        enemyPos.x, enemyPos.y,
+      );
+
+      // Generic projectile for events without an archetype (e.g. dotTick).
+      if (!route.consumesProjectile) {
+        this.spellProjectiles.trySpawn(event, playerPos.x, playerPos.y, enemyPos.x, enemyPos.y);
+      }
+
+      // abilityCast events carry no damage/heal — skip the CombatAnimator entirely
+      // (it would otherwise emit dodge/death/etc. branches that don't apply).
+      if (event.type !== "abilityCast") {
+        this.combatAnimator.processEvent(
+          event,
+          playerPos.x, playerPos.y,
+          enemyPos.x, enemyPos.y,
+          { suppressSlash: route.suppressSlash },
+        );
+      }
     }
 
     for (const event of gains) {
@@ -264,6 +294,7 @@ export class BattleScene {
     // Update animations
     this.combatAnimator.update(deltaMs);
     this.spellProjectiles.update(deltaMs);
+    this.abilityVisuals.update(deltaMs);
     this.gainPopups.update(deltaMs);
 
     // Apply death animation effects to enemy sprite
@@ -778,6 +809,7 @@ export class BattleScene {
   destroy() {
     this.combatAnimator.clear();
     this.spellProjectiles.clear();
+    this.abilityVisuals.clear();
     this.gainPopups.clear();
     this.container.destroy({ children: true });
   }

--- a/web-v3/src/canvas/systems/AbilityVisualSystem.ts
+++ b/web-v3/src/canvas/systems/AbilityVisualSystem.ts
@@ -1,0 +1,478 @@
+import { Container, Graphics, Sprite, Texture, Assets } from "pixi.js";
+import type { AbilityVisualArchetype, CombatEventData, SkillVisual } from "../../types";
+
+/**
+ * Per-archetype combat visual renderer. Driven by the skill's `visual.archetype`
+ * (sent via Char.Skills) and the ability id on each combat event. Falls back to
+ * sensible defaults for unknown archetypes.
+ *
+ * Archetypes:
+ *  - RANGED_PROJECTILE: sprite (or colored orb) arcs caster -> target.
+ *  - MELEE_STRIKE: pulses the ability icon at the impact point (caller skips red slash).
+ *  - HEAL_AURA: rising green/gold aura on target.
+ *  - BUFF_AURA: rising aura + icon flash on self/ally.
+ *  - DEBUFF_AURA: sinking dark aura on enemy.
+ *  - AREA_BURST: radial wave at target.
+ *  - SUMMON_POOF: sparkle puff at caster.
+ */
+
+const PROJECTILE_DURATION_MS = 420;
+const TRAIL_COUNT = 8;
+
+const ICON_PULSE_DURATION_MS = 420;
+const ICON_PULSE_START_SCALE = 0.4;
+const ICON_PULSE_END_SCALE = 1.4;
+const ICON_PULSE_TARGET_SIZE = 64;
+
+const AURA_DURATION_MS = 700;
+const AURA_RADIUS = 56;
+
+const AREA_BURST_DURATION_MS = 520;
+const AREA_BURST_RADIUS = 110;
+
+const SUMMON_POOF_DURATION_MS = 650;
+const SUMMON_POOF_PARTICLES = 14;
+
+const ARCHETYPE_DEFAULT_COLOR: Record<AbilityVisualArchetype, number> = {
+  RANGED_PROJECTILE: 0xc8a8f0,
+  MELEE_STRIKE: 0xf0c674,
+  HEAL_AURA: 0x90e090,
+  BUFF_AURA: 0xf0d68a,
+  DEBUFF_AURA: 0x9060c0,
+  AREA_BURST: 0xf08060,
+  SUMMON_POOF: 0xb294bb,
+};
+
+function hexToNumber(hex: string | null | undefined, fallback: number): number {
+  if (!hex || typeof hex !== "string") return fallback;
+  const trimmed = hex.startsWith("#") ? hex.slice(1) : hex;
+  const n = parseInt(trimmed, 16);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+interface RangedProjectile {
+  sx: number; sy: number; ex: number; ey: number;
+  elapsed: number;
+  duration: number;
+  color: number;
+  glowColor: number;
+  sprite: Sprite | null;
+  trail: Array<{ x: number; y: number }>;
+  arcHeight: number;
+}
+
+interface IconPulse {
+  x: number; y: number;
+  elapsed: number;
+  duration: number;
+  sprite: Sprite | null;
+  tint: number;
+}
+
+interface Aura {
+  x: number; y: number;
+  elapsed: number;
+  duration: number;
+  color: number;
+  direction: "rise" | "fall";
+}
+
+interface AreaBurst {
+  x: number; y: number;
+  elapsed: number;
+  duration: number;
+  color: number;
+}
+
+interface PoofParticle {
+  x: number; y: number;
+  vx: number; vy: number;
+  elapsed: number;
+  lifetime: number;
+  color: number;
+  size: number;
+}
+
+/** Per-event archetype resolution result returned to BattleScene. */
+export interface ArchetypeRoute {
+  archetype: AbilityVisualArchetype | null;
+  /** Whether the new system handles the projectile/impact (BattleScene should skip SpellProjectile/red slash). */
+  consumesProjectile: boolean;
+  /** Whether CombatAnimator should suppress its red slash for this event. */
+  suppressSlash: boolean;
+}
+
+export class AbilityVisualSystem {
+  readonly container = new Container();
+  private graphics = new Graphics();
+  private spriteLayer = new Container();
+  private projectiles: RangedProjectile[] = [];
+  private iconPulses: IconPulse[] = [];
+  private auras: Aura[] = [];
+  private bursts: AreaBurst[] = [];
+  private poofs: PoofParticle[] = [];
+  private textureCache = new Map<string, Texture | null>();
+
+  constructor() {
+    this.container.addChild(this.graphics);
+    this.container.addChild(this.spriteLayer);
+  }
+
+  /**
+   * Route a combat event through the archetype dispatcher.
+   * - Returns archetype + flags so BattleScene knows what other systems to skip.
+   * - Mutates internal state to play the relevant animation.
+   */
+  processEvent(
+    event: CombatEventData,
+    archetype: AbilityVisualArchetype | null,
+    visual: SkillVisual | null,
+    imageFallback: string | null,
+    playerX: number, playerY: number,
+    enemyX: number, enemyY: number,
+  ): ArchetypeRoute {
+    if (!archetype) {
+      return { archetype: null, consumesProjectile: false, suppressSlash: false };
+    }
+
+    const color = hexToNumber(visual?.color, ARCHETYPE_DEFAULT_COLOR[archetype]);
+    const accentColor = hexToNumber(visual?.accentColor, color);
+    const projectileImage = visual?.projectileImage ?? imageFallback ?? null;
+
+    // Caster and target positions depend on who sourced the event.
+    const sx = event.sourceIsPlayer ? playerX : enemyX;
+    const sy = event.sourceIsPlayer ? playerY : enemyY;
+
+    // For buffs/heals on self, target is the player. For debuffs on enemy, target is enemy.
+    // We let event.targetIsPlayer drive this when present (abilityCast); otherwise infer.
+    const targetIsPlayer = event.type === "abilityCast"
+      ? event.targetIsPlayer
+      : !event.sourceIsPlayer;
+    const tx = targetIsPlayer ? playerX : enemyX;
+    const ty = targetIsPlayer ? playerY : enemyY;
+
+    switch (archetype) {
+      case "RANGED_PROJECTILE":
+        this.spawnRangedProjectile(sx, sy, tx, ty, color, accentColor, projectileImage);
+        return { archetype, consumesProjectile: true, suppressSlash: false };
+
+      case "MELEE_STRIKE":
+        // Caller still does lunge/shake via CombatAnimator; we replace the red slash
+        // with a pulse of the ability icon at the impact point.
+        this.spawnIconPulse(tx, ty, projectileImage, color);
+        return { archetype, consumesProjectile: true, suppressSlash: true };
+
+      case "HEAL_AURA":
+        this.spawnAura(tx, ty, color, "rise");
+        this.spawnIconPulse(tx, ty - 10, projectileImage, color);
+        return { archetype, consumesProjectile: true, suppressSlash: false };
+
+      case "BUFF_AURA":
+        this.spawnAura(tx, ty, color, "rise");
+        this.spawnIconPulse(tx, ty - 10, projectileImage, color);
+        return { archetype, consumesProjectile: true, suppressSlash: false };
+
+      case "DEBUFF_AURA":
+        this.spawnAura(tx, ty, color, "fall");
+        this.spawnIconPulse(tx, ty + 10, projectileImage, color);
+        return { archetype, consumesProjectile: true, suppressSlash: false };
+
+      case "AREA_BURST":
+        this.spawnAreaBurst(tx, ty, color);
+        return { archetype, consumesProjectile: true, suppressSlash: false };
+
+      case "SUMMON_POOF":
+        this.spawnSummonPoof(sx, sy, color, accentColor);
+        return { archetype, consumesProjectile: true, suppressSlash: false };
+    }
+    return { archetype: null, consumesProjectile: false, suppressSlash: false };
+  }
+
+  private spawnRangedProjectile(
+    sx: number, sy: number, ex: number, ey: number,
+    color: number, glowColor: number,
+    imagePath: string | null,
+  ) {
+    const proj: RangedProjectile = {
+      sx, sy, ex, ey,
+      elapsed: 0,
+      duration: PROJECTILE_DURATION_MS,
+      color,
+      glowColor,
+      sprite: null,
+      trail: [],
+      arcHeight: 0.2,
+    };
+    this.projectiles.push(proj);
+
+    if (imagePath) {
+      const cached = this.textureCache.get(imagePath);
+      if (cached) {
+        proj.sprite = this.attachSprite(cached, color);
+      } else if (cached !== null) {
+        Assets.load(imagePath).then((tex: unknown) => {
+          const texture = tex instanceof Texture ? tex : null;
+          this.textureCache.set(imagePath, texture);
+          if (texture && this.projectiles.includes(proj)) {
+            proj.sprite = this.attachSprite(texture, color);
+          }
+        }).catch(() => {
+          this.textureCache.set(imagePath, null);
+        });
+      }
+    }
+  }
+
+  private attachSprite(texture: Texture, tint: number): Sprite {
+    const sprite = new Sprite(texture);
+    sprite.anchor.set(0.5);
+    sprite.width = 32;
+    sprite.height = 32;
+    sprite.tint = tint;
+    this.spriteLayer.addChild(sprite);
+    return sprite;
+  }
+
+  private spawnIconPulse(x: number, y: number, imagePath: string | null, tint: number) {
+    const pulse: IconPulse = { x, y, elapsed: 0, duration: ICON_PULSE_DURATION_MS, sprite: null, tint };
+    this.iconPulses.push(pulse);
+    if (!imagePath) return;
+    const cached = this.textureCache.get(imagePath);
+    if (cached) {
+      pulse.sprite = this.attachSprite(cached, 0xffffff);
+    } else if (cached !== null) {
+      Assets.load(imagePath).then((tex: unknown) => {
+        const texture = tex instanceof Texture ? tex : null;
+        this.textureCache.set(imagePath, texture);
+        if (texture && this.iconPulses.includes(pulse)) {
+          pulse.sprite = this.attachSprite(texture, 0xffffff);
+        }
+      }).catch(() => {
+        this.textureCache.set(imagePath, null);
+      });
+    }
+  }
+
+  private spawnAura(x: number, y: number, color: number, direction: "rise" | "fall") {
+    this.auras.push({ x, y, elapsed: 0, duration: AURA_DURATION_MS, color, direction });
+  }
+
+  private spawnAreaBurst(x: number, y: number, color: number) {
+    this.bursts.push({ x, y, elapsed: 0, duration: AREA_BURST_DURATION_MS, color });
+  }
+
+  private spawnSummonPoof(x: number, y: number, color: number, accent: number) {
+    for (let i = 0; i < SUMMON_POOF_PARTICLES; i++) {
+      const angle = (Math.PI * 2 * i) / SUMMON_POOF_PARTICLES + (Math.random() - 0.5) * 0.4;
+      const speed = 40 + Math.random() * 60;
+      this.poofs.push({
+        x, y,
+        vx: Math.cos(angle) * speed,
+        vy: Math.sin(angle) * speed - 30,
+        elapsed: 0,
+        lifetime: SUMMON_POOF_DURATION_MS * (0.7 + Math.random() * 0.6),
+        color: Math.random() > 0.5 ? color : accent,
+        size: 2 + Math.random() * 2,
+      });
+    }
+  }
+
+  update(deltaMs: number) {
+    // Projectiles
+    for (let i = this.projectiles.length - 1; i >= 0; i--) {
+      const p = this.projectiles[i];
+      p.elapsed += deltaMs;
+      const t = Math.min(1, p.elapsed / p.duration);
+      const pos = this.arcPosition(p, t);
+      p.trail.push({ x: pos.x, y: pos.y });
+      if (p.trail.length > TRAIL_COUNT) p.trail.shift();
+      if (p.sprite) {
+        p.sprite.x = pos.x;
+        p.sprite.y = pos.y;
+        // Slight wobble + rotation for life
+        p.sprite.rotation += (deltaMs / 1000) * 4;
+      }
+      if (t >= 1) {
+        if (p.sprite) {
+          this.spriteLayer.removeChild(p.sprite);
+          p.sprite.destroy();
+        }
+        // Brief impact burst at endpoint
+        this.spawnAreaBurst(p.ex, p.ey, p.color);
+        this.projectiles.splice(i, 1);
+      }
+    }
+
+    // Icon pulses
+    for (let i = this.iconPulses.length - 1; i >= 0; i--) {
+      const pulse = this.iconPulses[i];
+      pulse.elapsed += deltaMs;
+      const t = Math.min(1, pulse.elapsed / pulse.duration);
+      if (pulse.sprite) {
+        const scale = ICON_PULSE_START_SCALE + (ICON_PULSE_END_SCALE - ICON_PULSE_START_SCALE) * easeOutCubic(t);
+        pulse.sprite.x = pulse.x;
+        pulse.sprite.y = pulse.y;
+        pulse.sprite.width = ICON_PULSE_TARGET_SIZE * scale;
+        pulse.sprite.height = ICON_PULSE_TARGET_SIZE * scale;
+        pulse.sprite.alpha = 1 - t;
+      }
+      if (t >= 1) {
+        if (pulse.sprite) {
+          this.spriteLayer.removeChild(pulse.sprite);
+          pulse.sprite.destroy();
+        }
+        this.iconPulses.splice(i, 1);
+      }
+    }
+
+    // Auras
+    for (let i = this.auras.length - 1; i >= 0; i--) {
+      const a = this.auras[i];
+      a.elapsed += deltaMs;
+      if (a.elapsed >= a.duration) this.auras.splice(i, 1);
+    }
+
+    // Area bursts
+    for (let i = this.bursts.length - 1; i >= 0; i--) {
+      const b = this.bursts[i];
+      b.elapsed += deltaMs;
+      if (b.elapsed >= b.duration) this.bursts.splice(i, 1);
+    }
+
+    // Poof particles
+    for (let i = this.poofs.length - 1; i >= 0; i--) {
+      const p = this.poofs[i];
+      p.elapsed += deltaMs;
+      const dt = deltaMs / 1000;
+      p.x += p.vx * dt;
+      p.y += p.vy * dt;
+      p.vy += 120 * dt;
+      p.vx *= 0.97;
+      if (p.elapsed >= p.lifetime) this.poofs.splice(i, 1);
+    }
+
+    this.draw();
+  }
+
+  private arcPosition(p: RangedProjectile, t: number): { x: number; y: number } {
+    const eased = 1 - (1 - t) * (1 - t);
+    const x = p.sx + (p.ex - p.sx) * eased;
+    const baseY = p.sy + (p.ey - p.sy) * eased;
+    const arc = -p.arcHeight * Math.hypot(p.ex - p.sx, p.ey - p.sy) * 4 * t * (1 - t);
+    return { x, y: baseY + arc };
+  }
+
+  private draw() {
+    const g = this.graphics;
+    g.clear();
+
+    // Projectile trails + glows (used even when a sprite is present)
+    for (const p of this.projectiles) {
+      for (let i = 0; i < p.trail.length; i++) {
+        const tp = p.trail[i];
+        const trailT = i / Math.max(1, p.trail.length);
+        const trailAlpha = trailT * 0.4;
+        const size = 3 + trailT * 4;
+        g.circle(tp.x, tp.y, size * 1.5);
+        g.fill({ color: p.glowColor, alpha: trailAlpha * 0.25 });
+        g.circle(tp.x, tp.y, size);
+        g.fill({ color: p.color, alpha: trailAlpha });
+      }
+      // If no sprite, render an orb at the head
+      if (!p.sprite) {
+        const t = Math.min(1, p.elapsed / p.duration);
+        const pos = this.arcPosition(p, t);
+        g.circle(pos.x, pos.y, 14);
+        g.fill({ color: p.glowColor, alpha: 0.18 });
+        g.circle(pos.x, pos.y, 8);
+        g.fill({ color: p.glowColor, alpha: 0.4 });
+        g.circle(pos.x, pos.y, 5);
+        g.fill({ color: p.color, alpha: 0.9 });
+        g.circle(pos.x, pos.y, 2);
+        g.fill({ color: 0xffffff, alpha: 0.7 });
+      }
+    }
+
+    // Auras — circular gradient that rises (buff/heal) or sinks (debuff).
+    for (const a of this.auras) {
+      const t = Math.min(1, a.elapsed / a.duration);
+      const eased = easeOutCubic(t);
+      const dy = a.direction === "rise" ? -eased * 30 : eased * 22;
+      const cy = a.y + dy;
+      const alpha = (1 - t) * 0.45;
+      // Outer halo
+      g.circle(a.x, cy, AURA_RADIUS * (0.6 + eased * 0.6));
+      g.fill({ color: a.color, alpha: alpha * 0.4 });
+      // Mid ring
+      g.circle(a.x, cy, AURA_RADIUS * (0.45 + eased * 0.4));
+      g.fill({ color: a.color, alpha: alpha * 0.5 });
+      // Inner bright core
+      g.circle(a.x, cy, AURA_RADIUS * 0.25);
+      g.fill({ color: 0xffffff, alpha: alpha * 0.5 });
+      // Direction streaks: vertical lines moving up or down
+      const lineCount = 6;
+      for (let i = 0; i < lineCount; i++) {
+        const ox = (i / lineCount - 0.5) * AURA_RADIUS * 1.4;
+        const lineLen = 14 + eased * 18;
+        const startY = cy + (a.direction === "rise" ? lineLen : -lineLen);
+        g.moveTo(a.x + ox, startY);
+        g.lineTo(a.x + ox, cy);
+        g.stroke({ color: a.color, alpha: alpha * 0.8, width: 1.5 });
+      }
+    }
+
+    // Area burst — radial expanding ring at impact site.
+    for (const b of this.bursts) {
+      const t = Math.min(1, b.elapsed / b.duration);
+      const eased = easeOutCubic(t);
+      const radius = AREA_BURST_RADIUS * eased;
+      const alpha = (1 - t) * 0.7;
+      // Filled disc fades fastest
+      g.circle(b.x, b.y, radius * 0.5);
+      g.fill({ color: b.color, alpha: alpha * 0.35 });
+      // Ring outline
+      g.circle(b.x, b.y, radius);
+      g.stroke({ color: b.color, alpha, width: 3 });
+      g.circle(b.x, b.y, radius * 0.7);
+      g.stroke({ color: 0xffffff, alpha: alpha * 0.6, width: 1.5 });
+    }
+
+    // Summon poof — sparkle particles.
+    for (const p of this.poofs) {
+      const t = p.elapsed / p.lifetime;
+      const alpha = t < 0.2 ? t / 0.2 : 1 - (t - 0.2) / 0.8;
+      const size = p.size * (1 - t * 0.5);
+      g.circle(p.x, p.y, size * 2.4);
+      g.fill({ color: p.color, alpha: alpha * 0.15 });
+      g.circle(p.x, p.y, size);
+      g.fill({ color: p.color, alpha: alpha * 0.85 });
+      g.circle(p.x, p.y, size * 0.4);
+      g.fill({ color: 0xffffff, alpha: alpha * 0.7 });
+    }
+  }
+
+  clear() {
+    for (const p of this.projectiles) {
+      if (p.sprite) {
+        this.spriteLayer.removeChild(p.sprite);
+        p.sprite.destroy();
+      }
+    }
+    for (const p of this.iconPulses) {
+      if (p.sprite) {
+        this.spriteLayer.removeChild(p.sprite);
+        p.sprite.destroy();
+      }
+    }
+    this.projectiles.length = 0;
+    this.iconPulses.length = 0;
+    this.auras.length = 0;
+    this.bursts.length = 0;
+    this.poofs.length = 0;
+    this.graphics.clear();
+  }
+}
+
+function easeOutCubic(t: number): number {
+  return 1 - (1 - t) ** 3;
+}

--- a/web-v3/src/canvas/systems/AbilityVisualSystem.ts
+++ b/web-v3/src/canvas/systems/AbilityVisualSystem.ts
@@ -144,10 +144,14 @@ export class AbilityVisualSystem {
     const sy = event.sourceIsPlayer ? playerY : enemyY;
 
     // For buffs/heals on self, target is the player. For debuffs on enemy, target is enemy.
-    // We let event.targetIsPlayer drive this when present (abilityCast); otherwise infer.
+    // We let event.targetIsPlayer drive this when present (abilityCast); for heals the
+    // target follows the source (1v1 view: caster heals themselves or an ally shown at
+    // the player slot); otherwise infer (damage events: target is the opponent).
     const targetIsPlayer = event.type === "abilityCast"
       ? event.targetIsPlayer
-      : !event.sourceIsPlayer;
+      : event.type === "heal"
+        ? event.sourceIsPlayer
+        : !event.sourceIsPlayer;
     const tx = targetIsPlayer ? playerX : enemyX;
     const ty = targetIsPlayer ? playerY : enemyY;
 

--- a/web-v3/src/canvas/systems/CombatAnimator.ts
+++ b/web-v3/src/canvas/systems/CombatAnimator.ts
@@ -161,7 +161,14 @@ export class CombatAnimator {
     this.container.addChild(this.particleGraphics);
   }
 
-  processEvent(event: CombatEventData, playerX: number, playerY: number, enemyX: number, enemyY: number) {
+  processEvent(
+    event: CombatEventData,
+    playerX: number,
+    playerY: number,
+    enemyX: number,
+    enemyY: number,
+    options: { suppressSlash?: boolean } = {},
+  ) {
     const type = event.type;
 
     if (type === "dodge") {
@@ -210,8 +217,11 @@ export class CombatAnimator {
       const dy = targetY - (event.sourceIsPlayer ? playerY : enemyY);
       this.addLunge(attacker, dx * LUNGE_DISTANCE, dy * LUNGE_DISTANCE);
 
-      // Slash at the impact point
-      this.addSlash(targetX, targetY);
+      // Slash at the impact point — suppressed when an archetype-aware
+      // visual (e.g. MELEE_STRIKE icon pulse) is taking over.
+      if (!options.suppressSlash) {
+        this.addSlash(targetX, targetY);
+      }
 
       // Defender shakes on hit
       this.addShake(defender);

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -98,6 +98,30 @@ import type {
 } from "../types";
 import { MAX_CHAT_MESSAGES_PER_CHANNEL } from "../constants";
 import { safeNumber } from "../utils";
+import type { AbilityVisualArchetype, SkillVisual } from "../types";
+
+const KNOWN_ARCHETYPES: ReadonlySet<AbilityVisualArchetype> = new Set([
+  "RANGED_PROJECTILE",
+  "MELEE_STRIKE",
+  "HEAL_AURA",
+  "BUFF_AURA",
+  "DEBUFF_AURA",
+  "AREA_BURST",
+  "SUMMON_POOF",
+]);
+
+function parseSkillVisual(raw: unknown): SkillVisual | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  const archetypeStr = typeof obj.archetype === "string" ? obj.archetype : "";
+  if (!KNOWN_ARCHETYPES.has(archetypeStr as AbilityVisualArchetype)) return null;
+  return {
+    archetype: archetypeStr as AbilityVisualArchetype,
+    projectileImage: typeof obj.projectileImage === "string" ? obj.projectileImage : null,
+    color: typeof obj.color === "string" ? obj.color : null,
+    accentColor: typeof obj.accentColor === "string" ? obj.accentColor : null,
+  };
+}
 
 interface GmcpContext {
   setVitals: Dispatch<SetStateAction<Vitals>>;
@@ -692,6 +716,7 @@ export function applyGmcpPackage(
             effectType: typeof entry.effectType === "string" ? entry.effectType : "DIRECT_DAMAGE",
             classRestriction: typeof entry.classRestriction === "string" ? entry.classRestriction : null,
             image: typeof entry.image === "string" ? entry.image : null,
+            visual: parseSkillVisual(entry.visual),
             receivedAt: now,
           })),
       );
@@ -951,6 +976,7 @@ export function applyGmcpPackage(
         xpGained: safeNumber(packet.xpGained),
         goldGained: safeNumber(packet.goldGained),
         petName: typeof packet.petName === "string" ? packet.petName : null,
+        targetIsPlayer: packet.targetIsPlayer === true,
       });
       break;
     }
@@ -1697,6 +1723,7 @@ export function applyGmcpPackage(
             // a separate "Pet" badge on the card.
             classRestriction: null,
             image: typeof entry.image === "string" ? entry.image : null,
+            visual: parseSkillVisual(entry.visual),
             receivedAt: now,
             source: "pet" as const,
           })),

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -400,6 +400,27 @@ export interface CombatTarget {
   targetCategory: string | null;
 }
 
+/**
+ * Per-skill visual archetype that drives how the web client renders the
+ * cast moment. Sent in the Char.Skills GMCP payload as `visual.archetype`.
+ * Falls back to RANGED_PROJECTILE if unknown.
+ */
+export type AbilityVisualArchetype =
+  | "RANGED_PROJECTILE"
+  | "MELEE_STRIKE"
+  | "HEAL_AURA"
+  | "BUFF_AURA"
+  | "DEBUFF_AURA"
+  | "AREA_BURST"
+  | "SUMMON_POOF";
+
+export interface SkillVisual {
+  archetype: AbilityVisualArchetype;
+  projectileImage: string | null;
+  color: string | null;
+  accentColor: string | null;
+}
+
 export interface SkillSummary {
   id: string;
   name: string;
@@ -412,6 +433,7 @@ export interface SkillSummary {
   effectType: string;
   classRestriction: string | null;
   image: string | null;
+  visual: SkillVisual | null;
   receivedAt: number;
   /**
    * "self" for player abilities (cast via `cast <id>`), "pet" for pet signature skills
@@ -438,6 +460,8 @@ export interface CombatEventData {
   xpGained: number;
   goldGained: number;
   petName: string | null;
+  /** True when the visible target of a non-damaging cast is the local player. */
+  targetIsPlayer: boolean;
 }
 
 export interface StatEntry {


### PR DESCRIPTION
## Summary

Adds richer per-ability visuals in the combat canvas. Each ability now carries a **visual archetype** (auto-derived from effect/target/class, overridable in YAML) that drives how its cast is rendered:

- **RANGED_PROJECTILE** — the ability's icon (or a custom sprite) arcs from caster to target with a trail
- **MELEE_STRIKE** — lunge + the ability icon pulses at the impact point (replaces the generic red slash)
- **HEAL_AURA** — rising aura + icon flash on the target
- **BUFF_AURA** — rising aura + icon flash on self/ally
- **DEBUFF_AURA** — sinking dark aura + icon flash on enemy
- **AREA_BURST** — radial expanding wave at the target
- **SUMMON_POOF** — sparkle puff at the caster

A new `CombatEvent.AbilityCast` variant fills a long-standing gap: pure buffs/debuffs/taunts/summons previously emitted no combat event, so the canvas saw nothing when you cast Blessing or Hex.

## Server changes (Kotlin)

- `AbilityVisualArchetype` enum + `AbilityVisual(archetype, projectileImage?, color?, accentColor?)` on `AbilityDefinition`
- `deriveDefaultVisual(effect, targetType, requiredClass)` picks a sensible archetype when YAML omits `visual:`
- Optional `visual:` block in `AbilityDefinitionConfig` (parsed in `AbilityRegistryLoader`); blank archetype falls back to derived default, unknown archetype strings also fall back
- `CombatEvent.AbilityCast(abilityId, abilityName, targetName, targetId, targetIsPlayer, sourceIsPlayer)` emitted from APPLY_STATUS, TAUNT, and SUMMON_PET paths in `AbilitySystem` (single-enemy, self, ally, all-enemies, all-allies)
- `Char.Skills` GMCP payload now includes `visual: { archetype, projectileImage, color, accentColor }`
- 10 new tests in `AbilityVisualLoaderTest`; 1 new test in `GmcpEmitterTest`

## Web changes (TypeScript)

- `SkillVisual` type + `SkillSummary.visual`; `CombatEventData.targetIsPlayer`
- Skills exposed to the canvas via `gameStateRef.current.skillsById`
- New `AbilityVisualSystem` (~370 lines) handles all archetypes — loads the ability image as a Pixi sprite for projectiles/icon-pulses, draws auras/bursts/poofs via Graphics
- `CombatAnimator.processEvent` accepts `{ suppressSlash }` so melee archetypes replace the red slash with the icon pulse
- `BattleScene` looks up the archetype per event and routes accordingly; events without a known archetype keep the existing generic projectile/slash behaviour

## Test plan

- [x] `./gradlew ktlintCheck test` passes
- [x] `bun run lint` clean
- [x] `bun run build` succeeds (typecheck + vite build)
- [ ] Smoke test in browser: cast one ability of each archetype and confirm the right effect plays
  - [ ] Power Strike (warrior, DIRECT_DAMAGE) → melee strike with icon pulse, no red slash
  - [ ] Arcane Bolt (mage, DIRECT_DAMAGE) → ranged projectile sprite arcs to enemy
  - [ ] Heal (cleric, DIRECT_HEAL on self) → rising aura on player
  - [ ] Blessing (cleric, APPLY_STATUS self) → buff aura + icon flash (previously invisible)
  - [ ] Hex (mage, APPLY_STATUS enemy) → debuff aura on enemy
  - [ ] Cleave (warrior, AREA_DAMAGE) → radial burst at target
  - [ ] Summon Wolf (ranger, SUMMON_PET) → sparkle poof at caster
- [ ] Verify pet skills still render (their `visual` is null, so they fall through to the generic path)

## Notes

- Archetype auto-derivation means no YAML changes are required for existing abilities — every ability gets a reasonable visual on day one
- Pet skills' GMCP payload doesn't include `visual` yet; that's a follow-up