### PR TITLE
feat(web): auto-populated pet control bar next to quickbar

### DIFF
--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -551,8 +551,21 @@ function App() {
       }
       const target = event.target as HTMLElement;
       if (target.tagName === "INPUT" || target.tagName === "TEXTAREA") return;
-      // Shift+digit routes to the pet bar; plain digit routes to the player quickbar.
-      // event.key is "!" / "@" / "#" on shift+1/2/3 — fall back to event.code "Digit1" etc.
+      // Quickbar first: if the keypress resolved to a digit character, route there
+      // regardless of Shift state. This keeps AZERTY/similar layouts working — typing
+      // "1" requires Shift on those layouts, so a Shift-first branch would hijack it.
+      const keyDigit = parseInt(event.key, 10);
+      if (keyDigit >= 1 && keyDigit <= 9) {
+        const skill = quickbar.slots[keyDigit - 1];
+        if (!skill) return;
+        const elapsed = Date.now() - skill.receivedAt;
+        const remaining = Math.max(0, skill.cooldownRemainingMs - elapsed);
+        if (remaining > 0) return;
+        handleCastSkill(skill.id, skill.cooldownMs);
+        return;
+      }
+      // Otherwise, Shift+DigitN (QWERTY shift produces "!"/"@"/"#" — not a digit) routes
+      // to the pet bar. Using event.code makes this layout-independent for that case.
       if (event.shiftKey && event.code.startsWith("Digit")) {
         const petDigit = parseInt(event.code.slice(5), 10);
         if (petDigit >= 1 && petDigit <= 9) {
@@ -563,16 +576,6 @@ function App() {
           if (remaining > 0) return;
           handleCastSkill(skill.id, skill.cooldownMs);
         }
-        return;
-      }
-      const digit = parseInt(event.key, 10);
-      if (digit >= 1 && digit <= 9) {
-        const skill = quickbar.slots[digit - 1];
-        if (!skill) return;
-        const elapsed = Date.now() - skill.receivedAt;
-        const remaining = Math.max(0, skill.cooldownRemainingMs - elapsed);
-        if (remaining > 0) return;
-        handleCastSkill(skill.id, skill.cooldownMs);
       }
     };
     window.addEventListener("keydown", onKeyDown);

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -163,13 +163,10 @@ function App() {
     { updateMap, loadZoneMap, resetMap },
   );
   const audio = useAudioEngine();
-  // Merge player abilities with pet skills so the quickbar and spellbook can show both.
-  // Pet skills get `source: "pet"` which makes `handleCastSkill` route them through `pet <id>`.
-  const allSkills = useMemo(
-    () => [...state.skills, ...state.petSkills],
-    [state.skills, state.petSkills],
-  );
-  const quickbar = useQuickbar(allSkills, state.character.name);
+  // Player abilities feed the quickbar and spellbook. Pet skills get their own auto-populated
+  // PetBar (Shift+1/2/3) so they don't compete for quickbar slots; `handleCastSkill` still
+  // routes pet skills through `pet <id>` when invoked.
+  const quickbar = useQuickbar(state.skills, state.character.name);
 
   const {
     pushHistory,
@@ -554,6 +551,20 @@ function App() {
       }
       const target = event.target as HTMLElement;
       if (target.tagName === "INPUT" || target.tagName === "TEXTAREA") return;
+      // Shift+digit routes to the pet bar; plain digit routes to the player quickbar.
+      // event.key is "!" / "@" / "#" on shift+1/2/3 — fall back to event.code "Digit1" etc.
+      if (event.shiftKey && event.code.startsWith("Digit")) {
+        const petDigit = parseInt(event.code.slice(5), 10);
+        if (petDigit >= 1 && petDigit <= 9) {
+          const skill = state.petSkills[petDigit - 1];
+          if (!skill) return;
+          const elapsed = Date.now() - skill.receivedAt;
+          const remaining = Math.max(0, skill.cooldownRemainingMs - elapsed);
+          if (remaining > 0) return;
+          handleCastSkill(skill.id, skill.cooldownMs);
+        }
+        return;
+      }
       const digit = parseInt(event.key, 10);
       if (digit >= 1 && digit <= 9) {
         const skill = quickbar.slots[digit - 1];
@@ -566,7 +577,7 @@ function App() {
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [quickbar.slots, handleCastSkill]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [quickbar.slots, state.petSkills, handleCastSkill]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const sendChatMessage = (channel: ChatChannel, message: string, target: string | null): boolean => {
     const body = message.trim();
@@ -706,6 +717,7 @@ function App() {
         onQuickbarSwap={quickbar.swap}
         onQuickbarAssign={quickbar.assign}
         onQuickbarClear={quickbar.clear}
+        petSkills={state.petSkills}
         activePopout={state.activePopout}
         onCommand={sendCommand}
         onOpenPanel={(panel) => openPanel(panel)}
@@ -861,7 +873,7 @@ function App() {
 
         {drawerPanel === "spellbook" && (
           <SpellbookPanel
-            skills={allSkills}
+            skills={state.skills}
             quickbarSlotIds={quickbar.slotIds}
             playerClass={displayClassName}
             playerLevel={state.vitals.level ?? 1}

--- a/web-v3/src/components/GameShell.tsx
+++ b/web-v3/src/components/GameShell.tsx
@@ -16,6 +16,7 @@ interface GameShellProps {
   onQuickbarSwap: (fromIndex: number, toIndex: number) => void;
   onQuickbarAssign: (slotIndex: number, skillId: string) => void;
   onQuickbarClear: (slotIndex: number) => void;
+  petSkills: SkillSummary[];
   activePopout: PopoutPanel;
   onCommand: (cmd: string) => void;
   onOpenPanel: (panel: PopoutPanel) => void;
@@ -40,6 +41,7 @@ export function GameShell({
   onQuickbarSwap,
   onQuickbarAssign,
   onQuickbarClear,
+  petSkills,
   activePopout,
   onCommand,
   onOpenPanel,
@@ -97,6 +99,7 @@ export function GameShell({
         onQuickbarSwap={onQuickbarSwap}
         onQuickbarAssign={onQuickbarAssign}
         onQuickbarClear={onQuickbarClear}
+        petSkills={petSkills}
         activePopout={activePopout}
         onOpenPanel={onOpenPanel}
         onCastSkill={onCastSkill}

--- a/web-v3/src/components/VitalsBar.tsx
+++ b/web-v3/src/components/VitalsBar.tsx
@@ -94,7 +94,7 @@ interface SkillSlotProps {
   onClear: (index: number) => void;
 }
 
-function SkillSlot({ skill, index, onCast, onDragStart, onDragOver, onDragLeave, onDrop, onClear }: SkillSlotProps) {
+function useSkillCooldown(skill: SkillSummary): { onCooldown: boolean; fraction: number } {
   const [now, setNow] = useState(() => Date.now());
 
   useEffect(() => {
@@ -107,6 +107,11 @@ function SkillSlot({ skill, index, onCast, onDragStart, onDragOver, onDragLeave,
   const remaining = skill.cooldownRemainingMs > 0 ? Math.max(0, skill.cooldownRemainingMs - elapsed) : 0;
   const onCooldown = remaining > 0;
   const fraction = onCooldown && skill.cooldownMs > 0 ? remaining / skill.cooldownMs : 0;
+  return { onCooldown, fraction };
+}
+
+function SkillSlot({ skill, index, onCast, onDragStart, onDragOver, onDragLeave, onDrop, onClear }: SkillSlotProps) {
+  const { onCooldown, fraction } = useSkillCooldown(skill);
 
   return (
     <button
@@ -146,18 +151,7 @@ function PetSkillSlot({
   index: number;
   onCast: (id: string, cd: number) => void;
 }) {
-  const [now, setNow] = useState(() => Date.now());
-
-  useEffect(() => {
-    if (skill.cooldownRemainingMs <= 0) return;
-    const interval = setInterval(() => setNow(Date.now()), 250);
-    return () => clearInterval(interval);
-  }, [skill.cooldownRemainingMs, skill.receivedAt]);
-
-  const elapsed = now - skill.receivedAt;
-  const remaining = skill.cooldownRemainingMs > 0 ? Math.max(0, skill.cooldownRemainingMs - elapsed) : 0;
-  const onCooldown = remaining > 0;
-  const fraction = onCooldown && skill.cooldownMs > 0 ? remaining / skill.cooldownMs : 0;
+  const { onCooldown, fraction } = useSkillCooldown(skill);
 
   return (
     <button

--- a/web-v3/src/components/VitalsBar.tsx
+++ b/web-v3/src/components/VitalsBar.tsx
@@ -66,6 +66,8 @@ interface VitalsBarProps {
   onQuickbarSwap: (fromIndex: number, toIndex: number) => void;
   onQuickbarAssign: (slotIndex: number, skillId: string) => void;
   onQuickbarClear: (slotIndex: number) => void;
+  /** Active pet's signature skills — auto-populates the pet bar (Shift+1/2/3). Empty when no pet. */
+  petSkills: SkillSummary[];
   activePopout: PopoutPanel;
   onOpenPanel: (panel: PopoutPanel) => void;
   onCastSkill: (skillId: string, cooldownMs: number) => void;
@@ -131,6 +133,51 @@ function SkillSlot({ skill, index, onCast, onDragStart, onDragOver, onDragLeave,
   );
 }
 
+/**
+ * Pet skill slot — auto-populated, no drag/drop, no per-character persistence.
+ * Hotkey label shows "⇧N" (Shift+digit).
+ */
+function PetSkillSlot({
+  skill,
+  index,
+  onCast,
+}: {
+  skill: SkillSummary;
+  index: number;
+  onCast: (id: string, cd: number) => void;
+}) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (skill.cooldownRemainingMs <= 0) return;
+    const interval = setInterval(() => setNow(Date.now()), 250);
+    return () => clearInterval(interval);
+  }, [skill.cooldownRemainingMs, skill.receivedAt]);
+
+  const elapsed = now - skill.receivedAt;
+  const remaining = skill.cooldownRemainingMs > 0 ? Math.max(0, skill.cooldownRemainingMs - elapsed) : 0;
+  const onCooldown = remaining > 0;
+  const fraction = onCooldown && skill.cooldownMs > 0 ? remaining / skill.cooldownMs : 0;
+
+  return (
+    <button
+      type="button"
+      className={`vbar-skill vbar-pet-skill${onCooldown ? " vbar-skill-cd" : ""}`}
+      disabled={onCooldown}
+      title={`${skill.name} (pet) — Shift+${index + 1}`}
+      onClick={() => onCast(skill.id, skill.cooldownMs)}
+      aria-label={`${skill.name} pet skill — Shift+${index + 1}`}
+    >
+      {skill.image
+        ? <img src={skill.image} alt="" className="vbar-skill-img" draggable={false} />
+        : <SkillCastIcon className="vbar-skill-icon" classRestriction={null} targetType={skill.targetType} />
+      }
+      {onCooldown && <span className="vbar-skill-sweep" style={{ height: `${fraction * 100}%` }} />}
+      <span className="vbar-skill-key">{`⇧${index + 1}`}</span>
+    </button>
+  );
+}
+
 function EmptySkillSlot({
   index,
   onDragOver,
@@ -163,6 +210,7 @@ export function VitalsBar({
   onQuickbarSwap,
   onQuickbarAssign,
   onQuickbarClear,
+  petSkills,
   activePopout,
   onOpenPanel,
   onCastSkill,
@@ -181,6 +229,7 @@ export function VitalsBar({
   const navRef = useRef<HTMLElement | null>(null);
 
   const hasAnySkill = quickbarSlots.some((s) => s !== null);
+  const hasPet = petSkills.length > 0;
 
   useEffect(() => {
     const node = navRef.current;
@@ -200,7 +249,7 @@ export function VitalsBar({
     return () => {
       resizeObserver.disconnect();
     };
-  }, [onHeightChange, loggedIn, hasAnySkill, showPanels, connected]);
+  }, [onHeightChange, loggedIn, hasAnySkill, hasPet, showPanels, connected]);
 
   const submitInput = (e: FormEvent) => {
     e.preventDefault();
@@ -268,10 +317,12 @@ export function VitalsBar({
         </div>
       )}
 
-      {/* Quickbar skills (horizontal scroll) */}
-      {loggedIn && hasAnySkill && (
+      {/* Quickbar skills + pet bar (horizontal scroll). Pet bar appears to the right
+          of the quickbar with a small divider, auto-populated from the active pet's
+          signature skills. */}
+      {loggedIn && (hasAnySkill || hasPet) && (
         <div className="vbar-skills">
-          {quickbarSlots.map((skill, i) =>
+          {hasAnySkill && quickbarSlots.map((skill, i) =>
             skill ? (
               <SkillSlot
                 key={skill.id}
@@ -293,6 +344,21 @@ export function VitalsBar({
                 onDrop={handleSkillDrop}
               />
             ),
+          )}
+          {hasPet && (
+            <>
+              {hasAnySkill && <span className="vbar-petbar-divider" aria-hidden="true" />}
+              <div className="vbar-petbar" role="group" aria-label="Pet skills">
+                {petSkills.map((skill, i) => (
+                  <PetSkillSlot
+                    key={skill.id}
+                    skill={skill}
+                    index={i}
+                    onCast={onCastSkill}
+                  />
+                ))}
+              </div>
+            </>
           )}
         </div>
       )}

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -16331,6 +16331,43 @@ html:has(.game-shell),
   font-family: var(--font-mono);
 }
 
+/* Pet control bar — auto-populated, shown to the right of the quickbar with a divider. */
+.vbar-petbar {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.vbar-petbar-divider {
+  flex-shrink: 0;
+  width: 2px;
+  align-self: stretch;
+  margin: 2px 4px;
+  background: linear-gradient(
+    180deg,
+    transparent,
+    rgb(168 151 210 / 35%) 30%,
+    rgb(168 151 210 / 35%) 70%,
+    transparent
+  );
+  border-radius: 1px;
+}
+
+.vbar-pet-skill {
+  border-color: rgb(168 151 210 / 55%);
+  background: linear-gradient(135deg, rgb(70 60 100 / 92%), rgb(54 48 82 / 88%));
+}
+
+.vbar-pet-skill:not(:disabled):hover {
+  border-color: rgb(216 197 232 / 80%);
+  box-shadow: 0 0 0 1px rgb(216 197 232 / 30%);
+}
+
+.vbar-pet-skill .vbar-skill-key {
+  color: rgb(216 197 232 / 90%);
+  font-size: 0.55rem;
+}
+
 /* Bottom action row: panel toggle, status, input toggle */
 .vbar-actions {
   display: flex;


### PR DESCRIPTION
## Summary

Pet skills no longer share the player quickbar or spellbook. They get their own auto-populated bar to the right of the quickbar that appears whenever a pet is active (`state.petSkills` non-empty). The bar holds 1 slot per signature skill (typically 1–3) and is bound to **Shift+1/2/3**.

## Changes

- **App.tsx** — drop the `allSkills = [...skills, ...petSkills]` merge; `useQuickbar` takes `state.skills` only, `SpellbookPanel` receives `state.skills` only, and the keydown handler grows a Shift+digit branch that routes to `state.petSkills`. Shift handling uses `event.code` (`Digit1`/`Digit2`/...) so it's keyboard-layout-independent.
- **GameShell + VitalsBar** — thread `petSkills` down and render a new `PetSkillSlot` group right after the quickbar, separated by a soft vertical divider. The pet slot reuses the cooldown sweep but skips drag/drop since the bar is fully server-driven.
- **styles.css** — lavender-tinted pet slots, faint divider, hotkey label rendered as `⇧N`.

No server / GMCP changes: `Char.Pet.Skills` already replaces the array when the pet despawns, so the bar disappears automatically. Pet casts still route through `pet <id>` via the existing `handleCastSkill` branch.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run build` succeeds (typecheck + vite build)
- [x] `./gradlew ktlintCheck test` green
- [ ] Browser smoke test (couldn't exercise locally — needs a real pet):
  - [ ] Summon a pet → pet bar appears with its 1–3 signature skills, divider visible to the right of the quickbar
  - [ ] Click a pet slot → fires `pet <id>` and shows the cooldown sweep
  - [ ] Shift+1/2/3 casts the matching pet slot (and plain 1–9 still casts the player quickbar)
  - [ ] Dismiss the pet → pet bar disappears
  - [ ] Spellbook no longer lists pet skills