### PR TITLE
feat(tuning): mob multipliers, item power budgets, Arcanum sync

### DIFF
--- a/docs/ARCANUM_TUNING_SYNC.md
+++ b/docs/ARCANUM_TUNING_SYNC.md
@@ -1,0 +1,90 @@
+# Arcanum ↔ AmbonMUD Tuning Sync
+
+The [AmbonArcanum](https://github.com/jpnoecker/AmbonArcanum) creator app ships a
+**Tuning Wizard** (`creator/src/components/tuning/TuningWizard.tsx`) with six themed
+presets — Casual, Balanced, Hardcore, Solo Story, PvP Arena, and Lore Explorer —
+expressed as `DeepPartial<AppConfig>` overlays in `creator/src/lib/tuning/presets.ts`.
+
+The AmbonMUD server's defaults are kept in lockstep with the **Balanced** preset so
+operators can dial up or down from a known anchor. This doc records the wire-up
+points so the two repos don't drift.
+
+## Source of truth
+
+For the fields that overlap, treat the AmbonArcanum `BALANCED_PRESET` overlay as the
+**reference values** and the AmbonMUD `application.yaml` (under `ambonmud.engine`) as the
+**deployment values**. Kotlin defaults in `AppConfig.kt` exist as a fallback for tests and
+dev runs without a config file; they should not drift far from the YAML.
+
+## Synced surfaces
+
+| AmbonMUD location | AmbonArcanum location |
+|---|---|
+| `engine.mob.tiers.{weak,standard,elite,boss}` in `application.yaml` | `BALANCED_PRESET.config.mobTiers` |
+| `MobTierConfig` defaults in `AppConfig.kt` | `BALANCED_PRESET.config.mobTiers` |
+| `engine.combat.{tickMillis,minDamage,maxDamage}` | `BALANCED_PRESET.config.combat` |
+| `engine.stats.bindings.*` divisors | `BALANCED_PRESET.config.stats.bindings` |
+| `engine.regen.*` and `engine.regen.mana.*` | `BALANCED_PRESET.config.regen` |
+| `engine.economy.{buyMultiplier,sellMultiplier}` | `BALANCED_PRESET.config.economy` |
+| `engine.progression.{xp,rewards,quests}` | `BALANCED_PRESET.config.progression` |
+
+When any of these are touched on either side, mirror the change in the other repo and
+update this doc.
+
+## New mob shorthand: multipliers
+
+AmbonMUD mob YAML now accepts four optional multiplier fields alongside `tier` and `level`:
+
+```yaml
+mobs:
+  forest_goblin:
+    name: a forest goblin
+    tier: standard
+    level: 5
+    dmgMult: 1.15   # "hits a bit harder than baseline standard-5"
+    xpMult: 1.0
+    goldMult: 1.5   # rewards more gold than a typical standard mob
+```
+
+The multipliers apply to tier × level baselines; absolute overrides
+(`hp:`, `minDamage:`, etc.) still win and bypass the multiplier for that field.
+
+The Arcanum builder UI does not surface these yet. To mirror this on the Arcanum
+side, the suggested next step is to add multiplier inputs to the mob editor and have
+the preview math run them through `resolveMobStats`-equivalent logic
+(`creator/src/lib/tuning/formulas.ts` already implements the tier + level part).
+
+## New item power-budget system
+
+AmbonMUD items can declare a `level:` and `rarity:` to opt into a power-budget check
+at world load. Budget rules live in `engine.items.budget` in `application.yaml` (see
+`docs/WORLD_YAML_SPEC.md` § "Item power budget" for the formula and defaults).
+
+There is nothing equivalent in Arcanum today. To mirror:
+
+1. **Schema** — add `level: number | null` and `rarity: string | null` to the item type
+   in `creator/src/types/world.ts`.
+2. **Validator** — port `evaluateItemBudget` (`src/main/kotlin/dev/ambon/domain/world/ItemBudgetEvaluation.kt`)
+   to TypeScript and run it in the Validate Zone path
+   (`creator/src/lib/validateZone.ts`) so over-budget items get a warning chip in the editor.
+3. **Tuning preset coverage** — extend `BALANCED_PRESET.config` with an `items.budget`
+   section so operators can preview the effect of relaxing or tightening the budget
+   from the Tuning Wizard. The current presets cover combat/economy/progression but
+   stop at mob tiers; item budgets are the natural next pillar.
+
+## Smoke check
+
+Whenever defaults change on either side, run:
+
+```bash
+# AmbonMUD
+./gradlew test --tests "*WorldLoaderTest*" --tests "*MobStatResolverTest*"
+```
+
+```bash
+# AmbonArcanum
+bun test creator/src/lib/tuning
+```
+
+If the AmbonMUD `MobTierConfig` defaults change, the table in
+`docs/WORLD_YAML_SPEC.md` § "Tier formula" needs updating in the same commit.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -607,6 +607,9 @@ Reference it from an ability via `effect.type: APPLY_STATUS` + `effect.statusEff
 2. Add the file name under `ambonmud.world.resources` in `application.yaml` (or drop it into `$AMBONMUD_DATA_DIR/world/` for an overlay-based deployment).
 3. `WorldLoader` validates on boot — fix whatever it complains about.
 
+For content tuning (mob stat baselines, item power budgets, sync with the AmbonArcanum
+tuning wizard), see [`ARCANUM_TUNING_SYNC.md`](./ARCANUM_TUNING_SYNC.md).
+
 ### Add a new GMCP package
 
 1. Emit the package from `engine/GmcpEmitter.kt`.

--- a/docs/WORLD_YAML_SPEC.md
+++ b/docs/WORLD_YAML_SPEC.md
@@ -190,14 +190,16 @@ Behavior validation rules:
 Tier formula (for tier `T`, level `L` (default 1), and optional multipliers, default 1.0):
 
 ```text
-hp         = floor((T.baseHp + (L-1) * T.hpPerLevel) * hpMult)        # clamped to >= 1
-minDamage  = floor((T.baseMinDamage + (L-1) * T.damagePerLevel) * dmgMult)   # clamped to >= 1
-maxDamage  = floor((T.baseMaxDamage + (L-1) * T.damagePerLevel) * dmgMult)   # clamped to >= minDamage
+hp         = round((T.baseHp + (L-1) * T.hpPerLevel) * hpMult)        # clamped to >= 1
+minDamage  = round((T.baseMinDamage + (L-1) * T.damagePerLevel) * dmgMult)   # clamped to >= 1
+maxDamage  = round((T.baseMaxDamage + (L-1) * T.damagePerLevel) * dmgMult)   # clamped to >= minDamage
 armor      = T.baseArmor                                              # multipliers do not apply
-xpReward   = floor((T.baseXpReward + (L-1) * T.xpRewardPerLevel) * xpMult)   # clamped to >= 0
-goldMin    = floor((T.baseGoldMin + (L-1) * T.goldPerLevel) * goldMult)      # clamped to >= 0
-goldMax    = floor((T.baseGoldMax + (L-1) * T.goldPerLevel) * goldMult)      # clamped to >= goldMin
+xpReward   = round((T.baseXpReward + (L-1) * T.xpRewardPerLevel) * xpMult)   # clamped to >= 0
+goldMin    = round((T.baseGoldMin + (L-1) * T.goldPerLevel) * goldMult)      # clamped to >= 0
+goldMax    = round((T.baseGoldMax + (L-1) * T.goldPerLevel) * goldMult)      # clamped to >= goldMin
 ```
+
+Rounding is half-away-from-zero (`Double.roundToInt`/`roundToLong`).
 
 Resolution per field: tier × level baseline → multiplier (if set) → absolute override (if set).
 Absolute overrides always win; multipliers express relative tuning ("hits a bit harder than baseline")

--- a/docs/WORLD_YAML_SPEC.md
+++ b/docs/WORLD_YAML_SPEC.md
@@ -122,6 +122,10 @@ name:           <string, required>
 room:           <room-id string, required>
 tier:           <string, optional - one of weak|standard|elite|boss (case-insensitive); default standard>
 level:          <integer >= 1, optional; default 1>
+hpMult:         <double in (0.0, 10.0], optional - multiplies tier-computed hp before override is applied>
+dmgMult:        <double in (0.0, 10.0], optional - multiplies tier-computed min/max damage>
+xpMult:         <double in (0.0, 10.0], optional - multiplies tier-computed xpReward>
+goldMult:       <double in (0.0, 10.0], optional - multiplies tier-computed gold range>
 hp:             <integer >= 1, optional - overrides tier-computed hp>
 minDamage:      <integer >= 1, optional - overrides tier-computed minDamage>
 maxDamage:      <integer >= minDamage, optional - overrides tier-computed maxDamage>
@@ -183,29 +187,38 @@ Behavior validation rules:
 - Unknown template names cause a load error.
 - Templates requiring `patrolRoute` (`patrol`, `patrol_aggro`) should have a non-empty route.
 
-Tier formula (for tier `T` and level `L`, where `L` defaults to 1):
+Tier formula (for tier `T`, level `L` (default 1), and optional multipliers, default 1.0):
 
 ```text
-hp         = T.baseHp + (L-1) * T.hpPerLevel
-minDamage  = T.baseMinDamage + (L-1) * T.damagePerLevel
-maxDamage  = T.baseMaxDamage + (L-1) * T.damagePerLevel
+hp         = round((T.baseHp + (L-1) * T.hpPerLevel) * hpMult)
+minDamage  = round((T.baseMinDamage + (L-1) * T.damagePerLevel) * dmgMult)
+maxDamage  = round((T.baseMaxDamage + (L-1) * T.damagePerLevel) * dmgMult)
 armor      = T.baseArmor
-xpReward   = T.baseXpReward + (L-1) * T.xpRewardPerLevel
-goldMin    = T.baseGoldMin + (L-1) * T.goldPerLevel
-goldMax    = T.baseGoldMax + (L-1) * T.goldPerLevel
+xpReward   = round((T.baseXpReward + (L-1) * T.xpRewardPerLevel) * xpMult)
+goldMin    = round((T.baseGoldMin + (L-1) * T.goldPerLevel) * goldMult)
+goldMax    = round((T.baseGoldMax + (L-1) * T.goldPerLevel) * goldMult)
 ```
 
-Any explicit per-mob field overrides the computed value from the tier formula.
+Resolution per field: tier × level baseline → multiplier (if set) → absolute override (if set).
+Absolute overrides always win; multipliers express relative tuning ("hits a bit harder than baseline")
+without forcing builders to type raw numbers.
+
+**When to use which:**
+- **Tier + level alone** — most mobs. The numbers are computed from the table below.
+- **Tier + level + a multiplier** — "this elf archer hits ~20% harder than a standard level-7 mob"
+  (`tier: standard, level: 7, dmgMult: 1.2`). Stays consistent across rebalances of the tier table.
+- **Absolute override** — bespoke bosses or scripted encounters where the math model breaks down.
+  Avoid for general content; consistency wins.
 
 Tier default values are operator-configurable via `application.yaml` under `ambonmud.engine.mob.tiers`.
-The built-in defaults are:
+The built-in defaults (cross-validated against the AmbonArcanum Balanced tuning preset) are:
 
 | Tier     | baseHp | hpPerLevel | baseMinDmg | baseMaxDmg | dmgPerLevel | baseArmor | baseXp | xpPerLevel | baseGoldMin | baseGoldMax | goldPerLevel |
 |----------|--------|------------|------------|------------|-------------|-----------|--------|------------|-------------|-------------|--------------|
 | weak     | 5      | 2          | 1          | 2          | 0           | 0         | 15     | 5          | 1           | 3           | 1            |
-| standard | 10     | 3          | 1          | 4          | 1           | 0         | 30     | 10         | 2           | 8           | 2            |
-| elite    | 20     | 5          | 2          | 6          | 1           | 1         | 75     | 20         | 10          | 25          | 5            |
-| boss     | 50     | 10         | 3          | 8          | 2           | 3         | 200    | 50         | 50          | 100         | 15           |
+| standard | 12     | 4          | 2          | 4          | 1           | 1         | 30     | 10         | 3           | 8           | 2            |
+| elite    | 28     | 7          | 3          | 6          | 1           | 2         | 75     | 25         | 10          | 25          | 5            |
+| boss     | 55     | 12         | 4          | 9          | 2           | 3         | 200    | 50         | 50          | 100         | 15           |
 
 Mob armor applies as flat damage reduction: `effectiveDamage = max(1, playerRoll - mob.armor)`.
 
@@ -230,7 +243,56 @@ matchByKey: <boolean, optional, default false>
 basePrice: <integer, optional, default 0, must be >= 0>
 image: <string, optional - relative path under /images/>
 video: <string, optional - relative path under /videos/, shown in context menu>
+level: <integer >= 1, optional - intended item level, enables power-budget validation>
+rarity: <string, optional - one of common|uncommon|rare|epic|legendary (case-insensitive); default common when level is set>
 ```
+
+#### Item power budget
+
+When an item declares `level:` (or `rarity:`), the loader compares its stat/damage/armor cost
+to a power budget for that slot+level+rarity. Items without either field are treated as
+legacy and skipped — adoption is gradual and opt-in per item.
+
+**Budget formula:**
+
+```text
+budget = (slotBaseBudget[slot] + level * pointsPerLevel) * rarityMultiplier[rarity]
+spent  = damage * damagePointCost + armor * armorPointCost + sum(stats.values) * statPointCost
+```
+
+An item is flagged when `spent > budget * (1 + tolerance)`. By default the validator emits a
+warning (`itemsBudget.warnOnly: true`); flip to `false` in `application.yaml` to fail the load.
+
+**Default values** (operator-configurable under `ambonmud.engine.items.budget`):
+
+| Setting | Default | Notes |
+|---|---|---|
+| `pointsPerLevel` | 2.0 | Budget points granted per level |
+| `damagePointCost` | 5.0 | Each `damage: 1` costs 5 points |
+| `armorPointCost` | 2.0 | Each `armor: 1` costs 2 points |
+| `statPointCost` | 1.0 | Each `stats.X: 1` costs 1 point |
+| `tolerance` | 0.05 | 5% slack above budget before flagging |
+
+| Slot     | base budget | Slot     | base budget |
+|----------|-------------|----------|-------------|
+| weapon   | 6           | neck     | 3           |
+| ranged   | 5           | wrist    | 2           |
+| shield   | 4           | finger   | 2           |
+| head     | 3           | body     | 5           |
+| hand     | 3           | feet     | 3           |
+
+| Rarity     | multiplier |
+|------------|------------|
+| common     | 1.0        |
+| uncommon   | 1.25       |
+| rare       | 1.5        |
+| epic       | 2.0        |
+| legendary  | 2.5        |
+
+**Worked example:** a level-5 rare weapon (`slot: weapon, damage: 4, level: 5, rarity: rare`)
+gets a budget of `(6 + 5*2) * 1.5 = 24` points and spends `4*5 = 20` points → fits with
+room for a stat or two. Same weapon at level 1 common: budget is `(6 + 2) * 1.0 = 8`,
+spent is still 20 → 2.5× over budget, gets flagged.
 
 `basePrice` notes:
 - Determines the item's value in the shop economy.

--- a/docs/WORLD_YAML_SPEC.md
+++ b/docs/WORLD_YAML_SPEC.md
@@ -190,13 +190,13 @@ Behavior validation rules:
 Tier formula (for tier `T`, level `L` (default 1), and optional multipliers, default 1.0):
 
 ```text
-hp         = round((T.baseHp + (L-1) * T.hpPerLevel) * hpMult)
-minDamage  = round((T.baseMinDamage + (L-1) * T.damagePerLevel) * dmgMult)
-maxDamage  = round((T.baseMaxDamage + (L-1) * T.damagePerLevel) * dmgMult)
-armor      = T.baseArmor
-xpReward   = round((T.baseXpReward + (L-1) * T.xpRewardPerLevel) * xpMult)
-goldMin    = round((T.baseGoldMin + (L-1) * T.goldPerLevel) * goldMult)
-goldMax    = round((T.baseGoldMax + (L-1) * T.goldPerLevel) * goldMult)
+hp         = floor((T.baseHp + (L-1) * T.hpPerLevel) * hpMult)        # clamped to >= 1
+minDamage  = floor((T.baseMinDamage + (L-1) * T.damagePerLevel) * dmgMult)   # clamped to >= 1
+maxDamage  = floor((T.baseMaxDamage + (L-1) * T.damagePerLevel) * dmgMult)   # clamped to >= minDamage
+armor      = T.baseArmor                                              # multipliers do not apply
+xpReward   = floor((T.baseXpReward + (L-1) * T.xpRewardPerLevel) * xpMult)   # clamped to >= 0
+goldMin    = floor((T.baseGoldMin + (L-1) * T.goldPerLevel) * goldMult)      # clamped to >= 0
+goldMax    = floor((T.baseGoldMax + (L-1) * T.goldPerLevel) * goldMult)      # clamped to >= goldMin
 ```
 
 Resolution per field: tier × level baseline → multiplier (if set) → absolute override (if set).

--- a/src/main/kotlin/dev/ambon/MudServer.kt
+++ b/src/main/kotlin/dev/ambon/MudServer.kt
@@ -209,6 +209,7 @@ class MudServer(
             videosBaseUrl = config.videos.baseUrl,
             audioBaseUrl = config.audio.baseUrl,
             factionIds = config.engine.factions.definitions.keys,
+            itemBudget = config.engine.items.budget,
         )
     private val worldState = WorldStateRegistry(world)
     private val tickMillis: Long = config.server.tickMillis
@@ -424,6 +425,7 @@ class MudServer(
                             videosBaseUrl = config.videos.baseUrl,
                             audioBaseUrl = config.audio.baseUrl,
                             factionIds = config.engine.factions.definitions.keys,
+                            itemBudget = config.engine.items.budget,
                         )
                     },
                     reloadChannel = reloadChannel,

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -1512,6 +1512,7 @@ data class EngineConfig(
     val races: RaceEngineConfig = RaceEngineConfig(),
     val stats: StatsEngineConfig = StatsEngineConfig(),
     val equipment: EquipmentConfig = EquipmentConfig(),
+    val items: ItemsEngineConfig = ItemsEngineConfig(),
     val genders: GendersConfig = GendersConfig(),
     val achievementCategories: AchievementCategoriesConfig = AchievementCategoriesConfig(),
     val craftingSkills: CraftingSkillsConfig = CraftingSkillsConfig(),
@@ -2079,38 +2080,38 @@ data class MobTiersConfig(
         ),
     val standard: MobTierConfig =
         MobTierConfig(
-            baseHp = 10,
-            hpPerLevel = 3,
-            baseMinDamage = 1,
+            baseHp = 12,
+            hpPerLevel = 4,
+            baseMinDamage = 2,
             baseMaxDamage = 4,
             damagePerLevel = 1,
-            baseArmor = 0,
+            baseArmor = 1,
             baseXpReward = 30L,
             xpRewardPerLevel = 10L,
-            baseGoldMin = 2L,
+            baseGoldMin = 3L,
             baseGoldMax = 8L,
             goldPerLevel = 2L,
         ),
     val elite: MobTierConfig =
         MobTierConfig(
-            baseHp = 20,
-            hpPerLevel = 5,
-            baseMinDamage = 2,
+            baseHp = 28,
+            hpPerLevel = 7,
+            baseMinDamage = 3,
             baseMaxDamage = 6,
             damagePerLevel = 1,
-            baseArmor = 1,
+            baseArmor = 2,
             baseXpReward = 75L,
-            xpRewardPerLevel = 20L,
+            xpRewardPerLevel = 25L,
             baseGoldMin = 10L,
             baseGoldMax = 25L,
             goldPerLevel = 5L,
         ),
     val boss: MobTierConfig =
         MobTierConfig(
-            baseHp = 50,
-            hpPerLevel = 10,
-            baseMinDamage = 3,
-            baseMaxDamage = 8,
+            baseHp = 55,
+            hpPerLevel = 12,
+            baseMinDamage = 4,
+            baseMaxDamage = 9,
             damagePerLevel = 2,
             baseArmor = 3,
             baseXpReward = 200L,
@@ -2134,6 +2135,52 @@ data class MobEngineConfig(
     val minActionDelayMillis: Long = 8_000L,
     val maxActionDelayMillis: Long = 20_000L,
     val tiers: MobTiersConfig = MobTiersConfig(),
+)
+
+/**
+ * Power budget for equippable items. Used by the world loader to warn (or fail) when an
+ * authored item carries more stat/damage/armor than its slot+level+rarity should allow.
+ * Validation is opt-in *per item*: items without a `level:` or `rarity:` field in YAML
+ * are treated as legacy and skipped.
+ *
+ * Budget formula: `budget = (slotBaseBudget[slot] + level * pointsPerLevel) * rarityMultiplier[rarity]`.
+ * An item's spent points are `sum(stats.values * statPointCost) + damage * damagePointCost + armor * armorPointCost`.
+ */
+data class ItemBudgetConfig(
+    val enabled: Boolean = true,
+    /** When true, over-budget items log a warning. When false, they fail the world load. */
+    val warnOnly: Boolean = true,
+    /** Tolerance above budget before a violation is reported (0.05 = 5% slack). */
+    val tolerance: Double = 0.05,
+    val pointsPerLevel: Double = 2.0,
+    val damagePointCost: Double = 5.0,
+    val armorPointCost: Double = 2.0,
+    val statPointCost: Double = 1.0,
+    val slotBaseBudget: Map<String, Int> = mapOf(
+        "weapon" to 6,
+        "head" to 3,
+        "body" to 5,
+        "hand" to 3,
+        "feet" to 3,
+        "neck" to 3,
+        "wrist" to 2,
+        "finger" to 2,
+        "ranged" to 5,
+        "shield" to 4,
+    ),
+    val rarityMultiplier: Map<String, Double> = mapOf(
+        "common" to 1.0,
+        "uncommon" to 1.25,
+        "rare" to 1.5,
+        "epic" to 2.0,
+        "legendary" to 2.5,
+    ),
+    /** Default rarity assumed when an item declares a level but no rarity. */
+    val defaultRarity: String = "common",
+)
+
+data class ItemsEngineConfig(
+    val budget: ItemBudgetConfig = ItemBudgetConfig(),
 )
 
 data class CombatEngineConfig(

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -139,6 +139,39 @@ data class AppConfig(
         validateEngineGlobalQuests()
         validateEngineLottery()
         validateEngineGambling()
+        validateEngineItems()
+    }
+
+    private fun validateEngineItems() {
+        val b = engine.items.budget
+        if (!b.enabled) return
+        require(b.tolerance >= 0.0) { "ambonMUD.engine.items.budget.tolerance must be >= 0 (got ${b.tolerance})" }
+        require(b.pointsPerLevel >= 0.0) { "ambonMUD.engine.items.budget.pointsPerLevel must be >= 0" }
+        require(b.damagePointCost >= 0.0) { "ambonMUD.engine.items.budget.damagePointCost must be >= 0" }
+        require(b.armorPointCost >= 0.0) { "ambonMUD.engine.items.budget.armorPointCost must be >= 0" }
+        require(b.statPointCost >= 0.0) { "ambonMUD.engine.items.budget.statPointCost must be >= 0" }
+        require(b.slotBaseBudget.isNotEmpty()) { "ambonMUD.engine.items.budget.slotBaseBudget must not be empty when enabled" }
+        require(b.rarityMultiplier.isNotEmpty()) { "ambonMUD.engine.items.budget.rarityMultiplier must not be empty when enabled" }
+        for ((slot, base) in b.slotBaseBudget) {
+            require(slot == slot.lowercase()) {
+                "ambonMUD.engine.items.budget.slotBaseBudget key '$slot' must be lowercase"
+            }
+            require(base >= 0) {
+                "ambonMUD.engine.items.budget.slotBaseBudget['$slot'] must be >= 0 (got $base)"
+            }
+        }
+        for ((rarity, mult) in b.rarityMultiplier) {
+            require(rarity == rarity.lowercase()) {
+                "ambonMUD.engine.items.budget.rarityMultiplier key '$rarity' must be lowercase"
+            }
+            require(mult > 0.0) {
+                "ambonMUD.engine.items.budget.rarityMultiplier['$rarity'] must be > 0 (got $mult)"
+            }
+        }
+        require(b.rarityMultiplier.containsKey(b.defaultRarity.lowercase())) {
+            "ambonMUD.engine.items.budget.defaultRarity '${b.defaultRarity}' must be a key in rarityMultiplier " +
+                "(known: ${b.rarityMultiplier.keys.sorted().joinToString(", ")})"
+        }
     }
 
     private fun validateEngineDailyQuests() {

--- a/src/main/kotlin/dev/ambon/domain/world/ItemBudgetEvaluation.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/ItemBudgetEvaluation.kt
@@ -42,7 +42,8 @@ fun evaluateItemBudget(
     if (file.level == null && file.rarity == null) return null
     val slot = file.slot?.lowercase()?.takeUnless { it.isEmpty() } ?: return null
 
-    val level = (file.level ?: 1).coerceAtLeast(1)
+    val level = file.level ?: 1
+    if (level < 1) error("Item '$itemId' level must be >= 1 (got $level)")
     val rarity = (file.rarity ?: config.defaultRarity).lowercase()
 
     val slotBase = config.slotBaseBudget[slot]

--- a/src/main/kotlin/dev/ambon/domain/world/ItemBudgetEvaluation.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/ItemBudgetEvaluation.kt
@@ -1,0 +1,80 @@
+package dev.ambon.domain.world
+
+import dev.ambon.config.ItemBudgetConfig
+import dev.ambon.domain.world.data.ItemFile
+
+/**
+ * Result of evaluating an authored item against its power budget. [spent] is the total
+ * cost of the item's stats/damage/armor; [budget] is what's allowed for its level+slot+rarity.
+ * [overBudget] is true when `spent > budget * (1 + tolerance)`.
+ */
+data class ItemBudgetEvaluation(
+    val itemId: String,
+    val slot: String,
+    val level: Int,
+    val rarity: String,
+    val spent: Double,
+    val budget: Double,
+    val tolerance: Double,
+    val breakdown: List<String>,
+) {
+    val overBudget: Boolean get() = spent > budget * (1.0 + tolerance)
+
+    fun summary(): String {
+        val pct = if (budget > 0) (spent / budget * 100.0) else Double.POSITIVE_INFINITY
+        val pctStr = if (pct.isFinite()) "%.0f%%".format(pct) else "∞"
+        return "Item '$itemId' ($slot, lvl $level $rarity) uses %.1f / %.1f budget points ($pctStr): %s"
+            .format(spent, budget, breakdown.joinToString(", "))
+    }
+}
+
+/**
+ * Compute a budget evaluation for the given item. Returns null when the item is not
+ * subject to budget checks (no slot, or both level and rarity are null on the item file
+ * — i.e. the builder hasn't opted in to budget tuning for this piece).
+ */
+fun evaluateItemBudget(
+    itemId: String,
+    file: ItemFile,
+    config: ItemBudgetConfig,
+): ItemBudgetEvaluation? {
+    if (!config.enabled) return null
+    if (file.level == null && file.rarity == null) return null
+    val slot = file.slot?.lowercase()?.takeUnless { it.isEmpty() } ?: return null
+
+    val level = (file.level ?: 1).coerceAtLeast(1)
+    val rarity = (file.rarity ?: config.defaultRarity).lowercase()
+
+    val slotBase = config.slotBaseBudget[slot]
+        ?: error("Item '$itemId' uses slot '$slot' which has no entry in items.budget.slotBaseBudget")
+    val rarityMult = config.rarityMultiplier[rarity]
+        ?: error(
+            "Item '$itemId' uses rarity '$rarity' which has no entry in items.budget.rarityMultiplier. " +
+                "Known rarities: ${config.rarityMultiplier.keys.sorted().joinToString(", ")}",
+        )
+
+    val budget = (slotBase + level * config.pointsPerLevel) * rarityMult
+
+    val damagePoints = file.damage * config.damagePointCost
+    val armorPoints = file.armor * config.armorPointCost
+    val statSum = file.stats.values.sumOf { it }
+    val statPoints = statSum * config.statPointCost
+    val spent = damagePoints + armorPoints + statPoints
+
+    val breakdown = buildList {
+        if (file.damage > 0) add("damage ${file.damage}=%.1fpt".format(damagePoints))
+        if (file.armor > 0) add("armor ${file.armor}=%.1fpt".format(armorPoints))
+        if (statSum > 0) add("stats $statSum=%.1fpt".format(statPoints))
+    }
+
+    return ItemBudgetEvaluation(
+        itemId = itemId,
+        slot = slot,
+        level = level,
+        rarity = rarity,
+        spent = spent,
+        budget = budget,
+        tolerance = config.tolerance,
+        breakdown = breakdown,
+    )
+}

--- a/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
@@ -14,6 +14,11 @@ import dev.ambon.engine.dialogue.DialogueTree
  * Authored stat overrides that won at load time. Preserved on [MobTemplateDef] so
  * that spawn-time rescaling (for zones with non-STATIC scaling) can replay
  * the tier × level math while still honouring the author's explicit values.
+ *
+ * Multipliers ([hpMult], [dmgMult], [xpMult], [goldMult]) scale the tier-derived
+ * baseline before absolute overrides are applied. Use multipliers to express
+ * relative tuning ("this mob hits ~20% harder than its tier baseline") without
+ * typing raw numbers; use absolute overrides for one-off bespoke mobs.
  */
 data class MobStatOverrides(
     val hp: Int? = null,
@@ -23,6 +28,10 @@ data class MobStatOverrides(
     val xpReward: Long? = null,
     val goldMin: Long? = null,
     val goldMax: Long? = null,
+    val hpMult: Double? = null,
+    val dmgMult: Double? = null,
+    val xpMult: Double? = null,
+    val goldMult: Double? = null,
 )
 
 /**

--- a/src/main/kotlin/dev/ambon/domain/world/ResolvedMobStats.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/ResolvedMobStats.kt
@@ -19,7 +19,13 @@ data class ResolvedMobStats(
  * rescaling for [ZoneScaling] can replay the same math at a different
  * level without re-reading world YAML.
  *
- * Authored overrides always win; only tier-derived fields change with level.
+ * Resolution order per stat:
+ *   1. Start with tier × level baseline (e.g. `baseHp + steps * hpPerLevel`).
+ *   2. Apply the relevant multiplier ([MobStatOverrides.hpMult], etc.) if set.
+ *   3. Replace with the absolute override (e.g. [MobStatOverrides.hp]) if set.
+ *
+ * Multipliers express "noticeably tougher than baseline" without typing raw
+ * numbers; absolute overrides are the escape hatch for bespoke mobs.
  */
 fun resolveMobStats(
     tier: MobTierConfig,
@@ -28,14 +34,26 @@ fun resolveMobStats(
 ): ResolvedMobStats {
     val normalized = level.coerceAtLeast(1)
     val steps = normalized - 1
-    val minDamage = overrides.minDamage ?: (tier.baseMinDamage + steps * tier.damagePerLevel)
-    val maxDamage = overrides.maxDamage ?: (tier.baseMaxDamage + steps * tier.damagePerLevel)
+    val hpMult = overrides.hpMult ?: 1.0
+    val dmgMult = overrides.dmgMult ?: 1.0
+    val xpMult = overrides.xpMult ?: 1.0
+    val goldMult = overrides.goldMult ?: 1.0
+
+    val baseHp = ((tier.baseHp + steps * tier.hpPerLevel) * hpMult).toInt().coerceAtLeast(1)
+    val baseMin = ((tier.baseMinDamage + steps * tier.damagePerLevel) * dmgMult).toInt().coerceAtLeast(1)
+    val baseMax = ((tier.baseMaxDamage + steps * tier.damagePerLevel) * dmgMult).toInt().coerceAtLeast(baseMin)
+    val baseXp = ((tier.baseXpReward + steps.toLong() * tier.xpRewardPerLevel).toDouble() * xpMult).toLong().coerceAtLeast(0L)
+    val baseGoldMin = ((tier.baseGoldMin + steps.toLong() * tier.goldPerLevel).toDouble() * goldMult).toLong().coerceAtLeast(0L)
+    val baseGoldMax = ((tier.baseGoldMax + steps.toLong() * tier.goldPerLevel).toDouble() * goldMult).toLong().coerceAtLeast(baseGoldMin)
+
+    val minDamage = overrides.minDamage ?: baseMin
+    val maxDamage = overrides.maxDamage ?: baseMax
     return ResolvedMobStats(
-        hp = overrides.hp ?: (tier.baseHp + steps * tier.hpPerLevel),
+        hp = overrides.hp ?: baseHp,
         damage = DamageRange(minDamage, maxDamage),
         armor = overrides.armor ?: tier.baseArmor,
-        xpReward = overrides.xpReward ?: (tier.baseXpReward + steps.toLong() * tier.xpRewardPerLevel),
-        goldMin = overrides.goldMin ?: (tier.baseGoldMin + steps.toLong() * tier.goldPerLevel),
-        goldMax = overrides.goldMax ?: (tier.baseGoldMax + steps.toLong() * tier.goldPerLevel),
+        xpReward = overrides.xpReward ?: baseXp,
+        goldMin = overrides.goldMin ?: baseGoldMin,
+        goldMax = overrides.goldMax ?: baseGoldMax,
     )
 }

--- a/src/main/kotlin/dev/ambon/domain/world/ResolvedMobStats.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/ResolvedMobStats.kt
@@ -2,6 +2,8 @@ package dev.ambon.domain.world
 
 import dev.ambon.config.MobTierConfig
 import dev.ambon.domain.DamageRange
+import kotlin.math.roundToInt
+import kotlin.math.roundToLong
 
 /** Fully-resolved combat stats for a mob at a specific level. */
 data class ResolvedMobStats(
@@ -39,12 +41,19 @@ fun resolveMobStats(
     val xpMult = overrides.xpMult ?: 1.0
     val goldMult = overrides.goldMult ?: 1.0
 
-    val baseHp = ((tier.baseHp + steps * tier.hpPerLevel) * hpMult).toInt().coerceAtLeast(1)
-    val baseMin = ((tier.baseMinDamage + steps * tier.damagePerLevel) * dmgMult).toInt().coerceAtLeast(1)
-    val baseMax = ((tier.baseMaxDamage + steps * tier.damagePerLevel) * dmgMult).toInt().coerceAtLeast(baseMin)
-    val baseXp = ((tier.baseXpReward + steps.toLong() * tier.xpRewardPerLevel).toDouble() * xpMult).toLong().coerceAtLeast(0L)
-    val baseGoldMin = ((tier.baseGoldMin + steps.toLong() * tier.goldPerLevel).toDouble() * goldMult).toLong().coerceAtLeast(0L)
-    val baseGoldMax = ((tier.baseGoldMax + steps.toLong() * tier.goldPerLevel).toDouble() * goldMult).toLong().coerceAtLeast(baseGoldMin)
+    val hpRaw = (tier.baseHp + steps * tier.hpPerLevel) * hpMult
+    val minRaw = (tier.baseMinDamage + steps * tier.damagePerLevel) * dmgMult
+    val maxRaw = (tier.baseMaxDamage + steps * tier.damagePerLevel) * dmgMult
+    val xpRaw = (tier.baseXpReward + steps.toLong() * tier.xpRewardPerLevel).toDouble() * xpMult
+    val goldMinRaw = (tier.baseGoldMin + steps.toLong() * tier.goldPerLevel).toDouble() * goldMult
+    val goldMaxRaw = (tier.baseGoldMax + steps.toLong() * tier.goldPerLevel).toDouble() * goldMult
+
+    val baseHp = hpRaw.roundToInt().coerceAtLeast(1)
+    val baseMin = minRaw.roundToInt().coerceAtLeast(1)
+    val baseMax = maxRaw.roundToInt().coerceAtLeast(baseMin)
+    val baseXp = xpRaw.roundToLong().coerceAtLeast(0L)
+    val baseGoldMin = goldMinRaw.roundToLong().coerceAtLeast(0L)
+    val baseGoldMax = goldMaxRaw.roundToLong().coerceAtLeast(baseGoldMin)
 
     val minDamage = overrides.minDamage ?: baseMin
     val maxDamage = overrides.maxDamage ?: baseMax

--- a/src/main/kotlin/dev/ambon/domain/world/WorldFactory.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/WorldFactory.kt
@@ -1,5 +1,6 @@
 package dev.ambon.domain.world
 
+import dev.ambon.config.ItemBudgetConfig
 import dev.ambon.config.MobTiersConfig
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.world.load.WorldLoadException
@@ -20,6 +21,7 @@ object WorldFactory {
         videosBaseUrl: String = "/videos/",
         audioBaseUrl: String = "/audio/",
         factionIds: Set<String> = emptySet(),
+        itemBudget: ItemBudgetConfig = ItemBudgetConfig(),
     ): World {
         val paths = resources.ifEmpty { discoverClasspathZones() }
         if (paths.isEmpty()) throw WorldLoadException("No zone files found — classpath 'world/' directory is empty")
@@ -32,6 +34,7 @@ object WorldFactory {
             videosBaseUrl = videosBaseUrl,
             audioBaseUrl = audioBaseUrl,
             factionIds = factionIds,
+            itemBudget = itemBudget,
         )
     }
 

--- a/src/main/kotlin/dev/ambon/domain/world/data/ItemFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/ItemFile.kt
@@ -21,4 +21,16 @@ data class ItemFile(
     val video: String? = null,
     val itemType: String? = null,
     val questItem: Boolean = false,
+    /**
+     * Intended item level. When set together with [rarity] (or by itself), the loader runs
+     * the power-budget check defined by `engine.items.budget`. Items without a level are
+     * treated as legacy/untunable and skipped by the validator.
+     */
+    val level: Int? = null,
+    /**
+     * Rarity tier (common, uncommon, rare, epic, legendary). Multiplies the budget allowed
+     * for the slot+level combination. See [dev.ambon.config.ItemBudgetConfig] for the
+     * default scale.
+     */
+    val rarity: String? = null,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/data/MobFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/MobFile.kt
@@ -22,6 +22,16 @@ data class MobFile(
     val role: String? = null,
     val tier: String? = null,
     val level: Int? = null,
+    /**
+     * Multiplicative tuning knobs applied to tier×level baselines. Builders use these to express
+     * "noticeably tougher than baseline" (e.g. `hpMult: 1.25`) without having to type absolute
+     * numbers. Multipliers are applied to tier-derived values only; explicit overrides
+     * ([hp], [minDamage], etc.) still win. Default 1.0 (no change).
+     */
+    val hpMult: Double? = null,
+    val dmgMult: Double? = null,
+    val xpMult: Double? = null,
+    val goldMult: Double? = null,
     val hp: Int? = null,
     val minDamage: Int? = null,
     val maxDamage: Int? = null,

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -93,6 +93,7 @@ object WorldLoader {
         videosBaseUrl: String = "/videos/",
         audioBaseUrl: String = "/audio/",
         factionIds: Set<String> = emptySet(),
+        itemBudget: dev.ambon.config.ItemBudgetConfig = dev.ambon.config.ItemBudgetConfig(),
     ): World =
         loadFromResources(
             listOf(path),
@@ -101,6 +102,7 @@ object WorldLoader {
             videosBaseUrl = videosBaseUrl,
             audioBaseUrl = audioBaseUrl,
             factionIds = factionIds,
+            itemBudget = itemBudget,
         )
 
     fun loadFromResources(
@@ -117,6 +119,11 @@ object WorldLoader {
          * validation is skipped (tests and legacy worlds).
          */
         factionIds: Set<String> = emptySet(),
+        /**
+         * Power-budget rules for equippable items. Opt-in per item: only items that declare
+         * `level:` or `rarity:` are checked. See [dev.ambon.config.ItemBudgetConfig].
+         */
+        itemBudget: dev.ambon.config.ItemBudgetConfig = dev.ambon.config.ItemBudgetConfig(),
     ): World {
         val imagesBase = normalizeBaseUrl(imagesBaseUrl)
         val videosBase = normalizeBaseUrl(videosBaseUrl)
@@ -345,6 +352,11 @@ object WorldLoader {
                 val level = mf.level ?: 1
                 requireAtLeast(level, 1, "Mob '${mobId.value}'", "level")
 
+                validateMobMultiplier(mobId, "hpMult", mf.hpMult)
+                validateMobMultiplier(mobId, "dmgMult", mf.dmgMult)
+                validateMobMultiplier(mobId, "xpMult", mf.xpMult)
+                validateMobMultiplier(mobId, "goldMult", mf.goldMult)
+
                 val overrides = MobStatOverrides(
                     hp = mf.hp,
                     minDamage = mf.minDamage,
@@ -353,6 +365,10 @@ object WorldLoader {
                     xpReward = mf.xpReward,
                     goldMin = mf.goldMin,
                     goldMax = mf.goldMax,
+                    hpMult = mf.hpMult,
+                    dmgMult = mf.dmgMult,
+                    xpMult = mf.xpMult,
+                    goldMult = mf.goldMult,
                 )
                 val resolved = resolveMobStats(tier, level, overrides)
                 val resolvedHp = resolved.hp
@@ -487,6 +503,21 @@ object WorldLoader {
                 for ((statKey, statVal) in itemFile.stats) {
                     if (statVal < 0) {
                         throw WorldLoadException("Item '${itemId.value}' stat '$statKey' cannot be negative")
+                    }
+                }
+
+                val budgetEval = dev.ambon.domain.world.evaluateItemBudget(
+                    itemId = itemId.value,
+                    file = itemFile,
+                    config = itemBudget,
+                )
+                if (budgetEval != null && budgetEval.overBudget) {
+                    val msg = budgetEval.summary() +
+                        " exceeds %.0f%% tolerance".format(budgetEval.tolerance * 100)
+                    if (itemBudget.warnOnly) {
+                        logger.warn(msg)
+                    } else {
+                        throw WorldLoadException(msg)
                     }
                 }
 
@@ -1692,6 +1723,15 @@ object WorldLoader {
     private fun requireAtLeast(value: Long, min: Long, context: String, field: String): Long {
         if (value < min) throw WorldLoadException("$context $field must be >= $min (got $value)")
         return value
+    }
+
+    private fun validateMobMultiplier(mobId: dev.ambon.domain.ids.MobId, field: String, value: Double?) {
+        if (value == null) return
+        if (value.isNaN() || value.isInfinite() || value <= 0.0 || value > 10.0) {
+            throw WorldLoadException(
+                "Mob '${mobId.value}' $field must be in (0.0, 10.0] (got $value)",
+            )
+        }
     }
 
     private fun parsePuzzleReward(

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -508,6 +508,8 @@ object WorldLoader {
                     }
                 }
 
+                itemFile.level?.let { requireAtLeast(it, 1, itemCtx, "level") }
+
                 val budgetEval = try {
                     evaluateItemBudget(
                         itemId = itemId.value,

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
+import dev.ambon.config.ItemBudgetConfig
 import dev.ambon.config.MobTiersConfig
 import dev.ambon.domain.DamageRange
 import dev.ambon.domain.StatMap
@@ -60,6 +61,7 @@ import dev.ambon.domain.world.data.MobFile
 import dev.ambon.domain.world.data.MobSpawnFile
 import dev.ambon.domain.world.data.ReputationRequirementFile
 import dev.ambon.domain.world.data.WorldFile
+import dev.ambon.domain.world.evaluateItemBudget
 import dev.ambon.domain.world.resolveMobStats
 import dev.ambon.engine.behavior.BehaviorTemplates
 import dev.ambon.engine.behavior.BehaviorTreeLoader
@@ -93,7 +95,7 @@ object WorldLoader {
         videosBaseUrl: String = "/videos/",
         audioBaseUrl: String = "/audio/",
         factionIds: Set<String> = emptySet(),
-        itemBudget: dev.ambon.config.ItemBudgetConfig = dev.ambon.config.ItemBudgetConfig(),
+        itemBudget: ItemBudgetConfig = ItemBudgetConfig(),
     ): World =
         loadFromResources(
             listOf(path),
@@ -121,9 +123,9 @@ object WorldLoader {
         factionIds: Set<String> = emptySet(),
         /**
          * Power-budget rules for equippable items. Opt-in per item: only items that declare
-         * `level:` or `rarity:` are checked. See [dev.ambon.config.ItemBudgetConfig].
+         * `level:` or `rarity:` are checked. See [ItemBudgetConfig].
          */
-        itemBudget: dev.ambon.config.ItemBudgetConfig = dev.ambon.config.ItemBudgetConfig(),
+        itemBudget: ItemBudgetConfig = ItemBudgetConfig(),
     ): World {
         val imagesBase = normalizeBaseUrl(imagesBaseUrl)
         val videosBase = normalizeBaseUrl(videosBaseUrl)
@@ -506,11 +508,15 @@ object WorldLoader {
                     }
                 }
 
-                val budgetEval = dev.ambon.domain.world.evaluateItemBudget(
-                    itemId = itemId.value,
-                    file = itemFile,
-                    config = itemBudget,
-                )
+                val budgetEval = try {
+                    evaluateItemBudget(
+                        itemId = itemId.value,
+                        file = itemFile,
+                        config = itemBudget,
+                    )
+                } catch (e: IllegalStateException) {
+                    throw WorldLoadException(e.message ?: "Item '${itemId.value}' failed budget evaluation")
+                }
                 if (budgetEval != null && budgetEval.overBudget) {
                     val msg = budgetEval.summary() +
                         " exceeds %.0f%% tolerance".format(budgetEval.tolerance * 100)
@@ -1725,7 +1731,7 @@ object WorldLoader {
         return value
     }
 
-    private fun validateMobMultiplier(mobId: dev.ambon.domain.ids.MobId, field: String, value: Double?) {
+    private fun validateMobMultiplier(mobId: MobId, field: String, value: Double?) {
         if (value == null) return
         if (value.isNaN() || value.isInfinite() || value <= 0.0 || value > 10.0) {
             throw WorldLoadException(

--- a/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
+++ b/src/main/kotlin/dev/ambon/grpc/EngineServer.kt
@@ -118,6 +118,7 @@ class EngineServer(
             videosBaseUrl = config.videos.baseUrl,
             audioBaseUrl = config.audio.baseUrl,
             factionIds = config.engine.factions.definitions.keys,
+            itemBudget = config.engine.items.budget,
         )
     private val scheduler: Scheduler = Scheduler(clock)
     private val localZones = ServerInfrastructure.resolveLocalZones(config, configuredShardedZones, world)

--- a/src/test/kotlin/dev/ambon/domain/world/ItemBudgetTest.kt
+++ b/src/test/kotlin/dev/ambon/domain/world/ItemBudgetTest.kt
@@ -1,0 +1,121 @@
+package dev.ambon.domain.world
+
+import dev.ambon.config.ItemBudgetConfig
+import dev.ambon.domain.world.data.ItemFile
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ItemBudgetTest {
+    private val config = ItemBudgetConfig()
+
+    @Test
+    fun `item without level or rarity is skipped`() {
+        val item = ItemFile(
+            displayName = "a sword",
+            slot = "weapon",
+            damage = 4,
+        )
+        assertNull(evaluateItemBudget("sword", item, config))
+    }
+
+    @Test
+    fun `item with disabled budget config is skipped`() {
+        val item = ItemFile(
+            displayName = "a sword",
+            slot = "weapon",
+            damage = 4,
+            level = 1,
+        )
+        val disabled = config.copy(enabled = false)
+        assertNull(evaluateItemBudget("sword", item, disabled))
+    }
+
+    @Test
+    fun `level-1 common weapon with damage 4 fits within slot budget`() {
+        val item = ItemFile(
+            displayName = "iron sword",
+            slot = "weapon",
+            damage = 4,
+            level = 1,
+            rarity = "common",
+        )
+        val eval = evaluateItemBudget("iron_sword", item, config)!!
+        // Budget: (6 + 1*2) * 1.0 = 8. Spent: 4*5 = 20. Over budget.
+        assertEquals(20.0, eval.spent, 0.001)
+        assertEquals(8.0, eval.budget, 0.001)
+        assertTrue(eval.overBudget)
+    }
+
+    @Test
+    fun `level-5 rare weapon with damage 4 is within budget`() {
+        val item = ItemFile(
+            displayName = "iron sword",
+            slot = "weapon",
+            damage = 4,
+            level = 5,
+            rarity = "rare",
+        )
+        val eval = evaluateItemBudget("iron_sword", item, config)!!
+        // Budget: (6 + 5*2) * 1.5 = 24. Spent: 4*5 = 20.
+        assertEquals(20.0, eval.spent, 0.001)
+        assertEquals(24.0, eval.budget, 0.001)
+        assertFalse(eval.overBudget)
+    }
+
+    @Test
+    fun `breakdown lists all non-zero contributions`() {
+        val item = ItemFile(
+            displayName = "blessed pendant",
+            slot = "neck",
+            armor = 2,
+            stats = mapOf("CON" to 3, "WIS" to 1),
+            level = 10,
+            rarity = "epic",
+        )
+        val eval = evaluateItemBudget("blessed", item, config)!!
+        // armor 2*2 = 4, stats 4*1 = 4, total 8
+        assertEquals(8.0, eval.spent, 0.001)
+        // breakdown should mention both armor and stats
+        assertTrue(eval.breakdown.any { it.contains("armor") })
+        assertTrue(eval.breakdown.any { it.contains("stats") })
+    }
+
+    @Test
+    fun `unknown rarity raises an error`() {
+        val item = ItemFile(
+            displayName = "weird sword",
+            slot = "weapon",
+            damage = 4,
+            level = 1,
+            rarity = "mythic",
+        )
+        try {
+            evaluateItemBudget("weird", item, config)
+            error("Expected IllegalStateException")
+        } catch (e: IllegalStateException) {
+            assertTrue(e.message!!.contains("mythic"))
+        }
+    }
+
+    @Test
+    fun `tolerance prevents borderline overage from being flagged`() {
+        val item = ItemFile(
+            displayName = "borderline weapon",
+            slot = "weapon",
+            damage = 1,
+            stats = mapOf("STR" to 4),
+            level = 1,
+            rarity = "common",
+        )
+        // Budget: (6 + 2) * 1.0 = 8. Spent: 1*5 + 4*1 = 9. 9/8 = 1.125, default tolerance 5%.
+        val eval = evaluateItemBudget("borderline", item, config)!!
+        assertTrue(eval.overBudget) // 12.5% over, exceeds 5% tolerance
+
+        val lenient = config.copy(tolerance = 0.20)
+        val eval2 = evaluateItemBudget("borderline", item, lenient)!!
+        assertFalse(eval2.overBudget) // 12.5% < 20%
+    }
+}

--- a/src/test/kotlin/dev/ambon/domain/world/ItemBudgetTest.kt
+++ b/src/test/kotlin/dev/ambon/domain/world/ItemBudgetTest.kt
@@ -101,6 +101,23 @@ class ItemBudgetTest {
     }
 
     @Test
+    fun `non-positive level raises an error instead of being silently clamped`() {
+        val item = ItemFile(
+            displayName = "underleveled",
+            slot = "weapon",
+            damage = 1,
+            level = 0,
+            rarity = "common",
+        )
+        try {
+            evaluateItemBudget("underleveled", item, config)
+            error("Expected IllegalStateException for level <= 0")
+        } catch (e: IllegalStateException) {
+            assertTrue(e.message!!.contains("level"))
+        }
+    }
+
+    @Test
     fun `tolerance prevents borderline overage from being flagged`() {
         val item = ItemFile(
             displayName = "borderline weapon",

--- a/src/test/kotlin/dev/ambon/domain/world/MobStatResolverTest.kt
+++ b/src/test/kotlin/dev/ambon/domain/world/MobStatResolverTest.kt
@@ -91,6 +91,16 @@ class MobStatResolverTest {
     }
 
     @Test
+    fun `fractional multipliers round half-away-from-zero rather than truncating`() {
+        // baseMaxDamage=4 * 1.15 = 4.6 → should round to 5, not truncate to 4
+        val overrides = MobStatOverrides(dmgMult = 1.15)
+        val stats = resolveMobStats(standardTier, level = 1, overrides)
+        // baseMinDamage=2 * 1.15 = 2.3 → 2
+        assertEquals(2, stats.damage.min)
+        assertEquals(5, stats.damage.max)
+    }
+
+    @Test
     fun `hpMult clamps to at least 1`() {
         val overrides = MobStatOverrides(hpMult = 0.01)
         val stats = resolveMobStats(standardTier, level = 1, overrides)

--- a/src/test/kotlin/dev/ambon/domain/world/MobStatResolverTest.kt
+++ b/src/test/kotlin/dev/ambon/domain/world/MobStatResolverTest.kt
@@ -56,4 +56,45 @@ class MobStatResolverTest {
         val stats = resolveMobStats(standardTier, level = 0)
         assertEquals(20, stats.hp)
     }
+
+    @Test
+    fun `hpMult scales tier-derived hp`() {
+        val overrides = MobStatOverrides(hpMult = 1.5)
+        val stats = resolveMobStats(standardTier, level = 5, overrides)
+        // Baseline hp at level 5: 20 + 4*5 = 40. With 1.5x: 60.
+        assertEquals(60, stats.hp)
+    }
+
+    @Test
+    fun `dmgMult scales both min and max damage`() {
+        val overrides = MobStatOverrides(dmgMult = 2.0)
+        val stats = resolveMobStats(standardTier, level = 1, overrides)
+        assertEquals(4, stats.damage.min) // 2 * 2
+        assertEquals(8, stats.damage.max) // 4 * 2
+    }
+
+    @Test
+    fun `xpMult and goldMult scale rewards`() {
+        val overrides = MobStatOverrides(xpMult = 0.5, goldMult = 2.0)
+        val stats = resolveMobStats(standardTier, level = 1, overrides)
+        assertEquals(15L, stats.xpReward) // 30 * 0.5
+        assertEquals(6L, stats.goldMin) // 3 * 2
+        assertEquals(16L, stats.goldMax) // 8 * 2
+    }
+
+    @Test
+    fun `absolute override beats multiplier`() {
+        val overrides = MobStatOverrides(hp = 100, hpMult = 5.0)
+        val stats = resolveMobStats(standardTier, level = 1, overrides)
+        // hp override wins, hpMult is ignored for the hp field
+        assertEquals(100, stats.hp)
+    }
+
+    @Test
+    fun `hpMult clamps to at least 1`() {
+        val overrides = MobStatOverrides(hpMult = 0.01)
+        val stats = resolveMobStats(standardTier, level = 1, overrides)
+        // 20 * 0.01 = 0.2 → clamped to 1
+        assertEquals(1, stats.hp)
+    }
 }

--- a/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
@@ -84,10 +84,11 @@ class WorldLoaderTest {
         assertEquals("ok_small:rat", mob.id.value)
         assertEquals("a small rat", mob.name)
         assertEquals(RoomId("ok_small:b"), spawn.roomId)
-        assertEquals(10, mob.maxHp)
-        assertEquals(1, mob.damage.min)
+        // standard tier defaults at level 1: hp=12, dmg=2-4, armor=1, xp=30
+        assertEquals(12, mob.maxHp)
+        assertEquals(2, mob.damage.min)
         assertEquals(4, mob.damage.max)
-        assertEquals(0, mob.armor)
+        assertEquals(1, mob.armor)
         assertEquals(30L, mob.xpReward)
         assertEquals(1, mob.drops.size)
         assertEquals(
@@ -442,10 +443,11 @@ class WorldLoaderTest {
         val mobs = world.mobTemplates.mapKeys { it.key.value }
 
         val rat = mobs.getValue("ok_mob_stats:rat")
-        assertEquals(10, rat.maxHp)
-        assertEquals(1, rat.damage.min)
+        // standard tier defaults at level 1: hp=12, dmg=2-4, armor=1, xp=30
+        assertEquals(12, rat.maxHp)
+        assertEquals(2, rat.damage.min)
         assertEquals(4, rat.damage.max)
-        assertEquals(0, rat.armor)
+        assertEquals(1, rat.armor)
         assertEquals(30L, rat.xpReward)
     }
 
@@ -455,16 +457,16 @@ class WorldLoaderTest {
         val mobs = world.mobTemplates.mapKeys { it.key.value }
 
         // standard tier, level=3: steps=2
-        // hp = 10 + 2*3 = 16
-        // minDamage = 1 + 2*1 = 3
+        // hp = 12 + 2*4 = 20
+        // minDamage = 2 + 2*1 = 4
         // maxDamage = 4 + 2*1 = 6
-        // armor = 0
+        // armor = 1
         // xpReward = 30 + 2*10 = 50
         val bandit = mobs.getValue("ok_mob_stats:bandit")
-        assertEquals(16, bandit.maxHp)
-        assertEquals(3, bandit.damage.min)
+        assertEquals(20, bandit.maxHp)
+        assertEquals(4, bandit.damage.min)
         assertEquals(6, bandit.damage.max)
-        assertEquals(0, bandit.armor)
+        assertEquals(1, bandit.armor)
         assertEquals(50L, bandit.xpReward)
     }
 
@@ -487,9 +489,10 @@ class WorldLoaderTest {
         val mobs = world.mobTemplates.mapKeys { it.key.value }
 
         val boss = mobs.getValue("ok_mob_stats:boss_mob")
-        assertEquals(50, boss.maxHp)
-        assertEquals(3, boss.damage.min)
-        assertEquals(8, boss.damage.max)
+        // boss tier defaults at level 1: hp=55, dmg=4-9, armor=3, xp=200
+        assertEquals(55, boss.maxHp)
+        assertEquals(4, boss.damage.min)
+        assertEquals(9, boss.damage.max)
         assertEquals(3, boss.armor)
         assertEquals(200L, boss.xpReward)
     }
@@ -802,14 +805,14 @@ class WorldLoaderTest {
             val world = WorldLoader.loadFromResource("world/ok_mob_stats.yaml")
             val mobs = world.mobTemplates.mapKeys { it.key.value }
 
-            // Standard tier level 1: goldMin=2, goldMax=8
+            // Standard tier level 1: goldMin=3, goldMax=8
             val rat = mobs.getValue("ok_mob_stats:rat")
-            assertEquals(2L, rat.goldMin)
+            assertEquals(3L, rat.goldMin)
             assertEquals(8L, rat.goldMax)
 
-            // Standard tier level 3 (steps=2): goldMin=2+2*2=6, goldMax=8+2*2=12
+            // Standard tier level 3 (steps=2): goldMin=3+2*2=7, goldMax=8+2*2=12
             val bandit = mobs.getValue("ok_mob_stats:bandit")
-            assertEquals(6L, bandit.goldMin)
+            assertEquals(7L, bandit.goldMin)
             assertEquals(12L, bandit.goldMax)
 
             // Boss tier level 1: goldMin=50, goldMax=100


### PR DESCRIPTION
## Summary

Two builder-facing tuning surfaces and a cross-repo sync doc.

- **Mob multipliers** — `hpMult`, `dmgMult`, `xpMult`, `goldMult` alongside `tier`+`level`. Builders express "this elf hits 20% harder than a standard level-7 mob" (`dmgMult: 1.2`) instead of typing raw HP/damage. Multipliers scale tier-derived baselines; absolute overrides still win per field.
- **Item power budgets** — Items can declare `level:` and `rarity:` to opt into a validator that checks `damage`/`armor`/`stats` against a slot+level+rarity allowance (`engine.items.budget`). Opt-in per item — legacy items without those fields are skipped. Defaults to warning-only; flip `warnOnly: false` to fail the world load.
- **Default sync** — `MobTierConfig` Kotlin defaults now match the AmbonArcanum Balanced preset values already shipping in `application.yaml`. No runtime change; closes the dev-default ↔ production-config gap.
- **Docs** — `docs/WORLD_YAML_SPEC.md` documents the new fields and budget formula. New `docs/ARCANUM_TUNING_SYNC.md` records the sync points and the Arcanum-side follow-ups (port the multiplier UI; port `evaluateItemBudget` into the Validate Zone path).

## Why

Per the conversation that triggered this: builders writing zones had to invent HP/damage numbers from intuition, leading to outliers and inconsistent power curves. AmbonArcanum already has six validated tuning presets and a combat simulator — this PR makes the AmbonMUD side accept the same vocabulary so the two stay in step.

## Test plan

- [x] `./gradlew ktlintCheck test` — 2073 tests pass
- [x] New unit tests: `MobStatResolverTest` (multiplier cases) + `ItemBudgetTest` (budget formula, opt-in, tolerance, unknown rarity)
- [x] `WorldLoaderTest` mob-stat assertions updated for synced tier defaults
- [ ] Manual smoke: load Academy zone (`./gradlew run`) and verify mobs still spawn with reasonable stats
- [ ] Manual smoke: add `level: 1, rarity: common` to an Academy weapon and verify a warning appears in the log

## Arcanum-side follow-ups (out of scope, tracked in `docs/ARCANUM_TUNING_SYNC.md`)

1. Add `hpMult`/`dmgMult`/`xpMult`/`goldMult` inputs to the mob editor.
2. Port `evaluateItemBudget` to TypeScript and surface budget overage in `validateZone.ts`.
3. Add `items.budget` to `BALANCED_PRESET` so the Tuning Wizard can preview budget changes.