### PR TITLE
feat(commands): add areas and run for movement parity

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -31,6 +31,17 @@ sealed interface Command {
         val dir: Direction,
     ) : Command
 
+    /** Executes a sequence of moves as if the player typed each individually. */
+    data class Run(
+        val steps: List<Direction>,
+    ) : Command
+
+    /** Lists known zones, optionally filtered to those overlapping a level range. */
+    data class Areas(
+        val minLevel: Int?,
+        val maxLevel: Int?,
+    ) : Command
+
     data class LookDir(
         val dir: Direction,
     ) : Command
@@ -1035,6 +1046,14 @@ object CommandParser {
             Command.Time
         }?.let { return it }
 
+        matchPrefix(line, listOf("areas", "area")) { rest ->
+            parseAreasArgs(rest, line)
+        }?.let { return it }
+
+        matchPrefix(line, listOf("run")) { rest ->
+            parseRunArg(rest, line)
+        }?.let { return it }
+
         matchPrefix(line, listOf("whisper", "wh")) { rest ->
             parseTargetMessage(rest, line, "whisper <target> <msg>") { target, msg -> Command.Whisper(target, msg) }
         }?.let { return it }
@@ -1721,6 +1740,57 @@ object CommandParser {
             }
         }
         return null
+    }
+
+    /** Maximum steps a single `run` command can expand to. */
+    const val MAX_RUN_STEPS = 100
+
+    private fun parseAreasArgs(rest: String, line: String): Command {
+        val trimmed = rest.trim()
+        if (trimmed.isEmpty()) return Command.Areas(null, null)
+        val parts = trimmed.split(Regex("\\s+"))
+        return when (parts.size) {
+            1 -> {
+                val n = parts[0].toIntOrNull()
+                if (n == null || n < 0) {
+                    Command.Invalid(line, "areas [<minLevel> [<maxLevel>]]")
+                } else {
+                    Command.Areas(n, n)
+                }
+            }
+            2 -> {
+                val min = parts[0].toIntOrNull()
+                val max = parts[1].toIntOrNull()
+                if (min == null || max == null || min < 0 || max < min) {
+                    Command.Invalid(line, "areas <minLevel> <maxLevel> (max >= min, both >= 0)")
+                } else {
+                    Command.Areas(min, max)
+                }
+            }
+            else -> Command.Invalid(line, "areas [<minLevel> [<maxLevel>]]")
+        }
+    }
+
+    private fun parseRunArg(rest: String, line: String): Command {
+        val raw = rest.replace("\\s+".toRegex(), "").lowercase()
+        if (raw.isEmpty()) return Command.Invalid(line, "run <directions> (e.g. 5n3e or nnsw)")
+        val steps = mutableListOf<Direction>()
+        var i = 0
+        while (i < raw.length) {
+            val countStart = i
+            while (i < raw.length && raw[i].isDigit()) i++
+            val count = if (i == countStart) 1 else raw.substring(countStart, i).toIntOrNull() ?: 0
+            if (count < 1) return Command.Invalid(line, "run <directions> — step count must be >= 1")
+            if (i >= raw.length) return Command.Invalid(line, "run <directions> — trailing count with no direction")
+            val dir = parseDirectionOrNull(raw[i].toString())
+                ?: return Command.Invalid(line, "run <directions> — unknown direction '${raw[i]}'")
+            repeat(count) { steps.add(dir) }
+            if (steps.size > MAX_RUN_STEPS) {
+                return Command.Invalid(line, "run <directions> — too many steps (max $MAX_RUN_STEPS)")
+            }
+            i++
+        }
+        return Command.Run(steps)
     }
 
     private fun parseDirectionOrNull(s: String): Direction? =

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -1784,10 +1784,10 @@ object CommandParser {
             if (i >= raw.length) return Command.Invalid(line, "run <directions> — trailing count with no direction")
             val dir = parseDirectionOrNull(raw[i].toString())
                 ?: return Command.Invalid(line, "run <directions> — unknown direction '${raw[i]}'")
-            repeat(count) { steps.add(dir) }
-            if (steps.size > MAX_RUN_STEPS) {
+            if (count > MAX_RUN_STEPS - steps.size) {
                 return Command.Invalid(line, "run <directions> — too many steps (max $MAX_RUN_STEPS)")
             }
+            repeat(count) { steps.add(dir) }
             i++
         }
         return Command.Run(steps)

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
@@ -60,12 +60,33 @@ class NavigationHandler(
         this.router = router
         router.on<Command.Look> { sid, _ -> handleLook(sid) }
         router.on<Command.Move> { sid, cmd -> handleMove(sid, cmd) }
+        router.on<Command.Run> { sid, cmd -> handleRun(sid, cmd) }
         router.on<Command.Exits> { sid, _ -> handleExits(sid) }
         router.on<Command.LookDir> { sid, cmd -> handleLookDir(sid, cmd) }
         router.on<Command.LookAt> { sid, cmd -> handleLookAt(sid, cmd) }
         router.on<Command.Recall> { sid, _ -> handleRecall(sid) }
         router.on<Command.Depart> { sid, _ -> handleDepart(sid) }
         router.on<Command.Petition> { sid, cmd -> handlePetition(sid, cmd) }
+    }
+
+    private suspend fun handleRun(sessionId: SessionId, cmd: Command.Run) {
+        if (cmd.steps.isEmpty()) {
+            outbound.send(OutboundEvent.SendError(sessionId, "Usage: run <directions> (e.g. 5n3e)"))
+            return
+        }
+        for (dir in cmd.steps) {
+            val me = players.get(sessionId) ?: return
+            val room = world.rooms[me.roomId]
+            // If the next step crosses zones, run it and stop — the handoff is async
+            // and subsequent steps would race against it.
+            val crossesZone = room != null &&
+                (
+                    room.remoteExits.contains(dir) ||
+                        room.exits[dir]?.let { !world.rooms.containsKey(it) } == true
+                )
+            handleMove(sessionId, Command.Move(dir))
+            if (crossesZone) return
+        }
     }
 
     private suspend fun handleLook(sessionId: SessionId) {

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
@@ -5,7 +5,9 @@ import dev.ambon.config.RecallConfig
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.items.ItemInstance
+import dev.ambon.domain.world.Direction
 import dev.ambon.domain.world.LockableState
+import dev.ambon.domain.world.Room
 import dev.ambon.engine.GuildHallSystem
 import dev.ambon.engine.HouseEntryResult
 import dev.ambon.engine.HousingSystem
@@ -77,16 +79,33 @@ class NavigationHandler(
         for (dir in cmd.steps) {
             val me = players.get(sessionId) ?: return
             val room = world.rooms[me.roomId]
-            // If the next step crosses zones, run it and stop — the handoff is async
-            // and subsequent steps would race against it.
-            val crossesZone = room != null &&
-                (
-                    room.remoteExits.contains(dir) ||
-                        room.exits[dir]?.let { !world.rooms.containsKey(it) } == true
-                )
+            // If the next step initiates an async cross-zone handoff, run it and stop
+            // — subsequent steps would race against the async transfer.
+            val crossesZone = room != null && willCrossZone(sessionId, room, dir)
             handleMove(sessionId, Command.Move(dir))
             if (crossesZone) return
         }
+    }
+
+    /**
+     * Mirrors the cross-zone decision points in [handleMove]: standard remote
+     * exits, puzzle-unlocked exits whose target is off-engine, and house / guild
+     * hall exits whose resolved origin is off-engine. Any of these dispatch the
+     * move through the async [attemptCrossZoneMove] path, so a `run` must stop
+     * after issuing them.
+     */
+    private fun willCrossZone(sessionId: SessionId, room: Room, dir: Direction): Boolean {
+        if (room.remoteExits.contains(dir)) return true
+        val to = room.exits[dir] ?: puzzleSystem?.getUnlockedExitTarget(room.id, dir) ?: return false
+        if (housingSystem?.isHouseExit(to) == true) {
+            val origin = housingSystem.resolveHouseExit(sessionId) ?: return false
+            return !world.rooms.containsKey(origin)
+        }
+        if (guildHallSystem?.isGuildHallExit(to) == true) {
+            val origin = guildHallSystem.resolveHallExit(sessionId) ?: return false
+            return !world.rooms.containsKey(origin)
+        }
+        return !world.rooms.containsKey(to)
     }
 
     private suspend fun handleLook(sessionId: SessionId) {

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldInfoHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldInfoHandler.kt
@@ -1,6 +1,9 @@
 package dev.ambon.engine.commands.handlers
 
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.ids.idZone
+import dev.ambon.domain.world.ScalingMode
+import dev.ambon.domain.world.World
 import dev.ambon.engine.WeatherSystem
 import dev.ambon.engine.WorldEventSystem
 import dev.ambon.engine.WorldTimeSystem
@@ -16,11 +19,13 @@ class WorldInfoHandler(
     private val weatherSystem: WeatherSystem,
     private val worldEventSystem: WorldEventSystem,
 ) : CommandHandler {
+    private val world = ctx.world
     private val players = ctx.players
     private val outbound = ctx.outbound
 
     override fun register(router: CommandRouter) {
         router.on<Command.Time> { sid, _ -> handleTime(sid) }
+        router.on<Command.Areas> { sid, cmd -> handleAreas(sid, cmd) }
     }
 
     private suspend fun handleTime(sessionId: SessionId) {
@@ -47,6 +52,67 @@ class WorldInfoHandler(
             for ((_, def) in activeEvents) {
                 outbound.send(OutboundEvent.SendInfo(sessionId, "    ${def.displayName}: ${def.description}"))
             }
+        }
+    }
+
+    private suspend fun handleAreas(sessionId: SessionId, cmd: Command.Areas) {
+        val ranges = computeZoneLevelRanges(world)
+        val filtered = ranges.filter { (_, range) ->
+            val lo = cmd.minLevel
+            val hi = cmd.maxLevel
+            when {
+                range == null -> lo == null && hi == null
+                lo != null && hi != null -> range.last >= lo && range.first <= hi
+                lo != null -> range.last >= lo
+                hi != null -> range.first <= hi
+                else -> true
+            }
+        }.toList().sortedWith(
+            compareBy({ it.second?.first ?: Int.MAX_VALUE }, { it.first }),
+        )
+
+        val header = when {
+            cmd.minLevel != null && cmd.maxLevel != null && cmd.minLevel != cmd.maxLevel ->
+                "[ Areas — level ${cmd.minLevel}-${cmd.maxLevel} ]"
+            cmd.minLevel != null && cmd.maxLevel != null ->
+                "[ Areas — level ${cmd.minLevel} ]"
+            cmd.minLevel != null -> "[ Areas — level >= ${cmd.minLevel} ]"
+            cmd.maxLevel != null -> "[ Areas — level <= ${cmd.maxLevel} ]"
+            else -> "[ Areas ]"
+        }
+        outbound.send(OutboundEvent.SendInfo(sessionId, header))
+        if (filtered.isEmpty()) {
+            outbound.send(OutboundEvent.SendInfo(sessionId, "  (no matching areas)"))
+            return
+        }
+        for ((zone, range) in filtered) {
+            val levelStr = when {
+                range == null -> "—"
+                range.first == range.last -> "lvl ${range.first}"
+                else -> "lvl ${range.first}-${range.last}"
+            }
+            outbound.send(OutboundEvent.SendInfo(sessionId, "  $zone  ($levelStr)"))
+        }
+    }
+
+    /**
+     * Returns each zone's effective level range. Prefers the authored BOUNDED
+     * scaling range; otherwise infers from the min/max level across the zone's
+     * mob templates. Zones with no level signal map to null.
+     */
+    private fun computeZoneLevelRanges(world: World): Map<String, IntRange?> {
+        val zones = world.zones()
+        val mobLevelsByZone = HashMap<String, MutableList<Int>>()
+        for ((id, template) in world.mobTemplates) {
+            val zone = idZone(id.value)
+            if (template.level > 0) {
+                mobLevelsByZone.getOrPut(zone) { mutableListOf() }.add(template.level)
+            }
+        }
+        return zones.associateWith { zone ->
+            val scaling = world.zoneScaling(zone)
+            val authored = if (scaling.mode == ScalingMode.BOUNDED) scaling.levelRange else null
+            authored ?: mobLevelsByZone[zone]?.let { IntRange(it.min(), it.max()) }
         }
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -912,6 +912,16 @@ ambonmud:
           usage: recall
           category: navigation
           staff: false
+        run:
+          usage: run <directions> (e.g. 5n3e)
+          description: Move along a sequence of directions. Numeric prefixes repeat — '5n3e' walks five north then three east.
+          category: navigation
+          staff: false
+        areas:
+          usage: areas [<minLevel> [<maxLevel>]]
+          description: List known areas. With one level, shows areas covering that level; with two, shows areas overlapping the range.
+          category: navigation
+          staff: false
         say:
           usage: say <msg> or '<msg>
           category: communication

--- a/src/test/kotlin/dev/ambon/engine/commands/AreasCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/AreasCommandTest.kt
@@ -1,0 +1,101 @@
+package dev.ambon.engine.commands
+
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.config.WeatherConfig
+import dev.ambon.config.WorldEventsConfig
+import dev.ambon.config.WorldTimeConfig
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.engine.CombatSystem
+import dev.ambon.engine.LoginResult
+import dev.ambon.engine.MobRegistry
+import dev.ambon.engine.WeatherSystem
+import dev.ambon.engine.WorldEventSystem
+import dev.ambon.engine.WorldStateRegistry
+import dev.ambon.engine.WorldTimeSystem
+import dev.ambon.engine.commands.handlers.EngineContext
+import dev.ambon.engine.commands.handlers.WorldInfoHandler
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.drainAll
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Clock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AreasCommandTest {
+    private val world = dev.ambon.test.TestWorlds.okSmall
+    private val roomA: RoomId = world.startRoom
+
+    @Test
+    fun `areas with no filter lists known zones`() =
+        runTest {
+            val h = harness()
+            h.router.handle(h.sid, Command.Areas(null, null))
+            val texts = h.outbound.drainAll().filterIsInstance<OutboundEvent.SendInfo>().map { it.text }
+            assertTrue(texts.any { it.startsWith("[ Areas") }, "Expected header, got: $texts")
+            assertTrue(texts.any { it.contains("ok_small") }, "Expected ok_small zone in output: $texts")
+        }
+
+    @Test
+    fun `areas with level filter excludes zones outside range`() =
+        runTest {
+            val h = harness()
+            // ok_small's only mob is level 1 (default); filter to 50-60 should exclude it.
+            h.router.handle(h.sid, Command.Areas(50, 60))
+            val texts = h.outbound.drainAll().filterIsInstance<OutboundEvent.SendInfo>().map { it.text }
+            assertFalse(texts.any { it.contains("ok_small") }, "Expected ok_small to be filtered out: $texts")
+            assertTrue(texts.any { it.contains("no matching areas") }, "Expected empty placeholder: $texts")
+        }
+
+    @Test
+    fun `areas with overlapping range includes zone`() =
+        runTest {
+            val h = harness()
+            h.router.handle(h.sid, Command.Areas(1, 5))
+            val texts = h.outbound.drainAll().filterIsInstance<OutboundEvent.SendInfo>().map { it.text }
+            assertTrue(texts.any { it.contains("ok_small") }, "Expected ok_small zone in output: $texts")
+        }
+
+    private data class Harness(
+        val sid: SessionId,
+        val router: CommandRouter,
+        val outbound: LocalOutboundBus,
+    )
+
+    private suspend fun harness(): Harness {
+        val items = ItemRegistry()
+        items.loadSpawns(world.itemSpawns)
+        val outbound = LocalOutboundBus()
+        val players = dev.ambon.test.buildTestPlayerRegistry(roomA, InMemoryPlayerRepository(), items)
+        val mobs = MobRegistry()
+        val worldState = WorldStateRegistry(world)
+        val router = CommandRouter(outbound = outbound, players = players)
+        val ctx = EngineContext(
+            players = players,
+            mobs = mobs,
+            world = world,
+            items = items,
+            outbound = outbound,
+            combat = CombatSystem(players, mobs, items, outbound),
+            gmcpEmitter = null,
+            worldState = worldState,
+        )
+        val clock = Clock.systemUTC()
+        WorldInfoHandler(
+            ctx = ctx,
+            worldTimeSystem = WorldTimeSystem(WorldTimeConfig(), clock),
+            weatherSystem = WeatherSystem(WeatherConfig(), clock),
+            worldEventSystem = WorldEventSystem(WorldEventsConfig(), clock),
+        ).register(router)
+        val sid = SessionId(1)
+        val res = players.login(sid, "Cartograph", "password")
+        require(res == LoginResult.Ok)
+        outbound.drainAll()
+        return Harness(sid, router, outbound)
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
@@ -1065,4 +1065,96 @@ class CommandParserTest {
     fun `describe check without player name is Invalid`() {
         assertTrue(CommandParser.parse("describe check") is Command.Invalid)
     }
+
+    // ---- Areas ----
+
+    @Test
+    fun `areas with no args returns Areas with nulls`() {
+        assertEquals(Command.Areas(null, null), CommandParser.parse("areas"))
+        assertEquals(Command.Areas(null, null), CommandParser.parse("area"))
+    }
+
+    @Test
+    fun `areas with single level returns Areas with same min and max`() {
+        assertEquals(Command.Areas(5, 5), CommandParser.parse("areas 5"))
+    }
+
+    @Test
+    fun `areas with two levels returns Areas with range`() {
+        assertEquals(Command.Areas(3, 10), CommandParser.parse("areas 3 10"))
+    }
+
+    @Test
+    fun `areas with bad range returns Invalid`() {
+        assertTrue(CommandParser.parse("areas 10 3") is Command.Invalid)
+        assertTrue(CommandParser.parse("areas foo") is Command.Invalid)
+        assertTrue(CommandParser.parse("areas 1 2 3") is Command.Invalid)
+        assertTrue(CommandParser.parse("areas -1") is Command.Invalid)
+    }
+
+    // ---- Run ----
+
+    @Test
+    fun `run parses single direction`() {
+        assertEquals(Command.Run(listOf(Direction.NORTH)), CommandParser.parse("run n"))
+    }
+
+    @Test
+    fun `run parses consecutive single chars`() {
+        assertEquals(
+            Command.Run(listOf(Direction.NORTH, Direction.SOUTH, Direction.EAST, Direction.WEST)),
+            CommandParser.parse("run nsew"),
+        )
+    }
+
+    @Test
+    fun `run parses count prefixes`() {
+        val expected = Command.Run(
+            listOf(
+                Direction.NORTH,
+                Direction.NORTH,
+                Direction.NORTH,
+                Direction.NORTH,
+                Direction.NORTH,
+                Direction.EAST,
+                Direction.EAST,
+                Direction.EAST,
+            ),
+        )
+        assertEquals(expected, CommandParser.parse("run 5n3e"))
+    }
+
+    @Test
+    fun `run accepts up and down`() {
+        assertEquals(
+            Command.Run(listOf(Direction.UP, Direction.UP, Direction.DOWN)),
+            CommandParser.parse("run 2u1d"),
+        )
+    }
+
+    @Test
+    fun `run ignores internal whitespace`() {
+        assertEquals(
+            Command.Run(listOf(Direction.NORTH, Direction.NORTH, Direction.EAST)),
+            CommandParser.parse("run 2n 1e"),
+        )
+    }
+
+    @Test
+    fun `run with no arg is Invalid`() {
+        assertTrue(CommandParser.parse("run") is Command.Invalid)
+        assertTrue(CommandParser.parse("run   ") is Command.Invalid)
+    }
+
+    @Test
+    fun `run with bad direction is Invalid`() {
+        assertTrue(CommandParser.parse("run nxn") is Command.Invalid)
+        assertTrue(CommandParser.parse("run 5") is Command.Invalid)
+        assertTrue(CommandParser.parse("run 0n") is Command.Invalid)
+    }
+
+    @Test
+    fun `run with too many steps is Invalid`() {
+        assertTrue(CommandParser.parse("run 200n") is Command.Invalid)
+    }
 }

--- a/src/test/kotlin/dev/ambon/engine/commands/RunCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/RunCommandTest.kt
@@ -1,0 +1,105 @@
+package dev.ambon.engine.commands
+
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.world.Direction
+import dev.ambon.engine.CombatSystem
+import dev.ambon.engine.LoginResult
+import dev.ambon.engine.MobRegistry
+import dev.ambon.engine.WorldStateRegistry
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.drainAll
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RunCommandTest {
+    private val world = dev.ambon.test.TestWorlds.okSmall
+    private val roomA: RoomId = world.startRoom
+    private val roomB = RoomId("ok_small:b")
+
+    @Test
+    fun `run executes multiple moves in sequence`() =
+        runTest {
+            val h = harness()
+            // a -> b -> a (north then south)
+            h.router.handle(h.sid, Command.Run(listOf(Direction.NORTH, Direction.SOUTH)))
+            h.outbound.drainAll()
+            assertEquals(roomA, h.players.get(h.sid)?.roomId)
+        }
+
+    @Test
+    fun `run keeps trying after an invalid move`() =
+        runTest {
+            val h = harness()
+            // From a, can go north to b. Going north again fails. Then south goes back to a.
+            h.router.handle(h.sid, Command.Run(listOf(Direction.NORTH, Direction.NORTH, Direction.SOUTH)))
+            val outs = h.outbound.drainAll()
+            assertEquals(roomA, h.players.get(h.sid)?.roomId)
+            // The middle step should have failed with "can't go that way".
+            assertTrue(
+                outs.any { it is OutboundEvent.SendError && it.text.contains("can't go", ignoreCase = true) },
+                "Expected a failed-move error among outputs",
+            )
+        }
+
+    @Test
+    fun `run with empty steps sends usage error`() =
+        runTest {
+            val h = harness()
+            h.router.handle(h.sid, Command.Run(emptyList()))
+            val outs = h.outbound.drainAll()
+            assertTrue(
+                outs.any { it is OutboundEvent.SendError && it.text.contains("Usage", ignoreCase = true) },
+                "Expected usage error for empty run",
+            )
+            assertEquals(roomA, h.players.get(h.sid)?.roomId)
+        }
+
+    @Test
+    fun `parser run command moves player to destination`() =
+        runTest {
+            val h = harness()
+            val cmd = CommandParser.parse("run 1n") as Command.Run
+            h.router.handle(h.sid, cmd)
+            h.outbound.drainAll()
+            assertEquals(roomB, h.players.get(h.sid)?.roomId)
+        }
+
+    private data class Harness(
+        val sid: SessionId,
+        val players: dev.ambon.engine.PlayerRegistry,
+        val router: CommandRouter,
+        val outbound: LocalOutboundBus,
+    )
+
+    private suspend fun harness(): Harness {
+        val items = ItemRegistry()
+        items.loadSpawns(world.itemSpawns)
+        val outbound = LocalOutboundBus()
+        val players = dev.ambon.test.buildTestPlayerRegistry(roomA, InMemoryPlayerRepository(), items)
+        val mobs = MobRegistry()
+        val worldState = WorldStateRegistry(world)
+        val router =
+            buildTestRouter(
+                world = world,
+                players = players,
+                mobs = mobs,
+                items = items,
+                combat = CombatSystem(players, mobs, items, outbound),
+                outbound = outbound,
+                worldState = worldState,
+            )
+        val sid = SessionId(1)
+        val res = players.login(sid, "Runner", "password")
+        require(res == LoginResult.Ok)
+        outbound.drainAll()
+        return Harness(sid, players, router, outbound)
+    }
+}


### PR DESCRIPTION
## Summary
- New `areas [<minLevel> [<maxLevel>]]` command lists known zones with their level ranges (authored BOUNDED scaling range, falling back to min/max of mob template levels in that zone), filtered by overlap with the requested range.
- New `run <directions>` command walks a sequence of single-letter directions with numeric repeats — `run 5n3e` resolves to five norths followed by three easts. Each step reuses the normal move handler so blocked/invalid moves emit their usual feedback (matching feature-parity request). Capped at 100 steps; bails out on cross-zone hops to avoid racing the async handoff.
- Both register under `ambonmud.commands.entries` in `application.yaml`, so the web client's autocomplete, command palette, and help panel pick them up automatically via the existing `Server.Commands` GMCP packet — no TS changes needed.

## Test plan
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew test --tests "dev.ambon.engine.commands.*"`
- [x] New unit tests:
  - `CommandParserTest` — covers `areas` (no-arg, single level, range, invalid cases) and `run` (single dir, multi-char, count prefixes, up/down, whitespace, invalid direction, count overflow)
  - `AreasCommandTest` — router test verifying header, filtering, and empty-result message
  - `RunCommandTest` — router test verifying sequential moves, behavior on invalid steps, and parser→handler round-trip
- [x] `bun run lint` and `bun run build` in `web-v3/` — clean