### PR TITLE
feat(multiclass): add maxClasses cap and exponential gold scaling

### DIFF
--- a/docs/GMCP_PROTOCOL.md
+++ b/docs/GMCP_PROTOCOL.md
@@ -1208,6 +1208,8 @@ Subscribe with `"Trainer 1"`.
   "availableSkillPoints": 3,
   "multiclassMinLevel": 10,
   "multiclassGoldCost": 500,
+  "multiclassMaxClasses": 3,
+  "multiclassUnlockedCount": 1,
   "abilities": [
     {
       "id": "power_strike",
@@ -1233,7 +1235,9 @@ Subscribe with `"Trainer 1"`.
 | `classUnlocked`        | boolean            | Whether this class is unlocked for the player |
 | `availableSkillPoints` | int                | Points the player can spend right now |
 | `multiclassMinLevel`   | int                | Minimum level to unlock a new class |
-| `multiclassGoldCost`   | long               | Gold cost to unlock a new class |
+| `multiclassGoldCost`   | long               | Gold cost for **this player's next** unlock — already includes the exponential `goldCostMultiplier` scaling |
+| `multiclassMaxClasses` | int                | Hard cap on the player's total unlocked classes (including starter) |
+| `multiclassUnlockedCount` | int             | Player's current unlocked-class count (compare to `multiclassMaxClasses` to detect "at limit") |
 | `abilities[]`          | array              | Abilities available to learn at this trainer |
 | `abilities[].id`       | string             | Ability ID (for `train learn <id>`) |
 | `abilities[].levelRequired` | int           | Minimum player level to learn |

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -2302,9 +2302,43 @@ data class RespecConfig(
 data class MulticlassConfig(
     /** Minimum player level required to unlock an additional class. */
     val minLevel: Int = 10,
-    /** Gold cost to unlock a new class at a trainer. */
+    /** Base gold cost to unlock a new class at a trainer (charged for the first trainer unlock). */
     val goldCost: Long = 500L,
-)
+    /**
+     * Maximum number of classes a player may have unlocked (including their starter class).
+     * Defaults to effectively unlimited so existing deployments keep working unchanged;
+     * curated `application.yaml` ships a tighter cap.
+     */
+    val maxClasses: Int = Int.MAX_VALUE,
+    /**
+     * Exponential multiplier applied per additional class beyond the first trainer unlock.
+     * Cost for the Nth trainer unlock is `goldCost * goldCostMultiplier^(N-1)`, so the first
+     * trainer unlock costs `goldCost`, the second `goldCost * multiplier`, and so on. Default
+     * 1.0 keeps the cost flat (no-op).
+     */
+    val goldCostMultiplier: Double = 1.0,
+) {
+    init {
+        require(minLevel >= 1) { "multiclass.minLevel must be >= 1, got $minLevel" }
+        require(goldCost >= 0L) { "multiclass.goldCost must be >= 0, got $goldCost" }
+        require(maxClasses >= 1) { "multiclass.maxClasses must be >= 1, got $maxClasses" }
+        require(goldCostMultiplier >= 1.0) {
+            "multiclass.goldCostMultiplier must be >= 1.0, got $goldCostMultiplier"
+        }
+    }
+
+    /**
+     * Gold required for the next trainer unlock given the player's current unlocked-class
+     * count (which always includes the starter class, so the first trainer unlock passes
+     * `currentlyUnlocked = 1`). Saturates at [Long.MAX_VALUE] for absurd configurations.
+     */
+    fun costFor(currentlyUnlocked: Int): Long {
+        val priorTrainerUnlocks = (currentlyUnlocked - 1).coerceAtLeast(0)
+        if (priorTrainerUnlocks == 0 || goldCostMultiplier == 1.0) return goldCost
+        val scaled = goldCost.toDouble() * Math.pow(goldCostMultiplier, priorTrainerUnlocks.toDouble())
+        return if (scaled >= Long.MAX_VALUE.toDouble()) Long.MAX_VALUE else scaled.toLong()
+    }
+}
 
 data class GlobalQuestObjectiveConfig(
     /** Objective type: "kill", "gather", or "craft". */

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -713,7 +713,9 @@ class GmcpEmitter(
                 image = trainer.image,
                 availableSkillPoints = availableSkillPoints,
                 multiclassMinLevel = multiclassConfig.minLevel,
-                multiclassGoldCost = multiclassConfig.goldCost,
+                multiclassGoldCost = multiclassConfig.costFor(player.unlockedClasses.size),
+                multiclassMaxClasses = multiclassConfig.maxClasses,
+                multiclassUnlockedCount = player.unlockedClasses.size,
                 classes = classPayloads,
             ),
             supportCheck = "Trainer",
@@ -2455,7 +2457,12 @@ class GmcpEmitter(
         val image: String?,
         val availableSkillPoints: Int,
         val multiclassMinLevel: Int,
+        /** Gold cost for *this player's next* unlock; already includes the exponential scaling. */
         val multiclassGoldCost: Long,
+        /** Hard cap on the player's total unlocked classes (including starter). */
+        val multiclassMaxClasses: Int,
+        /** Player's current unlocked-class count (including starter). */
+        val multiclassUnlockedCount: Int,
         /**
          * One entry per class this trainer teaches. Always non-empty. Single-class
          * trainers emit a one-element list — clients can still render the old

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/TrainerHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/TrainerHandler.kt
@@ -85,13 +85,16 @@ class TrainerHandler(
 
                 if (!classUnlocked) {
                     val unlockArg = if (trainer.isMultiClass) " ${className.lowercase()}" else ""
-                    outbound.send(
-                        OutboundEvent.SendInfo(
-                            sessionId,
-                            "  ** $className class locked. Use 'train unlock$unlockArg' to pay " +
-                                "${multiclassConfig.goldCost} gold (requires level ${multiclassConfig.minLevel}). **",
-                        ),
-                    )
+                    val atLimit = me.unlockedClasses.size >= multiclassConfig.maxClasses
+                    val lockMsg = if (atLimit) {
+                        "  ** $className class locked. You have reached the limit of " +
+                            "${multiclassConfig.maxClasses} unlocked classes. **"
+                    } else {
+                        val cost = multiclassConfig.costFor(me.unlockedClasses.size)
+                        "  ** $className class locked. Use 'train unlock$unlockArg' to pay " +
+                            "$cost gold (requires level ${multiclassConfig.minLevel}). **"
+                    }
+                    outbound.send(OutboundEvent.SendInfo(sessionId, lockMsg))
                     continue
                 }
 
@@ -348,7 +351,16 @@ class TrainerHandler(
                 )
                 return
             }
-            val cost = multiclassConfig.goldCost
+            if (me.unlockedClasses.size >= multiclassConfig.maxClasses) {
+                outbound.send(
+                    OutboundEvent.SendError(
+                        sessionId,
+                        "You have already unlocked the maximum of ${multiclassConfig.maxClasses} classes.",
+                    ),
+                )
+                return
+            }
+            val cost = multiclassConfig.costFor(me.unlockedClasses.size)
             if (!me.isStaff && me.gold < cost) {
                 outbound.send(
                     OutboundEvent.SendError(

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1861,6 +1861,11 @@ ambonmud:
     multiclass:
       minLevel: 15
       goldCost: 500
+      # Hard cap on total unlocked classes per player (includes the starter class).
+      maxClasses: 3
+      # Exponential scaling on gold cost: the Nth trainer unlock costs
+      # goldCost * goldCostMultiplier^(N-1). With these values: 500g, then 1000g, then 2000g.
+      goldCostMultiplier: 2.0
     housing:
       enabled: true
       entryExitDirection: SOUTH

--- a/src/test/kotlin/dev/ambon/engine/commands/TrainerUnlockEconomicsTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/TrainerUnlockEconomicsTest.kt
@@ -1,0 +1,262 @@
+package dev.ambon.engine.commands
+
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.config.MulticlassConfig
+import dev.ambon.config.RespecConfig
+import dev.ambon.config.SkillPointsConfig
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.world.Room
+import dev.ambon.domain.world.TrainerDefinition
+import dev.ambon.domain.world.World
+import dev.ambon.engine.CombatSystem
+import dev.ambon.engine.MobRegistry
+import dev.ambon.engine.TrainerRegistry
+import dev.ambon.engine.abilities.AbilityRegistry
+import dev.ambon.engine.abilities.AbilitySystem
+import dev.ambon.engine.commands.handlers.EngineContext
+import dev.ambon.engine.commands.handlers.TrainerHandler
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.MutableClock
+import dev.ambon.test.buildTestPlayerRegistry
+import dev.ambon.test.drainAll
+import dev.ambon.test.errorMessages
+import dev.ambon.test.infoMessages
+import dev.ambon.test.loginOrFail
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TrainerUnlockEconomicsTest {
+    @Nested
+    inner class CostFor {
+        @Test
+        fun `flat cost when multiplier is 1`() {
+            val cfg = MulticlassConfig(goldCost = 500, goldCostMultiplier = 1.0)
+            // Starter only: first trainer unlock pays the base.
+            assertEquals(500L, cfg.costFor(currentlyUnlocked = 1))
+            assertEquals(500L, cfg.costFor(currentlyUnlocked = 5))
+        }
+
+        @Test
+        fun `exponential scaling kicks in after the first trainer unlock`() {
+            val cfg = MulticlassConfig(goldCost = 500, goldCostMultiplier = 2.0)
+            assertEquals(500L, cfg.costFor(currentlyUnlocked = 1)) // 500 * 2^0
+            assertEquals(1000L, cfg.costFor(currentlyUnlocked = 2)) // 500 * 2^1
+            assertEquals(2000L, cfg.costFor(currentlyUnlocked = 3)) // 500 * 2^2
+            assertEquals(4000L, cfg.costFor(currentlyUnlocked = 4)) // 500 * 2^3
+        }
+
+        @Test
+        fun `non-integer multiplier rounds toward zero`() {
+            val cfg = MulticlassConfig(goldCost = 100, goldCostMultiplier = 1.5)
+            assertEquals(100L, cfg.costFor(currentlyUnlocked = 1))
+            assertEquals(150L, cfg.costFor(currentlyUnlocked = 2))
+            assertEquals(225L, cfg.costFor(currentlyUnlocked = 3))
+        }
+
+        @Test
+        fun `zero or negative current count is treated as the first unlock`() {
+            val cfg = MulticlassConfig(goldCost = 500, goldCostMultiplier = 2.0)
+            assertEquals(500L, cfg.costFor(currentlyUnlocked = 0))
+            assertEquals(500L, cfg.costFor(currentlyUnlocked = -3))
+        }
+
+        @Test
+        fun `validation rejects bad inputs`() {
+            assertThrows(IllegalArgumentException::class.java) { MulticlassConfig(maxClasses = 0) }
+            assertThrows(IllegalArgumentException::class.java) { MulticlassConfig(goldCost = -1) }
+            assertThrows(IllegalArgumentException::class.java) { MulticlassConfig(minLevel = 0) }
+            assertThrows(IllegalArgumentException::class.java) { MulticlassConfig(goldCostMultiplier = 0.5) }
+        }
+    }
+
+    // ── Router-level integration ─────────────────────────────────────────
+
+    companion object {
+        private val TRAINER_ROOM = RoomId("test:trainer")
+        private val SID = SessionId(1L)
+    }
+
+    private lateinit var clock: MutableClock
+    private lateinit var outbound: LocalOutboundBus
+    private lateinit var repo: InMemoryPlayerRepository
+    private lateinit var items: ItemRegistry
+    private lateinit var router: CommandRouter
+    private lateinit var players: dev.ambon.engine.PlayerRegistry
+
+    private val skillPointsConfig = SkillPointsConfig(interval = 2)
+    private val respecConfig = RespecConfig(enabled = true, goldCost = 1000, cooldownMs = 0)
+
+    private fun buildWorld(): World = World(
+        rooms = mapOf(
+            TRAINER_ROOM to Room(
+                id = TRAINER_ROOM,
+                title = "Hall of Mentors",
+                description = "Trainers of every stripe gather here.",
+                exits = emptyMap(),
+            ),
+        ),
+        startRoom = TRAINER_ROOM,
+    )
+
+    private fun setUpHandler(multiclassConfig: MulticlassConfig) {
+        clock = MutableClock(0L)
+        outbound = LocalOutboundBus()
+        repo = InMemoryPlayerRepository()
+        items = ItemRegistry()
+        val world = buildWorld()
+        players = buildTestPlayerRegistry(
+            startRoom = TRAINER_ROOM,
+            repo = repo,
+            items = items,
+            clock = clock,
+        )
+        val mobs = MobRegistry()
+        val combat = CombatSystem(players, mobs, items, outbound)
+        val abilityRegistry = AbilityRegistry()
+        val abilitySystem = AbilitySystem(
+            players = players,
+            registry = abilityRegistry,
+            outbound = outbound,
+            combat = combat,
+            clock = clock,
+        )
+        val trainerRegistry = TrainerRegistry()
+        trainerRegistry.register(
+            listOf(
+                TrainerDefinition(
+                    id = "polyglot_trainer",
+                    name = "Master Polyglot",
+                    classNames = listOf("MAGE", "ROGUE", "WARRIOR"),
+                    roomId = TRAINER_ROOM,
+                ),
+            ),
+        )
+        val ctx = EngineContext(
+            players = players,
+            mobs = mobs,
+            world = world,
+            items = items,
+            outbound = outbound,
+            combat = combat,
+            gmcpEmitter = null,
+            worldState = null,
+        )
+        router = CommandRouter(outbound = outbound, players = players)
+        TrainerHandler(
+            ctx = ctx,
+            abilitySystem = abilitySystem,
+            trainerRegistry = trainerRegistry,
+            skillPointsConfig = skillPointsConfig,
+            multiclassConfig = multiclassConfig,
+            respecConfig = respecConfig,
+            clock = clock,
+        ).register(router)
+    }
+
+    private suspend fun loginAt(level: Int, gold: Long, starterClass: String = "MAGE") {
+        repo.create(
+            dev.ambon.persistence.PlayerCreationRequest(
+                name = "Tester",
+                startRoomId = TRAINER_ROOM,
+                nowEpochMs = 0L,
+                passwordHash = dev.ambon.test.TestPasswordHasher.hash("password"),
+                ansiEnabled = false,
+            ),
+        )
+        players.loginOrFail(SID, "Tester", "password")
+        outbound.drainAll()
+        val me = players.get(SID)!!
+        me.level = level
+        me.gold = gold
+        me.playerClass = starterClass
+        me.unlockedClasses.clear()
+        me.unlockedClasses.add(starterClass)
+    }
+
+    @BeforeEach
+    fun setUp() {
+        // Each test calls setUpHandler() with its own multiclass config.
+    }
+
+    @Test
+    fun `gold cost scales exponentially across successive unlocks`() = runTest {
+        setUpHandler(MulticlassConfig(minLevel = 1, goldCost = 500, maxClasses = 5, goldCostMultiplier = 2.0))
+        loginAt(level = 20, gold = 5000)
+        val me = players.get(SID)!!
+
+        // 1st trainer unlock: starter MAGE → +ROGUE, costs 500 (base).
+        router.handle(SID, Command.Train.Unlock(className = "rogue"))
+        assertEquals(setOf("MAGE", "ROGUE"), me.unlockedClasses)
+        assertEquals(4500L, me.gold)
+
+        // 2nd trainer unlock: +WARRIOR, costs 500 * 2^1 = 1000.
+        router.handle(SID, Command.Train.Unlock(className = "warrior"))
+        assertEquals(setOf("MAGE", "ROGUE", "WARRIOR"), me.unlockedClasses)
+        assertEquals(3500L, me.gold)
+    }
+
+    @Test
+    fun `unlock fails when player would exceed maxClasses`() = runTest {
+        setUpHandler(MulticlassConfig(minLevel = 1, goldCost = 100, maxClasses = 2, goldCostMultiplier = 1.0))
+        loginAt(level = 20, gold = 5000)
+        val me = players.get(SID)!!
+
+        router.handle(SID, Command.Train.Unlock(className = "rogue"))
+        assertEquals(2, me.unlockedClasses.size)
+        outbound.drainAll()
+
+        router.handle(SID, Command.Train.Unlock(className = "warrior"))
+        val errs = outbound.drainAll().errorMessages(SID)
+        assertTrue(
+            errs.any { it.contains("maximum of 2 classes") },
+            "Expected max-classes error, got: $errs",
+        )
+        assertFalse("WARRIOR" in me.unlockedClasses)
+        assertEquals(4900L, me.gold) // unchanged after failed unlock
+    }
+
+    @Test
+    fun `train list shows scaled cost for the next unlock`() = runTest {
+        setUpHandler(MulticlassConfig(minLevel = 1, goldCost = 500, maxClasses = 5, goldCostMultiplier = 2.0))
+        loginAt(level = 20, gold = 5000)
+        // Already unlocked one class via trainer → next cost should be 500 * 2 = 1000.
+        players.get(SID)!!.unlockedClasses.add("ROGUE")
+        outbound.drainAll()
+
+        router.handle(SID, Command.Train.List)
+        val texts = outbound.drainAll().infoMessages(SID)
+        assertTrue(
+            texts.any { it.contains("pay 1000 gold") },
+            "Expected scaled cost in lock hint, got: $texts",
+        )
+    }
+
+    @Test
+    fun `train list reports limit reached instead of cost when at max`() = runTest {
+        setUpHandler(MulticlassConfig(minLevel = 1, goldCost = 500, maxClasses = 2, goldCostMultiplier = 2.0))
+        loginAt(level = 20, gold = 5000)
+        players.get(SID)!!.unlockedClasses.add("ROGUE") // now at max=2
+        outbound.drainAll()
+
+        router.handle(SID, Command.Train.List)
+        val texts = outbound.drainAll().infoMessages(SID)
+        assertTrue(
+            texts.any { it.contains("limit of 2 unlocked classes") },
+            "Expected limit-reached hint, got: $texts",
+        )
+        assertFalse(
+            texts.any { it.contains("pay") && it.contains("gold") },
+            "Should not show pay-gold hint when at limit, got: $texts",
+        )
+    }
+}

--- a/web-v3/src/components/TrainerPanel.tsx
+++ b/web-v3/src/components/TrainerPanel.tsx
@@ -174,21 +174,42 @@ export function TrainerPanel({ trainer, playerLevel, playerGold, onCommand }: Tr
           <p className="trainer-locked-msg">
             The <strong>{classLabel}</strong> class is locked.
           </p>
-          <p className="trainer-locked-req">
-            Requires level {trainer.multiclassMinLevel} and {trainer.multiclassGoldCost.toLocaleString()} gold.
-          </p>
           {(() => {
-            const canUnlock = playerLevel >= trainer.multiclassMinLevel && playerGold >= trainer.multiclassGoldCost;
+            const atLimit = trainer.multiclassUnlockedCount >= trainer.multiclassMaxClasses;
+            if (atLimit) {
+              return (
+                <>
+                  <p className="trainer-locked-req">
+                    You have reached the limit of {trainer.multiclassMaxClasses} unlocked classes.
+                  </p>
+                  <button
+                    type="button"
+                    className="trainer-unlock-btn trainer-unlock-btn-disabled"
+                    disabled
+                    title="Class limit reached"
+                  >
+                    Class limit reached
+                  </button>
+                </>
+              );
+            }
+            const canUnlock =
+              playerLevel >= trainer.multiclassMinLevel && playerGold >= trainer.multiclassGoldCost;
             return (
-              <button
-                type="button"
-                className={`trainer-unlock-btn${canUnlock ? "" : " trainer-unlock-btn-disabled"}`}
-                disabled={!canUnlock}
-                title={canUnlock ? `Unlock the ${classLabel} class` : "Requirements not met"}
-                onClick={() => onCommand(unlockCmd)}
-              >
-                Unlock {classLabel} ({trainer.multiclassGoldCost.toLocaleString()} gold)
-              </button>
+              <>
+                <p className="trainer-locked-req">
+                  Requires level {trainer.multiclassMinLevel} and {trainer.multiclassGoldCost.toLocaleString()} gold.
+                </p>
+                <button
+                  type="button"
+                  className={`trainer-unlock-btn${canUnlock ? "" : " trainer-unlock-btn-disabled"}`}
+                  disabled={!canUnlock}
+                  title={canUnlock ? `Unlock the ${classLabel} class` : "Requirements not met"}
+                  onClick={() => onCommand(unlockCmd)}
+                >
+                  Unlock {classLabel} ({trainer.multiclassGoldCost.toLocaleString()} gold)
+                </button>
+              </>
             );
           })()}
         </div>

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -2109,6 +2109,8 @@ export function applyGmcpPackage(
         availableSkillPoints: safeNumber(packet.availableSkillPoints),
         multiclassMinLevel: safeNumber(packet.multiclassMinLevel, 10),
         multiclassGoldCost: safeNumber(packet.multiclassGoldCost, 500),
+        multiclassMaxClasses: safeNumber(packet.multiclassMaxClasses, Number.MAX_SAFE_INTEGER),
+        multiclassUnlockedCount: safeNumber(packet.multiclassUnlockedCount, 1),
         classes,
       };
       ctx.setTrainer(trainer);

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -880,7 +880,12 @@ export interface TrainerData {
   image: string | null;
   availableSkillPoints: number;
   multiclassMinLevel: number;
+  /** Gold cost for *this player's next* unlock; already scaled by the multiplier. */
   multiclassGoldCost: number;
+  /** Hard cap on the player's total unlocked classes (including starter). */
+  multiclassMaxClasses: number;
+  /** Player's current unlocked-class count (including starter). */
+  multiclassUnlockedCount: number;
   /** One entry per class this trainer teaches. Always non-empty. */
   classes: TrainerClass[];
 }


### PR DESCRIPTION
## Summary

Two new knobs on `MulticlassConfig` (`ambonmud.engine.multiclass`):

- **`maxClasses`** — hard cap on a player's total unlocked classes (starter counts toward it). Kotlin default is effectively unlimited so external configs that omit it keep working; bundled `application.yaml` ships `3`.
- **`goldCostMultiplier`** — exponential scaling. The Nth trainer unlock costs `goldCost × multiplier^(N-1)`, so with the bundled defaults the cost goes **500g → 1000g → 2000g**. Defaults to `1.0` (flat / no-op).

Cost is computed via a single new `MulticlassConfig.costFor(currentlyUnlocked)` helper used by both `TrainerHandler` and `GmcpEmitter`, with overflow-safe `Long.MAX_VALUE` saturation.

### User-visible behavior

- `train list` lock hint now shows the *next* dynamic cost, or "limit of N unlocked classes" when the player is at the cap.
- `train unlock` rejects with a clear error when the player would exceed `maxClasses` and uses the scaled cost.
- `Trainer.List` GMCP payload's `multiclassGoldCost` is now per-player (already scaled). New `multiclassMaxClasses` and `multiclassUnlockedCount` fields let the web `TrainerPanel` render a disabled "Class limit reached" button.

### Bundled config (`application.yaml`)

```yaml
multiclass:
  minLevel: 15
  goldCost: 500
  maxClasses: 3
  goldCostMultiplier: 2.0
```

### Files

- `AppConfig.kt` — extended `MulticlassConfig` + `costFor()` helper + `init` validation
- `TrainerHandler.kt` — dynamic cost in lock hint + max-class guard in unlock path
- `GmcpEmitter.kt` — per-player cost + new payload fields
- `web-v3/{types.ts, gmcp/applyGmcpPackage.ts, components/TrainerPanel.tsx}` — surface the cap on the client
- `docs/GMCP_PROTOCOL.md` — payload doc updated
- `application.yaml` — bundled defaults
- `TrainerUnlockEconomicsTest.kt` — new focused tests

## Test plan

- [x] `./gradlew ktlintCheck` clean
- [x] `./gradlew test --tests "*Trainer*" --tests "*AppConfig*" --tests "*PersistenceFieldCoverage*"` all green
- [x] `bun run lint` (web client) clean
- [ ] Manual smoke: visit a multi-class trainer, verify lock hint shows scaled cost, unlock first class (base price), unlock second (×multiplier), confirm third unlock blocked at `maxClasses=3` with the limit message and disabled web button