### PR TITLE
feat(items): accept Arcanum design-time metadata fields

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/world/data/ItemFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/ItemFile.kt
@@ -21,4 +21,16 @@ data class ItemFile(
     val video: String? = null,
     val itemType: String? = null,
     val questItem: Boolean = false,
+    /**
+     * Optional design-time metadata authored by the Arcanum creator. Accepted
+     * for round-trip preservation; the server treats `damage`, `armor`, and
+     * `stats` above as authoritative and does not recompute them from
+     * `level`/`tier`/`archetype`.
+     */
+    val level: Int? = null,
+    val tier: String? = null,
+    val archetype: String? = null,
+    val primaryStat: String? = null,
+    val secondaryStat: String? = null,
+    val tertiaryStat: String? = null,
 )

--- a/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
@@ -1,12 +1,16 @@
 package dev.ambon.domain.world.load
 
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.items.ItemSlot
 import dev.ambon.domain.items.ItemType
 import dev.ambon.domain.world.Direction
 import dev.ambon.domain.world.WorldFactory
+import dev.ambon.domain.world.data.ItemFile
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
@@ -266,6 +270,38 @@ class WorldLoaderTest {
         val helm = items.getValue("ok_item_metadata:helm")
         assertEquals(ItemSlot.HEAD, helm.instance.item.slot)
         assertEquals(2, helm.instance.item.armor)
+    }
+
+    @Test
+    fun `ItemFile deserializes Arcanum metadata fields with strict mapping`() {
+        // Round-trip via a strict mapper (FAIL_ON_UNKNOWN_PROPERTIES enabled)
+        // proves the new fields are actually declared on ItemFile, not just
+        // silently dropped by WorldLoader's lenient mapper.
+        val strictMapper =
+            ObjectMapper(YAMLFactory())
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
+                .registerModule(KotlinModule.Builder().build())
+        val yaml =
+            """
+            displayName: "test blade"
+            slot: weapon
+            damage: 5
+            level: 10
+            tier: rare
+            archetype: damage
+            primaryStat: STR
+            secondaryStat: DEX
+            tertiaryStat: CON
+            """.trimIndent()
+        val item: ItemFile = strictMapper.readValue(yaml)
+        assertEquals(10, item.level)
+        assertEquals("rare", item.tier)
+        assertEquals("damage", item.archetype)
+        assertEquals("STR", item.primaryStat)
+        assertEquals("DEX", item.secondaryStat)
+        assertEquals("CON", item.tertiaryStat)
+        // Existing fields still authoritative.
+        assertEquals(5, item.damage)
     }
 
     @Test

--- a/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
@@ -254,6 +254,21 @@ class WorldLoaderTest {
     }
 
     @Test
+    fun `accepts Arcanum design-time metadata fields without affecting authored stats`() {
+        val world = WorldLoader.loadFromResource("world/ok_item_metadata.yaml")
+        val items = world.itemSpawns.associateBy { it.instance.id.value }
+
+        val sword = items.getValue("ok_item_metadata:sword")
+        assertEquals(ItemSlot.WEAPON, sword.instance.item.slot)
+        assertEquals(5, sword.instance.item.damage)
+        assertEquals(2, sword.instance.item.stats["STR"])
+
+        val helm = items.getValue("ok_item_metadata:helm")
+        assertEquals(ItemSlot.HEAD, helm.instance.item.slot)
+        assertEquals(2, helm.instance.item.armor)
+    }
+
+    @Test
     fun `loads declared item types and quest-item flag`() {
         val world = WorldLoader.loadFromResource("world/ok_item_types.yaml")
         val items = world.itemSpawns.associateBy { it.instance.id.value }

--- a/src/test/resources/world/ok_item_metadata.yaml
+++ b/src/test/resources/world/ok_item_metadata.yaml
@@ -1,0 +1,26 @@
+zone: ok_item_metadata
+startRoom: a
+rooms:
+  a:
+    title: "Room A"
+    description: "Start."
+items:
+  sword:
+    displayName: "a short sword"
+    slot: weapon
+    damage: 5
+    stats:
+      STR: 2
+    level: 10
+    tier: rare
+    archetype: damage
+    primaryStat: STR
+    secondaryStat: DEX
+  helm:
+    displayName: "a leather cap"
+    slot: head
+    armor: 2
+    level: 5
+    tier: common
+    archetype: armor
+    primaryStat: CON


### PR DESCRIPTION
## Summary

Adds optional `level` / `tier` / `archetype` / `primaryStat` / `secondaryStat` / `tertiaryStat` fields to `ItemFile` so items exported from the Arcanum creator round-trip through the YAML loader. The server keeps `damage`, `armor`, and `stats` as the authoritative gameplay values and does not recompute them from these design-time fields.

Per the sync spec, the optional ">20% budget-vs-authored" validation warning is intentionally not implemented (no server-side budget formula yet).

## Test plan

- [x] `./gradlew ktlintCheck` — clean
- [x] `./gradlew test` — full suite passes, including new `accepts Arcanum design-time metadata fields without affecting authored stats` test