### PR TITLE
fix(multiclass): widen maxClasses to Long for JS-sentinel decoding

### DIFF
--- a/docs/GMCP_PROTOCOL.md
+++ b/docs/GMCP_PROTOCOL.md
@@ -1236,7 +1236,7 @@ Subscribe with `"Trainer 1"`.
 | `availableSkillPoints` | int                | Points the player can spend right now |
 | `multiclassMinLevel`   | int                | Minimum level to unlock a new class |
 | `multiclassGoldCost`   | long               | Gold cost for **this player's next** unlock — already includes the exponential `goldCostMultiplier` scaling |
-| `multiclassMaxClasses` | int                | Hard cap on the player's total unlocked classes (including starter) |
+| `multiclassMaxClasses` | long               | Hard cap on the player's total unlocked classes (including starter). Long-typed so "unlimited" sentinels written by JS tooling (e.g. `Number.MAX_SAFE_INTEGER`) round-trip cleanly |
 | `multiclassUnlockedCount` | int             | Player's current unlocked-class count (compare to `multiclassMaxClasses` to detect "at limit") |
 | `abilities[]`          | array              | Abilities available to learn at this trainer |
 | `abilities[].id`       | string             | Ability ID (for `train learn <id>`) |

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -2350,8 +2350,11 @@ data class MulticlassConfig(
      * Maximum number of classes a player may have unlocked (including their starter class).
      * Defaults to effectively unlimited so existing deployments keep working unchanged;
      * curated `application.yaml` ships a tighter cap.
+     *
+     * Typed as [Long] so config overlays written by JavaScript tooling (which often uses
+     * `Number.MAX_SAFE_INTEGER` = 2^53−1 as an "unlimited" sentinel) decode without overflow.
      */
-    val maxClasses: Int = Int.MAX_VALUE,
+    val maxClasses: Long = Long.MAX_VALUE,
     /**
      * Exponential multiplier applied per additional class beyond the first trainer unlock.
      * Cost for the Nth trainer unlock is `goldCost * goldCostMultiplier^(N-1)`, so the first

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -2460,7 +2460,7 @@ class GmcpEmitter(
         /** Gold cost for *this player's next* unlock; already includes the exponential scaling. */
         val multiclassGoldCost: Long,
         /** Hard cap on the player's total unlocked classes (including starter). */
-        val multiclassMaxClasses: Int,
+        val multiclassMaxClasses: Long,
         /** Player's current unlocked-class count (including starter). */
         val multiclassUnlockedCount: Int,
         /**

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/TrainerHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/TrainerHandler.kt
@@ -85,7 +85,7 @@ class TrainerHandler(
 
                 if (!classUnlocked) {
                     val unlockArg = if (trainer.isMultiClass) " ${className.lowercase()}" else ""
-                    val atLimit = me.unlockedClasses.size >= multiclassConfig.maxClasses
+                    val atLimit = me.unlockedClasses.size.toLong() >= multiclassConfig.maxClasses
                     val lockMsg = if (atLimit) {
                         "  ** $className class locked. You have reached the limit of " +
                             "${multiclassConfig.maxClasses} unlocked classes. **"
@@ -351,7 +351,7 @@ class TrainerHandler(
                 )
                 return
             }
-            if (me.unlockedClasses.size >= multiclassConfig.maxClasses) {
+            if (me.unlockedClasses.size.toLong() >= multiclassConfig.maxClasses) {
                 outbound.send(
                     OutboundEvent.SendError(
                         sessionId,

--- a/src/test/kotlin/dev/ambon/config/AppConfigLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/config/AppConfigLoaderTest.kt
@@ -531,4 +531,20 @@ class AppConfigLoaderTest {
         val valid = AppConfig(server = ServerConfig(sessionOutboundQueueCapacity = 100_000), world = validWorld)
         valid.validated() // should not throw
     }
+
+    @Test
+    fun `multiclass maxClasses decodes JavaScript MAX_SAFE_INTEGER sentinel`() {
+        // Regression: prod overlay YAML carried `maxClasses: 9007199254740991` (Number.MAX_SAFE_INTEGER,
+        // the JS-side "unlimited" sentinel). Hoplite refused to decode that into the original `Int`
+        // field and crash-looped the server. Widening the field to `Long` makes the sentinel round-trip.
+        val jsMaxSafeInteger = 9_007_199_254_740_991L
+        val source = PropertySource.map(
+            mapOf("ambonmud.engine.multiclass.maxClasses" to jsMaxSafeInteger.toString()),
+        )
+        val config = AppConfigLoader.load(
+            resourcePath = testResourcePath,
+            extraSources = listOf(source),
+        )
+        assertEquals(jsMaxSafeInteger, config.engine.multiclass.maxClasses)
+    }
 }


### PR DESCRIPTION
## Summary
- Production crash-looped on boot because `application-local.yaml` carried `maxClasses: 9007199254740991` (`Number.MAX_SAFE_INTEGER`, the JS "unlimited" sentinel from our config-authoring tooling) and Hoplite refused to decode that into `MulticlassConfig.maxClasses: Int`.
- Widen `MulticlassConfig.maxClasses` and the matching `Trainer.List` GMCP field to `Long`. Wire format is unchanged (TS already uses `number`; the sentinel fits exactly in `Number`).
- Added a regression test in `AppConfigLoaderTest` that decodes the sentinel via Hoplite end-to-end.

## Test plan
- [x] `./gradlew ktlintCheck` — passes
- [x] `./gradlew test --tests "dev.ambon.config.AppConfigLoaderTest" --tests "dev.ambon.engine.commands.TrainerUnlockEconomicsTest"` — passes (covers the Hoplite path + trainer comparison + GMCP DTO emission)
- [ ] Once merged, deploy to prod and confirm `application-local.yaml` no longer crashes the loader (the original stack trace was the `Could not decode 9007199254740991 into a Int` at `application-local.yaml:2084:18`).