### PR TITLE
feat(combat): add consider command with web client threat assessment

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -15,6 +15,7 @@ import dev.ambon.engine.status.StatusEffectSystem
 import dev.ambon.metrics.GameMetrics
 import java.time.Clock
 import java.util.Random
+import kotlin.math.ceil
 
 data class CombatSystemConfig(
     val tickMillis: Long = 1_000L,
@@ -26,6 +27,49 @@ data class CombatSystemConfig(
     val detailedFeedbackRoomBroadcastEnabled: Boolean = false,
     val bindings: StatBindingsConfig = StatBindingsConfig(),
 )
+
+/** Seven-tier verbal threat rating, ordered from safest to deadliest. */
+enum class ConsiderRating(
+    val label: String,
+    val flavor: String,
+) {
+    TRIVIAL("trivial", "barely a warm-up — they would fall in moments."),
+    EASY("easy", "you should win without breaking a sweat."),
+    FAVORED("favored", "the odds favor you, but you'll take some hits."),
+    EVEN("even", "an even match — it could go either way."),
+    RISKY("risky", "you would be hard pressed to come out on top."),
+    DANGEROUS("dangerous", "this fight would likely be the end of you."),
+    SUICIDAL("suicidal", "you'd be cut down in seconds. Run."),
+}
+
+/** Result of a successful `consider` calculation — fed to both narrative output and GMCP. */
+data class ConsiderResult(
+    val mobId: String,
+    val mobName: String,
+    val mobLevel: Int,
+    val mobMaxHp: Int,
+    val mobCategory: String,
+    val mobImage: String?,
+    val playerLevel: Int,
+    val playerMaxHp: Int,
+    val playerAvgDamage: Int,
+    val mobAvgDamage: Int,
+    val hitsToKillMob: Int,
+    val hitsToKillPlayer: Int,
+    val dodgeChancePct: Int,
+    val winChancePct: Int,
+    val rating: ConsiderRating,
+)
+
+sealed interface ConsiderOutcome {
+    data class Ok(
+        val result: ConsiderResult,
+    ) : ConsiderOutcome
+
+    data class Error(
+        val message: String,
+    ) : ConsiderOutcome
+}
 
 data class CombatSystemCallbacks(
     val onMobRemoved: suspend (MobId, RoomId) -> Unit = { _, _ -> },
@@ -185,6 +229,87 @@ class CombatSystem(
         broadcastToRoom(players, outbound, roomId, "${player.name} attacks ${mob.name}.", exclude = sessionId)
 
         return null
+    }
+
+    /**
+     * Estimate the player's odds against a mob in the same room without engaging.
+     *
+     * Uses expected-value damage (mean of the damage range) on both sides, applies
+     * the player's equipment attack/armor bonuses, the player's STR-derived melee
+     * bonus, and the player's dodge chance. The hits-to-kill ratio is converted into
+     * a win-chance percentage and bucketed into a [ConsiderRating]. Pet contributions
+     * and status-effect modifiers other than current stat mods are deliberately
+     * ignored so the player gets a baseline read on their own capabilities.
+     */
+    fun consider(
+        sessionId: SessionId,
+        keywordRaw: String,
+    ): ConsiderOutcome {
+        val player = players.get(sessionId) ?: return ConsiderOutcome.Error(ERR_NOT_CONNECTED)
+        val keyword = keywordRaw.trim()
+        if (keyword.isEmpty()) return ConsiderOutcome.Error("Consider what?")
+
+        val matches = findMobsInRoom(player.roomId, keyword)
+        if (matches.isEmpty()) return ConsiderOutcome.Error("You don't see '$keyword' here.")
+
+        val mob = matches.first()
+        if (!mob.role.isCombatant) {
+            return ConsiderOutcome.Error("${mob.name} isn't a threat — no need to size them up.")
+        }
+
+        val stats = resolvePlayerStats(player, items, statusEffects)
+        val equip = items.equipmentBonuses(sessionId)
+        val strBonus =
+            PlayerState.statBonus(
+                stats[config.bindings.meleeDamageStat],
+                config.bindings.meleeDamageDivisor,
+            )
+        val playerAvgRoll = (config.minDamage + config.maxDamage) / 2.0
+        val playerAvgDamage = (playerAvgRoll + equip.attack + strBonus - mob.armor).coerceAtLeast(1.0)
+
+        val mobAvgRoll = (mob.damage.min + mob.damage.max) / 2.0
+        val dodgePct =
+            ((stats[config.bindings.dodgeStat] - PlayerState.BASE_STAT) * config.bindings.dodgePerPoint)
+                .coerceIn(0, config.bindings.maxDodgePercent)
+        val effectiveMobDamage = (mobAvgRoll * (1.0 - dodgePct / 100.0)).coerceAtLeast(0.1)
+
+        val hitsToKillMob = ceil(mob.maxHp.toDouble() / playerAvgDamage).toInt().coerceAtLeast(1)
+        val hitsToKillPlayer = ceil(player.maxHp.toDouble() / effectiveMobDamage).toInt().coerceAtLeast(1)
+
+        val winChancePct =
+            (hitsToKillPlayer.toDouble() / (hitsToKillPlayer + hitsToKillMob) * 100.0)
+                .toInt()
+                .coerceIn(0, 100)
+
+        val rating = when {
+            winChancePct >= 95 -> ConsiderRating.TRIVIAL
+            winChancePct >= 75 -> ConsiderRating.EASY
+            winChancePct >= 60 -> ConsiderRating.FAVORED
+            winChancePct >= 40 -> ConsiderRating.EVEN
+            winChancePct >= 25 -> ConsiderRating.RISKY
+            winChancePct >= 10 -> ConsiderRating.DANGEROUS
+            else -> ConsiderRating.SUICIDAL
+        }
+
+        return ConsiderOutcome.Ok(
+            ConsiderResult(
+                mobId = mob.id.value,
+                mobName = mob.name,
+                mobLevel = mob.level,
+                mobMaxHp = mob.maxHp,
+                mobCategory = mob.category,
+                mobImage = mob.image,
+                playerLevel = player.level,
+                playerMaxHp = player.maxHp,
+                playerAvgDamage = playerAvgDamage.toInt(),
+                mobAvgDamage = mobAvgRoll.toInt().coerceAtLeast(1),
+                hitsToKillMob = hitsToKillMob,
+                hitsToKillPlayer = hitsToKillPlayer,
+                dodgeChancePct = dodgePct,
+                winChancePct = winChancePct,
+                rating = rating,
+            ),
+        )
     }
 
     suspend fun flee(

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -169,6 +169,41 @@ class GmcpEmitter(
         emit(sessionId, "Char.Vitals", payload)
     }
 
+    /**
+     * Push a one-shot threat assessment to the player's web client so it can render a
+     * `consider` panel — verbal rating, win percentage, hits-to-kill comparison, and
+     * the underlying numbers driving the call. Routed under the Char.Combat package
+     * family so it ships under the same auto-opt-in subscription as Char.Combat.
+     */
+    suspend fun sendCombatConsider(
+        sessionId: SessionId,
+        result: ConsiderResult,
+    ) {
+        emit(
+            sessionId,
+            "Char.Combat.Consider",
+            CombatConsiderPayload(
+                mobId = result.mobId,
+                mobName = result.mobName,
+                mobLevel = result.mobLevel,
+                mobMaxHp = result.mobMaxHp,
+                mobCategory = result.mobCategory,
+                mobImage = result.mobImage,
+                playerLevel = result.playerLevel,
+                playerMaxHp = result.playerMaxHp,
+                playerAvgDamage = result.playerAvgDamage,
+                mobAvgDamage = result.mobAvgDamage,
+                hitsToKillMob = result.hitsToKillMob,
+                hitsToKillPlayer = result.hitsToKillPlayer,
+                dodgeChancePct = result.dodgeChancePct,
+                winChancePct = result.winChancePct,
+                rating = result.rating.name,
+                ratingLabel = result.rating.label,
+                ratingFlavor = result.rating.flavor,
+            ),
+        )
+    }
+
     suspend fun sendCharCombat(sessionId: SessionId) {
         val target = getCombatTarget(sessionId)
         emit(
@@ -2280,6 +2315,27 @@ class GmcpEmitter(
         val targetMaxHp: Int?,
         val targetImage: String?,
         val targetCategory: String?,
+    )
+
+    @Suppress("unused") // Jackson serializes all fields
+    private data class CombatConsiderPayload(
+        val mobId: String,
+        val mobName: String,
+        val mobLevel: Int,
+        val mobMaxHp: Int,
+        val mobCategory: String,
+        val mobImage: String?,
+        val playerLevel: Int,
+        val playerMaxHp: Int,
+        val playerAvgDamage: Int,
+        val mobAvgDamage: Int,
+        val hitsToKillMob: Int,
+        val hitsToKillPlayer: Int,
+        val dodgeChancePct: Int,
+        val winChancePct: Int,
+        val rating: String,
+        val ratingLabel: String,
+        val ratingFlavor: String,
     )
 
     private data class ZoneMapPayload(

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -239,6 +239,11 @@ sealed interface Command {
         val target: String,
     ) : Command
 
+    /** Assess a mob's threat level without engaging. */
+    data class Consider(
+        val target: String,
+    ) : Command
+
     data object Flee : Command
 
     data object Recall : Command
@@ -1293,6 +1298,14 @@ object CommandParser {
 
         // kill
         requiredArg(line, listOf("kill"), "kill <mob>", { Command.Kill(it) })?.let { return it }
+
+        // consider — assess a mob's threat without attacking
+        requiredArg(
+            line,
+            listOf("consider", "con"),
+            "consider <mob>",
+            { Command.Consider(it) },
+        )?.let { return it }
 
         // goto
         requiredArg(line, listOf("goto"), "goto <zone:room | room | zone:>", { Command.Goto(it) })?.let { return it }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/CombatHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/CombatHandler.kt
@@ -2,6 +2,7 @@ package dev.ambon.engine.commands.handlers
 
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.world.World
+import dev.ambon.engine.ConsiderOutcome
 import dev.ambon.engine.DuelSystem
 import dev.ambon.engine.HousingSystem
 import dev.ambon.engine.abilities.AbilitySystem
@@ -30,8 +31,37 @@ class CombatHandler(
 
     override fun register(router: CommandRouter) {
         router.on<Command.Kill> { sid, cmd -> handleKill(sid, cmd) }
+        router.on<Command.Consider> { sid, cmd -> handleConsider(sid, cmd) }
         router.on<Command.Flee> { sid, _ -> handleFlee(sid) }
         router.on<Command.Cast> { sid, cmd -> handleCast(sid, cmd) }
+    }
+
+    private suspend fun handleConsider(
+        sessionId: SessionId,
+        cmd: Command.Consider,
+    ) {
+        when (val outcome = combat.consider(sessionId, cmd.target)) {
+            is ConsiderOutcome.Error -> {
+                outbound.send(OutboundEvent.SendError(sessionId, outcome.message))
+            }
+            is ConsiderOutcome.Ok -> {
+                val r = outcome.result
+                outbound.send(
+                    OutboundEvent.SendInfo(
+                        sessionId,
+                        "You size up ${r.mobName} (lvl ${r.mobLevel}): ${r.rating.flavor}",
+                    ),
+                )
+                outbound.send(
+                    OutboundEvent.SendText(
+                        sessionId,
+                        "  Estimated win chance: ${r.winChancePct}%  " +
+                            "(your ~${r.playerAvgDamage} dmg vs their ~${r.mobAvgDamage} dmg).",
+                    ),
+                )
+                gmcpEmitter?.sendCombatConsider(sessionId, r)
+            }
+        }
     }
 
     private suspend fun handleKill(

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -998,6 +998,10 @@ ambonmud:
           usage: kill <mob>
           category: combat
           staff: false
+        consider:
+          usage: consider/con <mob>
+          category: combat
+          staff: false
         flee:
           usage: flee
           category: combat

--- a/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
@@ -1361,4 +1361,75 @@ class CombatSystemTest {
             assertNull(combat.startCombat(sid, "rat"))
             assertEquals(listOf(sid), entered)
         }
+
+    @Test
+    fun `consider returns easy rating against a weak mob`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            val mob =
+                MobState(
+                    MobId("demo:rat"),
+                    "a rat",
+                    fixture.roomId,
+                    hp = 4,
+                    maxHp = 4,
+                    damage = DamageRange(1, 1),
+                    level = 1,
+                )
+            fixture.mobs.upsert(mob)
+
+            val combat = fixture.buildCombat(minDamage = 4, maxDamage = 4)
+            val sid = SessionId(70L)
+            fixture.players.loginOrFail(sid, "Hero")
+
+            val outcome = combat.consider(sid, "rat")
+            assertTrue(outcome is ConsiderOutcome.Ok, "expected Ok, got $outcome")
+            val result = (outcome as ConsiderOutcome.Ok).result
+            assertEquals("a rat", result.mobName)
+            assertTrue(
+                result.rating in setOf(ConsiderRating.TRIVIAL, ConsiderRating.EASY),
+                "expected easy/trivial rating, got ${result.rating} (win%=${result.winChancePct})",
+            )
+            assertTrue(result.winChancePct >= 75, "expected high win chance, got ${result.winChancePct}")
+            assertEquals(1, result.hitsToKillMob)
+        }
+
+    @Test
+    fun `consider returns suicidal rating against an overwhelming mob`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            val mob =
+                MobState(
+                    MobId("demo:dragon"),
+                    "an ancient dragon",
+                    fixture.roomId,
+                    hp = 10_000,
+                    maxHp = 10_000,
+                    damage = DamageRange(500, 500),
+                    level = 60,
+                )
+            fixture.mobs.upsert(mob)
+
+            val combat = fixture.buildCombat(minDamage = 1, maxDamage = 1)
+            val sid = SessionId(71L)
+            fixture.players.loginOrFail(sid, "Squire")
+
+            val outcome = combat.consider(sid, "dragon")
+            val result = (outcome as ConsiderOutcome.Ok).result
+            assertEquals(ConsiderRating.SUICIDAL, result.rating)
+            assertTrue(result.winChancePct < 10, "expected very low win chance, got ${result.winChancePct}")
+        }
+
+    @Test
+    fun `consider rejects unknown target`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            val combat = fixture.buildCombat()
+            val sid = SessionId(72L)
+            fixture.players.loginOrFail(sid, "Wanderer")
+
+            val outcome = combat.consider(sid, "ghost")
+            assertTrue(outcome is ConsiderOutcome.Error)
+            assertTrue((outcome as ConsiderOutcome.Error).message.contains("don't see"))
+        }
 }

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
@@ -123,6 +123,13 @@ class CommandParserTest {
     }
 
     @Test
+    fun `parses consider with full and short aliases`() {
+        assertEquals(Command.Consider("orc"), CommandParser.parse("consider orc"))
+        assertEquals(Command.Consider("orc"), CommandParser.parse("con orc"))
+        assertTrue(CommandParser.parse("consider") is Command.Invalid)
+    }
+
+    @Test
     fun `parses look direction`() {
         val c1 = CommandParser.parse("look north")
         assertEquals(Command.LookDir(Direction.NORTH), c1)

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -40,9 +40,26 @@ import { useMiniMap } from "./hooks/useMiniMap";
 import { useQuickbar } from "./hooks/useQuickbar";
 import { useOnboarding } from "./hooks/useOnboarding";
 import { canvasCallbacks, gameStateRef, pendingCastRef } from "./canvas/GameStateBridge";
-import type { ChatChannel, FeaturePopoutFocus, LookTargetInfo, PopoutPanel } from "./types";
+import type {
+  ChatChannel,
+  ConsiderRating,
+  FeaturePopoutFocus,
+  LookTargetInfo,
+  PopoutPanel,
+} from "./types";
 import { sortExits, titleCaseWords } from "./utils";
 import "./styles.css";
+
+// ── Consider (threat assessment) helpers ────────────────────────────────────
+const CONSIDER_TIER_CLASS: Record<ConsiderRating, string> = {
+  TRIVIAL: "consider-tier-trivial",
+  EASY: "consider-tier-easy",
+  FAVORED: "consider-tier-favored",
+  EVEN: "consider-tier-even",
+  RISKY: "consider-tier-risky",
+  DANGEROUS: "consider-tier-dangerous",
+  SUICIDAL: "consider-tier-suicidal",
+};
 
 // ── Look-target (Examine) helpers ───────────────────────────────────────────
 function formatItemSlot(slot: string): string {
@@ -495,6 +512,16 @@ function App() {
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
   }, [state.lookTarget]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Close consider card on Escape
+  useEffect(() => {
+    if (!state.considerResult) return;
+    const handler = (e: globalThis.KeyboardEvent) => {
+      if (e.key === "Escape") state.setConsiderResult(null);
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [state.considerResult]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Close NPC dialogue / quest offers on Escape — but only when the
   // conversation has reached a state with no further choices (mirrors the
@@ -1394,6 +1421,85 @@ function App() {
               <p className="look-target-desc">{state.lookTarget.description}</p>
             )}
             {state.lookTarget.type === "item" && renderItemStats(state.lookTarget)}
+          </div>
+        </div>
+      )}
+
+      {/* Consider — verbal threat assessment for a mob in the current room */}
+      {state.considerResult && (
+        <div
+          className="consider-backdrop"
+          role="presentation"
+          onClick={() => state.setConsiderResult(null)}
+        >
+          <div
+            className={`consider-card ${CONSIDER_TIER_CLASS[state.considerResult.rating]}`}
+            role="dialog"
+            aria-modal="true"
+            aria-label={`Threat assessment for ${state.considerResult.mobName}`}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              type="button"
+              className="consider-close"
+              aria-label="Close"
+              onClick={() => state.setConsiderResult(null)}
+            >
+              &#x2715;
+            </button>
+            <div className="consider-header">
+              <span className="consider-tier-badge">{state.considerResult.ratingLabel}</span>
+              <span className="consider-name">{state.considerResult.mobName}</span>
+              <span className="consider-meta">
+                Lv {state.considerResult.mobLevel} {state.considerResult.mobCategory}
+              </span>
+            </div>
+            <p className="consider-flavor">{state.considerResult.ratingFlavor}</p>
+            <div className="consider-winrate" aria-label="Estimated win chance">
+              <div className="consider-winrate-label">
+                <span>Estimated win chance</span>
+                <span className="consider-winrate-pct">{state.considerResult.winChancePct}%</span>
+              </div>
+              <div className="consider-winrate-bar" role="progressbar"
+                aria-valuenow={state.considerResult.winChancePct}
+                aria-valuemin={0} aria-valuemax={100}>
+                <div
+                  className="consider-winrate-fill"
+                  style={{ width: `${state.considerResult.winChancePct}%` }}
+                />
+              </div>
+            </div>
+            <dl className="consider-stats">
+              <div className="consider-stat">
+                <dt>Your hit</dt>
+                <dd>~{state.considerResult.playerAvgDamage} dmg</dd>
+              </div>
+              <div className="consider-stat">
+                <dt>Their hit</dt>
+                <dd>~{state.considerResult.mobAvgDamage} dmg</dd>
+              </div>
+              <div className="consider-stat">
+                <dt>Hits to kill {state.considerResult.mobName.split(" ").slice(-1)[0]}</dt>
+                <dd>{state.considerResult.hitsToKillMob}</dd>
+              </div>
+              <div className="consider-stat">
+                <dt>Hits to kill you</dt>
+                <dd>{state.considerResult.hitsToKillPlayer}</dd>
+              </div>
+              {state.considerResult.dodgeChancePct > 0 && (
+                <div className="consider-stat">
+                  <dt>Your dodge</dt>
+                  <dd>{state.considerResult.dodgeChancePct}%</dd>
+                </div>
+              )}
+              <div className="consider-stat">
+                <dt>Level diff</dt>
+                <dd>
+                  {state.considerResult.mobLevel - state.considerResult.playerLevel > 0 ? "+" : ""}
+                  {state.considerResult.mobLevel - state.considerResult.playerLevel}
+                </dd>
+              </div>
+            </dl>
           </div>
         </div>
       )}

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -36,6 +36,8 @@ import type {
   PendingGuildInvite,
   InProgressAchievement,
   ItemSummary,
+  ConsiderRating,
+  ConsiderResult,
   LookTargetInfo,
   LoginErrorState,
   LoginPromptState,
@@ -181,6 +183,7 @@ interface GmcpContext {
   setStaffWorldInfo: Dispatch<SetStateAction<StaffWorldZone[]>>;
   setStaffMobTemplates: Dispatch<SetStateAction<StaffMobZone[]>>;
   setLookTarget: Dispatch<SetStateAction<LookTargetInfo | null>>;
+  setConsiderResult: Dispatch<SetStateAction<ConsiderResult | null>>;
   pushBroadcast: (sender: string, message: string) => void;
   setPossessing: Dispatch<SetStateAction<string | null>>;
   setCraftingSkills: Dispatch<SetStateAction<CraftingSkill[]>>;
@@ -292,6 +295,32 @@ export function applyGmcpPackage(
           targetCategory: typeof packet.targetCategory === "string" ? packet.targetCategory : null,
         });
       }
+      break;
+    }
+
+    case "Char.Combat.Consider": {
+      const packet = data as Partial<Record<string, unknown>>;
+      const rating = typeof packet.rating === "string" ? (packet.rating as ConsiderRating) : "EVEN";
+      ctx.setConsiderResult({
+        mobId: typeof packet.mobId === "string" ? packet.mobId : "",
+        mobName: typeof packet.mobName === "string" ? packet.mobName : "Unknown",
+        mobLevel: safeNumber(packet.mobLevel, 0),
+        mobMaxHp: safeNumber(packet.mobMaxHp, 0),
+        mobCategory: typeof packet.mobCategory === "string" ? packet.mobCategory : "",
+        mobImage: typeof packet.mobImage === "string" ? packet.mobImage : null,
+        playerLevel: safeNumber(packet.playerLevel, 0),
+        playerMaxHp: safeNumber(packet.playerMaxHp, 0),
+        playerAvgDamage: safeNumber(packet.playerAvgDamage, 0),
+        mobAvgDamage: safeNumber(packet.mobAvgDamage, 0),
+        hitsToKillMob: safeNumber(packet.hitsToKillMob, 0),
+        hitsToKillPlayer: safeNumber(packet.hitsToKillPlayer, 0),
+        dodgeChancePct: safeNumber(packet.dodgeChancePct, 0),
+        winChancePct: safeNumber(packet.winChancePct, 0),
+        rating,
+        ratingLabel: typeof packet.ratingLabel === "string" ? packet.ratingLabel : rating.toLowerCase(),
+        ratingFlavor: typeof packet.ratingFlavor === "string" ? packet.ratingFlavor : "",
+        receivedAt: Date.now(),
+      });
       break;
     }
 

--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -609,6 +609,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     setWhoPlayers([]);
     setZoneInstances({ zone: null, currentEngineId: null, instances: [] });
     setCombatTarget(null);
+    setConsiderResult(null);
     setCharStats(null);
     setQuests([]);
     setQuestsAvailable([]);

--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -53,6 +53,7 @@ import type {
   LevelUpNotification,
   LoginErrorState,
   LoginPromptState,
+  ConsiderResult,
   LookTargetInfo,
   LotteryInfo,
   MailEntry,
@@ -290,6 +291,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
   const [staffWorldInfo, setStaffWorldInfo] = useState<StaffWorldZone[]>([]);
   const [staffMobTemplates, setStaffMobTemplates] = useState<StaffMobZone[]>([]);
   const [lookTarget, setLookTarget] = useState<LookTargetInfo | null>(null);
+  const [considerResult, setConsiderResult] = useState<ConsiderResult | null>(null);
   const [spriteList, setSpriteList] = useState<SpriteList>({ active: null, sprites: [] });
 
   // ── UI chrome ─────────────────────────────────────
@@ -536,6 +538,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
         pushBroadcast: (sender: string, message: string) => setBroadcast({ sender, message }),
         setPossessing,
         setLookTarget,
+        setConsiderResult,
         setCraftingSkills,
         setCraftingRecipes,
         setCraftingNodes,
@@ -701,7 +704,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     loginPrompt, loginError, reconnecting, setReconnecting, savedCharacters, setSavedCharacters,
     // Staff / meta
     serverAssets, serverCommands, emotePresets, serverFeatures, staffWorldInfo, staffMobTemplates,
-    lookTarget, setLookTarget, spriteList,
+    lookTarget, setLookTarget, considerResult, setConsiderResult, spriteList,
     // UI
     activePopout, setActivePopout, broadcast, setBroadcast, possessing, toast, setToast, uiFeedbackFeed,
     levelUpNotification, setLevelUpNotification,

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -8609,6 +8609,182 @@ body {
   }
 }
 
+/* ── Consider (threat assessment) modal ───────────────────── */
+.consider-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-inspect);
+  display: grid;
+  place-items: center;
+  padding: var(--space-4);
+  background: rgb(14 16 28 / 65%);
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  animation: lookTargetBackdropIn 180ms var(--ease-out-soft);
+}
+
+.consider-card {
+  position: relative;
+  width: min(440px, 100%);
+  max-height: calc(100dvh - 40px);
+  overflow-y: auto;
+  padding: var(--space-4) var(--space-5);
+  background: linear-gradient(165deg, rgb(48 55 82 / 97%), rgb(38 47 71 / 95%));
+  border: 1px solid rgb(146 136 180 / 30%);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg), var(--shadow-glow);
+  color: var(--text-primary);
+  animation: lookTargetCardIn 220ms var(--ease-out-soft);
+  display: grid;
+  gap: var(--space-3);
+  --consider-accent: var(--color-accent-lavender, #b9a5e0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .consider-backdrop,
+  .consider-card {
+    animation: none;
+  }
+}
+
+.consider-close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--line-soft);
+  border-radius: 999px;
+  background: rgb(40 46 68 / 70%);
+  color: var(--text-primary);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 160ms var(--ease-out-soft), transform 160ms var(--ease-out-soft);
+}
+
+.consider-close:hover { background: rgb(62 70 104 / 90%); }
+.consider-close:active { transform: scale(0.96); }
+.consider-close:focus-visible {
+  outline: 2px solid var(--color-primary-lavender);
+  outline-offset: 2px;
+}
+
+.consider-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-2);
+  padding-right: var(--space-6);
+}
+
+.consider-name {
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.consider-meta {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  text-transform: capitalize;
+}
+
+.consider-tier-badge {
+  padding: 2px 10px;
+  border-radius: 999px;
+  background: var(--consider-accent);
+  color: #15182a;
+  font-weight: 700;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: 0 0 12px var(--consider-accent);
+}
+
+.consider-flavor {
+  margin: 0;
+  font-style: italic;
+  color: var(--text-secondary);
+  line-height: 1.45;
+}
+
+.consider-winrate {
+  display: grid;
+  gap: 6px;
+}
+
+.consider-winrate-label {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.consider-winrate-pct {
+  color: var(--consider-accent);
+  font-weight: 700;
+}
+
+.consider-winrate-bar {
+  height: 10px;
+  background: rgb(20 23 38 / 80%);
+  border: 1px solid var(--line-soft);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.consider-winrate-fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--consider-accent), color-mix(in srgb, var(--consider-accent) 60%, white));
+  box-shadow: 0 0 10px var(--consider-accent);
+  transition: width 300ms var(--ease-out-soft);
+}
+
+.consider-stats {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-2) var(--space-3);
+}
+
+.consider-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 10px;
+  background: rgb(20 23 38 / 50%);
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius-sm, 6px);
+}
+
+.consider-stat dt {
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.consider-stat dd {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+/* Seven tiers — colors track danger from safe (green) to deadly (red). */
+.consider-tier-trivial   { --consider-accent: #8fd9b6; }
+.consider-tier-easy      { --consider-accent: #b8e07a; }
+.consider-tier-favored   { --consider-accent: #e6d27a; }
+.consider-tier-even      { --consider-accent: #d9c89a; }
+.consider-tier-risky     { --consider-accent: #e8a467; }
+.consider-tier-dangerous { --consider-accent: #d97b6e; }
+.consider-tier-suicidal  { --consider-accent: #b94a52; }
+
+@media (max-width: 599px) {
+  .consider-card { padding: var(--space-3) var(--space-4); }
+  .consider-name { font-size: 1.1rem; }
+}
+
 /* ── Possession vignette overlay ── */
 
 .possession-vignette {

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -400,6 +400,36 @@ export interface CombatTarget {
   targetCategory: string | null;
 }
 
+export type ConsiderRating =
+  | "TRIVIAL"
+  | "EASY"
+  | "FAVORED"
+  | "EVEN"
+  | "RISKY"
+  | "DANGEROUS"
+  | "SUICIDAL";
+
+export interface ConsiderResult {
+  mobId: string;
+  mobName: string;
+  mobLevel: number;
+  mobMaxHp: number;
+  mobCategory: string;
+  mobImage: string | null;
+  playerLevel: number;
+  playerMaxHp: number;
+  playerAvgDamage: number;
+  mobAvgDamage: number;
+  hitsToKillMob: number;
+  hitsToKillPlayer: number;
+  dodgeChancePct: number;
+  winChancePct: number;
+  rating: ConsiderRating;
+  ratingLabel: string;
+  ratingFlavor: string;
+  receivedAt: number;
+}
+
 /**
  * Per-skill visual archetype that drives how the web client renders the
  * cast moment. Sent in the Char.Skills GMCP payload as `visual.archetype`.


### PR DESCRIPTION
## Summary

Adds `consider <mob>` (alias `con`) — a classic MUD threat-assessment command that tells the player roughly how likely they are to beat a mob in their current room, without engaging combat.

- **Computation** lives in `CombatSystem.consider()`: uses player effective stats (equipment, status mods, STR bonus, dodge%) vs. mob avg damage / max HP / armor; computes hits-to-kill on both sides and converts the ratio into a win-chance percentage.
- **Seven-tier rating** (`ConsiderRating`): TRIVIAL → EASY → FAVORED → EVEN → RISKY → DANGEROUS → SUICIDAL, each with a flavor line.
- **Telnet output**: `SendInfo` with the verbal rating + flavor, plus a numbers line (your avg damage vs. theirs, win %).
- **GMCP**: new `Char.Combat.Consider` package — rides the existing `Char.Combat` package family auto-opt-in via prefix match, so no transport changes needed.
- **Web client**: glass-morphism card overlay (Esc/click-outside to dismiss) with tier badge, italic flavor line, animated win-chance bar, and stat grid (your hit / their hit / hits-to-kill mob / hits-to-kill you / dodge / level diff). Tier accent color shifts soft-green → deep-red across the seven tiers.

## Test plan
- [x] `CombatSystemTest.consider*` — weak mob → easy/trivial, dragon → suicidal, unknown target → error
- [x] `CommandParserTest.parses consider*` — full + short alias, missing arg
- [x] `./gradlew ktlintCheck test` clean
- [x] `bun run lint` clean
- [ ] Manual: `./gradlew demo`, walk to Academy mob, type `consider rat` and verify the card renders and dismisses correctly