### PR TITLE
feat(combat): wimpy auto-flee + character pane control

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -342,10 +342,7 @@ class CombatSystem(
         targetSid: SessionId,
         target: PlayerState,
     ): Boolean {
-        val threshold = target.wimpyThresholdPct
-        if (threshold <= 0 || target.maxHp <= 0) return false
-        val hpPct = (target.hp.toDouble() / target.maxHp * 100.0).toInt()
-        if (hpPct > threshold) return false
+        if (!isAtOrBelowWimpyThreshold(target)) return false
         if (playerTarget[targetSid] == null) return false
         outbound.send(OutboundEvent.SendText(targetSid, "Your wounds force you to disengage!"))
         flee(targetSid, forced = true)
@@ -357,16 +354,25 @@ class CombatSystem(
         targetSid: SessionId,
         target: PlayerState,
     ): Boolean {
-        val threshold = target.wimpyThresholdPct
-        if (threshold <= 0 || target.maxHp <= 0) return false
-        val hpPct = (target.hp.toDouble() / target.maxHp * 100.0).toInt()
-        if (hpPct > threshold) return false
+        if (!isAtOrBelowWimpyThreshold(target)) return false
         if (pvpTarget[targetSid] == null) return false
         val opponent = pvpTarget[targetSid]?.let { players.get(it) }?.name ?: "your opponent"
         endPvpCombat(targetSid)
         outbound.send(OutboundEvent.SendText(targetSid, "You are forced to flee from $opponent!"))
         outbound.send(OutboundEvent.SendPrompt(targetSid))
         return true
+    }
+
+    /**
+     * Returns true iff the player has wimpy enabled and their current HP is at or below the
+     * configured percentage of max. Uses integer cross-multiplication rather than a truncated
+     * percent because `(hp.toDouble() / maxHp * 100).toInt()` floors values like 25.5% to 25
+     * and would fire one HP early — e.g. at 51/200 HP for a 25% threshold.
+     */
+    private fun isAtOrBelowWimpyThreshold(target: PlayerState): Boolean {
+        val threshold = target.wimpyThresholdPct
+        if (threshold <= 0 || target.maxHp <= 0) return false
+        return target.hp * 100 <= threshold * target.maxHp
     }
 
     override fun remapSession(
@@ -501,6 +507,11 @@ class CombatSystem(
         for (state in entries) {
             if (ran >= maxPerTick) break
             if (now < state.nextTickAtMs) continue
+            // The snapshot can go stale mid-tick: an earlier iteration (or wimpy auto-flee
+            // on this state's target) may have called endPvpCombat, which removes the
+            // reciprocal entry too. Skip stale states so we don't apply a phantom hit
+            // after the fight has already ended.
+            if (pvpCombatStates[state.attackerSid] !== state) continue
 
             val attacker = players.get(state.attackerSid)
             val target = players.get(state.targetSid)

--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -332,6 +332,43 @@ class CombatSystem(
         return null
     }
 
+    /**
+     * If the player has wimpy enabled and their current HP% is at or below the threshold,
+     * break PvE combat with the "forced to flee" path. Returns true if combat was broken.
+     * Called after a mob lands a hit on a still-alive player so the next mob tick can't
+     * resolve before the player has a chance to escape.
+     */
+    private suspend fun checkWimpyAutoFlee(
+        targetSid: SessionId,
+        target: PlayerState,
+    ): Boolean {
+        val threshold = target.wimpyThresholdPct
+        if (threshold <= 0 || target.maxHp <= 0) return false
+        val hpPct = (target.hp.toDouble() / target.maxHp * 100.0).toInt()
+        if (hpPct > threshold) return false
+        if (playerTarget[targetSid] == null) return false
+        outbound.send(OutboundEvent.SendText(targetSid, "Your wounds force you to disengage!"))
+        flee(targetSid, forced = true)
+        return true
+    }
+
+    /** PvP variant — disengages the PvP fight when the player's HP drops below the wimpy threshold. */
+    private suspend fun checkWimpyAutoFleePvp(
+        targetSid: SessionId,
+        target: PlayerState,
+    ): Boolean {
+        val threshold = target.wimpyThresholdPct
+        if (threshold <= 0 || target.maxHp <= 0) return false
+        val hpPct = (target.hp.toDouble() / target.maxHp * 100.0).toInt()
+        if (hpPct > threshold) return false
+        if (pvpTarget[targetSid] == null) return false
+        val opponent = pvpTarget[targetSid]?.let { players.get(it) }?.name ?: "your opponent"
+        endPvpCombat(targetSid)
+        outbound.send(OutboundEvent.SendText(targetSid, "You are forced to flee from $opponent!"))
+        outbound.send(OutboundEvent.SendPrompt(targetSid))
+        return true
+    }
+
     override fun remapSession(
         oldSid: SessionId,
         newSid: SessionId,
@@ -523,6 +560,10 @@ class CombatSystem(
                         loserName = target.name,
                         loser = target,
                     )
+                    ran++
+                    continue
+                }
+                if (checkWimpyAutoFleePvp(state.targetSid, target)) {
                     ran++
                     continue
                 }
@@ -929,6 +970,8 @@ class CombatSystem(
                         roomMessage = "${target.name} has been slain by ${mob.name}.",
                         killerName = mob.name,
                     )
+                } else {
+                    checkWimpyAutoFlee(targetSid, target)
                 }
             }
 

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -502,6 +502,7 @@ class GmcpEmitter(
                 sprite = resolveSprite(player),
                 isStaff = player.isStaff,
                 autolootEnabled = player.autolootEnabled,
+                wimpyThresholdPct = player.wimpyThresholdPct,
             ),
         )
     }
@@ -2541,6 +2542,7 @@ class GmcpEmitter(
         val sprite: String,
         val isStaff: Boolean,
         val autolootEnabled: Boolean,
+        val wimpyThresholdPct: Int,
     )
 
     private data class SessionAuthTokenPayload(

--- a/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
@@ -598,6 +598,17 @@ class PlayerRegistry(
         persistIfClaimed(ps)
     }
 
+    /** Sets the wimpy auto-flee HP-percent threshold. Caller is responsible for clamping to 0..95. */
+    suspend fun setWimpyThresholdPct(
+        sessionId: SessionId,
+        pct: Int,
+    ) {
+        val ps = players[sessionId] ?: return
+        if (ps.wimpyThresholdPct == pct) return
+        ps.wimpyThresholdPct = pct
+        persistIfClaimed(ps)
+    }
+
     fun findSessionByName(name: String): SessionId? = sessionByLowerName[normalizeName(name).lowercase()]
 
     fun isNameOnline(

--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -116,6 +116,13 @@ data class PlayerState(
     /** When true, items dropped by mobs the player kills are auto-looted into inventory. */
     var autolootEnabled: Boolean = false,
     /**
+     * Auto-flee HP-percent threshold (1..95). When the player's HP drops below this percentage
+     * of max after a mob hit, combat is broken automatically. `0` disables wimpy. Default `10`
+     * is intentionally cautious — it kicks in once the player is in real danger but late enough
+     * not to interrupt routine fights.
+     */
+    var wimpyThresholdPct: Int = 10,
+    /**
      * SHA-256 hash of the remember-me auth token.
      * Tracked on [PlayerState] so [persistIfClaimed] doesn't wipe it on every
      * save — otherwise disconnect would erase the token the client still
@@ -266,6 +273,7 @@ fun PlayerRecord.toPlayerState(sessionId: SessionId): PlayerState =
         authTokenHash = authTokenHash,
         authTokenIssuedAt = authTokenIssuedAt,
         autolootEnabled = autolootEnabled,
+        wimpyThresholdPct = wimpyThresholdPct,
         lastRespecAtMs = lastRespecAtMs,
     )
 
@@ -324,6 +332,7 @@ fun PlayerState.toPlayerRecord(lastSeenEpochMs: Long): PlayerRecord {
         authTokenHash = authTokenHash,
         authTokenIssuedAt = authTokenIssuedAt,
         autolootEnabled = autolootEnabled,
+        wimpyThresholdPct = wimpyThresholdPct,
         lastRespecAtMs = lastRespecAtMs,
     )
 }

--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -116,8 +116,8 @@ data class PlayerState(
     /** When true, items dropped by mobs the player kills are auto-looted into inventory. */
     var autolootEnabled: Boolean = false,
     /**
-     * Auto-flee HP-percent threshold (1..95). When the player's HP drops below this percentage
-     * of max after a mob hit, combat is broken automatically. `0` disables wimpy. Default `10`
+     * Auto-flee HP-percent threshold (0..95, where 0 disables). When the player's HP is at or
+     * below this percentage of max after a mob hit, combat is broken automatically. Default `10`
      * is intentionally cautious — it kicks in once the player is in real danger but late enough
      * not to interrupt routine fights.
      */

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -27,6 +27,14 @@ sealed interface Command {
 
     data object AutolootStatus : Command
 
+    /**
+     * Set or query the wimpy auto-flee threshold.
+     * `null` arg → status. `"off"` / `0` → disable. `1..95` → enable at that HP%.
+     */
+    data class Wimpy(
+        val arg: String?,
+    ) : Command
+
     data class Move(
         val dir: Direction,
     ) : Command
@@ -1307,6 +1315,11 @@ object CommandParser {
             { Command.Consider(it) },
         )?.let { return it }
 
+        // wimpy <n|on|off> — set auto-flee HP% threshold
+        matchPrefix(line, listOf("wimpy")) { rest ->
+            Command.Wimpy(rest.trim().takeIf { it.isNotBlank() })
+        }?.let { return it }
+
         // goto
         requiredArg(line, listOf("goto"), "goto <zone:room | room | zone:>", { Command.Goto(it) })?.let { return it }
 
@@ -1678,6 +1691,7 @@ object CommandParser {
             "autoloot on" -> Command.AutolootOn
             "autoloot off" -> Command.AutolootOff
             "autoloot status", "autoloot" -> Command.AutolootStatus
+            "wimpy" -> Command.Wimpy(null)
             "clear" -> Command.Clear
             "colors" -> Command.Colors
             "who" -> Command.Who

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/UiHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/UiHandler.kt
@@ -54,6 +54,7 @@ class UiHandler(
         router.on<Command.AutolootOn> { sid, _ -> handleAutoloot(sid, AutolootAction.ON) }
         router.on<Command.AutolootOff> { sid, _ -> handleAutoloot(sid, AutolootAction.OFF) }
         router.on<Command.AutolootStatus> { sid, _ -> handleAutoloot(sid, AutolootAction.STATUS) }
+        router.on<Command.Wimpy> { sid, cmd -> handleWimpy(sid, cmd) }
         router.on<Command.Clear> { sid, _ ->
             outbound.send(OutboundEvent.ClearScreen(sid))
         }
@@ -82,6 +83,11 @@ class UiHandler(
         outbound.send(OutboundEvent.SendInfo(sessionId, "ANSI disabled"))
     }
 
+    private companion object {
+        const val DEFAULT_WIMPY_PCT = 10
+        const val MAX_WIMPY_PCT = 95
+    }
+
     private enum class AutolootAction { ON, OFF, STATUS }
 
     private suspend fun handleAutoloot(
@@ -105,6 +111,43 @@ class UiHandler(
                 outbound.send(OutboundEvent.SendInfo(sessionId, "Auto-loot is $status."))
             }
         }
+    }
+
+    private suspend fun handleWimpy(
+        sessionId: SessionId,
+        cmd: Command.Wimpy,
+    ) {
+        val me = players.get(sessionId) ?: return
+        val rawArg = cmd.arg
+        if (rawArg.isNullOrBlank()) {
+            val status = if (me.wimpyThresholdPct <= 0) "OFF" else "${me.wimpyThresholdPct}%"
+            outbound.send(OutboundEvent.SendInfo(sessionId, "Wimpy: $status (auto-flee threshold)."))
+            return
+        }
+        val arg = rawArg.trim().lowercase()
+        val newPct = when (arg) {
+            "off", "0", "no", "disable" -> 0
+            "on", "default" -> DEFAULT_WIMPY_PCT
+            else -> arg.toIntOrNull()
+        }
+        if (newPct == null || newPct !in 0..MAX_WIMPY_PCT) {
+            outbound.send(
+                OutboundEvent.SendError(
+                    sessionId,
+                    "Usage: wimpy [off | 0-$MAX_WIMPY_PCT]",
+                ),
+            )
+            return
+        }
+        players.setWimpyThresholdPct(sessionId, newPct)
+        gmcpEmitter?.sendCharName(sessionId, me)
+        val msg =
+            if (newPct == 0) {
+                "Wimpy disabled — you will not auto-flee."
+            } else {
+                "Wimpy set to $newPct% — combat will break when your HP drops below that."
+            }
+        outbound.send(OutboundEvent.SendInfo(sessionId, msg))
     }
 
     private suspend fun handleScreenReaderToggle(sessionId: SessionId, requestedOn: Boolean) {

--- a/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
@@ -94,6 +94,8 @@ data class PlayerRecord(
     val description: String = "",
     /** When true, items dropped by mobs the player kills are auto-looted into inventory. */
     val autolootEnabled: Boolean = false,
+    /** Auto-flee HP% threshold (1..95); 0 disables wimpy. Default 10. */
+    val wimpyThresholdPct: Int = 10,
     /** Epoch-ms of the last stat/ability respec. 0 means never respec'd. */
     val lastRespecAtMs: Long = 0L,
     /** Persisted dialogue-flag set used to gate quests behind prior conversations. */

--- a/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
@@ -82,6 +82,7 @@ object PlayersTable : Table("players") {
     val screenReaderEnabled = bool("screen_reader_enabled").default(false)
     val description = text("description").default("")
     val autolootEnabled = bool("autoloot_enabled").default(false)
+    val wimpyThresholdPct = integer("wimpy_threshold_pct").default(10)
     val lastRespecAtMs = long("last_respec_at_ms").default(0L)
     val dialogueFlags = text("dialogue_flags").default("[]")
 
@@ -142,6 +143,7 @@ object PlayersTable : Table("players") {
             screenReaderEnabled = row[screenReaderEnabled],
             description = row[description],
             autolootEnabled = row[autolootEnabled],
+            wimpyThresholdPct = row[wimpyThresholdPct],
             lastRespecAtMs = row[lastRespecAtMs],
             dialogueFlags = safeReadJson(row[dialogueFlags], dialogueFlagsType, emptySet()),
         ).migrateDefaults()
@@ -201,6 +203,7 @@ object PlayersTable : Table("players") {
         statement[screenReaderEnabled] = record.screenReaderEnabled
         statement[description] = record.description
         statement[autolootEnabled] = record.autolootEnabled
+        statement[wimpyThresholdPct] = record.wimpyThresholdPct
         statement[lastRespecAtMs] = record.lastRespecAtMs
         statement[dialogueFlags] = jsonMapper.writeValueAsString(record.dialogueFlags)
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1002,6 +1002,10 @@ ambonmud:
           usage: consider/con <mob>
           category: combat
           staff: false
+        wimpy:
+          usage: wimpy [off | 0-95]
+          category: combat
+          staff: false
         flee:
           usage: flee
           category: combat

--- a/src/main/resources/db/migration/V39__add_wimpy_threshold_pct.sql
+++ b/src/main/resources/db/migration/V39__add_wimpy_threshold_pct.sql
@@ -1,0 +1,1 @@
+ALTER TABLE players ADD COLUMN wimpy_threshold_pct INTEGER NOT NULL DEFAULT 10;

--- a/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
@@ -1491,6 +1491,42 @@ class CombatSystemTest {
         }
 
     @Test
+    fun `wimpy threshold compares via exact ratio not truncated percent`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            // Damage exactly 1 per tick at max=200, threshold=25.
+            // 51/200 = 25.5% — must NOT trigger a 25% threshold (truncation bug would fire here).
+            // 50/200 = 25.0% — must trigger.
+            val mob =
+                MobState(
+                    MobId("demo:slow"),
+                    "a slow slime",
+                    fixture.roomId,
+                    hp = 10_000,
+                    maxHp = 10_000,
+                    damage = DamageRange(1, 1),
+                )
+            fixture.mobs.upsert(mob)
+
+            val combat = fixture.buildCombat(rng = Random(1))
+            val sid = SessionId(93L)
+            fixture.players.loginOrFail(sid, "Picky")
+            val player = fixture.players.get(sid)!!
+            player.maxHp = 200
+            player.hp = 52 // first tick → 51 = 25.5% (must not fire)
+            player.wimpyThresholdPct = 25
+
+            assertNull(combat.startCombat(sid, "slime"))
+            fixture.tickCombat(combat)
+            assertEquals(51, player.hp)
+            assertTrue(combat.isInCombat(sid), "wimpy must not fire at 25.5% for a 25% threshold")
+
+            fixture.tickCombat(combat) // 50 → 25.0% exactly
+            assertEquals(50, player.hp)
+            assertNull(combat.currentTarget(sid), "wimpy must fire at exactly the threshold")
+        }
+
+    @Test
     fun `wimpy of 0 never fires`() =
         runTest {
             val fixture = CombatTestFixture()

--- a/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
@@ -1421,6 +1421,105 @@ class CombatSystemTest {
         }
 
     @Test
+    fun `wimpy disengages combat when player drops below threshold`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            val mob =
+                MobState(
+                    MobId("demo:ogre"),
+                    "an ogre",
+                    fixture.roomId,
+                    hp = 1000,
+                    maxHp = 1000,
+                    damage = DamageRange(100, 100),
+                )
+            fixture.mobs.upsert(mob)
+
+            val combat = fixture.buildCombat(rng = Random(1))
+            val sid = SessionId(90L)
+            fixture.players.loginOrFail(sid, "Wimper")
+            val player = fixture.players.get(sid)!!
+            player.maxHp = 200
+            player.hp = 200
+            player.wimpyThresholdPct = 25
+
+            assertNull(combat.startCombat(sid, "ogre"))
+            fixture.tickCombat(combat)
+
+            assertTrue(player.hp < player.maxHp, "expected damage to land")
+            // Player has 100 HP / 200 max = 50% — above 25% threshold, should still be in combat
+            assertTrue(combat.isInCombat(sid), "expected still in combat above threshold")
+
+            fixture.tickCombat(combat)
+            // After second hit: 0 HP would be death; but wimpy fires at threshold-or-below
+            // 50% → after 100 more damage: 0 hp = death. So threshold check happens just below 50%.
+            // Player would die before wimpy fires — so use a less-deadly mob for the trigger test below.
+        }
+
+    @Test
+    fun `wimpy fires before death when threshold is generous`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            val mob =
+                MobState(
+                    MobId("demo:wolf"),
+                    "a wolf",
+                    fixture.roomId,
+                    hp = 1000,
+                    maxHp = 1000,
+                    damage = DamageRange(20, 20),
+                )
+            fixture.mobs.upsert(mob)
+
+            val combat = fixture.buildCombat(rng = Random(1))
+            val sid = SessionId(91L)
+            fixture.players.loginOrFail(sid, "Cautious")
+            val player = fixture.players.get(sid)!!
+            player.maxHp = 100
+            player.hp = 100
+            player.wimpyThresholdPct = 50
+
+            assertNull(combat.startCombat(sid, "wolf"))
+            // Two ticks: 100 → 80 (80% > 50%) → 60 (60% > 50%). One more: 40 (≤50%) → wimpy fires.
+            fixture.tickCombat(combat) // 80
+            assertTrue(combat.isInCombat(sid))
+            fixture.tickCombat(combat) // 60
+            assertTrue(combat.isInCombat(sid))
+            fixture.tickCombat(combat) // 40 → wimpy
+            assertNull(combat.currentTarget(sid), "expected wimpy to break combat at threshold")
+            assertTrue(player.hp > 0, "expected player still alive")
+        }
+
+    @Test
+    fun `wimpy of 0 never fires`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            val mob =
+                MobState(
+                    MobId("demo:wolf"),
+                    "a wolf",
+                    fixture.roomId,
+                    hp = 1000,
+                    maxHp = 1000,
+                    damage = DamageRange(10, 10),
+                )
+            fixture.mobs.upsert(mob)
+
+            val combat = fixture.buildCombat(rng = Random(1))
+            val sid = SessionId(92L)
+            fixture.players.loginOrFail(sid, "Reckless")
+            val player = fixture.players.get(sid)!!
+            player.maxHp = 100
+            player.hp = 100
+            player.wimpyThresholdPct = 0
+
+            assertNull(combat.startCombat(sid, "wolf"))
+            repeat(5) { fixture.tickCombat(combat) }
+            // Player at 50% — never fled since wimpy=0
+            assertTrue(combat.isInCombat(sid), "expected still in combat with wimpy disabled")
+        }
+
+    @Test
     fun `consider rejects unknown target`() =
         runTest {
             val fixture = CombatTestFixture()

--- a/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
@@ -1421,7 +1421,7 @@ class CombatSystemTest {
         }
 
     @Test
-    fun `wimpy disengages combat when player drops below threshold`() =
+    fun `wimpy does not fire above threshold`() =
         runTest {
             val fixture = CombatTestFixture()
             val mob =
@@ -1446,14 +1446,9 @@ class CombatSystemTest {
             assertNull(combat.startCombat(sid, "ogre"))
             fixture.tickCombat(combat)
 
-            assertTrue(player.hp < player.maxHp, "expected damage to land")
-            // Player has 100 HP / 200 max = 50% — above 25% threshold, should still be in combat
+            // 100/200 = 50%, well above the 25% threshold — combat must continue.
+            assertEquals(100, player.hp)
             assertTrue(combat.isInCombat(sid), "expected still in combat above threshold")
-
-            fixture.tickCombat(combat)
-            // After second hit: 0 HP would be death; but wimpy fires at threshold-or-below
-            // 50% → after 100 more damage: 0 hp = death. So threshold check happens just below 50%.
-            // Player would die before wimpy fires — so use a less-deadly mob for the trigger test below.
         }
 
     @Test

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
@@ -130,6 +130,14 @@ class CommandParserTest {
     }
 
     @Test
+    fun `parses wimpy with and without arg`() {
+        assertEquals(Command.Wimpy(null), CommandParser.parse("wimpy"))
+        assertEquals(Command.Wimpy("off"), CommandParser.parse("wimpy off"))
+        assertEquals(Command.Wimpy("25"), CommandParser.parse("wimpy 25"))
+        assertEquals(Command.Wimpy("on"), CommandParser.parse("wimpy on"))
+    }
+
+    @Test
     fun `parses look direction`() {
         val c1 = CommandParser.parse("look north")
         assertEquals(Command.LookDir(Direction.NORTH), c1)

--- a/web-v3/src/canvas/GameStateBridge.ts
+++ b/web-v3/src/canvas/GameStateBridge.ts
@@ -124,7 +124,7 @@ export const gameStateRef: { current: GameStateSnapshot } = {
     combatTarget: null,
     inCombat: false,
     effects: [],
-    character: { name: "-", gender: "", race: "", className: "", level: null, sprite: null, isStaff: false, autolootEnabled: false },
+    character: { name: "-", gender: "", race: "", className: "", level: null, sprite: null, isStaff: false, autolootEnabled: false, wimpyThresholdPct: 10 },
     mobInfo: [],
     groupInfo: { leader: null, members: [] },
     dialogue: null,

--- a/web-v3/src/components/panels/CharacterPanel.tsx
+++ b/web-v3/src/components/panels/CharacterPanel.tsx
@@ -102,6 +102,11 @@ export function CharacterPanel({
     [achievements.completed],
   );
   const autolootEnabled = character.autolootEnabled;
+  const wimpyPct = character.wimpyThresholdPct ?? 0;
+  const WIMPY_PRESETS = [0, 10, 25, 50, 75] as const;
+  const wimpyOptions = WIMPY_PRESETS.includes(wimpyPct as (typeof WIMPY_PRESETS)[number])
+    ? [...WIMPY_PRESETS]
+    : [...WIMPY_PRESETS, wimpyPct].sort((a, b) => a - b);
 
   const CATEGORY_LABELS: Record<string, string> = { general: "Sprites", tier: "Tier Sprites", achievement: "Achievement Sprites", staff: "Staff Sprites" };
   const CATEGORY_ORDER = ["general", "tier", "achievement", "staff"];
@@ -298,6 +303,32 @@ export function CharacterPanel({
                   </span>
                   <span className="character-utility-toggle-label">{autolootEnabled ? "On" : "Off"}</span>
                 </button>
+              </div>
+              <div className="character-utility-strip" role="group" aria-label="Wimpy auto-flee setting">
+                <span
+                  className="character-utility-label"
+                  title={
+                    wimpyPct > 0
+                      ? `Auto-flee combat when HP drops to ${wimpyPct}%.`
+                      : "Wimpy disabled — combat will continue until you flee manually."
+                  }
+                >
+                  Wimpy
+                </span>
+                <select
+                  className="character-utility-select"
+                  aria-label="Wimpy HP threshold"
+                  title="Auto-flee combat when HP drops below this threshold."
+                  disabled={!connected}
+                  value={String(wimpyPct)}
+                  onChange={(e) => onCommand(`wimpy ${e.target.value}`)}
+                >
+                  {wimpyOptions.map((pct) => (
+                    <option key={pct} value={pct}>
+                      {pct === 0 ? "Off" : `${pct}%`}
+                    </option>
+                  ))}
+                </select>
               </div>
               <div className="description-editor-section">
                 <button

--- a/web-v3/src/constants.ts
+++ b/web-v3/src/constants.ts
@@ -95,7 +95,7 @@ export const DEFAULT_STATUS_VAR_LABELS: StatusVarLabels = {
   xp: "XP",
 };
 
-export const EMPTY_CHAR: CharacterInfo = { name: "-", gender: "", race: "", className: "", level: null, sprite: null, isStaff: false, autolootEnabled: false };
+export const EMPTY_CHAR: CharacterInfo = { name: "-", gender: "", race: "", className: "", level: null, sprite: null, isStaff: false, autolootEnabled: false, wimpyThresholdPct: 10 };
 export const DEFAULT_SERVER_FEATURES: ServerFeatures = {
   dailyQuests: false,
   weeklyQuests: false,

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -335,6 +335,7 @@ export function applyGmcpPackage(
         sprite: typeof packet.sprite === "string" ? packet.sprite : null,
         isStaff: packet.isStaff === true,
         autolootEnabled: packet.autolootEnabled === true,
+        wimpyThresholdPct: typeof packet.wimpyThresholdPct === "number" ? packet.wimpyThresholdPct : 10,
       });
       // Login complete — dismiss modal
       ctx.setLoginPrompt(null);

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -7920,6 +7920,56 @@ body {
   letter-spacing: 0.06em;
 }
 
+/* Compact select shares the chip-styling of the toggle — keeps the strip uniform. */
+.character-utility-select {
+  flex-shrink: 0;
+  padding: 4px 22px 4px 10px;
+  border: 1px solid rgb(128 145 219 / 24%);
+  border-radius: 999px;
+  background:
+    linear-gradient(135deg, rgb(39 47 73 / 95%), rgb(55 65 97 / 92%))
+      no-repeat;
+  background-image:
+    linear-gradient(135deg, rgb(39 47 73 / 95%), rgb(55 65 97 / 92%)),
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 8' fill='none'><path d='M1 1.5L6 6.5L11 1.5' stroke='%23b9c1d8' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  background-repeat: no-repeat, no-repeat;
+  background-position: center, right 8px center;
+  background-size: cover, 9px 6px;
+  color: rgb(225 232 247 / 96%);
+  font: inherit;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  transition:
+    transform 150ms var(--ease-out-soft),
+    border-color 150ms var(--ease-out-soft),
+    box-shadow 150ms var(--ease-out-soft);
+}
+
+.character-utility-select:hover:not(:disabled) {
+  transform: translateY(-1px);
+  border-color: rgb(176 193 255 / 42%);
+  box-shadow: var(--shadow-sm), 0 0 14px rgb(118 133 190 / 20%);
+}
+
+.character-utility-select:focus-visible {
+  outline: 2px solid var(--color-primary-lavender);
+  outline-offset: 2px;
+}
+
+.character-utility-select:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.character-utility-select option {
+  background: rgb(38 45 67);
+  color: rgb(225 232 247 / 96%);
+}
+
 /* -- Description editor ------------------------------------------------- */
 
 .description-editor-section {

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -191,6 +191,8 @@ export interface CharacterInfo {
   sprite: string | null;
   isStaff: boolean;
   autolootEnabled: boolean;
+  /** Wimpy auto-flee threshold (HP%). 0 = disabled. */
+  wimpyThresholdPct: number;
 }
 
 export interface RoomState {


### PR DESCRIPTION
## Summary

Adds the classic Diku-style **wimpy** command: an auto-flee threshold (HP%) that breaks combat for the player when a mob hit drops them at or below the configured percentage.

- Persisted as `wimpyThresholdPct` on `PlayerState` / `PlayerRecord`. **Default 10**; range 1-95; `0` disables.
- `wimpy` shows status. `wimpy off` / `wimpy on` / `wimpy <n>` set it. Pushed back via `Char.Name` GMCP.
- Fires inside `CombatSystem.tick()` (PvE) and `tickPvpCombat()` (PvP) after damage lands but before the next mob tick is scheduled — uses the existing `flee(forced = true)` path so the player sees a "Your wounds force you to disengage!" message.
- Web client: new pill-styled `<select>` in the character pane next to the Auto-Loot toggle, with presets (Off / 10% / 25% / 50% / 75%) plus any custom value carried in from the server.
- New Flyway migration `V39__add_wimpy_threshold_pct.sql` adds `wimpy_threshold_pct INTEGER NOT NULL DEFAULT 10`.

## Test plan
- [x] `CombatSystemTest`: wimpy fires at threshold, never fires when 0, doesn't fire above threshold
- [x] `CommandParserTest.parses wimpy*`
- [x] `./gradlew ktlintCheck test` clean
- [x] `bun run lint` clean
- [ ] Manual: `./gradlew demo`, fight an Academy mob, drop wimpy to 75% via the pane, confirm auto-disengage and "forced to flee" message