### PR TITLE
feat(combat): victory toast card on kill with XP, gold, and looted items

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -1645,7 +1645,7 @@ class CombatSystem(
         val rolledDrops = rollDrops(mob)
         callbacks.onRoomItemsChanged(mob.roomId)
         broadcastToRoom(players, outbound, mob.roomId, "${mob.name} dies.")
-        applyAutolootForKiller(killerSessionId, mob.roomId, mobCarried + rolledDrops)
+        val lootedItems = applyAutolootForKiller(killerSessionId, mob.roomId, mobCarried + rolledDrops)
         val goldGained = grantKillGold(killerSessionId, mob)
         grantGroupKillXp(killerSessionId, mob)
         onCombatEvent(
@@ -1655,6 +1655,7 @@ class CombatSystem(
                 targetId = mob.id.value,
                 xpGained = mob.xpReward,
                 goldGained = goldGained,
+                lootedItems = lootedItems,
             ),
         )
 
@@ -1774,12 +1775,12 @@ class CombatSystem(
         killerSessionId: SessionId,
         roomId: RoomId,
         candidates: List<dev.ambon.domain.items.ItemInstance>,
-    ) {
-        if (candidates.isEmpty()) return
-        if (petSystem?.isPetSession(killerSessionId) == true) return
-        val killer = players.get(killerSessionId) ?: return
-        if (!killer.autolootEnabled) return
-        if (killer.roomId != roomId) return
+    ): List<String> {
+        if (candidates.isEmpty()) return emptyList()
+        if (petSystem?.isPetSession(killerSessionId) == true) return emptyList()
+        val killer = players.get(killerSessionId) ?: return emptyList()
+        if (!killer.autolootEnabled) return emptyList()
+        if (killer.roomId != roomId) return emptyList()
 
         val looted = mutableListOf<dev.ambon.domain.items.ItemInstance>()
         for (candidate in candidates) {
@@ -1789,11 +1790,12 @@ class CombatSystem(
             looted += taken
             onItemAutoLooted(killerSessionId, taken)
         }
-        if (looted.isEmpty()) return
+        if (looted.isEmpty()) return emptyList()
 
-        val names = looted.joinToString(", ") { it.item.displayName }
-        outbound.send(OutboundEvent.SendInfo(killerSessionId, "You loot $names."))
+        val names = looted.map { it.item.displayName }
+        outbound.send(OutboundEvent.SendInfo(killerSessionId, "You loot ${names.joinToString(", ")}."))
         callbacks.onRoomItemsChanged(roomId)
+        return names
     }
 }
 

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -1022,6 +1022,7 @@ class GmcpEmitter(
                 targetId = event.targetId,
                 xpGained = event.xpGained,
                 goldGained = event.goldGained,
+                lootedItems = event.lootedItems,
             )
             is CombatEvent.Death -> CombatEventPayload(
                 type = "death",
@@ -2747,6 +2748,7 @@ class GmcpEmitter(
         val shieldRemaining: Int? = null,
         val petName: String? = null,
         val targetIsPlayer: Boolean? = null,
+        val lootedItems: List<String> = emptyList(),
     )
 
     // ---------- stats payload ----------

--- a/src/main/kotlin/dev/ambon/engine/events/CombatEvent.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/CombatEvent.kt
@@ -49,6 +49,7 @@ sealed interface CombatEvent {
         val targetId: String,
         val xpGained: Long,
         val goldGained: Long,
+        val lootedItems: List<String> = emptyList(),
     ) : CombatEvent
 
     data class Death(

--- a/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
@@ -1146,6 +1146,73 @@ class CombatSystemTest {
         }
 
     @Test
+    fun `Kill combat event carries autolooted item names`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            val mob = MobState(MobId("demo:rat"), "a rat", fixture.roomId, hp = 1, maxHp = 1)
+            fixture.mobs.upsert(mob)
+            fixture.items.addMobItem(
+                mob.id,
+                ItemInstance(ItemId("demo:tail"), Item(keyword = "tail", displayName = "a rat tail")),
+            )
+            fixture.items.addMobItem(
+                mob.id,
+                ItemInstance(ItemId("demo:ear"), Item(keyword = "ear", displayName = "a rat ear")),
+            )
+
+            val combat = fixture.buildCombat(rng = Random(2))
+
+            val sid = SessionId(301L)
+            fixture.players.loginOrFail(sid, "VictoryToaster")
+            fixture.players.setAutolootEnabled(sid, true)
+
+            val combatEvents = mutableListOf<CombatEvent>()
+            combat.onCombatEvent = { _, event -> combatEvents += event }
+
+            assertNull(combat.startCombat(sid, "rat"))
+            fixture.tickCombat(combat)
+
+            val kill = combatEvents.filterIsInstance<CombatEvent.Kill>().firstOrNull()
+            assertNotNull(kill, "Expected a Kill combat event, got: $combatEvents")
+            assertEquals(
+                listOf("a rat tail", "a rat ear"),
+                kill!!.lootedItems,
+                "Kill event should carry autolooted item display names in pickup order",
+            )
+        }
+
+    @Test
+    fun `Kill combat event has empty lootedItems when autoloot is disabled`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            val mob = MobState(MobId("demo:rat"), "a rat", fixture.roomId, hp = 1, maxHp = 1)
+            fixture.mobs.upsert(mob)
+            fixture.items.addMobItem(
+                mob.id,
+                ItemInstance(ItemId("demo:tail"), Item(keyword = "tail", displayName = "a rat tail")),
+            )
+
+            val combat = fixture.buildCombat(rng = Random(2))
+
+            val sid = SessionId(302L)
+            fixture.players.loginOrFail(sid, "NoAutoloot")
+            fixture.players.setAutolootEnabled(sid, false)
+
+            val combatEvents = mutableListOf<CombatEvent>()
+            combat.onCombatEvent = { _, event -> combatEvents += event }
+
+            assertNull(combat.startCombat(sid, "rat"))
+            fixture.tickCombat(combat)
+
+            val kill = combatEvents.filterIsInstance<CombatEvent.Kill>().firstOrNull()
+            assertNotNull(kill, "Expected a Kill combat event, got: $combatEvents")
+            assertTrue(
+                kill!!.lootedItems.isEmpty(),
+                "Kill event should have empty lootedItems when autoloot is off, got: ${kill.lootedItems}",
+            )
+        }
+
+    @Test
     fun `autoloot also picks up rolled loot-table drops`() =
         runTest {
             val fixture = CombatTestFixture()

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -1132,6 +1132,35 @@ class GmcpEmitterTest {
             assertTrue(events[0].jsonData.contains("\"type\":\"kill\""))
             assertTrue(events[0].jsonData.contains("\"xpGained\":100"))
             assertTrue(events[0].jsonData.contains("\"goldGained\":25"))
+            // Empty loot list serializes as [] so the web client always sees the
+            // field as an array (avoids null-vs-array branching on the client).
+            assertTrue(
+                events[0].jsonData.contains("\"lootedItems\":[]"),
+                "Expected empty lootedItems array in payload: ${events[0].jsonData}",
+            )
+        }
+
+    @Test
+    fun `sendCombatEvent emits kill JSON with lootedItems`() =
+        runTest {
+            val e = emitter("Char.Combat.Event")
+            e.sendCombatEvent(
+                sid,
+                CombatEvent.Kill(
+                    targetName = "Goblin",
+                    targetId = "mob-1",
+                    xpGained = 100L,
+                    goldGained = 25L,
+                    lootedItems = listOf("a rusty dagger", "a copper coin"),
+                ),
+            )
+            val events = drainGmcp()
+            assertEquals(1, events.size)
+            assertTrue(events[0].jsonData.contains("\"type\":\"kill\""))
+            assertTrue(
+                events[0].jsonData.contains("\"lootedItems\":[\"a rusty dagger\",\"a copper coin\"]"),
+                "Expected lootedItems array in payload: ${events[0].jsonData}",
+            )
         }
 
     @Test

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -30,6 +30,7 @@ import { HelpContent } from "./components/HelpContent";
 import { Atlas } from "./components/Atlas";
 import { LevelUpBanner } from "./components/LevelUpBanner";
 import { QuestCompleteToast } from "./components/QuestCompleteToast";
+import { CombatVictoryToast } from "./components/CombatVictoryToast";
 import { LoginModal } from "./canvas/LoginModal";
 import { CharacterPicker } from "./components/CharacterPicker";
 import { CommandPalette } from "./components/CommandPalette";
@@ -1550,6 +1551,14 @@ function App() {
         notifications={state.questNotifications}
         onDismiss={(id) =>
           state.setQuestNotifications((prev) => prev.filter((n) => n.id !== id))
+        }
+      />
+
+      {/* Combat victory toast — surfaces kills (target, XP, gold, autolooted items). */}
+      <CombatVictoryToast
+        notifications={state.combatVictoryNotifications}
+        onDismiss={(id) =>
+          state.setCombatVictoryNotifications((prev) => prev.filter((n) => n.id !== id))
         }
       />
 

--- a/web-v3/src/components/CombatVictoryToast.tsx
+++ b/web-v3/src/components/CombatVictoryToast.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from "react";
+import type { CombatVictoryNotification } from "../types";
+
+interface CombatVictoryToastProps {
+  notifications: CombatVictoryNotification[];
+  onDismiss: (id: string) => void;
+}
+
+/**
+ * Top-right toast surfaced when the local player lands a killing blow.
+ *
+ * Shows the defeated enemy plus XP/gold/autolooted-items earned for ~4.5s
+ * then fades. Click to dismiss early. Only the most recent kill is rendered;
+ * back-to-back kills replace the prior toast so rapid pulls don't stack the
+ * corner with N cards.
+ */
+export function CombatVictoryToast({ notifications, onDismiss }: CombatVictoryToastProps) {
+  const current = notifications.length > 0 ? notifications[notifications.length - 1] : null;
+  if (!current) return null;
+  return (
+    <CombatVictoryToastInner
+      key={current.id}
+      notification={current}
+      onDismiss={() => onDismiss(current.id)}
+    />
+  );
+}
+
+interface InnerProps {
+  notification: CombatVictoryNotification;
+  onDismiss: () => void;
+}
+
+function CombatVictoryToastInner({ notification, onDismiss }: InnerProps) {
+  const [closing, setClosing] = useState(false);
+
+  useEffect(() => {
+    const fade = window.setTimeout(() => setClosing(true), 4500);
+    return () => window.clearTimeout(fade);
+  }, []);
+
+  useEffect(() => {
+    if (!closing) return;
+    const clear = window.setTimeout(() => onDismiss(), 350);
+    return () => window.clearTimeout(clear);
+  }, [closing, onDismiss]);
+
+  const { targetName, xpGained, goldGained, lootedItems } = notification;
+  const hasRewards = xpGained > 0 || goldGained > 0 || lootedItems.length > 0;
+
+  return (
+    <div
+      className={`combat-victory-toast${closing ? " combat-victory-toast-closing" : ""}`}
+      role="status"
+      aria-live="polite"
+      onClick={() => setClosing(true)}
+    >
+      <div className="combat-victory-toast-header">
+        <span className="combat-victory-toast-icon" aria-hidden="true">{"⚔"}</span>
+        <div className="combat-victory-toast-titles">
+          <span className="combat-victory-toast-eyebrow">Victory</span>
+          <span className="combat-victory-toast-name">{targetName} defeated</span>
+        </div>
+      </div>
+      {hasRewards && (
+        <ul className="combat-victory-toast-rewards" role="list">
+          {xpGained > 0 && (
+            <li className="combat-victory-toast-reward combat-victory-toast-reward-xp">
+              <span className="combat-victory-toast-reward-amount">+{xpGained}</span>
+              <span className="combat-victory-toast-reward-label">XP</span>
+            </li>
+          )}
+          {goldGained > 0 && (
+            <li className="combat-victory-toast-reward combat-victory-toast-reward-gold">
+              <span className="combat-victory-toast-reward-amount">+{goldGained}</span>
+              <span className="combat-victory-toast-reward-label">Gold</span>
+            </li>
+          )}
+        </ul>
+      )}
+      {lootedItems.length > 0 && (
+        <ul className="combat-victory-toast-loot" role="list">
+          {lootedItems.map((name, i) => (
+            <li key={`${name}-${i}`} className="combat-victory-toast-loot-item">
+              <span className="combat-victory-toast-loot-bullet" aria-hidden="true">{"◆"}</span>
+              <span className="combat-victory-toast-loot-name">{name}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web-v3/src/components/CombatVictoryToast.tsx
+++ b/web-v3/src/components/CombatVictoryToast.tsx
@@ -46,7 +46,7 @@ function CombatVictoryToastInner({ notification, onDismiss }: InnerProps) {
   }, [closing, onDismiss]);
 
   const { targetName, xpGained, goldGained, lootedItems } = notification;
-  const hasRewards = xpGained > 0 || goldGained > 0 || lootedItems.length > 0;
+  const hasRewards = xpGained > 0 || goldGained > 0;
 
   return (
     <div

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -1009,6 +1009,9 @@ export function applyGmcpPackage(
         goldGained: safeNumber(packet.goldGained),
         petName: typeof packet.petName === "string" ? packet.petName : null,
         targetIsPlayer: packet.targetIsPlayer === true,
+        lootedItems: Array.isArray(packet.lootedItems)
+          ? packet.lootedItems.filter((s): s is string => typeof s === "string")
+          : [],
       });
       break;
     }

--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -145,7 +145,6 @@ function combatEventToLogMessage(event: CombatEventData): CombatLogMessage | nul
 
 const MAX_COMBAT_LOG = 200;
 const MAX_QUEST_NOTIFICATIONS = 5;
-const MAX_COMBAT_VICTORY_NOTIFICATIONS = 3;
 const MAX_FRIEND_NOTIFICATIONS = 5;
 const MAX_UI_FEEDBACK_FEED = 20;
 const MAX_SYSTEM_ACTIVITY = 12;
@@ -336,10 +335,10 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
         lootedItems: event.lootedItems,
         receivedAt: Date.now(),
       };
-      setCombatVictoryNotifications((prev) => {
-        const next = [...prev, notification];
-        return next.length > MAX_COMBAT_VICTORY_NOTIFICATIONS ? next.slice(-MAX_COMBAT_VICTORY_NOTIFICATIONS) : next;
-      });
+      // Replace (rather than append) so back-to-back kills don't queue stale
+      // toasts behind the active one — otherwise the active toast's dismissal
+      // resurfaces a prior kill several seconds late.
+      setCombatVictoryNotifications([notification]);
     }
   }, [pushCombatLogMessage]);
 

--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -21,6 +21,7 @@ import type {
   CombatEventData,
   CombatLogMessage,
   CombatTarget,
+  CombatVictoryNotification,
   CommandEntry,
   ContainerContents,
   CraftingNode,
@@ -144,6 +145,7 @@ function combatEventToLogMessage(event: CombatEventData): CombatLogMessage | nul
 
 const MAX_COMBAT_LOG = 200;
 const MAX_QUEST_NOTIFICATIONS = 5;
+const MAX_COMBAT_VICTORY_NOTIFICATIONS = 3;
 const MAX_FRIEND_NOTIFICATIONS = 5;
 const MAX_UI_FEEDBACK_FEED = 20;
 const MAX_SYSTEM_ACTIVITY = 12;
@@ -194,6 +196,8 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
   const gainEventsRef = useRef<GainEvent[]>([]);
   const [levelUpNotification, setLevelUpNotification] = useState<LevelUpNotification | null>(null);
   const levelUpIdRef = useRef(0);
+  const [combatVictoryNotifications, setCombatVictoryNotifications] = useState<CombatVictoryNotification[]>([]);
+  const combatVictoryIdRef = useRef(0);
   const [duelState, setDuelState] = useState<DuelState | null>(null);
   const [duelChallenge, setDuelChallenge] = useState<DuelChallenge | null>(null);
 
@@ -322,6 +326,21 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     canvasEvents.push(event);
     const logMsg = combatEventToLogMessage(event);
     if (logMsg) pushCombatLogMessage(logMsg);
+    if (event.type === "kill" && event.targetName) {
+      combatVictoryIdRef.current += 1;
+      const notification: CombatVictoryNotification = {
+        id: `combat-victory-${combatVictoryIdRef.current}`,
+        targetName: event.targetName,
+        xpGained: event.xpGained,
+        goldGained: event.goldGained,
+        lootedItems: event.lootedItems,
+        receivedAt: Date.now(),
+      };
+      setCombatVictoryNotifications((prev) => {
+        const next = [...prev, notification];
+        return next.length > MAX_COMBAT_VICTORY_NOTIFICATIONS ? next.slice(-MAX_COMBAT_VICTORY_NOTIFICATIONS) : next;
+      });
+    }
   }, [pushCombatLogMessage]);
 
   const pushUiFeedback = useCallback((feedback: UiFeedback) => {
@@ -626,6 +645,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     setShop(null);
     setPuzzle(null);
     setQuestNotifications([]);
+    setCombatVictoryNotifications([]);
     setCraftingSkills([]);
     setCraftingRecipes([]);
     setCraftingNodes([]);
@@ -713,6 +733,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     // UI
     activePopout, setActivePopout, broadcast, setBroadcast, possessing, toast, setToast, uiFeedbackFeed,
     levelUpNotification, setLevelUpNotification,
+    combatVictoryNotifications, setCombatVictoryNotifications,
     // Setters needed by App
     setQuestsAvailable,
     // GMCP

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -17386,3 +17386,172 @@ html:has(.game-shell),
     animation-duration: 80ms;
   }
 }
+
+/* ── Combat victory toast — kill summary card ──────────────────── */
+.combat-victory-toast {
+  position: fixed;
+  /* Offset below the quest toast slot so the two never overlap when a
+     quest turn-in and a kill land in the same frame. */
+  top: calc(var(--space-4, 16px) + 56px + 180px);
+  right: var(--space-4, 16px);
+  z-index: 240;
+  width: min(320px, calc(100vw - 32px));
+  padding: 14px 16px;
+  background: linear-gradient(
+    155deg,
+    color-mix(in srgb, var(--c-dusty-rose, #c97f7f) 22%, var(--c-surface-raised, #1e2340)) 0%,
+    var(--c-surface-raised, #1e2340) 60%,
+    color-mix(in srgb, var(--c-soft-gold, #f0c674) 14%, var(--c-surface-raised, #1e2340)) 100%
+  );
+  border: 1px solid color-mix(in srgb, var(--c-dusty-rose, #c97f7f) 45%, transparent);
+  border-radius: 14px;
+  box-shadow:
+    0 18px 48px rgba(0, 0, 0, 0.45),
+    0 0 0 1px color-mix(in srgb, var(--c-dusty-rose, #c97f7f) 22%, transparent),
+    0 0 32px color-mix(in srgb, var(--c-dusty-rose, #c97f7f) 28%, transparent);
+  color: var(--c-text-primary, #d8dcef);
+  cursor: pointer;
+  animation: combatVictoryToastIn 380ms var(--ease-out-soft, cubic-bezier(0.22, 1, 0.36, 1));
+  backdrop-filter: blur(8px);
+}
+
+.combat-victory-toast.combat-victory-toast-closing {
+  animation: combatVictoryToastOut 320ms var(--ease-out-soft, cubic-bezier(0.22, 1, 0.36, 1)) forwards;
+}
+
+@keyframes combatVictoryToastIn {
+  from {
+    opacity: 0;
+    transform: translateX(24px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+}
+
+@keyframes combatVictoryToastOut {
+  from {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(16px) scale(0.97);
+  }
+}
+
+.combat-victory-toast-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.combat-victory-toast-icon {
+  font-size: 22px;
+  filter: drop-shadow(0 0 6px color-mix(in srgb, var(--c-dusty-rose, #c97f7f) 60%, transparent));
+}
+
+.combat-victory-toast-titles {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.combat-victory-toast-eyebrow {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: color-mix(in srgb, var(--c-dusty-rose, #c97f7f) 75%, var(--c-text-secondary, #8890b0));
+  font-weight: 600;
+}
+
+.combat-victory-toast-name {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--c-text-primary, #d8dcef);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.combat-victory-toast-rewards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0 0 8px 0;
+  padding: 0;
+  list-style: none;
+}
+
+.combat-victory-toast-reward {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  background: color-mix(in srgb, var(--c-surface-base, #131630) 60%, transparent);
+  border: 1px solid color-mix(in srgb, var(--c-text-secondary, #8890b0) 25%, transparent);
+}
+
+.combat-victory-toast-reward-amount {
+  font-weight: 700;
+}
+
+.combat-victory-toast-reward-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--c-text-secondary, #8890b0);
+}
+
+.combat-victory-toast-reward-xp {
+  border-color: color-mix(in srgb, var(--c-accent-lavender, #b294bb) 45%, transparent);
+  color: color-mix(in srgb, var(--c-accent-lavender, #b294bb) 80%, var(--c-text-primary, #d8dcef));
+}
+
+.combat-victory-toast-reward-gold {
+  border-color: color-mix(in srgb, var(--c-soft-gold, #f0c674) 55%, transparent);
+  color: color-mix(in srgb, var(--c-soft-gold, #f0c674) 90%, var(--c-text-primary, #d8dcef));
+}
+
+.combat-victory-toast-loot {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 6px 0 0 0;
+  list-style: none;
+  border-top: 1px solid color-mix(in srgb, var(--c-text-secondary, #8890b0) 18%, transparent);
+}
+
+.combat-victory-toast-loot-item {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--c-text-primary, #d8dcef);
+  min-width: 0;
+}
+
+.combat-victory-toast-loot-bullet {
+  color: color-mix(in srgb, var(--c-moss-green, #b5bd68) 80%, var(--c-text-primary, #d8dcef));
+  font-size: 10px;
+  flex: 0 0 auto;
+}
+
+.combat-victory-toast-loot-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .combat-victory-toast,
+  .combat-victory-toast.combat-victory-toast-closing {
+    animation-duration: 80ms;
+  }
+}

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -494,6 +494,8 @@ export interface CombatEventData {
   petName: string | null;
   /** True when the visible target of a non-damaging cast is the local player. */
   targetIsPlayer: boolean;
+  /** Display names of items autolooted from the kill (only set on type=="kill"). */
+  lootedItems: string[];
 }
 
 export interface StatEntry {
@@ -629,6 +631,19 @@ export interface MailMessage {
 export interface MailNotification {
   from: string;
   unreadCount: number;
+}
+
+/**
+ * Top-right toast surfaced when the local player lands a killing blow. Built
+ * from `Char.Combat.Event` packets of `type: "kill"` and shown once per kill.
+ */
+export interface CombatVictoryNotification {
+  id: string;
+  targetName: string;
+  xpGained: number;
+  goldGained: number;
+  lootedItems: string[];
+  receivedAt: number;
 }
 
 export interface QuestNotification {


### PR DESCRIPTION
## Summary
- Adds a top-right victory toast surfaced when the local player lands a killing blow, mirroring the existing quest-complete toast pattern
- Shows defeated enemy + XP / gold / autolooted item names; auto-fades after 4.5s, click to dismiss
- Toast is positioned below the quest-complete slot so a simultaneous quest turn-in + kill don't overlap

## Implementation notes
- **Server**: `CombatEvent.Kill` now carries `lootedItems: List<String>`; `applyAutolootForKiller` returns the display names and they're emitted on `Char.Combat.Event`. Empty list serializes as `[]` so the client never has to branch on null vs array.
- **Web**: `combatVictoryNotifications` state (cap 3) populated from `pushCombatEvent` when `type==="kill"`. New `CombatVictoryToast.tsx` styled with dusty-rose accents (vs the quest toast's gold) and a loot list under the XP/gold chips.
- **Scope decisions** (from the design discussion): toast-style only — no full-screen banner; victory-only — no defeat card; loot list shows autolooted items only (drops left on the ground aren't included).

## Test plan
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew test` — full Kotlin suite green
- [x] `bunx tsc --noEmit -p tsconfig.app.json` in `web-v3/`
- [x] `bun run lint` in `web-v3/`
- [x] New unit tests: `CombatSystemTest` (Kill event carries autolooted names; empty when autoloot off), `GmcpEmitterTest` (kill JSON emits `lootedItems` array, both empty and populated cases)
- [ ] Manual: `./gradlew demo`, kill any mob with autoloot on — verify toast appears with enemy name, XP, gold, and looted items