### PR TITLE
feat(web): compact mob card with expanded look modal and image zoom

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -1746,6 +1746,8 @@ data class CommandsConfig(
             "get" to CommandMetadata("get/take/pickup <item>", "Pick up an item", "items", requiresTarget = true),
             "drop" to CommandMetadata("drop <item>", "Drop an item", "items", requiresTarget = true),
             "use" to CommandMetadata("use <item>", "Use a consumable item", "items", requiresTarget = true),
+            "quickheal" to CommandMetadata("quickheal/qh", "Auto-use best healing potion", "combat"),
+            "quickmana" to CommandMetadata("quickmana/qm", "Auto-use best mana potion", "combat"),
             "give" to CommandMetadata("give <item> <player>", "Give an item to a player", "items", requiresTarget = true),
             "talk" to CommandMetadata("talk <npc>", "Start a conversation with an NPC", "social", requiresTarget = true),
             "kill" to CommandMetadata("kill <mob>", "Attack a mob", "combat", requiresTarget = true),

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -2286,6 +2286,13 @@ class GmcpEmitter(
             enchantments = item.enchantments.ifEmpty { null },
             consumable = if (item.item.consumable) true else null,
             useEffect = item.item.onUse?.describe(),
+            onUse = item.item.onUse?.let { effect ->
+                if (effect.healHp > 0 || effect.healMana > 0) {
+                    ItemUseEffectPayload(healHp = effect.healHp, healMana = effect.healMana)
+                } else {
+                    null
+                }
+            },
             itemType = item.item.resolvedType().label(),
             questItem = if (item.item.questItem) true else null,
             stackKey = computeStackKey(item),
@@ -2432,9 +2439,15 @@ class GmcpEmitter(
         val enchantments: List<String>? = null,
         val consumable: Boolean? = null,
         val useEffect: String? = null,
+        val onUse: ItemUseEffectPayload? = null,
         val itemType: String,
         val questItem: Boolean? = null,
         val stackKey: String,
+    )
+
+    private data class ItemUseEffectPayload(
+        val healHp: Int,
+        val healMana: Int,
     )
 
     private data class EquipmentSlotPayload(

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -98,6 +98,12 @@ sealed interface Command {
         val keyword: String,
     ) : Command
 
+    /** Auto-select and consume the best HP potion. See [Command.QuickMana] for the mana counterpart. */
+    data object QuickHeal : Command
+
+    /** Auto-select and consume the best mana potion. */
+    data object QuickMana : Command
+
     data class Give(
         val keyword: String,
         val playerName: String,
@@ -852,6 +858,10 @@ object CommandParser {
 
         // use
         requiredArg(line, listOf("use"), "use <item>", { Command.Use(it) })?.let { return it }
+
+        // quick heal / quick mana
+        matchPrefix(line, listOf("quickheal", "qh")) { Command.QuickHeal }?.let { return it }
+        matchPrefix(line, listOf("quickmana", "qm")) { Command.QuickMana }?.let { return it }
 
         // give
         matchPrefix(line, listOf("give")) { rest ->

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ItemHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ItemHandler.kt
@@ -3,7 +3,9 @@ package dev.ambon.engine.commands.handlers
 import dev.ambon.config.SkillPointsConfig
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.items.ItemSlot
+import dev.ambon.domain.items.ItemUseEffect
 import dev.ambon.engine.EquipmentSlotRegistry
 import dev.ambon.engine.HousingSystem
 import dev.ambon.engine.PlayerProgression
@@ -49,8 +51,65 @@ class ItemHandler(
         router.on<Command.Get> { sid, cmd -> handleGet(sid, cmd) }
         router.on<Command.Drop> { sid, cmd -> handleDrop(sid, cmd) }
         router.on<Command.Use> { sid, cmd -> handleUse(sid, cmd) }
+        router.on<Command.QuickHeal> { sid, _ -> handleQuickPotion(sid, PotionKind.HP) }
+        router.on<Command.QuickMana> { sid, _ -> handleQuickPotion(sid, PotionKind.MANA) }
         router.on<Command.Give> { sid, cmd -> handleGive(sid, cmd) }
     }
+
+    internal enum class PotionKind { HP, MANA }
+
+    private suspend fun handleQuickPotion(
+        sessionId: SessionId,
+        kind: PotionKind,
+    ) {
+        if (isBlocked(sessionId, allowInCombat = true)) return
+        players.withPlayer(sessionId) { me ->
+            val (current, max, label) = when (kind) {
+                PotionKind.HP -> Triple(me.hp, me.maxHp, "HP")
+                PotionKind.MANA -> Triple(me.mana, me.maxMana, "mana")
+            }
+            val missing = max - current
+            if (missing <= 0) {
+                outbound.send(OutboundEvent.SendError(sessionId, "Your $label is already full."))
+                return
+            }
+            val inventory = items.inventory(me.sessionId)
+            val candidates = inventory.filter { instance ->
+                val effect = instance.item.onUse ?: return@filter false
+                instance.item.consumable && healAmountFor(effect, kind) > 0
+            }
+            if (candidates.isEmpty()) {
+                val potionWord = if (kind == PotionKind.HP) "healing potion" else "mana potion"
+                outbound.send(OutboundEvent.SendError(sessionId, "You aren't carrying any $potionWord."))
+                return
+            }
+            val chosen = selectBestPotion(candidates, missing, kind)
+            val result = items.useItemById(me.sessionId, chosen.id)
+            applyUseResult(sessionId, result)
+        }
+    }
+
+    /**
+     * Picks the least powerful potion that fully restores [missing]; if none qualify, picks the most powerful.
+     * Ties broken by inventory order (stable).
+     */
+    internal fun selectBestPotion(
+        candidates: List<ItemInstance>,
+        missing: Int,
+        kind: PotionKind,
+    ): ItemInstance {
+        val sufficient = candidates.filter { healAmountFor(it.item.onUse!!, kind) >= missing }
+        return if (sufficient.isNotEmpty()) {
+            sufficient.minBy { healAmountFor(it.item.onUse!!, kind) }
+        } else {
+            candidates.maxBy { healAmountFor(it.item.onUse!!, kind) }
+        }
+    }
+
+    private fun healAmountFor(
+        effect: ItemUseEffect,
+        kind: PotionKind,
+    ): Int = if (kind == PotionKind.HP) effect.healHp else effect.healMana
 
     /**
      * Returns true (and sends an error) if the player is in a state that blocks the item command.
@@ -240,14 +299,28 @@ class ItemHandler(
     ) {
         if (isBlocked(sessionId, allowInCombat = true)) return
         players.withPlayer(sessionId) { me ->
-            when (val result = items.useItem(me.sessionId, cmd.keyword)) {
-                is ItemRegistry.UseResult.Used -> {
-                    val effect = result.item.item.onUse
-                    if (effect == null) {
-                        outbound.send(OutboundEvent.SendError(sessionId, "${result.item.item.displayName} cannot be used."))
-                        return
-                    }
-                    outbound.send(OutboundEvent.SendInfo(sessionId, "You use ${result.item.item.displayName}."))
+            val result = items.useItem(me.sessionId, cmd.keyword)
+            if (result is ItemRegistry.UseResult.NotFound) {
+                outbound.send(OutboundEvent.SendError(sessionId, "You aren't carrying or wearing '${cmd.keyword}'."))
+                return
+            }
+            applyUseResult(sessionId, result)
+        }
+    }
+
+    private suspend fun applyUseResult(
+        sessionId: SessionId,
+        result: ItemRegistry.UseResult,
+    ) {
+        when (result) {
+            is ItemRegistry.UseResult.Used -> {
+                val effect = result.item.item.onUse
+                if (effect == null) {
+                    outbound.send(OutboundEvent.SendError(sessionId, "${result.item.item.displayName} cannot be used."))
+                    return
+                }
+                outbound.send(OutboundEvent.SendInfo(sessionId, "You use ${result.item.item.displayName}."))
+                players.withPlayer(sessionId) { me ->
                     if (effect.healHp > 0) {
                         val previousHp = me.hp
                         me.healHp(effect.healHp)
@@ -270,33 +343,33 @@ class ItemHandler(
                             outbound.send(OutboundEvent.SendInfo(sessionId, "Your mana is already full."))
                         }
                     }
-                    if (effect.grantXp > 0L) {
-                        grantScaledItemXp(sessionId, effect.grantXp)
-                    }
-                    if (result.consumed) {
-                        outbound.send(OutboundEvent.SendInfo(sessionId, "${result.item.item.displayName} is consumed."))
-                        afterEquipChange(sessionId, combat, items, gmcpEmitter, markStatsDirty)
-                    } else if (result.remainingCharges != null) {
-                        outbound.send(
-                            OutboundEvent.SendInfo(
-                                sessionId,
-                                "${result.item.item.displayName} has ${result.remainingCharges} charge(s) remaining.",
-                            ),
-                        )
-                    }
                 }
-                is ItemRegistry.UseResult.NotFound ->
-                    outbound.send(OutboundEvent.SendError(sessionId, "You aren't carrying or wearing '${cmd.keyword}'."))
-                is ItemRegistry.UseResult.NotUsable ->
-                    outbound.send(OutboundEvent.SendError(sessionId, "${result.item.item.displayName} cannot be used."))
-                is ItemRegistry.UseResult.NoCharges ->
+                if (effect.grantXp > 0L) {
+                    grantScaledItemXp(sessionId, effect.grantXp)
+                }
+                if (result.consumed) {
+                    outbound.send(OutboundEvent.SendInfo(sessionId, "${result.item.item.displayName} is consumed."))
+                    afterEquipChange(sessionId, combat, items, gmcpEmitter, markStatsDirty)
+                } else if (result.remainingCharges != null) {
                     outbound.send(
-                        OutboundEvent.SendError(
+                        OutboundEvent.SendInfo(
                             sessionId,
-                            "${result.item.item.displayName} has no charges remaining.",
+                            "${result.item.item.displayName} has ${result.remainingCharges} charge(s) remaining.",
                         ),
                     )
+                }
             }
+            is ItemRegistry.UseResult.NotFound ->
+                outbound.send(OutboundEvent.SendError(sessionId, "That item is no longer available."))
+            is ItemRegistry.UseResult.NotUsable ->
+                outbound.send(OutboundEvent.SendError(sessionId, "${result.item.item.displayName} cannot be used."))
+            is ItemRegistry.UseResult.NoCharges ->
+                outbound.send(
+                    OutboundEvent.SendError(
+                        sessionId,
+                        "${result.item.item.displayName} has no charges remaining.",
+                    ),
+                )
         }
     }
 

--- a/src/main/kotlin/dev/ambon/engine/items/ItemRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/items/ItemRegistry.kt
@@ -399,6 +399,19 @@ class ItemRegistry {
     }
 
     /**
+     * Use a specific owned item by [itemId]. Same semantics as [useItem] but
+     * resolves the item by id rather than keyword, so callers (e.g. quickheal)
+     * can target one exact inventory entry.
+     */
+    fun useItemById(
+        sessionId: SessionId,
+        itemId: ItemId,
+    ): UseResult {
+        val match = findOwnedItemMatchById(sessionId, itemId) ?: return UseResult.NotFound
+        return applyUse(sessionId, match)
+    }
+
+    /**
      * Use an item from inventory or equipment by keyword.
      */
     fun useItem(
@@ -406,6 +419,13 @@ class ItemRegistry {
         keyword: String,
     ): UseResult {
         val match = findOwnedItemMatch(sessionId, keyword) ?: return UseResult.NotFound
+        return applyUse(sessionId, match)
+    }
+
+    private fun applyUse(
+        sessionId: SessionId,
+        match: MatchedOwnedItem,
+    ): UseResult {
         if (match.item.item.onUse == null) return UseResult.NotUsable(match.item)
 
         val currentCharges = match.item.item.charges
@@ -541,6 +561,35 @@ class ItemRegistry {
         val inv = inventoryItems[sessionId] ?: return null
         val idx = findMatchingItemIndex(inv, keyword)
         return if (idx >= 0) inv[idx] else null
+    }
+
+    private fun findOwnedItemMatchById(
+        sessionId: SessionId,
+        itemId: ItemId,
+    ): MatchedOwnedItem? {
+        val inv = inventoryItems[sessionId]
+        if (inv != null) {
+            val invIdx = inv.indexOfFirst { it.id == itemId }
+            if (invIdx >= 0) {
+                return MatchedOwnedItem(
+                    item = inv[invIdx],
+                    location = HeldItemLocation.INVENTORY,
+                    index = invIdx,
+                )
+            }
+        }
+        val equipped = equippedItems[sessionId]
+        if (equipped != null) {
+            val entry = equipped.entries.firstOrNull { (_, equippedItem) -> equippedItem.id == itemId }
+            if (entry != null) {
+                return MatchedOwnedItem(
+                    item = entry.value,
+                    location = HeldItemLocation.EQUIPPED,
+                    slot = entry.key,
+                )
+            }
+        }
+        return null
     }
 
     private fun findOwnedItemMatch(

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
@@ -104,6 +104,16 @@ class CommandParserTest {
     }
 
     @Test
+    fun `parses quickheal and quickmana with aliases`() {
+        assertEquals(Command.QuickHeal, CommandParser.parse("quickheal"))
+        assertEquals(Command.QuickHeal, CommandParser.parse("qh"))
+        assertEquals(Command.QuickHeal, CommandParser.parse("QuickHeal"))
+        assertEquals(Command.QuickMana, CommandParser.parse("quickmana"))
+        assertEquals(Command.QuickMana, CommandParser.parse("qm"))
+        assertEquals(Command.QuickMana, CommandParser.parse("QUICKMANA"))
+    }
+
+    @Test
     fun `parses give command with multi-word item`() {
         assertEquals(Command.Give("shimmering potion", "Bob"), CommandParser.parse("give shimmering potion Bob"))
     }

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterQuickPotionTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterQuickPotionTest.kt
@@ -1,0 +1,211 @@
+package dev.ambon.engine.commands
+
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.domain.ids.ItemId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.items.Item
+import dev.ambon.domain.items.ItemInstance
+import dev.ambon.domain.items.ItemUseEffect
+import dev.ambon.domain.world.load.WorldLoader
+import dev.ambon.engine.CombatSystem
+import dev.ambon.engine.LoginResult
+import dev.ambon.engine.MobRegistry
+import dev.ambon.engine.PlayerRegistry
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.drainAll
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CommandRouterQuickPotionTest {
+    @Test
+    fun `quickheal with no potion sends error`() =
+        runTest {
+            val env = setup()
+            env.player.hp = 10
+            env.player.maxHp = 100
+
+            env.router.handle(env.sid, Command.QuickHeal)
+
+            val outs = env.outbound.drainAll()
+            assertTrue(
+                outs.any { it is OutboundEvent.SendError && it.text.contains("healing potion") },
+                "Expected 'no healing potion' error. got=$outs",
+            )
+        }
+
+    @Test
+    fun `quickheal at full HP sends error`() =
+        runTest {
+            val env = setup()
+            env.player.maxHp = 100
+            env.player.hp = 100
+            env.items.addToInventory(env.sid, hpPotion("lesser", heal = 25))
+
+            env.router.handle(env.sid, Command.QuickHeal)
+
+            val outs = env.outbound.drainAll()
+            assertTrue(
+                outs.any { it is OutboundEvent.SendError && it.text.contains("HP is already full") },
+                "Expected 'already full' error. got=$outs",
+            )
+            assertEquals(1, env.items.inventory(env.sid).size)
+        }
+
+    @Test
+    fun `quickheal picks least powerful potion that fully restores`() =
+        runTest {
+            val env = setup()
+            env.player.maxHp = 100
+            env.player.hp = 70 // missing 30
+            env.items.addToInventory(env.sid, hpPotion("minor", heal = 10)) // insufficient
+            env.items.addToInventory(env.sid, hpPotion("lesser", heal = 50)) // first sufficient — should pick
+            env.items.addToInventory(env.sid, hpPotion("greater", heal = 200)) // sufficient but wasteful
+
+            env.router.handle(env.sid, Command.QuickHeal)
+
+            val remaining = env.items.inventory(env.sid).map { it.item.keyword }.toSet()
+            assertEquals(setOf("minor", "greater"), remaining, "Lesser potion should be consumed")
+            assertEquals(100, env.player.hp)
+        }
+
+    @Test
+    fun `quickheal falls back to most powerful when none fully restore`() =
+        runTest {
+            val env = setup()
+            env.player.maxHp = 200
+            env.player.hp = 10 // missing 190
+            env.items.addToInventory(env.sid, hpPotion("minor", heal = 10))
+            env.items.addToInventory(env.sid, hpPotion("lesser", heal = 50))
+            env.items.addToInventory(env.sid, hpPotion("medium", heal = 100))
+
+            env.router.handle(env.sid, Command.QuickHeal)
+
+            val remaining = env.items.inventory(env.sid).map { it.item.keyword }.toSet()
+            assertEquals(setOf("minor", "lesser"), remaining, "Medium (most powerful) should be consumed")
+            assertEquals(110, env.player.hp)
+        }
+
+    @Test
+    fun `quickmana ignores HP-only potions and picks mana potion`() =
+        runTest {
+            val env = setup()
+            env.player.maxMana = 50
+            env.player.mana = 10 // missing 40
+            env.items.addToInventory(env.sid, hpPotion("hp_only", heal = 100))
+            env.items.addToInventory(env.sid, manaPotion("blue", restore = 50))
+
+            env.router.handle(env.sid, Command.QuickMana)
+
+            val remaining = env.items.inventory(env.sid).map { it.item.keyword }.toSet()
+            assertEquals(setOf("hp_only"), remaining, "Mana potion should be consumed, HP potion untouched")
+            assertEquals(50, env.player.mana)
+        }
+
+    @Test
+    fun `quickheal ignores non-consumables and non-heal consumables`() =
+        runTest {
+            val env = setup()
+            env.player.maxHp = 100
+            env.player.hp = 50
+            // A non-consumable item with a heal effect should be skipped.
+            env.items.addToInventory(
+                env.sid,
+                ItemInstance(
+                    ItemId("ok_small:wand"),
+                    Item(
+                        keyword = "wand",
+                        displayName = "a wand",
+                        consumable = false,
+                        onUse = ItemUseEffect(healHp = 100),
+                    ),
+                ),
+            )
+            // A consumable XP scroll (no heal) should be skipped.
+            env.items.addToInventory(
+                env.sid,
+                ItemInstance(
+                    ItemId("ok_small:scroll"),
+                    Item(
+                        keyword = "scroll",
+                        displayName = "a scroll",
+                        consumable = true,
+                        onUse = ItemUseEffect(grantXp = 100L),
+                    ),
+                ),
+            )
+
+            env.router.handle(env.sid, Command.QuickHeal)
+
+            val outs = env.outbound.drainAll()
+            assertTrue(
+                outs.any { it is OutboundEvent.SendError && it.text.contains("healing potion") },
+                "Expected 'no healing potion' error. got=$outs",
+            )
+            // Wand and scroll should both still be in inventory.
+            assertEquals(2, env.items.inventory(env.sid).size)
+            assertEquals(50, env.player.hp)
+        }
+
+    private fun hpPotion(keyword: String, heal: Int): ItemInstance =
+        ItemInstance(
+            ItemId("ok_small:$keyword"),
+            Item(
+                keyword = keyword,
+                displayName = "a $keyword potion",
+                consumable = true,
+                onUse = ItemUseEffect(healHp = heal),
+            ),
+        )
+
+    private fun manaPotion(keyword: String, restore: Int): ItemInstance =
+        ItemInstance(
+            ItemId("ok_small:$keyword"),
+            Item(
+                keyword = keyword,
+                displayName = "a $keyword mana potion",
+                consumable = true,
+                onUse = ItemUseEffect(healMana = restore),
+            ),
+        )
+
+    private data class TestEnv(
+        val items: ItemRegistry,
+        val players: PlayerRegistry,
+        val outbound: LocalOutboundBus,
+        val router: CommandRouter,
+        val sid: SessionId,
+        val player: dev.ambon.engine.PlayerState,
+    )
+
+    private suspend fun setup(): TestEnv {
+        val world = WorldLoader.loadFromResource("world/ok_small.yaml")
+        val items = ItemRegistry()
+        items.loadSpawns(world.itemSpawns)
+        val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
+        val mobs = MobRegistry()
+        val outbound = LocalOutboundBus()
+        val combat = CombatSystem(players, mobs, items, outbound)
+        val router = buildTestRouter(
+            world = world,
+            players = players,
+            mobs = mobs,
+            items = items,
+            combat = combat,
+            outbound = outbound,
+        )
+
+        val sid = SessionId(1L)
+        val res = players.login(sid, "Quaffer", "password")
+        require(res == LoginResult.Ok) { "Login failed: $res" }
+        outbound.drainAll()
+
+        val player = players.get(sid)!!
+        return TestEnv(items, players, outbound, router, sid, player)
+    }
+}

--- a/web-terminal/src/App.tsx
+++ b/web-terminal/src/App.tsx
@@ -716,6 +716,10 @@ function App() {
             sendCommand(`sell ${keyword}`, true);
             focusComposer();
           }}
+          onCommand={(command) => {
+            sendCommand(command, true);
+            focusComposer();
+          }}
         />
 
         <ChatPanel

--- a/web-terminal/src/components/panels/WorldPanel.tsx
+++ b/web-terminal/src/components/panels/WorldPanel.tsx
@@ -41,6 +41,7 @@ interface WorldPanelProps {
   onPickUpItem: (itemName: string) => void;
   onBuyItem: (keyword: string) => void;
   onSellItem: (keyword: string) => void;
+  onCommand: (command: string) => void;
 }
 
 export function WorldPanel({
@@ -79,6 +80,7 @@ export function WorldPanel({
   onPickUpItem,
   onBuyItem,
   onSellItem,
+  onCommand,
 }: WorldPanelProps) {
   return (
     <section className="panel panel-world" aria-label="World state">
@@ -190,12 +192,14 @@ export function WorldPanel({
             hasRoomDetails={hasRoomDetails}
             combatTarget={combatTarget}
             vitals={vitals}
+            inventory={inventory}
             skills={skills}
             mobs={mobs}
             onCastSkill={onCastSkill}
             onRefreshSkills={onRefreshSkills}
             onFlee={onFlee}
             onAttackMob={onAttackMob}
+            onCommand={onCommand}
           />
         ) : (
           <article className="subpanel split-list">

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -159,6 +159,12 @@ function App() {
   const [videoUrl, setVideoUrl] = useState<string | null>(null);
   const [videoClosing, setVideoClosing] = useState(false);
 
+  // Expanded mob detail card — opened from canvas Look button
+  const [mobDetail, setMobDetail] = useState<{ name: string; description: string; image: string | null } | null>(null);
+
+  // Full-size image preview — opened by clicking the entity preview sprite
+  const [imagePreviewUrl, setImagePreviewUrl] = useState<string | null>(null);
+
   // Ctrl+K command palette
   const [showCommandPalette, setShowCommandPalette] = useState(false);
   const [featureFocus, setFeatureFocus] = useState<FeaturePopoutFocus>(null);
@@ -393,6 +399,8 @@ function App() {
       openPanel("questOffers");
     };
     canvasCallbacks.openVideo = (url: string) => setVideoUrl(url);
+    canvasCallbacks.openMobDetail = (detail) => setMobDetail(detail);
+    canvasCallbacks.openImagePreview = (url: string) => setImagePreviewUrl(url);
     canvasCallbacks.prefillCommand = (text: string) => prefillInput(text);
     return () => {
       canvasCallbacks.sendCommand = null;
@@ -413,6 +421,8 @@ function App() {
       canvasCallbacks.dismissDialogue = null;
       canvasCallbacks.openQuestOffers = null;
       canvasCallbacks.openVideo = null;
+      canvasCallbacks.openMobDetail = null;
+      canvasCallbacks.openImagePreview = null;
       canvasCallbacks.prefillCommand = null;
     };
   }, [sendCommand]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -752,6 +762,7 @@ function App() {
         vitals={state.vitals}
         combatLogMessages={state.combatLogMessages}
         combatTarget={state.combatTarget}
+        inventory={state.inventory}
         quickbarSlots={quickbar.slots}
         onQuickbarSwap={quickbar.swap}
         onQuickbarAssign={quickbar.assign}
@@ -1355,6 +1366,76 @@ function App() {
               className="video-modal-player"
             />
           </div>
+        </div>
+      )}
+
+      {/* Expanded mob detail card — full description + larger portrait */}
+      {mobDetail && (
+        <div
+          className="entity-detail-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-label={`${mobDetail.name} details`}
+          onClick={() => setMobDetail(null)}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") setMobDetail(null);
+          }}
+        >
+          <div className="entity-detail-card" onClick={(e) => e.stopPropagation()}>
+            <button
+              className="entity-detail-close"
+              aria-label="Close"
+              autoFocus
+              onClick={() => setMobDetail(null)}
+            >
+              {"✕"}
+            </button>
+            {mobDetail.image && (
+              <button
+                type="button"
+                className="entity-detail-portrait-btn"
+                aria-label="Zoom portrait"
+                onClick={() => setImagePreviewUrl(mobDetail.image)}
+              >
+                <img
+                  className="entity-detail-portrait"
+                  src={mobDetail.image}
+                  alt={mobDetail.name}
+                />
+              </button>
+            )}
+            <h2 className="entity-detail-name">{mobDetail.name}</h2>
+            <p className="entity-detail-description">{mobDetail.description}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Full-size image preview — opened by clicking an entity portrait */}
+      {imagePreviewUrl && (
+        <div
+          className="image-preview-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Image preview"
+          onClick={() => setImagePreviewUrl(null)}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") setImagePreviewUrl(null);
+          }}
+        >
+          <button
+            className="image-preview-close"
+            aria-label="Close image"
+            autoFocus
+            onClick={() => setImagePreviewUrl(null)}
+          >
+            {"✕"}
+          </button>
+          <img
+            className="image-preview-img"
+            src={imagePreviewUrl}
+            alt=""
+            onClick={(e) => e.stopPropagation()}
+          />
         </div>
       )}
 

--- a/web-v3/src/canvas/GameStateBridge.ts
+++ b/web-v3/src/canvas/GameStateBridge.ts
@@ -84,6 +84,8 @@ export const canvasCallbacks: {
   dismissDialogue: (() => void) | null;
   openQuestOffers: ((mobKeyword: string) => void) | null;
   loadZoneMap: ((zone: string, rooms: Array<{ id: string; x: number; y: number; exits: Record<string, string> }>) => void) | null;
+  openMobDetail: ((detail: { name: string; description: string; image: string | null }) => void) | null;
+  openImagePreview: ((url: string) => void) | null;
 } = {
   sendCommand: null,
   prefillCommand: null,
@@ -106,6 +108,8 @@ export const canvasCallbacks: {
   dismissDialogue: null,
   openQuestOffers: null,
   loadZoneMap: null,
+  openMobDetail: null,
+  openImagePreview: null,
 };
 
 export const pendingCastRef: { current: PendingCast | null } = { current: null };

--- a/web-v3/src/canvas/systems/EntityPopout.ts
+++ b/web-v3/src/canvas/systems/EntityPopout.ts
@@ -19,6 +19,17 @@ interface PopoutAction {
   label: string;
   command: string;
   color: number;
+  onClick?: () => void;
+}
+
+const DESCRIPTION_PREVIEW_CHARS = 140;
+
+function truncateDescription(text: string): { preview: string; truncated: boolean } {
+  if (text.length <= DESCRIPTION_PREVIEW_CHARS) return { preview: text, truncated: false };
+  let cut = text.slice(0, DESCRIPTION_PREVIEW_CHARS);
+  const lastSpace = cut.lastIndexOf(" ");
+  if (lastSpace > DESCRIPTION_PREVIEW_CHARS * 0.6) cut = cut.slice(0, lastSpace);
+  return { preview: cut.trimEnd() + "…", truncated: true };
 }
 
 export class EntityPopout {
@@ -100,8 +111,18 @@ export class EntityPopout {
       actions.push({ label: "Attack", command: `kill ${name}`, color: 0xd4888a });
     }
 
-    // Look is always available
-    actions.push({ label: "Look", command: `look ${name}`, color: 0x64b5f6 });
+    // Look is always available — opens an expanded detail card with the
+    // full description (and large image) without going through the server.
+    const fullDescription = description ?? "";
+    const lookImage = image ?? null;
+    actions.push({
+      label: "Look",
+      command: `look ${name}`,
+      color: 0x64b5f6,
+      onClick: () => {
+        canvasCallbacks.openMobDetail?.({ name, description: fullDescription, image: lookImage });
+      },
+    });
 
     // Consider — threat assessment, shown for anything that can be attacked
     if (isAggressive || !isNpc) {
@@ -127,7 +148,8 @@ export class EntityPopout {
     if (info?.questGiver) roleParts.push("Quest Giver");
     if (info?.aggressive) roleParts.push("Hostile");
     const roleLabel = roleParts.join(" \u00B7 ");
-    const subtitle = description || roleLabel || (maxHp > 0 ? `HP: ${hp}/${maxHp}` : "");
+    const previewDescription = description ? truncateDescription(description).preview : "";
+    const subtitle = previewDescription || roleLabel || (maxHp > 0 ? `HP: ${hp}/${maxHp}` : "");
     const tint = isAggressive ? 0xd4888a : info?.shopKeeper ? 0x81a2be : info?.questGiver ? 0xf0c674 : 0xf0c674;
     this.show(name + roleTag, subtitle, image ?? null, tint, actions);
   }
@@ -191,6 +213,15 @@ export class EntityPopout {
         preview.texture = tex;
         preview.tint = 0xffffff;
       }).catch(() => { /* keep placeholder */ });
+      preview.eventMode = "static";
+      preview.cursor = "zoom-in";
+      preview.removeAllListeners();
+      preview.on("pointerdown", (e) => {
+        e.stopPropagation();
+        canvasCallbacks.openImagePreview?.(image);
+      });
+    } else {
+      preview.eventMode = "none";
     }
 
     this.titleText.text = title;
@@ -274,7 +305,13 @@ export class EntityPopout {
       btnContainer.addChild(btnLabel);
 
       const cmd = action.command;
+      const onClick = action.onClick;
       btnContainer.on("pointerdown", () => {
+        if (onClick) {
+          onClick();
+          this.hide();
+          return;
+        }
         if (cmd.startsWith("__video__:")) {
           canvasCallbacks.openVideo?.(cmd.slice("__video__:".length));
         } else if (cmd.startsWith("__prefill__:")) {

--- a/web-v3/src/combat/quickPotion.ts
+++ b/web-v3/src/combat/quickPotion.ts
@@ -1,0 +1,42 @@
+import type { ItemSummary } from "../types";
+
+export type PotionKind = "hp" | "mana";
+
+export interface QuickPotionPick {
+  item: ItemSummary;
+  /** How much that potion would restore for the chosen kind. */
+  amount: number;
+  /** True if the chosen potion would fully restore the missing amount. */
+  fullyRestores: boolean;
+}
+
+/**
+ * Selects the least powerful potion in [inventory] that fully restores [missing] for [kind].
+ * Falls back to the most powerful potion when none fully restore. Returns null when no candidate
+ * exists or the player isn't missing any of the resource.
+ */
+export function selectQuickPotion(
+  inventory: readonly ItemSummary[],
+  missing: number,
+  kind: PotionKind,
+): QuickPotionPick | null {
+  if (missing <= 0) return null;
+  const candidates: { item: ItemSummary; amount: number }[] = [];
+  for (const item of inventory) {
+    if (!item.consumable) continue;
+    const amount = kind === "hp" ? item.onUse?.healHp ?? 0 : item.onUse?.healMana ?? 0;
+    if (amount > 0) candidates.push({ item, amount });
+  }
+  if (candidates.length === 0) return null;
+
+  const sufficient = candidates.filter((c) => c.amount >= missing);
+  const pool = sufficient.length > 0 ? sufficient : candidates;
+  const pick = sufficient.length > 0
+    ? pool.reduce((best, cur) => (cur.amount < best.amount ? cur : best))
+    : pool.reduce((best, cur) => (cur.amount > best.amount ? cur : best));
+  return {
+    item: pick.item,
+    amount: pick.amount,
+    fullyRestores: pick.amount >= missing,
+  };
+}

--- a/web-v3/src/components/GameShell.tsx
+++ b/web-v3/src/components/GameShell.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { PixiCanvas } from "../canvas/PixiCanvas";
 import { CombatLog } from "./CombatLog";
 import { VitalsBar } from "./VitalsBar";
-import type { CombatLogMessage, CombatTarget, PopoutPanel, SkillSummary, Vitals } from "../types";
+import type { CombatLogMessage, CombatTarget, ItemSummary, PopoutPanel, SkillSummary, Vitals } from "../types";
 import type { AudioEngine } from "../hooks/useAudioEngine";
 
 interface GameShellProps {
@@ -12,6 +12,7 @@ interface GameShellProps {
   vitals: Vitals;
   combatLogMessages: CombatLogMessage[];
   combatTarget: CombatTarget | null;
+  inventory: ItemSummary[];
   quickbarSlots: (SkillSummary | null)[];
   onQuickbarSwap: (fromIndex: number, toIndex: number) => void;
   onQuickbarAssign: (slotIndex: number, skillId: string) => void;
@@ -37,6 +38,7 @@ export function GameShell({
   vitals,
   combatLogMessages,
   combatTarget,
+  inventory,
   quickbarSlots,
   onQuickbarSwap,
   onQuickbarAssign,
@@ -95,6 +97,7 @@ export function GameShell({
         connected={connected}
         loggedIn={loggedIn}
         vitals={vitals}
+        inventory={inventory}
         quickbarSlots={quickbarSlots}
         onQuickbarSwap={onQuickbarSwap}
         onQuickbarAssign={onQuickbarAssign}

--- a/web-v3/src/components/VitalsBar.tsx
+++ b/web-v3/src/components/VitalsBar.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 import type { DragEvent, FormEvent, KeyboardEvent } from "react";
-import type { PopoutPanel, SkillSummary, Vitals } from "../types";
+import type { ItemSummary, PopoutPanel, SkillSummary, Vitals } from "../types";
 import type { AudioEngine } from "../hooks/useAudioEngine";
 import { AudioControls } from "./AudioControls";
+import { selectQuickPotion } from "../combat/quickPotion";
 import { percent } from "../utils";
 import {
   CharacterAvatarIcon,
@@ -62,6 +63,7 @@ interface VitalsBarProps {
   connected: boolean;
   loggedIn: boolean;
   vitals: Vitals;
+  inventory: ItemSummary[];
   quickbarSlots: (SkillSummary | null)[];
   onQuickbarSwap: (fromIndex: number, toIndex: number) => void;
   onQuickbarAssign: (slotIndex: number, skillId: string) => void;
@@ -200,6 +202,7 @@ export function VitalsBar({
   connected,
   loggedIn,
   vitals,
+  inventory,
   quickbarSlots,
   onQuickbarSwap,
   onQuickbarAssign,
@@ -287,29 +290,67 @@ export function VitalsBar({
   return (
     <nav ref={navRef} className="vbar" aria-label="Action bar">
       {/* Vitals row */}
-      {loggedIn && (
-        <div className="vbar-vitals">
-          <div className="vbar-vital" title={`HP: ${vitals.hp}/${vitals.maxHp}`}>
-            <span className="vbar-vital-label">HP</span>
-            <div className="vbar-vital-track">
-              <span className="vbar-vital-fill vbar-vital-hp" style={{ width: `${percent(vitals.hp, vitals.maxHp)}%` }} />
+      {loggedIn && (() => {
+        const hpPick = selectQuickPotion(inventory, vitals.maxHp - vitals.hp, "hp");
+        const manaPick = selectQuickPotion(inventory, vitals.maxMana - vitals.mana, "mana");
+        const hpDisabled = vitals.hp >= vitals.maxHp || hpPick === null;
+        const manaDisabled = vitals.mana >= vitals.maxMana || manaPick === null;
+        const hpTitle = vitals.hp >= vitals.maxHp
+          ? "HP is full"
+          : hpPick
+            ? `Quick Heal — ${hpPick.item.name} (+${hpPick.amount} HP${hpPick.fullyRestores ? ", fully restores" : ""})`
+            : "No healing potion in inventory";
+        const manaTitle = vitals.mana >= vitals.maxMana
+          ? "Mana is full"
+          : manaPick
+            ? `Quick Mana — ${manaPick.item.name} (+${manaPick.amount} mana${manaPick.fullyRestores ? ", fully restores" : ""})`
+            : "No mana potion in inventory";
+        return (
+          <div className="vbar-vitals">
+            <div className="vbar-vital" title={`HP: ${vitals.hp}/${vitals.maxHp}`}>
+              <span className="vbar-vital-label">HP</span>
+              <div className="vbar-vital-track">
+                <span className="vbar-vital-fill vbar-vital-hp" style={{ width: `${percent(vitals.hp, vitals.maxHp)}%` }} />
+              </div>
+              <span className="vbar-vital-text">{vitals.hp}/{vitals.maxHp}</span>
             </div>
-            <span className="vbar-vital-text">{vitals.hp}/{vitals.maxHp}</span>
-          </div>
-          <div className="vbar-vital" title={`MP: ${vitals.mana}/${vitals.maxMana}`}>
-            <span className="vbar-vital-label">MP</span>
-            <div className="vbar-vital-track">
-              <span className="vbar-vital-fill vbar-vital-mp" style={{ width: `${percent(vitals.mana, vitals.maxMana)}%` }} />
+            <button
+              type="button"
+              className="vbar-quick-potion vbar-quick-potion-hp"
+              onClick={() => onCommand("quickheal")}
+              disabled={hpDisabled}
+              title={hpTitle}
+              aria-label={hpTitle}
+            >
+              <span className="vbar-quick-potion-icon" aria-hidden="true">+</span>
+              <span className="vbar-quick-potion-label">Heal</span>
+            </button>
+            <div className="vbar-vital" title={`MP: ${vitals.mana}/${vitals.maxMana}`}>
+              <span className="vbar-vital-label">MP</span>
+              <div className="vbar-vital-track">
+                <span className="vbar-vital-fill vbar-vital-mp" style={{ width: `${percent(vitals.mana, vitals.maxMana)}%` }} />
+              </div>
+              <span className="vbar-vital-text">{vitals.mana}/{vitals.maxMana}</span>
             </div>
-            <span className="vbar-vital-text">{vitals.mana}/{vitals.maxMana}</span>
+            <button
+              type="button"
+              className="vbar-quick-potion vbar-quick-potion-mana"
+              onClick={() => onCommand("quickmana")}
+              disabled={manaDisabled}
+              title={manaTitle}
+              aria-label={manaTitle}
+            >
+              <span className="vbar-quick-potion-icon" aria-hidden="true">+</span>
+              <span className="vbar-quick-potion-label">Mana</span>
+            </button>
+            <div className="vbar-gold">
+              <span className="vbar-gold-coin" />
+              <span className="vbar-gold-text">{vitals.gold.toLocaleString()}</span>
+            </div>
+            <AudioControls audio={audio} />
           </div>
-          <div className="vbar-gold">
-            <span className="vbar-gold-coin" />
-            <span className="vbar-gold-text">{vitals.gold.toLocaleString()}</span>
-          </div>
-          <AudioControls audio={audio} />
-        </div>
-      )}
+        );
+      })()}
 
       {/* Quickbar skills + pet bar (horizontal scroll). Pet bar appears to the right
           of the quickbar with a small divider, auto-populated from the active pet's

--- a/web-v3/src/components/panels/CombatPanel.tsx
+++ b/web-v3/src/components/panels/CombatPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import type { CombatTarget, RoomMob, SkillSummary, Vitals } from "../../types";
+import type { CombatTarget, ItemSummary, RoomMob, SkillSummary, Vitals } from "../../types";
+import { selectQuickPotion } from "../../combat/quickPotion";
 import { percent } from "../../utils";
 import { CrosshairIcon, FleeIcon, RefreshIcon, SkillCastIcon } from "../Icons";
 
@@ -10,12 +11,14 @@ interface CombatPanelProps {
   hasRoomDetails: boolean;
   combatTarget: CombatTarget | null;
   vitals: Vitals;
+  inventory: ItemSummary[];
   skills: SkillSummary[];
   mobs: RoomMob[];
   onCastSkill: (skillId: string, cooldownMs: number) => void;
   onRefreshSkills: () => void;
   onFlee: () => void;
   onAttackMob: (mobName: string) => void;
+  onCommand: (cmd: string) => void;
 }
 
 export function CombatPanel({
@@ -23,12 +26,14 @@ export function CombatPanel({
   hasRoomDetails,
   combatTarget,
   vitals,
+  inventory,
   skills,
   mobs,
   onCastSkill,
   onRefreshSkills,
   onFlee,
   onAttackMob,
+  onCommand,
 }: CombatPanelProps) {
   const [now, setNow] = useState(() => Date.now());
   const [activeTab, setActiveTab] = useState<AbilityTab>("all");
@@ -187,27 +192,67 @@ export function CombatPanel({
       )}
 
       {/* Action bar */}
-      <div className="combat-action-bar">
-        <button
-          type="button"
-          className="combat-flee-button"
-          title="Flee from combat"
-          onClick={onFlee}
-        >
-          <FleeIcon className="combat-action-icon" />
-          <span>Flee</span>
-        </button>
-        <button
-          type="button"
-          className="soft-button"
-          onClick={onRefreshSkills}
-          disabled={!connected || !hasRoomDetails}
-          title="Refresh skills"
-        >
-          <RefreshIcon className="combat-action-icon" />
-          <span>Skills</span>
-        </button>
-      </div>
+      {(() => {
+        const hpPick = selectQuickPotion(inventory, vitals.maxHp - vitals.hp, "hp");
+        const manaPick = selectQuickPotion(inventory, vitals.maxMana - vitals.mana, "mana");
+        const hpDisabled = vitals.hp >= vitals.maxHp || hpPick === null;
+        const manaDisabled = vitals.mana >= vitals.maxMana || manaPick === null;
+        const hpTitle = vitals.hp >= vitals.maxHp
+          ? "HP is full"
+          : hpPick
+            ? `Quick Heal — ${hpPick.item.name} (+${hpPick.amount} HP${hpPick.fullyRestores ? ", fully restores" : ""})`
+            : "No healing potion in inventory";
+        const manaTitle = vitals.mana >= vitals.maxMana
+          ? "Mana is full"
+          : manaPick
+            ? `Quick Mana — ${manaPick.item.name} (+${manaPick.amount} mana${manaPick.fullyRestores ? ", fully restores" : ""})`
+            : "No mana potion in inventory";
+        return (
+          <div className="combat-action-bar">
+            <button
+              type="button"
+              className="combat-flee-button"
+              title="Flee from combat"
+              onClick={onFlee}
+            >
+              <FleeIcon className="combat-action-icon" />
+              <span>Flee</span>
+            </button>
+            <button
+              type="button"
+              className="soft-button"
+              onClick={onRefreshSkills}
+              disabled={!connected || !hasRoomDetails}
+              title="Refresh skills"
+            >
+              <RefreshIcon className="combat-action-icon" />
+              <span>Skills</span>
+            </button>
+            <button
+              type="button"
+              className="soft-button combat-quick-potion combat-quick-potion-hp"
+              onClick={() => onCommand("quickheal")}
+              disabled={hpDisabled}
+              title={hpTitle}
+              aria-label={hpTitle}
+            >
+              <span aria-hidden="true">+</span>
+              <span>Heal</span>
+            </button>
+            <button
+              type="button"
+              className="soft-button combat-quick-potion combat-quick-potion-mana"
+              onClick={() => onCommand("quickmana")}
+              disabled={manaDisabled}
+              title={manaTitle}
+              aria-label={manaTitle}
+            >
+              <span aria-hidden="true">+</span>
+              <span>Mana</span>
+            </button>
+          </div>
+        );
+      })()}
     </article>
   );
 }

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -230,6 +230,15 @@ function isChatChannel(value: string): value is ChatChannel {
   return CHAT_CHANNEL_SET.has(value as ChatChannel);
 }
 
+function parseOnUse(raw: unknown): { healHp: number; healMana: number } | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const obj = raw as Record<string, unknown>;
+  const healHp = typeof obj.healHp === "number" ? obj.healHp : 0;
+  const healMana = typeof obj.healMana === "number" ? obj.healMana : 0;
+  if (healHp <= 0 && healMana <= 0) return undefined;
+  return { healHp, healMana };
+}
+
 function parseMobEffects(raw: unknown): StatusEffect[] | undefined {
   if (!Array.isArray(raw)) return undefined;
   const effects = raw
@@ -483,6 +492,7 @@ export function applyGmcpPackage(
               enchantments: Array.isArray(entry.enchantments) ? entry.enchantments.filter((e): e is string => typeof e === "string") : undefined,
               consumable: typeof entry.consumable === "boolean" ? entry.consumable : undefined,
               useEffect: typeof entry.useEffect === "string" ? entry.useEffect : undefined,
+              onUse: parseOnUse(entry.onUse),
             }))
         : [];
 
@@ -529,6 +539,7 @@ export function applyGmcpPackage(
           enchantments: Array.isArray(packet.enchantments) ? (packet.enchantments as unknown[]).filter((e): e is string => typeof e === "string") : undefined,
           consumable: typeof packet.consumable === "boolean" ? packet.consumable : undefined,
           useEffect: typeof packet.useEffect === "string" ? packet.useEffect : undefined,
+          onUse: parseOnUse(packet.onUse),
         },
       ]);
       break;

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -14530,6 +14530,146 @@ body {
   outline: none;
 }
 
+/* ── Entity detail modal (Look) ────────────────────────────── */
+
+.entity-detail-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 250;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(0 0 0 / 70%);
+  backdrop-filter: blur(8px);
+  animation: videoFadeIn 0.25s ease-out forwards;
+  padding: 24px;
+}
+
+.entity-detail-card {
+  position: relative;
+  width: min(520px, 96vw);
+  max-height: 88vh;
+  overflow-y: auto;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--glass-edge);
+  background: rgb(18 22 34 / 96%);
+  box-shadow: 0 8px 32px rgb(0 0 0 / 60%);
+  padding: 32px 28px 24px;
+  text-align: center;
+  color: var(--color-text-primary, #d8dcef);
+}
+
+.entity-detail-close {
+  position: absolute;
+  top: -14px;
+  right: -14px;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 1px solid var(--glass-edge);
+  background: rgb(42 16 64 / 92%);
+  color: var(--color-accent-violet, #b9aed8);
+  font-size: 1rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
+}
+
+.entity-detail-close:hover {
+  background: rgb(62 26 84 / 92%);
+}
+
+.entity-detail-portrait-btn {
+  display: inline-block;
+  padding: 0;
+  margin: 0 auto 14px;
+  background: transparent;
+  border: none;
+  cursor: zoom-in;
+  border-radius: 10px;
+}
+
+.entity-detail-portrait {
+  display: block;
+  width: 220px;
+  height: 220px;
+  object-fit: cover;
+  border-radius: 10px;
+  border: 1px solid var(--glass-edge);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 40%);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.entity-detail-portrait-btn:hover .entity-detail-portrait,
+.entity-detail-portrait-btn:focus-visible .entity-detail-portrait {
+  transform: scale(1.03);
+  box-shadow: 0 6px 20px rgb(0 0 0 / 55%);
+}
+
+.entity-detail-name {
+  margin: 0 0 12px;
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--color-text-primary, #d8dcef);
+}
+
+.entity-detail-description {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  color: var(--color-text-secondary, #c0c5dc);
+  white-space: pre-wrap;
+  text-align: left;
+}
+
+/* ── Full-size image preview ───────────────────────────────── */
+
+.image-preview-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 260;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(0 0 0 / 88%);
+  backdrop-filter: blur(10px);
+  animation: videoFadeIn 0.25s ease-out forwards;
+  padding: 24px;
+  cursor: zoom-out;
+}
+
+.image-preview-img {
+  max-width: 96vw;
+  max-height: 92vh;
+  border-radius: 8px;
+  box-shadow: 0 12px 48px rgb(0 0 0 / 70%);
+  cursor: default;
+}
+
+.image-preview-close {
+  position: absolute;
+  top: 24px;
+  right: 24px;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  border: 1px solid var(--glass-edge);
+  background: rgb(42 16 64 / 92%);
+  color: var(--color-accent-violet, #b9aed8);
+  font-size: 1.1rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.image-preview-close:hover {
+  background: rgb(62 26 84 / 92%);
+}
+
 /* ── Command Palette (Ctrl+K) ──────────────────────────────── */
 
 .cmd-palette-backdrop {
@@ -16684,6 +16824,58 @@ html:has(.game-shell),
   background: linear-gradient(135deg, rgb(212 184 92 / 18%), rgb(189 168 115 / 12%));
   border: 1px solid rgb(212 184 92 / 36%);
   border-radius: 999px;
+}
+
+.vbar-quick-potion {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 9px;
+  border-radius: 999px;
+  border: 1px solid var(--line-faint);
+  background: linear-gradient(135deg, rgb(255 255 255 / 6%), rgb(255 255 255 / 2%));
+  color: var(--text-secondary);
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease, opacity 0.15s ease;
+  flex-shrink: 0;
+}
+
+.vbar-quick-potion-icon {
+  font-size: 0.85rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.vbar-quick-potion-hp {
+  color: var(--color-hp-light);
+  border-color: rgb(158 191 117 / 38%);
+  background: linear-gradient(135deg, rgb(158 191 117 / 18%), rgb(158 191 117 / 8%));
+}
+
+.vbar-quick-potion-hp:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 0 8px rgb(158 191 117 / 30%);
+  background: linear-gradient(135deg, rgb(158 191 117 / 28%), rgb(158 191 117 / 14%));
+}
+
+.vbar-quick-potion-mana {
+  color: var(--color-mana-light);
+  border-color: rgb(127 182 207 / 38%);
+  background: linear-gradient(135deg, rgb(127 182 207 / 18%), rgb(127 182 207 / 8%));
+}
+
+.vbar-quick-potion-mana:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 0 8px rgb(127 182 207 / 30%);
+  background: linear-gradient(135deg, rgb(127 182 207 / 28%), rgb(127 182 207 / 14%));
+}
+
+.vbar-quick-potion:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
 }
 
 .vbar-gold-coin {

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -16878,6 +16878,40 @@ html:has(.game-shell),
   cursor: not-allowed;
 }
 
+/* Combat panel variant — inherits .soft-button base, adds HP/mana color tinting. */
+.combat-quick-potion {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.combat-quick-potion-hp {
+  color: var(--color-hp-light);
+  border-color: rgb(158 191 117 / 38%);
+  background: linear-gradient(135deg, rgb(158 191 117 / 18%), rgb(158 191 117 / 8%));
+}
+
+.combat-quick-potion-hp:hover:not(:disabled) {
+  box-shadow: 0 0 8px rgb(158 191 117 / 30%);
+  background: linear-gradient(135deg, rgb(158 191 117 / 28%), rgb(158 191 117 / 14%));
+}
+
+.combat-quick-potion-mana {
+  color: var(--color-mana-light);
+  border-color: rgb(127 182 207 / 38%);
+  background: linear-gradient(135deg, rgb(127 182 207 / 18%), rgb(127 182 207 / 8%));
+}
+
+.combat-quick-potion-mana:hover:not(:disabled) {
+  box-shadow: 0 0 8px rgb(127 182 207 / 30%);
+  background: linear-gradient(135deg, rgb(127 182 207 / 28%), rgb(127 182 207 / 14%));
+}
+
+.combat-quick-potion:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
 .vbar-gold-coin {
   width: 12px;
   height: 12px;

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -251,6 +251,8 @@ export interface ItemSummary {
   enchantments?: string[];
   consumable?: boolean;
   useEffect?: string;
+  /** Numeric on-use restoration. Sent alongside [useEffect] for consumables that heal HP or mana. */
+  onUse?: { healHp: number; healMana: number };
   /** Server-resolved category. Falls back to "misc" if missing for older servers. */
   itemType?: ItemType;
   /** True when the item is soulbound — cannot be dropped, sold, traded, given. */

--- a/web-v3/test/quickPotion.test.ts
+++ b/web-v3/test/quickPotion.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { selectQuickPotion } from "../src/combat/quickPotion";
+import type { ItemSummary } from "../src/types";
+
+function hpPotion(name: string, heal: number, consumable = true): ItemSummary {
+  return {
+    id: `i:${name}`,
+    name,
+    keyword: name,
+    slot: null,
+    consumable,
+    onUse: { healHp: heal, healMana: 0 },
+  };
+}
+
+function manaPotion(name: string, restore: number): ItemSummary {
+  return {
+    id: `i:${name}`,
+    name,
+    keyword: name,
+    slot: null,
+    consumable: true,
+    onUse: { healHp: 0, healMana: restore },
+  };
+}
+
+describe("selectQuickPotion", () => {
+  test("returns null when nothing is missing", () => {
+    const pick = selectQuickPotion([hpPotion("lesser", 25)], 0, "hp");
+    expect(pick).toBeNull();
+  });
+
+  test("returns null when no candidate potion exists", () => {
+    const pick = selectQuickPotion([manaPotion("blue", 50)], 30, "hp");
+    expect(pick).toBeNull();
+  });
+
+  test("picks the least powerful potion that fully restores the missing amount", () => {
+    const inv = [hpPotion("minor", 10), hpPotion("lesser", 50), hpPotion("greater", 200)];
+    const pick = selectQuickPotion(inv, 30, "hp");
+    expect(pick).not.toBeNull();
+    expect(pick?.item.name).toBe("lesser");
+    expect(pick?.amount).toBe(50);
+    expect(pick?.fullyRestores).toBe(true);
+  });
+
+  test("falls back to the most powerful potion when none fully restore", () => {
+    const inv = [hpPotion("minor", 10), hpPotion("lesser", 50), hpPotion("medium", 100)];
+    const pick = selectQuickPotion(inv, 190, "hp");
+    expect(pick).not.toBeNull();
+    expect(pick?.item.name).toBe("medium");
+    expect(pick?.amount).toBe(100);
+    expect(pick?.fullyRestores).toBe(false);
+  });
+
+  test("mana kind ignores HP-only potions", () => {
+    const inv = [hpPotion("red", 100), manaPotion("blue", 50)];
+    const pick = selectQuickPotion(inv, 40, "mana");
+    expect(pick?.item.name).toBe("blue");
+    expect(pick?.amount).toBe(50);
+  });
+
+  test("ignores non-consumable items even if they have a heal onUse", () => {
+    const inv = [hpPotion("wand", 100, false)];
+    const pick = selectQuickPotion(inv, 50, "hp");
+    expect(pick).toBeNull();
+  });
+
+  test("ignores consumables without an onUse heal value", () => {
+    const inv: ItemSummary[] = [
+      { id: "i:scroll", name: "scroll", keyword: "scroll", slot: null, consumable: true },
+    ];
+    const pick = selectQuickPotion(inv, 50, "hp");
+    expect(pick).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Initial mob popout now shows a truncated ~140-char description preview so the card stays compact.
- **Look** button no longer fires a server `look` command — it opens a client-side detail modal with the full description and a 220×220 portrait.
- Clicking the portrait (in the popout or in the detail card) opens a full-size image overlay. Both modals close on backdrop click, Esc, or the X button.
- New `openMobDetail` / `openImagePreview` callbacks on `canvasCallbacks`; `PopoutAction` gains an optional `onClick` so Pixi buttons can run client-side handlers without routing through the command-string protocol.
- Bundles in-progress quick-potion combat work (new `quickPotion.ts`, `CommandRouterQuickPotionTest.kt`, vitals-bar quick-potion buttons, related GMCP/inventory plumbing) currently sitting on the working tree.

## Test plan
- [ ] Click a mob with a long description — confirm the popout shows a truncated preview, not the full text.
- [ ] Click **Look** — confirm the expanded card opens with the full description and larger portrait; no `look` text appears in the chat log.
- [ ] Click the small portrait in the popout — confirm the full-size image overlay opens.
- [ ] Click the portrait inside the detail card — confirm it also opens the image overlay (stacked above the detail card).
- [ ] Confirm Esc, backdrop click, and X all close each modal.
- [ ] `./gradlew ktlintCheck test` passes (includes the new quick-potion test).
- [ ] `bun run lint` and `tsc -b` in `web-v3/` pass.