### PR TITLE
feat: demo mode — one-click guest characters with /claim upgrade

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -1295,6 +1295,12 @@ data class CharacterCreationConfig(
     val defaultRace: String = "HUMAN",
     val defaultClass: String = "WARRIOR",
     val defaultGender: String = "enby",
+    /**
+     * When true, typing "demo" at the login name prompt spawns an ephemeral
+     * demo character using the configured default race/class. The character
+     * disappears at disconnect unless they run `/claim`.
+     */
+    val demoEnabled: Boolean = true,
 )
 
 data class EmotePresetConfig(

--- a/src/main/kotlin/dev/ambon/engine/DemoNameGenerator.kt
+++ b/src/main/kotlin/dev/ambon/engine/DemoNameGenerator.kt
@@ -1,0 +1,87 @@
+package dev.ambon.engine
+
+import kotlin.random.Random
+
+/**
+ * Generates fantasy-flavored names for demo (guest) characters.
+ *
+ * A demo name is a curated fantasy first name with a small numeric suffix
+ * (e.g. "Aelara42", "Brogan7"). The suffix keeps names unique among
+ * concurrently-online demo characters and reduces the chance of collision
+ * with a registered account.
+ *
+ * Callers pass [isTaken] to test candidate names against both the online
+ * registry and the persistent repo. Generation retries up to [maxAttempts]
+ * times before falling back to a longer suffix that is virtually guaranteed
+ * to be unique.
+ */
+class DemoNameGenerator(
+    private val random: Random = Random.Default,
+) {
+    suspend fun generate(isTaken: suspend (String) -> Boolean, maxAttempts: Int = 20): String {
+        repeat(maxAttempts) {
+            val candidate = buildCandidate(suffixDigits = 2)
+            if (!isTaken(candidate)) return candidate
+        }
+        // Fallback: a longer suffix to guarantee a free slot.
+        repeat(maxAttempts) {
+            val candidate = buildCandidate(suffixDigits = 4)
+            if (!isTaken(candidate)) return candidate
+        }
+        // Last resort — shouldn't happen in practice unless the world has
+        // tens of thousands of online demos. Names are still valid per
+        // PlayerRegistry.isValidName (2..16 chars, alnum/_, no leading digit).
+        return buildCandidate(suffixDigits = 5)
+    }
+
+    private fun buildCandidate(suffixDigits: Int): String {
+        val name = FANTASY_NAMES[random.nextInt(FANTASY_NAMES.size)]
+        val max = pow10(suffixDigits)
+        val suffix = random.nextInt(max)
+        // 16-char cap: pick names short enough that name + 5 digits fits.
+        return "$name$suffix"
+    }
+
+    private fun pow10(n: Int): Int {
+        var v = 1
+        repeat(n) { v *= 10 }
+        return v
+    }
+
+    companion object {
+        // Hand-picked fantasy names: max 10 chars so a 4-5 digit suffix keeps
+        // the total under the 16-char name limit.
+        internal val FANTASY_NAMES = listOf(
+            "Aelara",
+            "Brogan",
+            "Cyrene",
+            "Drystan",
+            "Elowen",
+            "Fenris",
+            "Galen",
+            "Halina",
+            "Ivar",
+            "Joren",
+            "Kaeli",
+            "Larian",
+            "Mira",
+            "Nyx",
+            "Orin",
+            "Petra",
+            "Quill",
+            "Rowan",
+            "Sable",
+            "Tova",
+            "Ulrich",
+            "Vesna",
+            "Wren",
+            "Xanth",
+            "Yara",
+            "Zorin",
+            "Anara",
+            "Bryn",
+            "Calix",
+            "Darra",
+        )
+    }
+}

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -24,6 +24,7 @@ import dev.ambon.engine.commands.handlers.AdminHandler
 import dev.ambon.engine.commands.handlers.AuctionHandler
 import dev.ambon.engine.commands.handlers.AutoQuestHandler
 import dev.ambon.engine.commands.handlers.BankHandler
+import dev.ambon.engine.commands.handlers.ClaimHandler
 import dev.ambon.engine.commands.handlers.CombatHandler
 import dev.ambon.engine.commands.handlers.CommunicationHandler
 import dev.ambon.engine.commands.handlers.CraftingHandler
@@ -231,6 +232,9 @@ class GameEngine(
             maxWrongPasswordRetries = loginConfig.maxWrongPasswordRetries,
             maxFailedLoginAttemptsBeforeDisconnect = loginConfig.maxFailedAttemptsBeforeDisconnect,
             maxConcurrentLogins = loginConfig.maxConcurrentLogins,
+            demoEnabled = engineConfig.characterCreation.demoEnabled,
+            demoDefaultRace = engineConfig.characterCreation.defaultRace,
+            demoDefaultClass = engineConfig.characterCreation.defaultClass,
             onAfterLogin = { sid ->
                 players.get(sid)?.lastActivityEpochMs = clock.millis()
                 housingSystem?.onPlayerLogin(sid)
@@ -1332,6 +1336,10 @@ class GameEngine(
             FriendsHandler(
                 ctx = ctx,
                 friendsSystem = friendsSystem,
+            ),
+            ClaimHandler(
+                ctx = ctx,
+                onClaimed = { sid -> issueAuthToken(sid) },
             ),
             HousingHandler(
                 ctx = ctx,

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -1339,6 +1339,7 @@ class GameEngine(
             ),
             ClaimHandler(
                 ctx = ctx,
+                getEngineScope = { engineScope },
                 onClaimed = { sid -> issueAuthToken(sid) },
             ),
             HousingHandler(

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -526,6 +526,7 @@ class GmcpEmitter(
                 isStaff = player.isStaff,
                 autolootEnabled = player.autolootEnabled,
                 wimpyThresholdPct = player.wimpyThresholdPct,
+                isDemo = player.playerId == null,
             ),
         )
     }
@@ -2595,6 +2596,12 @@ class GmcpEmitter(
         val isStaff: Boolean,
         val autolootEnabled: Boolean,
         val wimpyThresholdPct: Int,
+        /**
+         * True for unclaimed demo characters (no persistent account). Web client
+         * surfaces a "Save your progress" prompt when set. Flips to false after
+         * a successful `/claim`.
+         */
+        val isDemo: Boolean,
     )
 
     private data class SessionAuthTokenPayload(

--- a/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
@@ -45,6 +45,26 @@ sealed interface CreateResult {
 }
 
 /**
+ * Result of converting a demo (unclaimed) character into a real account
+ * via [PlayerRegistry.claim].
+ */
+sealed interface ClaimResult {
+    data class Ok(
+        val playerId: PlayerId,
+        val name: String,
+    ) : ClaimResult
+
+    /** Session has no player bound, or the player is already claimed. */
+    data object NotDemo : ClaimResult
+
+    data object InvalidName : ClaimResult
+
+    data object InvalidPassword : ClaimResult
+
+    data object Taken : ClaimResult
+}
+
+/**
  * Result of the async credential-resolution phase of login.
  * No in-memory engine state is modified during this phase.
  */
@@ -314,6 +334,131 @@ class PlayerRegistry(
         }
     }
 
+    /**
+     * Creates an ephemeral demo character and binds it to [sessionId].
+     *
+     * The character is **not** persisted to the repository — it lives only in
+     * memory and disappears when the session disconnects. Internally this builds
+     * a [PlayerRecord] just like account creation but skips the `repo.create`
+     * call and sets [PlayerState.playerId] to `null`, so [persistIfClaimed] is
+     * a no-op for the lifetime of the session.
+     *
+     * If the player later runs `/claim` they will be upgraded to a real account
+     * via [claim], at which point a real [PlayerRecord] is written.
+     */
+    suspend fun createDemo(
+        sessionId: SessionId,
+        name: String,
+        defaultAnsiEnabled: Boolean = false,
+        race: String = "HUMAN",
+        playerClass: String = "WARRIOR",
+    ): CreateResult {
+        if (players.containsKey(sessionId)) return CreateResult.InvalidName
+        if (!isValidName(name)) return CreateResult.InvalidName
+        if (isNameOnline(name, sessionId)) return CreateResult.Taken
+
+        fun base(id: String): Int = statRegistry?.get(id)?.baseStat ?: PlayerState.BASE_STAT
+        val raceMods = raceRegistry?.get(race)?.statMods ?: StatMap.EMPTY
+        val statKeys = statRegistry?.all()?.map { it.id } ?: listOf("STR", "DEX", "CON", "INT", "WIS", "CHA")
+        val resolvedStats = statKeys.associateWith { id -> base(id) + raceMods[id] }
+        val classDef = classRegistry?.get(playerClass)
+        val classStartRoom = classStartRooms[playerClass.uppercase()]
+            ?: classDef?.startRoom?.let { RoomId(it) }
+        val (starterInventory, starterEquipped) = resolveStarterEquipment(classDef?.starterEquipment.orEmpty())
+
+        val now = clock.millis()
+        // PlayerId(0L) is a sentinel — the PlayerState's playerId is overwritten
+        // to null below so this record id is never used.
+        val record = PlayerRecord(
+            id = PlayerId(0L),
+            name = name,
+            roomId = classStartRoom ?: startRoom,
+            stats = resolvedStats,
+            gender = defaultGender,
+            race = race,
+            playerClass = playerClass,
+            createdAtEpochMs = now,
+            lastSeenEpochMs = now,
+            passwordHash = "",
+            ansiEnabled = defaultAnsiEnabled,
+            gold = startingGold,
+            autolootEnabled = true,
+            inventoryItems = starterInventory,
+            equippedItems = starterEquipped,
+        )
+        bindDemoSession(sessionId, record)
+        return CreateResult.Ok
+    }
+
+    /**
+     * Converts the demo character bound to [sessionId] into a real account.
+     *
+     * Validates [newName] (or keeps the current demo name if null) and [password],
+     * checks the name isn't taken, persists a fresh [PlayerRecord] via
+     * `repo.create`, and updates the in-memory [PlayerState] (`name`, `playerId`,
+     * `passwordHash`) plus the session-by-name index. After this returns
+     * successfully, [persistIfClaimed] writes the player's full current state
+     * (inventory, gold, xp, etc.) and the character is indistinguishable from
+     * one created through the normal login flow.
+     */
+    suspend fun claim(
+        sessionId: SessionId,
+        newNameRaw: String?,
+        passwordRaw: String,
+    ): ClaimResult {
+        val ps = players[sessionId] ?: return ClaimResult.NotDemo
+        if (ps.playerId != null) return ClaimResult.NotDemo
+
+        val targetName = normalizeName(newNameRaw ?: ps.name)
+        val password = normalizePassword(passwordRaw)
+        if (!isValidName(targetName)) return ClaimResult.InvalidName
+        if (!isValidPassword(password)) return ClaimResult.InvalidPassword
+        // Allow keeping the same name (case-insensitive match against self),
+        // otherwise the name must be free both online and in the repo.
+        val keepingSameName = targetName.equals(ps.name, ignoreCase = true)
+        if (!keepingSameName) {
+            if (isNameOnline(targetName, sessionId)) return ClaimResult.Taken
+            if (repo.findByName(targetName) != null) return ClaimResult.Taken
+        }
+
+        val hash = withContext(hashingContext) { passwordHasher.hash(password) }
+        val now = clock.millis()
+
+        val record = try {
+            repo.create(
+                PlayerCreationRequest(
+                    name = targetName,
+                    startRoomId = ps.roomId,
+                    nowEpochMs = now,
+                    passwordHash = hash,
+                    ansiEnabled = ps.ansiEnabled,
+                    race = ps.race,
+                    playerClass = ps.playerClass,
+                    gender = ps.gender,
+                    stats = ps.stats.values,
+                    gold = ps.gold,
+                    // Starter inventory/equipment lives in ItemRegistry and is
+                    // persisted by the trailing persistIfClaimed call below.
+                ),
+            )
+        } catch (_: PersistenceException) {
+            return ClaimResult.Taken
+        }
+
+        // Re-index by name if it changed
+        if (!keepingSameName) {
+            sessionByLowerName.remove(ps.name.lowercase())
+        }
+        ps.name = targetName
+        ps.playerId = record.id
+        ps.passwordHash = hash
+        sessionByLowerName[targetName.lowercase()] = sessionId
+
+        // Persist current runtime state (xp, hp, inventory, equipment, etc.).
+        persistIfClaimed(ps)
+        return ClaimResult.Ok(record.id, targetName)
+    }
+
     suspend fun create(
         sessionId: SessionId,
         nameRaw: String,
@@ -332,6 +477,36 @@ class PlayerRegistry(
             is CreateAccountPrep.Ready -> applyCreateAccount(sessionId, prep.record)
             CreateAccountPrep.InvalidInput -> CreateResult.InvalidName
             CreateAccountPrep.Taken -> CreateResult.Taken
+        }
+    }
+
+    /**
+     * Ephemeral variant of [bindSession] for demo characters. Skips the
+     * trailing `repo.save` and nullifies [PlayerState.playerId] so the player
+     * is never persisted (see [persistIfClaimed]).
+     */
+    private fun bindDemoSession(
+        sessionId: SessionId,
+        boundRecord: PlayerRecord,
+    ) {
+        val xpTotal = boundRecord.xpTotal.coerceAtLeast(0L)
+        val level = progression.computeLevel(xpTotal)
+        val ps = boundRecord.copy(xpTotal = xpTotal, level = level).toPlayerState(sessionId)
+        ps.playerId = null
+        progression.applyLevelStats(ps, level)
+        ps.hp = ps.maxHp
+        ps.mana = ps.maxMana
+        players[sessionId] = ps
+        rebuildAllPlayersSnapshot()
+        roomMembers.getOrPut(ps.roomId) { mutableSetOf() }.add(sessionId)
+        sessionByLowerName[ps.name.lowercase()] = sessionId
+        items.ensurePlayer(sessionId)
+        for (item in boundRecord.inventoryItems) {
+            items.addToInventory(sessionId, item)
+        }
+        for ((slotName, item) in boundRecord.equippedItems) {
+            val slot = ItemSlot.parse(slotName) ?: continue
+            items.setEquippedItem(sessionId, slot, item)
         }
     }
 

--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -43,7 +43,7 @@ data class PlayerState(
     var gold: Long = 0L,
     // Immutable after creation — cached here so persistIfClaimed avoids a repo lookup.
     val createdAtEpochMs: Long = 0L,
-    val passwordHash: String = "",
+    var passwordHash: String = "",
     var activeQuests: Map<String, QuestState> = emptyMap(),
     var completedQuestIds: Set<String> = emptySet(),
     /**

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -9,6 +9,17 @@ sealed interface Command {
 
     data object Quit : Command
 
+    /**
+     * Convert the current demo character into a real account.
+     * Two forms:
+     * - `claim <password>` keeps the current (auto-generated) name
+     * - `claim <newname> <password>` chooses a new name as well
+     */
+    data class Claim(
+        val newName: String?,
+        val password: String,
+    ) : Command
+
     data object AnsiOn : Command
 
     data object AnsiOff : Command
@@ -794,6 +805,21 @@ object CommandParser {
             val msg = line.drop(1).trim()
             return if (msg.isEmpty()) Command.Invalid(line, "'<message>") else Command.Say(msg)
         }
+
+        // claim: "claim <password>" or "claim <name> <password>" — upgrades a demo character.
+        matchPrefix(line, listOf("claim")) { rest ->
+            val trimmed = rest.trim()
+            if (trimmed.isEmpty()) {
+                Command.Invalid(line, "claim <password>  or  claim <newname> <password>")
+            } else {
+                val parts = trimmed.split(Regex("\\s+"), limit = 2)
+                if (parts.size == 1) {
+                    Command.Claim(newName = null, password = parts[0])
+                } else {
+                    Command.Claim(newName = parts[0], password = parts[1])
+                }
+            }
+        }?.let { return it }
 
         // say: "say <msg>"
         requiredArg(line, listOf("say"), "say <message>", { Command.Say(it) })?.let { return it }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/AuctionHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/AuctionHandler.kt
@@ -86,6 +86,7 @@ class AuctionHandler(
     }
 
     private suspend fun handleSell(sessionId: SessionId, cmd: Command.AuctionSell) {
+        if (!requireClaimed(sessionId, players, outbound, "Posting auctions")) return
         val auction =
             auctionSystem
                 ?: return sendErrorWithFeedback(
@@ -144,6 +145,7 @@ class AuctionHandler(
     }
 
     private suspend fun handleBuy(sessionId: SessionId, cmd: Command.AuctionBuy) {
+        if (!requireClaimed(sessionId, players, outbound, "Buying from the auction house")) return
         val auction =
             auctionSystem
                 ?: return sendErrorWithFeedback(

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ClaimHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ClaimHandler.kt
@@ -7,9 +7,17 @@ import dev.ambon.engine.commands.CommandHandler
 import dev.ambon.engine.commands.CommandRouter
 import dev.ambon.engine.commands.on
 import dev.ambon.engine.events.OutboundEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 class ClaimHandler(
     ctx: EngineContext,
+    /**
+     * Returns the engine's coroutine scope. The handler dispatches the BCrypt
+     * + DB write portion of `claim` here so the engine tick loop is not
+     * blocked while a slow persistence backend completes.
+     */
+    private val getEngineScope: () -> CoroutineScope,
     private val onClaimed: suspend (SessionId) -> Unit = {},
 ) : CommandHandler {
     private val outbound = ctx.outbound
@@ -32,7 +40,18 @@ class ClaimHandler(
             return
         }
 
-        when (val result = players.claim(sessionId, cmd.newName, cmd.password)) {
+        // Off-tick: BCrypt and `repo.create` can be expensive (especially on
+        // Postgres). Launch on the engine scope so the tick loop and inbound
+        // draining keep moving while persistence completes. PlayerRegistry
+        // re-validates state inside `claim`, so a disconnect mid-flight is
+        // handled safely.
+        getEngineScope().launch {
+            handleClaimResult(sessionId, players.claim(sessionId, cmd.newName, cmd.password))
+        }
+    }
+
+    private suspend fun handleClaimResult(sessionId: SessionId, result: ClaimResult) {
+        when (result) {
             is ClaimResult.Ok -> {
                 outbound.send(
                     OutboundEvent.SendInfo(

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ClaimHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ClaimHandler.kt
@@ -1,0 +1,67 @@
+package dev.ambon.engine.commands.handlers
+
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.engine.ClaimResult
+import dev.ambon.engine.commands.Command
+import dev.ambon.engine.commands.CommandHandler
+import dev.ambon.engine.commands.CommandRouter
+import dev.ambon.engine.commands.on
+import dev.ambon.engine.events.OutboundEvent
+
+class ClaimHandler(
+    ctx: EngineContext,
+    private val onClaimed: suspend (SessionId) -> Unit = {},
+) : CommandHandler {
+    private val outbound = ctx.outbound
+    private val players = ctx.players
+    private val gmcpEmitter = ctx.gmcpEmitter
+
+    override fun register(router: CommandRouter) {
+        router.on<Command.Claim> { sid, cmd -> handleClaim(sid, cmd) }
+    }
+
+    private suspend fun handleClaim(sessionId: SessionId, cmd: Command.Claim) {
+        val me = players.get(sessionId) ?: return
+        if (me.playerId != null) {
+            outbound.send(
+                OutboundEvent.SendError(
+                    sessionId,
+                    "Your character is already saved. There's nothing to claim.",
+                ),
+            )
+            return
+        }
+
+        when (val result = players.claim(sessionId, cmd.newName, cmd.password)) {
+            is ClaimResult.Ok -> {
+                outbound.send(
+                    OutboundEvent.SendInfo(
+                        sessionId,
+                        "Your character has been saved as ${result.name}. " +
+                            "You can log in again later with this name and password.",
+                    ),
+                )
+                val refreshed = players.get(sessionId)
+                if (refreshed != null) {
+                    gmcpEmitter?.sendCharName(sessionId, refreshed)
+                }
+                onClaimed(sessionId)
+            }
+            ClaimResult.NotDemo -> outbound.send(
+                OutboundEvent.SendError(sessionId, "Your character is already saved."),
+            )
+            ClaimResult.InvalidName -> outbound.send(
+                OutboundEvent.SendError(
+                    sessionId,
+                    "Invalid name. Use 2-16 chars: letters/digits/_ and cannot start with digit.",
+                ),
+            )
+            ClaimResult.InvalidPassword -> outbound.send(
+                OutboundEvent.SendError(sessionId, "Invalid password. Use 1-72 chars."),
+            )
+            ClaimResult.Taken -> outbound.send(
+                OutboundEvent.SendError(sessionId, "That name is already taken."),
+            )
+        }
+    }
+}

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/CommunicationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/CommunicationHandler.kt
@@ -148,6 +148,7 @@ class CommunicationHandler(
         sessionId: SessionId,
         cmd: Command.Gossip,
     ) {
+        if (!requireClaimed(sessionId, players, outbound, "Global chat")) return
         if (isBroadcastRateLimited(sessionId)) return
         broadcastGlobalChannel(
             sessionId = sessionId,
@@ -163,6 +164,7 @@ class CommunicationHandler(
         sessionId: SessionId,
         cmd: Command.Shout,
     ) {
+        if (!requireClaimed(sessionId, players, outbound, "Shout")) return
         if (isBroadcastRateLimited(sessionId)) return
         players.withPlayer(sessionId) { me ->
             val zone = me.roomId.zone
@@ -180,6 +182,7 @@ class CommunicationHandler(
         sessionId: SessionId,
         cmd: Command.Ooc,
     ) {
+        if (!requireClaimed(sessionId, players, outbound, "OOC chat")) return
         if (isBroadcastRateLimited(sessionId)) return
         broadcastGlobalChannel(
             sessionId = sessionId,

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/DuelHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/DuelHandler.kt
@@ -26,6 +26,7 @@ class DuelHandler(
     }
 
     private suspend fun handleDuel(sessionId: SessionId, cmd: Command.Duel) {
+        if (!requireClaimed(sessionId, players, outbound, "Dueling")) return
         val ds =
             duelSystem
                 ?: return sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, "Dueling is not available.", "duel", code = "UNAVAILABLE")

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/FriendsHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/FriendsHandler.kt
@@ -26,7 +26,7 @@ class FriendsHandler(
     ) {
         // Add/Remove mutate persistent state; List is fine for demo characters.
         if (cmd !is Command.Friend.List) {
-            if (!requireClaimed(sessionId, players, outbound, "Friend list")) return
+            if (!requireClaimed(sessionId, players, outbound, "Adding or removing friends")) return
         }
         val fs = requireSystemOrNull(sessionId, friendsSystem, "Friends", outbound) ?: return
         val err = when (cmd) {

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/FriendsHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/FriendsHandler.kt
@@ -12,6 +12,7 @@ class FriendsHandler(
     private val friendsSystem: FriendsSystem? = null,
 ) : CommandHandler {
     private val outbound = ctx.outbound
+    private val players = ctx.players
 
     override fun register(router: CommandRouter) {
         router.on<Command.Friend.List> { sid, _ -> handleFriendCmd(sid, Command.Friend.List) }
@@ -23,6 +24,10 @@ class FriendsHandler(
         sessionId: SessionId,
         cmd: Command.Friend,
     ) {
+        // Add/Remove mutate persistent state; List is fine for demo characters.
+        if (cmd !is Command.Friend.List) {
+            if (!requireClaimed(sessionId, players, outbound, "Friend list")) return
+        }
         val fs = requireSystemOrNull(sessionId, friendsSystem, "Friends", outbound) ?: return
         val err = when (cmd) {
             Command.Friend.List -> fs.listFriends(sessionId)

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/GuildHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/GuildHandler.kt
@@ -43,6 +43,11 @@ class GuildHandler(
         sessionId: SessionId,
         cmd: Command.Guild,
     ) {
+        // Read-only commands (Info, Roster) are allowed for demo characters;
+        // anything that mutates persistent state requires a real account.
+        if (cmd !is Command.Guild.Info && cmd !is Command.Guild.Roster) {
+            if (!requireClaimed(sessionId, players, outbound, "Guilds")) return
+        }
         val gs = requireSystemOrNull(sessionId, guildSystem, "Guilds", outbound) ?: return
         val err =
             when (cmd) {

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -77,6 +77,33 @@ internal suspend fun requirePlayerOnline(
     return targetSid
 }
 
+/**
+ * Returns `true` if [sessionId]'s player is a claimed (real) account.
+ * For unclaimed demo characters, sends a friendly error suggesting `/claim`
+ * and returns `false`. Handlers should early-return when this returns false.
+ *
+ * Used to gate features that touch persistent or social state (global chat,
+ * trade, mail send, guild, friends, duels, auction) so demo characters can't
+ * spam or grief without committing to an account.
+ */
+internal suspend fun requireClaimed(
+    sessionId: SessionId,
+    players: PlayerRegistry,
+    outbound: OutboundBus,
+    feature: String,
+): Boolean {
+    val me = players.get(sessionId) ?: return false
+    if (me.playerId != null) return true
+    outbound.send(
+        OutboundEvent.SendError(
+            sessionId,
+            "$feature is not available for demo characters. " +
+                "Type 'claim <password>' or 'claim <newname> <password>' to save your character first.",
+        ),
+    )
+    return false
+}
+
 /** Checks that [target] is in the same room as [me]; sends an error and returns false otherwise. */
 internal suspend fun requireSameRoom(
     sessionId: SessionId,

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/MailHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/MailHandler.kt
@@ -110,6 +110,7 @@ class MailHandler(
         sessionId: SessionId,
         cmd: Command.Mail.Send,
     ) {
+        if (!requireClaimed(sessionId, players, outbound, "Sending mail")) return
         players.withPlayer(sessionId) { me ->
             if (me.mailCompose != null) {
                 outbound.send(

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/TradeHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/TradeHandler.kt
@@ -33,6 +33,7 @@ class TradeHandler(
     }
 
     private suspend fun handleTradeRequest(sessionId: SessionId, cmd: Command.TradeRequest) {
+        if (!requireClaimed(sessionId, players, outbound, "Trading")) return
         val ts = tradeSystem ?: return sendUnavailable(sessionId)
 
         players.withPlayer(sessionId) { me ->

--- a/src/main/kotlin/dev/ambon/engine/events/LoginFlowHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/LoginFlowHandler.kt
@@ -79,6 +79,9 @@ internal sealed interface LoginState {
         val raceId: String,
         val classId: String,
     ) : LoginState
+
+    /** Demo character creation in-flight; player input is ignored until complete. */
+    data object AwaitingDemoCreate : LoginState
 }
 
 /** Result posted to [LoginFlowHandler.pendingAuthResults] by a background auth coroutine. */
@@ -101,6 +104,12 @@ private sealed interface PendingAuthResult {
     data class NewAccountAuth(
         override val sessionId: SessionId,
         val prep: dev.ambon.engine.CreateAccountPrep,
+    ) : PendingAuthResult
+
+    data class DemoCharacter(
+        override val sessionId: SessionId,
+        val name: String,
+        val defaultAnsiEnabled: Boolean,
     ) : PendingAuthResult
 }
 
@@ -133,6 +142,14 @@ internal class LoginFlowHandler(
     maxWrongPasswordRetries: Int,
     maxFailedLoginAttemptsBeforeDisconnect: Int,
     maxConcurrentLogins: Int,
+    /**
+     * If true, typing "demo" (case-insensitive) at the name prompt creates an
+     * ephemeral demo character using the configured default race/class.
+     */
+    private val demoEnabled: Boolean = true,
+    private val demoDefaultRace: String = "HUMAN",
+    private val demoDefaultClass: String = "WARRIOR",
+    private val demoNameGenerator: dev.ambon.engine.DemoNameGenerator = dev.ambon.engine.DemoNameGenerator(),
     internal val onAfterLogin: suspend (SessionId) -> Unit = {},
     /**
      * Called on the paths where the client just authenticated with a password
@@ -194,6 +211,13 @@ internal class LoginFlowHandler(
             return
         }
 
+        // Demo (guest) entry — type "demo" at the name prompt to spawn a
+        // throwaway character. Bypasses password and race/class pickers.
+        if (demoEnabled && name.equals("demo", ignoreCase = true)) {
+            startDemoCreation(sessionId)
+            return
+        }
+
         if (!players.isValidName(name)) {
             outbound.send(OutboundEvent.SendError(sessionId, invalidNameMessage))
             emitLoginError(sessionId, "name", invalidNameMessage)
@@ -221,6 +245,34 @@ internal class LoginFlowHandler(
         getEngineScope().launch {
             val exists = players.hasRegisteredName(name)
             pendingAuthResults.send(PendingAuthResult.NameLookup(sessionId, name, exists))
+        }
+    }
+
+    private suspend fun startDemoCreation(sessionId: SessionId) {
+        // Acquire a login slot if not already held (mirrors handleLoginName).
+        if (!sessionsHoldingLoginPermit.contains(sessionId)) {
+            if (!loginSemaphore.tryAcquire()) {
+                outbound.send(
+                    OutboundEvent.SendError(
+                        sessionId,
+                        "The server is currently at maximum login capacity. Please try again shortly.",
+                    ),
+                )
+                outbound.send(OutboundEvent.Close(sessionId, "Server at maximum login capacity"))
+                return
+            }
+            sessionsHoldingLoginPermit.add(sessionId)
+        }
+
+        pendingLogins[sessionId] = LoginState.AwaitingDemoCreate
+        val ansiDefault = sessionAnsiDefaults[sessionId] ?: false
+        getEngineScope().launch {
+            val chosen = demoNameGenerator.generate(
+                isTaken = { candidate ->
+                    players.isNameOnline(candidate) || players.hasRegisteredName(candidate)
+                },
+            )
+            pendingAuthResults.send(PendingAuthResult.DemoCharacter(sessionId, chosen, ansiDefault))
         }
     }
 
@@ -364,8 +416,13 @@ internal class LoginFlowHandler(
 
     internal suspend fun promptForName(sessionId: SessionId) {
         outbound.send(OutboundEvent.SendInfo(sessionId, "Enter your name:"))
+        if (demoEnabled) {
+            outbound.send(
+                OutboundEvent.SendInfo(sessionId, "(Or type 'demo' to play as a guest.)"),
+            )
+        }
         outbound.send(OutboundEvent.SendPrompt(sessionId))
-        emitLoginPrompt(sessionId, mapOf("state" to "name"))
+        emitLoginPrompt(sessionId, mapOf("state" to "name", "demoEnabled" to demoEnabled))
     }
 
     private suspend fun handlePendingAuthResult(result: PendingAuthResult) {
@@ -445,6 +502,41 @@ internal class LoginFlowHandler(
                     dev.ambon.engine.LoginCredentialPrep.InvalidInput -> {
                         outbound.send(OutboundEvent.SendError(sid, invalidNameMessage))
                         if (recordFailedLoginAttemptAndCloseIfNeeded(sid)) return
+                        pendingLogins[sid] = LoginState.AwaitingName
+                        promptForName(sid)
+                    }
+                }
+            }
+
+            is PendingAuthResult.DemoCharacter -> {
+                if (pendingLogins[sid] !is LoginState.AwaitingDemoCreate) return
+                val createResult = players.createDemo(
+                    sessionId = sid,
+                    name = result.name,
+                    defaultAnsiEnabled = result.defaultAnsiEnabled,
+                    race = demoDefaultRace,
+                    playerClass = demoDefaultClass,
+                )
+                when (createResult) {
+                    dev.ambon.engine.CreateResult.Ok -> {
+                        outbound.send(
+                            OutboundEvent.SendInfo(
+                                sid,
+                                "Welcome, ${result.name}! You're playing as a demo character. " +
+                                    "Type 'claim <password>' or 'claim <newname> <password>' to save your progress.",
+                            ),
+                        )
+                        finalizeSuccessfulLogin(sid)
+                    }
+                    dev.ambon.engine.CreateResult.Taken -> {
+                        // Extremely rare — re-roll once.
+                        pendingLogins[sid] = LoginState.AwaitingName
+                        promptForName(sid)
+                    }
+                    else -> {
+                        outbound.send(
+                            OutboundEvent.SendError(sid, "Could not create demo character. Please try again."),
+                        )
                         pendingLogins[sid] = LoginState.AwaitingName
                         promptForName(sid)
                     }

--- a/src/test/kotlin/dev/ambon/engine/DemoNameGeneratorTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/DemoNameGeneratorTest.kt
@@ -1,0 +1,72 @@
+package dev.ambon.engine
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class DemoNameGeneratorTest {
+    @Test
+    fun `generated name starts with a curated fantasy first name`() = runTest {
+        val gen = DemoNameGenerator(Random(0))
+        val name = gen.generate(isTaken = { false })
+        // Strip trailing digits — what remains must be a curated entry.
+        val stem = name.trimEnd { it.isDigit() }
+        assertTrue(
+            stem in DemoNameGenerator.FANTASY_NAMES,
+            "stem '$stem' (from '$name') should be one of the curated fantasy names",
+        )
+    }
+
+    @Test
+    fun `generated name fits within the 16-char player name limit`() = runTest {
+        val gen = DemoNameGenerator(Random(0))
+        repeat(50) {
+            val name = gen.generate(isTaken = { false })
+            assertTrue(name.length <= 16, "name '$name' must be <= 16 chars")
+        }
+    }
+
+    @Test
+    fun `generator retries when a candidate is taken`() = runTest {
+        val taken = mutableSetOf<String>()
+        val gen = DemoNameGenerator(Random(42))
+        val first = gen.generate(isTaken = { it in taken })
+        taken.add(first)
+        val second = gen.generate(isTaken = { it in taken })
+        assertNotEquals(first, second, "generator should not return a taken name")
+    }
+
+    @Test
+    fun `generator falls back when all short candidates are taken`() = runTest {
+        // Reject every 2-digit suffix; the fallback to 4-digit suffix should succeed.
+        var calls = 0
+        val gen = DemoNameGenerator(Random(0))
+        val name = gen.generate(
+            isTaken = { candidate ->
+                calls++
+                // Block all names with <= 6 digits worth of trailing numbers (only the
+                // initial 2-digit pass).
+                val trailingDigits = candidate.takeLastWhile { it.isDigit() }.length
+                trailingDigits <= 2
+            },
+            maxAttempts = 5,
+        )
+        assertTrue(
+            name.takeLastWhile { it.isDigit() }.length >= 3,
+            "fallback should use a longer suffix, got '$name'",
+        )
+        assertTrue(calls > 5, "expected the fallback pass to attempt more candidates")
+    }
+
+    @Test
+    fun `generator runs without throwing across many invocations`() = runTest {
+        val gen = DemoNameGenerator(Random(123))
+        val produced = (1..200).map { gen.generate(isTaken = { false }) }
+        // Just exercising the loop — we expect some variety with random seeds.
+        assertTrue(produced.distinct().size > 1)
+        assertEquals(200, produced.size)
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/DemoNameGeneratorTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/DemoNameGeneratorTest.kt
@@ -42,13 +42,12 @@ class DemoNameGeneratorTest {
     @Test
     fun `generator falls back when all short candidates are taken`() = runTest {
         // Reject every 2-digit suffix; the fallback to 4-digit suffix should succeed.
-        var calls = 0
+        // The fallback path is verified by observing that the returned name has a
+        // suffix longer than 2 digits — which only happens after the first pass
+        // is exhausted and the longer-suffix fallback engages.
         val gen = DemoNameGenerator(Random(0))
         val name = gen.generate(
             isTaken = { candidate ->
-                calls++
-                // Block all names with <= 6 digits worth of trailing numbers (only the
-                // initial 2-digit pass).
                 val trailingDigits = candidate.takeLastWhile { it.isDigit() }.length
                 trailingDigits <= 2
             },
@@ -58,7 +57,6 @@ class DemoNameGeneratorTest {
             name.takeLastWhile { it.isDigit() }.length >= 3,
             "fallback should use a longer suffix, got '$name'",
         )
-        assertTrue(calls > 5, "expected the fallback pass to attempt more candidates")
     }
 
     @Test

--- a/src/test/kotlin/dev/ambon/engine/GameEngineLoginFlowTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GameEngineLoginFlowTest.kt
@@ -1015,4 +1015,63 @@ class GameEngineLoginFlowTest {
 
             h.close()
         }
+
+    @Test
+    fun `typing demo at the name prompt spawns an unclaimed character`() =
+        runTest {
+            val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)
+            val h = GameEngineHarness.start(scope = this, clock = clock)
+
+            val sid = SessionId(1L)
+            runCurrent()
+
+            h.inbound.send(InboundEvent.Connected(sid))
+            h.inbound.send(InboundEvent.LineReceived(sid, "demo"))
+            advanceTimeBy(h.tickMillis * 2)
+            runCurrent()
+
+            val outs = h.outbound.drainAll()
+            val welcome = outs.firstOrNull {
+                it is OutboundEvent.SendInfo &&
+                    it.sessionId == sid &&
+                    it.text.startsWith("Welcome,") &&
+                    it.text.contains("demo character")
+            }
+            assertNotNull(welcome, "expected a welcome message for the demo character. got=$outs")
+
+            val player = h.players.get(sid)
+            assertNotNull(player, "expected a player bound to the session")
+            assertNull(player!!.playerId, "demo character should have a null playerId")
+            assertNull(
+                h.repo.findByName(player.name),
+                "demo character must not be persisted to the repository",
+            )
+
+            h.close()
+        }
+
+    @Test
+    fun `name prompt advertises demo mode`() =
+        runTest {
+            val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)
+            val h = GameEngineHarness.start(scope = this, clock = clock)
+
+            val sid = SessionId(1L)
+            runCurrent()
+            h.inbound.send(InboundEvent.Connected(sid))
+            advanceTimeBy(h.tickMillis)
+            runCurrent()
+
+            val outs = h.outbound.drainAll()
+            assertTrue(
+                outs.any {
+                    it is OutboundEvent.SendInfo &&
+                        it.sessionId == sid &&
+                        it.text.contains("'demo'", ignoreCase = true)
+                },
+                "Expected the name prompt to mention demo mode. got=$outs",
+            )
+
+            h.close()
+        }
 }

--- a/src/test/kotlin/dev/ambon/engine/PlayerRegistryDemoTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/PlayerRegistryDemoTest.kt
@@ -1,0 +1,133 @@
+package dev.ambon.engine
+
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.TestWorlds
+import dev.ambon.test.buildTestPlayerRegistry
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class PlayerRegistryDemoTest {
+    private val startRoom = TestWorlds.testWorld.startRoom
+
+    @Test
+    fun `createDemo binds an unclaimed player without persisting`() = runTest {
+        val repo = InMemoryPlayerRepository()
+        val registry = buildTestPlayerRegistry(startRoom, repo, ItemRegistry())
+
+        val result = registry.createDemo(SessionId(1), "Aelara42")
+
+        assertEquals(CreateResult.Ok, result)
+        val player = registry.get(SessionId(1))
+        assertNotNull(player)
+        assertEquals("Aelara42", player!!.name)
+        assertNull(player.playerId, "demo character should have a null playerId")
+        assertNull(repo.findByName("Aelara42"), "demo character should not be persisted to the repo")
+    }
+
+    @Test
+    fun `disconnect of demo character writes nothing to the repo`() = runTest {
+        val repo = InMemoryPlayerRepository()
+        val registry = buildTestPlayerRegistry(startRoom, repo, ItemRegistry())
+
+        registry.createDemo(SessionId(1), "Brogan9")
+        registry.disconnect(SessionId(1))
+
+        assertNull(registry.get(SessionId(1)))
+        assertNull(repo.findByName("Brogan9"))
+    }
+
+    @Test
+    fun `createDemo rejects a name already online`() = runTest {
+        val repo = InMemoryPlayerRepository()
+        val registry = buildTestPlayerRegistry(startRoom, repo, ItemRegistry())
+
+        registry.create(SessionId(1), "Cyrene", "password")
+        val result = registry.createDemo(SessionId(2), "Cyrene")
+
+        assertEquals(CreateResult.Taken, result)
+    }
+
+    @Test
+    fun `claim with password only keeps the demo name and persists`() = runTest {
+        val repo = InMemoryPlayerRepository()
+        val registry = buildTestPlayerRegistry(startRoom, repo, ItemRegistry())
+
+        registry.createDemo(SessionId(1), "Drystan3")
+        val result = registry.claim(SessionId(1), newNameRaw = null, passwordRaw = "secret")
+
+        assertTrue(result is ClaimResult.Ok)
+        val player = registry.get(SessionId(1))!!
+        assertEquals("Drystan3", player.name)
+        assertNotNull(player.playerId, "claim should give the player a real playerId")
+        val record = repo.findByName("Drystan3")
+        assertNotNull(record, "claim should persist the player to the repo")
+        assertTrue(record!!.passwordHash.isNotBlank(), "claim should set a password hash")
+    }
+
+    @Test
+    fun `claim with new name updates both the name index and the persisted record`() = runTest {
+        val repo = InMemoryPlayerRepository()
+        val registry = buildTestPlayerRegistry(startRoom, repo, ItemRegistry())
+
+        registry.createDemo(SessionId(1), "Fenris1")
+        val result = registry.claim(SessionId(1), newNameRaw = "Elowen", passwordRaw = "secret")
+
+        assertTrue(result is ClaimResult.Ok)
+        val player = registry.get(SessionId(1))!!
+        assertEquals("Elowen", player.name)
+        // Old name should no longer resolve, new one should.
+        assertNull(registry.getByName("Fenris1"), "old demo name should be unindexed after claim")
+        assertEquals(SessionId(1), registry.getByName("Elowen")?.sessionId)
+        assertNotNull(repo.findByName("Elowen"))
+        assertNull(repo.findByName("Fenris1"), "old demo name should not have been persisted")
+    }
+
+    @Test
+    fun `claim rejects a name already in the repository`() = runTest {
+        val repo = InMemoryPlayerRepository()
+        val registry = buildTestPlayerRegistry(startRoom, repo, ItemRegistry())
+
+        // Pre-existing real account
+        registry.create(SessionId(99), "Galen", "password")
+        registry.disconnect(SessionId(99))
+
+        registry.createDemo(SessionId(1), "Halina7")
+        val result = registry.claim(SessionId(1), newNameRaw = "Galen", passwordRaw = "secret")
+
+        assertEquals(ClaimResult.Taken, result)
+        assertNull(registry.get(SessionId(1))!!.playerId, "failed claim must leave demo unchanged")
+    }
+
+    @Test
+    fun `claim on an already-claimed player returns NotDemo`() = runTest {
+        val repo = InMemoryPlayerRepository()
+        val registry = buildTestPlayerRegistry(startRoom, repo, ItemRegistry())
+
+        registry.create(SessionId(1), "Ivar", "password")
+        val result = registry.claim(SessionId(1), newNameRaw = null, passwordRaw = "newsecret")
+
+        assertEquals(ClaimResult.NotDemo, result)
+    }
+
+    @Test
+    fun `claim rejects invalid passwords and names`() = runTest {
+        val repo = InMemoryPlayerRepository()
+        val registry = buildTestPlayerRegistry(startRoom, repo, ItemRegistry())
+
+        registry.createDemo(SessionId(1), "Joren5")
+        assertEquals(
+            ClaimResult.InvalidPassword,
+            registry.claim(SessionId(1), newNameRaw = null, passwordRaw = ""),
+        )
+        assertEquals(
+            ClaimResult.InvalidName,
+            registry.claim(SessionId(1), newNameRaw = "1bad", passwordRaw = "ok"),
+        )
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
@@ -27,6 +27,18 @@ class CommandParserTest {
     }
 
     @Test
+    fun `parser parses claim command`() {
+        assertEquals(Command.Claim(newName = null, password = "secret"), CommandParser.parse("claim secret"))
+        assertEquals(
+            Command.Claim(newName = "Aragorn", password = "secret pass"),
+            CommandParser.parse("claim Aragorn secret pass"),
+        )
+        // Missing password yields an Invalid command, not Claim
+        val invalid = CommandParser.parse("claim")
+        assertTrue(invalid is Command.Invalid, "expected Invalid for bare 'claim', got $invalid")
+    }
+
+    @Test
     fun `parser parses tell and t aliases`() {
         assertEquals(Command.Tell("Bob", "hi there"), CommandParser.parse("tell Bob hi there"))
         assertEquals(Command.Tell("Bob", "hi there"), CommandParser.parse("t Bob hi there"))

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -28,6 +28,7 @@ import { CombatLogPanel } from "./components/panels/CombatLogPanel";
 import { WorldAtmosphereHud } from "./components/WorldAtmosphereHud";
 import { HelpContent } from "./components/HelpContent";
 import { Atlas } from "./components/Atlas";
+import { DemoBanner } from "./components/DemoBanner";
 import { LevelUpBanner } from "./components/LevelUpBanner";
 import { QuestCompleteToast } from "./components/QuestCompleteToast";
 import { CombatVictoryToast } from "./components/CombatVictoryToast";
@@ -756,6 +757,12 @@ function App() {
 
   return (
     <>
+      {state.character.isDemo && (
+        <DemoBanner
+          autoOpen={(state.character.level ?? 1) >= 2}
+          onClaim={(line) => sendCommand(line)}
+        />
+      )}
       <GameShell
         connected={connected}
         hasCharacterProfile={hasCharacterProfile}

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -760,7 +760,9 @@ function App() {
       {state.character.isDemo && (
         <DemoBanner
           autoOpen={(state.character.level ?? 1) >= 2}
-          onClaim={(line) => sendCommand(line)}
+          // sendLine (not sendCommand) — claim contains the user's new password,
+          // so we must NOT push it into command history / localStorage.
+          onClaim={(line) => { sendLine(line); }}
         />
       )}
       <GameShell

--- a/web-v3/src/canvas/GameStateBridge.ts
+++ b/web-v3/src/canvas/GameStateBridge.ts
@@ -128,7 +128,7 @@ export const gameStateRef: { current: GameStateSnapshot } = {
     combatTarget: null,
     inCombat: false,
     effects: [],
-    character: { name: "-", gender: "", race: "", className: "", level: null, sprite: null, isStaff: false, autolootEnabled: false, wimpyThresholdPct: 10 },
+    character: { name: "-", gender: "", race: "", className: "", level: null, sprite: null, isStaff: false, autolootEnabled: false, wimpyThresholdPct: 10, isDemo: false },
     mobInfo: [],
     groupInfo: { leader: null, members: [] },
     dialogue: null,

--- a/web-v3/src/canvas/LoginModal.tsx
+++ b/web-v3/src/canvas/LoginModal.tsx
@@ -67,6 +67,21 @@ export function LoginModal({ loginPrompt, loginError, onSubmit }: LoginModalProp
               />
               <button type="submit" className="login-button">Enter</button>
             </form>
+            {loginPrompt.demoEnabled && (
+              <div className="login-demo-row">
+                <span className="login-demo-divider">— or —</span>
+                <button
+                  type="button"
+                  className="login-button login-button-secondary login-button-demo"
+                  onClick={() => onSubmit("demo")}
+                >
+                  Try Demo (One-click play)
+                </button>
+                <p className="login-demo-hint">
+                  Spawn a quick-start character. Your progress can be saved later from in-game.
+                </p>
+              </div>
+            )}
           </div>
         )}
 

--- a/web-v3/src/components/DemoBanner.tsx
+++ b/web-v3/src/components/DemoBanner.tsx
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { FormEvent } from "react";
+
+interface DemoBannerProps {
+  /**
+   * Auto-prompts the user with the claim modal as soon as it becomes true.
+   * Driven by App.tsx when the demo character first hits level 2.
+   */
+  autoOpen?: boolean;
+  /** Submits `claim [name] <password>` over the line interface. */
+  onClaim: (line: string) => void;
+}
+
+/**
+ * Persistent topbar banner shown while the character is an unclaimed demo.
+ * Click "Save Progress" to open a small modal collecting an optional new
+ * name and a required password, then sends a `claim` command.
+ */
+export function DemoBanner({ autoOpen = false, onClaim }: DemoBannerProps) {
+  const [manualOpen, setManualOpen] = useState(false);
+  const [dismissedAuto, setDismissedAuto] = useState(false);
+  const [name, setName] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // Render-time derivation: auto-opens once when autoOpen flips true, and stays
+  // closed if the user dismisses it. Manual reopening is independent.
+  const open = manualOpen || (autoOpen && !dismissedAuto);
+
+  const close = useCallback(() => {
+    setManualOpen(false);
+    setDismissedAuto(true);
+    setError(null);
+  }, []);
+
+  useEffect(() => {
+    if (open) inputRef.current?.focus();
+  }, [open]);
+
+  const handleSubmit = useCallback((e: FormEvent) => {
+    e.preventDefault();
+    const pw = password.trim();
+    if (pw.length === 0) {
+      setError("Password is required.");
+      return;
+    }
+    const trimmedName = name.trim();
+    const line = trimmedName.length > 0 ? `claim ${trimmedName} ${pw}` : `claim ${pw}`;
+    onClaim(line);
+    setPassword("");
+    setError(null);
+    setManualOpen(false);
+    setDismissedAuto(true);
+  }, [name, password, onClaim]);
+
+  return (
+    <>
+      <div className="demo-banner" role="status">
+        <span className="demo-banner-label">
+          <span className="demo-banner-tag">Demo</span>
+          You&rsquo;re playing as a guest &mdash; progress isn&rsquo;t saved.
+        </span>
+        <button
+          type="button"
+          className="demo-banner-button"
+          onClick={() => setManualOpen(true)}
+        >
+          Save Progress
+        </button>
+      </div>
+
+      {open && (
+        <div className="login-modal-backdrop" onClick={close}>
+          <div
+            className="login-modal demo-claim-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Save your demo character"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="login-modal-title">Save Your Character</h2>
+            <p className="login-step-sub">
+              Pick a password so you can log back in. You can also rename your character if you like.
+            </p>
+            {error && <p className="login-error">{error}</p>}
+            <form onSubmit={handleSubmit} className="login-form demo-claim-form">
+              <label className="demo-claim-field">
+                <span className="demo-claim-field-label">New name (optional)</span>
+                <input
+                  ref={inputRef}
+                  className="login-input"
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Leave blank to keep current name"
+                  autoComplete="off"
+                  spellCheck={false}
+                  maxLength={16}
+                />
+              </label>
+              <label className="demo-claim-field">
+                <span className="demo-claim-field-label">Password</span>
+                <input
+                  className="login-input"
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="Choose a password"
+                  autoComplete="new-password"
+                  required
+                />
+              </label>
+              <div className="login-choice-row">
+                <button type="submit" className="login-button">
+                  Save Character
+                </button>
+                <button
+                  type="button"
+                  className="login-button login-button-secondary"
+                  onClick={close}
+                >
+                  Not now
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/web-v3/src/constants.ts
+++ b/web-v3/src/constants.ts
@@ -95,7 +95,7 @@ export const DEFAULT_STATUS_VAR_LABELS: StatusVarLabels = {
   xp: "XP",
 };
 
-export const EMPTY_CHAR: CharacterInfo = { name: "-", gender: "", race: "", className: "", level: null, sprite: null, isStaff: false, autolootEnabled: false, wimpyThresholdPct: 10 };
+export const EMPTY_CHAR: CharacterInfo = { name: "-", gender: "", race: "", className: "", level: null, sprite: null, isStaff: false, autolootEnabled: false, wimpyThresholdPct: 10, isDemo: false };
 export const DEFAULT_SERVER_FEATURES: ServerFeatures = {
   dailyQuests: false,
   weeklyQuests: false,

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -347,6 +347,7 @@ export function applyGmcpPackage(
         isStaff: packet.isStaff === true,
         autolootEnabled: packet.autolootEnabled === true,
         wimpyThresholdPct: typeof packet.wimpyThresholdPct === "number" ? packet.wimpyThresholdPct : 10,
+        isDemo: packet.isDemo === true,
       });
       // Login complete — dismiss modal
       ctx.setLoginPrompt(null);
@@ -1542,7 +1543,12 @@ export function applyGmcpPackage(
     }
 
     case "Login.Prompt": {
-      const packet = data as LoginPromptState;
+      const rawPacket = data as Partial<LoginPromptState> & Record<string, unknown>;
+      // Default demoEnabled to false if missing (older server builds).
+      const packet =
+        rawPacket.state === "name"
+          ? ({ state: "name", demoEnabled: rawPacket.demoEnabled === true } as LoginPromptState)
+          : (rawPacket as LoginPromptState);
       // Only attempt auto-authentication on the initial "name" prompt.
       // Subsequent prompts (confirmCreate, password, raceSelection, etc.) must
       // always be shown to the user — otherwise the client intercepts every

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -14240,6 +14240,122 @@ body {
   justify-content: center;
 }
 
+/* ── Demo (one-click play) ──────────────────────── */
+
+.login-demo-row {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px solid rgb(255 255 255 / 8%);
+}
+
+.login-demo-divider {
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted, rgb(168 151 210 / 60%));
+}
+
+.login-button-demo {
+  background:
+    linear-gradient(140deg, rgb(124 180 132 / 50%), rgb(96 142 108 / 42%));
+  border-color: rgb(168 210 178 / 50%);
+}
+
+.login-button-demo:hover {
+  background:
+    linear-gradient(140deg, rgb(140 200 148 / 60%), rgb(108 156 120 / 52%));
+  border-color: rgb(190 226 200 / 70%);
+}
+
+.login-demo-hint {
+  margin: 0;
+  font-size: 11px;
+  text-align: center;
+  color: var(--text-muted, rgb(168 151 210 / 65%));
+  line-height: 1.4;
+}
+
+.demo-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 14px;
+  background:
+    linear-gradient(135deg, rgb(94 134 110 / 24%), rgb(74 110 94 / 16%));
+  border-bottom: 1px solid rgb(168 210 178 / 26%);
+  color: var(--text-primary, rgb(232 224 246));
+  font-size: 13px;
+  flex-wrap: wrap;
+}
+
+.demo-banner-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  line-height: 1.3;
+}
+
+.demo-banner-tag {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgb(168 210 178 / 30%);
+  color: rgb(232 248 232);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.demo-banner-button {
+  padding: 6px 14px;
+  border-radius: 6px;
+  border: 1px solid rgb(168 210 178 / 60%);
+  background:
+    linear-gradient(140deg, rgb(124 180 132 / 60%), rgb(96 142 108 / 50%));
+  color: rgb(248 252 248);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.demo-banner-button:hover {
+  background:
+    linear-gradient(140deg, rgb(140 200 148 / 72%), rgb(108 156 120 / 60%));
+  border-color: rgb(190 226 200 / 80%);
+}
+
+.demo-claim-modal {
+  max-width: 420px;
+}
+
+.demo-claim-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.demo-claim-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  text-align: left;
+}
+
+.demo-claim-field-label {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted, rgb(168 151 210 / 70%));
+}
+
 /* ── Portrait card grid (race / class picker) ────── */
 
 .login-modal--wide {

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -193,6 +193,11 @@ export interface CharacterInfo {
   autolootEnabled: boolean;
   /** Wimpy auto-flee threshold (HP%). 0 = disabled. */
   wimpyThresholdPct: number;
+  /**
+   * True for ephemeral demo characters. Surfaces a "Save your progress" banner
+   * in the UI and offers a `/claim` form. Flips to false after a successful claim.
+   */
+  isDemo: boolean;
 }
 
 export interface RoomState {
@@ -741,7 +746,7 @@ export interface LoginClassOption {
 }
 
 export type LoginPromptState =
-  | { state: "name" }
+  | { state: "name"; demoEnabled: boolean }
   | { state: "password"; name: string }
   | { state: "confirmCreate"; name: string }
   | { state: "newPassword"; name: string }


### PR DESCRIPTION
## Summary

Adds a one-click "Demo" mode so new players can jump into the world without committing to an account. The character is ephemeral (lives only in memory, vanishes on disconnect) and can be upgraded to a real persisted account at any time via `/claim`.

**Login flow**
- Telnet: typing `demo` (case-insensitive) at the name prompt spawns a demo character. The name prompt advertises it.
- Web: a "Try Demo (One-click play)" button next to the name input on the login modal.

A `DemoNameGenerator` picks a fantasy first name (Aelara, Brogan, Cyrene, …) plus a short numeric suffix, retrying against both online sessions and persisted records so collisions are negligible. Race/class come from existing `CharacterCreationConfig.defaultRace` / `defaultClass`. Demo behaviour is config-gated via `characterCreation.demoEnabled` (default true).

**Claim flow**
- `claim <password>` — keep the auto-generated name, just set a password
- `claim <newname> <password>` — also rename
- On success the character becomes a normal persisted account, an auth token is issued (so the next reconnect auto-logs in), and GMCP `Char.Name` re-emits with `isDemo: false`.

**Demo restrictions**
A new `requireClaimed` helper gates the "spammy / persistent" surfaces so demo characters can't be used to grief: gossip / shout / ooc, mail send, trade init, auction post and buy, duel challenge, guild mutations (Create / Invite / Kick / Promote / etc., but read-only Info & Roster stay open), and friend add/remove. Everything else (exploration, combat, quests, leveling, tells, looking around) is fully open.

**Web UI**
- `Char.Name` now carries an `isDemo` flag.
- Persistent topbar `DemoBanner` ("You're playing as a guest — progress isn't saved") with a Save Progress button.
- Claim modal collecting an optional new name and a required password — auto-opens once when the demo character first hits level 2 (a natural "I'm invested" moment).

## Test plan

- [x] `./gradlew ktlintCheck test` — green
- [x] `bun run lint` + `bun run build` in `web-v3/` — green
- [x] New unit tests: `DemoNameGeneratorTest`, `PlayerRegistryDemoTest`, demo paths added to `GameEngineLoginFlowTest`, `claim` parse cases added to `CommandParserTest`
- [ ] Manual: telnet `demo` spawns character, `/claim password` upgrades, `gossip foo` blocked while demo, `gossip foo` works after claim
- [ ] Manual: web "Try Demo" button → DemoBanner visible → Save Progress modal upgrades the character → banner disappears
- [ ] Manual: level a demo to 2, confirm claim modal auto-opens once