### PR TITLE
feat(movement): directional exit broadcasts and flee-relocates-player

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/world/Direction.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/Direction.kt
@@ -12,3 +12,31 @@ fun Direction.opposite(): Direction =
         Direction.UP -> Direction.DOWN
         Direction.DOWN -> Direction.UP
     }
+
+/**
+ * Movement-broadcast phrase for a departure in this direction.
+ * Used to build lines like `"Bob exits to the north."` or `"a goblin flees upward."`.
+ */
+fun Direction.exitPhrase(): String =
+    when (this) {
+        Direction.NORTH -> "to the north"
+        Direction.SOUTH -> "to the south"
+        Direction.EAST -> "to the east"
+        Direction.WEST -> "to the west"
+        Direction.UP -> "upward"
+        Direction.DOWN -> "downward"
+    }
+
+/**
+ * Movement-broadcast phrase for an arrival from this direction (i.e. where the arriver came from).
+ * Used to build lines like `"Bob arrives from the south."` or `"a goblin arrives from above."`.
+ */
+fun Direction.arrivePhrase(): String =
+    when (this) {
+        Direction.NORTH -> "from the north"
+        Direction.SOUTH -> "from the south"
+        Direction.EAST -> "from the east"
+        Direction.WEST -> "from the west"
+        Direction.UP -> "from above"
+        Direction.DOWN -> "from below"
+    }

--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -125,6 +125,13 @@ class CombatSystem(
      *  wired by GameEngine to emit GMCP inventory updates and advance collection quests. */
     var onItemAutoLooted: suspend (SessionId, dev.ambon.domain.items.ItemInstance) -> Unit = { _, _ -> }
 
+    /**
+     * Callback fired after [flee] or [fleePvp] successfully disengages the player; wired by
+     * GameEngine to relocate the player to an adjacent room (so flee actually escapes aggro,
+     * not just breaks the current fight). The boolean parameter is `true` for wimpy auto-flee.
+     */
+    var onPlayerFled: suspend (SessionId, Boolean) -> Unit = { _, _ -> }
+
     // Per-mob combat state (tracks tick timing)
     private data class MobCombatState(
         val mobId: MobId,
@@ -342,6 +349,9 @@ class CombatSystem(
                 "You flee from $mobName."
             }
         outbound.send(OutboundEvent.SendText(sessionId, msg))
+        // GameEngine wires this to relocate the player to an adjacent room. The prompt is
+        // sent after the room move so the new room's GMCP/look land before the prompt.
+        onPlayerFled(sessionId, forced)
         outbound.send(OutboundEvent.SendPrompt(sessionId))
         return null
     }
@@ -506,6 +516,7 @@ class CombatSystem(
 
         endPvpCombat(sessionId)
         outbound.send(OutboundEvent.SendText(sessionId, "You flee from $targetName."))
+        onPlayerFled(sessionId, false)
         outbound.send(OutboundEvent.SendPrompt(sessionId))
         return null
     }

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -8,8 +8,10 @@ import dev.ambon.domain.dungeon.DungeonDifficulty
 import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.world.LockableState
 import dev.ambon.domain.world.RoomFeature
 import dev.ambon.domain.world.World
+import dev.ambon.domain.world.opposite
 import dev.ambon.engine.QuestRegistry
 import dev.ambon.engine.QuestSystem
 import dev.ambon.engine.abilities.AbilityRegistry
@@ -58,6 +60,7 @@ import dev.ambon.engine.commands.handlers.TrainerHandler
 import dev.ambon.engine.commands.handlers.UiHandler
 import dev.ambon.engine.commands.handlers.WorldFeaturesHandler
 import dev.ambon.engine.commands.handlers.WorldInfoHandler
+import dev.ambon.engine.commands.handlers.movePlayerWithNotify
 import dev.ambon.engine.commands.handlers.sendLook
 import dev.ambon.engine.crafting.CraftingRegistry
 import dev.ambon.engine.crafting.CraftingSystem
@@ -890,6 +893,8 @@ class GameEngine(
 
     private val duelRng = java.util.Random()
 
+    private val fleeRng = java.util.Random()
+
     private val auctionSystem = AuctionSystem(
         items = items,
         clock = clock,
@@ -1179,6 +1184,46 @@ class GameEngine(
         // Push a fresh room look when a dead player respawns, so the web client
         // stops showing the room they died in.
         combatSystem.onPlayerRespawned = { sid -> ctx.sendLook(sid) }
+
+        // Flee relocates the player to an adjacent room so aggressive mobs (or other
+        // players in PvP) don't just keep hitting them. Prefer the direction opposite
+        // to the one they walked in from — they came from that room and survived, so
+        // it's more likely to be safe than a random new room.
+        combatSystem.onPlayerFled = onPlayerFled@{ sid, _ ->
+            val player = players.get(sid) ?: return@onPlayerFled
+            val from = player.roomId
+            val room = world.rooms[from] ?: return@onPlayerFled
+
+            val candidates = room.exits.entries.filter { (dir, dest) ->
+                if (!world.rooms.containsKey(dest)) return@filter false
+                if (room.remoteExits.contains(dir)) return@filter false
+                val door = worldState.doorOnExit(from, dir)
+                if (door != null && worldState.getDoorState(door.id) != LockableState.OPEN) return@filter false
+                true
+            }
+            if (candidates.isEmpty()) return@onPlayerFled
+
+            val preferred = player.lastEnterDirection?.opposite()
+            val chosen = candidates.firstOrNull { it.key == preferred }
+                ?: candidates[fleeRng.nextInt(candidates.size)]
+
+            movePlayerWithNotify(
+                sid,
+                from,
+                chosen.value,
+                "leaves.",
+                "enters.",
+                players,
+                outbound,
+                gmcpEmitter,
+                dialogueSystem,
+                direction = chosen.key,
+                departVerb = "flees",
+            )
+            player.lastEnterDirection = chosen.key
+            petSystem.followOwner(sid, chosen.value)
+            ctx.sendLook(sid)
+        }
 
         communicationHandler = CommunicationHandler(
             ctx = ctx,

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -1199,6 +1199,9 @@ class GameEngine(
                 if (room.remoteExits.contains(dir)) return@filter false
                 val door = worldState.doorOnExit(from, dir)
                 if (door != null && worldState.getDoorState(door.id) != LockableState.OPEN) return@filter false
+                // Honor achievement gates so flee can't bypass progression locks.
+                val gate = room.achievementGates[dir]
+                if (gate != null && gate.achievementId !in player.unlockedAchievementIds) return@filter false
                 true
             }
             if (candidates.isEmpty()) return@onPlayerFled

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -1220,7 +1220,6 @@ class GameEngine(
                 direction = chosen.key,
                 departVerb = "flees",
             )
-            player.lastEnterDirection = chosen.key
             petSystem.followOwner(sid, chosen.value)
             ctx.sendLook(sid)
         }

--- a/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
@@ -713,6 +713,11 @@ class PlayerRegistry(
         roomMembers.removeFromSet(ps.roomId, sessionId)
 
         ps.roomId = newRoom
+        // Any room change is a teleport at this layer; directional walks repopulate this
+        // immediately afterwards via movePlayerWithNotify. Clearing here keeps flee from
+        // retracing a stale direction after admin teleports, dungeon entry, housing,
+        // guild-hall entry, death/respawn, etc.
+        ps.lastEnterDirection = null
         roomMembers.getOrPut(newRoom) { mutableSetOf() }.add(sessionId)
 
         // Save room change if claimed

--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -9,6 +9,7 @@ import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.mail.MailMessage
 import dev.ambon.domain.mob.MobState
 import dev.ambon.domain.quest.QuestState
+import dev.ambon.domain.world.Direction
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.persistence.PlayerId
 import dev.ambon.persistence.PlayerRecord
@@ -131,6 +132,11 @@ data class PlayerState(
     var authTokenHash: String = "",
     /** Epoch-ms the current [authTokenHash] was issued. 0 when no token is set. */
     var authTokenIssuedAt: Long = 0L,
+    /**
+     * Direction the player most recently moved through to enter their current room.
+     * Used by flee to prefer retreating back the way they came. Runtime-only; not persisted.
+     */
+    var lastEnterDirection: Direction? = null,
 ) {
     data class MailComposeState(
         val recipientName: String,

--- a/src/main/kotlin/dev/ambon/engine/behavior/BtContext.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/BtContext.kt
@@ -5,7 +5,11 @@ import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.mob.MobState
+import dev.ambon.domain.world.Direction
 import dev.ambon.domain.world.World
+import dev.ambon.domain.world.arrivePhrase
+import dev.ambon.domain.world.exitPhrase
+import dev.ambon.domain.world.opposite
 import dev.ambon.engine.GmcpEmitter
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PlayerRegistry
@@ -31,20 +35,36 @@ class BtContext(
 /**
  * Notifies old-room players of departure, moves the mob, then notifies new-room players of arrival.
  * Emits GMCP room-mob add/remove events.
+ *
+ * When [direction] is non-null the depart/arrive broadcasts become
+ *   `"${mob.name} ${departVerb} to the north."` / `"${mob.name} arrives from the south."`
+ * and [departMsg]/[arriveMsg] are ignored.
  */
 suspend fun BtContext.moveMobWithNotify(
     destination: RoomId,
     departMsg: String = "${mob.name} leaves.",
     arriveMsg: String = "${mob.name} enters.",
+    direction: Direction? = null,
+    departVerb: String = "exits",
 ) {
     val from = mob.roomId
+    val departLine = if (direction != null) {
+        "${mob.name} $departVerb ${direction.exitPhrase()}."
+    } else {
+        departMsg
+    }
+    val arriveLine = if (direction != null) {
+        "${mob.name} arrives ${direction.opposite().arrivePhrase()}."
+    } else {
+        arriveMsg
+    }
     for (p in players.playersInRoom(from)) {
-        outbound.send(OutboundEvent.SendText(p.sessionId, departMsg))
+        outbound.send(OutboundEvent.SendText(p.sessionId, departLine))
     }
     gmcpEmitter?.broadcastRoomRemoveMob(from, mob.id.value, players)
     mobs.moveTo(mob.id, destination)
     for (p in players.playersInRoom(destination)) {
-        outbound.send(OutboundEvent.SendText(p.sessionId, arriveMsg))
+        outbound.send(OutboundEvent.SendText(p.sessionId, arriveLine))
     }
     gmcpEmitter?.broadcastRoomAddMob(destination, mob, players)
 }

--- a/src/main/kotlin/dev/ambon/engine/behavior/actions/FleeAction.kt
+++ b/src/main/kotlin/dev/ambon/engine/behavior/actions/FleeAction.kt
@@ -8,19 +8,19 @@ import dev.ambon.engine.behavior.moveMobWithNotify
 data object FleeAction : BtNode {
     override suspend fun tick(ctx: BtContext): BtResult {
         val room = ctx.world.rooms[ctx.mob.roomId] ?: return BtResult.FAILURE
-        val exits = room.exits.values.toList()
-        if (exits.isEmpty()) return BtResult.FAILURE
+        val exitsList = room.exits.entries.toList()
+        if (exitsList.isEmpty()) return BtResult.FAILURE
 
         // Disengage from combat first
         ctx.fleeMob(ctx.mob.id)
 
         // Pick a random exit and move
-        val destination = exits[ctx.rng.nextInt(exits.size)]
+        val pick = exitsList[ctx.rng.nextInt(exitsList.size)]
 
         ctx.moveMobWithNotify(
-            destination,
-            departMsg = "${ctx.mob.name} flees!",
-            arriveMsg = "${ctx.mob.name} arrives in a panic.",
+            pick.value,
+            direction = pick.key,
+            departVerb = "flees",
         )
 
         return BtResult.SUCCESS

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -11,6 +11,9 @@ import dev.ambon.domain.world.LockableState
 import dev.ambon.domain.world.Room
 import dev.ambon.domain.world.RoomFeature
 import dev.ambon.domain.world.World
+import dev.ambon.domain.world.arrivePhrase
+import dev.ambon.domain.world.exitPhrase
+import dev.ambon.domain.world.opposite
 import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.GmcpEmitter
 import dev.ambon.engine.MobRegistry
@@ -483,7 +486,21 @@ internal suspend fun EngineContext.movePlayer(
     departMsg: String,
     arriveMsg: String,
     dialogueSystem: dev.ambon.engine.dialogue.DialogueSystem? = null,
-) = movePlayerWithNotify(sessionId, from, to, departMsg, arriveMsg, players, outbound, gmcpEmitter, dialogueSystem)
+    direction: Direction? = null,
+    departVerb: String = "exits",
+) = movePlayerWithNotify(
+    sessionId,
+    from,
+    to,
+    departMsg,
+    arriveMsg,
+    players,
+    outbound,
+    gmcpEmitter,
+    dialogueSystem,
+    direction,
+    departVerb,
+)
 
 /**
  * Convenience extension on [EngineContext] that syncs item GMCP state,
@@ -555,6 +572,11 @@ internal suspend fun <T> requireSystemOrNull(
 /**
  * Notifies old-room players of departure, moves the player, then notifies new-room players of arrival.
  * Also fires [dialogueSystem] movement callbacks and emits GMCP room-player add/remove.
+ *
+ * When [direction] is non-null the depart/arrive broadcasts are built directionally:
+ *   `"${name} ${departVerb} to the north."` / `"${name} arrives from the south."`
+ * In that case [departMsg]/[arriveMsg] are ignored. When [direction] is null they are
+ * concatenated to the player name as `"${name} ${departMsg}"` (legacy behavior).
  */
 internal suspend fun movePlayerWithNotify(
     sessionId: SessionId,
@@ -566,11 +588,23 @@ internal suspend fun movePlayerWithNotify(
     outbound: OutboundBus,
     gmcpEmitter: GmcpEmitter?,
     dialogueSystem: dev.ambon.engine.dialogue.DialogueSystem? = null,
+    direction: Direction? = null,
+    departVerb: String = "exits",
 ) {
     val me = players.get(sessionId) ?: return
+    val departLine = if (direction != null) {
+        "${me.name} $departVerb ${direction.exitPhrase()}."
+    } else {
+        "${me.name} $departMsg"
+    }
+    val arriveLine = if (direction != null) {
+        "${me.name} arrives ${direction.opposite().arrivePhrase()}."
+    } else {
+        "${me.name} $arriveMsg"
+    }
     if (!me.invisible) {
         for (other in players.playersInRoom(from).filter { it.sessionId != me.sessionId }) {
-            outbound.send(OutboundEvent.SendText(other.sessionId, "${me.name} $departMsg"))
+            outbound.send(OutboundEvent.SendText(other.sessionId, departLine))
             gmcpEmitter?.sendRoomRemovePlayer(other.sessionId, me.name)
         }
     }
@@ -578,7 +612,7 @@ internal suspend fun movePlayerWithNotify(
     players.moveTo(sessionId, to)
     if (!me.invisible) {
         for (other in players.playersInRoom(to).filter { it.sessionId != me.sessionId }) {
-            outbound.send(OutboundEvent.SendText(other.sessionId, "${me.name} $arriveMsg"))
+            outbound.send(OutboundEvent.SendText(other.sessionId, arriveLine))
             gmcpEmitter?.sendRoomAddPlayer(other.sessionId, me)
         }
     }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -610,6 +610,9 @@ internal suspend fun movePlayerWithNotify(
     }
     dialogueSystem?.onPlayerMoved(sessionId)
     players.moveTo(sessionId, to)
+    // moveTo cleared lastEnterDirection (treats every room change as a teleport at that
+    // layer); restore it here for directional walks so flee can retrace the way in.
+    me.lastEnterDirection = direction
     if (!me.invisible) {
         for (other in players.playersInRoom(to).filter { it.sessionId != me.sessionId }) {
             outbound.send(OutboundEvent.SendText(other.sessionId, arriveLine))

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
@@ -176,6 +176,7 @@ class NavigationHandler(
                         gmcpEmitter,
                         dialogueSystem,
                     )
+                    me.lastEnterDirection = null
                     onPlayerMoved?.invoke(sessionId, origin)
                     outbound.send(OutboundEvent.SendText(sessionId, "You step outside and find yourself back where you came from."))
                     ctx.sendLook(sessionId)
@@ -206,6 +207,7 @@ class NavigationHandler(
                         gmcpEmitter,
                         dialogueSystem,
                     )
+                    me.lastEnterDirection = null
                     onPlayerMoved?.invoke(sessionId, origin)
                     outbound.send(OutboundEvent.SendText(sessionId, "You leave the guild hall and find yourself back where you came from."))
                     ctx.sendLook(sessionId)
@@ -232,7 +234,9 @@ class NavigationHandler(
                 outbound,
                 gmcpEmitter,
                 dialogueSystem,
+                direction = cmd.dir,
             )
+            me.lastEnterDirection = cmd.dir
             onPlayerMoved?.invoke(sessionId, to)
             ctx.sendLook(sessionId)
         }
@@ -279,6 +283,7 @@ class NavigationHandler(
                         gmcpEmitter,
                         dialogueSystem,
                     )
+                    me.lastEnterDirection = null
                     onPlayerMoved?.invoke(sessionId, result.entryRoomId)
                     outbound.send(OutboundEvent.SendText(sessionId, "You feel a familiar warmth and find yourself home."))
                     ctx.sendLook(sessionId)
@@ -318,6 +323,7 @@ class NavigationHandler(
             gmcpEmitter,
             dialogueSystem,
         )
+        me.lastEnterDirection = null
         onPlayerMoved?.invoke(sessionId, target)
         outbound.send(OutboundEvent.SendText(sessionId, msgs.arrival))
         ctx.sendLook(sessionId)
@@ -364,6 +370,7 @@ class NavigationHandler(
             dialogueSystem,
         )
         me.lastDeathZone = null
+        me.lastEnterDirection = null
         onPlayerMoved?.invoke(sessionId, target)
         ctx.sendLook(sessionId)
     }
@@ -396,6 +403,7 @@ class NavigationHandler(
             gmcpEmitter,
             dialogueSystem,
         )
+        me.lastEnterDirection = null
         onPlayerMoved?.invoke(sessionId, target)
         ctx.sendLook(sessionId)
     }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
@@ -176,7 +176,6 @@ class NavigationHandler(
                         gmcpEmitter,
                         dialogueSystem,
                     )
-                    me.lastEnterDirection = null
                     onPlayerMoved?.invoke(sessionId, origin)
                     outbound.send(OutboundEvent.SendText(sessionId, "You step outside and find yourself back where you came from."))
                     ctx.sendLook(sessionId)
@@ -207,7 +206,6 @@ class NavigationHandler(
                         gmcpEmitter,
                         dialogueSystem,
                     )
-                    me.lastEnterDirection = null
                     onPlayerMoved?.invoke(sessionId, origin)
                     outbound.send(OutboundEvent.SendText(sessionId, "You leave the guild hall and find yourself back where you came from."))
                     ctx.sendLook(sessionId)
@@ -236,7 +234,6 @@ class NavigationHandler(
                 dialogueSystem,
                 direction = cmd.dir,
             )
-            me.lastEnterDirection = cmd.dir
             onPlayerMoved?.invoke(sessionId, to)
             ctx.sendLook(sessionId)
         }
@@ -283,7 +280,6 @@ class NavigationHandler(
                         gmcpEmitter,
                         dialogueSystem,
                     )
-                    me.lastEnterDirection = null
                     onPlayerMoved?.invoke(sessionId, result.entryRoomId)
                     outbound.send(OutboundEvent.SendText(sessionId, "You feel a familiar warmth and find yourself home."))
                     ctx.sendLook(sessionId)
@@ -323,7 +319,6 @@ class NavigationHandler(
             gmcpEmitter,
             dialogueSystem,
         )
-        me.lastEnterDirection = null
         onPlayerMoved?.invoke(sessionId, target)
         outbound.send(OutboundEvent.SendText(sessionId, msgs.arrival))
         ctx.sendLook(sessionId)
@@ -370,7 +365,6 @@ class NavigationHandler(
             dialogueSystem,
         )
         me.lastDeathZone = null
-        me.lastEnterDirection = null
         onPlayerMoved?.invoke(sessionId, target)
         ctx.sendLook(sessionId)
     }
@@ -403,7 +397,6 @@ class NavigationHandler(
             gmcpEmitter,
             dialogueSystem,
         )
-        me.lastEnterDirection = null
         onPlayerMoved?.invoke(sessionId, target)
         ctx.sendLook(sessionId)
     }

--- a/src/test/kotlin/dev/ambon/engine/FleeMovementTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/FleeMovementTest.kt
@@ -176,6 +176,51 @@ class FleeMovementTest {
         }
 
     @Test
+    fun `flee respects achievement gates and never picks a gated exit`() =
+        runTest {
+            // ok_flee_gate: hall has open south (foyer) and achievement-gated north (sanctum).
+            // Alice starts in sanctum and walks south into hall, so lastEnterDirection = SOUTH
+            // and opposite = NORTH — which is the gated exit. With the gate honored, flee
+            // must reject NORTH and fall back to SOUTH (foyer); without the fix, the gated
+            // NORTH would be picked deterministically as the preferred direction.
+            val clock = java.time.Clock.fixed(java.time.Instant.EPOCH, java.time.ZoneOffset.UTC)
+            val repo = InMemoryPlayerRepository()
+            repo.createTestPlayer("Alice", RoomId("ok_flee_gate:sanctum"), password = "pw")
+            val h = GameEngineHarness.start(scope = this, world = TestWorlds.okFleeGate, clock = clock, repo = repo)
+
+            val sid = SessionId(1L)
+            runCurrent()
+            h.inbound.send(InboundEvent.Connected(sid))
+            h.inbound.send(InboundEvent.LineReceived(sid, "Alice"))
+            h.inbound.send(InboundEvent.LineReceived(sid, "pw"))
+            h.inbound.send(InboundEvent.LineReceived(sid, "s"))
+            h.inbound.send(InboundEvent.LineReceived(sid, "kill rat"))
+            advanceTimeBy(h.tickMillis)
+            runCurrent()
+            h.outbound.drainAll()
+
+            val hall = RoomId("ok_flee_gate:hall")
+            val foyer = RoomId("ok_flee_gate:foyer")
+            val sanctum = RoomId("ok_flee_gate:sanctum")
+            assertEquals(hall, h.players.get(sid)?.roomId, "Should be in hall before flee")
+            assertEquals(
+                Direction.SOUTH,
+                h.players.get(sid)?.lastEnterDirection,
+                "Setup precondition: walked south into hall",
+            )
+
+            h.inbound.send(InboundEvent.LineReceived(sid, "flee"))
+            advanceTimeBy(h.tickMillis)
+            runCurrent()
+
+            val landedIn = h.players.get(sid)?.roomId
+            assertNotEquals(sanctum, landedIn, "Flee must not bypass achievement gate to sanctum")
+            assertEquals(foyer, landedIn, "Flee should fall back to the open south exit")
+
+            h.close()
+        }
+
+    @Test
     fun `recall clears lastEnterDirection so subsequent flee picks random exit`() =
         runTest {
             val h = CommandRouterHarness.create()

--- a/src/test/kotlin/dev/ambon/engine/FleeMovementTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/FleeMovementTest.kt
@@ -1,0 +1,200 @@
+package dev.ambon.engine
+
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.world.Direction
+import dev.ambon.engine.commands.Command
+import dev.ambon.engine.events.InboundEvent
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.CommandRouterHarness
+import dev.ambon.test.GameEngineHarness
+import dev.ambon.test.TestWorlds
+import dev.ambon.test.createTestPlayer
+import dev.ambon.test.drainAll
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FleeMovementTest {
+    @Test
+    fun `directional move broadcasts use 'exits to' and 'arrives from' phrasing`() =
+        runTest {
+            val h = CommandRouterHarness.create()
+            val alice = SessionId(1)
+            val bob = SessionId(2)
+            val charlie = SessionId(3)
+            h.loginPlayer(alice, "Alice")
+            h.loginPlayer(bob, "Bob")
+            h.loginPlayer(charlie, "Charlie")
+
+            val startRoom = h.world.rooms.getValue(h.world.startRoom)
+            val northDir = startRoom.exits.keys.first { it == Direction.NORTH }
+
+            // Park Charlie in the north room so he sees the arrival.
+            h.router.handle(charlie, Command.Move(northDir))
+            h.drain()
+
+            h.router.handle(alice, Command.Move(northDir))
+            val outs = h.drain()
+
+            // Bob (in starting room) sees the directional depart.
+            assertTrue(
+                outs.any {
+                    it is OutboundEvent.SendText &&
+                        it.sessionId == bob &&
+                        it.text == "Alice exits to the north."
+                },
+                "Expected directional depart for Bob. got=$outs",
+            )
+            // Charlie (in destination room) sees the directional arrive.
+            assertTrue(
+                outs.any {
+                    it is OutboundEvent.SendText &&
+                        it.sessionId == charlie &&
+                        it.text == "Alice arrives from the south."
+                },
+                "Expected directional arrive for Charlie. got=$outs",
+            )
+        }
+
+    @Test
+    fun `move populates lastEnterDirection so flee can retrace`() =
+        runTest {
+            val h = CommandRouterHarness.create()
+            val alice = SessionId(1)
+            h.loginPlayer(alice, "Alice")
+
+            val startRoom = h.world.rooms.getValue(h.world.startRoom)
+            val northDir = startRoom.exits.keys.first { it == Direction.NORTH }
+
+            h.router.handle(alice, Command.Move(northDir))
+            h.drain()
+
+            assertEquals(
+                northDir,
+                h.players.get(alice)?.lastEnterDirection,
+                "Expected lastEnterDirection set to the move direction",
+            )
+        }
+
+    @Test
+    fun `flee from PvE relocates the player back the way they came`() =
+        runTest {
+            // ok_small: a (start) --N--> b (rat). Walking north sets lastEnterDirection=NORTH;
+            // flee should pick SOUTH (opposite) and put the player back in 'a'.
+            val clock = java.time.Clock.fixed(java.time.Instant.EPOCH, java.time.ZoneOffset.UTC)
+            val repo = InMemoryPlayerRepository()
+            repo.createTestPlayer("Alice", TestWorlds.okSmall.startRoom, password = "pw")
+            val h = GameEngineHarness.start(scope = this, world = TestWorlds.okSmall, clock = clock, repo = repo)
+
+            val sid = SessionId(1L)
+            runCurrent()
+            h.inbound.send(InboundEvent.Connected(sid))
+            h.inbound.send(InboundEvent.LineReceived(sid, "Alice"))
+            h.inbound.send(InboundEvent.LineReceived(sid, "pw"))
+            h.inbound.send(InboundEvent.LineReceived(sid, "n"))
+            h.inbound.send(InboundEvent.LineReceived(sid, "kill rat"))
+            advanceTimeBy(h.tickMillis)
+            runCurrent()
+            h.outbound.drainAll()
+
+            val roomA = RoomId("ok_small:a")
+            val roomB = RoomId("ok_small:b")
+            assertEquals(roomB, h.players.get(sid)?.roomId, "Should be in rat room before flee")
+
+            h.inbound.send(InboundEvent.LineReceived(sid, "flee"))
+            advanceTimeBy(h.tickMillis)
+            runCurrent()
+
+            assertEquals(roomA, h.players.get(sid)?.roomId, "Flee should retrace south to room a")
+            assertEquals(
+                Direction.SOUTH,
+                h.players.get(sid)?.lastEnterDirection,
+                "lastEnterDirection should track the flee direction",
+            )
+
+            h.close()
+        }
+
+    @Test
+    fun `flee broadcasts directional 'flees to' message to observers in old room`() =
+        runTest {
+            // ok_small: only one player in this scenario for simplicity. Add a witness in
+            // room b by reusing the harness: log Bob into b directly via repo so he sees
+            // Alice's flee broadcast leaving b.
+            val clock = java.time.Clock.fixed(java.time.Instant.EPOCH, java.time.ZoneOffset.UTC)
+            val repo = InMemoryPlayerRepository()
+            repo.createTestPlayer("Alice", TestWorlds.okSmall.startRoom, password = "pw")
+            repo.createTestPlayer("Bob", RoomId("ok_small:b"), password = "pw")
+            val h = GameEngineHarness.start(scope = this, world = TestWorlds.okSmall, clock = clock, repo = repo)
+
+            val aliceSid = SessionId(1L)
+            val bobSid = SessionId(2L)
+            runCurrent()
+
+            // Bob logs in first and stays in room b.
+            h.inbound.send(InboundEvent.Connected(bobSid))
+            h.inbound.send(InboundEvent.LineReceived(bobSid, "Bob"))
+            h.inbound.send(InboundEvent.LineReceived(bobSid, "pw"))
+            advanceTimeBy(h.tickMillis)
+            runCurrent()
+
+            // Alice walks north into b and starts combat.
+            h.inbound.send(InboundEvent.Connected(aliceSid))
+            h.inbound.send(InboundEvent.LineReceived(aliceSid, "Alice"))
+            h.inbound.send(InboundEvent.LineReceived(aliceSid, "pw"))
+            h.inbound.send(InboundEvent.LineReceived(aliceSid, "n"))
+            h.inbound.send(InboundEvent.LineReceived(aliceSid, "kill rat"))
+            advanceTimeBy(h.tickMillis)
+            runCurrent()
+            h.outbound.drainAll()
+
+            // Flee — observed by Bob who is still in b.
+            h.inbound.send(InboundEvent.LineReceived(aliceSid, "flee"))
+            advanceTimeBy(h.tickMillis)
+            runCurrent()
+
+            val outs = h.outbound.drainAll()
+            assertTrue(
+                outs.any {
+                    it is OutboundEvent.SendText &&
+                        it.sessionId == bobSid &&
+                        it.text == "Alice flees to the south."
+                },
+                "Expected directional flee broadcast in old room. got=$outs",
+            )
+
+            h.close()
+        }
+
+    @Test
+    fun `recall clears lastEnterDirection so subsequent flee picks random exit`() =
+        runTest {
+            val h = CommandRouterHarness.create()
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Alice")
+
+            val startRoom = h.world.rooms.getValue(h.world.startRoom)
+            val northDir = startRoom.exits.keys.firstOrNull { it == Direction.NORTH } ?: return@runTest
+
+            h.router.handle(sid, Command.Move(northDir))
+            h.drain()
+            assertNotEquals(null, h.players.get(sid)?.lastEnterDirection)
+
+            h.router.handle(sid, Command.Recall)
+            h.drain()
+
+            assertNull(
+                h.players.get(sid)?.lastEnterDirection,
+                "Recall should clear lastEnterDirection",
+            )
+        }
+}

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterTest.kt
@@ -144,15 +144,15 @@ class CommandRouterTest {
 
             assertTrue(
                 outs.any {
-                    it is OutboundEvent.SendText && it.sessionId == bob && it.text == "Alice leaves."
+                    it is OutboundEvent.SendText && it.sessionId == bob && it.text == "Alice exits to the north."
                 },
-                "Bob should see leave broadcast. got=$outs",
+                "Bob should see directional leave broadcast. got=$outs",
             )
             assertTrue(
                 outs.any {
-                    it is OutboundEvent.SendText && it.sessionId == charlie && it.text == "Alice enters."
+                    it is OutboundEvent.SendText && it.sessionId == charlie && it.text == "Alice arrives from the south."
                 },
-                "Charlie should see enter broadcast. got=$outs",
+                "Charlie should see directional enter broadcast. got=$outs",
             )
         }
 

--- a/src/test/kotlin/dev/ambon/test/TestFixtures.kt
+++ b/src/test/kotlin/dev/ambon/test/TestFixtures.kt
@@ -66,6 +66,7 @@ object TestWorlds {
     val okFeatures: World by lazy { WorldLoader.loadFromResource("world/ok_features.yaml") }
     val okPuzzles: World by lazy { WorldLoader.loadFromResource("world/ok_puzzles.yaml") }
     val okAchievementGate: World by lazy { WorldLoader.loadFromResource("world/ok_achievement_gate.yaml") }
+    val okFleeGate: World by lazy { WorldLoader.loadFromResource("world/ok_flee_gate.yaml") }
 }
 
 object TestPasswordHasher : PasswordHasher {

--- a/src/test/resources/world/ok_flee_gate.yaml
+++ b/src/test/resources/world/ok_flee_gate.yaml
@@ -1,0 +1,33 @@
+zone: ok_flee_gate
+lifespan: 1
+startRoom: hall
+mobs:
+  rat:
+    name: "a small rat"
+    room: hall
+    drops:
+      - itemId: tooth
+        chance: 1.0
+items:
+  tooth:
+    displayName: "a rat tooth"
+rooms:
+  hall:
+    title: "Locked Hall"
+    description: "A hall with one open exit south and a sealed door north."
+    exits:
+      south: foyer
+      north:
+        to: sanctum
+        requiresAchievement: hall_boss_slain
+        lockedMessage: "The sanctum door is sealed."
+  foyer:
+    title: "Foyer"
+    description: "A modest foyer."
+    exits:
+      north: hall
+  sanctum:
+    title: "Sanctum"
+    description: "A hidden sanctum."
+    exits:
+      south: hall


### PR DESCRIPTION
## Summary
- Movement broadcasts now read `"Alice exits to the north."` / `"Alice arrives from the south."` (and `"a goblin flees upward."` for mobs) so it's easier to follow people and mobs as they move. Recall, petition, depart, housing and guild-hall transitions keep their existing thematic wording.
- `flee` (manual and wimpy auto-flee) and PvP `flee` now actually move the player one room away after disengaging, so aggressive mobs don't immediately re-hit them. The fleer prefers retracing back the direction they came from when that's a valid intra-zone exit with no closed/locked door; otherwise a random valid exit; otherwise disengage-only (current behavior).
- New transient `PlayerState.lastEnterDirection` is populated on every directional walk and cleared on teleports so flee never retraces a stale direction.

## How it's wired
- `Direction.exitPhrase()` / `arrivePhrase()` build the new lines.
- `movePlayerWithNotify` (HandlerHelpers) and `BtContext.moveMobWithNotify` accept optional `direction` + `departVerb`; when `direction` is non-null the legacy `departMsg`/`arriveMsg` are bypassed in favour of `"<name> <verb> to the north."` / `"<name> arrives from the south."`.
- `CombatSystem` exposes a new `onPlayerFled: (SessionId, /*forced*/ Boolean) -> Unit` callback fired by `flee()` and `fleePvp()` after disengage; `GameEngine` wires it to pick the exit, move via `movePlayerWithNotify` with `departVerb = "flees"`, follow with pets, and send `look`.

## Test plan
- [x] `./gradlew ktlintCheck test` — full suite passes.
- [x] `FleeMovementTest` covers: directional broadcasts, `lastEnterDirection` populated on walk, PvE flee retraces back to the prior room, observers see the directional flee line, recall clears `lastEnterDirection`.
- [x] Updated `CommandRouterTest`'s movement broadcast assertions for the new wording.
- [ ] Manual smoke: walk between rooms with two clients (telnet + web), confirm broadcast wording on both sides.
- [ ] Manual smoke: aggro mob fight → `flee` → confirm the character actually relocates and the mob does not immediately hit again.