### PR TITLE
feat(web): flee toast notification on combat disengage

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -349,6 +349,7 @@ class CombatSystem(
                 "You flee from $mobName."
             }
         outbound.send(OutboundEvent.SendText(sessionId, msg))
+        onCombatEvent(sessionId, CombatEvent.Flee(targetName = mobName, forced = forced))
         // GameEngine wires this to relocate the player to an adjacent room. The prompt is
         // sent after the room move so the new room's GMCP/look land before the prompt.
         onPlayerFled(sessionId, forced)
@@ -383,6 +384,7 @@ class CombatSystem(
         val opponent = pvpTarget[targetSid]?.let { players.get(it) }?.name ?: "your opponent"
         endPvpCombat(targetSid)
         outbound.send(OutboundEvent.SendText(targetSid, "You are forced to flee from $opponent!"))
+        onCombatEvent(targetSid, CombatEvent.Flee(targetName = opponent, forced = true))
         outbound.send(OutboundEvent.SendPrompt(targetSid))
         return true
     }
@@ -516,6 +518,7 @@ class CombatSystem(
 
         endPvpCombat(sessionId)
         outbound.send(OutboundEvent.SendText(sessionId, "You flee from $targetName."))
+        onCombatEvent(sessionId, CombatEvent.Flee(targetName = targetName, forced = false))
         onPlayerFled(sessionId, false)
         outbound.send(OutboundEvent.SendPrompt(sessionId))
         return null

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -1058,6 +1058,11 @@ class GmcpEmitter(
                 targetIsPlayer = event.targetIsPlayer,
                 sourceIsPlayer = event.sourceIsPlayer,
             )
+            is CombatEvent.Flee -> CombatEventPayload(
+                type = "flee",
+                targetName = event.targetName,
+                forced = event.forced,
+            )
         }
         emit(sessionId, "Char.Combat.Event", payload, supportCheck = "Char.Combat.Event")
     }
@@ -2769,6 +2774,7 @@ class GmcpEmitter(
         val petName: String? = null,
         val targetIsPlayer: Boolean? = null,
         val lootedItems: List<String> = emptyList(),
+        val forced: Boolean? = null,
     )
 
     // ---------- stats payload ----------

--- a/src/main/kotlin/dev/ambon/engine/events/CombatEvent.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/CombatEvent.kt
@@ -94,4 +94,14 @@ sealed interface CombatEvent {
         val targetIsPlayer: Boolean,
         val sourceIsPlayer: Boolean,
     ) : CombatEvent
+
+    /**
+     * The local player disengaged from combat. [forced] is true for the wimpy
+     * auto-flee path so the client can distinguish a voluntary escape from a
+     * threshold-triggered one.
+     */
+    data class Flee(
+        val targetName: String,
+        val forced: Boolean,
+    ) : CombatEvent
 }

--- a/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
@@ -1656,4 +1656,27 @@ class CombatSystemTest {
             assertTrue(outcome is ConsiderOutcome.Error)
             assertTrue((outcome as ConsiderOutcome.Error).message.contains("don't see"))
         }
+
+    @Test
+    fun `flee emits Flee combat event with mob name and forced=false`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            val mob = MobState(MobId("demo:rat"), "a rat", fixture.roomId, hp = 50, maxHp = 50)
+            fixture.mobs.upsert(mob)
+
+            val combat = fixture.buildCombat(rng = Random(7))
+            val sid = SessionId(801L)
+            fixture.players.loginOrFail(sid, "Runner")
+
+            val combatEvents = mutableListOf<CombatEvent>()
+            combat.onCombatEvent = { _, event -> combatEvents += event }
+
+            assertNull(combat.startCombat(sid, "rat"))
+            assertNull(combat.flee(sid))
+
+            val flee = combatEvents.filterIsInstance<CombatEvent.Flee>().firstOrNull()
+            assertNotNull(flee, "Expected a Flee combat event, got: $combatEvents")
+            assertEquals("a rat", flee!!.targetName)
+            assertEquals(false, flee.forced)
+        }
 }

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -1172,6 +1172,21 @@ class GmcpEmitterTest {
         }
 
     @Test
+    fun `sendCombatEvent emits flee JSON with forced flag`() =
+        runTest {
+            val e = emitter("Char.Combat.Event")
+            e.sendCombatEvent(sid, CombatEvent.Flee(targetName = "a rat", forced = false))
+            e.sendCombatEvent(sid, CombatEvent.Flee(targetName = "Bandit", forced = true))
+            val events = drainGmcp()
+            assertEquals(2, events.size)
+            assertTrue(events[0].jsonData.contains("\"type\":\"flee\""))
+            assertTrue(events[0].jsonData.contains("\"targetName\":\"a rat\""))
+            assertTrue(events[0].jsonData.contains("\"forced\":false"))
+            assertTrue(events[1].jsonData.contains("\"targetName\":\"Bandit\""))
+            assertTrue(events[1].jsonData.contains("\"forced\":true"))
+        }
+
+    @Test
     fun `sendCombatEvent emits abilityCast JSON for buff or debuff`() =
         runTest {
             val e = emitter("Char.Combat")

--- a/src/test/kotlin/dev/ambon/engine/PvpCombatTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/PvpCombatTest.kt
@@ -2,6 +2,7 @@ package dev.ambon.engine
 
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.engine.events.CombatEvent
 import dev.ambon.test.CombatTestFixture
 import dev.ambon.test.drainAll
 import dev.ambon.test.loginOrFail
@@ -185,6 +186,29 @@ class PvpCombatTest {
 
         val messages = fixture.outbound.drainAll().textMessages(sid1)
         assertTrue(messages.any { it.contains("flee") })
+    }
+
+    @Test
+    fun `fleePvp emits Flee combat event with opponent name and forced=false`() = runTest {
+        val fixture = CombatTestFixture(roomId = roomId)
+        val combat = fixture.buildCombat()
+
+        val sid1 = SessionId(1L)
+        val sid2 = SessionId(2L)
+        fixture.players.loginOrFail(sid1, "Runner")
+        fixture.players.loginOrFail(sid2, "Chaser")
+
+        val events = mutableListOf<Pair<SessionId, CombatEvent>>()
+        combat.onCombatEvent = { sid, event -> events += sid to event }
+
+        combat.startPvpCombat(sid1, sid2)
+        assertNull(combat.fleePvp(sid1))
+
+        val flee = events.firstOrNull { it.first == sid1 && it.second is CombatEvent.Flee }
+        assertNotNull(flee, "Expected a Flee event for the fleeing player, got: $events")
+        val payload = flee!!.second as CombatEvent.Flee
+        assertEquals("Chaser", payload.targetName)
+        assertEquals(false, payload.forced)
     }
 
     @Test

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -32,6 +32,7 @@ import { DemoBanner } from "./components/DemoBanner";
 import { LevelUpBanner } from "./components/LevelUpBanner";
 import { QuestCompleteToast } from "./components/QuestCompleteToast";
 import { CombatVictoryToast } from "./components/CombatVictoryToast";
+import { FleeToast } from "./components/FleeToast";
 import { LoginModal } from "./canvas/LoginModal";
 import { CharacterPicker } from "./components/CharacterPicker";
 import { CommandPalette } from "./components/CommandPalette";
@@ -1649,6 +1650,14 @@ function App() {
         notifications={state.combatVictoryNotifications}
         onDismiss={(id) =>
           state.setCombatVictoryNotifications((prev) => prev.filter((n) => n.id !== id))
+        }
+      />
+
+      {/* Flee toast — surfaces voluntary and wimpy-forced disengages. */}
+      <FleeToast
+        notifications={state.fleeNotifications}
+        onDismiss={(id) =>
+          state.setFleeNotifications((prev) => prev.filter((n) => n.id !== id))
         }
       />
 

--- a/web-v3/src/components/FleeToast.tsx
+++ b/web-v3/src/components/FleeToast.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import type { FleeNotification } from "../types";
+
+interface FleeToastProps {
+  notifications: FleeNotification[];
+  onDismiss: (id: string) => void;
+}
+
+/**
+ * Top-right toast surfaced when the local player disengages from combat. Mirrors
+ * CombatVictoryToast — only the most recent flee is rendered, back-to-back
+ * flees replace rather than stack. Distinct color/icon so it doesn't read as
+ * a victory.
+ */
+export function FleeToast({ notifications, onDismiss }: FleeToastProps) {
+  const current = notifications.length > 0 ? notifications[notifications.length - 1] : null;
+  if (!current) return null;
+  return (
+    <FleeToastInner
+      key={current.id}
+      notification={current}
+      onDismiss={() => onDismiss(current.id)}
+    />
+  );
+}
+
+interface InnerProps {
+  notification: FleeNotification;
+  onDismiss: () => void;
+}
+
+function FleeToastInner({ notification, onDismiss }: InnerProps) {
+  const [closing, setClosing] = useState(false);
+
+  useEffect(() => {
+    const fade = window.setTimeout(() => setClosing(true), 4500);
+    return () => window.clearTimeout(fade);
+  }, []);
+
+  useEffect(() => {
+    if (!closing) return;
+    const clear = window.setTimeout(() => onDismiss(), 350);
+    return () => window.clearTimeout(clear);
+  }, [closing, onDismiss]);
+
+  const { targetName, forced } = notification;
+  const eyebrow = forced ? "Forced to flee" : "Escaped";
+  const subtitle = forced
+    ? `Wounds drove you away from ${targetName}`
+    : `You fled from ${targetName}`;
+
+  return (
+    <div
+      className={`flee-toast${forced ? " flee-toast-forced" : ""}${closing ? " flee-toast-closing" : ""}`}
+      role="status"
+      aria-live="polite"
+      onClick={() => setClosing(true)}
+    >
+      <div className="flee-toast-header">
+        <span className="flee-toast-icon" aria-hidden="true">{forced ? "☠" : "👟"}</span>
+        <div className="flee-toast-titles">
+          <span className="flee-toast-eyebrow">{eyebrow}</span>
+          <span className="flee-toast-name">{subtitle}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -1024,6 +1024,7 @@ export function applyGmcpPackage(
         lootedItems: Array.isArray(packet.lootedItems)
           ? packet.lootedItems.filter((s): s is string => typeof s === "string")
           : [],
+        forced: packet.forced === true,
       });
       break;
     }

--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -340,8 +340,11 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
       };
       // Replace (rather than append) so back-to-back kills don't queue stale
       // toasts behind the active one — otherwise the active toast's dismissal
-      // resurfaces a prior kill several seconds late.
+      // resurfaces a prior kill several seconds late. Also clear any active
+      // flee toast: kill and flee share a fixed corner slot, and the freshest
+      // outcome supersedes the stale one.
       setCombatVictoryNotifications([notification]);
+      setFleeNotifications([]);
     }
     if (event.type === "flee" && event.targetName) {
       fleeIdRef.current += 1;
@@ -351,7 +354,12 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
         forced: event.forced,
         receivedAt: Date.now(),
       };
+      // Mirror the kill path: share the corner slot, freshest outcome wins.
+      // A kill toast from the previous fight can still be on-screen (4.5s
+      // lifetime) when the player flees the next pull — without this the two
+      // cards stack at the same `top:` and overlap.
       setFleeNotifications([notification]);
+      setCombatVictoryNotifications([]);
     }
   }, [pushCombatLogMessage]);
 

--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -40,6 +40,7 @@ import type {
   EquipmentSlotDef,
   FactionActivity,
   FactionStanding,
+  FleeNotification,
   FriendEntry,
   FriendNotification,
   GainEvent,
@@ -197,6 +198,8 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
   const levelUpIdRef = useRef(0);
   const [combatVictoryNotifications, setCombatVictoryNotifications] = useState<CombatVictoryNotification[]>([]);
   const combatVictoryIdRef = useRef(0);
+  const [fleeNotifications, setFleeNotifications] = useState<FleeNotification[]>([]);
+  const fleeIdRef = useRef(0);
   const [duelState, setDuelState] = useState<DuelState | null>(null);
   const [duelChallenge, setDuelChallenge] = useState<DuelChallenge | null>(null);
 
@@ -339,6 +342,16 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
       // toasts behind the active one — otherwise the active toast's dismissal
       // resurfaces a prior kill several seconds late.
       setCombatVictoryNotifications([notification]);
+    }
+    if (event.type === "flee" && event.targetName) {
+      fleeIdRef.current += 1;
+      const notification: FleeNotification = {
+        id: `flee-${fleeIdRef.current}`,
+        targetName: event.targetName,
+        forced: event.forced,
+        receivedAt: Date.now(),
+      };
+      setFleeNotifications([notification]);
     }
   }, [pushCombatLogMessage]);
 
@@ -645,6 +658,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     setPuzzle(null);
     setQuestNotifications([]);
     setCombatVictoryNotifications([]);
+    setFleeNotifications([]);
     setCraftingSkills([]);
     setCraftingRecipes([]);
     setCraftingNodes([]);
@@ -733,6 +747,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     activePopout, setActivePopout, broadcast, setBroadcast, possessing, toast, setToast, uiFeedbackFeed,
     levelUpNotification, setLevelUpNotification,
     combatVictoryNotifications, setCombatVictoryNotifications,
+    fleeNotifications, setFleeNotifications,
     // Setters needed by App
     setQuestsAvailable,
     // GMCP

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -17901,8 +17901,9 @@ html:has(.game-shell),
 /* ── Flee toast — disengage summary card ───────────────────────── */
 .flee-toast {
   position: fixed;
-  /* Same slot as the victory toast — kill and flee can't fire on the same
-     tick, so sharing the position is safe and avoids stacking real estate. */
+  /* Shares the corner slot with the victory toast. `useGameState`
+     clears the other notification list whenever one fires, so the two cards
+     can never overlap even though both have ~4.5s lifetimes. */
   top: calc(var(--space-4, 16px) + 56px + 180px);
   right: var(--space-4, 16px);
   z-index: 240;

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -17897,3 +17897,121 @@ html:has(.game-shell),
     animation-duration: 80ms;
   }
 }
+
+/* ── Flee toast — disengage summary card ───────────────────────── */
+.flee-toast {
+  position: fixed;
+  /* Same slot as the victory toast — kill and flee can't fire on the same
+     tick, so sharing the position is safe and avoids stacking real estate. */
+  top: calc(var(--space-4, 16px) + 56px + 180px);
+  right: var(--space-4, 16px);
+  z-index: 240;
+  width: min(320px, calc(100vw - 32px));
+  padding: 14px 16px;
+  background: linear-gradient(
+    155deg,
+    color-mix(in srgb, var(--c-pale-blue, #81a2be) 24%, var(--c-surface-raised, #1e2340)) 0%,
+    var(--c-surface-raised, #1e2340) 60%,
+    color-mix(in srgb, var(--c-accent-lavender, #b294bb) 14%, var(--c-surface-raised, #1e2340)) 100%
+  );
+  border: 1px solid color-mix(in srgb, var(--c-pale-blue, #81a2be) 50%, transparent);
+  border-radius: 14px;
+  box-shadow:
+    0 18px 48px rgba(0, 0, 0, 0.45),
+    0 0 0 1px color-mix(in srgb, var(--c-pale-blue, #81a2be) 22%, transparent),
+    0 0 32px color-mix(in srgb, var(--c-pale-blue, #81a2be) 28%, transparent);
+  color: var(--c-text-primary, #d8dcef);
+  cursor: pointer;
+  animation: fleeToastIn 380ms var(--ease-out-soft, cubic-bezier(0.22, 1, 0.36, 1));
+  backdrop-filter: blur(8px);
+}
+
+.flee-toast.flee-toast-forced {
+  background: linear-gradient(
+    155deg,
+    color-mix(in srgb, var(--c-dusty-rose, #c97f7f) 26%, var(--c-surface-raised, #1e2340)) 0%,
+    var(--c-surface-raised, #1e2340) 60%,
+    color-mix(in srgb, var(--c-pale-blue, #81a2be) 14%, var(--c-surface-raised, #1e2340)) 100%
+  );
+  border-color: color-mix(in srgb, var(--c-dusty-rose, #c97f7f) 55%, transparent);
+  box-shadow:
+    0 18px 48px rgba(0, 0, 0, 0.45),
+    0 0 0 1px color-mix(in srgb, var(--c-dusty-rose, #c97f7f) 26%, transparent),
+    0 0 32px color-mix(in srgb, var(--c-dusty-rose, #c97f7f) 32%, transparent);
+}
+
+.flee-toast.flee-toast-closing {
+  animation: fleeToastOut 320ms var(--ease-out-soft, cubic-bezier(0.22, 1, 0.36, 1)) forwards;
+}
+
+@keyframes fleeToastIn {
+  from {
+    opacity: 0;
+    transform: translateX(24px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+}
+
+@keyframes fleeToastOut {
+  from {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(16px) scale(0.97);
+  }
+}
+
+.flee-toast-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.flee-toast-icon {
+  font-size: 22px;
+  filter: drop-shadow(0 0 6px color-mix(in srgb, var(--c-pale-blue, #81a2be) 60%, transparent));
+}
+
+.flee-toast-forced .flee-toast-icon {
+  filter: drop-shadow(0 0 6px color-mix(in srgb, var(--c-dusty-rose, #c97f7f) 65%, transparent));
+}
+
+.flee-toast-titles {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.flee-toast-eyebrow {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: color-mix(in srgb, var(--c-pale-blue, #81a2be) 80%, var(--c-text-secondary, #8890b0));
+  font-weight: 600;
+}
+
+.flee-toast-forced .flee-toast-eyebrow {
+  color: color-mix(in srgb, var(--c-dusty-rose, #c97f7f) 80%, var(--c-text-secondary, #8890b0));
+}
+
+.flee-toast-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--c-text-primary, #d8dcef);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .flee-toast,
+  .flee-toast.flee-toast-closing {
+    animation-duration: 80ms;
+  }
+}

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -503,6 +503,8 @@ export interface CombatEventData {
   targetIsPlayer: boolean;
   /** Display names of items autolooted from the kill (only set on type=="kill"). */
   lootedItems: string[];
+  /** True when the player disengaged via the wimpy threshold rather than typing `flee`. */
+  forced: boolean;
 }
 
 export interface StatEntry {
@@ -650,6 +652,18 @@ export interface CombatVictoryNotification {
   xpGained: number;
   goldGained: number;
   lootedItems: string[];
+  receivedAt: number;
+}
+
+/**
+ * Top-right toast surfaced when the local player disengages from combat via
+ * `flee` or the wimpy threshold. Built from `Char.Combat.Event` packets of
+ * `type: "flee"`.
+ */
+export interface FleeNotification {
+  id: string;
+  targetName: string;
+  forced: boolean;
   receivedAt: number;
 }
 


### PR DESCRIPTION
## Summary
- Add `CombatEvent.Flee(targetName, forced)` variant, emitted from `CombatSystem.flee`, `fleePvp`, and the wimpy auto-flee path.
- Marshal through `Char.Combat.Event` GMCP with a new optional `forced` flag.
- Surface a top-right `FleeToast` in the web client (pale-blue for voluntary `flee`, dusty-rose for wimpy-forced). Shares the victory-toast slot — both can't fire on the same tick.

## Test plan
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew test --tests dev.ambon.engine.CombatSystemTest --tests dev.ambon.engine.GmcpEmitterTest`
- [x] `./gradlew test --tests dev.ambon.engine.FleeMovementTest --tests dev.ambon.engine.PvpCombatTest --tests dev.ambon.engine.TankPetCombatTest`
- [x] `bun run lint` + `bun run build` in `web-v3/`
- [ ] Manual: start a fight, type `flee` → blue "Escaped" toast appears top-right; drop HP under wimpy → rose "Forced to flee" toast.