### PR TITLE
fix(web): login hero flicker + clearer demo/character copy

### DIFF
--- a/web-v3/src/canvas/LoginModal.tsx
+++ b/web-v3/src/canvas/LoginModal.tsx
@@ -57,9 +57,9 @@ export function LoginModal({ loginPrompt, loginError, onSubmit }: LoginModalProp
             {loginPrompt.demoEnabled && (
               <section className="login-card login-card--demo">
                 <div className="login-card-glyph" aria-hidden="true">✦</div>
-                <h2 className="login-card-title">Begin a new adventure</h2>
+                <h2 className="login-card-title">Try as a guest</h2>
                 <p className="login-card-body">
-                  Spawn instantly. No signup. Save your progress in-game with <code>/claim</code>.
+                  Spawn a demo character in one click — no signup, no setup. Use <code>/claim</code> in-game to keep them.
                 </p>
                 <button
                   type="button"
@@ -67,7 +67,7 @@ export function LoginModal({ loginPrompt, loginError, onSubmit }: LoginModalProp
                   onClick={() => onSubmit("demo")}
                 >
                   <span className="login-card-cta-sparkle" aria-hidden="true" />
-                  Begin Adventure
+                  Start Demo
                 </button>
               </section>
             )}
@@ -76,8 +76,10 @@ export function LoginModal({ loginPrompt, loginError, onSubmit }: LoginModalProp
 
             <section className="login-card login-card--signin">
               <div className="login-card-glyph" aria-hidden="true">✧</div>
-              <h2 className="login-card-title">Continue your story</h2>
-              <p className="login-card-body">Returning hero? Sign in with your character name.</p>
+              <h2 className="login-card-title">Create a full character</h2>
+              <p className="login-card-body">
+                Pick a name, race, and class. Sign in any time. Returning? Just enter your character name.
+              </p>
               <form onSubmit={handleSubmit} className="login-card-form">
                 <input
                   ref={inputRef}

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -14331,28 +14331,31 @@ body {
     );
 }
 
+/* Note: mix-blend-mode was removed here — combining it with filter: blur and
+   a position: fixed ancestor causes intermittent compositor flicker in
+   Chromium. Gradient alphas are tuned to give a similar glow without blend. */
 .login-scene-aurora {
   position: absolute;
   inset: -20% -10%;
   background:
     radial-gradient(
       ellipse 60% 30% at 30% 40%,
-      rgb(168 151 210 / 18%) 0%,
+      rgb(196 178 232 / 32%) 0%,
       transparent 60%
     ),
     radial-gradient(
       ellipse 50% 25% at 75% 55%,
-      rgb(140 174 201 / 14%) 0%,
+      rgb(168 196 222 / 26%) 0%,
       transparent 60%
     ),
     radial-gradient(
       ellipse 40% 20% at 50% 30%,
-      rgb(184 143 170 / 10%) 0%,
+      rgb(210 168 196 / 20%) 0%,
       transparent 60%
     );
   filter: blur(40px);
   animation: loginAuroraDrift 22s var(--ease-in-out-smooth) infinite alternate;
-  mix-blend-mode: screen;
+  will-change: transform, opacity;
 }
 
 @keyframes loginAuroraDrift {


### PR DESCRIPTION
Two follow-ups to #1163 (the magical login hero) that landed too late to make the merge:

## 1. Background flicker fix

The aurora layer combined `mix-blend-mode: screen` with `filter: blur(40px)` inside a `position: fixed` ancestor. That trio forces Chromium to keep recompositing the blend isolation layer on top of the blur layer, and it intermittently flickers as the compositor evicts and recreates the layer.

- Drop `mix-blend-mode: screen` on `.login-scene-aurora`.
- Bump the three radial-gradient alphas (and shift the hues slightly brighter) so the aurora still reads with similar intensity over the dark sky without needing the blend.
- Add `will-change: transform, opacity` so the GPU keeps the aurora promoted across the long drift cycle.

## 2. Clearer demo vs full-character framing

The previous copy ("Begin a new adventure" / "Continue your story") implied the left card was for new players and the right card was only for returning players. In reality the right card handles **both** new character creation and returning sign-in — and the left card is the disposable demo path. Rephrased so the contrast is demo vs real:

- **Demo card** — title "Try as a guest", CTA "Start Demo", body emphasizes no-signup and the `/claim` upgrade path.
- **Sign-in card** — title "Create a full character", body covers both new creation (name/race/class) and returning sign-in.

## Test plan

- [ ] `./gradlew demo` and confirm no flicker on the login background after 10–20s of idle observation
- [ ] Hover the demo CTA — pulse pauses, larger green glow shows
- [ ] Verify aurora is still visible (purple/blue/pink washes drifting against the dark sky)
- [ ] Click **Start Demo** → demo character spawns
- [ ] Type a new character name → confirm-create flow
- [ ] Type a returning character name → password prompt
- [ ] Reduced-motion: aurora animation stops, scene remains legible