### PR TITLE
fix(web): kill paint-property animations on login (Firefox flicker)

### DIFF
--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -14354,14 +14354,12 @@ body {
       transparent 60%
     );
   filter: blur(24px);
-  animation: loginAuroraDrift 22s var(--ease-in-out-smooth) infinite alternate;
 }
 
-@keyframes loginAuroraDrift {
-  0%   { transform: translate3d(-3%, -2%, 0) scale(1);    opacity: 0.85; }
-  50%  { transform: translate3d(4%, 1%, 0) scale(1.08);   opacity: 1; }
-  100% { transform: translate3d(-1%, 3%, 0) scale(1.04);  opacity: 0.9; }
-}
+/* Aurora drift animation removed: scale on a filter: blur layer forces
+   periodic re-rasterization that appears as a viewport-sized rectangular
+   flash in the empty scene area around the cards. Static aurora gives
+   the same color wash without the compositor churn. */
 
 /* Starfield — three layers built with stacked radial gradients (no images,
    no JS). Each layer animates at a different drift rate for parallax. */
@@ -14572,14 +14570,12 @@ body {
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
-  filter: drop-shadow(0 4px 24px rgb(168 151 210 / 35%));
-  animation: loginHeroTitleShimmer 6s var(--ease-in-out-smooth) infinite;
+  filter: drop-shadow(0 4px 24px rgb(168 151 210 / 32%));
 }
 
-@keyframes loginHeroTitleShimmer {
-  0%, 100% { filter: drop-shadow(0 4px 24px rgb(168 151 210 / 28%)); }
-  50%      { filter: drop-shadow(0 4px 32px rgb(190 168 115 / 38%)); }
-}
+/* Title shimmer removed: animating filter: drop-shadow forces full
+   re-rasterization of the title's region every frame, which manifested
+   as a rectangular flash in the top portion of the viewport. */
 
 .login-hero-tagline {
   margin: 0;
@@ -14814,10 +14810,9 @@ body {
   background: linear-gradient(140deg, rgb(140 200 148 / 75%), rgb(100 152 116 / 80%));
   border-color: rgb(190 226 200 / 60%);
   box-shadow:
-    inset 0 1px 0 rgb(232 248 232 / 26%),
-    0 6px 18px rgb(56 88 64 / 45%),
-    0 0 22px rgb(141 169 123 / 28%);
-  animation: loginCtaPulse 3.2s var(--ease-in-out-smooth) infinite;
+    inset 0 1px 0 rgb(232 248 232 / 28%),
+    0 6px 18px rgb(56 88 64 / 48%),
+    0 0 26px rgb(141 169 123 / 36%);
 }
 
 .login-card-cta--demo:hover {
@@ -14827,13 +14822,13 @@ body {
     inset 0 1px 0 rgb(232 248 232 / 34%),
     0 8px 24px rgb(56 88 64 / 55%),
     0 0 32px rgb(141 169 123 / 50%);
-  animation-play-state: paused;
 }
 
-@keyframes loginCtaPulse {
-  0%, 100% { box-shadow: inset 0 1px 0 rgb(232 248 232 / 26%), 0 6px 18px rgb(56 88 64 / 45%), 0 0 22px rgb(141 169 123 / 28%); }
-  50%      { box-shadow: inset 0 1px 0 rgb(232 248 232 / 32%), 0 6px 18px rgb(56 88 64 / 50%), 0 0 32px rgb(141 169 123 / 48%); }
-}
+/* loginCtaPulse animation removed: animating box-shadow is a paint
+   property, not a composited one. The repaints inside the (backdrop-
+   filtered) card forced backdrop-filter re-sampling on every frame,
+   which contributed to the rectangular compositor flash in the empty
+   scene area. Static glow looks essentially identical at rest. */
 
 .login-card-cta--signin {
   background: linear-gradient(140deg, rgb(132 116 184 / 75%), rgb(96 84 148 / 82%));


### PR DESCRIPTION
Firefox-only follow-up to #1163/#1164/#1165. The constant rectangular flash in the empty scene area is reproducible in Firefox but not Chrome, which fingered paint-property animations: Firefox is far stricter than Chromium about re-rasterizing filter / drop-shadow / box-shadow layers each frame.

Three offenders, all made static:

1. **Aurora** — animated `transform + scale + opacity` on a `filter: blur(24px)` layer. The `scale` part forces Firefox to re-rasterize the blur at each new scale; the viewport-sized aurora rectangle flashes in the empty scene area each time. Now static.
2. **Title shimmer** — animated `filter: drop-shadow`. Paint property → re-rasterizes the title's rectangular region every frame. Now a static (slightly bumped) drop shadow.
3. **Demo CTA pulse** — animated `box-shadow`. Paint property; repaints inside the (backdrop-filtered) card forced backdrop-filter resampling every frame. Now a static glow tuned to roughly the midpoint of the previous pulse.

Kept all GPU-safe animations: firefly drift + pulse (transform / opacity), island bob (transform), card glyph float (transform), card hover transitions.

## Test plan

- [ ] Open the login screen in **Firefox**, sit for 30s — no rectangular flashes in the empty scene area, no flashes near the title, no flashes around the demo CTA
- [ ] Confirm Chrome is still clean (regression check)
- [ ] Confirm aurora wash is still visible
- [ ] Confirm fireflies still drift/pulse subtly
- [ ] Confirm islands still bob gently
- [ ] Confirm demo CTA hover glow still appears