### PR TITLE
feat: archetypal item stats (PRIMARY/SECONDARY/TERTIARY) resolved per class

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -1948,6 +1948,7 @@ data class ClassDefinitionConfig(
     val image: String = "",
     val selectable: Boolean = true,
     val primaryStat: String = "",
+    val statPriorities: List<String> = emptyList(),
     val startRoom: String = "",
     val threatMultiplier: Double = 1.0,
     val starterEquipment: List<StarterEquipmentEntryConfig> = emptyList(),

--- a/src/main/kotlin/dev/ambon/domain/PlayerClassDef.kt
+++ b/src/main/kotlin/dev/ambon/domain/PlayerClassDef.kt
@@ -29,7 +29,7 @@ data class PlayerClassDef(
             .map { it.trim().uppercase() }
             .filter { it.isNotEmpty() }
         if (explicit.isNotEmpty()) return explicit
-        return listOfNotNull(primaryStat?.takeIf { it.isNotBlank() }?.uppercase())
+        return listOfNotNull(primaryStat?.trim()?.takeIf { it.isNotEmpty() }?.uppercase())
     }
 }
 

--- a/src/main/kotlin/dev/ambon/domain/PlayerClassDef.kt
+++ b/src/main/kotlin/dev/ambon/domain/PlayerClassDef.kt
@@ -17,16 +17,20 @@ data class PlayerClassDef(
 ) {
     /**
      * Effective archetypal priority list used to resolve PRIMARY/SECONDARY/
-     * TERTIARY stat keys on items. Prefers explicit [statPriorities]; falls
-     * back to a single-element list derived from [primaryStat] so legacy class
-     * YAMLs (which only declare a primaryStat) still get a PRIMARY mapping.
+     * TERTIARY stat keys on items. Prefers explicit [statPriorities] (trimmed,
+     * uppercased, with blanks dropped); falls back to a single-element list
+     * derived from [primaryStat] so legacy class YAMLs (which only declare a
+     * primaryStat) still get a PRIMARY mapping. Defensive normalization here
+     * means resolution works even for class defs constructed outside the
+     * loader (e.g. in tests).
      */
-    fun effectiveStatPriorities(): List<String> =
-        if (statPriorities.isNotEmpty()) {
-            statPriorities
-        } else {
-            listOfNotNull(primaryStat?.takeIf { it.isNotBlank() }?.uppercase())
-        }
+    fun effectiveStatPriorities(): List<String> {
+        val explicit = statPriorities
+            .map { it.trim().uppercase() }
+            .filter { it.isNotEmpty() }
+        if (explicit.isNotEmpty()) return explicit
+        return listOfNotNull(primaryStat?.takeIf { it.isNotBlank() }?.uppercase())
+    }
 }
 
 data class StarterEquipmentEntry(

--- a/src/main/kotlin/dev/ambon/domain/PlayerClassDef.kt
+++ b/src/main/kotlin/dev/ambon/domain/PlayerClassDef.kt
@@ -10,10 +10,24 @@ data class PlayerClassDef(
     val image: String = "",
     val selectable: Boolean = true,
     val primaryStat: String? = null,
+    val statPriorities: List<String> = emptyList(),
     val startRoom: String? = null,
     val threatMultiplier: Double = 1.0,
     val starterEquipment: List<StarterEquipmentEntry> = emptyList(),
-)
+) {
+    /**
+     * Effective archetypal priority list used to resolve PRIMARY/SECONDARY/
+     * TERTIARY stat keys on items. Prefers explicit [statPriorities]; falls
+     * back to a single-element list derived from [primaryStat] so legacy class
+     * YAMLs (which only declare a primaryStat) still get a PRIMARY mapping.
+     */
+    fun effectiveStatPriorities(): List<String> =
+        if (statPriorities.isNotEmpty()) {
+            statPriorities
+        } else {
+            listOfNotNull(primaryStat?.takeIf { it.isNotBlank() }?.uppercase())
+        }
+}
 
 data class StarterEquipmentEntry(
     val itemId: String,

--- a/src/main/kotlin/dev/ambon/domain/StatMap.kt
+++ b/src/main/kotlin/dev/ambon/domain/StatMap.kt
@@ -36,8 +36,43 @@ value class StatMap(
     /** Returns only non-zero entries. */
     fun nonZero(): Map<String, Int> = values.filter { it.value != 0 }
 
+    /**
+     * Returns a new [StatMap] with archetypal keys ("PRIMARY", "SECONDARY",
+     * "TERTIARY") resolved to concrete stat IDs via [priorities]. Concrete
+     * stat IDs pass through unchanged. Archetypal entries with no matching
+     * priority slot are dropped — an item that grants PRIMARY on a class with
+     * no priorities simply contributes nothing rather than crashing.
+     *
+     * Stats resolved to the same concrete ID are summed (e.g. an item with
+     * both `PRIMARY: 2` and `strength: 1` on a STR-primary class yields
+     * `STR: 3`).
+     */
+    fun resolveArchetypal(priorities: List<String>): StatMap {
+        if (values.isEmpty()) return this
+        val resolved = mutableMapOf<String, Int>()
+        for ((key, value) in values) {
+            val concrete =
+                when (key) {
+                    ARCHETYPAL_PRIMARY -> priorities.getOrNull(0)
+                    ARCHETYPAL_SECONDARY -> priorities.getOrNull(1)
+                    ARCHETYPAL_TERTIARY -> priorities.getOrNull(2)
+                    else -> key
+                } ?: continue
+            resolved.merge(concrete, value, Int::plus)
+        }
+        return StatMap(resolved)
+    }
+
     companion object {
         val EMPTY = StatMap()
+
+        const val ARCHETYPAL_PRIMARY = "PRIMARY"
+        const val ARCHETYPAL_SECONDARY = "SECONDARY"
+        const val ARCHETYPAL_TERTIARY = "TERTIARY"
+
+        val ARCHETYPAL_KEYS = setOf(ARCHETYPAL_PRIMARY, ARCHETYPAL_SECONDARY, ARCHETYPAL_TERTIARY)
+
+        fun isArchetypal(id: String): Boolean = id.uppercase() in ARCHETYPAL_KEYS
 
         fun of(vararg pairs: Pair<String, Int>): StatMap =
             StatMap(pairs.associate { (k, v) -> k.uppercase() to v })

--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -284,7 +284,7 @@ class CombatSystem(
             return ConsiderOutcome.Error("${mob.name} isn't a threat — no need to size them up.")
         }
 
-        val stats = resolvePlayerStats(player, items, statusEffects)
+        val stats = resolvePlayerStats(player, items, statusEffects, classRegistry)
         val equip = items.equipmentBonuses(sessionId)
         val playerAvgDamage = avgPlayerMeleeDamage(player, stats, equip, mob.armor)
 
@@ -554,9 +554,9 @@ class CombatSystem(
 
             val stunned = statusEffects?.hasPlayerEffect(state.attackerSid, "stun") == true
             if (!stunned) {
-                val attackerStats = resolvePlayerStats(attacker, items, statusEffects)
-                val attackerEquip = items.equipmentBonuses(state.attackerSid)
-                val targetEquip = items.equipmentBonuses(state.targetSid)
+                val attackerStats = resolvePlayerStats(attacker, items, statusEffects, classRegistry)
+                val attackerEquip = items.equipmentBonuses(state.attackerSid, classRegistry?.get(attacker.playerClass))
+                val targetEquip = items.equipmentBonuses(state.targetSid, classRegistry?.get(target.playerClass))
                 val swing = rollPlayerMeleeSwing(attacker, attackerStats, attackerEquip, targetEquip.armor)
                 var effectiveDamage = swing.final
 
@@ -814,7 +814,7 @@ class CombatSystem(
             // STUN check
             val stunned = statusEffects?.hasPlayerEffect(sessionId, "stun") == true
             if (!stunned) {
-                val playerStats = resolvePlayerStats(player, items, statusEffects)
+                val playerStats = resolvePlayerStats(player, items, statusEffects, classRegistry)
                 val swing = rollPlayerMeleeSwing(player, playerStats, playerBonuses, mob.armor)
                 val effectivePlayerDamage = swing.final
                 val playerFeedbackSuffix =
@@ -1074,7 +1074,7 @@ class CombatSystem(
 
         // Dodge check for offensive spells
         if (isOffensive) {
-            val targetStats = resolvePlayerStats(target, items, statusEffects)
+            val targetStats = resolvePlayerStats(target, items, statusEffects, classRegistry)
             val dodgePct =
                 ((targetStats[config.bindings.dodgeStat] - PlayerState.BASE_STAT) * config.bindings.dodgePerPoint)
                     .coerceIn(0, config.bindings.maxDodgePercent)
@@ -1207,7 +1207,7 @@ class CombatSystem(
         target: PlayerState,
         targetSid: SessionId,
     ) {
-        val targetStats = resolvePlayerStats(target, items, statusEffects)
+        val targetStats = resolvePlayerStats(target, items, statusEffects, classRegistry)
         val dodgePct =
             ((targetStats[config.bindings.dodgeStat] - PlayerState.BASE_STAT) * config.bindings.dodgePerPoint)
                 .coerceIn(0, config.bindings.maxDodgePercent)
@@ -1733,7 +1733,7 @@ class CombatSystem(
 
         for (sid in recipients) {
             val player = players.get(sid) ?: continue
-            val equipStats = items.equipmentBonuses(sid).stats
+            val equipStats = items.equipmentBonuses(sid, classRegistry?.get(player.playerClass)).stats
             val totalBonusStat = player.stats[config.bindings.xpBonusStat] + equipStats[config.bindings.xpBonusStat]
             val diminish = progression.diminishingKillXpMultiplier(player.level, mob.level)
             val afterDiminish =

--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -285,7 +285,7 @@ class CombatSystem(
         }
 
         val stats = resolvePlayerStats(player, items, statusEffects, classRegistry)
-        val equip = items.equipmentBonuses(sessionId)
+        val equip = items.equipmentBonuses(sessionId, classRegistry?.get(player.playerClass))
         val playerAvgDamage = avgPlayerMeleeDamage(player, stats, equip, mob.armor)
 
         val mobAvgRoll = (mob.damage.min + mob.damage.max) / 2.0
@@ -794,7 +794,7 @@ class CombatSystem(
                 continue
             }
 
-            val playerBonuses = items.equipmentBonuses(sessionId)
+            val playerBonuses = items.equipmentBonuses(sessionId, classRegistry?.get(player.playerClass))
 
             if (player.hp <= 0) {
                 metrics.onPlayerDeath()

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -447,6 +447,7 @@ class GameEngine(
             gmcpEmitter = gmcpEmitter,
             bindings = engineConfig.stats.bindings,
             metrics = metrics,
+            classRegistry = classRegistry,
         )
     }
 
@@ -758,6 +759,7 @@ class GameEngine(
             bindings = engineConfig.stats.bindings,
             metrics = metrics,
             dirtyNotifier = dirtyNotifier,
+            classRegistry = classRegistry,
         )
 
     init {
@@ -821,6 +823,7 @@ class GameEngine(
             groupSystem = groupSystem,
             mobs = mobs,
             progression = progression,
+            classRegistry = classRegistry,
             onCombatEvent = { sid, event -> gmcpEmitter.sendCombatEvent(sid, event) },
             onSummonPet = { sid, templateKey, durationMs ->
                 val player = players.get(sid) ?: return@AbilitySystem

--- a/src/main/kotlin/dev/ambon/engine/PlayerClassRegistryLoader.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerClassRegistryLoader.kt
@@ -21,6 +21,10 @@ object PlayerClassRegistryLoader {
                     image = defConfig.image,
                     selectable = defConfig.selectable,
                     primaryStat = defConfig.primaryStat.ifBlank { null },
+                    statPriorities =
+                        defConfig.statPriorities
+                            .map { it.trim().uppercase() }
+                            .filter { it.isNotEmpty() },
                     startRoom = defConfig.startRoom.ifBlank { null },
                     threatMultiplier = defConfig.threatMultiplier,
                     starterEquipment = defConfig.starterEquipment

--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -366,13 +366,21 @@ fun resolveEffectiveStats(
  * Convenience overload that gathers equipment bonuses and status-effect mods
  * from the (possibly null) [items] and [statusEffects] systems, then resolves
  * the player's effective stats in one call.
+ *
+ * When [classRegistry] is provided, equipment archetypal stats
+ * (PRIMARY/SECONDARY/TERTIARY) are resolved against the wearer's class
+ * priorities before being merged into effective stats. Callers that don't
+ * have the class registry available will lose any archetypal-stat bonuses on
+ * equipped items, but won't crash — concrete item stats still apply normally.
  */
 fun resolvePlayerStats(
     player: PlayerState,
     items: ItemRegistry?,
     statusEffects: dev.ambon.engine.status.StatusEffectSystem?,
+    classRegistry: PlayerClassRegistry? = null,
 ): StatMap {
-    val equip = items?.equipmentBonuses(player.sessionId) ?: ItemRegistry.EquipmentBonuses()
+    val classDef = classRegistry?.get(player.playerClass)
+    val equip = items?.equipmentBonuses(player.sessionId, classDef) ?: ItemRegistry.EquipmentBonuses()
     val mods = statusEffects?.getPlayerStatMods(player.sessionId) ?: StatMap.EMPTY
     return resolveEffectiveStats(player, equip, mods)
 }

--- a/src/main/kotlin/dev/ambon/engine/RegenSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/RegenSystem.kt
@@ -27,6 +27,7 @@ class RegenSystem(
     private val bindings: StatBindingsConfig = StatBindingsConfig(),
     private val metrics: GameMetrics = GameMetrics.noop(),
     private val dirtyNotifier: DirtyNotifier = DirtyNotifier.NO_OP,
+    private val classRegistry: PlayerClassRegistry? = null,
 ) : GameSystem {
     private val lastRegenAtMs = mutableMapOf<SessionId, Long>()
     private val lastManaRegenAtMs = mutableMapOf<SessionId, Long>()
@@ -62,7 +63,7 @@ class RegenSystem(
             ran++
 
             val sessionId = player.sessionId
-            val equipStats = items.equipmentBonuses(sessionId).stats
+            val equipStats = items.equipmentBonuses(sessionId, classRegistry?.get(player.playerClass)).stats
             val multiplier = if (inCombat(sessionId)) inCombatMultiplier else 1.0
 
             applyRegen(

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
@@ -45,6 +45,7 @@ class AbilitySystem(
     private val groupSystem: GroupSystem? = null,
     private val mobs: MobRegistry? = null,
     private val progression: PlayerProgression = PlayerProgression(),
+    private val classRegistry: dev.ambon.engine.PlayerClassRegistry? = null,
     private val onCombatEvent: suspend (SessionId, CombatEvent) -> Unit = { _, _ -> },
     val onSummonPet: suspend (SessionId, String, Long) -> Unit = { _, _, _ -> },
 ) : GameSystem {
@@ -136,7 +137,7 @@ class AbilitySystem(
                     ?: return "Cast ${ability.displayName} on whom?"
             }
 
-        val playerStats = resolvePlayerStats(player, items, statusEffects)
+        val playerStats = resolvePlayerStats(player, items, statusEffects, classRegistry)
 
         when (val effect = ability.effect) {
             is AbilityEffect.DirectDamage -> {
@@ -217,7 +218,7 @@ class AbilitySystem(
         when (val effect = ability.effect) {
             is AbilityEffect.DirectHeal -> {
                 deductManaAndCooldown(sessionId, player, ability, now)
-                val playerStats = resolvePlayerStats(player, items, statusEffects)
+                val playerStats = resolvePlayerStats(player, items, statusEffects, classRegistry)
                 val healAmount =
                     computeSpellHeal(bindings, player.level, playerStats, effect.minHeal, effect.maxHeal, rng)
                 val healed = applyHeal(sessionId, player, healAmount, dirtyNotifier)
@@ -308,7 +309,7 @@ class AbilitySystem(
         when (val effect = ability.effect) {
             is AbilityEffect.DirectHeal -> {
                 deductManaAndCooldown(sessionId, player, ability, now)
-                val playerStats = resolvePlayerStats(player, items, statusEffects)
+                val playerStats = resolvePlayerStats(player, items, statusEffects, classRegistry)
                 val healAmount =
                     computeSpellHeal(bindings, player.level, playerStats, effect.minHeal, effect.maxHeal, rng)
                 val healed = applyHeal(targetSid, target, healAmount, dirtyNotifier)
@@ -411,7 +412,7 @@ class AbilitySystem(
             return "No enemies in combat to hit."
         }
 
-        val playerStats = resolvePlayerStats(player, items, statusEffects)
+        val playerStats = resolvePlayerStats(player, items, statusEffects, classRegistry)
 
         when (val effect = ability.effect) {
             is AbilityEffect.DirectDamage -> {
@@ -470,7 +471,7 @@ class AbilitySystem(
         when (val effect = ability.effect) {
             is AbilityEffect.DirectHeal -> {
                 deductManaAndCooldown(sessionId, player, ability, now)
-                val playerStats = resolvePlayerStats(player, items, statusEffects)
+                val playerStats = resolvePlayerStats(player, items, statusEffects, classRegistry)
                 for (targetSid in groupMembers) {
                     val target = players.get(targetSid) ?: continue
                     val healAmount =

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/AdminHandler.kt
@@ -902,7 +902,7 @@ class AdminHandler(
             return
         }
         players.withPlayer(targetSid) { target ->
-            val effectiveStats = resolvePlayerStats(target, items, statusEffects)
+            val effectiveStats = resolvePlayerStats(target, items, statusEffects, classRegistry)
             val lines = buildString {
                 appendLine("=== Player Info: ${target.name} ===")
                 appendLine("Level: ${target.level}  |  XP: ${target.xpTotal}  |  Prestige: ${target.prestigeLevel}")

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ItemHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ItemHandler.kt
@@ -41,6 +41,7 @@ class ItemHandler(
     private val combat = ctx.combat
     private val outbound = ctx.outbound
     private val gmcpEmitter = ctx.gmcpEmitter
+    private val classRegistry = ctx.classRegistry
     private val equipSlots: EquipmentSlotRegistry? = ctx.equipmentSlotRegistry
 
     override fun register(router: CommandRouter) {
@@ -421,7 +422,7 @@ class ItemHandler(
         if (scaledXp <= 0L) return
 
         players.withPlayer(sessionId) { player ->
-            val equipCha = items.equipment(sessionId).values.sumOf { it.item.stats["CHA"] }
+            val equipCha = items.equipmentBonuses(sessionId, classRegistry?.get(player.playerClass)).stats["CHA"]
             val adjustedXp = progression.applyCharismaXpBonus(player.stats["CHA"] + equipCha, scaledXp)
 
             val result = players.grantXp(sessionId, adjustedXp, progression) ?: return

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ProgressionHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ProgressionHandler.kt
@@ -87,13 +87,14 @@ class ProgressionHandler(
                 StatDefinition("WIS", "Wisdom", "WIS"),
                 StatDefinition("CHA", "Charisma", "CHA"),
             )
+            val equipStats = items.equipmentBonuses(sessionId, classRegistry?.get(me.playerClass)).stats
             statDefs.chunked(3).forEach { row ->
                 outbound.send(
                     OutboundEvent.SendInfo(
                         sessionId,
                         "  " + row.joinToString("  ") { def ->
                             val base = me.stats[def.id]
-                            val equipBonus = equipped.values.sumOf { it.item.stats[def.id] }
+                            val equipBonus = equipStats[def.id]
                             "${def.abbreviation}: ${formatStat(base, equipBonus)}"
                         },
                     ),

--- a/src/main/kotlin/dev/ambon/engine/events/GmcpFlushHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/GmcpFlushHandler.kt
@@ -9,6 +9,7 @@ import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.GmcpEmitter
 import dev.ambon.engine.GroupSystem
 import dev.ambon.engine.MobRegistry
+import dev.ambon.engine.PlayerClassRegistry
 import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.PlayerState
 import dev.ambon.engine.items.ItemRegistry
@@ -32,6 +33,7 @@ class GmcpFlushHandler(
     private val gmcpEmitter: GmcpEmitter,
     private val bindings: StatBindingsConfig = StatBindingsConfig(),
     private val metrics: GameMetrics = GameMetrics.noop(),
+    private val classRegistry: PlayerClassRegistry? = null,
 ) {
     /** Flushes all dirty GMCP sets in one call. */
     suspend fun flushAll() {
@@ -88,8 +90,9 @@ class GmcpFlushHandler(
     suspend fun flushDirtyStats() {
         drainDirty(gmcpDirtyStats) { sid ->
             val player = players.get(sid) ?: return@drainDirty
-            val effectiveStats = resolvePlayerStats(player, items, statusEffectSystem)
-            val equipBonuses = items.equipmentBonuses(sid)
+            val classDef = classRegistry?.get(player.playerClass)
+            val effectiveStats = resolvePlayerStats(player, items, statusEffectSystem, classRegistry)
+            val equipBonuses = items.equipmentBonuses(sid, classDef)
             val dodgeStat = effectiveStats[bindings.dodgeStat]
             val dodgePct =
                 ((dodgeStat - PlayerState.BASE_STAT) * bindings.dodgePerPoint).coerceIn(0, bindings.maxDodgePercent)

--- a/src/main/kotlin/dev/ambon/engine/items/ItemRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/items/ItemRegistry.kt
@@ -1,5 +1,6 @@
 package dev.ambon.engine.items
 
+import dev.ambon.domain.PlayerClassDef
 import dev.ambon.domain.StatMap
 import dev.ambon.domain.ids.ItemId
 import dev.ambon.domain.ids.MobId
@@ -167,7 +168,10 @@ class ItemRegistry {
         val stats: StatMap = StatMap.EMPTY,
     )
 
-    fun equipmentBonuses(sessionId: SessionId): EquipmentBonuses {
+    fun equipmentBonuses(
+        sessionId: SessionId,
+        classDef: PlayerClassDef? = null,
+    ): EquipmentBonuses {
         val equipped = equippedItems[sessionId]?.values ?: return EquipmentBonuses()
         var attack = 0
         var armor = 0
@@ -176,6 +180,9 @@ class ItemRegistry {
             attack += inst.item.damage
             armor += inst.item.armor
             stats = stats + inst.item.stats
+        }
+        if (classDef != null) {
+            stats = stats.resolveArchetypal(classDef.effectiveStatPriorities())
         }
         return EquipmentBonuses(attack, armor, stats)
     }

--- a/src/test/kotlin/dev/ambon/engine/StatMapTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/StatMapTest.kt
@@ -74,4 +74,59 @@ class StatMapTest {
         assertEquals(5, result["STR"])
         assertEquals(1, result.values.size)
     }
+
+    @Test
+    fun `resolveArchetypal maps PRIMARY SECONDARY TERTIARY to priorities by index`() {
+        val item = StatMap(mapOf("PRIMARY" to 3, "SECONDARY" to 2, "TERTIARY" to 1))
+        val resolved = item.resolveArchetypal(listOf("STR", "CON", "DEX"))
+        assertEquals(3, resolved["STR"])
+        assertEquals(2, resolved["CON"])
+        assertEquals(1, resolved["DEX"])
+        // Archetypal keys themselves should not survive in the resolved map.
+        assertEquals(0, resolved["PRIMARY"])
+    }
+
+    @Test
+    fun `resolveArchetypal passes through concrete stat ids`() {
+        val item = StatMap(mapOf("PRIMARY" to 2, "DEX" to 4))
+        val resolved = item.resolveArchetypal(listOf("STR", "CON"))
+        assertEquals(2, resolved["STR"])
+        assertEquals(4, resolved["DEX"])
+    }
+
+    @Test
+    fun `resolveArchetypal sums concrete and archetypal contributions to the same stat`() {
+        // PRIMARY resolves to STR; the item also grants an explicit STR — both should merge.
+        val item = StatMap(mapOf("PRIMARY" to 2, "STR" to 1))
+        val resolved = item.resolveArchetypal(listOf("STR"))
+        assertEquals(3, resolved["STR"])
+    }
+
+    @Test
+    fun `resolveArchetypal drops archetypal entries with no matching priority slot`() {
+        // priorities only covers PRIMARY (index 0); SECONDARY and TERTIARY are dropped.
+        val item = StatMap(mapOf("PRIMARY" to 2, "SECONDARY" to 5))
+        val resolved = item.resolveArchetypal(listOf("STR"))
+        assertEquals(2, resolved["STR"])
+        assertEquals(0, resolved["SECONDARY"])
+        assertEquals(1, resolved.values.size)
+    }
+
+    @Test
+    fun `resolveArchetypal with empty priorities passes concrete stats through and drops archetypal`() {
+        val item = StatMap(mapOf("PRIMARY" to 2, "STR" to 4))
+        val resolved = item.resolveArchetypal(emptyList())
+        assertEquals(0, resolved["PRIMARY"])
+        assertEquals(4, resolved["STR"])
+    }
+
+    @Test
+    fun `isArchetypal recognises archetypal keys regardless of case`() {
+        assertTrue(StatMap.isArchetypal("PRIMARY"))
+        assertTrue(StatMap.isArchetypal("primary"))
+        assertTrue(StatMap.isArchetypal("Secondary"))
+        assertTrue(StatMap.isArchetypal("TERTIARY"))
+        assertFalse(StatMap.isArchetypal("STR"))
+        assertFalse(StatMap.isArchetypal("QUATERNARY"))
+    }
 }

--- a/src/test/kotlin/dev/ambon/engine/items/ItemRegistryTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/items/ItemRegistryTest.kt
@@ -1,5 +1,7 @@
 package dev.ambon.engine.items
 
+import dev.ambon.domain.PlayerClassDef
+import dev.ambon.domain.StatMap
 import dev.ambon.domain.ids.ItemId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
@@ -302,6 +304,108 @@ class ItemRegistryTest {
         val received = registry.inventory(toSid).single()
         assertEquals("helm", received.item.keyword)
     }
+
+    @Test
+    fun `equipmentBonuses resolves archetypal stats against class priorities`() {
+        val registry = ItemRegistry()
+        val sid = SessionId(1001L)
+
+        val boots =
+            ItemInstance(
+                id = ItemId("auringold:boots"),
+                item =
+                    Item(
+                        keyword = "boots",
+                        displayName = "auringold boots",
+                        slot = ItemSlot.FEET,
+                        armor = 2,
+                        stats = StatMap.of("PRIMARY" to 3, "SECONDARY" to 1),
+                    ),
+            )
+        registry.setEquippedItem(sid, ItemSlot.FEET, boots)
+
+        val warrior = classDef("WARRIOR", priorities = listOf("STR", "CON", "DEX"))
+        val warriorBonuses = registry.equipmentBonuses(sid, warrior)
+        assertEquals(3, warriorBonuses.stats["STR"])
+        assertEquals(1, warriorBonuses.stats["CON"])
+
+        // Same item, different wearer class — archetypal stats follow the new priorities.
+        val wizard = classDef("WIZARD", priorities = listOf("INT", "WIS", "CON"))
+        val wizardBonuses = registry.equipmentBonuses(sid, wizard)
+        assertEquals(0, wizardBonuses.stats["STR"])
+        assertEquals(3, wizardBonuses.stats["INT"])
+        assertEquals(1, wizardBonuses.stats["WIS"])
+    }
+
+    @Test
+    fun `equipmentBonuses without class returns raw archetypal keys unchanged`() {
+        val registry = ItemRegistry()
+        val sid = SessionId(1002L)
+        registry.setEquippedItem(
+            sid,
+            ItemSlot.FEET,
+            ItemInstance(
+                id = ItemId("auringold:boots"),
+                item =
+                    Item(
+                        keyword = "boots",
+                        displayName = "auringold boots",
+                        slot = ItemSlot.FEET,
+                        stats = StatMap.of("PRIMARY" to 3),
+                    ),
+            ),
+        )
+        // No classDef → archetypal entry stays as "PRIMARY" and contributes nothing
+        // to concrete stat lookups, which is the safe degraded-mode behavior.
+        val bonuses = registry.equipmentBonuses(sid)
+        assertEquals(0, bonuses.stats["STR"])
+        assertEquals(3, bonuses.stats["PRIMARY"])
+    }
+
+    @Test
+    fun `equipmentBonuses falls back to primaryStat when statPriorities is empty`() {
+        val registry = ItemRegistry()
+        val sid = SessionId(1003L)
+        registry.setEquippedItem(
+            sid,
+            ItemSlot.WEAPON,
+            ItemInstance(
+                id = ItemId("legacy:sword"),
+                item =
+                    Item(
+                        keyword = "sword",
+                        displayName = "an old sword",
+                        slot = ItemSlot.WEAPON,
+                        damage = 5,
+                        stats = StatMap.of("PRIMARY" to 2),
+                    ),
+            ),
+        )
+        // Legacy class declares only a primaryStat — effectiveStatPriorities should
+        // synthesize a single-element priority list so PRIMARY still resolves.
+        val legacyWarrior =
+            PlayerClassDef(
+                id = "WARRIOR",
+                displayName = "Warrior",
+                hpScalingRate = 1.0,
+                manaScalingRate = 1.0,
+                primaryStat = "STR",
+            )
+        val bonuses = registry.equipmentBonuses(sid, legacyWarrior)
+        assertEquals(2, bonuses.stats["STR"])
+    }
+
+    private fun classDef(
+        id: String,
+        priorities: List<String>,
+    ): PlayerClassDef =
+        PlayerClassDef(
+            id = id,
+            displayName = id,
+            hpScalingRate = 1.0,
+            manaScalingRate = 1.0,
+            statPriorities = priorities,
+        )
 
     private fun instance(
         id: String,

--- a/src/test/kotlin/dev/ambon/engine/items/ItemRegistryTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/items/ItemRegistryTest.kt
@@ -395,6 +395,40 @@ class ItemRegistryTest {
         assertEquals(2, bonuses.stats["STR"])
     }
 
+    @Test
+    fun `equipmentBonuses normalizes mixed-case and blank statPriorities defensively`() {
+        val registry = ItemRegistry()
+        val sid = SessionId(1004L)
+        registry.setEquippedItem(
+            sid,
+            ItemSlot.WEAPON,
+            ItemInstance(
+                id = ItemId("scruffy:dagger"),
+                item =
+                    Item(
+                        keyword = "dagger",
+                        displayName = "a scruffy dagger",
+                        slot = ItemSlot.WEAPON,
+                        stats = StatMap.of("PRIMARY" to 2, "SECONDARY" to 1),
+                    ),
+            ),
+        )
+        // PlayerClassDef constructed directly with mixed-case + blank entries
+        // (bypassing the loader's normalization) should still resolve correctly.
+        val sloppyClass =
+            PlayerClassDef(
+                id = "ROGUE",
+                displayName = "Rogue",
+                hpScalingRate = 1.0,
+                manaScalingRate = 1.0,
+                statPriorities = listOf("dex", "  ", "Con"),
+            )
+        val bonuses = registry.equipmentBonuses(sid, sloppyClass)
+        assertEquals(2, bonuses.stats["DEX"])
+        // Blank middle slot is dropped, so SECONDARY now maps to "Con" → "CON".
+        assertEquals(1, bonuses.stats["CON"])
+    }
+
     private fun classDef(
         id: String,
         priorities: List<String>,

--- a/src/test/kotlin/dev/ambon/engine/items/ItemRegistryTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/items/ItemRegistryTest.kt
@@ -396,6 +396,39 @@ class ItemRegistryTest {
     }
 
     @Test
+    fun `equipmentBonuses trims whitespace on legacy primaryStat fallback`() {
+        val registry = ItemRegistry()
+        val sid = SessionId(1005L)
+        registry.setEquippedItem(
+            sid,
+            ItemSlot.WEAPON,
+            ItemInstance(
+                id = ItemId("legacy:sword2"),
+                item =
+                    Item(
+                        keyword = "sword",
+                        displayName = "a worn sword",
+                        slot = ItemSlot.WEAPON,
+                        stats = StatMap.of("PRIMARY" to 4),
+                    ),
+            ),
+        )
+        // Legacy YAML with stray whitespace around primaryStat — must still
+        // resolve to "STR" rather than "STR " (which would silently bypass
+        // all downstream stat lookups).
+        val sloppyLegacy =
+            PlayerClassDef(
+                id = "WARRIOR",
+                displayName = "Warrior",
+                hpScalingRate = 1.0,
+                manaScalingRate = 1.0,
+                primaryStat = " STR ",
+            )
+        val bonuses = registry.equipmentBonuses(sid, sloppyLegacy)
+        assertEquals(4, bonuses.stats["STR"])
+    }
+
+    @Test
     fun `equipmentBonuses normalizes mixed-case and blank statPriorities defensively`() {
         val registry = ItemRegistry()
         val sid = SessionId(1004L)


### PR DESCRIPTION
## Summary
- Adds `statPriorities: List<String>` to `ClassDefinitionConfig` / `PlayerClassDef`, mirroring the Arcanum (creator) change so adaptive items can declare `PRIMARY: 3`, `SECONDARY: 1`, `TERTIARY: 1` and have those resolve against the wearer's class priorities. Legacy `primaryStat` still works (synthesized into a single-element priority list).
- New `StatMap.resolveArchetypal(priorities)` does the mapping. Concrete stat IDs pass through unchanged; archetypal entries with no priority slot are dropped (safe degrade rather than crash).
- Resolution applied in `ItemRegistry.equipmentBonuses(sessionId, classDef?)` and threaded through `resolvePlayerStats(...)` so combat/abilities/admin pinfo automatically see resolved stats. Also wired into the direct `.stats` consumers that don't go through `resolvePlayerStats`: regen (HP/mana regen stat), end-of-fight XP bonus, score display, and the charisma XP modifier on item use.
- Call sites that don't have a `PlayerClassRegistry` available get raw values — archetypal entries silently contribute zero rather than crashing.

## Test plan
- [x] `./gradlew ktlintCheck` passes
- [x] `./gradlew test` passes (full suite, including new `StatMapTest` cases for `resolveArchetypal` and new `ItemRegistryTest` cases covering `equipmentBonuses(sid, classDef)` across class swap, no-class fallback, and legacy-`primaryStat` fallback)
- [ ] Manual smoke: equip an item with `stats: { PRIMARY: 3 }` on a STR-primary class and confirm `score` shows the bonus under STR; respec to an INT-primary class and confirm the same item now boosts INT