### PR TITLE
feat: depart to last inn walked through in death zone

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -1225,6 +1225,7 @@ class GameEngine(
                 dialogueSystem,
                 direction = chosen.key,
                 departVerb = "flees",
+                world = world,
             )
             petSystem.followOwner(sid, chosen.value)
             ctx.sendLook(sid)

--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -65,6 +65,12 @@ data class PlayerState(
     var recallRoomId: RoomId? = null,
     /** Zone ID (e.g. "academy") of the player's last death. Drives `depart` from the sanctum. */
     var lastDeathZone: String? = null,
+    /**
+     * Per-zone checkpoint: the most recent inn room the player walked through in each zone.
+     * Used by `depart` to send the player back to a closer landmark than the zone start.
+     * Entries persist across deaths so a previously-discovered inn keeps acting as a checkpoint.
+     */
+    var lastInnByZone: MutableMap<String, RoomId> = mutableMapOf(),
     var friendsList: MutableSet<String> = mutableSetOf(),
     var bankGold: Long = 0L,
     var bankItems: MutableList<dev.ambon.domain.items.ItemInstance> = mutableListOf(),
@@ -251,6 +257,7 @@ fun PlayerRecord.toPlayerState(sessionId: SessionId): PlayerState =
         guildId = guildId,
         recallRoomId = recallRoomId,
         lastDeathZone = lastDeathZone,
+        lastInnByZone = lastInnByZone.mapValues { (_, v) -> RoomId(v) }.toMutableMap(),
         craftingSkills = craftingSkills.map { (key, state) ->
             key.lowercase() to state
         }.toMap().toMutableMap(),
@@ -315,6 +322,7 @@ fun PlayerState.toPlayerRecord(lastSeenEpochMs: Long): PlayerRecord {
         guildId = guildId,
         recallRoomId = recallRoomId,
         lastDeathZone = lastDeathZone,
+        lastInnByZone = lastInnByZone.mapValues { (_, v) -> v.value }.toMap(),
         craftingSkills = craftingSkills.toMap(),
         discoveredRecipes = discoveredRecipes.toSet(),
         craftingSpecialization = craftingSpecialization,

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -500,6 +500,7 @@ internal suspend fun EngineContext.movePlayer(
     dialogueSystem,
     direction,
     departVerb,
+    world,
 )
 
 /**
@@ -590,6 +591,7 @@ internal suspend fun movePlayerWithNotify(
     dialogueSystem: dev.ambon.engine.dialogue.DialogueSystem? = null,
     direction: Direction? = null,
     departVerb: String = "exits",
+    world: World? = null,
 ) {
     val me = players.get(sessionId) ?: return
     val departLine = if (direction != null) {
@@ -613,6 +615,11 @@ internal suspend fun movePlayerWithNotify(
     // moveTo cleared lastEnterDirection (treats every room change as a teleport at that
     // layer); restore it here for directional walks so flee can retrace the way in.
     me.lastEnterDirection = direction
+    // Record this room as the zone's inn checkpoint if it's an inn. `depart` from the sanctum
+    // will prefer the most recently-walked inn in the death zone over the zone start room.
+    if (world != null && world.rooms[to]?.inn == true) {
+        me.lastInnByZone[to.zone] = to
+    }
     if (!me.invisible) {
         for (other in players.playersInRoom(to).filter { it.sessionId != me.sessionId }) {
             outbound.send(OutboundEvent.SendText(other.sessionId, arriveLine))

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -610,16 +610,18 @@ internal suspend fun movePlayerWithNotify(
             gmcpEmitter?.sendRoomRemovePlayer(other.sessionId, me.name)
         }
     }
+    // Record this room as the zone's inn checkpoint if it's an inn. `depart` from the sanctum
+    // will prefer the most recently-walked inn in the death zone over the zone start room.
+    // Set this *before* moveTo so the persist inside moveTo captures the new checkpoint —
+    // otherwise a crash before the next persist would lose the inn marker.
+    if (world != null && world.rooms[to]?.inn == true) {
+        me.lastInnByZone[to.zone] = to
+    }
     dialogueSystem?.onPlayerMoved(sessionId)
     players.moveTo(sessionId, to)
     // moveTo cleared lastEnterDirection (treats every room change as a teleport at that
     // layer); restore it here for directional walks so flee can retrace the way in.
     me.lastEnterDirection = direction
-    // Record this room as the zone's inn checkpoint if it's an inn. `depart` from the sanctum
-    // will prefer the most recently-walked inn in the death zone over the zone start room.
-    if (world != null && world.rooms[to]?.inn == true) {
-        me.lastInnByZone[to.zone] = to
-    }
     if (!me.invisible) {
         for (other in players.playersInRoom(to).filter { it.sessionId != me.sessionId }) {
             outbound.send(OutboundEvent.SendText(other.sessionId, arriveLine))

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
@@ -370,8 +370,11 @@ class NavigationHandler(
         }
 
         // Prefer the last inn the player walked through in the death zone (autosave checkpoint).
-        // Fall back to the zone's configured start room, then the world's start room.
-        val target = me.lastInnByZone[deathZone] ?: world.zoneStartRoom(deathZone) ?: world.startRoom
+        // Fall back to the zone's configured start room, then the world's start room. The saved
+        // inn is only used if it still exists — world updates can remove or rename rooms, and a
+        // stale checkpoint must not strand the player at the spirit gate.
+        val savedInn = me.lastInnByZone[deathZone]?.takeIf { world.rooms.containsKey(it) }
+        val target = savedInn ?: world.zoneStartRoom(deathZone) ?: world.startRoom
         if (!world.rooms.containsKey(target)) {
             if (attemptCrossZoneMove(sessionId, target, onCrossZoneMove, router::suppressAutoPrompt)) {
                 me.lastDeathZone = null

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
@@ -176,6 +176,7 @@ class NavigationHandler(
                         outbound,
                         gmcpEmitter,
                         dialogueSystem,
+                        world = world,
                     )
                     onPlayerMoved?.invoke(sessionId, origin)
                     outbound.send(OutboundEvent.SendText(sessionId, "You step outside and find yourself back where you came from."))
@@ -206,6 +207,7 @@ class NavigationHandler(
                         outbound,
                         gmcpEmitter,
                         dialogueSystem,
+                        world = world,
                     )
                     onPlayerMoved?.invoke(sessionId, origin)
                     outbound.send(OutboundEvent.SendText(sessionId, "You leave the guild hall and find yourself back where you came from."))
@@ -234,6 +236,7 @@ class NavigationHandler(
                 gmcpEmitter,
                 dialogueSystem,
                 direction = cmd.dir,
+                world = world,
             )
             onPlayerMoved?.invoke(sessionId, to)
             ctx.sendLook(sessionId)
@@ -280,6 +283,7 @@ class NavigationHandler(
                         outbound,
                         gmcpEmitter,
                         dialogueSystem,
+                        world = world,
                     )
                     onPlayerMoved?.invoke(sessionId, result.entryRoomId)
                     outbound.send(OutboundEvent.SendText(sessionId, "You feel a familiar warmth and find yourself home."))
@@ -319,6 +323,7 @@ class NavigationHandler(
             outbound,
             gmcpEmitter,
             dialogueSystem,
+            world = world,
         )
         onPlayerMoved?.invoke(sessionId, target)
         outbound.send(OutboundEvent.SendText(sessionId, msgs.arrival))
@@ -364,7 +369,9 @@ class NavigationHandler(
             return
         }
 
-        val target = world.zoneStartRoom(deathZone) ?: world.startRoom
+        // Prefer the last inn the player walked through in the death zone (autosave checkpoint).
+        // Fall back to the zone's configured start room, then the world's start room.
+        val target = me.lastInnByZone[deathZone] ?: world.zoneStartRoom(deathZone) ?: world.startRoom
         if (!world.rooms.containsKey(target)) {
             if (attemptCrossZoneMove(sessionId, target, onCrossZoneMove, router::suppressAutoPrompt)) {
                 me.lastDeathZone = null
@@ -386,6 +393,7 @@ class NavigationHandler(
             outbound,
             gmcpEmitter,
             dialogueSystem,
+            world = world,
         )
         me.lastDeathZone = null
         onPlayerMoved?.invoke(sessionId, target)
@@ -419,6 +427,7 @@ class NavigationHandler(
             outbound,
             gmcpEmitter,
             dialogueSystem,
+            world = world,
         )
         onPlayerMoved?.invoke(sessionId, target)
         ctx.sendLook(sessionId)

--- a/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
@@ -54,6 +54,12 @@ data class PlayerRecord(
     val recallRoomId: RoomId? = null,
     /** Zone ID (e.g. "academy") of the player's last death. Spirit-gate return target. */
     val lastDeathZone: String? = null,
+    /**
+     * Per-zone "last inn walked through" checkpoint, used by `depart` to send the player
+     * back to a closer landmark than the zone start. Keys are zone IDs, values are full
+     * `<zone>:<room>` RoomId strings.
+     */
+    val lastInnByZone: Map<String, String> = emptyMap(),
     val craftingSkills: Map<String, CraftingSkillState> = emptyMap(),
     val discoveredRecipes: Set<String> = emptySet(),
     val craftingSpecialization: String? = null,

--- a/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
@@ -27,6 +27,7 @@ private val inventoryItemsType = object : TypeReference<List<ItemInstance>>() {}
 private val equippedItemsType = object : TypeReference<Map<String, ItemInstance>>() {}
 private val learnedAbilityIdsType = object : TypeReference<Set<String>>() {}
 private val unlockedClassesType = object : TypeReference<Set<String>>() {}
+private val lastInnByZoneType = object : TypeReference<Map<String, String>>() {}
 
 object PlayersTable : Table("players") {
     val id = long("id").autoIncrement("player_id_seq")
@@ -57,6 +58,7 @@ object PlayersTable : Table("players") {
     val guildId = varchar("guild_id", 64).nullable()
     val recallRoomId = varchar("recall_room_id", 128).nullable()
     val lastDeathZone = varchar("last_death_zone", 64).nullable()
+    val lastInnByZone = text("last_inn_by_zone").default("{}")
     val craftingSkills = text("crafting_skills").default("{}")
     val discoveredRecipes = text("discovered_recipes").default("[]")
     val craftingSpecialization = varchar("crafting_specialization", 64).nullable()
@@ -118,6 +120,7 @@ object PlayersTable : Table("players") {
             guildId = row[guildId],
             recallRoomId = row[recallRoomId]?.let { RoomId(it) },
             lastDeathZone = row[lastDeathZone],
+            lastInnByZone = safeReadJson(row[lastInnByZone], lastInnByZoneType, emptyMap()),
             craftingSkills = safeReadJson(row[craftingSkills], craftingSkillsType, emptyMap()),
             discoveredRecipes = safeReadJson(row[discoveredRecipes], discoveredRecipesType, emptySet()),
             craftingSpecialization = row[craftingSpecialization],
@@ -184,6 +187,7 @@ object PlayersTable : Table("players") {
         statement[guildId] = record.guildId
         statement[recallRoomId] = record.recallRoomId?.value
         statement[lastDeathZone] = record.lastDeathZone
+        statement[lastInnByZone] = jsonMapper.writeValueAsString(record.lastInnByZone)
         statement[craftingSkills] = jsonMapper.writeValueAsString(record.craftingSkills)
         statement[discoveredRecipes] = jsonMapper.writeValueAsString(record.discoveredRecipes)
         statement[craftingSpecialization] = record.craftingSpecialization

--- a/src/main/resources/db/migration/V40__add_last_inn_by_zone.sql
+++ b/src/main/resources/db/migration/V40__add_last_inn_by_zone.sql
@@ -1,0 +1,1 @@
+ALTER TABLE players ADD COLUMN last_inn_by_zone TEXT NOT NULL DEFAULT '{}';

--- a/src/test/kotlin/dev/ambon/engine/commands/DepartCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/DepartCommandTest.kt
@@ -95,6 +95,35 @@ class DepartCommandTest {
         }
 
     @Test
+    fun `depart falls back to zone start when saved inn no longer exists`() =
+        runTest {
+            // Saved checkpoint points at a room the world no longer contains (renamed/removed).
+            // depart must skip the stale entry and use the zone start, not error out.
+            val h = CommandRouterHarness.create(
+                clock = MutableClock(0L),
+                deathConfig = DeathConfig(sanctumRoom = outpost.value),
+            )
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Hero")
+
+            val player = h.players.get(sid)!!
+            player.lastInnByZone["test_zone"] = RoomId("test_zone:removed_inn")
+            player.lastDeathZone = "test_zone"
+            h.players.moveTo(sid, outpost)
+            h.drain()
+
+            h.router.handle(sid, Command.Depart)
+            h.drain()
+
+            assertEquals(
+                hub,
+                h.players.get(sid)!!.roomId,
+                "Expected fallback to zone start when saved inn is missing from world",
+            )
+            assertNull(h.players.get(sid)!!.lastDeathZone)
+        }
+
+    @Test
     fun `walking through an inn records the checkpoint per zone`() =
         runTest {
             // The harness places the player at hub. Walking north to outpost (flagged inn: true)

--- a/src/test/kotlin/dev/ambon/engine/commands/DepartCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/DepartCommandTest.kt
@@ -65,6 +65,59 @@ class DepartCommandTest {
         }
 
     @Test
+    fun `depart returns to last inn walked through in death zone`() =
+        runTest {
+            // Sanctum is at hub; outpost is the inn. Player visited the inn before dying
+            // somewhere in test_zone, so depart should land at the inn, not the zone start.
+            val h = CommandRouterHarness.create(
+                clock = MutableClock(0L),
+                deathConfig = DeathConfig(sanctumRoom = hub.value),
+            )
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Hero")
+
+            val player = h.players.get(sid)!!
+            player.lastInnByZone["test_zone"] = outpost
+            player.lastDeathZone = "test_zone"
+            // Player respawned at sanctum.
+            h.players.moveTo(sid, hub)
+            h.drain()
+
+            h.router.handle(sid, Command.Depart)
+            h.drain()
+
+            assertEquals(
+                outpost,
+                h.players.get(sid)!!.roomId,
+                "Expected depart to land at the visited inn, not the zone start",
+            )
+            assertNull(h.players.get(sid)!!.lastDeathZone)
+        }
+
+    @Test
+    fun `walking through an inn records the checkpoint per zone`() =
+        runTest {
+            // The harness places the player at hub. Walking north to outpost (flagged inn: true)
+            // should record outpost as the test_zone checkpoint without any explicit command.
+            val h = CommandRouterHarness.create(
+                clock = MutableClock(0L),
+                deathConfig = DeathConfig(sanctumRoom = hub.value),
+            )
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Hero")
+            h.drain()
+
+            h.router.handle(sid, Command.Move(dev.ambon.domain.world.Direction.NORTH))
+            h.drain()
+
+            assertEquals(
+                outpost,
+                h.players.get(sid)!!.lastInnByZone["test_zone"],
+                "Walking into the inn should populate lastInnByZone for that zone",
+            )
+        }
+
+    @Test
     fun `depart with no recorded death errors`() =
         runTest {
             val h = CommandRouterHarness.create(

--- a/src/test/kotlin/dev/ambon/persistence/PersistenceFieldCoverageTest.kt
+++ b/src/test/kotlin/dev/ambon/persistence/PersistenceFieldCoverageTest.kt
@@ -107,6 +107,8 @@ class PersistenceFieldCoverageTest {
                 ),
                 guildId = "knights",
                 recallRoomId = RoomId("town:square"),
+                lastDeathZone = "town",
+                lastInnByZone = mapOf("town" to "town:inn", "wilds" to "wilds:outpost"),
                 craftingSkills = mapOf(
                     "smithing" to CraftingSkillState(level = 5, xp = 120L),
                 ),


### PR DESCRIPTION
## Summary
- Adds a per-zone "last inn walked through" checkpoint to `PlayerState`, populated whenever the player enters a room flagged `inn: true`. Persisted to YAML (automatic via Jackson) and Postgres (new column + Flyway V40).
- `depart` from the sanctum now resolves the return target as `lastInnByZone[deathZone] ?? world.zoneStartRoom(deathZone) ?? world.startRoom`, giving death an autosave-checkpoint feel.
- `movePlayerWithNotify` gained an optional `world` parameter; direct call sites in `NavigationHandler` and the flee fallback in `GameEngine` thread it through so the inn flag can be checked on every move. The `EngineContext.movePlayer` extension passes it automatically.

Behavior notes:
- The map is never cleared on depart — visiting an inn is a permanent checkpoint discovery per zone, not a single-use save.
- Existing players with no recorded inn fall back to the prior behavior (zone start), so the change is fully backward-compatible.
- Not yet wired into GMCP; the spirit-gate UI still just shows "you can depart." Surfacing the actual return-room name in the client is a small follow-up if desired.

## Test plan
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew test --tests "*DepartCommandTest" --tests "*RestCommandTest" --tests "*FleeMovementTest" --tests "*PersistenceFieldCoverageTest" --tests "*YamlPlayerRepositoryTest"`
- [x] `./gradlew test --tests "dev.ambon.persistence.*" --tests "dev.ambon.engine.commands.*"`
- [x] New tests: `depart returns to last inn walked through in death zone`, `walking through an inn records the checkpoint per zone`
- [ ] Manual: kill a player in a zone with an inn they've passed through, confirm depart lands at the inn