### PR TITLE
feat(pets): scale pet stats with owner HP/damage/armor

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -412,13 +412,19 @@ data class AppConfig(
     }
 
     private fun validateEnginePets() {
+        require(engine.pets.maxHpRatio >= 0.0) { "ambonMUD.engine.pets.maxHpRatio must be >= 0" }
+        require(engine.pets.maxDamageRatio >= 0.0) { "ambonMUD.engine.pets.maxDamageRatio must be >= 0" }
+        require(engine.pets.maxArmorRatio >= 0.0) { "ambonMUD.engine.pets.maxArmorRatio must be >= 0" }
         engine.pets.definitions.forEach { (key, tmpl) ->
-            require(tmpl.hp > 0) { "ambonMUD.engine.pets.definitions.$key.hp must be > 0" }
-            require(tmpl.minDamage > 0) { "ambonMUD.engine.pets.definitions.$key.minDamage must be > 0" }
-            require(tmpl.maxDamage >= tmpl.minDamage) {
-                "ambonMUD.engine.pets.definitions.$key.maxDamage (${tmpl.maxDamage}) must be >= minDamage (${tmpl.minDamage})"
+            require(tmpl.hpRatio >= 0.0) { "ambonMUD.engine.pets.definitions.$key.hpRatio must be >= 0" }
+            require(tmpl.damageRatio >= 0.0) { "ambonMUD.engine.pets.definitions.$key.damageRatio must be >= 0" }
+            require(tmpl.armorRatio >= 0.0) { "ambonMUD.engine.pets.definitions.$key.armorRatio must be >= 0" }
+            require(tmpl.baseHp > 0) { "ambonMUD.engine.pets.definitions.$key.baseHp must be > 0" }
+            require(tmpl.baseMinDamage > 0) { "ambonMUD.engine.pets.definitions.$key.baseMinDamage must be > 0" }
+            require(tmpl.baseMaxDamage >= tmpl.baseMinDamage) {
+                "ambonMUD.engine.pets.definitions.$key.baseMaxDamage (${tmpl.baseMaxDamage}) must be >= baseMinDamage (${tmpl.baseMinDamage})"
             }
-            require(tmpl.armor >= 0) { "ambonMUD.engine.pets.definitions.$key.armor must be >= 0" }
+            require(tmpl.baseArmor >= 0) { "ambonMUD.engine.pets.definitions.$key.baseArmor must be >= 0" }
         }
     }
 
@@ -933,10 +939,23 @@ data class CurrenciesConfig(
 data class PetTemplateConfig(
     val name: String = "a pet",
     val description: String = "",
-    val hp: Int = 20,
-    val minDamage: Int = 1,
-    val maxDamage: Int = 4,
-    val armor: Int = 0,
+    /**
+     * Pet HP as a fraction of the owner's effective maxHp. 1.0 = same as owner.
+     * Combined with [baseHp] as a floor so low-level summons still feel substantial.
+     */
+    val hpRatio: Double = 0.6,
+    /** Pet melee damage as a fraction of the owner's displayed damage range. */
+    val damageRatio: Double = 0.5,
+    /** Pet armor as a fraction of the owner's equipped armor. */
+    val armorRatio: Double = 0.4,
+    /** Floor applied to scaled HP. Also used when no owner stats are available. */
+    val baseHp: Int = 20,
+    /** Floor applied to scaled min damage. */
+    val baseMinDamage: Int = 1,
+    /** Floor applied to scaled max damage. */
+    val baseMaxDamage: Int = 4,
+    /** Floor applied to scaled armor. */
+    val baseArmor: Int = 0,
     val image: String? = null,
     val spells: Map<String, PetSpellConfig> = emptyMap(),
     val defaultAttack: String? = null,
@@ -948,8 +967,18 @@ data class PetSpellConfig(
     val displayName: String = "",
     val message: String = "",
     val roomMessage: String = "",
+    /**
+     * Spell damage as a multiple of the pet's scaled melee swing. 1.0 = same as a normal
+     * swing; 2.0 = twice as hard. When set, the pet's already-scaled damage range is used as
+     * the anchor, so spells inherit level/gear scaling for free.
+     */
+    val damageRatio: Double? = null,
+    /** Heal as a fraction of the owner's maxHp. Used when [healMin]/[healMax] are not set. */
+    val healRatio: Double? = null,
+    /** Absolute fallback damage range, used when [damageRatio] is null. */
     val minDamage: Int? = null,
     val maxDamage: Int? = null,
+    /** Absolute fallback heal range, used when [healRatio] is null. */
     val healMin: Int = 0,
     val healMax: Int = 0,
     val statusEffectId: String? = null,
@@ -969,6 +998,12 @@ data class PetConfig(
      * being clobbered by auto-cast.
      */
     val manualSkillGraceMs: Long = 8_000L,
+    /** Global cap on [PetTemplateConfig.hpRatio]. Prevents a single template from trivializing content. */
+    val maxHpRatio: Double = 1.0,
+    /** Global cap on [PetTemplateConfig.damageRatio]. Prevents gear-stacked pets from out-DPS'ing the player. */
+    val maxDamageRatio: Double = 0.8,
+    /** Global cap on [PetTemplateConfig.armorRatio]. */
+    val maxArmorRatio: Double = 1.0,
 )
 
 data class BankConfig(

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -831,7 +831,17 @@ class GameEngine(
                 // summon() replaces the old pet internally but clients don't hear about it,
                 // leaving a ghost sprite until the owner moves rooms. See issue #1093.
                 val replacedPets = petSystem.getPets(sid).map { Triple(it.id, it.roomId, it.name) }
-                val pet = petSystem.summon(sid, templateKey, player.roomId, player.level, durationMs, player.name)
+                val classDef = classRegistry.get(player.playerClass)
+                val playerStats = resolvePlayerStats(player, items, statusEffectSystem, classRegistry)
+                val equipBonuses = items.equipmentBonuses(sid, classDef)
+                val dmgRange = combatSystem.damageRangeForDisplay(player, playerStats, equipBonuses.attack)
+                val ownerStats = PetSystem.OwnerStats(
+                    maxHp = player.maxHp,
+                    damageMin = dmgRange.first,
+                    damageMax = dmgRange.last,
+                    armor = equipBonuses.armor,
+                )
+                val pet = petSystem.summon(sid, templateKey, player.roomId, ownerStats, durationMs, player.name)
                 if (pet != null) {
                     outbound.send(OutboundEvent.SendText(sid, "You summon ${pet.name}!"))
                     emitPetState(sid, pet)

--- a/src/main/kotlin/dev/ambon/engine/PetSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/PetSystem.kt
@@ -58,12 +58,18 @@ class PetSystem(
      * Summons a pet from a template. Dismisses any existing pet first.
      * [durationMs] of 0 means permanent (no automatic expiry).
      * Returns the new pet MobState, or null if the template doesn't exist.
+     *
+     * Stats scale as a fraction of [owner]'s effective stats so pets keep pace with player
+     * level/gear curves. Each template defines `hpRatio`/`damageRatio`/`armorRatio`; the
+     * `baseHp`/`baseMinDamage`/`baseMaxDamage`/`baseArmor` floors keep low-level summons
+     * substantial. Global `maxHpRatio`/`maxDamageRatio`/`maxArmorRatio` caps in `PetConfig`
+     * prevent gear-stacked pets from trivializing content.
      */
     fun summon(
         ownerSid: SessionId,
         templateKey: String,
         roomId: RoomId,
-        ownerLevel: Int,
+        owner: OwnerStats,
         durationMs: Long = 0L,
         ownerName: String? = null,
     ): MobState? {
@@ -72,14 +78,18 @@ class PetSystem(
         // Dismiss existing pet
         dismissAll(ownerSid)
 
-        // Scale pet stats with owner level
-        val levelScale = 1.0 + (ownerLevel - 1) * 0.1
-        val scaledHp = (template.hp * levelScale).toInt().coerceAtLeast(1)
-        val scaledMinDmg = (template.minDamage * levelScale).toInt().coerceAtLeast(1)
-        val scaledMaxDmg = (template.maxDamage * levelScale).toInt().coerceAtLeast(1)
+        val hpRatio = template.hpRatio.coerceAtMost(config.maxHpRatio)
+        val dmgRatio = template.damageRatio.coerceAtMost(config.maxDamageRatio)
+        val armorRatio = template.armorRatio.coerceAtMost(config.maxArmorRatio)
+
+        val scaledHp = maxOf(template.baseHp, (owner.maxHp * hpRatio).toInt()).coerceAtLeast(1)
+        val scaledMinDmg = maxOf(template.baseMinDamage, (owner.damageMin * dmgRatio).toInt()).coerceAtLeast(1)
+        val scaledMaxDmg = maxOf(template.baseMaxDamage, (owner.damageMax * dmgRatio).toInt()).coerceAtLeast(scaledMinDmg)
+        val scaledArmor = maxOf(template.baseArmor, (owner.armor * armorRatio).toInt()).coerceAtLeast(0)
 
         val petId = MobId("pet:${UUID.randomUUID().toString().take(8)}")
-        val petSpells = template.spells.map { (key, sc) -> toMobSpell(key, sc) }
+        val petDamage = DamageRange(scaledMinDmg, scaledMaxDmg)
+        val petSpells = template.spells.map { (key, sc) -> toMobSpell(key, sc, petDamage, owner.maxHp) }
         val pet = MobState(
             id = petId,
             name = template.name,
@@ -87,8 +97,8 @@ class PetSystem(
             roomId = roomId,
             hp = scaledHp,
             maxHp = scaledHp,
-            damage = DamageRange(scaledMinDmg, scaledMaxDmg),
-            armor = template.armor,
+            damage = petDamage,
+            armor = scaledArmor,
             xpReward = 0L,
             templateKey = templateKey,
             image = resolveImage(template.image),
@@ -207,25 +217,44 @@ class PetSystem(
         if (sid != null) sessionToPet.remove(sid)
     }
 
-    private fun toMobSpell(key: String, sc: PetSpellConfig): MobSpell =
-        MobSpell(
+    private fun toMobSpell(
+        key: String,
+        sc: PetSpellConfig,
+        petDamage: DamageRange,
+        ownerMaxHp: Int,
+    ): MobSpell {
+        val scaledDamage: DamageRange? = when {
+            sc.damageRatio != null -> DamageRange(
+                (petDamage.min * sc.damageRatio).toInt().coerceAtLeast(1),
+                (petDamage.max * sc.damageRatio).toInt().coerceAtLeast(1),
+            )
+            sc.minDamage != null || sc.maxDamage != null -> DamageRange(
+                sc.minDamage ?: 1,
+                sc.maxDamage ?: (sc.minDamage ?: 1),
+            )
+            else -> null
+        }
+        val (healMin, healMax) = if (sc.healRatio != null) {
+            val anchor = (ownerMaxHp * sc.healRatio).toInt().coerceAtLeast(1)
+            anchor to anchor
+        } else {
+            sc.healMin to sc.healMax
+        }
+        return MobSpell(
             id = key,
             displayName = sc.displayName,
             message = sc.message,
             roomMessage = sc.roomMessage,
-            damage = if (sc.minDamage != null || sc.maxDamage != null) {
-                DamageRange(sc.minDamage ?: 1, sc.maxDamage ?: (sc.minDamage ?: 1))
-            } else {
-                null
-            },
-            healMin = sc.healMin,
-            healMax = sc.healMax,
+            damage = scaledDamage,
+            healMin = healMin,
+            healMax = healMax,
             statusEffectId = sc.statusEffectId?.let { StatusEffectId(it) },
             cooldownMs = sc.cooldownMs,
             weight = sc.weight,
             threatBonus = sc.threatBonus,
             image = resolveImage(sc.image),
         )
+    }
 
     /** Per-owner timestamp of the most recent manual `pet <skill>` trigger. */
     private val lastManualSkillCastMs = mutableMapOf<SessionId, Long>()
@@ -255,6 +284,17 @@ class PetSystem(
             ?: pet.spells.firstOrNull { it.displayName.lowercase().startsWith(q) }
             ?: pet.spells.firstOrNull { it.displayName.lowercase().contains(q) }
     }
+
+    /**
+     * Snapshot of the owner's effective combat stats at summon time. Pet stats are derived
+     * from these via per-template ratios so pets scale with both level and gear.
+     */
+    data class OwnerStats(
+        val maxHp: Int,
+        val damageMin: Int,
+        val damageMax: Int,
+        val armor: Int,
+    )
 
     data class ExpiredPet(
         val ownerSessionId: SessionId,

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1868,13 +1868,21 @@ ambonmud:
       definitions: {}
     pets:
       manualSkillGraceMs: 8000
+      # Global caps on ratio scaling — keep pets relevant without out-scaling players.
+      maxHpRatio: 1.0
+      maxDamageRatio: 0.8
+      maxArmorRatio: 1.0
       definitions:
         wolf_companion:
           name: a wolf companion
-          hp: 25
-          minDamage: 2
-          maxDamage: 5
-          armor: 1
+          # DPS pet: light HP/armor, strong damage.
+          hpRatio: 0.4
+          damageRatio: 0.7
+          armorRatio: 0.3
+          baseHp: 25
+          baseMinDamage: 2
+          baseMaxDamage: 5
+          baseArmor: 1
           description: A lean grey wolf with sharp yellow eyes, trained to fight alongside its bonded ranger.
           image: a2a1f51c3361391908f68af1083a59c1daa2242750af576ca59b9b5cec03ac62.png
           spells:
@@ -1882,8 +1890,7 @@ ambonmud:
               displayName: Bite
               message: "{pet} clamps onto {target} with vicious jaws"
               roomMessage: "{pet} clamps onto {target} with vicious jaws"
-              minDamage: 4
-              maxDamage: 8
+              damageRatio: 2.0
               statusEffectId: bleed
               cooldownMs: 6000
               weight: 2
@@ -1891,17 +1898,20 @@ ambonmud:
               displayName: Pounce
               message: "{pet} pounces on {target} and slams them to the ground"
               roomMessage: "{pet} pounces on {target} and slams them to the ground"
-              minDamage: 6
-              maxDamage: 10
+              damageRatio: 2.5
               statusEffectId: concuss
               cooldownMs: 12000
               weight: 1
         spirit_hawk:
           name: a spirit hawk
-          hp: 15
-          minDamage: 3
-          maxDamage: 7
-          armor: 0
+          # Glass DPS / utility: very low HP, no armor, but hits hard.
+          hpRatio: 0.3
+          damageRatio: 0.7
+          armorRatio: 0.0
+          baseHp: 15
+          baseMinDamage: 3
+          baseMaxDamage: 7
+          baseArmor: 0
           description: A large hawk wreathed in faint translucent light, striking at enemies with razor talons from above.
           image: f9c143caa4e04b89106323f85d699e9faf58909be1aaef81273b5fc5b5fb44fa.png
           spells:
@@ -1909,8 +1919,7 @@ ambonmud:
               displayName: Dive
               message: "{pet} folds its wings and rakes {target} with talons"
               roomMessage: "{pet} folds its wings and rakes {target} with talons"
-              minDamage: 8
-              maxDamage: 14
+              damageRatio: 2.0
               cooldownMs: 7000
               weight: 2
             screech:
@@ -1922,10 +1931,14 @@ ambonmud:
               weight: 1
         bear_guardian:
           name: a bear guardian
-          hp: 40
-          minDamage: 5
-          maxDamage: 10
-          armor: 2
+          # Tank pet: high HP and armor, lower damage, holds aggro.
+          hpRatio: 0.9
+          damageRatio: 0.4
+          armorRatio: 0.7
+          baseHp: 40
+          baseMinDamage: 5
+          baseMaxDamage: 10
+          baseArmor: 2
           description: A massive brown bear with thick scarred hide, summoned to absorb punishment and crush foes in its grip.
           image: e6ee852324a6ad9cab840afb3731f33ea000dd6da6dc7fc639f61fd2fb045dc0.png
           threatMultiplier: 2.0
@@ -1934,8 +1947,7 @@ ambonmud:
               displayName: Maul
               message: "{pet} swings a massive paw and mauls {target}"
               roomMessage: "{pet} swings a massive paw and mauls {target}"
-              minDamage: 10
-              maxDamage: 16
+              damageRatio: 2.0
               cooldownMs: 8000
               weight: 2
             roar:

--- a/src/test/kotlin/dev/ambon/engine/PetImageAndDismissTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/PetImageAndDismissTest.kt
@@ -35,14 +35,16 @@ class PetImageAndDismissTest {
             "fire_familiar" to PetTemplateConfig(
                 name = "a fire familiar",
                 description = "A small elemental of living flame.",
-                hp = 20,
-                minDamage = 2,
-                maxDamage = 5,
-                armor = 1,
+                baseHp = 20,
+                baseMinDamage = 2,
+                baseMaxDamage = 5,
+                baseArmor = 1,
                 image = "pets/fire_familiar.png",
             ),
         ),
     )
+
+    private val ownerStats = PetSystem.OwnerStats(maxHp = 30, damageMin = 1, damageMax = 3, armor = 0)
 
     // ─────────────────────────────────────────────────────────────────────────
     // Issue #1068 — pet image must be resolved against the asset host.
@@ -57,7 +59,7 @@ class PetImageAndDismissTest {
             imagesBaseUrl = "https://auringold.ambon.dev/img/",
         )
 
-        val pet = pets.summon(ownerSid, "fire_familiar", roomId, ownerLevel = 1)!!
+        val pet = pets.summon(ownerSid, "fire_familiar", roomId, ownerStats)!!
 
         assertTrue(
             pet.image == "https://auringold.ambon.dev/img/pets/fire_familiar.png",
@@ -74,7 +76,7 @@ class PetImageAndDismissTest {
             imagesBaseUrl = "https://auringold.ambon.dev/img",
         )
 
-        val pet = pets.summon(ownerSid, "fire_familiar", roomId, ownerLevel = 1)!!
+        val pet = pets.summon(ownerSid, "fire_familiar", roomId, ownerStats)!!
         assertTrue(
             pet.image == "https://auringold.ambon.dev/img/pets/fire_familiar.png",
             "expected normalized URL, got=${pet.image}",
@@ -85,7 +87,7 @@ class PetImageAndDismissTest {
     fun `pet image left untouched when template image is null`() {
         val cfg = PetConfig(definitions = mapOf("no_img" to PetTemplateConfig(name = "a wisp")))
         val pets = PetSystem(config = cfg, mobs = MobRegistry(), clock = MutableClock(0L), imagesBaseUrl = "https://x/")
-        val pet = pets.summon(ownerSid, "no_img", roomId, ownerLevel = 1)!!
+        val pet = pets.summon(ownerSid, "no_img", roomId, ownerStats)!!
         assertNull(pet.image)
     }
 
@@ -97,7 +99,7 @@ class PetImageAndDismissTest {
             ),
         )
         val pets = PetSystem(config = cfg, mobs = MobRegistry(), clock = MutableClock(0L), imagesBaseUrl = "https://x/")
-        val pet = pets.summon(ownerSid, "abs", roomId, ownerLevel = 1)!!
+        val pet = pets.summon(ownerSid, "abs", roomId, ownerStats)!!
         assertTrue(pet.image == "https://other.cdn.example/p.png", "got=${pet.image}")
     }
 
@@ -118,7 +120,7 @@ class PetImageAndDismissTest {
 
         fixture.players.loginOrFail(ownerSid, "Owner")
         fixture.players.loginOrFail(bystanderSid, "Bystander")
-        val pet = pets.summon(ownerSid, "fire_familiar", roomId, ownerLevel = 1)!!
+        val pet = pets.summon(ownerSid, "fire_familiar", roomId, ownerStats)!!
         fixture.outbound.drainAll()
 
         // Mirror what PetHandler/GameEngine do after dismissAll: broadcast removal
@@ -155,7 +157,7 @@ class PetImageAndDismissTest {
             clock = clock,
             imagesBaseUrl = "/images/",
         )
-        val pet = pets.summon(ownerSid, "fire_familiar", roomId, ownerLevel = 1, durationMs = 5_000L)!!
+        val pet = pets.summon(ownerSid, "fire_familiar", roomId, ownerStats, durationMs = 5_000L)!!
 
         clock.advance(5_000L)
         val expired = pets.tick()
@@ -173,7 +175,7 @@ class PetImageAndDismissTest {
             clock = MutableClock(0L),
             imagesBaseUrl = "/images/",
         )
-        val pet = pets.summon(ownerSid, "fire_familiar", roomId, ownerLevel = 1)!!
+        val pet = pets.summon(ownerSid, "fire_familiar", roomId, ownerStats)!!
 
         val dismissed = pets.onOwnerDisconnect(ownerSid)
         assertTrue(dismissed.size == 1, "onOwnerDisconnect must return dismissed pets, got=$dismissed")

--- a/src/test/kotlin/dev/ambon/engine/PetSkillTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/PetSkillTest.kt
@@ -56,23 +56,25 @@ class PetSkillTest {
         definitions = mapOf(
             "wolf_companion" to PetTemplateConfig(
                 name = "a wolf companion",
-                hp = 25,
-                minDamage = 2,
-                maxDamage = 2,
-                armor = 0,
+                baseHp = 25,
+                baseMinDamage = 2,
+                baseMaxDamage = 2,
+                baseArmor = 0,
                 spells = mapOf("bite" to biteSkill, "pounce" to pounceSkill),
             ),
             "bear_guardian" to PetTemplateConfig(
                 name = "a bear guardian",
-                hp = 40,
-                minDamage = 5,
-                maxDamage = 5,
-                armor = 2,
+                baseHp = 40,
+                baseMinDamage = 5,
+                baseMaxDamage = 5,
+                baseArmor = 2,
                 threatMultiplier = 2.0,
                 spells = mapOf("roar" to roarSkill),
             ),
         ),
     )
+
+    private val ownerStats = PetSystem.OwnerStats(maxHp = 30, damageMin = 1, damageMax = 3, armor = 0)
 
     private fun newFixture(): Fixture {
         val fixture = CombatTestFixture()
@@ -118,7 +120,7 @@ class PetSkillTest {
         val sid = SessionId(7L)
         fixture.base.players.loginOrFail(sid, "Ranger")
         val player = fixture.base.players.get(sid)!!
-        val pet = fixture.pets.summon(sid, petTemplate, player.roomId, player.level)!!
+        val pet = fixture.pets.summon(sid, petTemplate, player.roomId, ownerStats)!!
         val target = MobState(
             MobId("demo:goblin"),
             "a goblin",
@@ -181,7 +183,7 @@ class PetSkillTest {
         val sid = SessionId(7L)
         f.base.players.loginOrFail(sid, "Ranger")
         val player = f.base.players.get(sid)!!
-        f.pets.summon(sid, "wolf_companion", player.roomId, player.level)
+        f.pets.summon(sid, "wolf_companion", player.roomId, ownerStats)
 
         val result = f.combat.triggerPetSkill(sid, "bite")
         assertTrue(result is CombatSystem.PetSkillResult.Error)
@@ -289,7 +291,7 @@ class PetSkillTest {
         val sid = SessionId(7L)
         f.base.players.loginOrFail(sid, "Ranger")
         val player = f.base.players.get(sid)!!
-        val pet = f.pets.summon(sid, "wolf_companion", player.roomId, player.level)!!
+        val pet = f.pets.summon(sid, "wolf_companion", player.roomId, ownerStats)!!
 
         assertNotNull(f.pets.findSkill(pet, "bite"))
         assertNotNull(f.pets.findSkill(pet, "BITE"))

--- a/src/test/kotlin/dev/ambon/engine/PetSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/PetSystemTest.kt
@@ -1,6 +1,7 @@
 package dev.ambon.engine
 
 import dev.ambon.config.PetConfig
+import dev.ambon.config.PetSpellConfig
 import dev.ambon.config.PetTemplateConfig
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
@@ -20,23 +21,59 @@ class PetSystemTest {
     private val room1 = RoomId("test:room1")
     private val room2 = RoomId("test:room2")
 
+    // Stand-in for a low-level owner — floors should dominate.
+    private val lowLevelOwner = PetSystem.OwnerStats(maxHp = 30, damageMin = 1, damageMax = 3, armor = 0)
+
+    // Stand-in for a mid-level owner — ratios should dominate.
+    private val midLevelOwner = PetSystem.OwnerStats(maxHp = 200, damageMin = 20, damageMax = 40, armor = 10)
+
+    // Stand-in for a max-geared owner — global caps should bite.
+    private val highLevelOwner = PetSystem.OwnerStats(maxHp = 1_000, damageMin = 100, damageMax = 200, armor = 50)
+
     private val config = PetConfig(
         definitions = mapOf(
             "fire_familiar" to PetTemplateConfig(
                 name = "a fire familiar",
                 description = "A small elemental of living flame.",
-                hp = 20,
-                minDamage = 2,
-                maxDamage = 5,
-                armor = 1,
+                hpRatio = 0.5,
+                damageRatio = 0.5,
+                armorRatio = 0.4,
+                baseHp = 20,
+                baseMinDamage = 2,
+                baseMaxDamage = 5,
+                baseArmor = 1,
+                spells = mapOf(
+                    "scorch" to PetSpellConfig(
+                        displayName = "Scorch",
+                        damageRatio = 2.0,
+                    ),
+                    "mend" to PetSpellConfig(
+                        displayName = "Mend",
+                        healRatio = 0.1,
+                    ),
+                ),
             ),
             "stone_golem" to PetTemplateConfig(
                 name = "a stone golem",
                 description = "A hulking construct of animate stone.",
-                hp = 50,
-                minDamage = 4,
-                maxDamage = 8,
-                armor = 5,
+                hpRatio = 0.9,
+                damageRatio = 0.4,
+                armorRatio = 0.8,
+                baseHp = 50,
+                baseMinDamage = 4,
+                baseMaxDamage = 8,
+                baseArmor = 5,
+            ),
+            // Intentionally over-tuned to verify global caps.
+            "overtuned" to PetTemplateConfig(
+                name = "an overtuned pet",
+                hpRatio = 2.0,
+                damageRatio = 2.0,
+                armorRatio = 2.0,
+                baseHp = 1,
+                baseMinDamage = 1,
+                baseMaxDamage = 1,
+                baseArmor = 0,
             ),
         ),
     )
@@ -54,7 +91,7 @@ class PetSystemTest {
     inner class Summoning {
         @Test
         fun `summon creates a pet mob in the room`() {
-            val pet = pets.summon(sid1, "fire_familiar", room1, 1)
+            val pet = pets.summon(sid1, "fire_familiar", room1, lowLevelOwner)
             assertNotNull(pet)
             assertEquals("a fire familiar", pet!!.name)
             assertEquals(room1, pet.roomId)
@@ -68,13 +105,13 @@ class PetSystemTest {
 
         @Test
         fun `summon unknown template returns null`() {
-            assertNull(pets.summon(sid1, "nonexistent", room1, 1))
+            assertNull(pets.summon(sid1, "nonexistent", room1, lowLevelOwner))
         }
 
         @Test
         fun `summoning a second pet dismisses the first`() {
-            val pet1 = pets.summon(sid1, "fire_familiar", room1, 1)!!
-            val pet2 = pets.summon(sid1, "stone_golem", room1, 1)!!
+            val pet1 = pets.summon(sid1, "fire_familiar", room1, lowLevelOwner)!!
+            val pet2 = pets.summon(sid1, "stone_golem", room1, lowLevelOwner)!!
 
             assertNull(mobs.get(pet1.id))
             assertNotNull(mobs.get(pet2.id))
@@ -82,17 +119,59 @@ class PetSystemTest {
         }
 
         @Test
-        fun `pet stats scale with owner level`() {
-            val pet = pets.summon(sid1, "fire_familiar", room1, 10)!!
-            // Level 10: scale = 1 + (10-1)*0.1 = 1.9
-            assertEquals((20 * 1.9).toInt(), pet.maxHp)
-            assertTrue(pet.damage.min > 2) // scaled up from base
+        fun `low-level owner falls back to template floors`() {
+            // Owner stats are smaller than the floor — pet uses baseHp / baseMinDamage / baseMaxDamage / baseArmor.
+            val pet = pets.summon(sid1, "fire_familiar", room1, lowLevelOwner)!!
+            assertEquals(20, pet.maxHp)
+            assertEquals(2, pet.damage.min)
+            assertEquals(5, pet.damage.max)
+            assertEquals(1, pet.armor)
+        }
+
+        @Test
+        fun `mid-level owner scales pet via ratios`() {
+            val pet = pets.summon(sid1, "fire_familiar", room1, midLevelOwner)!!
+            // 200 * 0.5 = 100 HP, 20..40 * 0.5 = 10..20 damage, 10 * 0.4 = 4 armor.
+            assertEquals(100, pet.maxHp)
+            assertEquals(10, pet.damage.min)
+            assertEquals(20, pet.damage.max)
+            assertEquals(4, pet.armor)
+        }
+
+        @Test
+        fun `global ratio caps prevent gear-stacked pets from out-scaling owner`() {
+            val pet = pets.summon(sid1, "overtuned", room1, highLevelOwner)!!
+            // PetConfig defaults: maxHpRatio=1.0, maxDamageRatio=0.8, maxArmorRatio=1.0.
+            assertEquals(1_000, pet.maxHp) // capped at owner's full HP
+            assertEquals(80, pet.damage.min) // capped at owner damage * 0.8
+            assertEquals(160, pet.damage.max)
+            assertEquals(50, pet.armor) // capped at owner armor
+        }
+
+        @Test
+        fun `spell damageRatio anchors to pet's scaled melee swing`() {
+            val pet = pets.summon(sid1, "fire_familiar", room1, midLevelOwner)!!
+            val scorch = pet.spells.first { it.id == "scorch" }
+            // Pet melee was 10..20; scorch.damageRatio=2.0 → 20..40.
+            val scorchDamage = scorch.damage
+            assertNotNull(scorchDamage)
+            assertEquals(20, scorchDamage!!.min)
+            assertEquals(40, scorchDamage.max)
+        }
+
+        @Test
+        fun `spell healRatio anchors to owner maxHp`() {
+            val pet = pets.summon(sid1, "fire_familiar", room1, midLevelOwner)!!
+            val mend = pet.spells.first { it.id == "mend" }
+            // Owner maxHp 200 * healRatio 0.1 = 20.
+            assertEquals(20, mend.healMin)
+            assertEquals(20, mend.healMax)
         }
 
         @Test
         fun `different players have independent pets`() {
-            pets.summon(sid1, "fire_familiar", room1, 1)
-            pets.summon(sid2, "stone_golem", room1, 1)
+            pets.summon(sid1, "fire_familiar", room1, lowLevelOwner)
+            pets.summon(sid2, "stone_golem", room1, lowLevelOwner)
 
             assertEquals("a fire familiar", pets.getActivePet(sid1)?.name)
             assertEquals("a stone golem", pets.getActivePet(sid2)?.name)
@@ -100,7 +179,7 @@ class PetSystemTest {
 
         @Test
         fun `timed pet exists before duration expires`() {
-            val pet = pets.summon(sid1, "fire_familiar", room1, 1, durationMs = 5000L)
+            val pet = pets.summon(sid1, "fire_familiar", room1, lowLevelOwner, durationMs = 5000L)
             assertNotNull(pet)
 
             clock.advance(4999L)
@@ -111,7 +190,7 @@ class PetSystemTest {
 
         @Test
         fun `timed pet expires after duration`() {
-            pets.summon(sid1, "fire_familiar", room1, 1, durationMs = 5000L)
+            pets.summon(sid1, "fire_familiar", room1, lowLevelOwner, durationMs = 5000L)
 
             clock.advance(5000L)
             val expired = pets.tick()
@@ -123,7 +202,7 @@ class PetSystemTest {
 
         @Test
         fun `permanent pet does not expire`() {
-            pets.summon(sid1, "fire_familiar", room1, 1, durationMs = 0L)
+            pets.summon(sid1, "fire_familiar", room1, lowLevelOwner, durationMs = 0L)
 
             clock.advance(999_999L)
             val expired = pets.tick()
@@ -133,7 +212,7 @@ class PetSystemTest {
 
         @Test
         fun `dismissing a timed pet clears its expiry`() {
-            val pet = pets.summon(sid1, "fire_familiar", room1, 1, durationMs = 5000L)!!
+            val pet = pets.summon(sid1, "fire_familiar", room1, lowLevelOwner, durationMs = 5000L)!!
             pets.dismissAll(sid1)
 
             clock.advance(6000L)
@@ -147,7 +226,7 @@ class PetSystemTest {
     inner class Following {
         @Test
         fun `pet follows owner to new room`() {
-            val pet = pets.summon(sid1, "fire_familiar", room1, 1)!!
+            val pet = pets.summon(sid1, "fire_familiar", room1, lowLevelOwner)!!
 
             pets.followOwner(sid1, room2)
 
@@ -161,7 +240,7 @@ class PetSystemTest {
     inner class Dismissal {
         @Test
         fun `dismiss removes pet from mob registry`() {
-            val pet = pets.summon(sid1, "fire_familiar", room1, 1)!!
+            val pet = pets.summon(sid1, "fire_familiar", room1, lowLevelOwner)!!
             pets.dismissAll(sid1)
 
             assertNull(mobs.get(pet.id))
@@ -170,7 +249,7 @@ class PetSystemTest {
 
         @Test
         fun `onOwnerDisconnect dismisses pets`() {
-            val pet = pets.summon(sid1, "fire_familiar", room1, 1)!!
+            val pet = pets.summon(sid1, "fire_familiar", room1, lowLevelOwner)!!
             pets.onOwnerDisconnect(sid1)
 
             assertNull(mobs.get(pet.id))

--- a/src/test/kotlin/dev/ambon/engine/TankPetCombatTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/TankPetCombatTest.kt
@@ -167,7 +167,7 @@ class TankPetCombatTest {
         val mob = enemyMob(damage = DamageRange(10, 10))
         fixture.mobs.upsert(mob)
 
-        val pet = petSystem.summon(sid, "tank_bear", TEST_ROOM_ID, DEFAULT_OWNER_STATS)!!
+        petSystem.summon(sid, "tank_bear", TEST_ROOM_ID, DEFAULT_OWNER_STATS)!!
 
         combat.startCombat(sid, "goblin")
         fixture.outbound.drainAll()

--- a/src/test/kotlin/dev/ambon/engine/TankPetCombatTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/TankPetCombatTest.kt
@@ -23,6 +23,10 @@ import java.util.Random
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TankPetCombatTest {
+    private companion object {
+        val DEFAULT_OWNER_STATS = PetSystem.OwnerStats(maxHp = 30, damageMin = 1, damageMax = 3, armor = 0)
+    }
+
     private fun buildPetSystem(
         fixture: CombatTestFixture,
         threatMultiplier: Double = 3.0,
@@ -32,17 +36,17 @@ class TankPetCombatTest {
             definitions = mapOf(
                 "tank_bear" to PetTemplateConfig(
                     name = "a bear",
-                    hp = hp,
-                    minDamage = 2,
-                    maxDamage = 4,
-                    armor = 1,
+                    baseHp = hp,
+                    baseMinDamage = 2,
+                    baseMaxDamage = 4,
+                    baseArmor = 1,
                     threatMultiplier = threatMultiplier,
                 ),
                 "dps_sprite" to PetTemplateConfig(
                     name = "a sprite",
-                    hp = 20,
-                    minDamage = 3,
-                    maxDamage = 5,
+                    baseHp = 20,
+                    baseMinDamage = 3,
+                    baseMaxDamage = 5,
                     threatMultiplier = 0.0,
                 ),
             ),
@@ -81,7 +85,7 @@ class TankPetCombatTest {
         fixture.mobs.upsert(mob)
 
         // Summon a tank pet
-        val pet = petSystem.summon(sid, "tank_bear", TEST_ROOM_ID, ownerLevel = 1)
+        val pet = petSystem.summon(sid, "tank_bear", TEST_ROOM_ID, DEFAULT_OWNER_STATS)
         assertNotNull(pet)
         assertTrue(pet!!.threatMultiplier > 0.0)
         assertNotNull(petSystem.getPetSessionId(pet.id))
@@ -128,7 +132,7 @@ class TankPetCombatTest {
         fixture.mobs.upsert(mob)
 
         // Summon a DPS pet (no threat)
-        val pet = petSystem.summon(sid, "dps_sprite", TEST_ROOM_ID, ownerLevel = 1)
+        val pet = petSystem.summon(sid, "dps_sprite", TEST_ROOM_ID, DEFAULT_OWNER_STATS)
         assertNotNull(pet)
         assertEquals(0.0, pet!!.threatMultiplier)
         assertNull(petSystem.getPetSessionId(pet.id))
@@ -163,7 +167,7 @@ class TankPetCombatTest {
         val mob = enemyMob(damage = DamageRange(10, 10))
         fixture.mobs.upsert(mob)
 
-        val pet = petSystem.summon(sid, "tank_bear", TEST_ROOM_ID, ownerLevel = 1)!!
+        val pet = petSystem.summon(sid, "tank_bear", TEST_ROOM_ID, DEFAULT_OWNER_STATS)!!
 
         combat.startCombat(sid, "goblin")
         fixture.outbound.drainAll()
@@ -223,7 +227,7 @@ class TankPetCombatTest {
         val mob = enemyMob()
         fixture.mobs.upsert(mob)
 
-        val pet = petSystem.summon(sid, "tank_bear", TEST_ROOM_ID, ownerLevel = 1)!!
+        val pet = petSystem.summon(sid, "tank_bear", TEST_ROOM_ID, DEFAULT_OWNER_STATS)!!
         val petSid = petSystem.getPetSessionId(pet.id)!!
 
         combat.startCombat(sid, "goblin")
@@ -261,7 +265,7 @@ class TankPetCombatTest {
         val mob = enemyMob()
         fixture.mobs.upsert(mob)
 
-        val pet = petSystem.summon(sid, "tank_bear", TEST_ROOM_ID, ownerLevel = 1)!!
+        val pet = petSystem.summon(sid, "tank_bear", TEST_ROOM_ID, DEFAULT_OWNER_STATS)!!
         val petSid = petSystem.getPetSessionId(pet.id)!!
 
         combat.startCombat(sid, "goblin")
@@ -299,7 +303,7 @@ class TankPetCombatTest {
         val mob = enemyMob(hp = 1, templateKey = "goblin")
         fixture.mobs.upsert(mob)
 
-        val pet = petSystem.summon(sid, "tank_bear", TEST_ROOM_ID, ownerLevel = 1)!!
+        val pet = petSystem.summon(sid, "tank_bear", TEST_ROOM_ID, DEFAULT_OWNER_STATS)!!
         val petSid = petSystem.getPetSessionId(pet.id)!!
 
         combat.startCombat(sid, "goblin")
@@ -333,7 +337,7 @@ class TankPetCombatTest {
         val mob = enemyMob()
         fixture.mobs.upsert(mob)
 
-        val pet = petSystem.summon(sid, "tank_bear", TEST_ROOM_ID, ownerLevel = 1)!!
+        val pet = petSystem.summon(sid, "tank_bear", TEST_ROOM_ID, DEFAULT_OWNER_STATS)!!
         val petSid = petSystem.getPetSessionId(pet.id)!!
 
         combat.startCombat(sid, "goblin")

--- a/src/test/kotlin/dev/ambon/engine/abilities/PetSummonVisibilityTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/abilities/PetSummonVisibilityTest.kt
@@ -5,6 +5,7 @@ import dev.ambon.config.PetTemplateConfig
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.GmcpEmitter
 import dev.ambon.engine.PetSystem
+import dev.ambon.engine.PlayerState
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.test.AbilityTestFixture
 import dev.ambon.test.MutableClock
@@ -36,21 +37,24 @@ class PetSummonVisibilityTest {
             "fire_familiar" to PetTemplateConfig(
                 name = "a fire familiar",
                 description = "A small elemental of living flame.",
-                hp = 20,
-                minDamage = 2,
-                maxDamage = 5,
-                armor = 1,
+                baseHp = 20,
+                baseMinDamage = 2,
+                baseMaxDamage = 5,
+                baseArmor = 1,
             ),
             "stone_golem" to PetTemplateConfig(
                 name = "a stone golem",
                 description = "A lumbering construct of packed earth.",
-                hp = 30,
-                minDamage = 3,
-                maxDamage = 6,
-                armor = 2,
+                baseHp = 30,
+                baseMinDamage = 3,
+                baseMaxDamage = 6,
+                baseArmor = 2,
             ),
         ),
     )
+
+    private fun ownerStatsFor(player: PlayerState): PetSystem.OwnerStats =
+        PetSystem.OwnerStats(maxHp = player.maxHp, damageMin = 1, damageMax = 4, armor = 0)
 
     @Test
     fun `summoning a pet emits Room_AddMob to summoner and bystanders`() = runTest {
@@ -90,7 +94,7 @@ class PetSummonVisibilityTest {
             onSummonPet = { sid, templateKey, durationMs ->
                 val player = fixture.players.get(sid)
                 if (player != null) {
-                    val pet = petSystem.summon(sid, templateKey, player.roomId, player.level, durationMs, player.name)
+                    val pet = petSystem.summon(sid, templateKey, player.roomId, ownerStatsFor(player), durationMs, player.name)
                     if (pet != null) {
                         gmcpEmitter.broadcastRoomAddMob(player.roomId, pet, fixture.players)
                         val mobsInRoom = fixture.mobs.mobsInRoom(player.roomId)
@@ -187,7 +191,7 @@ class PetSummonVisibilityTest {
                 val player = fixture.players.get(sid)
                 if (player != null) {
                     val replacedPets = petSystem.getPets(sid).map { Triple(it.id, it.roomId, it.name) }
-                    val pet = petSystem.summon(sid, templateKey, player.roomId, player.level, durationMs, player.name)
+                    val pet = petSystem.summon(sid, templateKey, player.roomId, ownerStatsFor(player), durationMs, player.name)
                     if (pet != null) {
                         for ((oldId, oldRoomId, _) in replacedPets) {
                             if (oldId == pet.id) continue

--- a/src/test/kotlin/dev/ambon/engine/commands/PetCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/PetCommandTest.kt
@@ -91,13 +91,15 @@ class PetCommandTest {
             "fire_familiar" to PetTemplateConfig(
                 name = "a fire familiar",
                 description = "A small elemental of living flame.",
-                hp = 20,
-                minDamage = 2,
-                maxDamage = 5,
-                armor = 1,
+                baseHp = 20,
+                baseMinDamage = 2,
+                baseMaxDamage = 5,
+                baseArmor = 1,
             ),
         ),
     )
+
+    private val ownerStats = PetSystem.OwnerStats(maxHp = 30, damageMin = 1, damageMax = 3, armor = 0)
 
     private fun harness(): Triple<CommandRouterHarness, PetSystem, MobRegistry> {
         val mobs = MobRegistry()
@@ -128,7 +130,7 @@ class PetCommandTest {
             val sid = SessionId(1)
             h.loginPlayer(sid, "Alice")
             val player = h.players.get(sid)!!
-            petSystem.summon(sid, "fire_familiar", player.roomId, player.level)
+            petSystem.summon(sid, "fire_familiar", player.roomId, ownerStats)
             h.drain()
 
             h.router.handle(sid, Command.PetStatus)
@@ -144,7 +146,7 @@ class PetCommandTest {
             val sid = SessionId(1)
             h.loginPlayer(sid, "Alice")
             val player = h.players.get(sid)!!
-            petSystem.summon(sid, "fire_familiar", player.roomId, player.level)
+            petSystem.summon(sid, "fire_familiar", player.roomId, ownerStats)
             h.drain()
 
             h.router.handle(sid, Command.PetDismiss)
@@ -174,7 +176,7 @@ class PetCommandTest {
             val sid = SessionId(1)
             h.loginPlayer(sid, "Alice")
             val player = h.players.get(sid)!!
-            petSystem.summon(sid, "fire_familiar", player.roomId, player.level)
+            petSystem.summon(sid, "fire_familiar", player.roomId, ownerStats)
             h.drain()
 
             h.router.handle(sid, Command.PetName("Sparky"))


### PR DESCRIPTION
## Summary

Pets were scaling linearly with owner level (`1.0 + (level-1) * 0.1` — ~5.9× at L50) while player damage curves exponentially with level + gear (`CombatSystem.damageRangeForDisplay` uses `meleeLevelScalingRate.pow(level-1)`). Result: pets fall off hard past mid-game. Pet armor was never scaled at all.

This PR rewrites pet stat scaling so pets stay relevant.

## Changes

- **Config (`PetTemplateConfig`)** — templates now declare `hpRatio` / `damageRatio` / `armorRatio` (fraction of owner's effective stats) plus `baseHp` / `baseMinDamage` / `baseMaxDamage` / `baseArmor` floors for low-level summons.
- **Config (`PetSpellConfig`)** — `damageRatio` (multiple of pet's scaled melee) and `healRatio` (fraction of owner maxHp) let spells inherit scaling for free.
- **Config (`PetConfig`)** — global `maxHpRatio` / `maxDamageRatio` / `maxArmorRatio` caps prevent gear-stacked pets from trivializing content.
- **`PetSystem.summon`** — now takes `PetSystem.OwnerStats` (maxHp, damage min/max, armor) instead of `ownerLevel`. Pet stats = `max(template.baseX, owner.X * ratio)`, ratios capped by `PetConfig.maxXRatio`.
- **`GameEngine`** — call site builds `OwnerStats` from `resolvePlayerStats` + `items.equipmentBonuses` + `combatSystem.damageRangeForDisplay`.
- **`application.yaml`** — three bundled pets retuned by role:
  - Wolf companion (DPS): 0.4 HP / 0.7 dmg / 0.3 armor
  - Spirit hawk (glass scout): 0.3 HP / 0.7 dmg / 0.0 armor
  - Bear guardian (tank): 0.9 HP / 0.4 dmg / 0.7 armor
  Old absolute values preserved as floors.
- **Tests** — `PetSystemTest` extended with ratio scaling, floors, cap, and spell-anchor coverage. Five other pet tests updated for the new signature.

## Tradeoffs

- **Gear-stacking risk** — a well-geared player gets a stronger pet. Mitigated by the global cap multipliers (default 1.0 HP / 0.8 dmg / 1.0 armor).
- **Templates flattened to roles** — pet variety now comes from spells/threat/flavor rather than raw stat tiers. Intentional.

## Test plan

- [x] `./gradlew ktlintCheck test` green
- [ ] Manually summon each pet at level 1 and at a high-level character; confirm HP/damage scale sensibly
- [ ] Confirm spells (bite, dive, maul) hit harder on the geared character
- [ ] Confirm bear guardian still tanks effectively after scaling