### PR TITLE
feat(pets): add pet target type for ability spells

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -822,6 +822,7 @@ class GameEngine(
             statusEffects = statusEffectSystem,
             groupSystem = groupSystem,
             mobs = mobs,
+            petSystem = petSystem,
             progression = progression,
             classRegistry = classRegistry,
             onCombatEvent = { sid, event -> gmcpEmitter.sendCombatEvent(sid, event) },

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
@@ -420,6 +420,16 @@ class AbilitySystem(
                 if (healed > 0) {
                     dirtyNotifier.mobHpDirty(pet.id)
                     combat.addHealingThreat(sessionId, healed)
+                    onCombatEvent(
+                        sessionId,
+                        CombatEvent.Heal(
+                            abilityName = ability.displayName,
+                            targetName = pet.name,
+                            amount = healed,
+                            sourceIsPlayer = true,
+                            abilityId = ability.id.value,
+                        ),
+                    )
                 }
                 outbound.send(
                     OutboundEvent.SendText(
@@ -427,7 +437,6 @@ class AbilitySystem(
                         "Your ${ability.displayName} heals ${pet.name} for $healed HP.",
                     ),
                 )
-                emitAbilityCast(sessionId, ability, pet.name, pet.id.value, targetIsPlayer = false)
             }
             is AbilityEffect.ApplyStatus -> {
                 val sys = statusEffects ?: return "Status effects are not available."

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
@@ -12,6 +12,7 @@ import dev.ambon.engine.ERR_NOT_CONNECTED
 import dev.ambon.engine.GameSystem
 import dev.ambon.engine.GroupSystem
 import dev.ambon.engine.MobRegistry
+import dev.ambon.engine.PetSystem
 import dev.ambon.engine.PlayerProgression
 import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.PlayerState
@@ -44,6 +45,7 @@ class AbilitySystem(
     private val statusEffects: StatusEffectSystem? = null,
     private val groupSystem: GroupSystem? = null,
     private val mobs: MobRegistry? = null,
+    private val petSystem: PetSystem? = null,
     private val progression: PlayerProgression = PlayerProgression(),
     private val classRegistry: dev.ambon.engine.PlayerClassRegistry? = null,
     private val onCombatEvent: suspend (SessionId, CombatEvent) -> Unit = { _, _ -> },
@@ -108,6 +110,7 @@ class AbilitySystem(
             "ally" -> handleAllyCast(sessionId, player, ability, targetKeyword, now)
             "all_enemies" -> handleAllEnemiesCast(sessionId, player, ability, now)
             "all_allies" -> handleAllAlliesCast(sessionId, player, ability, now)
+            "pet" -> handlePetCast(sessionId, player, ability, now)
             else -> "Unknown target type '${ability.targetType}'."
         }
     }
@@ -385,6 +388,66 @@ class AbilitySystem(
             outbound,
             player.roomId,
             "${player.name} casts ${ability.displayName}.",
+            exclude = sessionId,
+        )
+        return null
+    }
+
+    /**
+     * Heals or buffs the caster's active pet. The target is always the caster's own pet —
+     * group members' pets are not addressable. Heal threat is generated against mobs already
+     * engaged with the healer, mirroring the player-heal threat model.
+     */
+    private suspend fun handlePetCast(
+        sessionId: SessionId,
+        player: PlayerState,
+        ability: AbilityDefinition,
+        now: Long,
+    ): String? {
+        val pets = petSystem ?: return "Pets are not available."
+        val pet = pets.getActivePet(sessionId) ?: return "You have no active pet."
+        if (pet.roomId != player.roomId) return "${pet.name} is not here."
+
+        when (val effect = ability.effect) {
+            is AbilityEffect.DirectHeal -> {
+                deductManaAndCooldown(sessionId, player, ability, now)
+                val playerStats = resolvePlayerStats(player, items, statusEffects, classRegistry)
+                val healAmount =
+                    computeSpellHeal(bindings, player.level, playerStats, effect.minHeal, effect.maxHeal, rng)
+                val before = pet.hp
+                pet.hp = (pet.hp + healAmount).coerceAtMost(pet.maxHp)
+                val healed = pet.hp - before
+                if (healed > 0) {
+                    dirtyNotifier.mobHpDirty(pet.id)
+                    combat.addHealingThreat(sessionId, healed)
+                }
+                outbound.send(
+                    OutboundEvent.SendText(
+                        sessionId,
+                        "Your ${ability.displayName} heals ${pet.name} for $healed HP.",
+                    ),
+                )
+                emitAbilityCast(sessionId, ability, pet.name, pet.id.value, targetIsPlayer = false)
+            }
+            is AbilityEffect.ApplyStatus -> {
+                val sys = statusEffects ?: return "Status effects are not available."
+                deductManaAndCooldown(sessionId, player, ability, now)
+                sys.applyToMob(pet.id, effect.statusEffectId, sessionId)
+                outbound.send(
+                    OutboundEvent.SendText(
+                        sessionId,
+                        "Your ${ability.displayName} empowers ${pet.name}!",
+                    ),
+                )
+                emitAbilityCast(sessionId, ability, pet.name, pet.id.value, targetIsPlayer = false)
+            }
+            else -> return "Spell misconfigured (unexpected effect for pet target)."
+        }
+        broadcastToRoom(
+            players,
+            outbound,
+            player.roomId,
+            "${player.name} casts ${ability.displayName} on ${pet.name}.",
             exclude = sessionId,
         )
         return null

--- a/src/test/kotlin/dev/ambon/engine/abilities/PetTargetSpellTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/abilities/PetTargetSpellTest.kt
@@ -3,9 +3,11 @@ package dev.ambon.engine.abilities
 import dev.ambon.config.PetConfig
 import dev.ambon.config.PetTemplateConfig
 import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.DirtyNotifier
 import dev.ambon.engine.PetSystem
 import dev.ambon.engine.PlayerState
+import dev.ambon.engine.events.CombatEvent
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.status.StatusEffectDefinition
 import dev.ambon.engine.status.StatusEffectId
@@ -57,6 +59,7 @@ class PetTargetSpellTest {
         val abilitySystem: AbilitySystem,
         val petSystem: PetSystem,
         val statusEffects: StatusEffectSystem,
+        val combatEvents: MutableList<Pair<SessionId, CombatEvent>>,
     )
 
     private fun buildHarness(): Harness {
@@ -111,12 +114,14 @@ class PetTargetSpellTest {
             ),
         )
 
+        val combatEvents = mutableListOf<Pair<SessionId, CombatEvent>>()
         val abilitySystem = fixture.buildAbilitySystem(
             registry = registry,
             statusEffects = statusEffects,
             petSystem = petSystem,
+            onCombatEvent = { sid, ev -> combatEvents.add(sid to ev) },
         )
-        return Harness(fixture, abilitySystem, petSystem, statusEffects)
+        return Harness(fixture, abilitySystem, petSystem, statusEffects, combatEvents)
     }
 
     @Test
@@ -144,6 +149,17 @@ class PetTargetSpellTest {
             messages.any { it.contains("Mend Pet heals a tank pet for 20 HP") },
             "Expected pet-heal message; got: $messages",
         )
+
+        // Combat log must see the heal so the canvas/UI can show a healing float
+        // on the pet — the same contract as self/ally heal paths.
+        val healEvent = h.combatEvents
+            .map { it.second }
+            .filterIsInstance<CombatEvent.Heal>()
+            .singleOrNull()
+        assertNotNull(healEvent, "Expected a CombatEvent.Heal for the pet target")
+        assertEquals("a tank pet", healEvent!!.targetName)
+        assertEquals(20, healEvent.amount)
+        assertEquals("mend_pet", healEvent.abilityId)
     }
 
     @Test

--- a/src/test/kotlin/dev/ambon/engine/abilities/PetTargetSpellTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/abilities/PetTargetSpellTest.kt
@@ -1,0 +1,198 @@
+package dev.ambon.engine.abilities
+
+import dev.ambon.config.PetConfig
+import dev.ambon.config.PetTemplateConfig
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.engine.DirtyNotifier
+import dev.ambon.engine.PetSystem
+import dev.ambon.engine.PlayerState
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.status.StatusEffectDefinition
+import dev.ambon.engine.status.StatusEffectId
+import dev.ambon.engine.status.StatusEffectRegistry
+import dev.ambon.engine.status.StatusEffectSystem
+import dev.ambon.test.AbilityTestFixture
+import dev.ambon.test.MutableClock
+import dev.ambon.test.TEST_ROOM_ID
+import dev.ambon.test.TEST_SESSION_ID
+import dev.ambon.test.drainAll
+import dev.ambon.test.loginOrFail
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.Random
+
+/**
+ * Tests for the `pet` ability target type — heal/buff abilities that route to
+ * the caster's currently-active pet. Group-mate pets are intentionally not addressable.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PetTargetSpellTest {
+    private val roomId = TEST_ROOM_ID
+    private val sid = TEST_SESSION_ID
+
+    private val petConfig = PetConfig(
+        definitions = mapOf(
+            "tank_pet" to PetTemplateConfig(
+                name = "a tank pet",
+                description = "A sturdy companion.",
+                baseHp = 100,
+                baseMinDamage = 1,
+                baseMaxDamage = 2,
+                baseArmor = 0,
+                threatMultiplier = 5.0,
+            ),
+        ),
+    )
+
+    private fun ownerStatsFor(player: PlayerState): PetSystem.OwnerStats =
+        PetSystem.OwnerStats(maxHp = player.maxHp, damageMin = 1, damageMax = 4, armor = 0)
+
+    private data class Harness(
+        val fixture: AbilityTestFixture,
+        val abilitySystem: AbilitySystem,
+        val petSystem: PetSystem,
+        val statusEffects: StatusEffectSystem,
+    )
+
+    private fun buildHarness(): Harness {
+        val clock = MutableClock(0L)
+        val rng = Random(42)
+        val fixture = AbilityTestFixture(roomId = roomId, clock = clock, rng = rng)
+        val petSystem = PetSystem(config = petConfig, mobs = fixture.mobs, clock = clock)
+
+        val statusRegistry = StatusEffectRegistry()
+        statusRegistry.register(
+            StatusEffectDefinition(
+                id = StatusEffectId("might"),
+                displayName = "Might",
+                effectType = "buff",
+                durationMs = 30_000,
+                stackBehavior = "none",
+            ),
+        )
+        val statusEffects = StatusEffectSystem(
+            registry = statusRegistry,
+            players = fixture.players,
+            mobs = fixture.mobs,
+            outbound = fixture.outbound,
+            clock = clock,
+            rng = rng,
+            dirtyNotifier = DirtyNotifier.NO_OP,
+        )
+
+        val registry = AbilityRegistry()
+        registry.register(
+            AbilityDefinition(
+                id = AbilityId("mend_pet"),
+                displayName = "Mend Pet",
+                description = "Restore HP to your pet.",
+                manaCostPct = 25.0,
+                cooldownMs = 0,
+                levelRequired = 1,
+                targetType = "pet",
+                effect = AbilityEffect.DirectHeal(minHeal = 20, maxHeal = 20),
+            ),
+        )
+        registry.register(
+            AbilityDefinition(
+                id = AbilityId("empower_pet"),
+                displayName = "Empower Pet",
+                description = "Buff your pet.",
+                manaCostPct = 25.0,
+                cooldownMs = 0,
+                levelRequired = 1,
+                targetType = "pet",
+                effect = AbilityEffect.ApplyStatus(StatusEffectId("might")),
+            ),
+        )
+
+        val abilitySystem = fixture.buildAbilitySystem(
+            registry = registry,
+            statusEffects = statusEffects,
+            petSystem = petSystem,
+        )
+        return Harness(fixture, abilitySystem, petSystem, statusEffects)
+    }
+
+    @Test
+    fun `pet-target heal restores pet HP and deducts mana`() = runTest {
+        val h = buildHarness()
+        h.fixture.players.loginOrFail(sid, "Tamer")
+        h.abilitySystem.syncAbilities(sid, 1)
+        val player = h.fixture.players.get(sid)!!
+        player.mana = 50
+
+        val pet = h.petSystem.summon(sid, "tank_pet", player.roomId, ownerStatsFor(player))!!
+        pet.hp = 10 // wounded
+        h.fixture.outbound.drainAll()
+
+        val err = h.abilitySystem.cast(sid, "mend_pet", null)
+        assertNull(err)
+
+        assertEquals(30, pet.hp, "Pet should be healed for 20 HP (capped at maxHp=100)")
+        assertTrue(player.mana < 50, "Mana should be deducted")
+
+        val messages = h.fixture.outbound.drainAll()
+            .filterIsInstance<OutboundEvent.SendText>()
+            .map { it.text }
+        assertTrue(
+            messages.any { it.contains("Mend Pet heals a tank pet for 20 HP") },
+            "Expected pet-heal message; got: $messages",
+        )
+    }
+
+    @Test
+    fun `pet-target buff applies status to pet not caster`() = runTest {
+        val h = buildHarness()
+        h.fixture.players.loginOrFail(sid, "Tamer")
+        h.abilitySystem.syncAbilities(sid, 1)
+        val player = h.fixture.players.get(sid)!!
+        player.mana = 50
+
+        val pet = h.petSystem.summon(sid, "tank_pet", player.roomId, ownerStatsFor(player))!!
+        h.fixture.outbound.drainAll()
+
+        val err = h.abilitySystem.cast(sid, "empower_pet", null)
+        assertNull(err)
+
+        assertTrue(h.statusEffects.hasMobEffect(pet.id, "buff"), "Buff should be applied to the pet")
+        assertTrue(!h.statusEffects.hasPlayerEffect(sid, "buff"), "Caster should not get the buff")
+    }
+
+    @Test
+    fun `pet-target cast fails when caster has no active pet`() = runTest {
+        val h = buildHarness()
+        h.fixture.players.loginOrFail(sid, "Lonely")
+        h.abilitySystem.syncAbilities(sid, 1)
+        val player = h.fixture.players.get(sid)!!
+        player.mana = 50
+
+        val err = h.abilitySystem.cast(sid, "mend_pet", null)
+        assertNotNull(err)
+        assertTrue(err!!.contains("no active pet"), "Expected no-pet error; got: $err")
+        assertEquals(50, player.mana, "Mana should not be consumed on failed pet cast")
+    }
+
+    @Test
+    fun `pet-target cast fails when pet is in a different room`() = runTest {
+        val h = buildHarness()
+        h.fixture.players.loginOrFail(sid, "Wanderer")
+        h.abilitySystem.syncAbilities(sid, 1)
+        val player = h.fixture.players.get(sid)!!
+        player.mana = 50
+
+        val pet = h.petSystem.summon(sid, "tank_pet", player.roomId, ownerStatsFor(player))!!
+        // Move pet away without the owner — simulates pet getting stranded.
+        h.fixture.mobs.moveTo(pet.id, RoomId("zone:elsewhere"))
+        h.fixture.outbound.drainAll()
+
+        val err = h.abilitySystem.cast(sid, "mend_pet", null)
+        assertNotNull(err)
+        assertEquals(50, player.mana, "Mana should not be consumed when pet is unreachable")
+    }
+}

--- a/src/test/kotlin/dev/ambon/test/AbilityTestFixture.kt
+++ b/src/test/kotlin/dev/ambon/test/AbilityTestFixture.kt
@@ -7,6 +7,7 @@ import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.CombatSystemConfig
 import dev.ambon.engine.DirtyNotifier
 import dev.ambon.engine.MobRegistry
+import dev.ambon.engine.PetSystem
 import dev.ambon.engine.PlayerProgression
 import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.abilities.AbilityRegistry
@@ -46,6 +47,7 @@ class AbilityTestFixture(
         // exact damage values without modeling the production scaling curve.
         bindings: StatBindingsConfig = deterministicMeleeBindings(),
         progression: PlayerProgression = PlayerProgression(bindings = bindings),
+        petSystem: PetSystem? = null,
     ): AbilitySystem =
         AbilitySystem(
             players = players,
@@ -57,6 +59,7 @@ class AbilityTestFixture(
             statusEffects = statusEffects,
             dirtyNotifier = dirtyNotifier,
             mobs = mobsForAbility ?: mobs,
+            petSystem = petSystem,
             bindings = bindings,
             progression = progression,
         )

--- a/src/test/kotlin/dev/ambon/test/AbilityTestFixture.kt
+++ b/src/test/kotlin/dev/ambon/test/AbilityTestFixture.kt
@@ -3,6 +3,7 @@ package dev.ambon.test
 import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.config.StatBindingsConfig
 import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.CombatSystemConfig
 import dev.ambon.engine.DirtyNotifier
@@ -12,6 +13,7 @@ import dev.ambon.engine.PlayerProgression
 import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.abilities.AbilityRegistry
 import dev.ambon.engine.abilities.AbilitySystem
+import dev.ambon.engine.events.CombatEvent
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.engine.status.StatusEffectSystem
 import dev.ambon.persistence.InMemoryPlayerRepository
@@ -48,6 +50,7 @@ class AbilityTestFixture(
         bindings: StatBindingsConfig = deterministicMeleeBindings(),
         progression: PlayerProgression = PlayerProgression(bindings = bindings),
         petSystem: PetSystem? = null,
+        onCombatEvent: suspend (SessionId, CombatEvent) -> Unit = { _, _ -> },
     ): AbilitySystem =
         AbilitySystem(
             players = players,
@@ -62,5 +65,6 @@ class AbilityTestFixture(
             petSystem = petSystem,
             bindings = bindings,
             progression = progression,
+            onCombatEvent = onCombatEvent,
         )
 }


### PR DESCRIPTION
## Summary
- Adds a new `pet` `targetType` to the ability system so creator-authored spells can heal/buff the caster's currently-active pet.
- Supports `DIRECT_HEAL` (caps at pet `maxHp`, generates healing threat against engaged mobs) and `APPLY_STATUS` (routes through existing `StatusEffectSystem.applyToMob`).
- Group-mate pets are intentionally not addressable — keeps the routing simple.

## Authoring example
```yaml
pet_mend:
  displayName: Mend Pet
  manaCostPct: 20
  cooldownMs: 4000
  levelRequired: 3
  targetType: pet
  effect:
    type: DIRECT_HEAL
    minHeal: 25
    maxHeal: 35
  requiredClass: RULER
```
No keyword needed — resolution always goes to the caster's own pet.

## Note on base branch
This is stacked on `feat/pet-stat-scaling` because the new tests use `PetSystem.summon(..., OwnerStats, ...)`, whose signature comes from that branch. Once the parent merges to `main`, the diff on this PR collapses to just the pet-target work.

## Test plan
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew test --tests "dev.ambon.engine.abilities.PetTargetSpellTest" --tests "dev.ambon.engine.abilities.AbilitySystemTest"`
- [x] `./gradlew test --tests "*Pet*"`
- [ ] Manual smoke: author a `pet`-target heal spell in `application-local.yaml`, summon a pet, take damage, cast — verify pet HP climbs and mob aggro shifts to the caster.