### PR TITLE
fix(combat): pass server-rendered text through combat events

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -842,6 +842,7 @@ class CombatSystem(
                         targetId = mob.id.value,
                         damage = effectivePlayerDamage,
                         sourceIsPlayer = true,
+                        text = playerHitText,
                     ),
                 )
                 if (config.detailedFeedbackEnabled && config.detailedFeedbackRoomBroadcastEnabled) {
@@ -897,9 +898,8 @@ class CombatSystem(
                 val petDamage = (petRoll - mob.armor).coerceAtLeast(1)
                 mob.takeDamage(petDamage)
                 dirtyNotifier.mobHpDirty(mob.id)
-                outbound.send(
-                    OutboundEvent.SendText(sessionId, "${pet.name} hits ${mob.name} for $petDamage damage."),
-                )
+                val petHitText = "${pet.name} hits ${mob.name} for $petDamage damage."
+                outbound.send(OutboundEvent.SendText(sessionId, petHitText))
                 onCombatEvent(
                     sessionId,
                     CombatEvent.PetHit(
@@ -907,13 +907,14 @@ class CombatSystem(
                         targetName = mob.name,
                         targetId = mob.id.value,
                         damage = petDamage,
+                        text = petHitText,
                     ),
                 )
                 broadcastToRoom(
                     players,
                     outbound,
                     mob.roomId,
-                    "${pet.name} hits ${mob.name} for $petDamage damage.",
+                    petHitText,
                     exclude = sessionId,
                 )
 
@@ -1079,15 +1080,15 @@ class CombatSystem(
                 ((targetStats[config.bindings.dodgeStat] - PlayerState.BASE_STAT) * config.bindings.dodgePerPoint)
                     .coerceIn(0, config.bindings.maxDodgePercent)
             if (dodgePct > 0 && rng.nextInt(100) < dodgePct) {
-                outbound.send(
-                    OutboundEvent.SendText(targetSid, "You dodge ${mob.name}'s ${spell.displayName}!"),
-                )
+                val dodgeText = "You dodge ${mob.name}'s ${spell.displayName}!"
+                outbound.send(OutboundEvent.SendText(targetSid, dodgeText))
                 onCombatEvent(
                     targetSid,
                     CombatEvent.Dodge(
                         targetName = target.name,
                         targetId = null,
                         sourceIsPlayer = false,
+                        text = dodgeText,
                     ),
                 )
                 return
@@ -1108,7 +1109,8 @@ class CombatSystem(
             val msg = spell.message
                 .replace("{target}", target.name)
                 .replace("{damage}", spellDamage.toString())
-            outbound.send(OutboundEvent.SendText(targetSid, "$msg for $spellDamage damage."))
+            val spellHitText = "$msg for $spellDamage damage."
+            outbound.send(OutboundEvent.SendText(targetSid, spellHitText))
 
             if (spell.roomMessage.isNotEmpty()) {
                 broadcastToRoom(
@@ -1142,6 +1144,7 @@ class CombatSystem(
                         targetId = null,
                         damage = spellDamage,
                         sourceIsPlayer = false,
+                        text = spellHitText,
                     ),
                 )
             }
@@ -1212,13 +1215,15 @@ class CombatSystem(
             ((targetStats[config.bindings.dodgeStat] - PlayerState.BASE_STAT) * config.bindings.dodgePerPoint)
                 .coerceIn(0, config.bindings.maxDodgePercent)
         if (dodgePct > 0 && rng.nextInt(100) < dodgePct) {
-            outbound.send(OutboundEvent.SendText(targetSid, "You dodge ${mob.name}'s attack!"))
+            val dodgeText = "You dodge ${mob.name}'s attack!"
+            outbound.send(OutboundEvent.SendText(targetSid, dodgeText))
             onCombatEvent(
                 targetSid,
                 CombatEvent.Dodge(
                     targetName = target.name,
                     targetId = null,
                     sourceIsPlayer = false,
+                    text = dodgeText,
                 ),
             )
             return
@@ -1269,6 +1274,7 @@ class CombatSystem(
                     targetId = null,
                     damage = mobDamage,
                     sourceIsPlayer = false,
+                    text = mobHitText,
                 ),
             )
         }
@@ -1297,22 +1303,22 @@ class CombatSystem(
         val petDamage = (mobRoll - pet.armor).coerceAtLeast(1)
         pet.takeDamage(petDamage)
         dirtyNotifier.mobHpDirty(pet.id)
-        outbound.send(
-            OutboundEvent.SendText(ownerSid, "${mob.name} hits ${pet.name} for $petDamage damage."),
-        )
+        val petHurtText = "${mob.name} hits ${pet.name} for $petDamage damage."
+        outbound.send(OutboundEvent.SendText(ownerSid, petHurtText))
         onCombatEvent(
             ownerSid,
             CombatEvent.PetHurt(
                 petName = pet.name,
                 attackerName = mob.name,
                 damage = petDamage,
+                text = petHurtText,
             ),
         )
         broadcastToRoom(
             players,
             outbound,
             mob.roomId,
-            "${mob.name} hits ${pet.name} for $petDamage damage.",
+            petHurtText,
             exclude = ownerSid,
         )
 
@@ -1450,6 +1456,7 @@ class CombatSystem(
                     targetName = target.name,
                     targetId = target.id.value,
                     damage = reduced,
+                    text = selfMsg,
                 ),
             )
             val roomMsg = skill.roomMessage

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -1004,6 +1004,7 @@ class GmcpEmitter(
                 targetId = event.targetId,
                 damage = event.damage,
                 sourceIsPlayer = event.sourceIsPlayer,
+                text = event.text,
             )
             is CombatEvent.AbilityHit -> CombatEventPayload(
                 type = "abilityHit",
@@ -1013,6 +1014,7 @@ class GmcpEmitter(
                 targetId = event.targetId,
                 damage = event.damage,
                 sourceIsPlayer = event.sourceIsPlayer,
+                text = event.text,
             )
             is CombatEvent.Heal -> CombatEventPayload(
                 type = "heal",
@@ -1021,12 +1023,14 @@ class GmcpEmitter(
                 targetName = event.targetName,
                 healing = event.amount,
                 sourceIsPlayer = event.sourceIsPlayer,
+                text = event.text,
             )
             is CombatEvent.Dodge -> CombatEventPayload(
                 type = "dodge",
                 targetName = event.targetName,
                 targetId = event.targetId,
                 sourceIsPlayer = event.sourceIsPlayer,
+                text = event.text,
             )
             is CombatEvent.DotTick -> CombatEventPayload(
                 type = "dotTick",
@@ -1034,12 +1038,14 @@ class GmcpEmitter(
                 targetName = event.targetName,
                 targetId = event.targetId,
                 damage = event.damage,
+                text = event.text,
             )
             is CombatEvent.HotTick -> CombatEventPayload(
                 type = "hotTick",
                 effectName = event.effectName,
                 targetName = event.targetName,
                 healing = event.amount,
+                text = event.text,
             )
             is CombatEvent.Kill -> CombatEventPayload(
                 type = "kill",
@@ -1059,6 +1065,7 @@ class GmcpEmitter(
                 attackerName = event.attackerName,
                 absorbed = event.absorbed,
                 shieldRemaining = event.remaining,
+                text = event.text,
             )
             is CombatEvent.PetHit -> CombatEventPayload(
                 type = "petHit",
@@ -1066,12 +1073,14 @@ class GmcpEmitter(
                 targetName = event.targetName,
                 targetId = event.targetId,
                 damage = event.damage,
+                text = event.text,
             )
             is CombatEvent.PetHurt -> CombatEventPayload(
                 type = "petHurt",
                 petName = event.petName,
                 attackerName = event.attackerName,
                 damage = event.damage,
+                text = event.text,
             )
             is CombatEvent.AbilityCast -> CombatEventPayload(
                 type = "abilityCast",
@@ -1081,6 +1090,7 @@ class GmcpEmitter(
                 targetId = event.targetId,
                 targetIsPlayer = event.targetIsPlayer,
                 sourceIsPlayer = event.sourceIsPlayer,
+                text = event.text,
             )
             is CombatEvent.Flee -> CombatEventPayload(
                 type = "flee",
@@ -2816,6 +2826,11 @@ class GmcpEmitter(
         val targetIsPlayer: Boolean? = null,
         val lootedItems: List<String> = emptyList(),
         val forced: Boolean? = null,
+        /**
+         * Server-rendered narrative line (custom config templates, stat-formula suffixes).
+         * When present, the web client combat log uses it instead of the hardcoded fallback.
+         */
+        val text: String? = null,
     )
 
     // ---------- stats payload ----------

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
@@ -225,6 +225,7 @@ class AbilitySystem(
                 val healAmount =
                     computeSpellHeal(bindings, player.level, playerStats, effect.minHeal, effect.maxHeal, rng)
                 val healed = applyHeal(sessionId, player, healAmount, dirtyNotifier)
+                val healText = "Your ${ability.displayName} heals you for $healed HP."
                 if (healed > 0) {
                     combat.addHealingThreat(sessionId, healed)
                     onCombatEvent(
@@ -235,15 +236,11 @@ class AbilitySystem(
                             amount = healed,
                             sourceIsPlayer = true,
                             abilityId = ability.id.value,
+                            text = healText,
                         ),
                     )
                 }
-                outbound.send(
-                    OutboundEvent.SendText(
-                        sessionId,
-                        "Your ${ability.displayName} heals you for $healed HP.",
-                    ),
-                )
+                outbound.send(OutboundEvent.SendText(sessionId, healText))
             }
             is AbilityEffect.ApplyStatus -> {
                 val sys =
@@ -316,6 +313,12 @@ class AbilitySystem(
                 val healAmount =
                     computeSpellHeal(bindings, player.level, playerStats, effect.minHeal, effect.maxHeal, rng)
                 val healed = applyHeal(targetSid, target, healAmount, dirtyNotifier)
+                val casterText =
+                    if (targetSid == sessionId) {
+                        "Your ${ability.displayName} heals you for $healed HP."
+                    } else {
+                        "Your ${ability.displayName} heals ${target.name} for $healed HP."
+                    }
                 if (healed > 0) {
                     combat.addHealingThreat(sessionId, healed)
                     onCombatEvent(
@@ -326,23 +329,12 @@ class AbilitySystem(
                             amount = healed,
                             sourceIsPlayer = true,
                             abilityId = ability.id.value,
+                            text = casterText,
                         ),
                     )
                 }
-                if (targetSid == sessionId) {
-                    outbound.send(
-                        OutboundEvent.SendText(
-                            sessionId,
-                            "Your ${ability.displayName} heals you for $healed HP.",
-                        ),
-                    )
-                } else {
-                    outbound.send(
-                        OutboundEvent.SendText(
-                            sessionId,
-                            "Your ${ability.displayName} heals ${target.name} for $healed HP.",
-                        ),
-                    )
+                outbound.send(OutboundEvent.SendText(sessionId, casterText))
+                if (targetSid != sessionId) {
                     outbound.send(
                         OutboundEvent.SendText(
                             targetSid,
@@ -417,6 +409,7 @@ class AbilitySystem(
                 val before = pet.hp
                 pet.hp = (pet.hp + healAmount).coerceAtMost(pet.maxHp)
                 val healed = pet.hp - before
+                val petHealText = "Your ${ability.displayName} heals ${pet.name} for $healed HP."
                 if (healed > 0) {
                     dirtyNotifier.mobHpDirty(pet.id)
                     combat.addHealingThreat(sessionId, healed)
@@ -428,15 +421,11 @@ class AbilitySystem(
                             amount = healed,
                             sourceIsPlayer = true,
                             abilityId = ability.id.value,
+                            text = petHealText,
                         ),
                     )
                 }
-                outbound.send(
-                    OutboundEvent.SendText(
-                        sessionId,
-                        "Your ${ability.displayName} heals ${pet.name} for $healed HP.",
-                    ),
-                )
+                outbound.send(OutboundEvent.SendText(sessionId, petHealText))
             }
             is AbilityEffect.ApplyStatus -> {
                 val sys = statusEffects ?: return "Status effects are not available."
@@ -549,6 +538,12 @@ class AbilitySystem(
                     val healAmount =
                         computeSpellHeal(bindings, player.level, playerStats, effect.minHeal, effect.maxHeal, rng)
                     val healed = applyHeal(targetSid, target, healAmount, dirtyNotifier)
+                    val casterText =
+                        if (targetSid == sessionId) {
+                            "Your ${ability.displayName} heals you for $healed HP."
+                        } else {
+                            "Your ${ability.displayName} heals ${target.name} for $healed HP."
+                        }
                     if (healed > 0) {
                         combat.addHealingThreat(sessionId, healed)
                         onCombatEvent(
@@ -559,23 +554,12 @@ class AbilitySystem(
                                 amount = healed,
                                 sourceIsPlayer = true,
                                 abilityId = ability.id.value,
+                                text = casterText,
                             ),
                         )
                     }
-                    if (targetSid == sessionId) {
-                        outbound.send(
-                            OutboundEvent.SendText(
-                                sessionId,
-                                "Your ${ability.displayName} heals you for $healed HP.",
-                            ),
-                        )
-                    } else {
-                        outbound.send(
-                            OutboundEvent.SendText(
-                                sessionId,
-                                "Your ${ability.displayName} heals ${target.name} for $healed HP.",
-                            ),
-                        )
+                    outbound.send(OutboundEvent.SendText(sessionId, casterText))
+                    if (targetSid != sessionId) {
                         outbound.send(
                             OutboundEvent.SendText(
                                 targetSid,
@@ -645,12 +629,8 @@ class AbilitySystem(
         mob.takeDamage(damage)
         dirtyNotifier.mobHpDirty(mob.id)
         combat.addThreat(mob.id, sessionId, damage.toDouble())
-        outbound.send(
-            OutboundEvent.SendText(
-                sessionId,
-                "Your ${ability.displayName} hits ${mob.name} for $damage damage.",
-            ),
-        )
+        val hitText = "Your ${ability.displayName} hits ${mob.name} for $damage damage."
+        outbound.send(OutboundEvent.SendText(sessionId, hitText))
         onCombatEvent(
             sessionId,
             CombatEvent.AbilityHit(
@@ -660,6 +640,7 @@ class AbilitySystem(
                 targetId = mob.id.value,
                 damage = damage,
                 sourceIsPlayer = true,
+                text = hitText,
             ),
         )
         if (mob.hp <= 0) {

--- a/src/main/kotlin/dev/ambon/engine/events/CombatEvent.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/CombatEvent.kt
@@ -1,11 +1,18 @@
 package dev.ambon.engine.events
 
+/**
+ * Each variant carries an optional [text] field with the server-rendered narrative line
+ * (custom config templates, stat-formula suffixes, etc.). When present, the web client
+ * combat log prefers it over its hardcoded fallback template. See
+ * `web-v3/src/hooks/useGameState.ts#combatEventToLogMessage`.
+ */
 sealed interface CombatEvent {
     data class MeleeHit(
         val targetName: String,
         val targetId: String?,
         val damage: Int,
         val sourceIsPlayer: Boolean,
+        val text: String? = null,
     ) : CombatEvent
 
     data class AbilityHit(
@@ -15,6 +22,7 @@ sealed interface CombatEvent {
         val targetId: String?,
         val damage: Int,
         val sourceIsPlayer: Boolean,
+        val text: String? = null,
     ) : CombatEvent
 
     data class Heal(
@@ -23,12 +31,14 @@ sealed interface CombatEvent {
         val amount: Int,
         val sourceIsPlayer: Boolean,
         val abilityId: String? = null,
+        val text: String? = null,
     ) : CombatEvent
 
     data class Dodge(
         val targetName: String,
         val targetId: String?,
         val sourceIsPlayer: Boolean,
+        val text: String? = null,
     ) : CombatEvent
 
     data class DotTick(
@@ -36,12 +46,14 @@ sealed interface CombatEvent {
         val targetName: String,
         val targetId: String?,
         val damage: Int,
+        val text: String? = null,
     ) : CombatEvent
 
     data class HotTick(
         val effectName: String,
         val targetName: String,
         val amount: Int,
+        val text: String? = null,
     ) : CombatEvent
 
     data class Kill(
@@ -61,6 +73,7 @@ sealed interface CombatEvent {
         val attackerName: String,
         val absorbed: Int,
         val remaining: Int,
+        val text: String? = null,
     ) : CombatEvent
 
     data class PetHit(
@@ -68,12 +81,14 @@ sealed interface CombatEvent {
         val targetName: String,
         val targetId: String?,
         val damage: Int,
+        val text: String? = null,
     ) : CombatEvent
 
     data class PetHurt(
         val petName: String,
         val attackerName: String,
         val damage: Int,
+        val text: String? = null,
     ) : CombatEvent
 
     /**
@@ -93,6 +108,7 @@ sealed interface CombatEvent {
         val targetId: String?,
         val targetIsPlayer: Boolean,
         val sourceIsPlayer: Boolean,
+        val text: String? = null,
     ) : CombatEvent
 
     /**

--- a/src/main/kotlin/dev/ambon/engine/status/StatusEffectSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/status/StatusEffectSystem.kt
@@ -175,12 +175,8 @@ class StatusEffectSystem(
                     if (typeConfig?.ticksDamage == true) {
                         player.takeDamage(value)
                         dirtyNotifier.playerVitalsDirty(sessionId)
-                        outbound.send(
-                            OutboundEvent.SendText(
-                                sessionId,
-                                "${def.displayName} burns you for $value damage.",
-                            ),
-                        )
+                        val dotText = "${def.displayName} burns you for $value damage."
+                        outbound.send(OutboundEvent.SendText(sessionId, dotText))
                         onCombatEvent(
                             sessionId,
                             CombatEvent.DotTick(
@@ -188,23 +184,21 @@ class StatusEffectSystem(
                                 targetName = player.name,
                                 targetId = null,
                                 damage = value,
+                                text = dotText,
                             ),
                         )
                     } else if (typeConfig?.ticksHealing == true) {
                         val healed = applyHeal(sessionId, player, value, dirtyNotifier)
                         if (healed > 0) {
-                            outbound.send(
-                                OutboundEvent.SendText(
-                                    sessionId,
-                                    "${def.displayName} heals you for $healed HP.",
-                                ),
-                            )
+                            val hotText = "${def.displayName} heals you for $healed HP."
+                            outbound.send(OutboundEvent.SendText(sessionId, hotText))
                             onCombatEvent(
                                 sessionId,
                                 CombatEvent.HotTick(
                                     effectName = def.displayName,
                                     targetName = player.name,
                                     amount = healed,
+                                    text = hotText,
                                 ),
                             )
                         }
@@ -233,12 +227,8 @@ class StatusEffectSystem(
                     dirtyNotifier.mobHpDirty(mobId)
                     val source = effect.sourceSessionId
                     if (source != null) {
-                        outbound.send(
-                            OutboundEvent.SendText(
-                                source,
-                                "${def.displayName} burns ${mob.name} for $value damage.",
-                            ),
-                        )
+                        val dotText = "${def.displayName} burns ${mob.name} for $value damage."
+                        outbound.send(OutboundEvent.SendText(source, dotText))
                         onCombatEvent(
                             source,
                             CombatEvent.DotTick(
@@ -246,6 +236,7 @@ class StatusEffectSystem(
                                 targetName = mob.name,
                                 targetId = mobId.value,
                                 damage = value,
+                                text = dotText,
                             ),
                         )
                     }

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -1049,6 +1049,7 @@ export function applyGmcpPackage(
           ? packet.lootedItems.filter((s): s is string => typeof s === "string")
           : [],
         forced: packet.forced === true,
+        text: typeof packet.text === "string" ? packet.text : null,
       });
       break;
     }

--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -110,6 +110,26 @@ let combatLogIdCounter = 0;
 function combatEventToLogMessage(event: CombatEventData): CombatLogMessage | null {
   const now = Date.now();
   const id = ++combatLogIdCounter;
+  // Server-rendered text (custom config templates, stat-formula suffixes) takes precedence
+  // over the hardcoded fallback templates below.
+  const styleForType: Record<string, CombatLogMessage["style"]> = {
+    meleeHit: "damage",
+    petHit: "damage",
+    petHurt: "damage",
+    abilityHit: "damage",
+    heal: "heal",
+    hotTick: "heal",
+    dotTick: "damage",
+    coldDot: "damage",
+    dodge: "dodge",
+    shieldAbsorb: "info",
+    kill: "kill",
+    death: "error",
+  };
+  if (event.text) {
+    const style = styleForType[event.type] ?? "info";
+    return { id, text: event.text, style, receivedAt: now };
+  }
   switch (event.type) {
     case "meleeHit":
       return event.sourceIsPlayer

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -519,6 +519,12 @@ export interface CombatEventData {
   lootedItems: string[];
   /** True when the player disengaged via the wimpy threshold rather than typing `flee`. */
   forced: boolean;
+  /**
+   * Server-rendered narrative line (e.g. custom config templates for mob/pet/ability messages,
+   * stat-formula suffixes on melee). When present, the combat log uses it verbatim instead of
+   * the hardcoded client template.
+   */
+  text: string | null;
 }
 
 export interface StatEntry {


### PR DESCRIPTION
## Summary

Pet attack custom messages (and mob/ability custom templates more broadly) never reached the web client. The overlay defines e.g.

```yaml
clockwork_dragon:
  defaultAttack: fire_breath
  spells:
    fire_breath:
      message: "{pet}'s fire breath deals {damage} damage to {target}."
```

…but the web combat log showed `a clockwork dragon hits Shade Kirot Aethiryn for 28 damage.`

## Root cause

Two facts together:
1. `web-v3/src/App.tsx` `onTextMessage` silently drops every non-GMCP server line — the comment says `Terminal removed`.
2. `combatEventToLogMessage` in `web-v3/src/hooks/useGameState.ts` builds combat-log entries entirely from `CombatEvent` GMCP fields using hardcoded fallback templates, e.g. `${petName} hits ${targetName} for ${damage} damage.`

So the `SendText` the engine emitted (with the resolved template) was thrown away, and the client manufactured a generic line from the structured event instead.

Same gap applied to mob spell `message`/`roomMessage`, the player-melee stat-formula suffixes, shield-absorb wording, dodge phrasing, etc.

## Fix

Optional `text: String?` field added to every narrative combat event (`MeleeHit`, `AbilityHit`, `Heal`, `Dodge`, `DotTick`, `HotTick`, `ShieldAbsorb`, `PetHit`, `PetHurt`, `AbilityCast`), threaded through `GmcpEmitter` and the `Char.Combat.Event` payload. Engine call sites populate `text` wherever they already render a `SendText` for that event. Web client prefers `event.text` when present, falling back to its existing hardcoded template.

Touched systems:
- `CombatSystem.executePetSkill` — pet signature-skill messages (the original bug)
- `CombatSystem` pet melee fallback + `executeMobMeleeOnPet`
- `CombatSystem.executeMobSpell` — mob spell custom templates and dodge phrasing
- `CombatSystem` player-vs-mob melee (preserves stat-formula suffix) + mob-vs-player melee (preserves shield-absorbed wording)
- `CombatSystem` mob-melee dodge
- `AbilitySystem` — direct heal (self/ally/pet/all-allies) and `applySpellDamage`
- `StatusEffectSystem` — DoT/HoT ticks on players and mobs

PvP melee `MeleeHit` was deliberately not threaded — it has a pre-existing `${'$'}{target.name}` literal-escape bug in `CombatSystem.kt` ~line 571 that should be fixed separately rather than propagated into a new code path.

## Test plan

- [x] `./gradlew compileKotlin compileTestKotlin` — green
- [x] `./gradlew test --tests "*Pet*" --tests "*MobSpell*" --tests "*GmcpEmitter*" --tests "*StatusEffect*" --tests "*Ability*"` — green
- [x] `./gradlew ktlintCheck` — green
- [x] `bunx tsc --noEmit` in `web-v3/` — green
- [ ] Manual: summon a clockwork dragon, engage a mob, confirm the combat log shows the configured `fire_breath` message
- [ ] Manual: take DoT damage and confirm the configured DoT message appears