### PR TITLE
feat(abilities): composite effects combining damage/heal with status

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -2479,6 +2479,12 @@ data class AbilityEffectConfig(
     val margin: Double = 10.0,
     val petTemplateKey: String = "",
     val durationMs: Long = 0L,
+    /**
+     * Child effects used when [type] is `COMPOSITE`. The ability pays its
+     * mana/cooldown once and every child resolves against the same target.
+     * Ignored for non-composite types.
+     */
+    val effects: List<AbilityEffectConfig> = emptyList(),
 )
 
 data class SkillPointsConfig(

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -18,7 +18,7 @@ import dev.ambon.domain.world.World
 import dev.ambon.engine.abilities.AbilityDefinition
 import dev.ambon.engine.abilities.AbilityId
 import dev.ambon.engine.abilities.AbilitySystem
-import dev.ambon.engine.abilities.toEffectType
+import dev.ambon.engine.abilities.primaryEffectType
 import dev.ambon.engine.events.CombatEvent
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
@@ -493,7 +493,7 @@ class GmcpEmitter(
                     cooldownRemainingMs = cooldownRemainingMs(a.id).coerceAtLeast(0L),
                     levelRequired = a.levelRequired,
                     targetType = a.targetType,
-                    effectType = a.effect.toEffectType(),
+                    effectType = a.effect.primaryEffectType(),
                     classRestriction = a.requiredClass,
                     image = a.image,
                     prerequisites = a.prerequisites.map { it.value },
@@ -821,7 +821,7 @@ class GmcpEmitter(
             manaCost = manaCost.coerceAtLeast(0),
             cooldownMs = ability.cooldownMs,
             targetType = ability.targetType,
-            effectType = ability.effect.toEffectType(),
+            effectType = ability.effect.primaryEffectType(),
             image = ability.image,
             prerequisites = ability.prerequisites.map { it.value },
             tree = ability.tree,

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilityDefinition.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilityDefinition.kt
@@ -46,7 +46,38 @@ sealed interface AbilityEffect {
         val petTemplateKey: String,
         val durationMs: Long = 0L,
     ) : AbilityEffect
+
+    /**
+     * Combines multiple effects into a single ability cast. The ability pays
+     * its mana/cooldown once; every child effect resolves against the same
+     * primary target. All children must be compatible with the ability's
+     * `targetType` — composite is intended for stacking effects on the same
+     * target (e.g. "damage + apply DoT"), not for cross-target combos.
+     * Nested composites are flattened by the runtime.
+     */
+    data class Composite(
+        val effects: List<AbilityEffect>,
+    ) : AbilityEffect {
+        init {
+            require(effects.isNotEmpty()) { "Composite ability effect must have at least one child effect" }
+        }
+    }
 }
+
+/** Returns a flat list of leaf effects, recursively unwrapping any [AbilityEffect.Composite]. */
+fun AbilityEffect.flatten(): List<AbilityEffect> = when (this) {
+    is AbilityEffect.Composite -> effects.flatMap { it.flatten() }
+    else -> listOf(this)
+}
+
+/**
+ * Effect type string sent to the web client. For composites the *primary*
+ * (first leaf) child's type is used — the client uses this for category
+ * styling, and a "damage + status" composite should still register as
+ * damage in the UI. Use [toEffectType] when you want the literal composite
+ * marker.
+ */
+fun AbilityEffect.primaryEffectType(): String = flatten().first().toEffectType()
 
 fun AbilityEffect.toEffectType(): String = when (this) {
     is AbilityEffect.DirectDamage -> "DIRECT_DAMAGE"
@@ -55,6 +86,7 @@ fun AbilityEffect.toEffectType(): String = when (this) {
     is AbilityEffect.AreaDamage -> "AREA_DAMAGE"
     is AbilityEffect.Taunt -> "TAUNT"
     is AbilityEffect.SummonPet -> "SUMMON_PET"
+    is AbilityEffect.Composite -> "COMPOSITE"
 }
 
 /**
@@ -123,6 +155,8 @@ data class AbilityDefinition(
  * - AREA_DAMAGE: AREA_BURST.
  * - TAUNT: BUFF_AURA on the caster.
  * - SUMMON_PET: SUMMON_POOF.
+ * - COMPOSITE: defers to the first child effect (composites are typically
+ *   "damage + status" — the dominant child drives the cast visual).
  */
 fun deriveDefaultVisual(
     effect: AbilityEffect,
@@ -150,6 +184,7 @@ fun deriveDefaultVisual(
         is AbilityEffect.AreaDamage -> AbilityVisualArchetype.AREA_BURST
         is AbilityEffect.Taunt -> AbilityVisualArchetype.BUFF_AURA
         is AbilityEffect.SummonPet -> AbilityVisualArchetype.SUMMON_POOF
+        is AbilityEffect.Composite -> deriveDefaultVisual(effect.flatten().first(), targetType, requiredClass).archetype
     }
     return AbilityVisual(archetype = archetype)
 }

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilityRegistryLoader.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilityRegistryLoader.kt
@@ -1,5 +1,6 @@
 package dev.ambon.engine.abilities
 
+import dev.ambon.config.AbilityEffectConfig
 import dev.ambon.config.AbilityEngineConfig
 import dev.ambon.config.AbilityVisualConfig
 import dev.ambon.domain.DamageRange
@@ -14,37 +15,7 @@ object AbilityRegistryLoader {
         val imagesBase = if (imagesBaseUrl.endsWith("/")) imagesBaseUrl else "$imagesBaseUrl/"
         for ((key, defConfig) in config.definitions) {
             val targetType = defConfig.targetType.trim().lowercase()
-            val effect =
-                when (defConfig.effect.type.uppercase()) {
-                    "DIRECT_DAMAGE" ->
-                        AbilityEffect.DirectDamage(
-                            damage = DamageRange(defConfig.effect.minDamage, defConfig.effect.maxDamage),
-                        )
-                    "DIRECT_HEAL" ->
-                        AbilityEffect.DirectHeal(
-                            minHeal = defConfig.effect.minHeal,
-                            maxHeal = defConfig.effect.maxHeal,
-                        )
-                    "APPLY_STATUS" ->
-                        AbilityEffect.ApplyStatus(
-                            statusEffectId = StatusEffectId(defConfig.effect.statusEffectId),
-                        )
-                    "AREA_DAMAGE" ->
-                        AbilityEffect.AreaDamage(
-                            damage = DamageRange(defConfig.effect.minDamage, defConfig.effect.maxDamage),
-                        )
-                    "TAUNT" ->
-                        AbilityEffect.Taunt(
-                            flatThreat = defConfig.effect.flatThreat,
-                            margin = defConfig.effect.margin,
-                        )
-                    "SUMMON_PET" ->
-                        AbilityEffect.SummonPet(
-                            petTemplateKey = defConfig.effect.petTemplateKey,
-                            durationMs = defConfig.effect.durationMs,
-                        )
-                    else -> continue
-                }
+            val effect = parseEffect(defConfig.effect) ?: continue
             val requiredClass = defConfig.requiredClass.ifBlank { null }
             val prerequisites = defConfig.prerequisites.map { AbilityId(it) }.toSet()
             val tree = defConfig.tree.ifBlank { "" }
@@ -72,6 +43,41 @@ object AbilityRegistryLoader {
         }
         validateNoPrerequisiteCycles(registry)
     }
+
+    /**
+     * Parses a single [AbilityEffectConfig] into an [AbilityEffect], recursing
+     * for composite effects. Returns null for unknown types or for composites
+     * with no parseable children, so the caller can skip the whole ability.
+     */
+    private fun parseEffect(config: AbilityEffectConfig): AbilityEffect? =
+        when (config.type.uppercase()) {
+            "DIRECT_DAMAGE" -> AbilityEffect.DirectDamage(
+                damage = DamageRange(config.minDamage, config.maxDamage),
+            )
+            "DIRECT_HEAL" -> AbilityEffect.DirectHeal(
+                minHeal = config.minHeal,
+                maxHeal = config.maxHeal,
+            )
+            "APPLY_STATUS" -> AbilityEffect.ApplyStatus(
+                statusEffectId = StatusEffectId(config.statusEffectId),
+            )
+            "AREA_DAMAGE" -> AbilityEffect.AreaDamage(
+                damage = DamageRange(config.minDamage, config.maxDamage),
+            )
+            "TAUNT" -> AbilityEffect.Taunt(
+                flatThreat = config.flatThreat,
+                margin = config.margin,
+            )
+            "SUMMON_PET" -> AbilityEffect.SummonPet(
+                petTemplateKey = config.petTemplateKey,
+                durationMs = config.durationMs,
+            )
+            "COMPOSITE" -> {
+                val children = config.effects.mapNotNull { parseEffect(it) }
+                if (children.isEmpty()) null else AbilityEffect.Composite(effects = children)
+            }
+            else -> null
+        }
 
     /**
      * Resolves the [AbilityVisual] for an ability. An empty [AbilityVisualConfig.archetype]

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilityRegistryLoader.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilityRegistryLoader.kt
@@ -5,6 +5,9 @@ import dev.ambon.config.AbilityEngineConfig
 import dev.ambon.config.AbilityVisualConfig
 import dev.ambon.domain.DamageRange
 import dev.ambon.engine.status.StatusEffectId
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
 
 object AbilityRegistryLoader {
     fun load(
@@ -15,7 +18,14 @@ object AbilityRegistryLoader {
         val imagesBase = if (imagesBaseUrl.endsWith("/")) imagesBaseUrl else "$imagesBaseUrl/"
         for ((key, defConfig) in config.definitions) {
             val targetType = defConfig.targetType.trim().lowercase()
-            val effect = parseEffect(defConfig.effect) ?: continue
+            val effect = parseEffect(defConfig.effect)
+            if (effect == null) {
+                logger.warn {
+                    "Ability '$key' skipped: effect type '${defConfig.effect.type}' is unknown " +
+                        "or has unparseable children."
+                }
+                continue
+            }
             val requiredClass = defConfig.requiredClass.ifBlank { null }
             val prerequisites = defConfig.prerequisites.map { AbilityId(it) }.toSet()
             val tree = defConfig.tree.ifBlank { "" }
@@ -46,8 +56,12 @@ object AbilityRegistryLoader {
 
     /**
      * Parses a single [AbilityEffectConfig] into an [AbilityEffect], recursing
-     * for composite effects. Returns null for unknown types or for composites
-     * with no parseable children, so the caller can skip the whole ability.
+     * for composite effects. Returns null for unknown effect types. For
+     * composites, returns null if any declared child fails to parse — partial
+     * composites are not allowed because they would silently change the
+     * intended combat behavior (e.g. a typo'd child silently dropped from a
+     * damage+status spell). Composites with an empty `effects` list are also
+     * rejected. The caller surfaces a warning and skips the whole ability.
      */
     private fun parseEffect(config: AbilityEffectConfig): AbilityEffect? =
         when (config.type.uppercase()) {
@@ -73,8 +87,24 @@ object AbilityRegistryLoader {
                 durationMs = config.durationMs,
             )
             "COMPOSITE" -> {
-                val children = config.effects.mapNotNull { parseEffect(it) }
-                if (children.isEmpty()) null else AbilityEffect.Composite(effects = children)
+                if (config.effects.isEmpty()) {
+                    logger.warn {
+                        "COMPOSITE effect has no children — composites must declare at least one child effect."
+                    }
+                    null
+                } else {
+                    val children = config.effects.map { child ->
+                        val parsed = parseEffect(child)
+                        if (parsed == null) {
+                            logger.warn {
+                                "COMPOSITE child of type '${child.type}' failed to parse — " +
+                                    "the entire composite will be rejected to avoid partial behavior."
+                            }
+                        }
+                        parsed
+                    }
+                    if (children.any { it == null }) null else AbilityEffect.Composite(effects = children.filterNotNull())
+                }
             }
             else -> null
         }

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
@@ -115,7 +115,7 @@ class AbilitySystem(
         }
     }
 
-    @Suppress("CyclomaticComplexity", "LongMethod")
+    @Suppress("CyclomaticComplexity", "LongMethod", "ReturnCount")
     private suspend fun handleEnemyCast(
         sessionId: SessionId,
         player: PlayerState,
@@ -123,6 +123,18 @@ class AbilitySystem(
         targetKeyword: String?,
         now: Long,
     ): String? {
+        val effects = ability.effect.flatten()
+        for (e in effects) {
+            when (e) {
+                is AbilityEffect.DirectDamage,
+                is AbilityEffect.AreaDamage,
+                is AbilityEffect.Taunt,
+                is AbilityEffect.ApplyStatus,
+                -> {}
+                else -> return "Spell misconfigured (unexpected effect for enemy target)."
+            }
+        }
+
         val keyword =
             targetKeyword
                 ?: if (combat.isInCombat(sessionId)) {
@@ -140,68 +152,39 @@ class AbilitySystem(
                     ?: return "Cast ${ability.displayName} on whom?"
             }
 
-        val playerStats = resolvePlayerStats(player, items, statusEffects, classRegistry)
+        if (effects.any { it is AbilityEffect.AreaDamage } && mobs == null) {
+            return "Area damage is not available."
+        }
+        if (effects.any { it is AbilityEffect.ApplyStatus } && statusEffects == null) {
+            return "Status effects are not available."
+        }
+        if (effects.any { it is AbilityEffect.Taunt } && !combat.isMobInCombat(mob.id)) {
+            return "${mob.name} is not in combat."
+        }
 
-        when (val effect = ability.effect) {
-            is AbilityEffect.DirectDamage -> {
-                deductManaAndCooldown(sessionId, player, ability, now)
-                val damage = computeSpellDamage(bindings, player.level, playerStats, effect.damage, rng)
-                applySpellDamage(sessionId, mob, ability, damage)
-            }
-            is AbilityEffect.AreaDamage -> {
-                val mobRegistry = mobs ?: return "Area damage is not available."
+        val areaTargets: List<MobState>? =
+            if (effects.any { it is AbilityEffect.AreaDamage }) {
                 val groupMembers =
                     groupSystem?.membersInRoom(sessionId, player.roomId)
                         ?: listOf(sessionId)
-
-                // Find all mobs in room that are in combat with any group member
-                val targetMobs =
-                    mobRegistry.mobsInRoom(player.roomId).filter { m ->
+                val found =
+                    mobs!!.mobsInRoom(player.roomId).filter { m ->
                         combat.isMobInCombat(m.id) &&
                             groupMembers.any { sid -> combat.threatTable.hasThreat(m.id, sid) }
                     }
+                if (found.isEmpty()) return "No enemies in combat to hit."
+                found
+            } else {
+                null
+            }
 
-                if (targetMobs.isEmpty()) {
-                    return "No enemies in combat to hit."
-                }
+        val playerStats = resolvePlayerStats(player, items, statusEffects, classRegistry)
+        deductManaAndCooldown(sessionId, player, ability, now)
 
-                deductManaAndCooldown(sessionId, player, ability, now)
-                for (m in targetMobs) {
-                    val damage = computeSpellDamage(bindings, player.level, playerStats, effect.damage, rng)
-                    applySpellDamage(sessionId, m, ability, damage)
-                }
-            }
-            is AbilityEffect.Taunt -> {
-                if (!combat.isMobInCombat(mob.id)) {
-                    return "${mob.name} is not in combat."
-                }
-                deductManaAndCooldown(sessionId, player, ability, now)
-                val currentMax = combat.threatTable.maxThreatValue(mob.id)
-                combat.threatTable.setThreat(mob.id, sessionId, currentMax + effect.margin + effect.flatThreat)
-                outbound.send(
-                    OutboundEvent.SendText(
-                        sessionId,
-                        "You taunt ${mob.name}! It turns to face you.",
-                    ),
-                )
-                emitAbilityCast(sessionId, ability, mob.name, mob.id.value, targetIsPlayer = false)
-            }
-            is AbilityEffect.ApplyStatus -> {
-                val sys =
-                    statusEffects
-                        ?: return "Status effects are not available."
-                deductManaAndCooldown(sessionId, player, ability, now)
-                sys.applyToMob(mob.id, effect.statusEffectId, sessionId)
-                outbound.send(
-                    OutboundEvent.SendText(
-                        sessionId,
-                        "Your ${ability.displayName} afflicts ${mob.name}!",
-                    ),
-                )
-                emitAbilityCast(sessionId, ability, mob.name, mob.id.value, targetIsPlayer = false)
-            }
-            else -> return "Spell misconfigured (unexpected effect for enemy target)."
+        for (effect in effects) {
+            executeEnemyEffect(sessionId, player, ability, mob, effect, playerStats, areaTargets)
         }
+
         broadcastToRoom(
             players,
             outbound,
@@ -212,16 +195,101 @@ class AbilitySystem(
         return null
     }
 
+    private suspend fun executeEnemyEffect(
+        sessionId: SessionId,
+        player: PlayerState,
+        ability: AbilityDefinition,
+        mob: MobState,
+        effect: AbilityEffect,
+        playerStats: StatMap,
+        areaTargets: List<MobState>?,
+    ) {
+        when (effect) {
+            is AbilityEffect.DirectDamage -> {
+                val damage = computeSpellDamage(bindings, player.level, playerStats, effect.damage, rng)
+                applySpellDamage(sessionId, mob, ability, damage)
+            }
+            is AbilityEffect.AreaDamage -> {
+                for (m in areaTargets.orEmpty()) {
+                    val damage = computeSpellDamage(bindings, player.level, playerStats, effect.damage, rng)
+                    applySpellDamage(sessionId, m, ability, damage)
+                }
+            }
+            is AbilityEffect.Taunt -> {
+                val currentMax = combat.threatTable.maxThreatValue(mob.id)
+                combat.threatTable.setThreat(
+                    mob.id,
+                    sessionId,
+                    currentMax + effect.margin + effect.flatThreat,
+                )
+                outbound.send(
+                    OutboundEvent.SendText(
+                        sessionId,
+                        "You taunt ${mob.name}! It turns to face you.",
+                    ),
+                )
+                emitAbilityCast(sessionId, ability, mob.name, mob.id.value, targetIsPlayer = false)
+            }
+            is AbilityEffect.ApplyStatus -> {
+                statusEffects!!.applyToMob(mob.id, effect.statusEffectId, sessionId)
+                outbound.send(
+                    OutboundEvent.SendText(
+                        sessionId,
+                        "Your ${ability.displayName} afflicts ${mob.name}!",
+                    ),
+                )
+                emitAbilityCast(sessionId, ability, mob.name, mob.id.value, targetIsPlayer = false)
+            }
+            else -> {}
+        }
+    }
+
     private suspend fun handleSelfCast(
         sessionId: SessionId,
         player: PlayerState,
         ability: AbilityDefinition,
         now: Long,
     ): String? {
-        when (val effect = ability.effect) {
+        val effects = ability.effect.flatten()
+        for (e in effects) {
+            when (e) {
+                is AbilityEffect.DirectHeal,
+                is AbilityEffect.ApplyStatus,
+                is AbilityEffect.SummonPet,
+                -> {}
+                else -> return "Spell misconfigured (unexpected effect for self target)."
+            }
+        }
+        if (effects.any { it is AbilityEffect.ApplyStatus } && statusEffects == null) {
+            return "Status effects are not available."
+        }
+
+        val playerStats = resolvePlayerStats(player, items, statusEffects, classRegistry)
+        deductManaAndCooldown(sessionId, player, ability, now)
+
+        for (effect in effects) {
+            executeSelfEffect(sessionId, player, ability, effect, playerStats)
+        }
+
+        broadcastToRoom(
+            players,
+            outbound,
+            player.roomId,
+            "${player.name} casts ${ability.displayName}.",
+            exclude = sessionId,
+        )
+        return null
+    }
+
+    private suspend fun executeSelfEffect(
+        sessionId: SessionId,
+        player: PlayerState,
+        ability: AbilityDefinition,
+        effect: AbilityEffect,
+        playerStats: StatMap,
+    ) {
+        when (effect) {
             is AbilityEffect.DirectHeal -> {
-                deductManaAndCooldown(sessionId, player, ability, now)
-                val playerStats = resolvePlayerStats(player, items, statusEffects, classRegistry)
                 val healAmount =
                     computeSpellHeal(bindings, player.level, playerStats, effect.minHeal, effect.maxHeal, rng)
                 val healed = applyHeal(sessionId, player, healAmount, dirtyNotifier)
@@ -243,11 +311,7 @@ class AbilitySystem(
                 outbound.send(OutboundEvent.SendText(sessionId, healText))
             }
             is AbilityEffect.ApplyStatus -> {
-                val sys =
-                    statusEffects
-                        ?: return "Status effects are not available."
-                deductManaAndCooldown(sessionId, player, ability, now)
-                sys.applyToPlayer(sessionId, effect.statusEffectId, sessionId)
+                statusEffects!!.applyToPlayer(sessionId, effect.statusEffectId, sessionId)
                 dirtyNotifier.playerStatusDirty(sessionId)
                 outbound.send(
                     OutboundEvent.SendText(
@@ -258,20 +322,11 @@ class AbilitySystem(
                 emitAbilityCast(sessionId, ability, player.name, null, targetIsPlayer = true)
             }
             is AbilityEffect.SummonPet -> {
-                deductManaAndCooldown(sessionId, player, ability, now)
                 onSummonPet(sessionId, effect.petTemplateKey, effect.durationMs)
                 emitAbilityCast(sessionId, ability, player.name, null, targetIsPlayer = true)
             }
-            else -> return "Spell misconfigured (unexpected effect for self target)."
+            else -> {}
         }
-        broadcastToRoom(
-            players,
-            outbound,
-            player.roomId,
-            "${player.name} casts ${ability.displayName}.",
-            exclude = sessionId,
-        )
-        return null
     }
 
     private suspend fun handleAllyCast(
@@ -306,10 +361,47 @@ class AbilitySystem(
 
         val target = players.get(targetSid) ?: return "Target not found."
 
-        when (val effect = ability.effect) {
+        val effects = ability.effect.flatten()
+        for (e in effects) {
+            when (e) {
+                is AbilityEffect.DirectHeal,
+                is AbilityEffect.ApplyStatus,
+                -> {}
+                else -> return "Spell misconfigured (unexpected effect for ally target)."
+            }
+        }
+        if (effects.any { it is AbilityEffect.ApplyStatus } && statusEffects == null) {
+            return "Status effects are not available."
+        }
+
+        val playerStats = resolvePlayerStats(player, items, statusEffects, classRegistry)
+        deductManaAndCooldown(sessionId, player, ability, now)
+
+        for (effect in effects) {
+            executeAllyEffect(sessionId, player, ability, targetSid, target, effect, playerStats)
+        }
+
+        broadcastToRoom(
+            players,
+            outbound,
+            player.roomId,
+            "${player.name} casts ${ability.displayName}.",
+            exclude = sessionId,
+        )
+        return null
+    }
+
+    private suspend fun executeAllyEffect(
+        sessionId: SessionId,
+        player: PlayerState,
+        ability: AbilityDefinition,
+        targetSid: SessionId,
+        target: PlayerState,
+        effect: AbilityEffect,
+        playerStats: StatMap,
+    ) {
+        when (effect) {
             is AbilityEffect.DirectHeal -> {
-                deductManaAndCooldown(sessionId, player, ability, now)
-                val playerStats = resolvePlayerStats(player, items, statusEffects, classRegistry)
                 val healAmount =
                     computeSpellHeal(bindings, player.level, playerStats, effect.minHeal, effect.maxHeal, rng)
                 val healed = applyHeal(targetSid, target, healAmount, dirtyNotifier)
@@ -344,11 +436,7 @@ class AbilitySystem(
                 }
             }
             is AbilityEffect.ApplyStatus -> {
-                val sys =
-                    statusEffects
-                        ?: return "Status effects are not available."
-                deductManaAndCooldown(sessionId, player, ability, now)
-                sys.applyToPlayer(targetSid, effect.statusEffectId, sessionId)
+                statusEffects!!.applyToPlayer(targetSid, effect.statusEffectId, sessionId)
                 dirtyNotifier.playerStatusDirty(targetSid)
                 if (targetSid == sessionId) {
                     outbound.send(
@@ -373,16 +461,8 @@ class AbilitySystem(
                 }
                 emitAbilityCast(sessionId, ability, target.name, null, targetIsPlayer = (targetSid == sessionId))
             }
-            else -> return "Spell misconfigured (unexpected effect for ally target)."
+            else -> {}
         }
-        broadcastToRoom(
-            players,
-            outbound,
-            player.roomId,
-            "${player.name} casts ${ability.displayName}.",
-            exclude = sessionId,
-        )
-        return null
     }
 
     /**
@@ -400,10 +480,46 @@ class AbilitySystem(
         val pet = pets.getActivePet(sessionId) ?: return "You have no active pet."
         if (pet.roomId != player.roomId) return "${pet.name} is not here."
 
-        when (val effect = ability.effect) {
+        val effects = ability.effect.flatten()
+        for (e in effects) {
+            when (e) {
+                is AbilityEffect.DirectHeal,
+                is AbilityEffect.ApplyStatus,
+                -> {}
+                else -> return "Spell misconfigured (unexpected effect for pet target)."
+            }
+        }
+        if (effects.any { it is AbilityEffect.ApplyStatus } && statusEffects == null) {
+            return "Status effects are not available."
+        }
+
+        val playerStats = resolvePlayerStats(player, items, statusEffects, classRegistry)
+        deductManaAndCooldown(sessionId, player, ability, now)
+
+        for (effect in effects) {
+            executePetEffect(sessionId, player, ability, pet, effect, playerStats)
+        }
+
+        broadcastToRoom(
+            players,
+            outbound,
+            player.roomId,
+            "${player.name} casts ${ability.displayName} on ${pet.name}.",
+            exclude = sessionId,
+        )
+        return null
+    }
+
+    private suspend fun executePetEffect(
+        sessionId: SessionId,
+        player: PlayerState,
+        ability: AbilityDefinition,
+        pet: MobState,
+        effect: AbilityEffect,
+        playerStats: StatMap,
+    ) {
+        when (effect) {
             is AbilityEffect.DirectHeal -> {
-                deductManaAndCooldown(sessionId, player, ability, now)
-                val playerStats = resolvePlayerStats(player, items, statusEffects, classRegistry)
                 val healAmount =
                     computeSpellHeal(bindings, player.level, playerStats, effect.minHeal, effect.maxHeal, rng)
                 val before = pet.hp
@@ -428,9 +544,7 @@ class AbilitySystem(
                 outbound.send(OutboundEvent.SendText(sessionId, petHealText))
             }
             is AbilityEffect.ApplyStatus -> {
-                val sys = statusEffects ?: return "Status effects are not available."
-                deductManaAndCooldown(sessionId, player, ability, now)
-                sys.applyToMob(pet.id, effect.statusEffectId, sessionId)
+                statusEffects!!.applyToMob(pet.id, effect.statusEffectId, sessionId)
                 outbound.send(
                     OutboundEvent.SendText(
                         sessionId,
@@ -439,26 +553,32 @@ class AbilitySystem(
                 )
                 emitAbilityCast(sessionId, ability, pet.name, pet.id.value, targetIsPlayer = false)
             }
-            else -> return "Spell misconfigured (unexpected effect for pet target)."
+            else -> {}
         }
-        broadcastToRoom(
-            players,
-            outbound,
-            player.roomId,
-            "${player.name} casts ${ability.displayName} on ${pet.name}.",
-            exclude = sessionId,
-        )
-        return null
     }
 
-    @Suppress("CyclomaticComplexity", "LongMethod")
+    @Suppress("CyclomaticComplexity", "LongMethod", "ReturnCount")
     private suspend fun handleAllEnemiesCast(
         sessionId: SessionId,
         player: PlayerState,
         ability: AbilityDefinition,
         now: Long,
     ): String? {
+        val effects = ability.effect.flatten()
+        for (e in effects) {
+            when (e) {
+                is AbilityEffect.DirectDamage,
+                is AbilityEffect.AreaDamage,
+                is AbilityEffect.ApplyStatus,
+                -> {}
+                else -> return "Spell misconfigured (unexpected effect for all_enemies target)."
+            }
+        }
         val mobRegistry = mobs ?: return "Area damage is not available."
+        if (effects.any { it is AbilityEffect.ApplyStatus } && statusEffects == null) {
+            return "Status effects are not available."
+        }
+
         val groupMembers =
             groupSystem?.membersInRoom(sessionId, player.roomId)
                 ?: listOf(sessionId)
@@ -474,40 +594,12 @@ class AbilitySystem(
         }
 
         val playerStats = resolvePlayerStats(player, items, statusEffects, classRegistry)
+        deductManaAndCooldown(sessionId, player, ability, now)
 
-        when (val effect = ability.effect) {
-            is AbilityEffect.DirectDamage -> {
-                deductManaAndCooldown(sessionId, player, ability, now)
-                for (m in targetMobs) {
-                    val damage = computeSpellDamage(bindings, player.level, playerStats, effect.damage, rng)
-                    applySpellDamage(sessionId, m, ability, damage)
-                }
-            }
-            is AbilityEffect.AreaDamage -> {
-                deductManaAndCooldown(sessionId, player, ability, now)
-                for (m in targetMobs) {
-                    val damage = computeSpellDamage(bindings, player.level, playerStats, effect.damage, rng)
-                    applySpellDamage(sessionId, m, ability, damage)
-                }
-            }
-            is AbilityEffect.ApplyStatus -> {
-                val sys =
-                    statusEffects
-                        ?: return "Status effects are not available."
-                deductManaAndCooldown(sessionId, player, ability, now)
-                for (m in targetMobs) {
-                    sys.applyToMob(m.id, effect.statusEffectId, sessionId)
-                    emitAbilityCast(sessionId, ability, m.name, m.id.value, targetIsPlayer = false)
-                }
-                outbound.send(
-                    OutboundEvent.SendText(
-                        sessionId,
-                        "Your ${ability.displayName} afflicts all enemies!",
-                    ),
-                )
-            }
-            else -> return "Spell misconfigured (unexpected effect for all_enemies target)."
+        for (effect in effects) {
+            executeAllEnemiesEffect(sessionId, player, ability, targetMobs, effect, playerStats)
         }
+
         broadcastToRoom(
             players,
             outbound,
@@ -518,21 +610,94 @@ class AbilitySystem(
         return null
     }
 
-    @Suppress("CyclomaticComplexity", "LongMethod")
+    private suspend fun executeAllEnemiesEffect(
+        sessionId: SessionId,
+        player: PlayerState,
+        ability: AbilityDefinition,
+        targetMobs: List<MobState>,
+        effect: AbilityEffect,
+        playerStats: StatMap,
+    ) {
+        when (effect) {
+            is AbilityEffect.DirectDamage -> {
+                for (m in targetMobs) {
+                    val damage = computeSpellDamage(bindings, player.level, playerStats, effect.damage, rng)
+                    applySpellDamage(sessionId, m, ability, damage)
+                }
+            }
+            is AbilityEffect.AreaDamage -> {
+                for (m in targetMobs) {
+                    val damage = computeSpellDamage(bindings, player.level, playerStats, effect.damage, rng)
+                    applySpellDamage(sessionId, m, ability, damage)
+                }
+            }
+            is AbilityEffect.ApplyStatus -> {
+                for (m in targetMobs) {
+                    statusEffects!!.applyToMob(m.id, effect.statusEffectId, sessionId)
+                    emitAbilityCast(sessionId, ability, m.name, m.id.value, targetIsPlayer = false)
+                }
+                outbound.send(
+                    OutboundEvent.SendText(
+                        sessionId,
+                        "Your ${ability.displayName} afflicts all enemies!",
+                    ),
+                )
+            }
+            else -> {}
+        }
+    }
+
+    @Suppress("CyclomaticComplexity", "LongMethod", "ReturnCount")
     private suspend fun handleAllAlliesCast(
         sessionId: SessionId,
         player: PlayerState,
         ability: AbilityDefinition,
         now: Long,
     ): String? {
+        val effects = ability.effect.flatten()
+        for (e in effects) {
+            when (e) {
+                is AbilityEffect.DirectHeal,
+                is AbilityEffect.ApplyStatus,
+                -> {}
+                else -> return "Spell misconfigured (unexpected effect for all_allies target)."
+            }
+        }
+        if (effects.any { it is AbilityEffect.ApplyStatus } && statusEffects == null) {
+            return "Status effects are not available."
+        }
+
         val groupMembers =
             groupSystem?.membersInRoom(sessionId, player.roomId)
                 ?: listOf(sessionId)
 
-        when (val effect = ability.effect) {
+        val playerStats = resolvePlayerStats(player, items, statusEffects, classRegistry)
+        deductManaAndCooldown(sessionId, player, ability, now)
+
+        for (effect in effects) {
+            executeAllAlliesEffect(sessionId, player, ability, groupMembers, effect, playerStats)
+        }
+
+        broadcastToRoom(
+            players,
+            outbound,
+            player.roomId,
+            "${player.name} casts ${ability.displayName}!",
+            exclude = sessionId,
+        )
+        return null
+    }
+
+    private suspend fun executeAllAlliesEffect(
+        sessionId: SessionId,
+        player: PlayerState,
+        ability: AbilityDefinition,
+        groupMembers: List<SessionId>,
+        effect: AbilityEffect,
+        playerStats: StatMap,
+    ) {
+        when (effect) {
             is AbilityEffect.DirectHeal -> {
-                deductManaAndCooldown(sessionId, player, ability, now)
-                val playerStats = resolvePlayerStats(player, items, statusEffects, classRegistry)
                 for (targetSid in groupMembers) {
                     val target = players.get(targetSid) ?: continue
                     val healAmount =
@@ -570,12 +735,8 @@ class AbilitySystem(
                 }
             }
             is AbilityEffect.ApplyStatus -> {
-                val sys =
-                    statusEffects
-                        ?: return "Status effects are not available."
-                deductManaAndCooldown(sessionId, player, ability, now)
                 for (targetSid in groupMembers) {
-                    sys.applyToPlayer(targetSid, effect.statusEffectId, sessionId)
+                    statusEffects!!.applyToPlayer(targetSid, effect.statusEffectId, sessionId)
                     dirtyNotifier.playerStatusDirty(targetSid)
                     val targetPlayer = players.get(targetSid)
                     if (targetSid == sessionId) {
@@ -608,16 +769,8 @@ class AbilitySystem(
                     )
                 }
             }
-            else -> return "Spell misconfigured (unexpected effect for all_allies target)."
+            else -> {}
         }
-        broadcastToRoom(
-            players,
-            outbound,
-            player.roomId,
-            "${player.name} casts ${ability.displayName}!",
-            exclude = sessionId,
-        )
-        return null
     }
 
     private suspend fun applySpellDamage(

--- a/src/test/kotlin/dev/ambon/engine/abilities/AbilitySystemCompositeTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/abilities/AbilitySystemCompositeTest.kt
@@ -1,0 +1,258 @@
+package dev.ambon.engine.abilities
+
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.domain.DamageRange
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.mob.MobState
+import dev.ambon.engine.DirtyNotifier
+import dev.ambon.engine.MobRegistry
+import dev.ambon.engine.PlayerRegistry
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.status.StatusEffectDefinition
+import dev.ambon.engine.status.StatusEffectId
+import dev.ambon.engine.status.StatusEffectRegistry
+import dev.ambon.engine.status.StatusEffectSystem
+import dev.ambon.test.AbilityTestFixture
+import dev.ambon.test.MutableClock
+import dev.ambon.test.TEST_ROOM_ID
+import dev.ambon.test.TEST_SESSION_ID
+import dev.ambon.test.drainAll
+import dev.ambon.test.loginOrFail
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.Random
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AbilitySystemCompositeTest {
+    private val roomId = TEST_ROOM_ID
+    private val sid = TEST_SESSION_ID
+
+    @Test
+    fun `composite enemy spell deals damage and applies status with mana deducted once`() =
+        runTest {
+            val h = buildHarness()
+            h.players.loginOrFail(sid, "Caster")
+            h.abilitySystem.syncAbilities(sid, 1)
+            val player = h.players.get(sid)!!
+            player.mana = 20
+
+            val mob = MobState(MobId("zone:rat"), "a rat", roomId, hp = 50, maxHp = 50)
+            h.mobs.upsert(mob)
+            h.outbound.drainAll()
+
+            val err = h.abilitySystem.cast(sid, "fire_bolt", "rat")
+            assertNull(err)
+
+            // Damage applied (5 from DirectDamage)
+            assertEquals(45, mob.hp)
+            // Status applied
+            assertTrue(h.statusEffects.activeMobEffects(mob.id).any { it.id == "ignite" })
+            // Mana deducted ONCE (40% of 20 = 8), not twice
+            assertEquals(12, player.mana)
+
+            val messages =
+                h.outbound
+                    .drainAll()
+                    .filterIsInstance<OutboundEvent.SendText>()
+                    .map { it.text }
+            assertTrue(messages.any { it.contains("Fire Bolt hits a rat for 5 damage") })
+            assertTrue(messages.any { it.contains("Fire Bolt afflicts a rat") })
+        }
+
+    @Test
+    fun `composite self spell heals and applies buff with cooldown set once`() =
+        runTest {
+            val h = buildHarness()
+            h.players.loginOrFail(sid, "Cleric")
+            h.abilitySystem.syncAbilities(sid, 1)
+            val player = h.players.get(sid)!!
+            player.mana = 20
+            player.hp = 5
+            h.outbound.drainAll()
+
+            val err = h.abilitySystem.cast(sid, "blessing", null)
+            assertNull(err)
+
+            assertEquals(10, player.hp)
+            assertTrue(h.statusEffects.activePlayerEffects(sid).any { it.id == "shield" })
+            assertEquals(12, player.mana)
+
+            // Cooldown should be set (single cooldown on the ability, not per sub-effect)
+            val ability = h.registry.findByKeyword("blessing")!!
+            val cdRemaining = h.abilitySystem.cooldownRemainingMs(sid, ability.id)
+            assertTrue(cdRemaining > 0L, "Composite ability should set cooldown")
+        }
+
+    @Test
+    fun `composite with target-incompatible child returns misconfigured error`() =
+        runTest {
+            val h = buildHarness()
+            h.players.loginOrFail(sid, "Caster")
+            h.abilitySystem.syncAbilities(sid, 1)
+            val player = h.players.get(sid)!!
+            player.mana = 20
+
+            val mob = MobState(MobId("zone:rat"), "a rat", roomId, hp = 20, maxHp = 20)
+            h.mobs.upsert(mob)
+
+            // bad_mix targets ENEMY but composes DirectDamage with DirectHeal
+            // (heal is not valid for enemy targets).
+            val err = h.abilitySystem.cast(sid, "bad_mix", "rat")
+            assertNotNull(err)
+            assertTrue(err!!.contains("misconfigured"), "got: $err")
+            // Mana should NOT be deducted on validation failure
+            assertEquals(20, player.mana)
+            // Mob unharmed
+            assertEquals(20, mob.hp)
+        }
+
+    @Test
+    fun `flatten unwraps nested composites`() {
+        val inner = AbilityEffect.Composite(
+            effects = listOf(
+                AbilityEffect.DirectDamage(DamageRange(1, 1)),
+                AbilityEffect.ApplyStatus(StatusEffectId("ignite")),
+            ),
+        )
+        val outer = AbilityEffect.Composite(
+            effects = listOf(
+                inner,
+                AbilityEffect.Taunt(flatThreat = 1.0, margin = 1.0),
+            ),
+        )
+        val flat = outer.flatten()
+        assertEquals(3, flat.size)
+        assertTrue(flat[0] is AbilityEffect.DirectDamage)
+        assertTrue(flat[1] is AbilityEffect.ApplyStatus)
+        assertTrue(flat[2] is AbilityEffect.Taunt)
+    }
+
+    @Test
+    fun `primaryEffectType returns first leaf type for composites`() {
+        val composite = AbilityEffect.Composite(
+            effects = listOf(
+                AbilityEffect.DirectDamage(DamageRange(5, 5)),
+                AbilityEffect.ApplyStatus(StatusEffectId("ignite")),
+            ),
+        )
+        assertEquals("DIRECT_DAMAGE", composite.primaryEffectType())
+        assertEquals("COMPOSITE", composite.toEffectType())
+    }
+
+    private fun buildHarness(
+        clock: MutableClock = MutableClock(0L),
+        rng: Random = Random(42),
+    ): CompositeHarness {
+        val fixture = AbilityTestFixture(roomId = roomId, clock = clock, rng = rng)
+        val statusRegistry = StatusEffectRegistry()
+        statusRegistry.register(
+            StatusEffectDefinition(
+                id = StatusEffectId("ignite"),
+                displayName = "Ignite",
+                effectType = "dot",
+                durationMs = 6000,
+                tickIntervalMs = 2000,
+                tickMinValue = 5,
+                tickMaxValue = 5,
+            ),
+        )
+        statusRegistry.register(
+            StatusEffectDefinition(
+                id = StatusEffectId("shield"),
+                displayName = "Shield",
+                effectType = "shield",
+                durationMs = 30000,
+                shieldAmount = 20,
+                stackBehavior = "none",
+            ),
+        )
+        val statusEffects =
+            StatusEffectSystem(
+                registry = statusRegistry,
+                players = fixture.players,
+                mobs = fixture.mobs,
+                outbound = fixture.outbound,
+                clock = fixture.clock,
+                rng = rng,
+                dirtyNotifier = DirtyNotifier.NO_OP,
+            )
+        val registry = AbilityRegistry()
+        registry.register(
+            AbilityDefinition(
+                id = AbilityId("fire_bolt"),
+                displayName = "Fire Bolt",
+                description = "Hits and burns.",
+                manaCostPct = 40.0,
+                cooldownMs = 0,
+                levelRequired = 1,
+                targetType = "enemy",
+                effect = AbilityEffect.Composite(
+                    effects = listOf(
+                        AbilityEffect.DirectDamage(DamageRange(5, 5)),
+                        AbilityEffect.ApplyStatus(StatusEffectId("ignite")),
+                    ),
+                ),
+            ),
+        )
+        registry.register(
+            AbilityDefinition(
+                id = AbilityId("blessing"),
+                displayName = "Blessing",
+                description = "Heal and shield.",
+                manaCostPct = 40.0,
+                cooldownMs = 5000,
+                levelRequired = 1,
+                targetType = "self",
+                effect = AbilityEffect.Composite(
+                    effects = listOf(
+                        AbilityEffect.DirectHeal(minHeal = 5, maxHeal = 5),
+                        AbilityEffect.ApplyStatus(StatusEffectId("shield")),
+                    ),
+                ),
+            ),
+        )
+        registry.register(
+            AbilityDefinition(
+                id = AbilityId("bad_mix"),
+                displayName = "Bad Mix",
+                description = "Mismatched target/effect.",
+                manaCostPct = 40.0,
+                cooldownMs = 0,
+                levelRequired = 1,
+                targetType = "enemy",
+                effect = AbilityEffect.Composite(
+                    effects = listOf(
+                        AbilityEffect.DirectDamage(DamageRange(5, 5)),
+                        AbilityEffect.DirectHeal(minHeal = 5, maxHeal = 5),
+                    ),
+                ),
+            ),
+        )
+        val abilitySystem = fixture.buildAbilitySystem(
+            registry = registry,
+            statusEffects = statusEffects,
+        )
+        return CompositeHarness(
+            players = fixture.players,
+            mobs = fixture.mobs,
+            outbound = fixture.outbound,
+            abilitySystem = abilitySystem,
+            statusEffects = statusEffects,
+            registry = registry,
+        )
+    }
+
+    private data class CompositeHarness(
+        val players: PlayerRegistry,
+        val mobs: MobRegistry,
+        val outbound: LocalOutboundBus,
+        val abilitySystem: AbilitySystem,
+        val statusEffects: StatusEffectSystem,
+        val registry: AbilityRegistry,
+    )
+}

--- a/src/test/kotlin/dev/ambon/engine/abilities/AbilityVisualLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/abilities/AbilityVisualLoaderTest.kt
@@ -232,4 +232,48 @@ class AbilityVisualLoaderTest {
         )
         assertEquals(0, registry.all().size)
     }
+
+    @Test
+    fun `composite with any unparseable child rejects whole ability`() {
+        // Mixing one valid child with one typo'd child must NOT load a partial
+        // composite — the typo would silently change combat behavior.
+        val registry = AbilityRegistry()
+        AbilityRegistryLoader.load(
+            AbilityEngineConfig(
+                definitions = mapOf(
+                    "typo_dot" to AbilityDefinitionConfig(
+                        targetType = "ENEMY",
+                        effect = AbilityEffectConfig(
+                            type = "COMPOSITE",
+                            effects = listOf(
+                                AbilityEffectConfig(type = "DIRECT_DAMAGE", minDamage = 5, maxDamage = 5),
+                                AbilityEffectConfig(type = "APPLY_STTUS", statusEffectId = "ignite"),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            registry,
+            imagesBaseUrl = "/img/",
+        )
+        assertEquals(0, registry.all().size)
+    }
+
+    @Test
+    fun `composite with empty effects list is skipped`() {
+        val registry = AbilityRegistry()
+        AbilityRegistryLoader.load(
+            AbilityEngineConfig(
+                definitions = mapOf(
+                    "empty" to AbilityDefinitionConfig(
+                        targetType = "ENEMY",
+                        effect = AbilityEffectConfig(type = "COMPOSITE", effects = emptyList()),
+                    ),
+                ),
+            ),
+            registry,
+            imagesBaseUrl = "/img/",
+        )
+        assertEquals(0, registry.all().size)
+    }
 }

--- a/src/test/kotlin/dev/ambon/engine/abilities/AbilityVisualLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/abilities/AbilityVisualLoaderTest.kt
@@ -155,4 +155,81 @@ class AbilityVisualLoaderTest {
         )
         assertEquals(AbilityVisualArchetype.RANGED_PROJECTILE, a.visual.archetype)
     }
+
+    @Test
+    fun `composite parses children and derives visual from first child`() {
+        val a = load(
+            "fire_bolt_dot",
+            AbilityDefinitionConfig(
+                targetType = "ENEMY",
+                requiredClass = "MAGE",
+                effect = AbilityEffectConfig(
+                    type = "COMPOSITE",
+                    effects = listOf(
+                        AbilityEffectConfig(type = "DIRECT_DAMAGE", minDamage = 4, maxDamage = 8),
+                        AbilityEffectConfig(type = "APPLY_STATUS", statusEffectId = "ignite"),
+                    ),
+                ),
+            ),
+        )
+        val composite = a.effect as AbilityEffect.Composite
+        assertEquals(2, composite.effects.size)
+        assertEquals(AbilityEffect.DirectDamage::class, composite.effects[0]::class)
+        assertEquals(AbilityEffect.ApplyStatus::class, composite.effects[1]::class)
+        // First child is DirectDamage on mage → RANGED_PROJECTILE.
+        assertEquals(AbilityVisualArchetype.RANGED_PROJECTILE, a.visual.archetype)
+        assertEquals("DIRECT_DAMAGE", a.effect.primaryEffectType())
+    }
+
+    @Test
+    fun `composite flattens nested children`() {
+        val a = load(
+            "nested",
+            AbilityDefinitionConfig(
+                targetType = "ENEMY",
+                requiredClass = "MAGE",
+                effect = AbilityEffectConfig(
+                    type = "COMPOSITE",
+                    effects = listOf(
+                        AbilityEffectConfig(
+                            type = "COMPOSITE",
+                            effects = listOf(
+                                AbilityEffectConfig(type = "DIRECT_DAMAGE", minDamage = 1, maxDamage = 1),
+                                AbilityEffectConfig(type = "APPLY_STATUS", statusEffectId = "ignite"),
+                            ),
+                        ),
+                        AbilityEffectConfig(type = "AREA_DAMAGE", minDamage = 2, maxDamage = 2),
+                    ),
+                ),
+            ),
+        )
+        val flat = a.effect.flatten()
+        assertEquals(3, flat.size)
+        assertEquals(AbilityEffect.DirectDamage::class, flat[0]::class)
+        assertEquals(AbilityEffect.ApplyStatus::class, flat[1]::class)
+        assertEquals(AbilityEffect.AreaDamage::class, flat[2]::class)
+    }
+
+    @Test
+    fun `composite with only unknown child types is skipped`() {
+        val registry = AbilityRegistry()
+        AbilityRegistryLoader.load(
+            AbilityEngineConfig(
+                definitions = mapOf(
+                    "junk" to AbilityDefinitionConfig(
+                        targetType = "ENEMY",
+                        effect = AbilityEffectConfig(
+                            type = "COMPOSITE",
+                            effects = listOf(
+                                AbilityEffectConfig(type = "NOT_A_REAL_TYPE"),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            registry,
+            imagesBaseUrl = "/img/",
+        )
+        assertEquals(0, registry.all().size)
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `AbilityEffect.Composite(effects)` so a single ability can stack effects against the same target (e.g. damage + apply DoT, heal + apply buff).
- The ability pays mana and cooldown **once**; children execute in declaration order. Each cast handler validates all children for the target type and pre-checks dependencies before mana is deducted.
- YAML: set `effect.type: COMPOSITE` and supply a nested `effect.effects: [...]` list. Nested composites are flattened by the runtime.
- GMCP serializes the primary (first leaf) effect type via the new `primaryEffectType()` so the web client keeps categorizing composites naturally (a "fireball + burn" still styles as `DIRECT_DAMAGE`).

## What changed
- `AbilityDefinition.kt` — new `Composite` variant + `flatten()` and `primaryEffectType()` helpers; visual-archetype derivation delegates to the first child.
- `AbilityRegistryLoader.kt` — extracted `parseEffect()` and added `COMPOSITE` branch (recursive).
- `AppConfig.AbilityEffectConfig` — added `effects: List<AbilityEffectConfig>` field.
- `AbilitySystem.kt` — each of the 6 cast handlers (`enemy`, `self`, `ally`, `pet`, `all_enemies`, `all_allies`) now flattens the effect, validates compatibility up front, deducts mana once, and dispatches per-effect via extracted `execute<Target>Effect` helpers.
- `GmcpEmitter.kt` — swap `toEffectType()` → `primaryEffectType()` for skill payloads.

## Test plan
- [x] `./gradlew ktlintCheck` — clean.
- [x] `./gradlew test` — full suite passes, including new `AbilitySystemCompositeTest` covering: damage+status on an enemy with mana deducted once, heal+buff on self with single cooldown, validation rejection of mismatched target/effect combos, nested-composite flattening, and `primaryEffectType`.
- [ ] Author a sample composite ability in YAML and cast it in `./gradlew demo` to sanity-check the end-to-end path.