### PR TITLE
feat(effects): scale DoT/HoT ticks with caster level + stat

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -1194,12 +1194,22 @@ class CombatSystem(
             )
         }
 
-        // Apply status effect
+        // Apply status effect — mob is the caster; pass mob level so DOT/HOT
+        // ticks scale with mob power. Mobs have no stat bonus, so casterStats is
+        // omitted (the snapshot falls back to BASE_STAT).
         if (spell.statusEffectId != null && statusEffects != null) {
             if (isOffensive) {
-                statusEffects.applyToPlayer(targetSid, spell.statusEffectId)
+                statusEffects.applyToPlayer(
+                    sessionId = targetSid,
+                    effectId = spell.statusEffectId,
+                    casterLevel = mob.level,
+                )
             } else {
-                statusEffects.applyToMob(mob.id, spell.statusEffectId)
+                statusEffects.applyToMob(
+                    mobId = mob.id,
+                    effectId = spell.statusEffectId,
+                    casterLevel = mob.level,
+                )
             }
         }
     }
@@ -1479,7 +1489,15 @@ class CombatSystem(
         }
 
         if (skill.statusEffectId != null && statusEffects != null) {
-            statusEffects.applyToMob(target.id, skill.statusEffectId, threatSid)
+            // Pet is the caster — pet skills already scale via the pet's
+            // damage budget on the authored roll, so we scale the DOT/HOT tick
+            // off the pet's level for consistency. No stat bonus.
+            statusEffects.applyToMob(
+                mobId = target.id,
+                effectId = skill.statusEffectId,
+                sourceSessionId = threatSid,
+                casterLevel = pet.level,
+            )
         }
 
         // Threat: damage portion uses pet's threat multiplier (tank pets hold aggro);

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -637,6 +637,7 @@ class GameEngine(
             clock = clock,
             dirtyNotifier = dirtyNotifier,
             effectTypes = engineConfig.effectTypes,
+            bindings = engineConfig.stats.bindings,
         )
     private val groupSystem: GroupSystem =
         GroupSystem(

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
@@ -231,7 +231,13 @@ class AbilitySystem(
                 emitAbilityCast(sessionId, ability, mob.name, mob.id.value, targetIsPlayer = false)
             }
             is AbilityEffect.ApplyStatus -> {
-                statusEffects!!.applyToMob(mob.id, effect.statusEffectId, sessionId)
+                statusEffects!!.applyToMob(
+                    mobId = mob.id,
+                    effectId = effect.statusEffectId,
+                    sourceSessionId = sessionId,
+                    casterLevel = player.level,
+                    casterStats = playerStats,
+                )
                 outbound.send(
                     OutboundEvent.SendText(
                         sessionId,
@@ -311,7 +317,13 @@ class AbilitySystem(
                 outbound.send(OutboundEvent.SendText(sessionId, healText))
             }
             is AbilityEffect.ApplyStatus -> {
-                statusEffects!!.applyToPlayer(sessionId, effect.statusEffectId, sessionId)
+                statusEffects!!.applyToPlayer(
+                    sessionId = sessionId,
+                    effectId = effect.statusEffectId,
+                    sourceSessionId = sessionId,
+                    casterLevel = player.level,
+                    casterStats = playerStats,
+                )
                 dirtyNotifier.playerStatusDirty(sessionId)
                 outbound.send(
                     OutboundEvent.SendText(
@@ -436,7 +448,13 @@ class AbilitySystem(
                 }
             }
             is AbilityEffect.ApplyStatus -> {
-                statusEffects!!.applyToPlayer(targetSid, effect.statusEffectId, sessionId)
+                statusEffects!!.applyToPlayer(
+                    sessionId = targetSid,
+                    effectId = effect.statusEffectId,
+                    sourceSessionId = sessionId,
+                    casterLevel = player.level,
+                    casterStats = playerStats,
+                )
                 dirtyNotifier.playerStatusDirty(targetSid)
                 if (targetSid == sessionId) {
                     outbound.send(
@@ -544,7 +562,13 @@ class AbilitySystem(
                 outbound.send(OutboundEvent.SendText(sessionId, petHealText))
             }
             is AbilityEffect.ApplyStatus -> {
-                statusEffects!!.applyToMob(pet.id, effect.statusEffectId, sessionId)
+                statusEffects!!.applyToMob(
+                    mobId = pet.id,
+                    effectId = effect.statusEffectId,
+                    sourceSessionId = sessionId,
+                    casterLevel = player.level,
+                    casterStats = playerStats,
+                )
                 outbound.send(
                     OutboundEvent.SendText(
                         sessionId,
@@ -633,7 +657,13 @@ class AbilitySystem(
             }
             is AbilityEffect.ApplyStatus -> {
                 for (m in targetMobs) {
-                    statusEffects!!.applyToMob(m.id, effect.statusEffectId, sessionId)
+                    statusEffects!!.applyToMob(
+                        mobId = m.id,
+                        effectId = effect.statusEffectId,
+                        sourceSessionId = sessionId,
+                        casterLevel = player.level,
+                        casterStats = playerStats,
+                    )
                     emitAbilityCast(sessionId, ability, m.name, m.id.value, targetIsPlayer = false)
                 }
                 outbound.send(
@@ -736,7 +766,13 @@ class AbilitySystem(
             }
             is AbilityEffect.ApplyStatus -> {
                 for (targetSid in groupMembers) {
-                    statusEffects!!.applyToPlayer(targetSid, effect.statusEffectId, sessionId)
+                    statusEffects!!.applyToPlayer(
+                        sessionId = targetSid,
+                        effectId = effect.statusEffectId,
+                        sourceSessionId = sessionId,
+                        casterLevel = player.level,
+                        casterStats = playerStats,
+                    )
                     dirtyNotifier.playerStatusDirty(targetSid)
                     val targetPlayer = players.get(targetSid)
                     if (targetSid == sessionId) {

--- a/src/main/kotlin/dev/ambon/engine/status/ActiveEffect.kt
+++ b/src/main/kotlin/dev/ambon/engine/status/ActiveEffect.kt
@@ -9,6 +9,17 @@ data class ActiveEffect(
     var lastTickAtMs: Long,
     val sourceSessionId: SessionId?,
     var shieldRemaining: Int = 0,
+    /**
+     * Snapshot of the scaled per-tick value computed at apply time from the
+     * caster's level + relevant stat using the same shape as direct
+     * spell/heal damage. Null when no caster context was provided (e.g.
+     * environmental or admin-applied effects); the tick loop then falls
+     * back to rolling the authored `tickMinValue`..`tickMaxValue` range.
+     *
+     * Variance is applied per-tick (not snapshotted) so each tick still
+     * rolls a fresh spread.
+     */
+    val tickAnchor: Double? = null,
 )
 
 /** Immutable snapshot for display / GMCP. */

--- a/src/main/kotlin/dev/ambon/engine/status/StatusEffectSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/status/StatusEffectSystem.kt
@@ -159,10 +159,14 @@ class StatusEffectSystem(
         anchor: Double?,
     ): Int {
         if (anchor == null) return rollRange(rng, def.tickMinValue, def.tickMaxValue)
-        // Reuse the same variance window as direct spell damage so DOT/HOT
-        // roll-to-roll spread matches a comparable direct spell.
-        val varianceMin = bindings.spellVarianceMin
-        val varianceMax = bindings.spellVarianceMax
+        // Match the variance window of the comparable direct spell — DOTs use
+        // spell variance, HOTs use heal variance — so roll-to-roll spread stays
+        // consistent with the direct-cast equivalent.
+        val typeConfig = effectTypes.get(def.effectType)
+        val (varianceMin, varianceMax) = when {
+            typeConfig?.ticksHealing == true -> bindings.healVarianceMin to bindings.healVarianceMax
+            else -> bindings.spellVarianceMin to bindings.spellVarianceMax
+        }
         val span = varianceMax - varianceMin
         val variance = if (span <= 0.0) varianceMin else varianceMin + rng.nextDouble() * span
         return (anchor * variance).roundToInt().coerceAtLeast(1)

--- a/src/main/kotlin/dev/ambon/engine/status/StatusEffectSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/status/StatusEffectSystem.kt
@@ -2,6 +2,7 @@ package dev.ambon.engine.status
 
 import dev.ambon.bus.OutboundBus
 import dev.ambon.config.EffectTypesConfig
+import dev.ambon.config.StatBindingsConfig
 import dev.ambon.domain.StatMap
 import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.SessionId
@@ -9,6 +10,7 @@ import dev.ambon.engine.DirtyNotifier
 import dev.ambon.engine.GameSystem
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PlayerRegistry
+import dev.ambon.engine.PlayerState
 import dev.ambon.engine.applyHeal
 import dev.ambon.engine.events.CombatEvent
 import dev.ambon.engine.events.OutboundEvent
@@ -17,6 +19,8 @@ import dev.ambon.engine.rollRange
 import dev.ambon.engine.takeDamage
 import java.time.Clock
 import java.util.Random
+import kotlin.math.pow
+import kotlin.math.roundToInt
 
 class StatusEffectSystem(
     private val registry: StatusEffectRegistry,
@@ -27,6 +31,7 @@ class StatusEffectSystem(
     private val rng: Random = Random(),
     private val dirtyNotifier: DirtyNotifier = DirtyNotifier.NO_OP,
     private val effectTypes: EffectTypesConfig = EffectTypesConfig(),
+    private val bindings: StatBindingsConfig = StatBindingsConfig(),
 ) : GameSystem {
     /** Callback for combat events (DOT/HOT ticks); wired by GameEngine after construction. */
     var onCombatEvent: suspend (SessionId, CombatEvent) -> Unit = { _, _ -> }
@@ -39,14 +44,18 @@ class StatusEffectSystem(
         sessionId: SessionId,
         effectId: StatusEffectId,
         sourceSessionId: SessionId? = null,
-    ): Boolean = applyTo(playerEffects, sessionId, effectId, sourceSessionId)
+        casterLevel: Int? = null,
+        casterStats: StatMap? = null,
+    ): Boolean = applyTo(playerEffects, sessionId, effectId, sourceSessionId, casterLevel, casterStats)
 
     fun applyToMob(
         mobId: MobId,
         effectId: StatusEffectId,
         sourceSessionId: SessionId? = null,
+        casterLevel: Int? = null,
+        casterStats: StatMap? = null,
     ): Boolean {
-        val applied = applyTo(mobEffects, mobId, effectId, sourceSessionId)
+        val applied = applyTo(mobEffects, mobId, effectId, sourceSessionId, casterLevel, casterStats)
         if (applied) dirtyNotifier.mobHpDirty(mobId)
         return applied
     }
@@ -56,11 +65,13 @@ class StatusEffectSystem(
         key: K,
         effectId: StatusEffectId,
         sourceSessionId: SessionId?,
+        casterLevel: Int?,
+        casterStats: StatMap?,
     ): Boolean {
         val def = registry.get(effectId) ?: return false
         val now = clock.millis()
         val list = map.getOrPut(key) { mutableListOf() }
-        return applyEffect(list, def, now, sourceSessionId)
+        return applyEffect(list, def, now, sourceSessionId, casterLevel, casterStats)
     }
 
     private fun applyEffect(
@@ -68,6 +79,8 @@ class StatusEffectSystem(
         def: StatusEffectDefinition,
         now: Long,
         sourceSessionId: SessionId?,
+        casterLevel: Int?,
+        casterStats: StatMap?,
     ): Boolean {
         val existing = list.filter { it.definitionId == def.id }
         val effectiveMaxStacks = def.maxStacks.coerceAtLeast(1)
@@ -100,9 +113,59 @@ class StatusEffectSystem(
                 lastTickAtMs = now,
                 sourceSessionId = sourceSessionId,
                 shieldRemaining = def.shieldAmount,
+                tickAnchor = computeTickAnchor(def, casterLevel, casterStats),
             ),
         )
         return true
+    }
+
+    /**
+     * Snapshots a scaled per-tick anchor for damage/heal-over-time effects using
+     * the same shape as direct spell/heal damage:
+     *
+     *   anchor     = (tickMinValue + tickMaxValue) / 2
+     *   statBonus  = (stats[stat] - BASE_STAT) × statMultiplier
+     *   levelScale = levelScalingRate ^ (level - 1)
+     *   tickAnchor = (anchor + statBonus) × levelScale
+     *
+     * Variance is applied per-tick, not snapshotted, so each tick still rolls a
+     * fresh spread. Returns null when the effect doesn't tick damage/healing,
+     * when no caster context was provided, or when the authored range is zero
+     * (nothing to scale) — in which case the tick loop falls back to rolling
+     * the authored range directly.
+     */
+    private fun computeTickAnchor(
+        def: StatusEffectDefinition,
+        casterLevel: Int?,
+        casterStats: StatMap?,
+    ): Double? {
+        if (casterLevel == null) return null
+        if (def.tickIntervalMs <= 0L) return null
+        val typeConfig = effectTypes.get(def.effectType) ?: return null
+        val (statKey, statMul, rate) = when {
+            typeConfig.ticksDamage -> Triple(bindings.spellDamageStat, bindings.spellStatMultiplier, bindings.spellLevelScalingRate)
+            typeConfig.ticksHealing -> Triple(bindings.healStat, bindings.healStatMultiplier, bindings.healLevelScalingRate)
+            else -> return null
+        }
+        val anchor = (def.tickMinValue + def.tickMaxValue) / 2.0
+        val statTotal = casterStats?.get(statKey) ?: PlayerState.BASE_STAT
+        val statBonus = (statTotal - PlayerState.BASE_STAT) * statMul
+        val levelScale = rate.pow((casterLevel - 1).coerceAtLeast(0))
+        return (anchor + statBonus) * levelScale
+    }
+
+    private fun rollTickValue(
+        def: StatusEffectDefinition,
+        anchor: Double?,
+    ): Int {
+        if (anchor == null) return rollRange(rng, def.tickMinValue, def.tickMaxValue)
+        // Reuse the same variance window as direct spell damage so DOT/HOT
+        // roll-to-roll spread matches a comparable direct spell.
+        val varianceMin = bindings.spellVarianceMin
+        val varianceMax = bindings.spellVarianceMax
+        val span = varianceMax - varianceMin
+        val variance = if (span <= 0.0) varianceMin else varianceMin + rng.nextDouble() * span
+        return (anchor * variance).roundToInt().coerceAtLeast(1)
     }
 
     // ── Tick ───────────────────────────────────────────────────────────
@@ -171,7 +234,7 @@ class StatusEffectSystem(
                 // Tick DOT/HOT
                 if (def.tickIntervalMs > 0 && nowMs - effect.lastTickAtMs >= def.tickIntervalMs) {
                     effect.lastTickAtMs = nowMs
-                    val value = rollRange(rng, def.tickMinValue, def.tickMaxValue)
+                    val value = rollTickValue(def, effect.tickAnchor)
                     if (typeConfig?.ticksDamage == true) {
                         player.takeDamage(value)
                         dirtyNotifier.playerVitalsDirty(sessionId)
@@ -222,7 +285,7 @@ class StatusEffectSystem(
                     nowMs - effect.lastTickAtMs >= def.tickIntervalMs
                 ) {
                     effect.lastTickAtMs = nowMs
-                    val value = rollRange(rng, def.tickMinValue, def.tickMaxValue)
+                    val value = rollTickValue(def, effect.tickAnchor)
                     mob.takeDamage(value)
                     dirtyNotifier.mobHpDirty(mobId)
                     val source = effect.sourceSessionId

--- a/src/test/kotlin/dev/ambon/engine/status/StatusEffectScalingTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/status/StatusEffectScalingTest.kt
@@ -1,0 +1,214 @@
+package dev.ambon.engine.status
+
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.config.StatBindingsConfig
+import dev.ambon.domain.StatMap
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.engine.MobRegistry
+import dev.ambon.engine.PlayerRegistry
+import dev.ambon.engine.PlayerState
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.MutableClock
+import dev.ambon.test.TEST_ROOM_ID
+import dev.ambon.test.TEST_SESSION_ID
+import dev.ambon.test.TestFixtureBase
+import dev.ambon.test.buildTestPlayerRegistry
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.Random
+import kotlin.math.pow
+import kotlin.math.roundToInt
+
+/**
+ * Proves DOT/HOT tick values scale with caster level + relevant stat using
+ * the same formula as direct spell/heal damage, and that omitting the caster
+ * context falls back to the authored range (backward compatibility).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class StatusEffectScalingTest {
+    private val sid = TEST_SESSION_ID
+    private val mobId = MobId("zone:goblin")
+
+    /** Variance fixed at 1.0 so tick values are fully deterministic. */
+    private val bindings =
+        StatBindingsConfig(
+            spellDamageStat = "INT",
+            spellStatMultiplier = 1.0,
+            spellLevelScalingRate = 1.30,
+            spellVarianceMin = 1.0,
+            spellVarianceMax = 1.0,
+            healStat = "WIS",
+            healStatMultiplier = 1.0,
+            healLevelScalingRate = 1.30,
+            healVarianceMin = 1.0,
+            healVarianceMax = 1.0,
+        )
+
+    private inner class Fixture : TestFixtureBase {
+        val clock = MutableClock(0L)
+        val items = ItemRegistry()
+        val repo = InMemoryPlayerRepository()
+        override val roomId: RoomId = TEST_ROOM_ID
+        override val players: PlayerRegistry = buildTestPlayerRegistry(roomId, repo, items, clock = clock)
+        override val mobs = MobRegistry()
+        val outbound = LocalOutboundBus()
+        val registry = StatusEffectRegistry()
+        val system =
+            StatusEffectSystem(
+                registry = registry,
+                players = players,
+                mobs = mobs,
+                outbound = outbound,
+                clock = clock,
+                rng = Random(42),
+                bindings = bindings,
+            )
+
+        fun login() {
+            runBlocking { players.login(sid, "Caster", "pass", defaultAnsiEnabled = false) }
+        }
+
+        fun registerDot(min: Int = 5, max: Int = 5) {
+            registry.register(
+                StatusEffectDefinition(
+                    id = StatusEffectId("ignite"),
+                    displayName = "Ignite",
+                    effectType = "dot",
+                    durationMs = 6000,
+                    tickIntervalMs = 2000,
+                    tickMinValue = min,
+                    tickMaxValue = max,
+                ),
+            )
+        }
+
+        fun registerHot(min: Int = 3, max: Int = 3) {
+            registry.register(
+                StatusEffectDefinition(
+                    id = StatusEffectId("rejuv"),
+                    displayName = "Rejuvenation",
+                    effectType = "hot",
+                    durationMs = 6000,
+                    tickIntervalMs = 2000,
+                    tickMinValue = min,
+                    tickMaxValue = max,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `DOT tick scales with caster level`() =
+        runTest {
+            val h = Fixture()
+            h.login()
+            val mob = h.spawnMob(id = mobId, name = "Dummy", hp = 5000)
+            h.registerDot(min = 10, max = 10)
+
+            // Level 10 caster, no stat bonus (casterStats omitted, like a mob caster)
+            // → anchor = 10 × 1.30^9 ≈ 106
+            val expected = (10.0 * 1.30.pow(9)).roundToInt()
+            h.system.applyToMob(
+                mobId = mobId,
+                effectId = StatusEffectId("ignite"),
+                casterLevel = 10,
+            )
+            h.clock.advance(2000)
+            h.system.tick(h.clock.millis())
+
+            assertEquals(5000 - expected, mob.hp, "DOT tick should scale with level")
+        }
+
+    @Test
+    fun `DOT tick scales with caster spell-damage stat`() =
+        runTest {
+            val h = Fixture()
+            h.login()
+            val mob = h.spawnMob(id = mobId, name = "Dummy", hp = 5000)
+            h.registerDot(min = 10, max = 10)
+
+            // Level 1, INT = BASE + 20 → anchor = (10 + 20×1.0) × 1.0 = 30
+            val intBonus = 20
+            val expected = (10.0 + intBonus * 1.0).roundToInt()
+            h.system.applyToMob(
+                mobId = mobId,
+                effectId = StatusEffectId("ignite"),
+                casterLevel = 1,
+                casterStats = StatMap.of("INT" to PlayerState.BASE_STAT + intBonus),
+            )
+            h.clock.advance(2000)
+            h.system.tick(h.clock.millis())
+
+            assertEquals(5000 - expected, mob.hp, "DOT tick should scale with INT")
+        }
+
+    @Test
+    fun `HOT tick scales with caster level and WIS`() =
+        runTest {
+            val h = Fixture()
+            h.login()
+            val player = h.players.get(sid)!!
+            player.maxHp = 100_000
+            player.hp = 1
+            h.registerHot(min = 4, max = 4)
+
+            // Level 5, WIS = BASE + 6 → anchor = (4 + 6×1.0) × 1.30^4 ≈ 28.561
+            val wisBonus = 6
+            val expected = ((4.0 + wisBonus * 1.0) * 1.30.pow(4)).roundToInt()
+            h.system.applyToPlayer(
+                sessionId = sid,
+                effectId = StatusEffectId("rejuv"),
+                casterLevel = 5,
+                casterStats = StatMap.of("WIS" to PlayerState.BASE_STAT + wisBonus),
+            )
+            h.clock.advance(2000)
+            h.system.tick(h.clock.millis())
+
+            assertEquals(1 + expected, player.hp, "HOT tick should scale with level + WIS")
+        }
+
+    @Test
+    fun `omitting caster context falls back to authored range`() =
+        runTest {
+            val h = Fixture()
+            h.login()
+            val mob = h.spawnMob(id = mobId, name = "Dummy", hp = 100)
+            h.registerDot(min = 5, max = 5)
+
+            // No casterLevel passed → tickAnchor is null → uses authored rollRange(5, 5) = 5
+            h.system.applyToMob(mobId = mobId, effectId = StatusEffectId("ignite"))
+            h.clock.advance(2000)
+            h.system.tick(h.clock.millis())
+
+            assertEquals(95, mob.hp, "Without caster context, DOT should use authored range")
+        }
+
+    @Test
+    fun `snapshot is taken at apply time and does not change mid-duration`() =
+        runTest {
+            val h = Fixture()
+            h.login()
+            val mob = h.spawnMob(id = mobId, name = "Dummy", hp = 100_000)
+            h.registerDot(min = 10, max = 10)
+
+            h.system.applyToMob(
+                mobId = mobId,
+                effectId = StatusEffectId("ignite"),
+                casterLevel = 1,
+            )
+            // Tick at 2s — level 1, anchor 10
+            h.clock.advance(2000)
+            h.system.tick(h.clock.millis())
+            // Tick at 4s — same snapshot, still 10
+            h.clock.advance(2000)
+            h.system.tick(h.clock.millis())
+
+            assertTrue(mob.hp == 100_000 - 20, "Both ticks should use level-1 snapshot (10 each)")
+        }
+}

--- a/src/test/kotlin/dev/ambon/engine/status/StatusEffectScalingTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/status/StatusEffectScalingTest.kt
@@ -211,4 +211,47 @@ class StatusEffectScalingTest {
 
             assertTrue(mob.hp == 100_000 - 20, "Both ticks should use level-1 snapshot (10 each)")
         }
+
+    @Test
+    fun `HOT tick uses heal variance, not spell variance`() =
+        runTest {
+            // Heal variance is locked to 2.0× while spell variance is 1.0× — the
+            // tick must follow the heal binding, otherwise HOT roll-to-roll
+            // spread silently drifts from direct heals.
+            val healVarianceBindings =
+                bindings.copy(
+                    spellVarianceMin = 1.0,
+                    spellVarianceMax = 1.0,
+                    healVarianceMin = 2.0,
+                    healVarianceMax = 2.0,
+                )
+            val h = Fixture()
+            // Rebuild the system with the variance-skewed bindings.
+            val skewedSystem =
+                StatusEffectSystem(
+                    registry = h.registry,
+                    players = h.players,
+                    mobs = h.mobs,
+                    outbound = h.outbound,
+                    clock = h.clock,
+                    rng = Random(42),
+                    bindings = healVarianceBindings,
+                )
+            h.login()
+            val player = h.players.get(sid)!!
+            player.maxHp = 100_000
+            player.hp = 1
+            h.registerHot(min = 4, max = 4)
+
+            // Level 1, no stat bonus → anchor = 4. Heal variance 2.0× → tick = 8.
+            skewedSystem.applyToPlayer(
+                sessionId = sid,
+                effectId = StatusEffectId("rejuv"),
+                casterLevel = 1,
+            )
+            h.clock.advance(2000)
+            skewedSystem.tick(h.clock.millis())
+
+            assertEquals(1 + 8, player.hp, "HOT should roll with heal variance window")
+        }
 }


### PR DESCRIPTION
## Summary

- DoT/HoT ticks previously rolled a flat authored range regardless of caster, leaving them trivial at endgame while direct spells/heals scaled with level + stat. Now they snapshot a scaled per-tick anchor at apply time using the same formula as direct spell/heal damage.
- DoTs scale on the spell bindings (INT, `spellLevelScalingRate`, `spellStatMultiplier`); HoTs scale on the heal bindings (WIS, `healLevelScalingRate`, `healStatMultiplier`). Variance is still applied per-tick.
- Snapshot is taken at apply time (not live) — `refresh`/`stack` interactions stay predictable and the source caster disconnecting doesn't break anything.
- Caster context is optional — `applyToPlayer`/`applyToMob` calls without it (environmental/admin) fall back to rolling the authored range, so existing behavior is preserved.
- AbilitySystem passes `player.level` + resolved stats at all 6 call sites. CombatSystem mob/pet sites pass `mob.level` / `pet.level` with no stat bonus.

## Test plan

- [x] `./gradlew ktlintCheck test` — green
- [x] New `StatusEffectScalingTest` covers: level scaling, stat scaling, HoT (WIS + level), authored-range fallback, snapshot invariance across ticks
- [x] Existing `StatusEffectSystemTest` + `AbilitySystemTest` + `AbilitySystemCompositeTest` still pass unchanged