### PR TITLE
feat(text-ui): show quest/dialogue/aggro markers on mob list

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -5,6 +5,7 @@ import dev.ambon.domain.ids.ItemId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.ids.qualifyId
+import dev.ambon.domain.mob.MobState
 import dev.ambon.domain.puzzle.PuzzleType
 import dev.ambon.domain.world.Direction
 import dev.ambon.domain.world.LockableState
@@ -248,6 +249,34 @@ internal suspend fun EngineContext.emitStylistGmcp(sessionId: SessionId) {
     }
 }
 
+/**
+ * Builds the inline status markers shown after a mob's name in the "You see:"
+ * line. The web client already paints these states on the canvas via GMCP; this
+ * brings parity to telnet / text clients.
+ *
+ * Marker precedence for quest state: turn-in beats accept-available beats
+ * dialogue (so the player always sees the most actionable hint). The aggro
+ * marker is independent and appended after.
+ *
+ * Each marker is wrapped in a `{c:NAME}…{/c}` color tag so [AnsiRenderer]
+ * lights it up on color-capable terminals while [PlainRenderer] strips the
+ * tags cleanly.
+ */
+internal fun mobMarkers(
+    mob: MobState,
+    hasQuestAvailable: Boolean,
+    hasQuestTurnIn: Boolean,
+): String {
+    val parts = mutableListOf<String>()
+    when {
+        hasQuestTurnIn -> parts.add("{c:turnin}(?){/c}")
+        hasQuestAvailable -> parts.add("{c:quest}(!){/c}")
+        mob.dialogue != null -> parts.add("{c:dialogue}(*){/c}")
+    }
+    if (mob.aggressive) parts.add("{c:aggro}[A]{/c}")
+    return parts.joinToString(" ")
+}
+
 /** Sends a full room description (title, description, exits, items, resources, players, mobs) to [sessionId]. */
 internal suspend fun sendLook(
     sessionId: SessionId,
@@ -343,10 +372,20 @@ internal suspend fun sendLook(
             }.sorted()
 
     val rawRoomMobs = mobs.mobsInRoom(roomId)
+    val mobIds = rawRoomMobs.map { it.id.value }
+    val questAvailable = questSystem?.questAvailableMobIds(sessionId, mobIds) ?: emptySet()
+    val questComplete = questSystem?.questCompleteMobIds(sessionId, mobIds) ?: emptySet()
     val roomMobs =
         rawRoomMobs
-            .map { it.name }
-            .sorted()
+            .sortedBy { it.name }
+            .map { mob ->
+                val markers = mobMarkers(
+                    mob = mob,
+                    hasQuestAvailable = mob.id.value in questAvailable,
+                    hasQuestTurnIn = mob.id.value in questComplete,
+                )
+                if (markers.isEmpty()) mob.name else "${mob.name} $markers"
+            }
 
     outbound.send(
         OutboundEvent.SendInfo(
@@ -385,9 +424,6 @@ internal suspend fun sendLook(
     )
     gmcpEmitter?.sendRoomPlayers(sessionId, rawRoomPlayers)
     gmcpEmitter?.sendRoomMobs(sessionId, rawRoomMobs)
-    val mobIds = rawRoomMobs.map { it.id.value }
-    val questAvailable = questSystem?.questAvailableMobIds(sessionId, mobIds) ?: emptySet()
-    val questComplete = questSystem?.questCompleteMobIds(sessionId, mobIds) ?: emptySet()
     gmcpEmitter?.sendRoomMobInfo(
         sessionId,
         gmcpEmitter.buildMobInfoEntries(

--- a/src/main/kotlin/dev/ambon/transport/AnsiRenderer.kt
+++ b/src/main/kotlin/dev/ambon/transport/AnsiRenderer.kt
@@ -20,7 +20,7 @@ class AnsiRenderer : TextRenderer {
             }
         return buildString {
             append(prefix)
-            append(text.normalizeToCrlf())
+            append(ColorTags.applyAnsi(text, prefix).normalizeToCrlf())
             append(reset)
             append("\r\n")
         }

--- a/src/main/kotlin/dev/ambon/transport/ColorTags.kt
+++ b/src/main/kotlin/dev/ambon/transport/ColorTags.kt
@@ -1,0 +1,36 @@
+package dev.ambon.transport
+
+/**
+ * Inline color-tag convention for engine-emitted text. Engine code wraps a
+ * span in `{c:NAME}…{/c}` to mark it as semantically colored; the active
+ * [TextRenderer] decides whether to translate the tags to ANSI escapes or
+ * strip them out.
+ *
+ * Keeping the markup transport-agnostic preserves the engine boundary —
+ * gameplay code never embeds ANSI codes directly.
+ */
+internal object ColorTags {
+    /** ANSI SGR codes per known tag name. */
+    private val ansiByTag = mapOf(
+        "quest" to "\u001B[93m", // bright yellow — quest available
+        "turnin" to "\u001B[92m", // bright green  — quest turn-in ready
+        "dialogue" to "\u001B[96m", // bright cyan   — has dialogue
+        "aggro" to "\u001B[91m", // bright red    — aggressive mob
+    )
+
+    private val tagRegex = Regex("""\{c:([a-z]+)\}|\{/c\}""")
+
+    /** Removes all `{c:NAME}…{/c}` tags, leaving the wrapped text in place. */
+    fun strip(text: String): String = tagRegex.replace(text, "")
+
+    /**
+     * Translates tags to ANSI escape sequences. `{c:NAME}` becomes the color
+     * for that tag (or stripped if unknown). `{/c}` re-asserts [baseColor] so
+     * the rest of the line keeps the line-kind's base color.
+     */
+    fun applyAnsi(text: String, baseColor: String): String =
+        tagRegex.replace(text) { match ->
+            val tagName = match.groupValues[1]
+            if (tagName.isEmpty()) baseColor else ansiByTag[tagName] ?: ""
+        }
+}

--- a/src/main/kotlin/dev/ambon/transport/PlainRenderer.kt
+++ b/src/main/kotlin/dev/ambon/transport/PlainRenderer.kt
@@ -4,7 +4,7 @@ class PlainRenderer : TextRenderer {
     override fun renderLine(
         text: String,
         kind: TextKind,
-    ): String = text.normalizeToCrlf() + "\r\n"
+    ): String = ColorTags.strip(text).normalizeToCrlf() + "\r\n"
 
     override fun renderPrompt(prompt: PromptSpec): String = prompt.text
 }

--- a/src/test/kotlin/dev/ambon/engine/commands/handlers/MobMarkersTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/handlers/MobMarkersTest.kt
@@ -1,0 +1,67 @@
+package dev.ambon.engine.commands.handlers
+
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.mob.MobState
+import dev.ambon.engine.dialogue.DialogueNode
+import dev.ambon.engine.dialogue.DialogueTree
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class MobMarkersTest {
+    private fun mob(
+        dialogue: DialogueTree? = null,
+        aggressive: Boolean = false,
+    ): MobState =
+        MobState(
+            id = MobId("zone:bob"),
+            name = "bob",
+            roomId = RoomId("zone:room1"),
+            dialogue = dialogue,
+            aggressive = aggressive,
+        )
+
+    private val dialogue =
+        DialogueTree(
+            rootNodeId = "root",
+            nodes = mapOf("root" to DialogueNode(text = "hi", choices = emptyList())),
+        )
+
+    @Test
+    fun `no flags produces no marker`() {
+        assertEquals("", mobMarkers(mob(), hasQuestAvailable = false, hasQuestTurnIn = false))
+    }
+
+    @Test
+    fun `quest available produces (!) marker`() {
+        val markers = mobMarkers(mob(), hasQuestAvailable = true, hasQuestTurnIn = false)
+        assertEquals("{c:quest}(!){/c}", markers)
+    }
+
+    @Test
+    fun `turn-in beats quest-available in marker precedence`() {
+        val markers = mobMarkers(mob(), hasQuestAvailable = true, hasQuestTurnIn = true)
+        assertEquals("{c:turnin}(?){/c}", markers)
+    }
+
+    @Test
+    fun `dialogue marker shows only when no quest marker applies`() {
+        val withDialogueOnly = mobMarkers(mob(dialogue = dialogue), hasQuestAvailable = false, hasQuestTurnIn = false)
+        assertEquals("{c:dialogue}(*){/c}", withDialogueOnly)
+
+        // Quest marker subsumes the dialogue hint — talking is how you'd get the quest anyway.
+        val withQuestAndDialogue =
+            mobMarkers(mob(dialogue = dialogue), hasQuestAvailable = true, hasQuestTurnIn = false)
+        assertEquals("{c:quest}(!){/c}", withQuestAndDialogue)
+    }
+
+    @Test
+    fun `aggressive marker stacks with other markers`() {
+        val aggroAlone = mobMarkers(mob(aggressive = true), hasQuestAvailable = false, hasQuestTurnIn = false)
+        assertEquals("{c:aggro}[A]{/c}", aggroAlone)
+
+        val questAndAggro =
+            mobMarkers(mob(aggressive = true), hasQuestAvailable = true, hasQuestTurnIn = false)
+        assertEquals("{c:quest}(!){/c} {c:aggro}[A]{/c}", questAndAggro)
+    }
+}

--- a/src/test/kotlin/dev/ambon/transport/AnsiRendererTest.kt
+++ b/src/test/kotlin/dev/ambon/transport/AnsiRendererTest.kt
@@ -36,6 +36,35 @@ class AnsiRendererTest {
         assertTrue(line.endsWith("\r\n"))
     }
 
+    @Test
+    fun `color tag is translated to ANSI escape`() {
+        val r = AnsiRenderer()
+        val line = r.renderLine("alpha {c:quest}(!){/c} omega", TextKind.NORMAL)
+        // {c:quest} -> bright yellow; {/c} -> base prefix (NORMAL = reset)
+        assertTrue(line.contains("\u001B[93m(!)"), "Expected quest color around (!): $line")
+        // Tag literals must not leak
+        assertFalse(line.contains("{c:quest}"), "Open tag should not leak: $line")
+        assertFalse(line.contains("{/c}"), "Close tag should not leak: $line")
+    }
+
+    @Test
+    fun `unknown color tag name is stripped without leaking`() {
+        val r = AnsiRenderer()
+        val line = r.renderLine("hello {c:bogus}world{/c}", TextKind.NORMAL)
+        assertTrue(line.contains("hello world"), "Wrapped text must survive: $line")
+        assertFalse(line.contains("{c:bogus}"), "Unknown open tag must be stripped: $line")
+        assertFalse(line.contains("{/c}"), "Close tag must be stripped: $line")
+    }
+
+    @Test
+    fun `close tag restores INFO base color`() {
+        val r = AnsiRenderer()
+        val line = r.renderLine("a{c:aggro}[A]{/c}b", TextKind.INFO)
+        // After {/c}, the INFO base color (dim + bright cyan) should be re-asserted so 'b' keeps it.
+        val infoPrefix = "\u001B[2m\u001B[96m"
+        assertTrue(line.contains("[A]" + infoPrefix + "b"), "Expected INFO prefix restored after {/c}: $line")
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `prompt rendering uses PromptSpec text not toString`() =

--- a/src/test/kotlin/dev/ambon/transport/PlainRendererTest.kt
+++ b/src/test/kotlin/dev/ambon/transport/PlainRendererTest.kt
@@ -36,6 +36,20 @@ class PlainRendererTest {
         assertEquals("a\r\nb\r\nc\r\nd\r\n", line)
     }
 
+    @Test
+    fun `color tags are stripped without leaving syntax`() {
+        val r = PlainRenderer()
+        val line = r.renderLine("alpha {c:quest}(!){/c} omega", TextKind.NORMAL)
+        assertEquals("alpha (!) omega\r\n", line)
+    }
+
+    @Test
+    fun `multiple and unknown color tags all strip cleanly`() {
+        val r = PlainRenderer()
+        val line = r.renderLine("{c:quest}(!){/c} bob {c:aggro}[A]{/c} {c:bogus}x{/c}", TextKind.INFO)
+        assertEquals("(!) bob [A] x\r\n", line)
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `prompt rendering uses PromptSpec text not toString`() =


### PR DESCRIPTION
## Summary
- Telnet / text players now see at-a-glance status hints on each mob in the `You see:` line — parity with the canvas indicators the web client already paints via GMCP.
- Introduces a transport-agnostic `{c:NAME}…{/c}` color-tag convention so engine code stays free of ANSI escapes (preserves the engine boundary).

## What players see

```
You see: Captain Vael (?), Old Marta (!), priest (*), wild boar [A]
```

| Marker | Meaning | Color |
|---|---|---|
| `(?)` | Quest turn-in ready here | green |
| `(!)` | Quest available to accept | yellow |
| `(*)` | Has dialogue (hidden when a quest marker would apply) | cyan |
| `[A]` | Aggressive — will attack on sight | red |

Precedence: turn-in beats accept-available beats dialogue. `[A]` stacks independently. ANSI clients get color; plain clients get the same ASCII markers without escape codes.

## Notes for reviewers
- The web client receives the same text *and* the GMCP canvas indicators, so the chat log will show the markers alongside the canvas glyph. Mild duplication, deliberate — it costs nothing on telnet and keeps a single code path.
- `{c:NAME}` with an unknown tag name strips silently rather than erroring, so future marker types can be added without coordinated transport changes.
- `{/c}` in the ANSI renderer re-asserts the line-kind's base color so a wrapped span doesn't bleed the kind color for the rest of the line.

## Test plan
- [x] `./gradlew ktlintCheck` — passes
- [x] `./gradlew test` — full suite passes
- [x] New unit coverage: `MobMarkersTest` (precedence + stacking), `ColorTags` translation via `AnsiRendererTest` (known tag, unknown tag, base-color restore), `PlainRendererTest` (single + multiple + unknown tag stripping)
- [ ] Manual smoke via `./gradlew demo`: enter Academy, confirm `(!)` next to a quest-giving NPC, `(?)` after completing objectives, plain mobs unchanged