### PR TITLE
feat(dialogue): accept_quest and turn_in_quest dialogue actions

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestHandler.kt
@@ -113,6 +113,14 @@ class DialogueQuestHandler(
             handleUnlockFlag(sessionId, action.removePrefix("unlock_flag:").trim())
             return
         }
+        if (action.startsWith("accept_quest:")) {
+            handleDialogueAcceptQuest(sessionId, action.removePrefix("accept_quest:").trim())
+            return
+        }
+        if (action.startsWith("turn_in_quest:")) {
+            handleDialogueTurnInQuest(sessionId, action.removePrefix("turn_in_quest:").trim())
+            return
+        }
         when (action) {
             "set_recall" -> {
                 val me = players.get(sessionId) ?: return
@@ -155,6 +163,49 @@ class DialogueQuestHandler(
                 }
             }
         }
+    }
+
+    /**
+     * Accept a quest as the outcome of a dialogue choice. Validates that the
+     * quest-giver is in the player's current room (always true for a
+     * well-configured dialogue, since the player is talking to that mob right
+     * now) — the check guards against authoring mistakes.
+     */
+    private suspend fun handleDialogueAcceptQuest(sessionId: SessionId, questId: String) {
+        if (questId.isEmpty()) return
+        val qs = questSystem ?: return
+        val me = players.get(sessionId) ?: return
+        val quest = questRegistry.get(questId)
+        if (quest == null) {
+            outbound.send(OutboundEvent.SendError(sessionId, "Unknown quest '$questId'."))
+            return
+        }
+        val roomMobIds = mobs.mobsInRoom(me.roomId).map { it.id.value }.toSet()
+        if (quest.giverMobId !in roomMobIds) {
+            outbound.send(OutboundEvent.SendError(sessionId, "The quest-giver isn't here."))
+            return
+        }
+        outbound.sendIfError(sessionId, qs.acceptQuest(sessionId, questId))
+    }
+
+    /**
+     * Turn in a quest as the outcome of a dialogue choice. Delegates to
+     * [QuestSystem.turnInQuestById], which checks the resolved turn-in NPC is
+     * present, then refreshes the quest-offer panel for that NPC so any open
+     * web client UI reflects the post-turn-in state.
+     */
+    private suspend fun handleDialogueTurnInQuest(sessionId: SessionId, questId: String) {
+        if (questId.isEmpty()) return
+        val qs = questSystem ?: return
+        val me = players.get(sessionId) ?: return
+        val quest = questRegistry.get(questId)
+        val roomMobIds = mobs.mobsInRoom(me.roomId).map { it.id.value }
+        val err = qs.turnInQuestById(sessionId, questId, roomMobIds)
+        if (err != null) {
+            outbound.send(OutboundEvent.SendError(sessionId, err))
+            return
+        }
+        refreshOffersAfterTurnIn(sessionId, qs, quest, roomMobIds)
     }
 
     private suspend fun handleUnlockFlag(sessionId: SessionId, flag: String) {

--- a/src/test/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestActionTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestActionTest.kt
@@ -1,0 +1,231 @@
+package dev.ambon.engine.commands.handlers
+
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.config.BankConfig
+import dev.ambon.config.StylistConfig
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.mob.MobState
+import dev.ambon.domain.quest.QuestDef
+import dev.ambon.domain.quest.QuestObjectiveDef
+import dev.ambon.domain.quest.QuestRewards
+import dev.ambon.engine.CombatSystem
+import dev.ambon.engine.MobRegistry
+import dev.ambon.engine.PlayerRegistry
+import dev.ambon.engine.QuestRegistry
+import dev.ambon.engine.QuestSystem
+import dev.ambon.engine.commands.Command
+import dev.ambon.engine.commands.CommandRouter
+import dev.ambon.engine.dialogue.DialogueChoice
+import dev.ambon.engine.dialogue.DialogueNode
+import dev.ambon.engine.dialogue.DialogueSystem
+import dev.ambon.engine.dialogue.DialogueTree
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.MutableClock
+import dev.ambon.test.TestWorlds
+import dev.ambon.test.buildTestPlayerRegistry
+import dev.ambon.test.drainAll
+import dev.ambon.test.loginOrFail
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DialogueQuestActionTest {
+    private val world = TestWorlds.testWorld
+    private val startRoom = world.startRoom
+    private val giverMobId = "test_zone:giver"
+    private val questId = "test_zone:fetch"
+
+    /**
+     * Quest with a single zero-count objective, so its objectives are
+     * immediately complete on accept; `npc_turn_in` completion keeps it in the
+     * active list (no auto-complete), so a subsequent turn-in dialogue choice
+     * has something to hand in.
+     */
+    private val quest =
+        QuestDef(
+            id = questId,
+            name = "Fetch",
+            description = "A simple fetch.",
+            giverMobId = giverMobId,
+            objectives =
+                listOf(
+                    QuestObjectiveDef(
+                        type = "kill",
+                        targetId = "test_zone:nonexistent",
+                        count = 0,
+                        description = "Nothing to do",
+                    ),
+                ),
+            rewards = QuestRewards(),
+            completionType = "npc_turn_in",
+        )
+
+    private val dialogueTree =
+        DialogueTree(
+            rootNodeId = "root",
+            nodes =
+                mapOf(
+                    "root" to
+                        DialogueNode(
+                            text = "Will you help?",
+                            choices =
+                                listOf(
+                                    DialogueChoice(
+                                        text = "Accept",
+                                        nextNodeId = null,
+                                        minLevel = null,
+                                        requiredClass = null,
+                                        action = "accept_quest:$questId",
+                                    ),
+                                    DialogueChoice(
+                                        text = "Turn it in",
+                                        nextNodeId = null,
+                                        minLevel = null,
+                                        requiredClass = null,
+                                        action = "turn_in_quest:$questId",
+                                    ),
+                                    DialogueChoice(
+                                        text = "Accept unknown",
+                                        nextNodeId = null,
+                                        minLevel = null,
+                                        requiredClass = null,
+                                        action = "accept_quest:test_zone:does_not_exist",
+                                    ),
+                                ),
+                        ),
+                ),
+        )
+
+    private data class Env(
+        val sid: SessionId,
+        val players: PlayerRegistry,
+        val mobs: MobRegistry,
+        val outbound: LocalOutboundBus,
+        val router: CommandRouter,
+        val questSystem: QuestSystem,
+    )
+
+    private suspend fun setup(): Env {
+        val repo = InMemoryPlayerRepository()
+        val items = ItemRegistry()
+        val outbound = LocalOutboundBus()
+        val clock = MutableClock(0L)
+        val players = buildTestPlayerRegistry(startRoom, repo, items, clock = clock)
+        val mobs = MobRegistry()
+        val combat = CombatSystem(players, mobs, items, outbound)
+
+        mobs.upsert(
+            MobState(
+                id = MobId(giverMobId),
+                name = "the giver",
+                roomId = startRoom,
+                dialogue = dialogueTree,
+            ),
+        )
+
+        val questRegistry = QuestRegistry().apply { register(quest) }
+        val questSystem =
+            QuestSystem(
+                registry = questRegistry,
+                players = players,
+                items = items,
+                outbound = outbound,
+                clock = clock,
+            )
+        val dialogueSystem = DialogueSystem(mobs, players, outbound)
+
+        val ctx =
+            EngineContext(
+                players = players,
+                mobs = mobs,
+                world = world,
+                items = items,
+                outbound = outbound,
+                combat = combat,
+                gmcpEmitter = null,
+                worldState = null,
+                questSystem = questSystem,
+                bankConfig = BankConfig(),
+                stylistConfig = StylistConfig(),
+            )
+        val handler =
+            DialogueQuestHandler(
+                ctx = ctx,
+                dialogueSystem = dialogueSystem,
+                questSystem = questSystem,
+                questRegistry = questRegistry,
+            )
+
+        val router = CommandRouter(outbound = outbound, players = players)
+        handler.register(router)
+
+        val sid = SessionId(1L)
+        players.loginOrFail(sid, "Hero")
+        outbound.drainAll()
+        return Env(sid, players, mobs, outbound, router, questSystem)
+    }
+
+    @Test
+    fun `accept_quest dialogue action adds the quest to active quests`() =
+        runTest {
+            val env = setup()
+
+            env.router.handle(env.sid, Command.Talk("giver"))
+            env.router.handle(env.sid, Command.DialogueChoice(1))
+            env.outbound.drainAll()
+
+            val ps = env.players.get(env.sid)!!
+            assertTrue(
+                ps.activeQuests.containsKey(questId),
+                "Expected quest in activeQuests after dialogue accept. got=${ps.activeQuests}",
+            )
+        }
+
+    @Test
+    fun `turn_in_quest dialogue action moves a ready quest to completedQuestIds`() =
+        runTest {
+            val env = setup()
+            // Pre-accept via QuestSystem so the quest is already in the active list
+            // (npc_turn_in + zero-count objective leaves it ready to hand in).
+            env.questSystem.acceptQuest(env.sid, questId)
+            env.outbound.drainAll()
+
+            env.router.handle(env.sid, Command.Talk("giver"))
+            env.router.handle(env.sid, Command.DialogueChoice(2))
+            env.outbound.drainAll()
+
+            val ps = env.players.get(env.sid)!!
+            assertFalse(
+                ps.activeQuests.containsKey(questId),
+                "Quest should be removed from activeQuests after turn-in. got=${ps.activeQuests}",
+            )
+            assertTrue(
+                ps.completedQuestIds.contains(questId),
+                "Quest should be in completedQuestIds after turn-in. got=${ps.completedQuestIds}",
+            )
+        }
+
+    @Test
+    fun `accept_quest with unknown quest id surfaces an error and accepts nothing`() =
+        runTest {
+            val env = setup()
+
+            env.router.handle(env.sid, Command.Talk("giver"))
+            env.router.handle(env.sid, Command.DialogueChoice(3))
+            val events = env.outbound.drainAll()
+
+            val ps = env.players.get(env.sid)!!
+            assertTrue(ps.activeQuests.isEmpty(), "No quest should be accepted: ${ps.activeQuests}")
+            val errors = events.filterIsInstance<OutboundEvent.SendError>().map { it.text }
+            assertTrue(
+                errors.any { it.contains("Unknown quest") },
+                "Expected an 'Unknown quest' error. got=$errors",
+            )
+        }
+}


### PR DESCRIPTION
## Summary
NPCs can now hand out and complete quests as the outcome of a dialogue choice, instead of forcing the player to leave the conversation to type `accept <name>` / `quest turnin <name>`.

Two new prefix actions in `DialogueQuestHandler.handleDialogueAction`:

- `action: \"accept_quest:<questId>\"` — accepts the named quest from the NPC the player is talking to.
- `action: \"turn_in_quest:<questId>\"` — hands the named quest in.

Both validate that the giver / resolved turn-in NPC is in the player's current room (same room check the explicit-command handlers do), so a misconfigured dialogue fails loudly rather than silently mutating quest state.

## YAML example

```yaml
mobs:
  giver:
    name: \"Old Marta\"
    dialogue:
      rootNodeId: root
      nodes:
        root:
          text: \"Will you help me, traveler?\"
          choices:
            - text: \"I will.\"
              action: \"accept_quest:tutorial:lost_cat\"
            - text: \"I found her.\"
              action: \"turn_in_quest:tutorial:lost_cat\"
            - text: \"Not today.\"
```

## Notes for reviewers
- Implementation mirrors `handleQuestAcceptById` / `handleQuestTurnInById` and reuses `refreshOffersAfterTurnIn` so any open web quest-offer panel reflects the post-turn-in state.
- Empty quest id silently no-ops (treated as misconfiguration); unknown quest id sends a `SendError` so designers see the mistake in-game.
- The existing `unlock_flag:` action remains the way to *gate* a quest's availability behind a conversation branch — designers can compose: unlock the flag in an early dialogue choice, then offer `accept_quest:` once the next node's branch becomes visible.

## Follow-up to #1186
The previous PR added the textual `(!)` / `(?)` / `(*)` / `[A]` markers on the room mob list. With those markers a telnet player can now *see* a quest-giver from across the room; this PR lets the conversation actually *do* the quest hand-off without breaking immersion.

## Test plan
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew test` — full suite green
- [x] New: `DialogueQuestActionTest` covers
  - `accept_quest` dialogue action adds the quest to active quests
  - `turn_in_quest` dialogue action moves a ready quest to `completedQuestIds`
  - `accept_quest` with unknown id surfaces an error and accepts nothing
- [ ] Manual smoke: add an `accept_quest:` choice to the Academy zone YAML, talk to the NPC, confirm the quest appears in `quest log`