### PR TITLE
fix(dialogue): auto-qualify bare quest id in accept_quest / turn_in_quest

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestHandler.kt
@@ -1,6 +1,7 @@
 package dev.ambon.engine.commands.handlers
 
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.ids.qualifyId
 import dev.ambon.domain.quest.QuestDef
 import dev.ambon.engine.AchievementRegistry
 import dev.ambon.engine.AchievementSystem
@@ -166,15 +167,20 @@ class DialogueQuestHandler(
     }
 
     /**
-     * Accept a quest as the outcome of a dialogue choice. Validates that the
-     * quest-giver is in the player's current room (always true for a
+     * Accept a quest as the outcome of a dialogue choice. The id may be bare
+     * (`auringold_visit_naraxian`) or fully qualified
+     * (`auringold_academy:auringold_visit_naraxian`); bare ids are resolved
+     * against the player's current zone, matching the convention used
+     * elsewhere in the world YAML (e.g. `turnInMob`). Validates that the
+     * quest-giver is in the player's current room — always true for a
      * well-configured dialogue, since the player is talking to that mob right
-     * now) — the check guards against authoring mistakes.
+     * now; the check guards against authoring mistakes.
      */
-    private suspend fun handleDialogueAcceptQuest(sessionId: SessionId, questId: String) {
-        if (questId.isEmpty()) return
+    private suspend fun handleDialogueAcceptQuest(sessionId: SessionId, rawQuestId: String) {
+        if (rawQuestId.isEmpty()) return
         val qs = questSystem ?: return
         val me = players.get(sessionId) ?: return
+        val questId = qualifyId(me.roomId.zone, rawQuestId)
         val quest = questRegistry.get(questId)
         if (quest == null) {
             outbound.send(OutboundEvent.SendError(sessionId, "Unknown quest '$questId'."))
@@ -194,10 +200,11 @@ class DialogueQuestHandler(
      * present, then refreshes the quest-offer panel for that NPC so any open
      * web client UI reflects the post-turn-in state.
      */
-    private suspend fun handleDialogueTurnInQuest(sessionId: SessionId, questId: String) {
-        if (questId.isEmpty()) return
+    private suspend fun handleDialogueTurnInQuest(sessionId: SessionId, rawQuestId: String) {
+        if (rawQuestId.isEmpty()) return
         val qs = questSystem ?: return
         val me = players.get(sessionId) ?: return
+        val questId = qualifyId(me.roomId.zone, rawQuestId)
         val quest = questRegistry.get(questId)
         val roomMobIds = mobs.mobsInRoom(me.roomId).map { it.id.value }
         val err = qs.turnInQuestById(sessionId, questId, roomMobIds)

--- a/src/test/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestActionTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestActionTest.kt
@@ -97,6 +97,15 @@ class DialogueQuestActionTest {
                                         requiredClass = null,
                                         action = "accept_quest:test_zone:does_not_exist",
                                     ),
+                                    DialogueChoice(
+                                        text = "Accept (bare id)",
+                                        nextNodeId = null,
+                                        minLevel = null,
+                                        requiredClass = null,
+                                        // Unqualified id — the handler should auto-qualify
+                                        // it against the conversation NPC's zone.
+                                        action = "accept_quest:fetch",
+                                    ),
                                 ),
                         ),
                 ),
@@ -226,6 +235,26 @@ class DialogueQuestActionTest {
             assertTrue(
                 errors.any { it.contains("Unknown quest") },
                 "Expected an 'Unknown quest' error. got=$errors",
+            )
+        }
+
+    @Test
+    fun `accept_quest auto-qualifies a bare quest id against the player's zone`() =
+        runTest {
+            val env = setup()
+
+            env.router.handle(env.sid, Command.Talk("giver"))
+            // Choice #4 carries action "accept_quest:fetch" — the engine should
+            // qualify that to "test_zone:fetch" (the registered id) using the
+            // player's current zone, the same convention `turnInMob` uses in
+            // world YAML.
+            env.router.handle(env.sid, Command.DialogueChoice(4))
+            env.outbound.drainAll()
+
+            val ps = env.players.get(env.sid)!!
+            assertTrue(
+                ps.activeQuests.containsKey(questId),
+                "Bare-id accept_quest should resolve to '$questId'. got=${ps.activeQuests}",
             )
         }
 }


### PR DESCRIPTION
## Summary
Follow-up to #1187. A dialogue YAML using a bare quest id like
```yaml
action: accept_quest:auringold_visit_naraxian
```
failed at runtime with `Unknown quest 'auringold_visit_naraxian'.` because quests are registered under their **zone-qualified** id (`auringold_academy:auringold_visit_naraxian`, see `WorldLoader.kt:636`). The new handlers were looking up the bare string verbatim.

Now the parsed id is run through `qualifyId(me.roomId.zone, …)`, so bare ids resolve against the player's current zone — matching the convention `turnInMob` and other YAML mob references already use. Fully-qualified ids continue to work unchanged (so cross-zone hand-offs remain possible).

## Effect on existing content
Designers can now write either form:
```yaml
action: accept_quest:visit_naraxian                                  # bare, in-zone
action: accept_quest:auringold_academy:visit_naraxian                # fully-qualified
```
The Auringold dialogue YAML that surfaced this bug works as-written after this fix.

## Test plan
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew test --tests \"*DialogueQuestActionTest\"` — all 4 cases pass, including the new \"accept_quest auto-qualifies a bare quest id\" regression
- [ ] Manual: redeploy to Auringold and confirm the quest dialogue accepts and turns in without YAML changes