### PR TITLE
fix(engine): keep room index in sync on player death respawn

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -1548,7 +1548,11 @@ class CombatSystem(
             val respawnRoom = sanctumRoomLookup()
                 ?: zoneStartRoomLookup(roomId.zone)
                 ?: player.roomId
-            player.roomId = respawnRoom
+            // Use moveTo (not a direct roomId assignment) so the registry's
+            // room→sessions index is updated. A direct assignment left the
+            // session indexed in the death room, so it kept receiving that
+            // room's mob enter/leave broadcasts after respawning/departing.
+            players.moveTo(sessionId, respawnRoom)
 
             // Restore a fraction of HP/mana. Leaves the player vulnerable so they have to rest in the sanctum.
             player.hp = ((player.maxHp * deathConfig.respawnHpFraction).toInt()).coerceAtLeast(1)


### PR DESCRIPTION
## Bug
After dying (→ sanctum) and departing, players kept seeing mobs wander in and
out of the **room they died in**, not their current room.

## Cause
`CombatSystem.handlePlayerDeath` set `player.roomId` **directly** instead of
using `PlayerRegistry.moveTo(...)`. The registry keeps a `roomMembers`
(room → sessions) index that `playersInRoom()` reads to pick recipients for
`Room.AddMob` / `Room.RemoveMob` broadcasts. The direct assignment updated the
player's room field but never the index, so the session stayed indexed in the
death room and kept receiving its mob enter/leave events. A later `depart`
(`moveTo`) only removed the player from the *sanctum* set, leaving the stale
death-room entry in place.

## Fix
Use `players.moveTo(sessionId, respawnRoom)` — the same path every other room
change uses — so the room index, `lastEnterDirection` clear, and persistence
all happen. (`moveTo`'s own comment already lists death/respawn as a case.)

Verified: `CombatSystemTest`, `PvpCombatTest`, `TankPetCombatTest` pass;
`ktlintCheck` green.