### PR TITLE
infra: make ec2 Postgres sidecar opt-in (default YAML)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,11 @@ on:
           - hobby
           - moderate
           - production
+      postgres-sidecar:
+        description: "Run a Postgres sidecar on the ec2 demo (load testing only — data is wiped on instance replacement; default is YAML)"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -92,6 +97,7 @@ jobs:
           [ -n "${{ vars.HOSTNAME }}" ] && ARGS="$ARGS --context hostname=${{ vars.HOSTNAME }}"
           [ -n "${{ vars.DOMAIN }}" ]   && ARGS="$ARGS --context domain=${{ vars.DOMAIN }}"
           [ -n "$ADMIN_TOKEN_SSM_PARAM" ] && ARGS="$ARGS --context adminTokenSsmParameterName=$ADMIN_TOKEN_SSM_PARAM"
+          [ "${{ inputs.postgres-sidecar }}" = "true" ] && ARGS="$ARGS --context postgresSidecar=true"
           npx cdk deploy --all --require-approval never $ARGS
 
   deploy-production:

--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -58,11 +58,13 @@ const adminTokenSsmParameterName =
   app.node.tryGetContext('adminTokenSsmParameterName') as string | undefined;
 
 // When true, deploys a Postgres 16 container on the same EC2 host and
-// switches the app to POSTGRES persistence. Demo-only — data lives on the
-// root EBS and is destroyed on instance replacement. Toggle with
-// --context postgresSidecar=false (or omit) to revert to YAML.
+// switches the app to POSTGRES persistence. Opt-in — default is YAML, which
+// is the right state for the always-on demo. The sidecar's data lives on the
+// root EBS and is destroyed on instance replacement, so it's only for demo
+// load testing. Enable with --context postgresSidecar=true; omit (or any
+// other value) to keep YAML.
 const postgresSidecar =
-  (app.node.tryGetContext('postgresSidecar') as string | undefined) !== 'false';
+  (app.node.tryGetContext('postgresSidecar') as string | undefined) === 'true';
 
 // JVM flags passed to the container as JAVA_OPTS. The default targets the
 // t4g.medium (4 GB RAM) demo instance: 2 GB fixed heap + Generational ZGC for

--- a/infra/lib/ec2-stack.ts
+++ b/infra/lib/ec2-stack.ts
@@ -100,10 +100,11 @@ export interface Ec2StackProps extends StackProps {
   readonly javaOpts?: string;
   /**
    * When true, launches a Postgres 16 container on the same host and flips
-   * the app to AMBONMUD_PERSISTENCE_BACKEND=POSTGRES. Data lives in a named
-   * docker volume (`pgdata`) on the root EBS, so it survives container
-   * recycles but **not** instance replacement. Intended for demo load
-   * testing — use RDS for anything you care about keeping.
+   * the app to AMBONMUD_PERSISTENCE_BACKEND=POSTGRES. Opt-in (default is YAML
+   * persistence). Data lives in a named docker volume (`pgdata`) on the root
+   * EBS, so it survives container recycles but **not** instance replacement.
+   * Intended for demo load testing — use RDS for anything you care about
+   * keeping.
    *
    * A random DB password is generated once at first boot and stashed in
    * /etc/ambonmud/db.env (root-only, 0600). Both containers read it via


### PR DESCRIPTION
@
## Summary

The ec2 demo stack defaulted to provisioning a Postgres sidecar (`postgresSidecar = context !== 'false'`), so any `cdk deploy` that replaced the instance silently flipped persistence back to `POSTGRES`. The demo runs on YAML; Postgres is only wanted for occasional load testing. This makes the sidecar opt-in.

## Changes

- **`infra/bin/infra.ts`** — default to YAML (`context === 'true'` to opt in, was `!== 'false'`).
- **`infra/lib/ec2-stack.ts`** — update `postgresSidecar` prop docs to reflect the opt-in default.
- **`.github/workflows/deploy.yml`** — add a `postgres-sidecar` `workflow_dispatch` boolean (default `false`), passed through as `--context postgresSidecar=true` only when set, so load tests can re-enable it from the Actions UI without a code change.

## Verification

- `npx tsc --noEmit` — clean.
- `cdk synth AmbonMUD-ec2` (default) — no `postgres.service` / `pgdata` / `POSTGRES_PASSWORD`; `AMBONMUD_PERSISTENCE_BACKEND=YAML`.
- `cdk synth ... --context postgresSidecar=true` — sidecar fully restored.

## Notes

Governs **future instance replacements** only. The live demo box is already on YAML, and routine `update-ambonmud` CI deploys only sed-swap the image tag (never touch persistence config), so nothing changes for the running instance.
@