### PR TITLE
fix(web): refresh trainer/station badge label when moving between like rooms

### DIFF
--- a/web-v3/src/canvas/scenes/WorldScene.ts
+++ b/web-v3/src/canvas/scenes/WorldScene.ts
@@ -1012,8 +1012,13 @@ export class WorldScene {
     if (hasStation !== this.stationVisible) {
       this.stationVisible = hasStation;
       this.stationBadge.visible = hasStation;
-      if (hasStation) {
-        const stationName = state.room.station!.split("_").map((w: string) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+    }
+    // Sync the label whenever a station is present (not just on the
+    // visibility transition) so moving between two station rooms updates the
+    // name instead of showing the previous room's station.
+    if (hasStation) {
+      const stationName = state.room.station!.split("_").map((w: string) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+      if (this.stationLabel.text !== stationName) {
         this.stationLabel.text = stationName;
       }
     }
@@ -1023,9 +1028,13 @@ export class WorldScene {
     if (hasTrainer !== this.trainerVisible) {
       this.trainerVisible = hasTrainer;
       this.trainerBadge.visible = hasTrainer;
-      if (hasTrainer) {
-        this.trainerLabel.text = state.room.trainer!;
-      }
+    }
+    // Keep the label synced with the current trainer's name even when moving
+    // directly between two trainer rooms — visibility stays true so the
+    // transition check above is skipped, which otherwise leaves the previous
+    // room's trainer name on the badge until you leave and return.
+    if (hasTrainer && this.trainerLabel.text !== state.room.trainer) {
+      this.trainerLabel.text = state.room.trainer!;
     }
 
     // Bank badge visibility


### PR DESCRIPTION
## Summary

Fixes the stale trainer name on the in-canvas room badge: entering a trainer room could show the *previous* trainer's name on the icon, and it wouldn't refresh until you opened the training menu or left the room and came back.

## Root cause

In `WorldScene.update()` the trainer badge's name label was only assigned inside the visibility-transition guard:

```ts
const hasTrainer = !!state.room.trainer;
if (hasTrainer !== this.trainerVisible) {   // only true on false→true / true→false
  this.trainerVisible = hasTrainer;
  this.trainerBadge.visible = hasTrainer;
  if (hasTrainer) this.trainerLabel.text = state.room.trainer!;
}
```

Walking **trainer room → trainer room** keeps `hasTrainer === true`, so the guard is skipped and the label keeps the old name. Leaving to a non-trainer room flips visibility off→on and re-runs the assignment, which is why the leave-and-return workaround "fixed" it.

## Fix

Move the label sync out of the transition guard — update it whenever a trainer is present and the name actually changed. The label pill is redrawn every frame in `layoutAll()`, so the new name (and its background) render immediately.

The crafting-station badge had the identical bug (station name gated on the visibility transition) and is fixed the same way. The door/container/lever badges already key their guard on the count value, so they were never affected.

## Test plan

- `eslint .` + `tsc -b` in `web-v3/` — green.
- Manual: walk between two adjacent rooms that each have a (different) trainer; the badge name now updates on arrival without opening the menu or backtracking. Same for two different crafting stations.
