### PR TITLE
fix(housing): render browsable room templates in panel

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -1844,7 +1844,7 @@ data class CommandsConfig(
             "recipes" to CommandMetadata("recipes [filter]", "Browse available recipes", "crafting"),
             "craftskills" to CommandMetadata("craftskills/professions", "View crafting skill levels", "crafting"),
             "house" to CommandMetadata("house [status]", "View your house info", "housing"),
-            "house_list" to CommandMetadata("house list", "Browse room templates (at broker)", "housing"),
+            "house_list" to CommandMetadata("house list", "Browse available room templates", "housing"),
             "house_buy" to CommandMetadata("house buy", "Purchase your house (at broker)", "housing"),
             "house_expand" to CommandMetadata(
                 "house expand <template> <direction>",

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -980,6 +980,10 @@ class GmcpEmitter(
         )
     }
 
+    suspend fun sendHousingTemplates(sessionId: SessionId, templates: List<HousingTemplatePayload>) {
+        emit(sessionId, "Housing.Templates", HousingTemplatesPayload(templates = templates))
+    }
+
     data class HousingRoomPayload(
         val templateId: String,
         val title: String,
@@ -991,6 +995,19 @@ class GmcpEmitter(
         val ownerName: String?,
         val rooms: List<HousingRoomPayload>,
         val available: Boolean,
+    )
+
+    data class HousingTemplatePayload(
+        val id: String,
+        val title: String,
+        val description: String,
+        val cost: Long,
+        val owned: Boolean,
+        val isEntry: Boolean,
+    )
+
+    private data class HousingTemplatesPayload(
+        val templates: List<HousingTemplatePayload>,
     )
 
     // ---------- combat events ----------

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -751,7 +751,7 @@ sealed interface Command {
         /** `house` or `house status` — show house summary. */
         data object Status : House
 
-        /** `house list` — show available room templates (at broker NPC). */
+        /** `house list` — show available room templates. */
         data object ListTemplates : House
 
         /** `house buy` — purchase your initial house (at broker NPC). */

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HousingHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HousingHandler.kt
@@ -58,9 +58,7 @@ class HousingHandler(
     private suspend fun handleListTemplates(sessionId: SessionId) {
         val hs = requireSystemOrNull(sessionId, housingSystem, "Housing", outbound) ?: return
         val me = players.get(sessionId) ?: return
-        if (!requireBroker(sessionId, me, command = "list")) return
-        val pid = me.playerId ?: return
-        val house = hs.getHouse(pid)
+        val house = me.playerId?.let { hs.getHouse(it) }
 
         outbound.send(OutboundEvent.SendText(sessionId, "Available Room Templates"))
         for ((_, template) in hs.templates) {
@@ -70,6 +68,20 @@ class HousingHandler(
             outbound.send(OutboundEvent.SendInfo(sessionId, "  ${template.title} (${template.id}) - $cost$label"))
             outbound.send(OutboundEvent.SendInfo(sessionId, "    ${template.description}"))
         }
+
+        gmcpEmitter?.sendHousingTemplates(
+            sessionId,
+            hs.templates.values.map { template ->
+                GmcpEmitter.HousingTemplatePayload(
+                    id = template.id,
+                    title = template.title,
+                    description = template.description,
+                    cost = template.cost,
+                    owned = house?.rooms?.any { it.templateId == template.id } == true,
+                    isEntry = template.isEntry,
+                )
+            },
+        )
     }
 
     private suspend fun handleBuy(sessionId: SessionId) {

--- a/src/test/kotlin/dev/ambon/engine/commands/HousingCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/HousingCommandTest.kt
@@ -231,7 +231,7 @@ class HousingCommandTest {
     }
 
     @Test
-    fun `house list rejected when not at a broker`() = runTest {
+    fun `house list shows templates from any room`() = runTest {
         val (h, _, _) = harness()
         val sid = SessionId(1)
         h.loginPlayer(sid, "Alice")
@@ -240,8 +240,11 @@ class HousingCommandTest {
 
         h.router.handle(sid, Command.House.ListTemplates)
 
-        val errors = h.drain().errorMessages(sid)
-        assertTrue(errors.any { it.contains("housing broker") }, "got=$errors")
+        val events = h.drain()
+        val errors = events.errorMessages(sid)
+        val infos = events.infoMessages(sid)
+        assertTrue(errors.isEmpty(), "expected no broker error, got=$errors")
+        assertTrue(infos.any { it.contains("Cottage Entryway") }, "got=$infos")
     }
 
     @Test

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -1180,6 +1180,7 @@ function App() {
             connected={connected}
             hasCharacterProfile={hasCharacterProfile}
             housing={state.housing}
+            templates={state.housingTemplates}
             room={state.room}
             uiFeedbackFeed={state.uiFeedbackFeed}
             onSendCommand={sendCommand}

--- a/web-v3/src/components/panels/HousingPanel.tsx
+++ b/web-v3/src/components/panels/HousingPanel.tsx
@@ -1,19 +1,46 @@
 import { useMemo, useState } from "react";
-import type { HousingInfo, RoomState, UiFeedbackEntry } from "../../types";
+import type { HousingInfo, HousingTemplate, RoomState, UiFeedbackEntry } from "../../types";
 
 interface HousingPanelProps {
   connected: boolean;
   hasCharacterProfile: boolean;
   housing: HousingInfo | null;
+  templates: HousingTemplate[];
   room: RoomState;
   uiFeedbackFeed: UiFeedbackEntry[];
   onSendCommand: (cmd: string) => void;
+}
+
+function TemplateList({ templates }: { templates: HousingTemplate[] }) {
+  if (templates.length === 0) return null;
+  return (
+    <div className="housing-templates-section">
+      <p className="housing-section-label">Available Templates</p>
+      <ul className="housing-room-list">
+        {templates.map((t) => (
+          <li key={t.id} className="housing-room-item">
+            <div className="housing-room-header">
+              <span className="housing-room-title">{t.title}</span>
+              <span className="housing-template-cost">{t.cost > 0 ? `${t.cost} gold` : "Free"}</span>
+            </div>
+            <p className="housing-room-desc">{t.description}</p>
+            <div className="housing-template-meta">
+              <span className="housing-room-template">{t.id}</span>
+              {t.owned && <span className="housing-template-badge">Owned</span>}
+              {t.isEntry && <span className="housing-template-badge housing-template-badge-entry">Entry</span>}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }
 
 export function HousingPanel({
   connected,
   hasCharacterProfile,
   housing,
+  templates,
   room,
   uiFeedbackFeed,
   onSendCommand,
@@ -44,9 +71,14 @@ export function HousingPanel({
           <span className="housing-empty-icon">{"\u{1F3E0}"}</span>
           <p className="empty-note">You don't own a house yet.</p>
           {room.housingBroker && housing?.available !== false ? (
-            <button type="button" className="housing-action-btn" onClick={() => onSendCommand("house buy")}>
-              Purchase a House
-            </button>
+            <div className="housing-actions">
+              <button type="button" className="housing-action-btn" onClick={() => onSendCommand("house buy")}>
+                Purchase a House
+              </button>
+              <button type="button" className="housing-action-btn" onClick={() => onSendCommand("house list")}>
+                Browse Templates
+              </button>
+            </div>
           ) : housing?.available === false ? (
             <p className="housing-hint">Housing is not available on this server.</p>
           ) : (
@@ -58,6 +90,7 @@ export function HousingPanel({
             </p>
           )}
         </div>
+        <TemplateList templates={templates} />
       </div>
     );
   }
@@ -136,6 +169,8 @@ export function HousingPanel({
           </li>
         ))}
       </ul>
+
+      <TemplateList templates={templates} />
 
       {inOwnHouse && (
         <div className="housing-customize-section">

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -32,6 +32,7 @@ import type {
   GuildMemberEntry,
   HousingInfo,
   HousingRoomInfo,
+  HousingTemplate,
   PendingGroupInvite,
   PendingGuildInvite,
   InProgressAchievement,
@@ -202,6 +203,7 @@ interface GmcpContext {
   setZoneInstances: Dispatch<SetStateAction<ZoneInstances>>;
   setSpriteList: Dispatch<SetStateAction<SpriteList>>;
   setHousing: Dispatch<SetStateAction<HousingInfo | null>>;
+  setHousingTemplates: Dispatch<SetStateAction<HousingTemplate[]>>;
   setTradeState: Dispatch<SetStateAction<TradeState | null>>;
   setAuctionListings: Dispatch<SetStateAction<AuctionListing[]>>;
   setLeaderboard: Dispatch<SetStateAction<Record<string, LeaderboardData>>>;
@@ -2121,6 +2123,24 @@ export function applyGmcpPackage(
             }))
         : [];
       ctx.setHousing({ hasHouse, ownerName, rooms, available });
+      break;
+    }
+
+    case "Housing.Templates": {
+      const packet = data as Partial<Record<string, unknown>>;
+      const templates: HousingTemplate[] = Array.isArray(packet.templates)
+        ? packet.templates
+            .filter((t): t is Record<string, unknown> => typeof t === "object" && t !== null)
+            .map((t) => ({
+              id: typeof t.id === "string" ? t.id : "",
+              title: typeof t.title === "string" ? t.title : "",
+              description: typeof t.description === "string" ? t.description : "",
+              cost: typeof t.cost === "number" ? t.cost : 0,
+              owned: t.owned === true,
+              isEntry: t.isEntry === true,
+            }))
+        : [];
+      ctx.setHousingTemplates(templates);
       break;
     }
 

--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -50,6 +50,7 @@ import type {
   GuildInfo,
   GuildMemberEntry,
   HousingInfo,
+  HousingTemplate,
   ItemSummary,
   LeaderboardData,
   LevelUpNotification,
@@ -293,6 +294,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
 
   // ── Housing & pets ────────────────────────────────
   const [housing, setHousing] = useState<HousingInfo | null>(null);
+  const [housingTemplates, setHousingTemplates] = useState<HousingTemplate[]>([]);
   const [petState, setPetState] = useState<PetState | null>(null);
 
   // ── Mail ──────────────────────────────────────────
@@ -616,6 +618,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
         setZoneInstances,
         setSpriteList,
         setHousing,
+        setHousingTemplates,
         setTradeState,
         setAuctionListings,
         setLeaderboard,
@@ -701,6 +704,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     setLoginError(null);
     setSavedCharacters([]);
     setHousing(null);
+    setHousingTemplates([]);
     setTradeState(null);
     setAuctionListings([]);
     setCurrencies([]);
@@ -764,7 +768,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     // World
     dialogue, setDialogue, zoneInstances, worldTime, worldWeather, worldEvents, zoneEnvironment, factions, factionActivity, dungeonInfo, dungeonCatalog,
     // Housing & pets
-    housing, petState,
+    housing, housingTemplates, petState,
     // Mail
     mailInbox, mailMessage, setMailMessage,
     // Leaderboard

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -16044,6 +16044,42 @@ body {
   line-height: 1.45;
 }
 
+.housing-templates-section {
+  padding: var(--space-2) 0;
+  border-top: 1px solid var(--line-faint);
+}
+
+.housing-template-cost {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--color-accent-soft-gold, var(--text-bright));
+  white-space: nowrap;
+}
+
+.housing-template-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: 4px;
+}
+
+.housing-template-badge {
+  font-size: 0.66rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+  border: 1px solid var(--line-subtle);
+  color: var(--text-muted);
+}
+
+.housing-template-badge-entry {
+  color: var(--color-accent-lavender, var(--text-secondary));
+  border-color: var(--color-accent-lavender, var(--line-subtle));
+}
+
 .housing-customize-section {
   padding: var(--space-2);
   border-top: 1px solid var(--line-faint);

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -976,6 +976,15 @@ export interface HousingRoomInfo {
   description: string;
 }
 
+export interface HousingTemplate {
+  id: string;
+  title: string;
+  description: string;
+  cost: number;
+  owned: boolean;
+  isEntry: boolean;
+}
+
 export interface HousingInfo {
   hasHouse: boolean;
   ownerName: string | null;


### PR DESCRIPTION
## Problem

The Housing panel's template buttons didn't work. Both **"Browse Templates"** (at a broker) and **"Templates"** (in your own house) fire `house list`, but:

1. **Output never reached the panel.** `house list` only printed template lines to the text terminal via `SendInfo` — there was no GMCP package carrying templates, so the React panel had nothing to render. Clicking looked like a no-op.
2. **The in-house "Templates" button always errored.** `handleListTemplates` called `requireBroker`, but house rooms aren't brokers, so it returned *"You need to be at a housing broker to do that."* — inconsistent with `house expand`, which has no such gate.

## Fix

**Engine**
- Dropped the broker requirement from `handleListTemplates` (read-only info; now consistent with `house expand`). `house buy` still requires a broker.
- Added a `Housing.Templates` GMCP package (`id`, `title`, `description`, `cost`, `owned`, `isEntry`), emitted alongside the existing text output so telnet is unaffected. The `Housing` prefix is already in the WebSocket auto-opt-in list, so no transport change needed.

**Web client**
- New `housingTemplates` state populated by the `Housing.Templates` handler.
- `TemplateList` section in `HousingPanel` showing each template with cost and **Owned**/**Entry** badges — rendered for homeowners and, newly, for prospective buyers standing at a broker (added a "Browse Templates" button to the empty state).

**Docs/tests**
- Updated help text/comment that said "(at broker)".
- Flipped the test that pinned the old broker gate to assert listing works from any room.

## Verification
- `./gradlew test --tests HousingCommandTest --tests CommandParserTest` — pass
- `./gradlew ktlintCheck` — clean
- web `eslint .` + `tsc -b` — clean

Not yet dogfooded end-to-end in a browser.