### PR TITLE
fix(web): make audio control state visible in skinned HUD

### DIFF
--- a/web-v3/src/components/AudioControls.tsx
+++ b/web-v3/src/components/AudioControls.tsx
@@ -4,15 +4,74 @@ import { VolumeOnIcon, VolumeOffIcon, MusicNoteIcon, WavesIcon, SpeechBubbleIcon
 
 interface AudioControlsProps {
   audio: AudioEngine;
+  /**
+   * Skinned (painted-gear) mode: the gear art is the affordance, so the hotspot
+   * opens a panel with an explicit sound toggle + sliders, and a status badge
+   * on the gear shows the current state. Without this, clicking would flip the
+   * mute state with no visible feedback at all.
+   */
+  skinned?: boolean;
 }
 
-export function AudioControls({ audio }: AudioControlsProps) {
+function VolumeSliders({ audio }: { audio: AudioEngine }) {
+  return (
+    <>
+      <div className="audio-slider-row">
+        <MusicNoteIcon className="audio-slider-icon" />
+        <input
+          type="range"
+          className="audio-slider"
+          min={0}
+          max={100}
+          value={Math.round(audio.musicVolume * 100)}
+          onChange={(e) => audio.setMusicVolume(parseInt(e.target.value, 10) / 100)}
+          title={`Music: ${Math.round(audio.musicVolume * 100)}%`}
+          aria-label="Music volume"
+        />
+      </div>
+      <div className="audio-slider-row">
+        <WavesIcon className="audio-slider-icon" />
+        <input
+          type="range"
+          className="audio-slider"
+          min={0}
+          max={100}
+          value={Math.round(audio.ambientVolume * 100)}
+          onChange={(e) => audio.setAmbientVolume(parseInt(e.target.value, 10) / 100)}
+          title={`Ambient: ${Math.round(audio.ambientVolume * 100)}%`}
+          aria-label="Ambient volume"
+        />
+      </div>
+      <div className="audio-slider-row">
+        <SpeechBubbleIcon className="audio-slider-icon" />
+        <input
+          type="range"
+          className="audio-slider"
+          min={0}
+          max={100}
+          value={Math.round(audio.voiceVolume * 100)}
+          onChange={(e) => audio.setVoiceVolume(parseInt(e.target.value, 10) / 100)}
+          title={`Voice: ${Math.round(audio.voiceVolume * 100)}%`}
+          aria-label="Voice volume"
+        />
+      </div>
+    </>
+  );
+}
+
+export function AudioControls({ audio, skinned = false }: AudioControlsProps) {
   const [expanded, setExpanded] = useState(false);
   const controlsRef = useRef<HTMLDivElement | null>(null);
 
   const toggleExpanded = useCallback(() => {
     setExpanded((prev) => !prev);
   }, []);
+
+  // Enabling audio also opens the sliders so the click visibly does something.
+  const toggleAudio = useCallback(() => {
+    if (!audio.enabled) setExpanded(true);
+    audio.toggle();
+  }, [audio]);
 
   // Close on Escape or click outside
   useEffect(() => {
@@ -35,12 +94,53 @@ export function AudioControls({ audio }: AudioControlsProps) {
     };
   }, [expanded]);
 
+  const panel = (
+    <div className="audio-sliders" role="group" aria-label="Volume controls">
+      {skinned && (
+        <button
+          type="button"
+          className={`audio-master-row${audio.enabled ? " audio-master-on" : ""}`}
+          onClick={audio.toggle}
+          aria-pressed={audio.enabled}
+        >
+          {audio.enabled
+            ? <VolumeOnIcon className="audio-slider-icon" />
+            : <VolumeOffIcon className="audio-slider-icon" />
+          }
+          <span>{audio.enabled ? "Sound on" : "Sound off"}</span>
+        </button>
+      )}
+      {audio.enabled && <VolumeSliders audio={audio} />}
+    </div>
+  );
+
+  if (skinned) {
+    return (
+      <div className="audio-controls audio-controls-skinned" ref={controlsRef}>
+        <button
+          type="button"
+          className="vskin-audio-hotspot"
+          onClick={toggleExpanded}
+          title="Audio settings"
+          aria-label="Audio settings"
+          aria-expanded={expanded}
+        >
+          <span
+            className={`vskin-audio-badge${audio.enabled ? " vskin-audio-badge-on" : ""}`}
+            aria-hidden="true"
+          />
+        </button>
+        {expanded && panel}
+      </div>
+    );
+  }
+
   return (
     <div className="audio-controls" ref={controlsRef}>
       <button
         type="button"
         className={`soft-button audio-toggle-btn${audio.enabled ? " audio-enabled" : ""}`}
-        onClick={audio.toggle}
+        onClick={toggleAudio}
         title={audio.enabled ? "Mute audio" : "Enable audio"}
         aria-label={audio.enabled ? "Mute audio" : "Enable audio"}
       >
@@ -63,49 +163,7 @@ export function AudioControls({ audio }: AudioControlsProps) {
         </button>
       )}
 
-      {audio.enabled && expanded && (
-        <div className="audio-sliders" role="group" aria-label="Volume controls">
-          <div className="audio-slider-row">
-            <MusicNoteIcon className="audio-slider-icon" />
-            <input
-              type="range"
-              className="audio-slider"
-              min={0}
-              max={100}
-              value={Math.round(audio.musicVolume * 100)}
-              onChange={(e) => audio.setMusicVolume(parseInt(e.target.value, 10) / 100)}
-              title={`Music: ${Math.round(audio.musicVolume * 100)}%`}
-              aria-label="Music volume"
-            />
-          </div>
-          <div className="audio-slider-row">
-            <WavesIcon className="audio-slider-icon" />
-            <input
-              type="range"
-              className="audio-slider"
-              min={0}
-              max={100}
-              value={Math.round(audio.ambientVolume * 100)}
-              onChange={(e) => audio.setAmbientVolume(parseInt(e.target.value, 10) / 100)}
-              title={`Ambient: ${Math.round(audio.ambientVolume * 100)}%`}
-              aria-label="Ambient volume"
-            />
-          </div>
-          <div className="audio-slider-row">
-            <SpeechBubbleIcon className="audio-slider-icon" />
-            <input
-              type="range"
-              className="audio-slider"
-              min={0}
-              max={100}
-              value={Math.round(audio.voiceVolume * 100)}
-              onChange={(e) => audio.setVoiceVolume(parseInt(e.target.value, 10) / 100)}
-              title={`Voice: ${Math.round(audio.voiceVolume * 100)}%`}
-              aria-label="Voice volume"
-            />
-          </div>
-        </div>
-      )}
+      {audio.enabled && expanded && panel}
     </div>
   );
 }

--- a/web-v3/src/components/AudioControls.tsx
+++ b/web-v3/src/components/AudioControls.tsx
@@ -95,7 +95,7 @@ export function AudioControls({ audio, skinned = false }: AudioControlsProps) {
   }, [expanded]);
 
   const panel = (
-    <div className="audio-sliders" role="group" aria-label="Volume controls">
+    <div className="audio-sliders" role="group" aria-label={skinned ? "Audio settings" : "Volume controls"}>
       {skinned && (
         <button
           type="button"
@@ -121,8 +121,8 @@ export function AudioControls({ audio, skinned = false }: AudioControlsProps) {
           type="button"
           className="vskin-audio-hotspot"
           onClick={toggleExpanded}
-          title="Audio settings"
-          aria-label="Audio settings"
+          title={audio.enabled ? "Audio settings (sound on)" : "Audio settings (sound off)"}
+          aria-label={audio.enabled ? "Audio settings (sound on)" : "Audio settings (sound off)"}
           aria-expanded={expanded}
         >
           <span

--- a/web-v3/src/components/CanvasVitalsHud.tsx
+++ b/web-v3/src/components/CanvasVitalsHud.tsx
@@ -70,7 +70,7 @@ export function CanvasVitalsHud({ vitals, inventory, serverAssets, onCommand, au
             aria-label={manaTitle}
           />
           <div className="vskin-gear">
-            <AudioControls audio={audio} />
+            <AudioControls audio={audio} skinned />
           </div>
         </div>
       </div>

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -18335,14 +18335,58 @@ html:has(.game-shell),
 }
 
 .vskin-gear .audio-controls,
-.vskin-gear .audio-controls > button {
+.vskin-audio-hotspot {
   width: 100%;
   height: 100%;
 }
 
-/* The painted gear is the visible affordance; the real control sits over it. */
-.vskin-gear .audio-controls > button {
-  opacity: 0;
+/* The painted gear is the visible affordance; the transparent hotspot sits over
+   it and opens the audio panel. A small badge in the gear's corner shows the
+   current sound state so the control reads as live, not just decoration. */
+.vskin-audio-hotspot {
+  position: relative;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.vskin-audio-badge {
+  position: absolute;
+  top: 4%;
+  right: 2%;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--text-disabled);
+  border: 1px solid rgb(0 0 0 / 35%);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 40%);
+}
+
+.vskin-audio-badge-on {
+  background: var(--color-status-online);
+  box-shadow: 0 0 6px var(--color-status-online), 0 1px 3px rgb(0 0 0 / 40%);
+}
+
+/* Master sound toggle row at the top of the skinned audio panel. */
+.audio-master-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius-md);
+  background: var(--surface-chip);
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.audio-master-row.audio-master-on {
+  color: var(--text-bright);
+  background: linear-gradient(135deg, rgb(91 121 84 / 78%), rgb(73 107 80 / 74%));
+  border-color: rgb(120 160 110 / 40%);
 }
 
 /* ── Skinned room sign (room_sign_bg art, with its own rope baked in) ───── */

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -18334,7 +18334,7 @@ html:has(.game-shell),
   pointer-events: auto;
 }
 
-.vskin-gear .audio-controls,
+.audio-controls-skinned,
 .vskin-audio-hotspot {
   width: 100%;
   height: 100%;
@@ -18347,8 +18347,19 @@ html:has(.game-shell),
   position: relative;
   padding: 0;
   border: none;
+  border-radius: 50%;
   background: none;
   cursor: pointer;
+}
+
+/* The hotspot is transparent, so it needs its own focus ring (it can't lean on
+   .soft-button's like the unskinned toggle does). Same for the master row. */
+.vskin-audio-hotspot:focus-visible,
+.audio-master-row:focus-visible {
+  outline: 2px solid transparent;
+  box-shadow:
+    0 0 0 2px rgb(184 216 232 / 58%),
+    0 0 0 4px rgb(216 197 232 / 30%);
 }
 
 .vskin-audio-badge {


### PR DESCRIPTION
## Problem

In the painted vitals-bar skin (`vitals_bar_bg` asset), the audio control is an invisible (`opacity: 0`) button stretched over the gear art. Clicking it silently flipped the mute state — the icon swap and green enabled tint were hidden, and the `▾` volume-sliders button was invisible too. Net effect: clicking the gear appeared to do nothing.

## Fix

**Skinned gear:**
- Clicking the gear now opens an audio panel — a labeled **Sound on / Sound off** toggle row (green when on) with the music/ambient/voice sliders below — instead of blind-toggling mute. New `skinned` prop on `AudioControls`.
- Small status badge on the gear corner: soft-glow green when sound is on, dim grey when off, so state is glanceable without opening the panel.
- Escape / click-outside close behavior unchanged.

**Unskinned HUD:**
- Enabling audio auto-expands the volume sliders, so the first click visibly does something beyond the icon swap.

**Shared:**
- Extracted `VolumeSliders` so both modes render the same slider rows.

## Styling

Design-system tokens throughout (`--color-status-online`, `--surface-chip`, `--line-soft`, spacing/radius vars); the master-row "on" state reuses the existing green gradient from `.audio-enabled`.

## Verification

- `bun run lint` — green
- `tsc -b` — green