### PR TITLE
fix(world): allow mob minDamage of 0 for harmless mobs

### DIFF
--- a/docs/WORLD_YAML_SPEC.md
+++ b/docs/WORLD_YAML_SPEC.md
@@ -129,7 +129,7 @@ room:           <room-id string, required>
 tier:           <string, optional - one of weak|standard|elite|boss (case-insensitive); default standard>
 level:          <integer >= 1, optional; default 1>
 hp:             <integer >= 1, optional - overrides tier-computed hp>
-minDamage:      <integer >= 1, optional - overrides tier-computed minDamage>
+minDamage:      <integer >= 0, optional - overrides tier-computed minDamage; 0 allows harmless mobs (e.g. a training dummy)>
 maxDamage:      <integer >= minDamage, optional - overrides tier-computed maxDamage>
 armor:          <integer >= 0, optional - overrides tier baseArmor (flat damage reduction, no level scaling)>
 xpReward:       <long >= 0, optional - overrides tier-computed xpReward>

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -385,7 +385,9 @@ object WorldLoader {
 
                 val mobCtx = "Mob '${mobId.value}'"
                 requireAtLeast(resolvedHp, 1, mobCtx, "resolved hp")
-                requireAtLeast(resolvedMinDamage, 1, mobCtx, "resolved minDamage")
+                // 0 is allowed so builders can make harmless mobs (e.g. a training
+                // dummy that never hits back); negative damage is still rejected.
+                requireAtLeast(resolvedMinDamage, 0, mobCtx, "resolved minDamage")
                 if (resolvedMaxDamage < resolvedMinDamage) {
                     throw WorldLoadException(
                         "Mob '${mobId.value}' resolved maxDamage ($resolvedMaxDamage) must be >= " +

--- a/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
@@ -579,6 +579,26 @@ class WorldLoaderTest {
     }
 
     @Test
+    fun `loads mob with zero damage range as a harmless mob`() {
+        val world = WorldLoader.loadFromResource("world/ok_mob_stats.yaml")
+        val mobs = world.mobTemplates.mapKeys { it.key.value }
+
+        val dummy = mobs.getValue("ok_mob_stats:harmless_dummy")
+        assertEquals(500, dummy.maxHp)
+        assertEquals(0, dummy.damage.min)
+        assertEquals(0, dummy.damage.max)
+    }
+
+    @Test
+    fun `fails when mob minDamage is negative`() {
+        val ex =
+            assertThrows(WorldLoadException::class.java) {
+                WorldLoader.loadFromResource("world/bad_mob_negative_damage.yaml")
+            }
+        assertTrue(ex.message!!.contains("minDamage", ignoreCase = true), "Got: ${ex.message}")
+    }
+
+    @Test
     fun `fails when mob drop chance is out of range`() {
         val ex =
             assertThrows(WorldLoadException::class.java) {

--- a/src/test/resources/world/bad_mob_negative_damage.yaml
+++ b/src/test/resources/world/bad_mob_negative_damage.yaml
@@ -1,0 +1,12 @@
+zone: bad_mob_negative_damage
+startRoom: room
+mobs:
+  rat:
+    name: "a rat"
+    room: room
+    minDamage: -1
+    maxDamage: 2
+rooms:
+  room:
+    title: "Room"
+    description: "A plain room."

--- a/src/test/resources/world/ok_mob_stats.yaml
+++ b/src/test/resources/world/ok_mob_stats.yaml
@@ -23,6 +23,13 @@ mobs:
     name: "the dungeon boss"
     room: hall
     tier: boss
+  harmless_dummy:
+    name: "a training dummy"
+    room: hall
+    hp: 500
+    minDamage: 0
+    maxDamage: 0
+    xpReward: 0
 rooms:
   hall:
     title: "Hall"


### PR DESCRIPTION
## Problem

`WorldLoader` rejected any mob whose resolved `minDamage` was below 1. That makes it impossible to author a harmless mob — e.g. a training dummy that never hits back — and it crashed the demo instance at boot when `playtesting.yaml` shipped one:

```
WorldLoadException: Mob 'playtesting:eternal_dummy' resolved minDamage must be >= 1 (got 0)
```

## Fix

- Relax the loader validation from `>= 1` to `>= 0` for resolved `minDamage`. Negative damage is still rejected, and `maxDamage >= minDamage` still holds, so a `0`/`0` range is now a valid "never hits" mob.
- Document the new bound in `WORLD_YAML_SPEC.md`.

## Why this is safe at runtime

- `rollRange` returns `min` when `max <= min`, so a 0-0 range rolls 0 — no RNG bound issues.
- A 0 roll flows through armor/shield mitigation harmlessly (damage floors at 0 already).
- `consider()` clamps effective mob damage to 0.1 before dividing, so no divide-by-zero in hits-to-kill math.

## Tests

- New positive case: `harmless_dummy` (minDamage/maxDamage 0) in `ok_mob_stats.yaml` loads with a 0-0 damage range.
- New negative case: `bad_mob_negative_damage.yaml` (minDamage -1) still fails validation.
- `ktlintCheck test integrationTest` — all green.
