### PR TITLE
fix(web): render auto-peek paragraph in the HUD room panel

### DIFF
--- a/web-v3/src/components/RoomPanel.tsx
+++ b/web-v3/src/components/RoomPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import type { RoomState } from "../types";
+import { formatPeekSentence } from "../utils";
 import { RoomExitsCompass } from "./RoomExitsCompass";
 
 interface RoomPanelProps {
@@ -35,6 +36,9 @@ export function RoomPanel({ room, exits, serverAssets, loggedIn, onCommand }: Ro
             <p className="room-panel-desc">
               {room.description || "No room description available yet."}
             </p>
+            {room.peek && room.peek.length > 0 && (
+              <p className="room-panel-peek">{formatPeekSentence(room.peek)}</p>
+            )}
           </div>
 
           <div className="room-panel-nav">

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -18954,6 +18954,15 @@ html:has(.game-shell),
   color: var(--text-secondary);
 }
 
+/* Auto-peek paragraph — quieter than the description so it reads as wayfinding, not prose. */
+.room-panel-peek {
+  margin: 6px 0 0;
+  font-size: 0.98rem;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
 .room-panel-nav {
   flex: 0 0 auto;
   display: flex;


### PR DESCRIPTION
## Summary

PR #1206 wired the auto-peek paragraph into the **room drawer popout** only. In graphical zones, players read room descriptions from the persistent **RoomPanel** between the canvas and the vitals bar — so the paragraph never appeared in normal play, even though `Room.Info` GMCP was carrying the `peek` data correctly.

This renders the same quiet italic peek sentence under the description in `RoomPanel`, reusing `formatPeekSentence`.

## Verification (headless browser against local `gradlew run`)

- Confirmed the server emits `"peek":[{"direction":"south","title":"The Grand Hall"}]` on `Room.Info` for a fresh demo character — server side was working all along
- New demo character at Academy Gates: panel shows *"You see The Grand Hall to the south."*
- Moved south: line updates to the 5-exit form *"…The Scholar's Study to the east, The Common Room to the west, and The Catacombs above you."*
- `autopeek off` in the terminal removes the paragraph live; `autopeek on` restores it
- Drawer popout rendering from #1206 still works

## Notes

- `web-v3/src/components/PopoutLayer.tsx` also renders a room description but is dead code (nothing imports it) — left untouched
- `bun run lint` passes
