### PR TITLE
feat(world): zone intro cinematics - autoplay on first entry, replay from map

### DIFF
--- a/docs/WORLD_YAML_SPEC.md
+++ b/docs/WORLD_YAML_SPEC.md
@@ -34,6 +34,8 @@ image:                  # zone-wide image defaults
 audio:                  # zone-wide audio defaults
   music: <string, optional>
   ambient: <string, optional>
+video: <string, optional - relative path under /videos/; zone cinematic that auto-plays
+        on a player's first entry to the zone and is replayable from the expanded map>
 rooms: <map<string, Room>, required, must be non-empty>
 mobs: <map<string, Mob>, optional, default {}>
 items: <map<string, Item>, optional, default {}>

--- a/src/main/kotlin/dev/ambon/domain/world/World.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/World.kt
@@ -19,6 +19,7 @@ class World(
     pvpZones: Set<String> = emptySet(),
     zoneStartRooms: Map<String, RoomId> = emptyMap(),
     zoneScaling: Map<String, ZoneScaling> = emptyMap(),
+    zoneVideos: Map<String, String> = emptyMap(),
     shopDefinitions: List<ShopDefinition> = emptyList(),
     trainerDefinitions: List<TrainerDefinition> = emptyList(),
     questDefinitions: List<QuestDef> = emptyList(),
@@ -65,6 +66,12 @@ class World(
 
     /** Returns the scaling config for a zone. Falls back to STATIC when unset. */
     fun zoneScaling(zoneId: String): ZoneScaling = _zoneScaling[zoneId] ?: ZoneScaling()
+
+    private val _zoneVideos = zoneVideos.toMutableMap()
+    val zoneVideos: Map<String, String> get() = _zoneVideos
+
+    /** Returns the cinematic video URL for a zone, or null when the zone has none. */
+    fun zoneVideo(zoneId: String): String? = _zoneVideos[zoneId]
 
     private val _shopDefinitions = shopDefinitions.toMutableList()
     val shopDefinitions: List<ShopDefinition> get() = _shopDefinitions
@@ -151,6 +158,9 @@ class World(
         source._zoneScaling[zone]?.let { _zoneScaling[zone] = it }
             ?: _zoneScaling.remove(zone)
 
+        source._zoneVideos[zone]?.let { _zoneVideos[zone] = it }
+            ?: _zoneVideos.remove(zone)
+
         return oldRoomIds - newRooms.keys
     }
 
@@ -185,6 +195,9 @@ class World(
 
         _zoneScaling.clear()
         _zoneScaling.putAll(source._zoneScaling)
+
+        _zoneVideos.clear()
+        _zoneVideos.putAll(source._zoneVideos)
 
         _shopDefinitions.clear()
         _shopDefinitions.addAll(source.shopDefinitions)

--- a/src/main/kotlin/dev/ambon/domain/world/data/WorldFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/WorldFile.kt
@@ -16,6 +16,8 @@ data class WorldFile(
     val scaling: ZoneScalingFile? = null,
     val image: ZoneImageDefaults? = null,
     val audio: ZoneAudioDefaults? = null,
+    /** Zone cinematic video (relative path under /videos/). Auto-plays on a player's first entry; replayable from the map. */
+    val video: String? = null,
     val rooms: Map<String, RoomFile>,
     val mobs: Map<String, MobFile> = emptyMap(),
     val items: Map<String, ItemFile> = emptyMap(),

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -157,6 +157,7 @@ object WorldLoader {
         val pvpZones = mutableSetOf<String>()
         val zoneStartRooms = LinkedHashMap<String, RoomId>()
         val zoneScalings = LinkedHashMap<String, ZoneScaling>()
+        val zoneVideos = LinkedHashMap<String, String>()
 
         // startRoomOverride wins; otherwise fall back to first file’s declared startRoom.
         val worldStart = startRoomOverride ?: normalizeId(files.first().zone, files.first().startRoom)
@@ -166,6 +167,7 @@ object WorldLoader {
             if (!zoneStartRooms.containsKey(zone)) {
                 zoneStartRooms[zone] = normalizeId(zone, file.startRoom)
             }
+            file.video?.takeIf { it.isNotBlank() }?.let { zoneVideos.putIfAbsent(zone, "$videosBase$it") }
             val declaredLifespanMinutes = file.lifespan
             if (!zoneLifespansMinutes.containsKey(zone)) {
                 zoneLifespansMinutes[zone] = declaredLifespanMinutes
@@ -1153,6 +1155,7 @@ object WorldLoader {
             pvpZones = pvpZones.toSet(),
             zoneStartRooms = zoneStartRooms.toMap(),
             zoneScaling = zoneScalings.toMap(),
+            zoneVideos = zoneVideos.toMap(),
             shopDefinitions = mergedShops.toList(),
             trainerDefinitions = mergedTrainers.toList(),
             questDefinitions = mergedQuests.toList(),

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -1670,6 +1670,23 @@ class GmcpEmitter(
         emit(sessionId, "Zone.Environment", payload)
     }
 
+    // ---------- zone cinematic ----------
+
+    /**
+     * Zone intro cinematic. [autoplay] is true only on the player's first-ever
+     * entry to the zone; the client keeps [url] around so the cinematic stays
+     * replayable from the expanded map.
+     */
+    data class ZoneCinematicPayload(
+        val zone: String,
+        val url: String,
+        val autoplay: Boolean,
+    )
+
+    suspend fun sendZoneCinematic(sessionId: SessionId, payload: ZoneCinematicPayload) {
+        emit(sessionId, "Zone.Cinematic", payload)
+    }
+
     /** Resolves the environment theme for a zone (zone override merged over defaults). */
     fun buildZoneEnvironmentPayload(zone: String): ZoneEnvironmentPayload {
         val defaults = environmentConfig.defaultTheme

--- a/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
@@ -822,6 +822,16 @@ class PlayerRegistry(
         persistIfClaimed(ps)
     }
 
+    /** Records that this player has watched [zone]'s intro cinematic so it won't auto-play again. */
+    suspend fun markZoneCinematicSeen(
+        sessionId: SessionId,
+        zone: String,
+    ) {
+        val ps = players[sessionId] ?: return
+        if (!ps.seenZoneCinematics.add(zone)) return
+        persistIfClaimed(ps)
+    }
+
     /** Sets the wimpy auto-flee HP-percent threshold. Caller is responsible for clamping to 0..95. */
     suspend fun setWimpyThresholdPct(
         sessionId: SessionId,

--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -53,6 +53,8 @@ data class PlayerState(
      * by [QuestSystem] to gate quests behind prior conversations.
      */
     var dialogueFlags: MutableSet<String> = mutableSetOf(),
+    /** Zones whose intro cinematic this player has already watched (auto-plays once per zone). */
+    var seenZoneCinematics: MutableSet<String> = mutableSetOf(),
     var unlockedAchievementIds: Set<String> = emptySet(),
     var achievementProgress: Map<String, AchievementState> = emptyMap(),
     var activeTitle: String? = null,
@@ -252,6 +254,7 @@ fun PlayerRecord.toPlayerState(sessionId: SessionId): PlayerState =
         activeQuests = activeQuests,
         completedQuestIds = completedQuestIds,
         dialogueFlags = dialogueFlags.toMutableSet(),
+        seenZoneCinematics = seenZoneCinematics.toMutableSet(),
         unlockedAchievementIds = unlockedAchievementIds,
         achievementProgress = achievementProgress,
         activeTitle = activeTitle,
@@ -318,6 +321,7 @@ fun PlayerState.toPlayerRecord(lastSeenEpochMs: Long): PlayerRecord {
         activeQuests = activeQuests,
         completedQuestIds = completedQuestIds,
         dialogueFlags = dialogueFlags.toSet(),
+        seenZoneCinematics = seenZoneCinematics.toSet(),
         unlockedAchievementIds = unlockedAchievementIds,
         achievementProgress = achievementProgress,
         activeTitle = activeTitle,

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -418,6 +418,16 @@ internal suspend fun sendLook(
         val zoneRooms = world.rooms.values.filter { it.id.zone == zone }
         gmcpEmitter.sendZoneMap(sessionId, zone, zoneRooms)
         gmcpEmitter.sendZoneEnvironment(sessionId, gmcpEmitter.buildZoneEnvironmentPayload(zone))
+        // Zone intro cinematic: auto-plays on the player's first-ever entry,
+        // then stays replayable from the expanded map.
+        world.zoneVideo(zone)?.let { videoUrl ->
+            val firstVisit = zone !in me.seenZoneCinematics
+            if (firstVisit) players.markZoneCinematicSeen(sessionId, zone)
+            gmcpEmitter.sendZoneCinematic(
+                sessionId,
+                GmcpEmitter.ZoneCinematicPayload(zone = zone, url = videoUrl, autoplay = firstVisit),
+            )
+        }
     }
 
     val isHousing = room.id.zone.startsWith("house_")

--- a/src/main/kotlin/dev/ambon/engine/events/GmcpEventHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/GmcpEventHandler.kt
@@ -81,6 +81,14 @@ class GmcpEventHandler(
                     sid,
                     gmcpEmitter.buildZoneEnvironmentPayload(room.id.zone),
                 )
+                // Re-sync the zone cinematic URL (never autoplay here) so the
+                // map's replay button survives reconnects.
+                world.zoneVideo(room.id.zone)?.let { videoUrl ->
+                    gmcpEmitter.sendZoneCinematic(
+                        sid,
+                        GmcpEmitter.ZoneCinematicPayload(zone = room.id.zone, url = videoUrl, autoplay = false),
+                    )
+                }
                 gmcpEmitter.sendRoomPlayers(sid, players.playersInRoom(player.roomId).toList())
                 gmcpEmitter.sendRoomMobs(sid, mobs.mobsInRoom(player.roomId))
                 gmcpEmitter.sendRoomItems(sid, items.itemsInRoom(player.roomId))

--- a/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
@@ -108,6 +108,8 @@ data class PlayerRecord(
     val lastRespecAtMs: Long = 0L,
     /** Persisted dialogue-flag set used to gate quests behind prior conversations. */
     val dialogueFlags: Set<String> = emptySet(),
+    /** Zones whose intro cinematic this player has already watched (auto-plays once per zone). */
+    val seenZoneCinematics: Set<String> = emptySet(),
 ) {
     /**
      * Applies legacy migration fixes after deserialization.

--- a/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
@@ -15,6 +15,7 @@ private val statsType = object : TypeReference<Map<String, Int>>() {}
 private val activeQuestsType = object : TypeReference<Map<String, QuestState>>() {}
 private val completedQuestIdsType = object : TypeReference<Set<String>>() {}
 private val dialogueFlagsType = object : TypeReference<Set<String>>() {}
+private val seenZoneCinematicsType = object : TypeReference<Set<String>>() {}
 private val unlockedAchievementIdsType = object : TypeReference<Set<String>>() {}
 private val achievementProgressType = object : TypeReference<Map<String, AchievementState>>() {}
 private val mailInboxType = object : TypeReference<List<MailMessage>>() {}
@@ -88,6 +89,7 @@ object PlayersTable : Table("players") {
     val wimpyThresholdPct = integer("wimpy_threshold_pct").default(10)
     val lastRespecAtMs = long("last_respec_at_ms").default(0L)
     val dialogueFlags = text("dialogue_flags").default("[]")
+    val seenZoneCinematics = text("seen_zone_cinematics").default("[]")
 
     override val primaryKey = PrimaryKey(id)
 
@@ -151,6 +153,7 @@ object PlayersTable : Table("players") {
             wimpyThresholdPct = row[wimpyThresholdPct],
             lastRespecAtMs = row[lastRespecAtMs],
             dialogueFlags = safeReadJson(row[dialogueFlags], dialogueFlagsType, emptySet()),
+            seenZoneCinematics = safeReadJson(row[seenZoneCinematics], seenZoneCinematicsType, emptySet()),
         ).migrateDefaults()
 
     /**
@@ -219,5 +222,6 @@ object PlayersTable : Table("players") {
         statement[wimpyThresholdPct] = record.wimpyThresholdPct
         statement[lastRespecAtMs] = record.lastRespecAtMs
         statement[dialogueFlags] = jsonMapper.writeValueAsString(record.dialogueFlags)
+        statement[seenZoneCinematics] = jsonMapper.writeValueAsString(record.seenZoneCinematics)
     }
 }

--- a/src/main/resources/db/migration/V42__seen_zone_cinematics.sql
+++ b/src/main/resources/db/migration/V42__seen_zone_cinematics.sql
@@ -1,0 +1,1 @@
+ALTER TABLE players ADD COLUMN seen_zone_cinematics TEXT NOT NULL DEFAULT '[]';

--- a/src/test/kotlin/dev/ambon/engine/commands/ZoneCinematicCommandRouterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/ZoneCinematicCommandRouterTest.kt
@@ -1,0 +1,118 @@
+package dev.ambon.engine.commands
+
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.world.load.WorldLoader
+import dev.ambon.engine.GmcpEmitter
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.toPlayerRecord
+import dev.ambon.engine.toPlayerState
+import dev.ambon.persistence.PlayerId
+import dev.ambon.test.CommandRouterHarness
+import dev.ambon.test.drainAll
+import dev.ambon.test.loginOrFail
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ZoneCinematicCommandRouterTest {
+    private fun cinematicPackets(events: List<OutboundEvent>): List<OutboundEvent.GmcpData> =
+        events.filterIsInstance<OutboundEvent.GmcpData>().filter { it.gmcpPackage == "Zone.Cinematic" }
+
+    private fun createHarness(): CommandRouterHarness {
+        val outbound = LocalOutboundBus()
+        val gmcpEmitter = GmcpEmitter(outbound = outbound, supportsPackage = { _, _ -> true })
+        return CommandRouterHarness.create(
+            world = WorldLoader.loadFromResource("world/ok_zone_video.yaml"),
+            outbound = outbound,
+            gmcpEmitter = gmcpEmitter,
+        )
+    }
+
+    @Test
+    fun `first zone entry autoplays the cinematic and marks it seen`() =
+        runTest {
+            val h = createHarness()
+            val sid = SessionId(1)
+            h.players.loginOrFail(sid, "Alice")
+            h.outbound.drainAll()
+
+            h.router.handle(sid, Command.Look)
+            val packets = cinematicPackets(h.outbound.drainAll())
+            assertEquals(1, packets.size, "Expected one Zone.Cinematic packet")
+            assertTrue(
+                packets[0].jsonData.contains("\"url\":\"/videos/intro_flyover.mp4\"") &&
+                    packets[0].jsonData.contains("\"autoplay\":true"),
+                "Expected autoplay cinematic, got=${packets[0].jsonData}",
+            )
+            assertTrue("ok_zone_video" in h.players.get(sid)!!.seenZoneCinematics)
+        }
+
+    @Test
+    fun `subsequent looks in the same zone do not resend the cinematic`() =
+        runTest {
+            val h = createHarness()
+            val sid = SessionId(2)
+            h.players.loginOrFail(sid, "Bob")
+            h.router.handle(sid, Command.Look)
+            h.outbound.drainAll()
+
+            h.router.handle(sid, Command.Look)
+            assertTrue(
+                cinematicPackets(h.outbound.drainAll()).isEmpty(),
+                "Zone unchanged — no Zone.Cinematic resend expected",
+            )
+        }
+
+    @Test
+    fun `players who already watched the cinematic get it without autoplay`() =
+        runTest {
+            val h = createHarness()
+            val sid = SessionId(3)
+            h.players.loginOrFail(sid, "Carol")
+            h.players.get(sid)!!.seenZoneCinematics.add("ok_zone_video")
+            h.outbound.drainAll()
+
+            h.router.handle(sid, Command.Look)
+            val packets = cinematicPackets(h.outbound.drainAll())
+            assertEquals(1, packets.size, "Replay URL should still be sent on zone entry")
+            assertTrue(
+                packets[0].jsonData.contains("\"autoplay\":false"),
+                "Expected autoplay=false for already-seen cinematic, got=${packets[0].jsonData}",
+            )
+        }
+
+    @Test
+    fun `zones without a cinematic emit nothing`() =
+        runTest {
+            val h = CommandRouterHarness.create() // default test world has no zone video
+            val sid = SessionId(4)
+            h.players.loginOrFail(sid, "Dave")
+            h.outbound.drainAll()
+
+            h.router.handle(sid, Command.Look)
+            assertTrue(cinematicPackets(h.outbound.drainAll()).isEmpty())
+        }
+
+    @Test
+    fun `seenZoneCinematics round-trips through PlayerRecord`() =
+        runTest {
+            val h = createHarness()
+            val sid = SessionId(5)
+            h.players.loginOrFail(sid, "Eve")
+            h.router.handle(sid, Command.Look)
+
+            val state = h.players.get(sid)!!
+            state.playerId = PlayerId(7L)
+            val record = state.toPlayerRecord(lastSeenEpochMs = 123L)
+            assertEquals(setOf("ok_zone_video"), record.seenZoneCinematics)
+
+            val restored = record.toPlayerState(SessionId(6))
+            assertTrue("ok_zone_video" in restored.seenZoneCinematics)
+            assertFalse("other_zone" in restored.seenZoneCinematics)
+        }
+}

--- a/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
@@ -211,6 +211,13 @@ class WorldLoaderTest {
     }
 
     @Test
+    fun `zone-level video resolves under the videos base url`() {
+        val world = WorldLoader.loadFromResource("world/ok_zone_video.yaml")
+        assertEquals("/videos/intro_flyover.mp4", world.zoneVideo("ok_zone_video"))
+        assertNull(world.zoneVideo("zone_without_video"))
+    }
+
+    @Test
     fun `loads zone lifespan minutes`() {
         val world = dev.ambon.test.TestWorlds.okSmall
 

--- a/src/test/resources/world/ok_zone_video.yaml
+++ b/src/test/resources/world/ok_zone_video.yaml
@@ -1,0 +1,14 @@
+zone: ok_zone_video
+startRoom: a
+video: intro_flyover.mp4
+rooms:
+  a:
+    title: Room A
+    description: A quiet room.
+    exits:
+      n: b
+  b:
+    title: Room B
+    description: Another quiet room.
+    exits:
+      s: a

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -162,7 +162,8 @@ function App() {
   const intentionalDisconnectRef = useRef(false);
   const connectedRef = useRef(false);
 
-  // Cinematic video state — driven by canvas openVideo callback
+  // Cinematic video state — driven by canvas openVideo callback (room videos,
+  // zone-cinematic autoplay, and the map's replay button all route through it)
   const [videoUrl, setVideoUrl] = useState<string | null>(null);
   const [videoClosing, setVideoClosing] = useState(false);
 
@@ -1265,25 +1266,38 @@ function App() {
 
         {drawerPanel === "map" && (
           <div className="drawer-map-body">
-            <div className="drawer-map-tabs" role="tablist" aria-label="Map views">
-              <button
-                type="button"
-                role="tab"
-                aria-selected={mapTab === "map"}
-                className={`drawer-map-tab ${mapTab === "map" ? "drawer-map-tab-active" : ""}`}
-                onClick={() => setMapTab("map")}
-              >
-                Local Map
-              </button>
-              <button
-                type="button"
-                role="tab"
-                aria-selected={mapTab === "atlas"}
-                className={`drawer-map-tab ${mapTab === "atlas" ? "drawer-map-tab-active" : ""}`}
-                onClick={() => setMapTab("atlas")}
-              >
-                Atlas
-              </button>
+            <div className="drawer-map-toolbar">
+              <div className="drawer-map-tabs" role="tablist" aria-label="Map views">
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={mapTab === "map"}
+                  className={`drawer-map-tab ${mapTab === "map" ? "drawer-map-tab-active" : ""}`}
+                  onClick={() => setMapTab("map")}
+                >
+                  Local Map
+                </button>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={mapTab === "atlas"}
+                  className={`drawer-map-tab ${mapTab === "atlas" ? "drawer-map-tab-active" : ""}`}
+                  onClick={() => setMapTab("atlas")}
+                >
+                  Atlas
+                </button>
+              </div>
+              {state.zoneCinematic && state.zoneCinematic.zone === currentZone && (
+                <button
+                  type="button"
+                  className="drawer-map-cinematic-btn"
+                  title="Replay this zone's intro cinematic"
+                  aria-label="Replay zone cinematic"
+                  onClick={() => setVideoUrl(state.zoneCinematic?.url ?? null)}
+                >
+                  <span aria-hidden="true">{"▶"}</span> Zone cinematic
+                </button>
+              )}
             </div>
             {/* Keep the canvas mounted so the minimap renderer can keep drawing into it
                 even while the Atlas tab is in front — switching back must not lose state. */}

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -77,6 +77,7 @@ import type {
   WorldArea,
   WorldTime,
   WorldWeather,
+  ZoneCinematicState,
   ZoneEnvironment,
   ZoneInstances,
   ZoneInstanceItem,
@@ -214,6 +215,9 @@ interface GmcpContext {
   setWorldWeather: Dispatch<SetStateAction<WorldWeather | null>>;
   setWorldEvents: Dispatch<SetStateAction<WorldEvent[]>>;
   setZoneEnvironment: Dispatch<SetStateAction<ZoneEnvironment | null>>;
+  setZoneCinematic: Dispatch<SetStateAction<ZoneCinematicState | null>>;
+  /** Opens the cinematic video modal (server-requested autoplay on first zone entry). */
+  openCinematic: (url: string) => void;
   setPetState: Dispatch<SetStateAction<PetState | null>>;
   setFactions: Dispatch<SetStateAction<FactionStanding[]>>;
   setBankState: Dispatch<SetStateAction<BankState | null>>;
@@ -2007,6 +2011,21 @@ export function applyGmcpPackage(
         transitionColors,
         weatherParticleOverrides,
       });
+      break;
+    }
+
+    case "Zone.Cinematic": {
+      const packet = data as Partial<Record<string, unknown>>;
+      const zone = typeof packet.zone === "string" ? packet.zone : "";
+      const url = typeof packet.url === "string" ? packet.url : "";
+      const autoplay = packet.autoplay === true;
+      if (zone && url) {
+        // State is sticky between zones — the map replay button gates on the
+        // cinematic's zone matching the current zone. Autoplay is an event:
+        // the server requests it at most once per player per zone.
+        ctx.setZoneCinematic({ zone, url });
+        if (autoplay) ctx.openCinematic(url);
+      }
       break;
     }
 

--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from "react";
 import type { SetStateAction } from "react";
 import { applyGmcpPackage } from "../gmcp/applyGmcpPackage";
+import { canvasCallbacks } from "../canvas/GameStateBridge";
 import { canvasEvents } from "../canvas/CanvasEventBus";
 import {
   DEFAULT_SERVER_FEATURES,
@@ -97,6 +98,7 @@ import type {
   WorldEvent,
   WorldTime,
   WorldWeather,
+  ZoneCinematicState,
   ZoneEnvironment,
   ZoneInstances,
   CurrencyActivity,
@@ -287,6 +289,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
   const [worldWeather, setWorldWeather] = useState<WorldWeather | null>(null);
   const [worldEvents, setWorldEvents] = useState<WorldEvent[]>([]);
   const [zoneEnvironment, setZoneEnvironment] = useState<ZoneEnvironment | null>(null);
+  const [zoneCinematic, setZoneCinematic] = useState<ZoneCinematicState | null>(null);
   const [factions, setFactions] = useState<FactionStanding[]>([]);
   const [dungeonInfo, setDungeonInfo] = useState<DungeonInfo | null>(null);
   const [dungeonCatalog, setDungeonCatalog] = useState<DungeonCatalogEntry[]>([]);
@@ -629,6 +632,10 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
         setWorldWeather,
         setWorldEvents,
         setZoneEnvironment,
+        setZoneCinematic,
+        // Zone-cinematic autoplay rides the same bridge as the canvas video
+        // button — App registers openVideo to open the cinematic modal.
+        openCinematic: (url: string) => { canvasCallbacks.openVideo?.(url); },
         setPetState,
         setFactions: applyFactions,
         setBankState,
@@ -677,6 +684,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     setDialogue(null);
     setWhoPlayers([]);
     setZoneInstances({ zone: null, currentEngineId: null, instances: [] });
+    setZoneCinematic(null);
     setCombatTarget(null);
     setConsiderResult(null);
     setCharStats(null);
@@ -766,7 +774,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     // Crafting
     craftingSkills, craftingRecipes, craftingNodes, gatherCooldownUntilMs,
     // World
-    dialogue, setDialogue, zoneInstances, worldTime, worldWeather, worldEvents, zoneEnvironment, factions, factionActivity, dungeonInfo, dungeonCatalog,
+    dialogue, setDialogue, zoneInstances, worldTime, worldWeather, worldEvents, zoneEnvironment, zoneCinematic, factions, factionActivity, dungeonInfo, dungeonCatalog,
     // Housing & pets
     housing, housingTemplates, petState,
     // Mail

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -10306,10 +10306,42 @@ body {
   min-height: 0;
 }
 
+.drawer-map-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
 .drawer-map-tabs {
   display: flex;
   gap: var(--space-1);
   padding: 0 var(--space-1);
+}
+
+/* Replay button for the zone intro cinematic — styled like a tab, gold accent. */
+.drawer-map-cinematic-btn {
+  appearance: none;
+  border: 1px solid rgb(219 191 128 / 28%);
+  background: rgb(73 62 39 / 50%);
+  color: rgb(234 219 195 / 90%);
+  padding: 6px 16px;
+  margin-right: var(--space-1);
+  border-radius: 999px;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition:
+    background-color 150ms var(--ease-out-soft),
+    border-color 150ms var(--ease-out-soft),
+    color 150ms var(--ease-out-soft);
+}
+
+.drawer-map-cinematic-btn:hover {
+  border-color: rgb(255 224 176 / 46%);
+  color: rgb(247 238 225 / 96%);
 }
 
 .drawer-map-tab {

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -43,6 +43,17 @@ export interface ZoneEnvironment {
   weatherParticleOverrides: Record<string, string>;
 }
 
+/**
+ * Zone intro cinematic — powers the map's replay button. Autoplay (first-ever
+ * zone entry) is handled as an event via the canvas video bridge, not state:
+ * the server marks the cinematic seen immediately, so it requests autoplay
+ * at most once per player per zone.
+ */
+export interface ZoneCinematicState {
+  zone: string;
+  url: string;
+}
+
 export interface CurrencyBalance {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary

Zone-level intro cinematics: a new `video:` field on zone YAML (sibling of `image:`/`audio:`) that **auto-plays the first time a player ever enters the zone** and stays **replayable from the expanded World Map**.

Motivation: the Arcanum already generates and uploads zone cinematics with nowhere to land — e.g. `a08be831e489…mp4` is live on the CDN but referenced by nothing. This gives them a schema home.

## How it works

**World schema**
- `WorldFile.video` → resolved under the videos base URL at load time (same as room videos) into `World.zoneVideos` / `zoneVideo(zoneId)`
- Carried through hot-reload (`mergeZone` / `replaceAll`); documented in `WORLD_YAML_SPEC.md`

**Engine**
- New `Zone.Cinematic {zone, url, autoplay}` GMCP, emitted from the existing zone-change block in `sendLook` (alongside Zone.Map/Zone.Environment — covered by the `"Zone 1"` auto-opt-in prefix)
- `autoplay=true` only on first-ever entry; the zone is immediately recorded in a new `seen_zone_cinematics` player column (Flyway **V42**, JSON set like `dialogue_flags`) so it can never autoplay twice
- Re-entries and `Core.Supports.Set` re-syncs send `autoplay=false` so the client always has the URL for replay after reconnects

**Web**
- Autoplay opens the existing cinematic modal via the canvas video bridge (`canvasCallbacks.openVideo`) — same path as the room-video play button; no setState-in-effect
- Expanded World Map toolbar gains a gold **"▶ Zone cinematic"** button, gated on the cinematic belonging to the current zone

## Tests

- `ZoneCinematicCommandRouterTest`: first-entry autoplay + marked seen, no resend on same-zone looks, `autoplay=false` for already-seen players, no packet for zones without video, PlayerRecord round-trip
- `WorldLoaderTest`: zone video resolves under the videos base URL (new `ok_zone_video.yaml` fixture)
- `PersistenceFieldCoverageTest` covers the new field; full `test` + `integrationTest` + `ktlintCheck` + web `tsc`/eslint pass

## Verified live (headless browser, local `gradlew run`)

Temporarily attached the orphaned CDN cinematic to the bundled Academy zone:
- New demo character → `Zone.Cinematic … autoplay:true` on the wire, video modal auto-opens with the correct URL
- Close modal → `look` again → does not reopen
- Open World Map → replay button visible → click → modal reopens
- `/videos/` static serving returns the mp4 (200, video/mp4)
