### PR TITLE
fix(web): hide canvas dialogue overlay while monster manual is open

### DIFF
--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -366,6 +366,7 @@ function App() {
       mobInfo: state.mobInfo,
       groupInfo: state.groupInfo,
       dialogue: state.dialogue,
+      monsterPanelOpen: monster !== null,
       quests: state.quests,
       questsAvailable: state.questsAvailable,
       shop: state.shop,

--- a/web-v3/src/canvas/GameStateBridge.ts
+++ b/web-v3/src/canvas/GameStateBridge.ts
@@ -40,6 +40,9 @@ export interface GameStateSnapshot {
   mobInfo: MobInfo[];
   groupInfo: GroupInfo;
   dialogue: DialogueState | null;
+  /** True while the monster-manual panel is open — it renders dialogue itself,
+   *  so the in-canvas DialogueOverlay must yield to avoid a doubled window. */
+  monsterPanelOpen: boolean;
   quests: QuestEntry[];
   questsAvailable: QuestAvailable[];
   shop: ShopState | null;
@@ -150,6 +153,7 @@ export const gameStateRef: { current: GameStateSnapshot } = {
     mobInfo: [],
     groupInfo: { leader: null, members: [] },
     dialogue: null,
+    monsterPanelOpen: false,
     quests: [],
     questsAvailable: [],
     shop: null,

--- a/web-v3/src/canvas/systems/DialogueOverlay.ts
+++ b/web-v3/src/canvas/systems/DialogueOverlay.ts
@@ -89,7 +89,9 @@ export class DialogueOverlay {
     const state = gameStateRef.current;
     const dialogue = state.dialogue;
 
-    if (!dialogue) {
+    // The monster-manual panel renders dialogue in its own styled window;
+    // showing the canvas overlay too would double the dialogue on screen.
+    if (!dialogue || state.monsterPanelOpen) {
       this.container.visible = false;
       this.fullBg.visible = false;
       this.fullBg.eventMode = "none";


### PR DESCRIPTION
The monster-manual panel renders NPC dialogue in its own styled parchment window, but the old PixiJS DialogueOverlay still drew its box behind it whenever dialogue state was set (screenshot in session). This bridges a monsterPanelOpen flag into the canvas state snapshot so the overlay yields while the panel is showing. Dialogues started by typing a talk command without the panel open still use the canvas overlay as before. Validated with bun run lint and tsc --noEmit.