### PR TITLE
fix(web): lottery countdown showed ~56 years; treat nextDrawingMs as epoch

### DIFF
--- a/web-v3/src/components/panels/LotteryPanel.tsx
+++ b/web-v3/src/components/panels/LotteryPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { LotteryInfo, UiFeedbackEntry } from "../../types";
 
 interface LotteryPanelProps {
@@ -20,6 +20,12 @@ function formatCountdown(ms: number): string {
 
 export function LotteryPanel({ lotteryInfo, uiFeedbackFeed, onCommand }: LotteryPanelProps) {
   const [ticketDraft, setTicketDraft] = useState("1");
+  // nextDrawingMs is an absolute epoch timestamp; tick so the pill counts down.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(timer);
+  }, []);
 
   const activeFeedback = useMemo(
     () => [...uiFeedbackFeed].reverse().find((e) => e.scope === "lottery") ?? null,
@@ -45,7 +51,7 @@ export function LotteryPanel({ lotteryInfo, uiFeedbackFeed, onCommand }: Lottery
               <p className="systems-card-label">Current Drawing</p>
               <h4>{lotteryInfo.jackpot.toLocaleString()} gold jackpot</h4>
             </div>
-            <span className="systems-pill">{formatCountdown(lotteryInfo.nextDrawingMs)}</span>
+            <span className="systems-pill">{formatCountdown(lotteryInfo.nextDrawingMs - now)}</span>
           </div>
           <dl className="systems-stat-grid">
             <div><dt>Your Tickets</dt><dd>{lotteryInfo.playerTickets}</dd></div>

--- a/web-v3/src/components/panels/SystemsPanel.tsx
+++ b/web-v3/src/components/panels/SystemsPanel.tsx
@@ -103,6 +103,17 @@ export function SystemsPanel({
     setActiveView(initialView);
   }, [initialView]);
 
+  // nextDrawingMs is an absolute epoch timestamp; tick while the lottery
+  // view is open so the pill counts down.
+  const [now, setNow] = useState(() => Date.now());
+  const lotteryViewOpen = activeView === "lottery" && lotteryInfo !== null;
+  useEffect(() => {
+    if (!lotteryViewOpen) return;
+    setNow(Date.now());
+    const timer = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(timer);
+  }, [lotteryViewOpen]);
+
   useEffect(() => {
     setPetNameDraft(petState?.active ? petState.name ?? "" : "");
   }, [petState?.active, petState?.name]);
@@ -400,7 +411,7 @@ export function SystemsPanel({
                     <p className="systems-card-label">Current Drawing</p>
                     <h4>{lotteryInfo.jackpot.toLocaleString()} gold jackpot</h4>
                   </div>
-                  <span className="systems-pill">{formatCountdown(lotteryInfo.nextDrawingMs)}</span>
+                  <span className="systems-pill">{formatCountdown(lotteryInfo.nextDrawingMs - now)}</span>
                 </div>
                 <dl className="systems-stat-grid">
                   <div><dt>Your Tickets</dt><dd>{lotteryInfo.playerTickets}</dd></div>


### PR DESCRIPTION
## Bug

The live instance lottery panel showed **494671h 39m** until the next draw.

`Lottery.Info` `nextDrawingMs` is an **absolute epoch timestamp** (`LotterySystem` sets `clock.millis() + drawingIntervalMs`), and the telnet path correctly subtracts current time before formatting. But both web panels (`LotteryPanel`, `SystemsPanel` lottery view) passed the raw timestamp straight into `formatCountdown()` as if it were a remaining-time duration — so the pill rendered the Unix epoch age (~56 years) instead of the time until the next draw. Pre-existing bug, surfaced by the dice-kiosk work (#1215) putting real eyes on the panel.

The overlay config is fine (`drawingIntervalMs: 3600000` = 1h).

## Fix

Subtract a ticking `Date.now()` at render in both panels. Side benefit: the pill now counts down live instead of freezing at whatever the last `Lottery.Info` said. The `SystemsPanel` ticker only runs while the lottery view is actually open, so other views are not re-rendered every second.

## Validation

- `bun run lint` and `tsc --noEmit` pass