### PR TITLE
fix(auction): demo characters saw silent failure when buying from auction panel

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/AuctionHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/AuctionHandler.kt
@@ -86,7 +86,7 @@ class AuctionHandler(
     }
 
     private suspend fun handleSell(sessionId: SessionId, cmd: Command.AuctionSell) {
-        if (!requireClaimed(sessionId, players, outbound, "Posting auctions")) return
+        if (!requireClaimed(sessionId, players, outbound, "Posting auctions", gmcpEmitter, "auction", "sell")) return
         val auction =
             auctionSystem
                 ?: return sendErrorWithFeedback(
@@ -145,7 +145,7 @@ class AuctionHandler(
     }
 
     private suspend fun handleBuy(sessionId: SessionId, cmd: Command.AuctionBuy) {
-        if (!requireClaimed(sessionId, players, outbound, "Buying from the auction house")) return
+        if (!requireClaimed(sessionId, players, outbound, "Buying from the auction house", gmcpEmitter, "auction", "buy")) return
         val auction =
             auctionSystem
                 ?: return sendErrorWithFeedback(

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/CommunicationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/CommunicationHandler.kt
@@ -148,7 +148,7 @@ class CommunicationHandler(
         sessionId: SessionId,
         cmd: Command.Gossip,
     ) {
-        if (!requireClaimed(sessionId, players, outbound, "Global chat")) return
+        if (!requireClaimed(sessionId, players, outbound, "Global chat", gmcpEmitter, "chat", "gossip")) return
         if (isBroadcastRateLimited(sessionId)) return
         broadcastGlobalChannel(
             sessionId = sessionId,
@@ -164,7 +164,7 @@ class CommunicationHandler(
         sessionId: SessionId,
         cmd: Command.Shout,
     ) {
-        if (!requireClaimed(sessionId, players, outbound, "Shout")) return
+        if (!requireClaimed(sessionId, players, outbound, "Shout", gmcpEmitter, "chat", "shout")) return
         if (isBroadcastRateLimited(sessionId)) return
         players.withPlayer(sessionId) { me ->
             val zone = me.roomId.zone
@@ -182,7 +182,7 @@ class CommunicationHandler(
         sessionId: SessionId,
         cmd: Command.Ooc,
     ) {
-        if (!requireClaimed(sessionId, players, outbound, "OOC chat")) return
+        if (!requireClaimed(sessionId, players, outbound, "OOC chat", gmcpEmitter, "chat", "ooc")) return
         if (isBroadcastRateLimited(sessionId)) return
         broadcastGlobalChannel(
             sessionId = sessionId,

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/DuelHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/DuelHandler.kt
@@ -26,7 +26,7 @@ class DuelHandler(
     }
 
     private suspend fun handleDuel(sessionId: SessionId, cmd: Command.Duel) {
-        if (!requireClaimed(sessionId, players, outbound, "Dueling")) return
+        if (!requireClaimed(sessionId, players, outbound, "Dueling", gmcpEmitter, "duel", "duel")) return
         val ds =
             duelSystem
                 ?: return sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, "Dueling is not available.", "duel", code = "UNAVAILABLE")

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/FriendsHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/FriendsHandler.kt
@@ -13,6 +13,7 @@ class FriendsHandler(
 ) : CommandHandler {
     private val outbound = ctx.outbound
     private val players = ctx.players
+    private val gmcpEmitter = ctx.gmcpEmitter
 
     override fun register(router: CommandRouter) {
         router.on<Command.Friend.List> { sid, _ -> handleFriendCmd(sid, Command.Friend.List) }
@@ -26,7 +27,7 @@ class FriendsHandler(
     ) {
         // Add/Remove mutate persistent state; List is fine for demo characters.
         if (cmd !is Command.Friend.List) {
-            if (!requireClaimed(sessionId, players, outbound, "Adding or removing friends")) return
+            if (!requireClaimed(sessionId, players, outbound, "Adding or removing friends", gmcpEmitter, "friends")) return
         }
         val fs = requireSystemOrNull(sessionId, friendsSystem, "Friends", outbound) ?: return
         val err = when (cmd) {

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/GuildHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/GuildHandler.kt
@@ -46,7 +46,7 @@ class GuildHandler(
         // Read-only commands (Info, Roster) are allowed for demo characters;
         // anything that mutates persistent state requires a real account.
         if (cmd !is Command.Guild.Info && cmd !is Command.Guild.Roster) {
-            if (!requireClaimed(sessionId, players, outbound, "Guilds")) return
+            if (!requireClaimed(sessionId, players, outbound, "Guilds", gmcpEmitter, "guild")) return
         }
         val gs = requireSystemOrNull(sessionId, guildSystem, "Guilds", outbound) ?: return
         val err =

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -92,22 +92,28 @@ internal suspend fun requirePlayerOnline(
  * Used to gate features that touch persistent or social state (global chat,
  * trade, mail send, guild, friends, duels, auction) so demo characters can't
  * spam or grief without committing to an account.
+ *
+ * Pass [gmcpEmitter] + [scope] for panel-driven features so the rejection also
+ * reaches the web client as scoped UI.Feedback — without it, panels show
+ * nothing and the action appears to silently fail.
  */
 internal suspend fun requireClaimed(
     sessionId: SessionId,
     players: PlayerRegistry,
     outbound: OutboundBus,
     feature: String,
+    gmcpEmitter: GmcpEmitter? = null,
+    scope: String? = null,
+    command: String? = null,
 ): Boolean {
     val me = players.get(sessionId) ?: return false
     if (me.playerId != null) return true
-    outbound.send(
-        OutboundEvent.SendError(
-            sessionId,
-            "$feature is not available for demo characters. " +
-                "Type 'claim <password>' or 'claim <newname> <password>' to save your character first.",
-        ),
-    )
+    val message = "$feature is not available for demo characters. " +
+        "Type 'claim <password>' or 'claim <newname> <password>' to save your character first."
+    outbound.send(OutboundEvent.SendError(sessionId, message))
+    if (scope != null) {
+        sendScopedFeedback(sessionId, gmcpEmitter, "error", message, scope, code = "DEMO_CHARACTER", command = command)
+    }
     return false
 }
 

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/MailHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/MailHandler.kt
@@ -110,7 +110,7 @@ class MailHandler(
         sessionId: SessionId,
         cmd: Command.Mail.Send,
     ) {
-        if (!requireClaimed(sessionId, players, outbound, "Sending mail")) return
+        if (!requireClaimed(sessionId, players, outbound, "Sending mail", gmcpEmitter, "mail", "send")) return
         players.withPlayer(sessionId) { me ->
             if (me.mailCompose != null) {
                 outbound.send(

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/TradeHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/TradeHandler.kt
@@ -33,7 +33,7 @@ class TradeHandler(
     }
 
     private suspend fun handleTradeRequest(sessionId: SessionId, cmd: Command.TradeRequest) {
-        if (!requireClaimed(sessionId, players, outbound, "Trading")) return
+        if (!requireClaimed(sessionId, players, outbound, "Trading", gmcpEmitter, "trade", "request")) return
         val ts = tradeSystem ?: return sendUnavailable(sessionId)
 
         players.withPlayer(sessionId) { me ->

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterAuctionTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterAuctionTest.kt
@@ -8,6 +8,7 @@ import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.world.load.WorldLoader
 import dev.ambon.engine.AuctionSystem
 import dev.ambon.engine.CombatSystem
+import dev.ambon.engine.CreateResult
 import dev.ambon.engine.LoginResult
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PlayerRegistry
@@ -255,6 +256,33 @@ class CommandRouterAuctionTest {
             assertTrue(
                 outs.any { it is OutboundEvent.SendError && it.text.contains("need 100 gold") },
                 "Expected an insufficient-gold rejection. got=$outs",
+            )
+        }
+
+    @Test
+    fun `buy is rejected for an unclaimed demo character without changing state`() =
+        runTest {
+            val env = setup()
+            giveSword(env.items, env.sellerSid)
+            env.auction.postListing(env.sellerSid, "Seller", "sword", 100)
+            val demoSid = SessionId(3L)
+            env.items.ensurePlayer(demoSid)
+            require(env.players.createDemo(demoSid, "Demobuyer") == CreateResult.Ok)
+            val demo = env.players.get(demoSid)!!
+            demo.gold = 500L
+            env.outbound.drainAll()
+            val listingId = env.auction.allListings().first().id
+
+            env.router.handle(demoSid, Command.AuctionBuy(listingId))
+
+            assertEquals(500L, demo.gold, "Demo buyer's gold should be untouched")
+            assertTrue(env.items.inventory(demoSid).isEmpty(), "No item should transfer")
+            assertEquals(1, env.auction.allListings().size, "Listing should remain available")
+
+            val outs = env.outbound.drainAll()
+            assertTrue(
+                outs.any { it is OutboundEvent.SendError && it.text.contains("demo characters") },
+                "Expected a demo-character rejection. got=$outs",
             )
         }
 

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -1208,6 +1208,7 @@ function App() {
             listings={state.auctionListings}
             inventory={state.inventory}
             playerName={state.character.name}
+            isDemo={state.character.isDemo}
             feedbackFeed={state.uiFeedbackFeed}
             onCommand={sendCommand}
           />

--- a/web-v3/src/components/panels/AuctionPanel.tsx
+++ b/web-v3/src/components/panels/AuctionPanel.tsx
@@ -7,11 +7,13 @@ interface Props {
   listings: AuctionListing[];
   inventory: ItemSummary[];
   playerName: string;
+  /** Unclaimed demo characters can browse but not buy or sell. */
+  isDemo: boolean;
   feedbackFeed: UiFeedbackEntry[];
   onCommand: (cmd: string) => void;
 }
 
-export function AuctionPanel({ listings, inventory, playerName, feedbackFeed, onCommand }: Props) {
+export function AuctionPanel({ listings, inventory, playerName, isDemo, feedbackFeed, onCommand }: Props) {
   const [view, setView] = useState<AuctionView>("browse");
   const [filter, setFilter] = useState("");
   const [selectedItemId, setSelectedItemId] = useState<string>("");
@@ -56,6 +58,10 @@ export function AuctionPanel({ listings, inventory, playerName, feedbackFeed, on
   );
 
   const createListing = () => {
+    if (isDemo) {
+      setLocalMessage("Demo characters can't post auction listings. Claim your character first.");
+      return;
+    }
     if (!selectedItem) {
       setLocalMessage("Choose an inventory item to list.");
       return;
@@ -124,6 +130,12 @@ export function AuctionPanel({ listings, inventory, playerName, feedbackFeed, on
         </button>
       </div>
 
+      {isDemo && (
+        <p className="auction-local-message auction-local-message-error">
+          Demo characters can browse the auction house but can&rsquo;t buy or sell.
+          Use &ldquo;Save Progress&rdquo; in the top bar to claim your character first.
+        </p>
+      )}
       {localMessage && <p className="auction-local-message">{localMessage}</p>}
       {activeFeedback && (
         <p className={`auction-local-message auction-local-message-${activeFeedback.type}`}>
@@ -180,6 +192,8 @@ export function AuctionPanel({ listings, inventory, playerName, feedbackFeed, on
                           <button
                             type="button"
                             className="auction-buy-btn"
+                            disabled={isDemo}
+                            title={isDemo ? "Claim your character to buy from the auction house." : undefined}
                             onClick={() => {
                               onCommand(`auction buy ${listing.id}`);
                               setLocalMessage(`Purchasing ${listing.itemName}.`);
@@ -245,6 +259,8 @@ export function AuctionPanel({ listings, inventory, playerName, feedbackFeed, on
                     <button
                       type="button"
                       className="auction-create-submit"
+                      disabled={isDemo}
+                      title={isDemo ? "Claim your character to post auction listings." : undefined}
                       onClick={createListing}
                     >
                       Post Listing

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -1710,6 +1710,12 @@ export function applyGmcpPackage(
         command: typeof raw.command === "string" ? raw.command : undefined,
       };
       ctx.pushUiFeedback(packet);
+      // Demo-character rejections can originate from anywhere (player context
+      // menus, chat input, panels) — surface them globally so the action never
+      // appears to silently fail. Panels with scoped feedback also show them inline.
+      if (packet.code === "DEMO_CHARACTER" && packet.message) {
+        ctx.setToast(packet.message);
+      }
       break;
     }
 

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -16895,11 +16895,17 @@ body {
   transition: background 0.15s, color 0.15s, border-color 0.15s, transform 0.15s;
 }
 
-.auction-buy-btn:hover {
+.auction-buy-btn:hover:not(:disabled) {
   background: var(--primary-glass);
   color: var(--text-primary);
   border-color: var(--primary-dim);
   transform: translateY(-1px);
+}
+
+.auction-buy-btn:disabled,
+.auction-create-submit:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 .auction-buy-btn-secondary {
@@ -17017,7 +17023,7 @@ body {
   transition: transform 0.15s, border-color 0.15s, background 0.15s;
 }
 
-.auction-create-submit:hover {
+.auction-create-submit:hover:not(:disabled) {
   transform: translateY(-1px);
   border-color: var(--color-primary-lavender);
   background: rgb(190 176 255 / 18%);


### PR DESCRIPTION
## Problem

Reported symptom: list an item on one player, view it on another, click **Buy** — the panel shows "Purchasing foo" and then nothing happens. No error, no gold deducted, item stays listed.

## Root cause

The buy itself works fine for claimed characters (verified end-to-end with two live sessions). The failure case is an **unclaimed demo/guest character** as the buyer: `requireClaimed` in `HandlerHelpers.kt` rejects the purchase but sends only a plain-text `SendError` to the terminal stream — unlike every other auction failure path (`LISTING_NOT_FOUND`, `INSUFFICIENT_GOLD`, `OWN_LISTING`, ...), it never emits scoped GMCP `UI.Feedback`. The auction panel only displays scoped feedback, so the rejection was invisible there and the click appeared to do nothing.

The same gap existed at every other `requireClaimed` call site: trade, duel, mail send, guild, friends, and gossip/shout/ooc.

## Fix

**Server**
- `requireClaimed` gains optional `gmcpEmitter`/`scope`/`command` params; when a scope is provided it also emits `UI.Feedback` with code `DEMO_CHARACTER`.
- All gated call sites are wired: auction (`auction`, buy/sell), trade (`trade`), duel (`duel`), mail send (`mail`), guild (`guild`), friends (`friends`), gossip/shout/ooc (`chat`).

**Web client**
- `AuctionPanel` receives `isDemo`; demo characters see a persistent hint ("claim your character first") and the **Buy** / **Post Listing** buttons are disabled rather than offering a dead-end click.
- Any `DEMO_CHARACTER` rejection also surfaces as the global game toast, since trade/duel/chat/friends actions can be triggered from context menus and inputs that have no scoped-feedback panel.

## Verification

- New router test: demo buyer is rejected, gold/listing/inventory unchanged, error message sent.
- Live WebSocket session as a demo character: all 10 gated commands (gossip, shout, ooc, trade, duel, mail send, guild create, friend add, auction buy, auction sell) emit `UI.Feedback {"type":"error","code":"DEMO_CHARACTER"}` with the correct scope/command.
- Live two-claimed-players session: purchase still transfers item + gold and clears the listing.
- `ktlintCheck test integrationTest` green; `eslint` + `tsc --noEmit` green.
