### PR TITLE
fix: cast aggro exploit, reserved demo name, ghost currency awards (playtest findings)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -259,6 +259,26 @@ class CombatSystem(
     }
 
     /**
+     * Engages combat between a player and a specific mob without keyword resolution
+     * or attack messaging. Used by hostile ability casts so an out-of-combat target
+     * fights back instead of being farmed risk-free from outside combat.
+     * No-op if the player already has a target, the mob is not a combatant, or
+     * either side is already dead.
+     */
+    suspend fun engageMobCombat(
+        sessionId: SessionId,
+        mob: MobState,
+    ) {
+        val player = players.get(sessionId) ?: return
+        if (playerTarget[sessionId] != null) return
+        if (!mob.role.isCombatant) return
+        if (mob.hp <= 0 || player.hp <= 0) return
+
+        registerCombatant(sessionId, mob.id, player, clock.millis())
+        onPlayerEnteredCombat(sessionId)
+    }
+
+    /**
      * Estimate the player's odds against a mob in the same room without engaging.
      *
      * Uses expected-value damage (mean of the damage range) on both sides, applies

--- a/src/main/kotlin/dev/ambon/engine/CurrencySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CurrencySystem.kt
@@ -30,17 +30,20 @@ class CurrencySystem(
 
     /**
      * Awards [amount] of [currencyId] to the player.
-     * Does nothing if the currency is not defined or amount is not positive.
+     * Returns `true` if the amount was credited. Returns `false` — without
+     * mutating anything — if the currency is not defined or amount is not
+     * positive, so callers can suppress player-facing award announcements.
      */
-    fun award(player: PlayerState, currencyId: String, amount: Long) {
-        if (amount <= 0) return
+    fun award(player: PlayerState, currencyId: String, amount: Long): Boolean {
+        if (amount <= 0) return false
         if (currencyId !in config.definitions) {
             log.warn { "Attempted to award unknown currency '$currencyId' to ${player.name}" }
-            return
+            return false
         }
         val current = player.currencies.getOrDefault(currencyId, 0L)
         player.currencies[currencyId] = current + amount
         log.debug { "Currency awarded: ${player.name} +$amount $currencyId (new balance: ${current + amount})" }
+        return true
     }
 
     /**

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -999,18 +999,19 @@ class GameEngine(
         combatSystem.onXpGained = { sid, amount, source -> gmcpEmitter.sendCharGain(sid, "xp", amount, source) }
         combatSystem.onGoldGained = { sid, amount, source -> gmcpEmitter.sendCharGain(sid, "gold", amount, source) }
         combatSystem.onPlayerDeath = { sid -> cleanupOnPlayerDeath(sid) }
-        combatSystem.onPvpKill = { sid -> notifyDailyQuest(sid, "pvpKill") }
         combatSystem.zoneStartRoomLookup = { zoneId -> world.zoneStartRoom(zoneId) }
         combatSystem.deathConfig = engineConfig.death
         combatSystem.sanctumRoomLookup = {
             engineConfig.death.sanctumRoom?.let { RoomId(it) }?.takeIf { world.rooms.containsKey(it) }
         }
+        // Single assignment: a second `onPvpKill =` would silently overwrite the first.
         combatSystem.onPvpKill = { killerSid ->
+            notifyDailyQuest(killerSid, "pvpKill")
             val killer = players.get(killerSid)
-            if (killer != null && currencySystem.honorPerPvpKill > 0) {
+            if (killer != null &&
                 currencySystem.award(killer, "honor", currencySystem.honorPerPvpKill)
-                val def = currencySystem.getDefinition("honor")
-                val displayName = def?.displayName ?: "Honor"
+            ) {
+                val displayName = currencySystem.getDefinition("honor")?.displayName ?: "Honor"
                 outbound.send(
                     OutboundEvent.SendInfo(
                         killerSid,
@@ -1043,15 +1044,16 @@ class GameEngine(
                 // Award secondary currencies from quest rewards
                 val questDef = questRegistry.get(questId)
                 if (questDef != null) {
+                    var awardedAny = false
                     for ((currencyId, amount) in questDef.rewards.currencies) {
-                        currencySystem.award(player, currencyId, amount)
-                        val def = currencySystem.getDefinition(currencyId)
-                        val displayName = def?.displayName ?: currencyId
+                        if (!currencySystem.award(player, currencyId, amount)) continue
+                        awardedAny = true
+                        val displayName = currencySystem.getDefinition(currencyId)?.displayName ?: currencyId
                         outbound.send(
                             OutboundEvent.SendInfo(sid, "[Currency] You receive $amount $displayName."),
                         )
                     }
-                    if (questDef.rewards.currencies.isNotEmpty()) emitCurrencies(sid, player)
+                    if (awardedAny) emitCurrencies(sid, player)
                 }
             }
         }
@@ -1344,10 +1346,11 @@ class GameEngine(
                     notifyDailyQuest(sid, "craft")
                     globalQuestSystem?.onEvent(sid, GlobalQuestObjectiveType.CRAFT)
                     val crafter = players.get(sid)
-                    if (crafter != null && currencySystem.tokensPerCraft > 0) {
+                    if (crafter != null &&
                         currencySystem.award(crafter, "crafting_tokens", currencySystem.tokensPerCraft)
-                        val def = currencySystem.getDefinition("crafting_tokens")
-                        val displayName = def?.displayName ?: "Crafting Tokens"
+                    ) {
+                        val displayName =
+                            currencySystem.getDefinition("crafting_tokens")?.displayName ?: "Crafting Tokens"
                         outbound.send(
                             OutboundEvent.SendInfo(
                                 sid,

--- a/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
@@ -62,6 +62,9 @@ sealed interface ClaimResult {
     data object InvalidPassword : ClaimResult
 
     data object Taken : ClaimResult
+
+    /** The requested name is reserved by the login flow (e.g. the "demo" guest keyword). */
+    data object Reserved : ClaimResult
 }
 
 /**
@@ -412,6 +415,7 @@ class PlayerRegistry(
 
         val targetName = normalizeName(newNameRaw ?: ps.name)
         val password = normalizePassword(passwordRaw)
+        if (isReservedName(targetName)) return ClaimResult.Reserved
         if (!isValidName(targetName)) return ClaimResult.InvalidName
         if (!isValidPassword(password)) return ClaimResult.InvalidPassword
         // Allow keeping the same name (case-insensitive match against self),
@@ -867,8 +871,16 @@ class PlayerRegistry(
             val ok = c.isLetterOrDigit() || c == '_'
             if (!ok) return false
         }
-        return true
+        return !isReservedName(name)
     }
+
+    /**
+     * Names that can never belong to an account because the login flow intercepts
+     * them as keywords before name resolution (see LoginFlowHandler's demo-guest
+     * entry). An account named "Demo" would be permanently unreachable: any case
+     * variant typed at the name prompt starts a guest session instead of logging in.
+     */
+    fun isReservedName(name: String): Boolean = normalizeName(name).lowercase() in RESERVED_NAMES
 
     /**
      * Remap a player from [oldSid] to [newSid] atomically.
@@ -919,4 +931,9 @@ class PlayerRegistry(
     private fun normalizeName(nameRaw: String): String = nameRaw.trim()
 
     private fun normalizePassword(passwordRaw: String): String = passwordRaw
+
+    companion object {
+        /** Lowercase names reserved by login-flow keywords. See [isReservedName]. */
+        val RESERVED_NAMES = setOf("demo")
+    }
 }

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
@@ -181,6 +181,10 @@ class AbilitySystem(
         val playerStats = resolvePlayerStats(player, items, statusEffects, classRegistry)
         deductManaAndCooldown(sessionId, player, ability, now)
 
+        // A hostile cast provokes its target: engage combat so the mob fights
+        // back instead of standing idle while being farmed from out of combat.
+        combat.engageMobCombat(sessionId, mob)
+
         for (effect in effects) {
             executeEnemyEffect(sessionId, player, ability, mob, effect, playerStats, areaTargets)
         }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ClaimHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ClaimHandler.kt
@@ -81,6 +81,13 @@ class ClaimHandler(
             ClaimResult.Taken -> outbound.send(
                 OutboundEvent.SendError(sessionId, "That name is already taken."),
             )
+            ClaimResult.Reserved -> outbound.send(
+                OutboundEvent.SendError(
+                    sessionId,
+                    "That name is reserved and cannot be used. Pick another with " +
+                        "'claim <newname> <password>'.",
+                ),
+            )
         }
     }
 }

--- a/src/test/kotlin/dev/ambon/engine/CurrencySystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/CurrencySystemTest.kt
@@ -53,8 +53,8 @@ class CurrencySystemTest {
     }
 
     @Test
-    fun `award increases balance`() {
-        system.award(player, "quest_points", 50)
+    fun `award increases balance and reports success`() {
+        assertTrue(system.award(player, "quest_points", 50))
         assertEquals(50L, system.balance(player, "quest_points"))
     }
 
@@ -66,21 +66,32 @@ class CurrencySystemTest {
     }
 
     @Test
-    fun `award with zero amount does nothing`() {
-        system.award(player, "quest_points", 0)
+    fun `award with zero amount does nothing and reports failure`() {
+        assertFalse(system.award(player, "quest_points", 0))
         assertEquals(0L, system.balance(player, "quest_points"))
     }
 
     @Test
-    fun `award with negative amount does nothing`() {
-        system.award(player, "quest_points", -5)
+    fun `award with negative amount does nothing and reports failure`() {
+        assertFalse(system.award(player, "quest_points", -5))
         assertEquals(0L, system.balance(player, "quest_points"))
     }
 
     @Test
-    fun `award unknown currency does nothing`() {
-        system.award(player, "unknown_currency", 100)
+    fun `award unknown currency does nothing and reports failure`() {
+        assertFalse(system.award(player, "unknown_currency", 100))
         assertFalse(player.currencies.containsKey("unknown_currency"))
+    }
+
+    @Test
+    fun `award reports failure when no currencies are defined`() {
+        // A server with tokensPerCraft/honorPerPvpKill set but no currency
+        // definitions must not credit (or announce) anything — callers gate
+        // their "[Currency] You receive ..." messages on this return value.
+        val undefinedSystem = CurrencySystem(config = CurrenciesConfig(definitions = emptyMap()))
+        assertFalse(undefinedSystem.award(player, "crafting_tokens", undefinedSystem.tokensPerCraft))
+        assertFalse(undefinedSystem.award(player, "honor", undefinedSystem.honorPerPvpKill))
+        assertTrue(player.currencies.isEmpty())
     }
 
     @Test

--- a/src/test/kotlin/dev/ambon/engine/PlayerRegistryDemoTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/PlayerRegistryDemoTest.kt
@@ -116,6 +116,34 @@ class PlayerRegistryDemoTest {
     }
 
     @Test
+    fun `claim rejects the reserved demo login keyword as a name`() = runTest {
+        val repo = InMemoryPlayerRepository()
+        val registry = buildTestPlayerRegistry(startRoom, repo, ItemRegistry())
+
+        registry.createDemo(SessionId(1), "Keris8")
+        // Any case variant of "demo" is intercepted by the login flow as the
+        // guest keyword, so a claimed account with that name could never log in.
+        for (reserved in listOf("demo", "Demo", "DEMO")) {
+            assertEquals(
+                ClaimResult.Reserved,
+                registry.claim(SessionId(1), newNameRaw = reserved, passwordRaw = "secret"),
+                "claim must reject reserved name '$reserved'",
+            )
+        }
+        assertNull(registry.get(SessionId(1))!!.playerId, "failed claim must leave demo unchanged")
+        assertNull(repo.findByName("Demo"))
+    }
+
+    @Test
+    fun `create rejects the reserved demo login keyword as a name`() = runTest {
+        val repo = InMemoryPlayerRepository()
+        val registry = buildTestPlayerRegistry(startRoom, repo, ItemRegistry())
+
+        assertEquals(CreateResult.InvalidName, registry.create(SessionId(1), "Demo", "password"))
+        assertNull(repo.findByName("Demo"))
+    }
+
+    @Test
     fun `claim rejects invalid passwords and names`() = runTest {
         val repo = InMemoryPlayerRepository()
         val registry = buildTestPlayerRegistry(startRoom, repo, ItemRegistry())

--- a/src/test/kotlin/dev/ambon/engine/abilities/AbilitySystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/abilities/AbilitySystemTest.kt
@@ -322,6 +322,64 @@ class AbilitySystemTest {
         }
 
     @Test
+    fun `cast at an out-of-combat mob engages combat so the target fights back`() =
+        runTest {
+            val h = buildSystem()
+            h.players.loginOrFail(sid, "Provoker")
+            h.abilitySystem.syncAbilities(sid, 1)
+            h.players.get(sid)!!.mana = 20
+
+            val mob = MobState(MobId("zone:rat"), "a rat", roomId, hp = 20, maxHp = 20)
+            h.mobs.upsert(mob)
+
+            assertFalse(h.combat.isInCombat(sid))
+            val err = h.abilitySystem.cast(sid, "magic_missile", "rat")
+            assertNull(err)
+
+            assertTrue(h.combat.isInCombat(sid), "a hostile cast must engage combat with its target")
+            assertEquals(mob.id, h.combat.currentTarget(sid))
+        }
+
+    @Test
+    fun `cast that kills its target does not leave the player stuck in combat`() =
+        runTest {
+            val h = buildSystem()
+            h.players.loginOrFail(sid, "Slayer")
+            h.abilitySystem.syncAbilities(sid, 1)
+            h.players.get(sid)!!.mana = 20
+
+            val mob = MobState(MobId("zone:rat"), "a rat", roomId, hp = 3, maxHp = 20)
+            h.mobs.upsert(mob)
+
+            val err = h.abilitySystem.cast(sid, "magic_missile", "rat")
+            assertNull(err)
+
+            assertNull(h.mobs.get(MobId("zone:rat")))
+            assertFalse(h.combat.isInCombat(sid), "combat must end when the spell kills the target")
+        }
+
+    @Test
+    fun `cast while fighting another mob does not retarget`() =
+        runTest {
+            val h = buildSystem()
+            h.players.loginOrFail(sid, "Splitter")
+            h.abilitySystem.syncAbilities(sid, 1)
+            h.players.get(sid)!!.mana = 20
+
+            val first = MobState(MobId("zone:rat"), "a rat", roomId, hp = 20, maxHp = 20)
+            val second = MobState(MobId("zone:bat"), "a bat", roomId, hp = 20, maxHp = 20)
+            h.mobs.upsert(first)
+            h.mobs.upsert(second)
+            assertNull(h.combat.startCombat(sid, "rat"))
+
+            val err = h.abilitySystem.cast(sid, "magic_missile", "bat")
+            assertNull(err)
+
+            assertEquals(first.id, h.combat.currentTarget(sid), "off-target cast must not switch the melee target")
+            assertEquals(15, second.hp)
+        }
+
+    @Test
     fun `knownAbilities reflects level`() =
         runTest {
             val h = buildSystem()


### PR DESCRIPTION
Fixes the three highest-severity findings from today's live playtest of mud.ambon.dev (telnet, fresh character + demo guest sessions).

## 1. Hostile casts never engaged combat — free-kill exploit (High)

**Observed live:** `cast hammer goblin` repeated until the goblin died. It never retaliated; full XP + gold awarded; zero damage taken. `applySpellDamage` added threat and handled the kill, but only the `kill` command ever called `startCombat` — threat is meaningless for a mob that isn't in combat.

**Fix:** new `CombatSystem.engageMobCombat(sessionId, mob)` — registers the combatant and fires `onPlayerEnteredCombat` without keyword resolution or attack messaging. `handleEnemyCast` invokes it after mana/cooldown are paid, so any hostile cast (damage, debuff, taunt-join) provokes its target. No-ops when the player already has a target, the mob is a non-combatant, or either side is dead.

**Tests:** out-of-combat cast engages combat with the target; killing cast does not leave the player stuck in combat; off-target cast while melee-engaged does not retarget.

## 2. `claim` accepted the reserved name "Demo" — account permanently unreachable (High)

**Observed live:** `claim Demo <password>` succeeded; the login flow intercepts any case variant of `demo` at the name prompt and starts a guest session, so that account can never log in again.

**Fix:** `PlayerRegistry.RESERVED_NAMES` (`demo`) + `isReservedName()`. `claim` returns a new `ClaimResult.Reserved` with a clear message ("That name is reserved and cannot be used…"), and `isValidName` now rejects reserved names so the create/login paths are covered even on servers with the demo flow disabled.

**Tests:** claim rejects `demo`/`Demo`/`DEMO` and leaves the demo character unchanged; create rejects the reserved name.

> Note: the live demo instance now has an orphaned `Demo` player record (created during the playtest, pre-fix). It may want manual cleanup in the player store.

## 3. Ghost "[Currency] You receive 1 Crafting Tokens." (Medium)

**Observed live:** crafting announced a Crafting Tokens award while `currencies` reported "No secondary currencies exist." Default config ships `tokensPerCraft = 1` with empty `definitions`; `CurrencySystem.award` silently dropped the award but the announcement was sent unconditionally.

**Fix:** `award()` now returns `Boolean` (credited or not, never mutating on failure). All three announcement sites — craft tokens, PvP honor, quest currency rewards — gate the player message and GMCP wallet refresh on it.

**Bonus latent bug fixed in the same block:** `combatSystem.onPvpKill` was assigned twice in `GameEngine`; the honor lambda silently overwrote the `notifyDailyQuest(sid, "pvpKill")` hook, so PvP-kill daily quest progress never fired. Merged into a single assignment.

**Tests:** award return-value semantics (success, zero/negative amount, unknown currency, empty definitions).

## Verification

- `./gradlew ktlintCheck test integrationTest` — all green.
- Findings 1 and 2 were reproduced live on mud.ambon.dev before writing the fixes; finding 3's root cause confirmed by code inspection (config defaults + silent no-op in `award`).
