### PR TITLE
feat(puzzles): telnet parity for riddles and sequence puzzles in look (#1218)

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -1881,6 +1881,7 @@ data class CommandsConfig(
             "put_in" to CommandMetadata("put <item> <container>", "Place an item in a container", "world", requiresTarget = true),
             "pull" to CommandMetadata("pull <lever>", "Pull a lever or object", "world", requiresTarget = true),
             "read" to CommandMetadata("read <sign>", "Read a sign or inscription", "world", requiresTarget = true),
+            "answer" to CommandMetadata("answer <text>", "Answer a riddle in the room", "world", requiresTarget = true),
             "title" to CommandMetadata("title <titleName> | title clear", "Set or clear your title", "progression", requiresTarget = true),
             "gender" to CommandMetadata("gender <option>", "Set your gender", "progression", requiresTarget = true),
             "sprite" to CommandMetadata("sprite list | set <id> | default", "Manage your character sprite", "progression"),

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -20,6 +20,7 @@ import dev.ambon.engine.GmcpEmitter
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.PlayerState
+import dev.ambon.engine.PuzzleSystem
 import dev.ambon.engine.QuestSystem
 import dev.ambon.engine.TrainerRegistry
 import dev.ambon.engine.WorldStateRegistry
@@ -173,7 +174,20 @@ internal suspend fun sendErrorWithFeedback(
 
 /** Convenience extension that delegates to the full [sendLook], pulling all dependencies from this context. */
 internal suspend fun EngineContext.sendLook(sessionId: SessionId) {
-    sendLook(sessionId, world, players, mobs, items, worldState, outbound, gmcpEmitter, gatheringRegistry, questSystem, trainerRegistry)
+    sendLook(
+        sessionId,
+        world,
+        players,
+        mobs,
+        items,
+        worldState,
+        outbound,
+        gmcpEmitter,
+        gatheringRegistry,
+        questSystem,
+        trainerRegistry,
+        puzzleSystem,
+    )
     emitShopGmcp(sessionId)
     emitBankGmcp(sessionId)
     emitPuzzleGmcp(sessionId)
@@ -299,6 +313,7 @@ internal suspend fun sendLook(
     gatheringRegistry: GatheringRegistry? = null,
     questSystem: QuestSystem? = null,
     trainerRegistry: TrainerRegistry? = null,
+    puzzleSystem: PuzzleSystem? = null,
 ) {
     val me = players.get(sessionId) ?: return
     val roomId = me.roomId
@@ -352,6 +367,35 @@ internal suspend fun sendLook(
                 }
             }
         outbound.send(OutboundEvent.SendInfo(sessionId, "You notice: $featureDesc"))
+    }
+
+    // Puzzles — parity with the web client's Puzzle.List popout. Without this,
+    // riddle questions and sequence progress are GMCP-only and telnet players
+    // have no way to discover them (issue #1218).
+    if (puzzleSystem != null) {
+        for (puzzle in puzzleSystem.puzzlesInRoom(roomId)) {
+            val solved = puzzleSystem.isSolved(sessionId, puzzle.id)
+            val line = when (puzzle.type) {
+                PuzzleType.RIDDLE -> {
+                    val question = puzzle.question ?: "An ancient riddle awaits your answer."
+                    if (solved) {
+                        "Riddle (solved): $question"
+                    } else {
+                        "Riddle: $question  (type 'answer <your guess>')"
+                    }
+                }
+                PuzzleType.SEQUENCE -> {
+                    if (solved) {
+                        "Puzzle (solved): the mechanisms here rest in their final arrangement."
+                    } else {
+                        val step = puzzleSystem.sequenceStep(sessionId, puzzle.id)
+                        "Puzzle: interact with the features here in the correct order " +
+                            "(step $step/${puzzle.steps.size})."
+                    }
+                }
+            }
+            outbound.send(OutboundEvent.SendInfo(sessionId, line))
+        }
     }
 
     // Crafting station

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1285,6 +1285,10 @@ ambonmud:
           usage: read <sign>
           category: world
           staff: false
+        answer:
+          usage: answer <text>
+          category: world
+          staff: false
         title:
           usage: title <titleName> | title clear
           category: progression

--- a/src/test/kotlin/dev/ambon/engine/WebClientParityTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/WebClientParityTest.kt
@@ -69,6 +69,7 @@ class WebClientParityTest {
             "Search" to "search",
             "Pull" to "pull",
             "Read" to "read",
+            "Answer" to "answer",
             "Put" to "put_in",
             "GetFrom" to "get_from",
             // Combat

--- a/src/test/kotlin/dev/ambon/engine/commands/PuzzleSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/PuzzleSystemTest.kt
@@ -203,6 +203,77 @@ class PuzzleSystemTest {
         )
     }
 
+    // ---- Telnet look parity (issue #1218) ----
+
+    @Test
+    fun `look shows the riddle question and answer hint`() = runTest {
+        val h = harness()
+
+        h.router.handle(h.sid, Command.Look)
+        val infos = h.outbound.drainAll().filterIsInstance<OutboundEvent.SendInfo>().map { it.text }
+
+        assertTrue(
+            infos.any {
+                it.startsWith("Riddle: ") && it.contains("What has roots") && it.contains("answer <your guess>")
+            },
+            "Expected riddle question + answer hint in look output, got: $infos",
+        )
+    }
+
+    @Test
+    fun `look marks a solved riddle as solved and stops prompting`() = runTest {
+        val h = harness()
+        h.router.handle(h.sid, Command.Answer("mountain"))
+        h.outbound.drainAll()
+
+        h.router.handle(h.sid, Command.Look)
+        val infos = h.outbound.drainAll().filterIsInstance<OutboundEvent.SendInfo>().map { it.text }
+
+        assertTrue(
+            infos.any { it.startsWith("Riddle (solved): ") },
+            "Expected solved riddle marker in look output, got: $infos",
+        )
+        assertFalse(
+            infos.any { it.contains("answer <your guess>") },
+            "A solved riddle should not re-prompt for an answer, got: $infos",
+        )
+    }
+
+    @Test
+    fun `look shows sequence puzzle progress`() = runTest {
+        val h = harness()
+
+        h.router.handle(h.sid, Command.Look)
+        var infos = h.outbound.drainAll().filterIsInstance<OutboundEvent.SendInfo>().map { it.text }
+        assertTrue(
+            infos.any { it.startsWith("Puzzle: ") && it.contains("step 0/3") },
+            "Expected sequence progress 0/3 in look output, got: $infos",
+        )
+
+        h.router.handle(h.sid, Command.Pull("red"))
+        h.outbound.drainAll()
+
+        h.router.handle(h.sid, Command.Look)
+        infos = h.outbound.drainAll().filterIsInstance<OutboundEvent.SendInfo>().map { it.text }
+        assertTrue(
+            infos.any { it.startsWith("Puzzle: ") && it.contains("step 1/3") },
+            "Expected sequence progress 1/3 after pulling red, got: $infos",
+        )
+    }
+
+    @Test
+    fun `look lists every riddle in a room`() = runTest {
+        val h = harness()
+        h.players.moveTo(h.sid, RoomId("ok_puzzles:lever_room"))
+        h.outbound.drainAll()
+
+        h.router.handle(h.sid, Command.Look)
+        val infos = h.outbound.drainAll().filterIsInstance<OutboundEvent.SendInfo>().map { it.text }
+
+        val riddleLines = infos.filter { it.startsWith("Riddle: ") }
+        assertEquals(3, riddleLines.size, "Expected all three lever_room riddles, got: $infos")
+    }
+
     // ---- Sequence puzzle tests ----
 
     @Test

--- a/src/test/kotlin/dev/ambon/engine/commands/RouterTestHelper.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/RouterTestHelper.kt
@@ -134,6 +134,7 @@ internal fun buildTestRouter(
         genderRegistry = genderRegistry,
         bankConfig = bankConfig ?: BankConfig(),
         stylistConfig = stylistConfig ?: StylistConfig(),
+        puzzleSystem = puzzleSystem,
     )
     val puzzleHandler = puzzleSystem?.let { PuzzleHandler(ctx = ctx, puzzleSystem = it) }
     listOfNotNull(


### PR DESCRIPTION
Closes #1218.

## Problem

Riddle questions and sequence-puzzle progress were emitted **only** via the GMCP `Puzzle.List` package (`emitPuzzleGmcp`), which feeds the web client's puzzle popout. Over telnet there was nothing: during the live-demo playtest, "The Door That Asks" presented a locked exit and zero discoverable interaction — `look`/`read`/`talk`/`unlock`/`listen` all dead-ended, the riddle question was never shown, and the `answer` verb wasn't documented anywhere (not even in `help`).

## Changes

**`look` now renders room puzzles as text**, mirroring what the web popout shows (`sendLook` in `HandlerHelpers.kt`, threaded `puzzleSystem` through the existing optional-dependency pattern):

```
Riddle: What has roots that nobody sees, ... never grows?  (type 'answer <your guess>')
Riddle (solved): What has roots that nobody sees, ...
Puzzle: interact with the features here in the correct order (step 1/3).
Puzzle (solved): the mechanisms here rest in their final arrangement.
```

- Unsolved riddles include the `answer` usage hint; solved ones drop the prompt (matching the web's "Solved" badge).
- Sequence puzzles show live step progress (matching the web's step dots), updating as levers are pulled.
- Null-question riddles fall back to the same default copy the web client uses.

**`answer` registered in the command manifest** (`AppConfig.defaultCommandEntries()` + `application.yaml`, updated together per the config rule). It now appears in `help` and, via `Server.Commands` GMCP, in the web command palette — it was previously invisible in both.

**Parity-test hardening:** added the `Answer → answer` mapping to `WebClientParityTest`, so any future parser command missing a manifest entry fails CI the way this one should have.

## Tests

New cases in `PuzzleSystemTest` (router-driven, against the `ok_puzzles` fixture):
- `look` shows the riddle question + answer hint
- solved riddles render as `Riddle (solved):` and stop prompting
- sequence progress renders `step 0/3` → `step 1/3` after pulling the first lever
- rooms with multiple riddles list every one

`ktlintCheck`, full `test`, and `integrationTest` all pass. (`RouterTestHelper` now wires `puzzleSystem` into the test `EngineContext`, matching production wiring.)
