### PR TITLE
fix(world): exempt in-combat mobs from zone resets (#1222)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -497,6 +497,7 @@ class GameEngine(
             behaviorTreeSystem = behaviorTreeSystem,
             gmcpEmitter = gmcpEmitter,
             clock = clock,
+            isMobInCombat = { mobId -> combatSystem.isMobInCombat(mobId) },
         )
     }
 

--- a/src/main/kotlin/dev/ambon/engine/ZoneResetHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/ZoneResetHandler.kt
@@ -1,6 +1,7 @@
 package dev.ambon.engine
 
 import dev.ambon.bus.OutboundBus
+import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.idZone
 import dev.ambon.domain.mob.MobState
@@ -129,6 +130,11 @@ internal class ZoneResetHandler(
     private val behaviorTreeSystem: BehaviorTreeSystem,
     private val gmcpEmitter: GmcpEmitter,
     private val clock: Clock,
+    /**
+     * Whether a mob is currently fighting a player. Mobs in combat survive
+     * zone resets (#1222); wired to [CombatSystem.isMobInCombat] by GameEngine.
+     */
+    private val isMobInCombat: (MobId) -> Boolean = { false },
 ) {
     private val zoneResetDueAtMillis: MutableMap<String, Long> =
         world.zoneLifespansMinutes
@@ -218,12 +224,20 @@ internal class ZoneResetHandler(
             (zoneMobSpawns.map { spawn -> spawn.id } + activeZoneMobIds)
                 .toSet()
 
+        // Mobs actively fighting a player survive the reset (#1222): yanking an
+        // opponent mid-swing forfeits kill credit and feels broken. Their spawn
+        // slots are skipped too — when the fight ends, the normal post-death
+        // respawn timer (or the next reset, once out of combat) refills the slot.
+        val survivingMobIds = zoneMobIds.filterTo(hashSetOf()) { mobId -> isMobInCombat(mobId) }
+
         for (mobId in zoneMobIds) {
+            if (mobId in survivingMobIds) continue
             mobRemovalCoordinator.removeMobExternally(mobId)
         }
 
         val referenceLevel = highestPlayerLevelInZone(players, zone)
         for (spawn in zoneMobSpawns) {
+            if (spawn.id in survivingMobIds) continue
             mobs.upsert(spawnToMobState(spawn, world, referenceLevel))
             mobSystem.onMobSpawned(spawn.id)
             behaviorTreeSystem.onMobSpawned(spawn.id)
@@ -236,7 +250,8 @@ internal class ZoneResetHandler(
         items.resetZone(
             zone = zone,
             roomIds = zoneRoomIds,
-            mobIds = zoneMobIds,
+            // Surviving mobs keep their carried loot for the imminent kill.
+            mobIds = zoneMobIds - survivingMobIds,
             spawns = zoneItemSpawns,
         )
 

--- a/src/test/kotlin/dev/ambon/engine/ZoneResetCombatExemptionTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/ZoneResetCombatExemptionTest.kt
@@ -1,0 +1,191 @@
+package dev.ambon.engine
+
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.engine.behavior.BehaviorTreeSystem
+import dev.ambon.engine.dialogue.DialogueSystem
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.engine.status.StatusEffectRegistry
+import dev.ambon.engine.status.StatusEffectSystem
+import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.MutableClock
+import dev.ambon.test.drainAll
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Zone resets must not yank a mob out from under a player mid-fight (#1222).
+ * Mobs in combat survive the reset; their spawn slot repopulates later via the
+ * normal post-death respawn timer or a subsequent reset once combat has ended.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ZoneResetCombatExemptionTest {
+    private val world = dev.ambon.test.TestWorlds.okSmall
+    private val ratId = MobId("ok_small:rat")
+    private val ratRoom = RoomId("ok_small:b")
+
+    private data class Harness(
+        val players: PlayerRegistry,
+        val mobs: MobRegistry,
+        val items: ItemRegistry,
+        val combat: CombatSystem,
+        val outbound: LocalOutboundBus,
+        val handler: ZoneResetHandler,
+        val clock: MutableClock,
+    )
+
+    private fun buildHarness(): Harness {
+        val clock = MutableClock(0L)
+        val outbound = LocalOutboundBus()
+        val mobs = MobRegistry()
+        val items = ItemRegistry()
+        items.loadSpawns(world.itemSpawns)
+        val players = PlayerRegistry(
+            startRoom = world.startRoom,
+            repo = InMemoryPlayerRepository(),
+            items = items,
+            clock = clock,
+        )
+        val behaviorTreeSystem = BehaviorTreeSystem(
+            world = world,
+            mobs = mobs,
+            players = players,
+            outbound = outbound,
+            clock = clock,
+        )
+        val mobSystem = MobSystem()
+        val combatSystem = CombatSystem(
+            players = players,
+            mobs = mobs,
+            items = items,
+            outbound = outbound,
+            clock = clock,
+        )
+        val dialogueSystem = DialogueSystem(
+            mobs = mobs,
+            players = players,
+            outbound = outbound,
+        )
+        val statusEffectSystem = StatusEffectSystem(
+            registry = StatusEffectRegistry(),
+            players = players,
+            mobs = mobs,
+            outbound = outbound,
+            clock = clock,
+        )
+        val worldState = WorldStateRegistry(world)
+        val gmcpEmitter = GmcpEmitter(
+            outbound = outbound,
+            supportsPackage = { _, _ -> false },
+        )
+        val mobRemovalCoordinator = MobRemovalCoordinator(
+            combatSystem = combatSystem,
+            dialogueSystem = dialogueSystem,
+            behaviorTreeSystem = behaviorTreeSystem,
+            mobs = mobs,
+            mobSystem = mobSystem,
+            statusEffectSystem = statusEffectSystem,
+        )
+        val handler = ZoneResetHandler(
+            world = world,
+            mobs = mobs,
+            items = items,
+            players = players,
+            outbound = outbound,
+            worldState = worldState,
+            mobRemovalCoordinator = mobRemovalCoordinator,
+            mobSystem = mobSystem,
+            behaviorTreeSystem = behaviorTreeSystem,
+            gmcpEmitter = gmcpEmitter,
+            clock = clock,
+            isMobInCombat = { mobId -> combatSystem.isMobInCombat(mobId) },
+        )
+        // Populate the world's initial mob spawns (GameEngine does this at boot).
+        for (spawn in world.mobSpawns) {
+            mobs.upsert(spawnToMobState(spawn, world))
+        }
+        return Harness(players, mobs, items, combatSystem, outbound, handler, clock)
+    }
+
+    /** Advances past the ok_small 1-minute lifespan and fires the reset tick. */
+    private suspend fun Harness.advancePastResetAndTick() {
+        clock.advance(61_000L)
+        handler.tick()
+    }
+
+    @Test
+    fun `zone reset replaces idle mobs with fresh copies`() = runTest {
+        val h = buildHarness()
+        val rat = h.mobs.get(ratId)!!
+        rat.hp = 1
+
+        h.advancePastResetAndTick()
+
+        val replaced = h.mobs.get(ratId)
+        assertNotNull(replaced, "rat should be repopulated by the reset")
+        assertEquals(replaced!!.maxHp, replaced.hp, "idle rat should be replaced by a fresh full-HP copy")
+    }
+
+    @Test
+    fun `zone reset spares a mob that is fighting a player`() = runTest {
+        val h = buildHarness()
+        val sid = dev.ambon.domain.ids.SessionId(1)
+        require(h.players.login(sid, "Fighter", "password") == LoginResult.Ok)
+        h.players.moveTo(sid, ratRoom)
+
+        assertNull(h.combat.startCombat(sid, "rat"))
+        val rat = h.mobs.get(ratId)!!
+        rat.hp = 5
+        h.outbound.drainAll()
+
+        h.advancePastResetAndTick()
+
+        // The fight is untouched: same mob instance, same damage, combat intact.
+        assertSame(rat, h.mobs.get(ratId), "in-combat rat must not be replaced by the reset")
+        assertEquals(5, rat.hp, "in-combat rat must keep its current HP through the reset")
+        assertTrue(h.combat.isInCombat(sid), "player must still be in combat after the reset")
+        assertEquals(ratId, h.combat.currentTarget(sid))
+
+        val texts = h.outbound.drainAll().filterIsInstance<OutboundEvent.SendText>().map { it.text }
+        assertFalse(
+            texts.any { it == "Your opponent vanishes." },
+            "no vanish message should be sent for an in-combat mob, got: $texts",
+        )
+        assertTrue(
+            texts.any { it == "The air shimmers as the area resets around you." },
+            "the reset notice itself should still reach players in the zone, got: $texts",
+        )
+    }
+
+    @Test
+    fun `a later reset replaces the mob once combat has ended`() = runTest {
+        val h = buildHarness()
+        val sid = dev.ambon.domain.ids.SessionId(1)
+        require(h.players.login(sid, "Fighter", "password") == LoginResult.Ok)
+        h.players.moveTo(sid, ratRoom)
+
+        assertNull(h.combat.startCombat(sid, "rat"))
+        h.mobs.get(ratId)!!.hp = 5
+
+        // First reset: rat survives because it is fighting.
+        h.advancePastResetAndTick()
+        assertEquals(5, h.mobs.get(ratId)!!.hp)
+
+        // Combat ends (player flees); the next reset reclaims the slot.
+        assertNull(h.combat.flee(sid))
+        h.advancePastResetAndTick()
+
+        val replaced = h.mobs.get(ratId)
+        assertNotNull(replaced, "rat slot should repopulate on the next reset after combat ends")
+        assertEquals(replaced!!.maxHp, replaced.hp, "post-combat reset should spawn a fresh rat")
+    }
+}


### PR DESCRIPTION
Closes #1222.

## Problem

A zone reset mid-fight removed the player's opponent ("The air shimmers as the area resets around you. / Your opponent vanishes.") with no kill credit — hit twice during the live-demo playtest, both times a few swings from the kill.

## Approach

Mobs **currently in combat are exempt from the reset** rather than duplicated:

- The reset skips `removeMobExternally` for fighting mobs — the swing-for-swing fight continues untouched.
- Their spawn slot is **not** repopulated during that reset. This matters because mob identity *is* the spawn id: `mobs.upsert(spawnToMobState(spawn))` would have silently *replaced* the live opponent, not stood a second copy next to it. (A true duplicate would need synthetic MobIds and ripple through the threat table, removal coordinator, behavior trees, GMCP payloads, and the death-respawn guard — plus open a double-boss-loot surface.)
- Their carried loot is excluded from `items.resetZone`'s mob-item wipe, so the imminent kill still drops everything.
- Self-healing afterward: when the fight ends in the mob's death, the existing `respawnSeconds` scheduler refills the slot exactly as for any normal kill. If the player flees instead, the next reset reclaims the slot once the mob is out of combat (covered by a test).

`ZoneResetHandler` gains an `isMobInCombat: (MobId) -> Boolean` probe (defaults to `{ false }`, i.e. prior behavior); `GameEngine` wires it to `CombatSystem.isMobInCombat`.

## Tests

New `ZoneResetCombatExemptionTest` (real subsystems, `ok_small` fixture, `MutableClock`):
- idle mobs are still replaced by fresh full-HP copies on reset (baseline preserved)
- an in-combat mob survives the reset — same instance, damage retained, combat state intact, no "Your opponent vanishes.", while the zone-reset notice still reaches the player
- after the player flees, the *next* reset reclaims the slot with a fresh spawn

`ktlintCheck`, full `test`, and `integrationTest` all pass.
