### PR TITLE
feat(world): respawnSeconds for ground items, doors, levers, and containers

### DIFF
--- a/docs/WORLD_YAML_SPEC.md
+++ b/docs/WORLD_YAML_SPEC.md
@@ -234,6 +234,7 @@ consumable: <boolean, optional, default false>
 charges: <integer, optional, must be > 0 when present>
 onUse: <OnUse, optional>
 room: <room-id string, optional>
+respawnSeconds: <long > 0, optional - requires room placement; see "Timed respawn" below>
 matchByKey: <boolean, optional, default false>
 basePrice: <integer, optional, default 0, must be >= 0>
 image: <string, optional - relative path under /images/>
@@ -271,6 +272,30 @@ Location rules for items:
 
 - `room` may be omitted (item starts unplaced).
 - `mob` placement is deprecated and rejected by the loader.
+
+### Timed respawn (`respawnSeconds` on items, doors, and features)
+
+Without `respawnSeconds`, ground items and stateful features (doors, levers,
+containers) only return to their authored state on a **zone reset** (`lifespan`).
+Setting `respawnSeconds` gives an individual spawn or feature its own timer:
+
+- **Item** (`items.<id>.respawnSeconds`): the item is re-placed in its `room`
+  that many seconds after it is observed missing from it. Requires `room`
+  placement; must be > 0.
+- **Door** (`exits.<dir>.door.respawnSeconds`): the door reverts to its
+  `initialState` (re-closing/re-locking, or re-opening) that many seconds after
+  it leaves it.
+- **Lever** (`features.<id>.respawnSeconds`): the lever snaps back to its
+  `initialState`.
+- **Container** (`features.<id>.respawnSeconds`): the container reverts to its
+  `initialState` *and refills its `items` list* that many seconds after either
+  its state or its contents differ from the authored initial condition. Note
+  that — like a `resetWithZone` zone reset — refilling replaces whatever is in
+  the container, including player-stored items.
+- `SIGN` features have no state; the loader rejects `respawnSeconds` on them.
+
+Timers are independent of, and reset by, zone resets: whenever the item or
+feature returns to its initial condition by any means, the timer disarms.
 
 ### `shops` map
 

--- a/src/main/kotlin/dev/ambon/domain/world/ItemSpawn.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/ItemSpawn.kt
@@ -6,4 +6,10 @@ import dev.ambon.domain.items.ItemInstance
 data class ItemSpawn(
     val instance: ItemInstance,
     val roomId: RoomId? = null,
+    /**
+     * Seconds after the instance leaves its spawn room before it is re-placed.
+     * Null = the item only returns on zone reset (the historical behavior).
+     * Only valid for room-placed spawns.
+     */
+    val respawnSeconds: Long? = null,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/RoomFeature.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/RoomFeature.kt
@@ -26,6 +26,8 @@ sealed class RoomFeature {
         val keyItemId: ItemId?,
         val keyConsumed: Boolean,
         val resetWithZone: Boolean,
+        /** Seconds out of [initialState] before the door reverts on its own. Null = zone reset only. */
+        val respawnSeconds: Long? = null,
     ) : RoomFeature()
 
     data class Container(
@@ -38,6 +40,11 @@ sealed class RoomFeature {
         val keyConsumed: Boolean,
         val resetWithZone: Boolean,
         val initialItems: List<ItemId>,
+        /**
+         * Seconds out of its initial condition (state or contents) before the
+         * container reverts and refills [initialItems]. Null = zone reset only.
+         */
+        val respawnSeconds: Long? = null,
     ) : RoomFeature()
 
     data class Lever(
@@ -47,6 +54,8 @@ sealed class RoomFeature {
         override val keyword: String,
         val initialState: LeverState,
         val resetWithZone: Boolean,
+        /** Seconds out of [initialState] before the lever snaps back. Null = zone reset only. */
+        val respawnSeconds: Long? = null,
     ) : RoomFeature()
 
     data class Sign(

--- a/src/main/kotlin/dev/ambon/domain/world/data/DoorFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/DoorFile.kt
@@ -5,4 +5,9 @@ data class DoorFile(
     val keyItemId: String? = null,
     val keyConsumed: Boolean = false,
     val resetWithZone: Boolean = true,
+    /**
+     * Seconds after the door leaves its initial state before it reverts
+     * (e.g. an opened door re-closes/re-locks). Null = zone reset only.
+     */
+    val respawnSeconds: Long? = null,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/data/FeatureFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/FeatureFile.kt
@@ -13,6 +13,12 @@ data class FeatureFile(
     val keyItemId: String? = null,
     val keyConsumed: Boolean = false,
     val resetWithZone: Boolean = true,
+    /**
+     * Seconds after the feature leaves its initial condition before it reverts
+     * (state restored; container contents refilled). Null = zone reset only.
+     * Not valid for SIGN.
+     */
+    val respawnSeconds: Long? = null,
     /** Initial item IDs inside this container. Only applies to CONTAINER type. */
     val items: List<String> = emptyList(),
     /** Text content. Only applies to SIGN type. */

--- a/src/main/kotlin/dev/ambon/domain/world/data/ItemFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/ItemFile.kt
@@ -16,6 +16,11 @@ data class ItemFile(
     val charges: Int? = null,
     val onUse: ItemUseEffect? = null,
     val room: String? = null,
+    /**
+     * Seconds after this room-placed item leaves its room before it respawns
+     * there. Null = the item only returns on zone reset. Requires `room`.
+     */
+    val respawnSeconds: Long? = null,
     val mob: String? = null,
     val matchByKey: Boolean = false,
     val basePrice: Int = 0,

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -291,6 +291,13 @@ object WorldLoader {
                                         doorFile.initialState,
                                         "Room ‘${fromId.value}’ door at ‘$dirStr’",
                                     )
+                                val doorRespawn = doorFile.respawnSeconds
+                                if (doorRespawn != null && doorRespawn <= 0L) {
+                                    throw WorldLoadException(
+                                        "Room '${fromId.value}' door at '$dirStr' respawnSeconds must be > 0 " +
+                                            "(got $doorRespawn)",
+                                    )
+                                }
                                 val dirAbbrev = dirAbbrev(dir)
                                 featList.add(
                                     RoomFeature.Door(
@@ -303,6 +310,7 @@ object WorldLoader {
                                         keyItemId = doorKeyItemId,
                                         keyConsumed = doorFile.keyConsumed,
                                         resetWithZone = doorFile.resetWithZone,
+                                        respawnSeconds = doorRespawn,
                                     ),
                                 )
                             }
@@ -543,6 +551,16 @@ object WorldLoader {
 
                 val roomId = roomRaw?.let { normalizeTarget(zone, it) }
 
+                val itemRespawn = itemFile.respawnSeconds
+                if (itemRespawn != null && itemRespawn <= 0L) {
+                    throw WorldLoadException("Item '${itemId.value}' respawnSeconds must be > 0 (got $itemRespawn)")
+                }
+                if (itemRespawn != null && roomId == null) {
+                    throw WorldLoadException(
+                        "Item '${itemId.value}' respawnSeconds requires room placement (set 'room')",
+                    )
+                }
+
                 mergedItems[itemId] =
                     ItemSpawn(
                         instance =
@@ -570,6 +588,7 @@ object WorldLoader {
                                     ),
                             ),
                         roomId = roomId,
+                        respawnSeconds = itemRespawn,
                     )
             }
 
@@ -1530,6 +1549,10 @@ object WorldLoader {
         val keyword = requireNonBlank(ff.keyword) {
             "Feature '$featId' keyword cannot be blank"
         }
+        val respawnSeconds = ff.respawnSeconds
+        if (respawnSeconds != null && respawnSeconds <= 0L) {
+            throw WorldLoadException("Feature '$featId' respawnSeconds must be > 0 (got $respawnSeconds)")
+        }
         return when (type) {
             "CONTAINER" -> {
                 val keyItemId =
@@ -1554,6 +1577,7 @@ object WorldLoader {
                     keyConsumed = ff.keyConsumed,
                     resetWithZone = ff.resetWithZone,
                     initialItems = initialItems,
+                    respawnSeconds = respawnSeconds,
                 )
             }
             "LEVER" -> {
@@ -1565,9 +1589,13 @@ object WorldLoader {
                     keyword = keyword,
                     initialState = initialState,
                     resetWithZone = ff.resetWithZone,
+                    respawnSeconds = respawnSeconds,
                 )
             }
             "SIGN" -> {
+                if (respawnSeconds != null) {
+                    throw WorldLoadException("Sign '$featId' cannot have respawnSeconds (signs have no state)")
+                }
                 val text = ff.text ?: throw WorldLoadException("Sign '$featId' must have a 'text' field")
                 RoomFeature.Sign(
                     id = featId,

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -484,6 +484,18 @@ class GameEngine(
             onLineReceived = ::handleLineReceived,
         )
 
+    private val timedRespawnHandler by lazy {
+        TimedRespawnHandler(
+            world = world,
+            items = items,
+            players = players,
+            outbound = outbound,
+            worldState = worldState,
+            gmcpEmitter = gmcpEmitter,
+            clock = clock,
+        )
+    }
+
     private val zoneResetHandler by lazy {
         ZoneResetHandler(
             world = world,
@@ -1161,7 +1173,10 @@ class GameEngine(
                 engineConfig = engineConfig,
                 imagesBaseUrl = imagesBaseUrl,
                 worldLoader = worldLoader,
-                onZoneScheduleRefresh = { zoneResetHandler.refreshSchedule() },
+                onZoneScheduleRefresh = {
+                    zoneResetHandler.refreshSchedule()
+                    timedRespawnHandler.refresh()
+                },
             )
         } else {
             null
@@ -1869,6 +1884,9 @@ class GameEngine(
 
                     // Reset zones when their lifespan elapses.
                     zoneResetHandler.tick()
+
+                    // Restore item spawns / features that declare their own respawnSeconds.
+                    timedRespawnHandler.tick()
                     metrics.recordTickPhase("outbound_flush", outboundFlushPhaseSample)
                 } catch (t: Throwable) {
                     if (t is kotlinx.coroutines.CancellationException) throw t

--- a/src/main/kotlin/dev/ambon/engine/TimedRespawnHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/TimedRespawnHandler.kt
@@ -1,0 +1,174 @@
+package dev.ambon.engine
+
+import dev.ambon.bus.OutboundBus
+import dev.ambon.domain.ids.ItemId
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.world.ItemSpawn
+import dev.ambon.domain.world.LockableState
+import dev.ambon.domain.world.RoomFeature
+import dev.ambon.domain.world.World
+import dev.ambon.engine.commands.handlers.buildFeaturePayload
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.items.ItemRegistry
+import java.time.Clock
+
+/**
+ * Restores individual item spawns and stateful room features that declare
+ * `respawnSeconds`, independently of the coarse zone-lifespan reset.
+ *
+ * - A room-placed item spawn with `respawnSeconds` is re-placed in its room
+ *   that many seconds after the instance is first observed missing from it.
+ * - A door/lever/container with `respawnSeconds` reverts to its authored
+ *   initial condition that many seconds after it is first observed out of it
+ *   (state changed, or — for containers — contents differing from
+ *   `initialItems`). Reverting a container refills its initial contents,
+ *   mirroring what the zone reset does for `resetWithZone` containers.
+ *
+ * Timers are observation-based (tick resolution) and reset whenever the spawn
+ * or feature returns to its initial condition by any means, including a zone
+ * reset. State is in-memory only: a restart re-arms timers from scratch.
+ *
+ * Called exclusively from the single-threaded engine dispatcher.
+ */
+internal class TimedRespawnHandler(
+    private val world: World,
+    private val items: ItemRegistry,
+    private val players: PlayerRegistry,
+    private val outbound: OutboundBus,
+    private val worldState: WorldStateRegistry,
+    private val gmcpEmitter: GmcpEmitter?,
+    private val clock: Clock,
+) {
+    private var trackedItemSpawns: List<ItemSpawn> = computeTrackedItems()
+    private var trackedFeatureIds: List<String> = computeTrackedFeatures()
+
+    /** When each tracked item instance was first observed missing from its spawn room. */
+    private val itemMissingSinceMs = mutableMapOf<ItemId, Long>()
+
+    /** When each tracked feature was first observed out of its initial condition. */
+    private val featureChangedSinceMs = mutableMapOf<String, Long>()
+
+    /** Re-scans the world for tracked spawns/features. Call after a hot reload. */
+    fun refresh() {
+        trackedItemSpawns = computeTrackedItems()
+        trackedFeatureIds = computeTrackedFeatures()
+        itemMissingSinceMs.clear()
+        featureChangedSinceMs.clear()
+    }
+
+    private fun computeTrackedItems(): List<ItemSpawn> =
+        world.itemSpawns.filter { it.respawnSeconds != null && it.roomId != null }
+
+    private fun computeTrackedFeatures(): List<String> =
+        worldState.featuresById.values
+            .filter { feature -> feature.respawnSecondsOrNull() != null }
+            .map { it.id }
+
+    /** Called once per engine tick. */
+    suspend fun tick() {
+        if (trackedItemSpawns.isEmpty() && trackedFeatureIds.isEmpty()) return
+        val now = clock.millis()
+        tickItems(now)
+        tickFeatures(now)
+    }
+
+    private suspend fun tickItems(now: Long) {
+        for (spawn in trackedItemSpawns) {
+            val roomId = spawn.roomId ?: continue
+            val respawnMs = (spawn.respawnSeconds ?: continue) * 1000L
+            val instanceId = spawn.instance.id
+            val present = items.itemsInRoom(roomId).any { it.id == instanceId }
+            if (present) {
+                itemMissingSinceMs.remove(instanceId)
+                continue
+            }
+            val missingSince = itemMissingSinceMs.getOrPut(instanceId) { now }
+            if (now - missingSince < respawnMs) continue
+
+            itemMissingSinceMs.remove(instanceId)
+            items.addRoomItem(roomId, spawn.instance)
+            for (p in players.playersInRoom(roomId)) {
+                outbound.send(OutboundEvent.SendText(p.sessionId, "${spawn.instance.item.displayName} appears."))
+                gmcpEmitter?.sendRoomItems(p.sessionId, items.itemsInRoom(roomId))
+            }
+        }
+    }
+
+    private suspend fun tickFeatures(now: Long) {
+        for (featureId in trackedFeatureIds) {
+            val feature = worldState.featuresById[featureId] ?: continue
+            val respawnSeconds = feature.respawnSecondsOrNull() ?: continue
+            if (isInInitialCondition(feature)) {
+                featureChangedSinceMs.remove(featureId)
+                continue
+            }
+            val changedSince = featureChangedSinceMs.getOrPut(featureId) { now }
+            if (now - changedSince < respawnSeconds * 1000L) continue
+
+            featureChangedSinceMs.remove(featureId)
+            revertFeature(feature)
+        }
+    }
+
+    private fun isInInitialCondition(feature: RoomFeature): Boolean = when (feature) {
+        is RoomFeature.Door -> worldState.getLockableState(feature.id) == feature.initialState
+        is RoomFeature.Lever -> worldState.getLeverState(feature.id) == feature.initialState
+        is RoomFeature.Container ->
+            worldState.getLockableState(feature.id) == feature.initialState && contentsMatchInitial(feature)
+        is RoomFeature.Sign -> true
+    }
+
+    private fun contentsMatchInitial(feature: RoomFeature.Container): Boolean {
+        val current = worldState.getContainerContents(feature.id).map { it.id.value }.sorted()
+        val initial = feature.initialItems.map { it.value }.sorted()
+        return current == initial
+    }
+
+    private suspend fun revertFeature(feature: RoomFeature) {
+        val message = when (feature) {
+            is RoomFeature.Door -> {
+                worldState.setLockableState(feature.id, feature.initialState)
+                if (feature.initialState == LockableState.OPEN) {
+                    "The ${feature.displayName} swings open."
+                } else {
+                    "The ${feature.displayName} swings shut."
+                }
+            }
+            is RoomFeature.Container -> {
+                worldState.setLockableState(feature.id, feature.initialState)
+                val instances = feature.initialItems.mapNotNull { items.createFromTemplate(it) }
+                worldState.resetContainer(feature.id, instances)
+                if (feature.initialState == LockableState.OPEN) {
+                    "${feature.displayName} creaks open, its contents restored."
+                } else {
+                    "${feature.displayName} clicks shut."
+                }
+            }
+            is RoomFeature.Lever -> {
+                worldState.setLeverState(feature.id, feature.initialState)
+                "${feature.displayName} snaps back into place."
+            }
+            is RoomFeature.Sign -> return
+        }
+        for (p in players.playersInRoom(feature.roomId)) {
+            outbound.send(OutboundEvent.SendText(p.sessionId, message))
+        }
+        emitRoomFeatures(feature.roomId)
+    }
+
+    private suspend fun emitRoomFeatures(roomId: RoomId) {
+        val emitter = gmcpEmitter ?: return
+        val room = world.rooms[roomId] ?: return
+        val payloads = room.features.map { buildFeaturePayload(it, worldState) }
+        for (p in players.playersInRoom(roomId)) {
+            emitter.sendRoomFeatures(p.sessionId, payloads)
+        }
+    }
+}
+
+private fun RoomFeature.respawnSecondsOrNull(): Long? = when (this) {
+    is RoomFeature.Door -> respawnSeconds
+    is RoomFeature.Container -> respawnSeconds
+    is RoomFeature.Lever -> respawnSeconds
+    is RoomFeature.Sign -> null
+}

--- a/src/test/kotlin/dev/ambon/engine/TimedRespawnHandlerTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/TimedRespawnHandlerTest.kt
@@ -1,0 +1,233 @@
+package dev.ambon.engine
+
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.world.LeverState
+import dev.ambon.domain.world.LockableState
+import dev.ambon.domain.world.RoomFeature
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.MutableClock
+import dev.ambon.test.drainAll
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TimedRespawnHandlerTest {
+    private val world = dev.ambon.test.TestWorlds.okTimedRespawn
+    private val hall = RoomId("ok_timed:hall")
+    private val sid = SessionId(1)
+
+    private data class Harness(
+        val players: PlayerRegistry,
+        val items: ItemRegistry,
+        val worldState: WorldStateRegistry,
+        val outbound: LocalOutboundBus,
+        val handler: TimedRespawnHandler,
+        val clock: MutableClock,
+    ) {
+        val lever: RoomFeature.Lever =
+            worldState.featuresById.values.filterIsInstance<RoomFeature.Lever>().single()
+        val chest: RoomFeature.Container =
+            worldState.featuresById.values.filterIsInstance<RoomFeature.Container>().single()
+        val door: RoomFeature.Door =
+            worldState.featuresById.values.filterIsInstance<RoomFeature.Door>().single()
+    }
+
+    private suspend fun buildHarness(): Harness {
+        val clock = MutableClock(0L)
+        val outbound = LocalOutboundBus()
+        val items = ItemRegistry()
+        items.loadSpawns(world.itemSpawns)
+        val players = PlayerRegistry(
+            startRoom = world.startRoom,
+            repo = InMemoryPlayerRepository(),
+            items = items,
+            clock = clock,
+        )
+        val worldState = WorldStateRegistry(world)
+        // Seed container initial contents the way GameEngine does at boot.
+        for (room in world.rooms.values) {
+            for (feature in room.features.filterIsInstance<RoomFeature.Container>()) {
+                for (inst in feature.initialItems.mapNotNull { items.createFromTemplate(it) }) {
+                    worldState.addToContainer(feature.id, inst)
+                }
+            }
+        }
+        val handler = TimedRespawnHandler(
+            world = world,
+            items = items,
+            players = players,
+            outbound = outbound,
+            worldState = worldState,
+            gmcpEmitter = null,
+            clock = clock,
+        )
+        require(players.login(sid, "Tester", "password") == LoginResult.Ok)
+        outbound.drainAll()
+        return Harness(players, items, worldState, outbound, handler, clock)
+    }
+
+    private fun Harness.coinInHall(): Boolean =
+        items.itemsInRoom(hall).any { it.item.keyword == "coin" }
+
+    // ---- Item respawn ----
+
+    @Test
+    fun `picked-up item respawns in its room after respawnSeconds`() = runTest {
+        val h = buildHarness()
+        h.items.takeFromRoom(sid, hall, "coin")
+        assertFalse(h.coinInHall())
+
+        // Timer arms on the first tick that observes the item missing.
+        h.handler.tick()
+        h.clock.advance(29_000L)
+        h.handler.tick()
+        assertFalse(h.coinInHall(), "coin must not respawn before 30s")
+
+        h.clock.advance(2_000L)
+        h.handler.tick()
+        assertTrue(h.coinInHall(), "coin should respawn after 30s")
+
+        val texts = h.outbound.drainAll().filterIsInstance<OutboundEvent.SendText>().map { it.text }
+        assertTrue(
+            texts.any { it == "a gleaming coin appears." },
+            "players in the room should see the item reappear, got: $texts",
+        )
+    }
+
+    @Test
+    fun `item without respawnSeconds never respawns on a timer`() = runTest {
+        val h = buildHarness()
+        h.items.takeFromRoom(sid, hall, "relic")
+
+        h.handler.tick()
+        h.clock.advance(3_600_000L)
+        h.handler.tick()
+
+        assertFalse(
+            h.items.itemsInRoom(hall).any { it.item.keyword == "relic" },
+            "relic has no respawnSeconds and must wait for a zone reset",
+        )
+    }
+
+    @Test
+    fun `returning the item before the timer fires disarms it`() = runTest {
+        val h = buildHarness()
+        val coin = h.items.takeFromRoom(sid, hall, "coin")!!
+        h.handler.tick()
+        h.clock.advance(15_000L)
+        h.handler.tick()
+
+        // Player drops it back: the missing-timer must reset.
+        h.items.addRoomItem(hall, coin)
+        h.handler.tick()
+
+        h.items.takeFromRoom(sid, hall, "coin")
+        h.handler.tick()
+        h.clock.advance(16_000L) // would fire if the old timer had kept running
+        h.handler.tick()
+        assertFalse(h.coinInHall(), "re-taking the item must restart the 30s timer")
+
+        h.clock.advance(15_000L)
+        h.handler.tick()
+        assertTrue(h.coinInHall())
+    }
+
+    // ---- Feature reverts ----
+
+    @Test
+    fun `pulled lever snaps back after respawnSeconds`() = runTest {
+        val h = buildHarness()
+        h.worldState.setLeverState(h.lever.id, LeverState.DOWN)
+
+        h.handler.tick()
+        h.clock.advance(9_000L)
+        h.handler.tick()
+        assertEquals(LeverState.DOWN, h.worldState.getLeverState(h.lever.id), "lever must hold for 10s")
+
+        h.clock.advance(2_000L)
+        h.handler.tick()
+        assertEquals(LeverState.UP, h.worldState.getLeverState(h.lever.id), "lever should snap back after 10s")
+
+        val texts = h.outbound.drainAll().filterIsInstance<OutboundEvent.SendText>().map { it.text }
+        assertTrue(
+            texts.any { it == "a sprung lever snaps back into place." },
+            "players in the room should see the lever reset, got: $texts",
+        )
+    }
+
+    @Test
+    fun `opened door reverts to its initial state`() = runTest {
+        val h = buildHarness()
+        h.worldState.setLockableState(h.door.id, LockableState.OPEN)
+
+        h.handler.tick()
+        h.clock.advance(21_000L)
+        h.handler.tick()
+
+        assertEquals(
+            LockableState.CLOSED,
+            h.worldState.getLockableState(h.door.id),
+            "door should re-close after its 20s respawnSeconds",
+        )
+    }
+
+    @Test
+    fun `looted container relocks and refills after respawnSeconds`() = runTest {
+        val h = buildHarness()
+        // Open the chest and loot the gem.
+        h.worldState.setLockableState(h.chest.id, LockableState.OPEN)
+        h.worldState.removeFromContainer(h.chest.id, "gem")
+        assertTrue(h.worldState.getContainerContents(h.chest.id).isEmpty())
+
+        h.handler.tick()
+        h.clock.advance(16_000L)
+        h.handler.tick()
+
+        assertEquals(LockableState.CLOSED, h.worldState.getLockableState(h.chest.id))
+        assertEquals(
+            listOf("ok_timed:gem"),
+            h.worldState.getContainerContents(h.chest.id).map { it.id.value },
+            "chest should refill its initial items",
+        )
+    }
+
+    @Test
+    fun `looting an open-state container still arms the timer via contents`() = runTest {
+        val h = buildHarness()
+        // State untouched (closed = initial), but contents drained: the contents
+        // mismatch alone must arm the revert timer.
+        h.worldState.removeFromContainer(h.chest.id, "gem")
+
+        h.handler.tick()
+        h.clock.advance(16_000L)
+        h.handler.tick()
+
+        assertEquals(
+            listOf("ok_timed:gem"),
+            h.worldState.getContainerContents(h.chest.id).map { it.id.value },
+        )
+    }
+
+    @Test
+    fun `untouched features never revert`() = runTest {
+        val h = buildHarness()
+        h.outbound.drainAll()
+
+        h.handler.tick()
+        h.clock.advance(3_600_000L)
+        h.handler.tick()
+
+        assertEquals(LeverState.UP, h.worldState.getLeverState(h.lever.id))
+        assertEquals(LockableState.CLOSED, h.worldState.getLockableState(h.chest.id))
+        val texts = h.outbound.drainAll().filterIsInstance<OutboundEvent.SendText>()
+        assertTrue(texts.isEmpty(), "no revert messages expected for untouched features, got: $texts")
+    }
+}

--- a/src/test/kotlin/dev/ambon/test/TestFixtures.kt
+++ b/src/test/kotlin/dev/ambon/test/TestFixtures.kt
@@ -67,6 +67,7 @@ object TestWorlds {
     val okPuzzles: World by lazy { WorldLoader.loadFromResource("world/ok_puzzles.yaml") }
     val okAchievementGate: World by lazy { WorldLoader.loadFromResource("world/ok_achievement_gate.yaml") }
     val okFleeGate: World by lazy { WorldLoader.loadFromResource("world/ok_flee_gate.yaml") }
+    val okTimedRespawn: World by lazy { WorldLoader.loadFromResource("world/ok_timed_respawn.yaml") }
 }
 
 object TestPasswordHasher : PasswordHasher {

--- a/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
@@ -9,6 +9,7 @@ import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.items.ItemSlot
 import dev.ambon.domain.items.ItemType
 import dev.ambon.domain.world.Direction
+import dev.ambon.domain.world.RoomFeature
 import dev.ambon.domain.world.WorldFactory
 import dev.ambon.domain.world.data.ItemFile
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -643,6 +644,51 @@ class WorldLoaderTest {
             }
         assertTrue(ex.message!!.contains("respawnSeconds", ignoreCase = true), "Got: ${ex.message}")
         assertTrue(ex.message!!.contains("> 0", ignoreCase = true), "Got: ${ex.message}")
+    }
+
+    @Test
+    fun `loads item and feature respawnSeconds`() {
+        val world = WorldLoader.loadFromResource("world/ok_timed_respawn.yaml")
+
+        val coin = world.itemSpawns.first { it.instance.id.value == "ok_timed:coin" }
+        assertEquals(30L, coin.respawnSeconds)
+        val relic = world.itemSpawns.first { it.instance.id.value == "ok_timed:relic" }
+        assertEquals(null, relic.respawnSeconds)
+
+        val features = world.rooms.getValue(RoomId("ok_timed:hall")).features
+        val lever = features.filterIsInstance<RoomFeature.Lever>().single()
+        assertEquals(10L, lever.respawnSeconds)
+        val chest = features.filterIsInstance<RoomFeature.Container>().single()
+        assertEquals(15L, chest.respawnSeconds)
+        val door = features.filterIsInstance<RoomFeature.Door>().single()
+        assertEquals(20L, door.respawnSeconds)
+    }
+
+    @Test
+    fun `fails when item respawnSeconds is zero`() {
+        val ex =
+            assertThrows(WorldLoadException::class.java) {
+                WorldLoader.loadFromResource("world/bad_item_respawn_zero.yaml")
+            }
+        assertTrue(ex.message!!.contains("respawnSeconds must be > 0"), "Got: ${ex.message}")
+    }
+
+    @Test
+    fun `fails when item respawnSeconds has no room placement`() {
+        val ex =
+            assertThrows(WorldLoadException::class.java) {
+                WorldLoader.loadFromResource("world/bad_item_respawn_unplaced.yaml")
+            }
+        assertTrue(ex.message!!.contains("requires room placement"), "Got: ${ex.message}")
+    }
+
+    @Test
+    fun `fails when a sign has respawnSeconds`() {
+        val ex =
+            assertThrows(WorldLoadException::class.java) {
+                WorldLoader.loadFromResource("world/bad_feature_respawn_sign.yaml")
+            }
+        assertTrue(ex.message!!.contains("cannot have respawnSeconds"), "Got: ${ex.message}")
     }
 
     @Test

--- a/src/test/resources/world/bad_feature_respawn_sign.yaml
+++ b/src/test/resources/world/bad_feature_respawn_sign.yaml
@@ -1,0 +1,14 @@
+zone: bad_feature_respawn_sign
+startRoom: a
+
+rooms:
+  a:
+    title: "Room A"
+    description: "A room."
+    features:
+      notice:
+        type: SIGN
+        displayName: "a notice board"
+        keyword: board
+        text: "Signs have no state to reset."
+        respawnSeconds: 30

--- a/src/test/resources/world/bad_item_respawn_unplaced.yaml
+++ b/src/test/resources/world/bad_item_respawn_unplaced.yaml
@@ -1,0 +1,13 @@
+zone: bad_item_respawn_unplaced
+startRoom: a
+
+items:
+  coin:
+    displayName: "a coin"
+    keyword: coin
+    respawnSeconds: 30
+
+rooms:
+  a:
+    title: "Room A"
+    description: "A room."

--- a/src/test/resources/world/bad_item_respawn_zero.yaml
+++ b/src/test/resources/world/bad_item_respawn_zero.yaml
@@ -1,0 +1,14 @@
+zone: bad_item_respawn_zero
+startRoom: a
+
+items:
+  coin:
+    displayName: "a coin"
+    keyword: coin
+    room: a
+    respawnSeconds: 0
+
+rooms:
+  a:
+    title: "Room A"
+    description: "A room."

--- a/src/test/resources/world/ok_timed_respawn.yaml
+++ b/src/test/resources/world/ok_timed_respawn.yaml
@@ -1,0 +1,51 @@
+zone: ok_timed
+startRoom: hall
+
+items:
+  coin:
+    displayName: "a gleaming coin"
+    keyword: coin
+    description: "It glints invitingly."
+    room: hall
+    respawnSeconds: 30
+  relic:
+    displayName: "a dusty relic"
+    keyword: relic
+    description: "Old and dusty. Only a zone reset brings it back."
+    room: hall
+  gem:
+    displayName: "a tiny gem"
+    keyword: gem
+    description: "Sparkles."
+
+rooms:
+  hall:
+    title: "Timed Hall"
+    description: "A room full of self-restoring things."
+    exits:
+      north:
+        to: vault
+        door:
+          initialState: closed
+          respawnSeconds: 20
+    features:
+      snap_lever:
+        type: LEVER
+        displayName: "a sprung lever"
+        keyword: lever
+        initialState: up
+        respawnSeconds: 10
+      gem_chest:
+        type: CONTAINER
+        displayName: "a self-filling chest"
+        keyword: chest
+        initialState: closed
+        respawnSeconds: 15
+        items:
+          - gem
+
+  vault:
+    title: "Vault"
+    description: "Behind the door."
+    exits:
+      south: hall


### PR DESCRIPTION
Follow-up to the zone-reset discussion on #1222: ground items and feature states previously had **no** respawn path of their own — once looted or toggled, they stayed that way until the zone-lifespan reset. Mobs (`respawnSeconds`) and gathering nodes already had individual timers; this brings items and features to parity, letting authors choose fine-grained timers where the coarse zone reset isn't the right tool.

## Schema (all optional, loader-validated `> 0`)

```yaml
items:
  coin:
    room: hall
    respawnSeconds: 30        # re-placed 30 s after it goes missing (requires room)

rooms:
  hall:
    exits:
      north:
        to: vault
        door:
          initialState: closed
          respawnSeconds: 20  # re-closes/re-locks 20 s after being opened
    features:
      snap_lever:
        type: LEVER
        respawnSeconds: 10    # snaps back to initialState
      gem_chest:
        type: CONTAINER
        respawnSeconds: 15    # reverts state AND refills its authored items
```

- Container refill uses the same wholesale-replace semantics as the `resetWithZone` zone reset (player-stored items are replaced — documented).
- `SIGN` features are stateless; the loader rejects `respawnSeconds` on them, as well as on unplaced items.

## Engine

New `TimedRespawnHandler`, ticked from the engine loop next to `ZoneResetHandler`:

- **Observation-based timers**: a timer arms the first tick a tracked spawn/feature is seen out of its initial condition, and disarms whenever it returns by any means (player puts the item back, closes the door, zone reset fires). No hooks needed in every pickup/interaction path.
- Containers count as "out of initial condition" when their **state or contents** differ — a looted-but-closed chest still refills.
- On revert, players in the room get a flavor line ("a sprung lever snaps back into place.", "a gleaming coin appears.") and a `Room.Features` GMCP refresh so the web canvas updates live.
- Hot reloads re-scan tracked spawns/features via the existing `onZoneScheduleRefresh` hook.
- State is in-memory; restarts re-arm timers (same as mob respawn scheduling).

## Tests

- `TimedRespawnHandlerTest` (new `ok_timed_respawn` fixture, `MutableClock`): item respawn at the boundary, no-timer item stays gone, timer disarms when the item is returned, lever/door/container reverts, contents-only looting arms the container timer, untouched features never revert.
- `WorldLoaderTest`: positive parse of all three field placements + three new `bad_*` fixtures (zero value, unplaced item, sign).
- Docs: `WORLD_YAML_SPEC.md` gains a "Timed respawn" section.

`ktlintCheck`, full `test`, and `integrationTest` all pass.
