### PR TITLE
fix: multi-word cast parsing, gather-quest consumption, eat/drink aliases (#1221, #1223, #1224)

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -1789,7 +1789,7 @@ data class CommandsConfig(
             "remove" to CommandMetadata("remove/unequip <slot>", "Unequip from a slot", "items", requiresTarget = true),
             "get" to CommandMetadata("get/take/pickup <item>", "Pick up an item", "items", requiresTarget = true),
             "drop" to CommandMetadata("drop <item>", "Drop an item", "items", requiresTarget = true),
-            "use" to CommandMetadata("use <item>", "Use a consumable item", "items", requiresTarget = true),
+            "use" to CommandMetadata("use/eat/drink <item>", "Use a consumable item", "items", requiresTarget = true),
             "quickheal" to CommandMetadata("quickheal/qh", "Auto-use best healing potion", "combat"),
             "quickmana" to CommandMetadata("quickmana/qm", "Auto-use best mana potion", "combat"),
             "give" to CommandMetadata("give <item> <player>", "Give an item to a player", "items", requiresTarget = true),

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -1098,6 +1098,9 @@ class GameEngine(
         questSystem.onItemRewarded = { sid, item ->
             gmcpEmitter.sendCharItemsAdd(sid, item)
         }
+        questSystem.onItemsConsumed = { sid ->
+            gmcpEmitter.sendCharItemsList(sid, items.inventory(sid), items.equipment(sid))
+        }
         questSystem.onLevelUp = ::onCombatLevelUp
         achievementSystem.onLevelUp = ::onCombatLevelUp
         combatSystem.onItemAutoLooted = { sid, item ->

--- a/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
@@ -49,6 +49,12 @@ class QuestSystem(
     var onItemRewarded: (suspend (SessionId, ItemInstance) -> Unit)? = null
 
     /**
+     * Invoked after collect-objective items are consumed at quest completion,
+     * so the engine can re-sync the client's full inventory list.
+     */
+    var onItemsConsumed: (suspend (SessionId) -> Unit)? = null
+
+    /**
      * Returns quests offered by this mob that the player can accept.
      *
      * Excludes quests already active, already completed, whose reputation ceiling
@@ -582,6 +588,7 @@ class QuestSystem(
                 rewards
             }
 
+        consumeCollectedItems(sessionId, quest)
         outbound.send(OutboundEvent.SendInfo(sessionId, "Quest complete: ${quest.name}!"))
         val grantedItems = grantItemRewards(sessionId, effectiveRewards.items)
         onQuestCompletedGmcp?.invoke(
@@ -614,6 +621,39 @@ class QuestSystem(
             onLevelUp = { result -> onLevelUp?.invoke(sessionId, result) },
         )
         if (effectiveRewards.xp == 0L) players.persistPlayer(ps.sessionId)
+    }
+
+    /**
+     * Removes the items gathered for collect-type objectives from the player's
+     * inventory when the quest completes — handing in the quest hands over the
+     * goods (#1223). Item matching mirrors the built-in collect handler: exact
+     * id, or any zone's `:<localId>` suffix. Consumption is best-effort: items
+     * the player no longer carries are simply skipped.
+     */
+    private suspend fun consumeCollectedItems(
+        sessionId: SessionId,
+        quest: QuestDef,
+    ) {
+        var removedAny = false
+        for (obj in quest.objectives) {
+            if (objectiveHandlers.collectHandler(obj.type) == null) continue
+            val localSuffix = ":${obj.targetId.substringAfterLast(':')}"
+            var removed = 0
+            var removedName: String? = null
+            while (removed < obj.count) {
+                val match = items.inventory(sessionId).firstOrNull { inv ->
+                    inv.id.value == obj.targetId || inv.id.value.endsWith(localSuffix)
+                } ?: break
+                if (items.removeFromInventoryById(sessionId, match.id) == null) break
+                removedName = match.item.displayName
+                removed++
+            }
+            if (removed > 0 && removedName != null) {
+                removedAny = true
+                outbound.send(OutboundEvent.SendText(sessionId, "You hand over ${removed}x $removedName."))
+            }
+        }
+        if (removedAny) onItemsConsumed?.invoke(sessionId)
     }
 
     private suspend fun sendObjectiveProgress(

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
@@ -32,6 +32,8 @@ import java.util.Random
 import kotlin.math.pow
 import kotlin.math.roundToInt
 
+private val WHITESPACE = Regex("\\s+")
+
 class AbilitySystem(
     private val players: PlayerRegistry,
     val registry: AbilityRegistry,
@@ -83,9 +85,26 @@ class AbilitySystem(
         val player = players.get(sessionId) ?: return ERR_NOT_CONNECTED
         ensureAbilitiesCurrent(sessionId)
 
-        // 1. Resolve ability
-        val ability = registry.findByKeyword(spellName)
-        if (ability == null || ability.id !in effectiveAbilities[sessionId].orEmpty()) {
+        // 1. Resolve ability. The parser splits `cast <word> <rest>` blindly, so a
+        //    multi-word spell name swallows part of itself into the target
+        //    ("cast hammer strike rat" arrives as spell "hammer", target
+        //    "strike rat"). Re-tokenize and try the longest known-spell prefix
+        //    first, treating the remainder as the target (#1221).
+        val known = effectiveAbilities[sessionId].orEmpty()
+        val tokens = buildList {
+            addAll(spellName.trim().split(WHITESPACE))
+            targetKeyword?.trim()?.takeIf { it.isNotEmpty() }?.let { addAll(it.split(WHITESPACE)) }
+        }
+        var ability: AbilityDefinition? = null
+        var resolvedTarget: String? = null
+        for (wordCount in tokens.size downTo 1) {
+            val candidate = registry.findByKeyword(tokens.take(wordCount).joinToString(" ")) ?: continue
+            if (candidate.id !in known) continue
+            ability = candidate
+            resolvedTarget = tokens.drop(wordCount).joinToString(" ").takeIf { it.isNotEmpty() }
+            break
+        }
+        if (ability == null) {
             return "You don't know a spell called '$spellName'."
         }
 
@@ -105,9 +124,9 @@ class AbilitySystem(
 
         // 4. Resolve target and apply
         return when (ability.targetType) {
-            "enemy" -> handleEnemyCast(sessionId, player, ability, targetKeyword, now)
+            "enemy" -> handleEnemyCast(sessionId, player, ability, resolvedTarget, now)
             "self" -> handleSelfCast(sessionId, player, ability, now)
-            "ally" -> handleAllyCast(sessionId, player, ability, targetKeyword, now)
+            "ally" -> handleAllyCast(sessionId, player, ability, resolvedTarget, now)
             "all_enemies" -> handleAllEnemiesCast(sessionId, player, ability, now)
             "all_allies" -> handleAllAlliesCast(sessionId, player, ability, now)
             "pet" -> handlePetCast(sessionId, player, ability, now)

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -891,8 +891,8 @@ object CommandParser {
         // drop
         requiredArg(line, listOf("drop"), "drop <item>", { Command.Drop(it) })?.let { return it }
 
-        // use
-        requiredArg(line, listOf("use"), "use <item>", { Command.Use(it) })?.let { return it }
+        // use — eat/drink are discoverability aliases; consumables all go through `use`.
+        requiredArg(line, listOf("use", "eat", "drink"), "use <item>", { Command.Use(it) })?.let { return it }
 
         // quick heal / quick mana
         matchPrefix(line, listOf("quickheal", "qh")) { Command.QuickHeal }?.let { return it }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1018,7 +1018,7 @@ ambonmud:
           category: items
           staff: false
         use:
-          usage: use <item>
+          usage: use/eat/drink <item>
           category: items
           staff: false
         give:

--- a/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/QuestSystemTest.kt
@@ -697,6 +697,72 @@ class QuestSystemTest {
         }
 
     @Test
+    fun `completing a collect quest consumes the gathered items`() =
+        runTest {
+            val c = SystemTestComponents(clockInitialMs = 1_000L)
+            val registry = QuestRegistry()
+            val collectItemId = "zone:shiny_rock"
+            val collectQuestId = "zone:collect_quest"
+            val collectQuest =
+                QuestDef(
+                    id = collectQuestId,
+                    name = "Collect Rocks",
+                    description = "Gather shiny rocks.",
+                    giverMobId = "zone:quest_giver",
+                    objectives =
+                        listOf(
+                            QuestObjectiveDef(
+                                type = "collect",
+                                targetId = collectItemId,
+                                count = 2,
+                                description = "Collect 2 shiny rocks",
+                            ),
+                        ),
+                    rewards = QuestRewards(xp = 50L, gold = 10L),
+                    completionType = "auto",
+                )
+            registry.register(collectQuest)
+            val qs =
+                QuestSystem(
+                    registry = registry,
+                    players = c.players,
+                    items = c.items,
+                    outbound = c.outbound,
+                    clock = c.clock,
+                )
+            var inventorySyncs = 0
+            qs.onItemsConsumed = { _ -> inventorySyncs++ }
+
+            val sid = SessionId(12L)
+            c.players.loginOrFail(sid, "Gatherer")
+            qs.acceptQuest(sid, collectQuestId)
+
+            // Three rocks in the bag; the quest only needs two.
+            repeat(3) {
+                c.items.addToInventory(
+                    sid,
+                    ItemInstance(id = ItemId(collectItemId), item = Item(keyword = "rock", displayName = "a shiny rock")),
+                )
+            }
+            c.outbound.drainAll()
+            qs.onItemCollected(sid, c.items.inventory(sid).first())
+
+            val ps = c.players.get(sid)!!
+            assertTrue(ps.completedQuestIds.contains(collectQuestId), "quest should auto-complete")
+            assertEquals(
+                1,
+                c.items.inventory(sid).count { it.id.value == collectItemId },
+                "turn-in should consume exactly the required 2 rocks and leave the spare",
+            )
+            assertEquals(1, inventorySyncs, "inventory re-sync callback should fire exactly once")
+            val texts = c.outbound.drainAll().filterIsInstance<OutboundEvent.SendText>().map { it.text }
+            assertTrue(
+                texts.any { it == "You hand over 2x a shiny rock." },
+                "player should see the hand-over message, got: $texts",
+            )
+        }
+
+    @Test
     fun `accepting collect quest with full required inventory auto-completes`() =
         runTest {
             val c = SystemTestComponents(clockInitialMs = 1_000L)

--- a/src/test/kotlin/dev/ambon/engine/abilities/AbilitySystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/abilities/AbilitySystemTest.kt
@@ -322,6 +322,38 @@ class AbilitySystemTest {
         }
 
     @Test
+    fun `cast resolves a multi-word spell name with a trailing target`() =
+        runTest {
+            val h = buildSystem()
+            h.players.loginOrFail(sid, "Caster")
+            h.abilitySystem.syncAbilities(sid, 1)
+            h.players.get(sid)!!.mana = 20
+
+            val mob = MobState(MobId("zone:rat"), "a rat", roomId, hp = 20, maxHp = 20)
+            h.mobs.upsert(mob)
+
+            // The parser splits "cast magic missile rat" into spell="magic",
+            // target="missile rat" — the longest known-spell prefix must win (#1221).
+            val err = h.abilitySystem.cast(sid, "magic", "missile rat")
+            assertNull(err)
+            assertEquals(15, mob.hp)
+        }
+
+    @Test
+    fun `cast with a full multi-word spell name and no target prompts for one`() =
+        runTest {
+            val h = buildSystem()
+            h.players.loginOrFail(sid, "Caster")
+            h.abilitySystem.syncAbilities(sid, 1)
+            h.players.get(sid)!!.mana = 20
+
+            // "cast magic missile" out of combat: the whole input is the spell
+            // name, not spell "magic" with target "missile".
+            val err = h.abilitySystem.cast(sid, "magic", "missile")
+            assertEquals("Cast Magic Missile on whom?", err)
+        }
+
+    @Test
     fun `cast at an out-of-combat mob engages combat so the target fights back`() =
         runTest {
             val h = buildSystem()

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
@@ -116,6 +116,14 @@ class CommandParserTest {
     }
 
     @Test
+    fun `eat and drink alias to use`() {
+        assertEquals(Command.Use("sandwich"), CommandParser.parse("eat sandwich"))
+        assertEquals(Command.Use("tea"), CommandParser.parse("drink tea"))
+        assertTrue(CommandParser.parse("eat") is Command.Invalid)
+        assertTrue(CommandParser.parse("drink") is Command.Invalid)
+    }
+
+    @Test
     fun `parses quickheal and quickmana with aliases`() {
         assertEquals(Command.QuickHeal, CommandParser.parse("quickheal"))
         assertEquals(Command.QuickHeal, CommandParser.parse("qh"))


### PR DESCRIPTION
Closes #1221, closes #1223, closes #1224 — the remaining quick-hit findings from the live-demo playtest, one commit each.

## #1221 — `cast hammer strike <target>` misparsed

The parser blindly splits `cast <word> <rest>`, so a multi-word spell name swallowed part of itself into the target (`spell="hammer", target="strike rat"`) and target resolution failed. `AbilitySystem.cast` now re-tokenizes the whole input and tries the **longest known-spell prefix** first, remainder = target:

- `cast hammer strike rat` → Hammer Strike @ rat ✓
- `cast hammer rat` (prefix form) → unchanged ✓
- `cast magic missile` (full name, no target) → "Cast Magic Missile on whom?" instead of treating "missile" as a target ✓
- Only abilities the caster **knows** participate in resolution, so an unknown longer name can't shadow a known shorter one; unknown input keeps the existing error message.

This also makes quoting unnecessary (the playtest note about `cast 'hammer strike'` failing) — greedy matching handles the ambiguity that quotes would have resolved.

## #1223 — gather-quest items not consumed on turn-in

`completeQuest` now removes `count` items per collect-type objective before announcing completion, with a `You hand over 2x a handful of cosmic scrap.` line. Details:

- Matching mirrors the built-in collect handler (exact id or `:<localId>` suffix), so cross-zone drops count the same way they did when progressing the objective.
- Best-effort: items dropped since completion are skipped rather than blocking turn-in (objective progress never regresses today — changing that would be a separate, bigger fix).
- Surplus copies beyond the required count stay in the bag.
- New `QuestSystem.onItemsConsumed` callback → GameEngine re-syncs the `Char.Items` GMCP list so the web inventory updates.
- Applies to both `npc_turn_in` and `auto` completion (shared path).

## #1224 — `eat`/`drink` aliases

`eat sandwich` / `drink tea` answered "Huh?". Both now alias to `Command.Use`, and the command manifest (AppConfig defaults + `application.yaml`, kept in sync) advertises `use/eat/drink <item>` in `help` and the web command palette.

## Tests

- `AbilitySystemTest`: multi-word spell + target resolves and damages; full name with no target prompts for one (existing prefix/exact-id tests cover regression).
- `QuestSystemTest`: completing a 2-rock collect quest consumes exactly 2 of 3 rocks, fires the inventory-sync callback once, and emits the hand-over message.
- `CommandParserTest`: `eat`/`drink` parse to `Command.Use`; bare verbs are `Invalid` with the `use <item>` usage.

`ktlintCheck`, full `test`, and `integrationTest` all pass.
