### PR TITLE
fix(world): single definite article in feature messages (#1220)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/TimedRespawnHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/TimedRespawnHandler.kt
@@ -8,6 +8,7 @@ import dev.ambon.domain.world.LockableState
 import dev.ambon.domain.world.RoomFeature
 import dev.ambon.domain.world.World
 import dev.ambon.engine.commands.handlers.buildFeaturePayload
+import dev.ambon.engine.commands.handlers.theCap
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
 import java.time.Clock
@@ -129,9 +130,9 @@ internal class TimedRespawnHandler(
             is RoomFeature.Door -> {
                 worldState.setLockableState(feature.id, feature.initialState)
                 if (feature.initialState == LockableState.OPEN) {
-                    "The ${feature.displayName} swings open."
+                    "${theCap(feature.displayName)} swings open."
                 } else {
-                    "The ${feature.displayName} swings shut."
+                    "${theCap(feature.displayName)} swings shut."
                 }
             }
             is RoomFeature.Container -> {
@@ -139,14 +140,14 @@ internal class TimedRespawnHandler(
                 val instances = feature.initialItems.mapNotNull { items.createFromTemplate(it) }
                 worldState.resetContainer(feature.id, instances)
                 if (feature.initialState == LockableState.OPEN) {
-                    "${feature.displayName} creaks open, its contents restored."
+                    "${theCap(feature.displayName)} creaks open, its contents restored."
                 } else {
-                    "${feature.displayName} clicks shut."
+                    "${theCap(feature.displayName)} clicks shut."
                 }
             }
             is RoomFeature.Lever -> {
                 worldState.setLeverState(feature.id, feature.initialState)
-                "${feature.displayName} snaps back into place."
+                "${theCap(feature.displayName)} snaps back into place."
             }
             is RoomFeature.Sign -> return
         }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -46,6 +46,27 @@ internal inline fun PlayerRegistry.withPlayer(
     block(player)
 }
 
+/**
+ * Definite-article form of a feature display name for mid-sentence use.
+ * Authored names usually carry their own indefinite article ("a lacquered
+ * curio chest"), so blindly prefixing "the " produced "the a lacquered curio
+ * chest" (#1220). Swaps a leading "a "/"an " for "the "; names already
+ * starting with "the" pass through; bare names get "the " prefixed.
+ */
+internal fun the(displayName: String): String {
+    val trimmed = displayName.trim()
+    val lower = trimmed.lowercase()
+    return when {
+        lower.startsWith("the ") -> trimmed
+        lower.startsWith("a ") -> "the ${trimmed.drop(2)}"
+        lower.startsWith("an ") -> "the ${trimmed.drop(3)}"
+        else -> "the $trimmed"
+    }
+}
+
+/** Sentence-initial variant of [the]: "The lacquered curio chest". */
+internal fun theCap(displayName: String): String = the(displayName).replaceFirstChar { it.uppercaseChar() }
+
 /** Sends the full GMCP Char.Items list (inventory + equipment) for [sessionId]. */
 internal suspend fun syncItemsGmcp(
     sessionId: SessionId,
@@ -854,7 +875,7 @@ internal suspend fun requireContainerOpen(
 ): Boolean {
     val state = worldState?.getContainerState(feature.id) ?: feature.initialState
     if (state != LockableState.OPEN) {
-        outbound.send(OutboundEvent.SendError(sessionId, "The ${feature.displayName} is not open."))
+        outbound.send(OutboundEvent.SendError(sessionId, "${theCap(feature.displayName)} is not open."))
         return false
     }
     return true

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
@@ -142,7 +142,7 @@ class NavigationHandler(
                     val doorState = worldState.getDoorState(door.id)
                     if (doorState != LockableState.OPEN) {
                         val reason = if (doorState == LockableState.LOCKED) "locked" else "closed"
-                        outbound.send(OutboundEvent.SendText(sessionId, "The ${door.displayName} is $reason."))
+                        outbound.send(OutboundEvent.SendText(sessionId, "${theCap(door.displayName)} is $reason."))
                         return
                     }
                 }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/PuzzleHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/PuzzleHandler.kt
@@ -220,11 +220,11 @@ class PuzzleHandler(
                 items.removeFromInventoryById(sessionId, keyItemId)
                 syncItemsGmcp(sessionId, items, gmcpEmitter)
             }
-            outbound.send(OutboundEvent.SendInfo(sessionId, "The $displayName swings open."))
+            outbound.send(OutboundEvent.SendInfo(sessionId, "${theCap(displayName)} swings open."))
             broadcastToRoomExcept(
                 roomId,
                 sessionId,
-                "The $displayName swings open.",
+                "${theCap(displayName)} swings open.",
                 players,
                 outbound,
             )

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldFeaturesHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldFeaturesHandler.kt
@@ -53,12 +53,12 @@ class WorldFeaturesHandler(
         keyword: String,
     ): Unit = withLockable(sessionId, keyword, "open") { me, lockable ->
         when (lockable.state) {
-            LockableState.LOCKED -> outbound.send(OutboundEvent.SendError(sessionId, "The ${lockable.displayName} is locked."))
-            LockableState.OPEN -> outbound.send(OutboundEvent.SendError(sessionId, "The ${lockable.displayName} is already open."))
+            LockableState.LOCKED -> outbound.send(OutboundEvent.SendError(sessionId, "${theCap(lockable.displayName)} is locked."))
+            LockableState.OPEN -> outbound.send(OutboundEvent.SendError(sessionId, "${theCap(lockable.displayName)} is already open."))
             LockableState.CLOSED -> {
                 lockable.applyState(LockableState.OPEN)
-                outbound.send(OutboundEvent.SendInfo(sessionId, "You open the ${lockable.displayName}."))
-                broadcastToRoomExcept(me.roomId, sessionId, "${me.name} opens the ${lockable.displayName}.", players, outbound)
+                outbound.send(OutboundEvent.SendInfo(sessionId, "You open ${the(lockable.displayName)}."))
+                broadcastToRoomExcept(me.roomId, sessionId, "${me.name} opens ${the(lockable.displayName)}.", players, outbound)
                 world.rooms[me.roomId]?.let { emitRoomFeatures(it) }
             }
         }
@@ -71,15 +71,15 @@ class WorldFeaturesHandler(
         when (lockable.state) {
             LockableState.OPEN -> {
                 lockable.applyState(LockableState.CLOSED)
-                outbound.send(OutboundEvent.SendInfo(sessionId, "You close the ${lockable.displayName}."))
-                broadcastToRoomExcept(me.roomId, sessionId, "${me.name} closes the ${lockable.displayName}.", players, outbound)
+                outbound.send(OutboundEvent.SendInfo(sessionId, "You close ${the(lockable.displayName)}."))
+                broadcastToRoomExcept(me.roomId, sessionId, "${me.name} closes ${the(lockable.displayName)}.", players, outbound)
                 world.rooms[me.roomId]?.let { emitRoomFeatures(it) }
             }
             LockableState.CLOSED -> outbound.send(
-                OutboundEvent.SendError(sessionId, "The ${lockable.displayName} is already closed."),
+                OutboundEvent.SendError(sessionId, "${theCap(lockable.displayName)} is already closed."),
             )
             LockableState.LOCKED -> outbound.send(
-                OutboundEvent.SendError(sessionId, "The ${lockable.displayName} is already closed and locked."),
+                OutboundEvent.SendError(sessionId, "${theCap(lockable.displayName)} is already closed and locked."),
             )
         }
     }
@@ -90,7 +90,7 @@ class WorldFeaturesHandler(
     ): Unit = withLockable(sessionId, keyword, "unlock") { me, lockable ->
         when {
             lockable.state != LockableState.LOCKED ->
-                outbound.send(OutboundEvent.SendError(sessionId, "The ${lockable.displayName} is not locked."))
+                outbound.send(OutboundEvent.SendError(sessionId, "${theCap(lockable.displayName)} is not locked."))
             lockable.keyItemId == null ->
                 outbound.send(OutboundEvent.SendError(sessionId, "That doesn't need a key."))
             else -> {
@@ -113,9 +113,9 @@ class WorldFeaturesHandler(
     ): Unit = withLockable(sessionId, keyword, "lock") { me, lockable ->
         when {
             lockable.state == LockableState.LOCKED ->
-                outbound.send(OutboundEvent.SendError(sessionId, "The ${lockable.displayName} is already locked."))
+                outbound.send(OutboundEvent.SendError(sessionId, "${theCap(lockable.displayName)} is already locked."))
             lockable.state != LockableState.CLOSED ->
-                outbound.send(OutboundEvent.SendError(sessionId, "The ${lockable.displayName} must be closed before locking."))
+                outbound.send(OutboundEvent.SendError(sessionId, "${theCap(lockable.displayName)} must be closed before locking."))
             lockable.keyItemId == null ->
                 outbound.send(OutboundEvent.SendError(sessionId, "That doesn't need a key."))
             else -> applyKeyAction(sessionId, me, lockable, LockableState.LOCKED, "lock", "locks")
@@ -129,10 +129,10 @@ class WorldFeaturesHandler(
         val feature = requireOpenContainer(sessionId, room, keyword, worldState, outbound) ?: return
         val contents = worldState?.getContainerContents(feature.id) ?: emptyList()
         if (contents.isEmpty()) {
-            outbound.send(OutboundEvent.SendInfo(sessionId, "The ${feature.displayName} is empty."))
+            outbound.send(OutboundEvent.SendInfo(sessionId, "${theCap(feature.displayName)} is empty."))
         } else {
             val list = contents.map { it.item.displayName }.sorted().joinToString(", ")
-            outbound.send(OutboundEvent.SendInfo(sessionId, "In the ${feature.displayName}: $list"))
+            outbound.send(OutboundEvent.SendInfo(sessionId, "In ${the(feature.displayName)}: $list"))
         }
         emitContainerContents(sessionId, feature)
     }
@@ -145,14 +145,14 @@ class WorldFeaturesHandler(
         val feature = requireOpenContainer(sessionId, room, containerKeyword, worldState, outbound) ?: return
         val item = worldState?.removeFromContainer(feature.id, itemKeyword)
         if (item == null) {
-            outbound.send(OutboundEvent.SendError(sessionId, "There is no '$itemKeyword' in the ${feature.displayName}."))
+            outbound.send(OutboundEvent.SendError(sessionId, "There is no '$itemKeyword' in ${the(feature.displayName)}."))
         } else {
             items.addToInventory(sessionId, item)
-            outbound.send(OutboundEvent.SendInfo(sessionId, "You take ${item.item.displayName} from the ${feature.displayName}."))
+            outbound.send(OutboundEvent.SendInfo(sessionId, "You take ${item.item.displayName} from ${the(feature.displayName)}."))
             broadcastToRoomExcept(
                 me.roomId,
                 sessionId,
-                "${me.name} takes ${item.item.displayName} from the ${feature.displayName}.",
+                "${me.name} takes ${item.item.displayName} from ${the(feature.displayName)}.",
                 players,
                 outbound,
             )
@@ -182,11 +182,11 @@ class WorldFeaturesHandler(
             outbound.send(OutboundEvent.SendError(sessionId, "You don't have any '$itemKeyword'."))
         } else {
             worldState?.addToContainer(feature.id, item)
-            outbound.send(OutboundEvent.SendInfo(sessionId, "You put ${item.item.displayName} in the ${feature.displayName}."))
+            outbound.send(OutboundEvent.SendInfo(sessionId, "You put ${item.item.displayName} in ${the(feature.displayName)}."))
             broadcastToRoomExcept(
                 me.roomId,
                 sessionId,
-                "${me.name} puts ${item.item.displayName} in the ${feature.displayName}.",
+                "${me.name} puts ${item.item.displayName} in ${the(feature.displayName)}.",
                 players,
                 outbound,
             )
@@ -207,8 +207,8 @@ class WorldFeaturesHandler(
         val state = worldState?.getLeverState(feature.id) ?: feature.initialState
         val newState = if (state == LeverState.UP) LeverState.DOWN else LeverState.UP
         worldState?.setLeverState(feature.id, newState)
-        outbound.send(OutboundEvent.SendInfo(sessionId, "You pull the ${feature.displayName}. It moves ${newState.name.lowercase()}."))
-        broadcastToRoomExcept(me.roomId, sessionId, "${me.name} pulls the ${feature.displayName}.", players, outbound)
+        outbound.send(OutboundEvent.SendInfo(sessionId, "You pull ${the(feature.displayName)}. It moves ${newState.name.lowercase()}."))
+        broadcastToRoomExcept(me.roomId, sessionId, "${me.name} pulls ${the(feature.displayName)}.", players, outbound)
         emitRoomFeatures(room)
         // Notify puzzle system of the lever interaction
         puzzleHandler?.onFeatureInteraction(sessionId, feature.keyword, "pull")
@@ -236,15 +236,15 @@ class WorldFeaturesHandler(
     ) {
         val key = findKeyInInventory(sessionId, lockable.keyItemId!!, items)
         if (key == null) {
-            outbound.send(OutboundEvent.SendError(sessionId, "You don't have the key for the ${lockable.displayName}."))
+            outbound.send(OutboundEvent.SendError(sessionId, "You don't have the key for ${the(lockable.displayName)}."))
         } else {
             lockable.applyState(newState)
             if (lockable.keyConsumed) items.removeFromInventory(sessionId, key.item.keyword)
-            outbound.send(OutboundEvent.SendInfo(sessionId, "You $verb the ${lockable.displayName}."))
+            outbound.send(OutboundEvent.SendInfo(sessionId, "You $verb ${the(lockable.displayName)}."))
             broadcastToRoomExcept(
                 me.roomId,
                 sessionId,
-                "${me.name} $verbThirdPerson the ${lockable.displayName}.",
+                "${me.name} $verbThirdPerson ${the(lockable.displayName)}.",
                 players,
                 outbound,
             )

--- a/src/test/kotlin/dev/ambon/engine/TimedRespawnHandlerTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/TimedRespawnHandlerTest.kt
@@ -158,7 +158,7 @@ class TimedRespawnHandlerTest {
 
         val texts = h.outbound.drainAll().filterIsInstance<OutboundEvent.SendText>().map { it.text }
         assertTrue(
-            texts.any { it == "a sprung lever snaps back into place." },
+            texts.any { it == "The sprung lever snaps back into place." },
             "players in the room should see the lever reset, got: $texts",
         )
     }

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterFeaturesTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterFeaturesTest.kt
@@ -167,6 +167,30 @@ class CommandRouterFeaturesTest {
         }
 
     @Test
+    fun `feature messages render a single definite article`() =
+        runTest {
+            val h = harness()
+
+            // "a supply chest" must read "the supply chest", not "the a supply chest" (#1220).
+            h.players.moveTo(h.sid, RoomId("ok_features:storeroom"))
+            h.router.handle(h.sid, Command.OpenFeature("chest"))
+            var outs = h.outbound.drainAll()
+            assertTrue(
+                outs.any { it is OutboundEvent.SendInfo && it.text == "You open the supply chest." },
+                "Expected single-article open message, got: $outs",
+            )
+
+            // "an iron lever" must read "The iron lever ..." in pull messages.
+            h.players.moveTo(h.sid, RoomId("ok_features:vault"))
+            h.router.handle(h.sid, Command.Pull("lever"))
+            outs = h.outbound.drainAll()
+            assertTrue(
+                outs.any { it is OutboundEvent.SendInfo && it.text == "You pull the iron lever. It moves down." },
+                "Expected single-article pull message, got: $outs",
+            )
+        }
+
+    @Test
     fun `open locked door fails with error`() =
         runTest {
             val h = harness()

--- a/src/test/kotlin/dev/ambon/engine/commands/handlers/DefiniteArticleTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/handlers/DefiniteArticleTest.kt
@@ -1,0 +1,38 @@
+package dev.ambon.engine.commands.handlers
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class DefiniteArticleTest {
+    @Test
+    fun `swaps a leading indefinite article for the`() {
+        assertEquals("the lacquered curio chest", the("a lacquered curio chest"))
+        assertEquals("the ostentatious brass lever", the("an ostentatious brass lever"))
+    }
+
+    @Test
+    fun `names already starting with the pass through`() {
+        assertEquals("the supply chest", the("the supply chest"))
+        assertEquals("The Door That Asks", the("The Door That Asks"))
+    }
+
+    @Test
+    fun `bare names get the prefixed`() {
+        assertEquals("the door to the north", the("door to the north"))
+    }
+
+    @Test
+    fun `does not mangle words that merely start with article letters`() {
+        assertEquals("the anvil", the("anvil"))
+        assertEquals("the theater door", the("theater door"))
+        assertEquals("the apple cart", the("apple cart"))
+    }
+
+    @Test
+    fun `theCap capitalizes the sentence-initial form`() {
+        assertEquals("The lacquered curio chest", theCap("a lacquered curio chest"))
+        assertEquals("The iron lever", theCap("an iron lever"))
+        assertEquals("The Door That Asks", theCap("The Door That Asks"))
+        assertEquals("The door to the north", theCap("door to the north"))
+    }
+}


### PR DESCRIPTION
Closes #1220.

## Problem

Feature messages hardcode `the `/`The ` before `displayName`s that already carry their own article — observed live as "You open the **a lacquered** curio chest." and "You pull the **an ostentatious** brass lever."

## Fix

Two small helpers in `HandlerHelpers.kt`:

- `the(name)` — definite-article form for mid-sentence use: swaps a leading `a `/`an ` for `the `; names already starting with `the` pass through (`The Door That Asks` stays untouched); bare names (`door to the north`) get `the ` prefixed.
- `theCap(name)` — sentence-initial variant (`The lacquered curio chest`).

Applied at every site that prepended an article to a feature name:

| File | Sites |
|---|---|
| `WorldFeaturesHandler` | open/close/unlock/lock (success, error, and room broadcasts), search ("In the X:", "X is empty"), get-from/put-in, pull |
| `NavigationHandler` | "The door to the north is locked." movement block |
| `PuzzleHandler` | auto-unlock "swings open" (player + broadcast) |
| `HandlerHelpers` | `requireOpenContainer` "is not open" |
| `TimedRespawnHandler` | revert flavor lines, now consistently sentence-cased ("The sprung lever snaps back into place.") |

Item display names inside the same messages ("You take **a silver coin** from the supply chest.") were already bare and remain untouched.

## Tests

- `DefiniteArticleTest` — article swap, `the`-passthrough (including capitalized proper names), bare-name prefixing, no mangling of words that merely start with article letters (`anvil`, `theater door`, `apple cart`), capitalization.
- `CommandRouterFeaturesTest` — end-to-end regression asserting the exact strings: "You open **the supply chest**." and "You pull **the iron lever**. It moves down." against the `ok_features` fixture (whose names are authored as "a supply chest" / "an iron lever").
- `TimedRespawnHandlerTest` updated for the sentence-cased revert line.

`ktlintCheck`, full `test`, and `integrationTest` all pass.
