### PR TITLE
docs(help): full command-manifest audit — every command documented, drift pinned by tests

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -1747,24 +1747,32 @@ data class CommandsConfig(
             "utility",
         )
 
+        // Categories the ordered list doesn't know about are appended at the
+        // end rather than silently dropped from help.
+        val categories = orderedCategories.filter { it in grouped } +
+            (grouped.keys - orderedCategories.toSet()).sorted()
+
         appendLine("Commands:")
-        for (category in orderedCategories) {
-            val cmds = grouped[category] ?: continue
-            for ((_, meta) in cmds) {
-                appendLine("    ${meta.usage}")
+        for (category in categories) {
+            appendLine("  [${category.replaceFirstChar { it.uppercaseChar() }}]")
+            for ((_, meta) in grouped.getValue(category)) {
+                appendLine(formatHelpLine(meta))
             }
         }
 
         if (isStaff) {
             val staffCmds = entries.entries.filter { it.value.staff }
             if (staffCmds.isNotEmpty()) {
-                appendLine("Staff commands (requires staff flag):")
+                appendLine("  [Staff] (requires staff flag)")
                 for ((_, meta) in staffCmds) {
-                    appendLine("    ${meta.usage}")
+                    appendLine(formatHelpLine(meta))
                 }
             }
         }
     }.trimEnd()
+
+    private fun formatHelpLine(meta: CommandMetadata): String =
+        if (meta.description.isEmpty()) "    ${meta.usage}" else "    ${meta.usage} — ${meta.description}"
 
     companion object {
         @Suppress("LongMethod")
@@ -1773,7 +1781,21 @@ data class CommandsConfig(
             "look" to CommandMetadata("look/l [target|direction]", "Look around, at a target, or in a direction", "navigation"),
             "move" to CommandMetadata("n/s/e/w/u/d", "Move in a direction", "navigation"),
             "exits" to CommandMetadata("exits/ex", "List available exits", "navigation"),
-            "recall" to CommandMetadata("recall", "Return to your recall point", "navigation"),
+            "recall" to CommandMetadata("recall", "Teleport to your recall point (set by resting at an inn)", "navigation"),
+            "rest" to CommandMetadata("rest", "Rest at an inn to make it your recall point.", "navigation"),
+            "depart" to CommandMetadata("depart", "Leave the death sanctum and return to the world", "navigation"),
+            "run" to CommandMetadata(
+                usage = "run <directions> (e.g. 5n3e)",
+                description = "Move along a sequence of directions. Numeric prefixes repeat — '5n3e' walks five north then three east.",
+                category = "navigation",
+                requiresTarget = true,
+            ),
+            "areas" to CommandMetadata(
+                usage = "areas [<minLevel> [<maxLevel>]]",
+                description = "List known areas. With one level, shows areas covering that level; " +
+                    "with two, shows areas overlapping the range.",
+                category = "navigation",
+            ),
             "say" to CommandMetadata("say <msg> or '<msg>", "Speak to the room", "communication", requiresTarget = true),
             "emote" to CommandMetadata("emote <msg>", "Perform an emote", "communication", requiresTarget = true),
             "pose" to CommandMetadata("pose <msg>", "Strike a pose", "communication", requiresTarget = true),
@@ -1794,17 +1816,77 @@ data class CommandsConfig(
             "quickmana" to CommandMetadata("quickmana/qm", "Auto-use best mana potion", "combat"),
             "give" to CommandMetadata("give <item> <player>", "Give an item to a player", "items", requiresTarget = true),
             "talk" to CommandMetadata("talk <npc>", "Start a conversation with an NPC", "social", requiresTarget = true),
+            "bye" to CommandMetadata("bye/goodbye", "End the current NPC conversation", "social"),
             "kill" to CommandMetadata("kill <mob>", "Attack a mob", "combat", requiresTarget = true),
             "flee" to CommandMetadata("flee", "Attempt to flee combat", "combat"),
             "cast" to CommandMetadata("cast/c <spell> [target]", "Cast a spell or ability", "combat", requiresTarget = true),
+            "consider" to CommandMetadata(
+                usage = "consider/con <mob>",
+                description = "Estimate your odds against a mob before attacking",
+                category = "combat",
+                requiresTarget = true,
+            ),
+            "wimpy" to CommandMetadata("wimpy [off | 0-95]", "View or set the HP percent where you auto-flee combat", "combat"),
+            "duel" to CommandMetadata(
+                usage = "duel <player> | duel accept | duel decline",
+                description = "Challenge another player to a PvP duel",
+                category = "combat",
+                requiresTarget = true,
+            ),
             "spells" to CommandMetadata("spells/abilities/skills", "List your abilities", "progression"),
             "effects" to CommandMetadata("effects/buffs/debuffs", "View active status effects", "progression"),
             "score" to CommandMetadata("score/sc", "View your character sheet", "progression"),
-            "balance" to CommandMetadata("gold/balance", "Check your gold", "shops"),
+            "balance" to CommandMetadata("gold/balance", "Check the gold you are carrying", "shops"),
             "currencies" to CommandMetadata("currencies/currency/wallet", "View secondary currencies", "progression"),
+            "reputation" to CommandMetadata("reputation/rep/factions", "View your faction standings", "progression"),
             "shop_list" to CommandMetadata("list/shop", "Browse a shop's wares", "shops"),
             "buy" to CommandMetadata("buy <item>", "Purchase from a shop", "shops", requiresTarget = true),
             "sell" to CommandMetadata("sell <item>", "Sell to a shop", "shops", requiresTarget = true),
+            "bank" to CommandMetadata("bank", "View bank balance and vault contents (requires a bank)", "shops"),
+            "deposit" to CommandMetadata(
+                usage = "deposit <amount|item>",
+                description = "Deposit gold or an item into your bank vault",
+                category = "shops",
+                requiresTarget = true,
+            ),
+            "withdraw" to CommandMetadata(
+                usage = "withdraw <amount|item>",
+                description = "Withdraw gold or an item from your bank vault",
+                category = "shops",
+                requiresTarget = true,
+            ),
+            "auction" to CommandMetadata("auction", "Browse auction house listings", "shops"),
+            "auction_sell" to CommandMetadata(
+                usage = "auction sell <item> <price>",
+                description = "List an item on the auction house",
+                category = "shops",
+                requiresTarget = true,
+            ),
+            "auction_buy" to CommandMetadata("auction buy <#>", "Buy an auction listing by number", "shops", requiresTarget = true),
+            "auction_cancel" to CommandMetadata(
+                usage = "auction cancel <#>",
+                description = "Cancel your listing and reclaim the item",
+                category = "shops",
+                requiresTarget = true,
+            ),
+            "trade" to CommandMetadata(
+                usage = "trade <player> | trade accept | trade cancel | trade status",
+                description = "Trade items and gold with another player",
+                category = "items",
+                requiresTarget = true,
+            ),
+            "trade_offer" to CommandMetadata(
+                usage = "trade offer <item> | trade offer <amount> gold",
+                description = "Add an item or gold to the active trade",
+                category = "items",
+                requiresTarget = true,
+            ),
+            "trade_remove" to CommandMetadata(
+                usage = "trade remove <item>",
+                description = "Remove an item from your trade offer",
+                category = "items",
+                requiresTarget = true,
+            ),
             "quest_log" to CommandMetadata("quest log/list", "View active quests", "quests"),
             "quest_info" to CommandMetadata("quest info <name>", "Quest details", "quests", requiresTarget = true),
             "quest_abandon" to CommandMetadata("quest abandon <name>", "Abandon a quest", "quests", requiresTarget = true),
@@ -1822,6 +1904,7 @@ data class CommandsConfig(
             "daily" to CommandMetadata("daily/dailies", "View daily quest board", "quests"),
             "weekly" to CommandMetadata("weekly", "View weekly quest board", "quests"),
             "gquest" to CommandMetadata("gquest/gq/global", "View active global quest status", "quests"),
+            "qoffers" to CommandMetadata("qoffers <mob>", "List the quests an NPC has to offer", "quests", requiresTarget = true),
             "group_invite" to CommandMetadata("group invite <player>", "Invite to your group", "groups", requiresTarget = true),
             "group_accept" to CommandMetadata("group accept", "Accept a group invite", "groups"),
             "group_leave" to CommandMetadata("group leave", "Leave your group", "groups"),
@@ -1840,10 +1923,23 @@ data class CommandsConfig(
             "guild_roster" to CommandMetadata("guild roster", "View guild members", "guilds"),
             "guild_info" to CommandMetadata("guild info (or just 'guild')", "Guild overview", "guilds"),
             "gchat" to CommandMetadata("gchat/g <message>", "Guild chat", "guilds", requiresTarget = true),
+            "guild_hall" to CommandMetadata(
+                usage = "guild hall [buy | expand <template> <direction> | enter | leave]",
+                description = "View, buy, expand, and visit your guild hall",
+                category = "guilds",
+            ),
             "gather" to CommandMetadata("gather/harvest/mine <node>", "Gather from a resource node", "crafting", requiresTarget = true),
             "craft" to CommandMetadata("craft/make <recipe>", "Craft an item from a recipe", "crafting", requiresTarget = true),
             "recipes" to CommandMetadata("recipes [filter]", "Browse available recipes", "crafting"),
             "craftskills" to CommandMetadata("craftskills/professions", "View crafting skill levels", "crafting"),
+            "specialize" to CommandMetadata("specialize/spec [profession]", "View or choose a crafting specialization", "crafting"),
+            "enchant" to CommandMetadata(
+                usage = "enchant <item> [enchantment]",
+                description = "Enchant an item with a known enchantment",
+                category = "crafting",
+                requiresTarget = true,
+            ),
+            "enchantments" to CommandMetadata("enchantments", "List available enchantments", "crafting"),
             "house" to CommandMetadata("house [status]", "View your house info", "housing"),
             "house_list" to CommandMetadata("house list", "Browse available room templates", "housing"),
             "house_buy" to CommandMetadata("house buy", "Purchase your house (at broker)", "housing"),
@@ -1882,13 +1978,48 @@ data class CommandsConfig(
             "pull" to CommandMetadata("pull <lever>", "Pull a lever or object", "world", requiresTarget = true),
             "read" to CommandMetadata("read <sign>", "Read a sign or inscription", "world", requiresTarget = true),
             "answer" to CommandMetadata("answer <text>", "Answer a riddle in the room", "world", requiresTarget = true),
+            "dungeon" to CommandMetadata(
+                usage = "dungeon enter <name> [difficulty] | dungeon leave",
+                description = "Enter or leave an instanced dungeon",
+                category = "world",
+                requiresTarget = true,
+            ),
             "title" to CommandMetadata("title <titleName> | title clear", "Set or clear your title", "progression", requiresTarget = true),
             "gender" to CommandMetadata("gender <option>", "Set your gender", "progression", requiresTarget = true),
             "sprite" to CommandMetadata("sprite list | set <id> | default", "Manage your character sprite", "progression"),
+            "describe" to CommandMetadata(
+                usage = "describe <text> | describe clear | describe check <player>",
+                description = "Set, clear, or view a character description",
+                category = "progression",
+                requiresTarget = true,
+            ),
+            "train" to CommandMetadata(
+                usage = "train [list] | train learn <ability> | train unlock <class> | train reset",
+                description = "Learn abilities, unlock classes, or respec at a class trainer",
+                category = "progression",
+            ),
+            "prestige" to CommandMetadata("prestige | prestige info", "Reset at max level for permanent prestige perks", "progression"),
+            "leaderboard" to CommandMetadata("leaderboard/top [category]", "View player leaderboards", "progression"),
+            "stylist" to CommandMetadata("stylist", "View race-change options and fee (requires a stylist)", "progression"),
+            "changerace" to CommandMetadata(
+                usage = "changerace <race>",
+                description = "Pay the stylist to change your race",
+                category = "progression",
+                requiresTarget = true,
+            ),
+            "pet" to CommandMetadata(
+                usage = "pet [status] | pet name <name> | pet skills | pet <skill> | pet dismiss",
+                description = "Manage your pet and trigger its skills",
+                category = "progression",
+            ),
             "friend" to CommandMetadata("friend list | add <player> | remove <player>", "Manage your friends list", "social"),
             "mail" to CommandMetadata("mail list | read <n> | send <player> | delete <n>", "Manage mail", "social"),
-            "lottery" to CommandMetadata("lottery [info] | lottery buy [count]", "View or buy lottery tickets", "social"),
-            "gamble" to CommandMetadata("gamble/dice <amount>", "Roll the dice at a tavern", "social"),
+            "lottery" to CommandMetadata(
+                usage = "lottery [info] | lottery buy [count]",
+                description = "View the lottery or buy tickets (buying requires a tavern)",
+                category = "social",
+            ),
+            "gamble" to CommandMetadata("gamble/dice <amount>", "Roll d100 against the house (requires a tavern)", "social"),
             "ansi" to CommandMetadata("ansi on/off", "Toggle color output", "utility"),
             "screenreader" to CommandMetadata("screenreader [on/off]", "Toggle screen reader mode", "utility"),
             "autoloot" to CommandMetadata(
@@ -1905,6 +2036,12 @@ data class CommandsConfig(
             "clear" to CommandMetadata("clear", "Clear the terminal", "utility"),
             "quit" to CommandMetadata("quit/exit", "Disconnect", "utility"),
             "phase" to CommandMetadata("phase/layer [instance]", "Switch zone instance", "utility"),
+            "time" to CommandMetadata("time", "Show the in-game time of day", "utility"),
+            "claim" to CommandMetadata(
+                usage = "claim <password> | claim <newname> <password>",
+                description = "Save a demo character as a permanent account",
+                category = "utility",
+            ),
             // Staff commands
             "goto" to CommandMetadata(
                 usage = "goto <zone:room | room | zone:>",
@@ -1969,6 +2106,50 @@ data class CommandsConfig(
             "broadcast" to CommandMetadata(
                 usage = "broadcast <message>",
                 description = "Send a server-wide announcement",
+                category = "admin",
+                staff = true,
+                requiresTarget = true,
+            ),
+            "heal" to CommandMetadata("heal [player]", "Fully restore a player's HP and mana", "admin", staff = true),
+            "pinfo" to CommandMetadata("pinfo <player>", "Inspect a player's state", "admin", staff = true, requiresTarget = true),
+            "setstaff" to CommandMetadata(
+                usage = "setstaff/grantstaff <player> | revokestaff <player>",
+                description = "Grant or revoke staff access",
+                category = "admin",
+                staff = true,
+                requiresTarget = true,
+            ),
+            "setgold" to CommandMetadata(
+                usage = "setgold <player> <amount>",
+                description = "Set a player's gold",
+                category = "admin",
+                staff = true,
+                requiresTarget = true,
+            ),
+            "setrace" to CommandMetadata(
+                usage = "setrace <player> <race>",
+                description = "Set a player's race",
+                category = "admin",
+                staff = true,
+                requiresTarget = true,
+            ),
+            "setclass" to CommandMetadata(
+                usage = "setclass <player> <class>",
+                description = "Set a player's class",
+                category = "admin",
+                staff = true,
+                requiresTarget = true,
+            ),
+            "setgender" to CommandMetadata(
+                usage = "setgender <player> <gender>",
+                description = "Set a player's gender",
+                category = "admin",
+                staff = true,
+                requiresTarget = true,
+            ),
+            "setxp" to CommandMetadata(
+                usage = "setxp <player> <xp>",
+                description = "Set a player's XP",
                 category = "admin",
                 staff = true,
                 requiresTarget = true,

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -923,480 +923,878 @@ ambonmud:
     commands:
       entries:
         help:
-          usage: help/?
-          category: utility
+          usage: "help/?"
+          description: "Show this help"
+          category: "utility"
           staff: false
         look:
-          usage: look/l [target|direction]
-          category: navigation
+          usage: "look/l [target|direction]"
+          description: "Look around, at a target, or in a direction"
+          category: "navigation"
           staff: false
         move:
-          usage: n/s/e/w/u/d
-          category: navigation
+          usage: "n/s/e/w/u/d"
+          description: "Move in a direction"
+          category: "navigation"
           staff: false
         exits:
-          usage: exits/ex
-          category: navigation
+          usage: "exits/ex"
+          description: "List available exits"
+          category: "navigation"
           staff: false
         recall:
-          usage: recall
-          category: navigation
+          usage: "recall"
+          description: "Teleport to your recall point (set by resting at an inn)"
+          category: "navigation"
           staff: false
         rest:
-          usage: rest
-          description: Rest at an inn to make it your recall point.
-          category: navigation
+          usage: "rest"
+          description: "Rest at an inn to make it your recall point."
+          category: "navigation"
+          staff: false
+        depart:
+          usage: "depart"
+          description: "Leave the death sanctum and return to the world"
+          category: "navigation"
           staff: false
         run:
-          usage: run <directions> (e.g. 5n3e)
-          description: Move along a sequence of directions. Numeric prefixes repeat — '5n3e' walks five north then three east.
-          category: navigation
+          usage: "run <directions> (e.g. 5n3e)"
+          description: "Move along a sequence of directions. Numeric prefixes repeat — '5n3e' walks five north then three east."
+          category: "navigation"
           staff: false
+          requiresTarget: true
         areas:
-          usage: areas [<minLevel> [<maxLevel>]]
-          description: List known areas. With one level, shows areas covering that level; with two, shows areas overlapping the range.
-          category: navigation
+          usage: "areas [<minLevel> [<maxLevel>]]"
+          description: "List known areas. With one level, shows areas covering that level; with two, shows areas overlapping the range."
+          category: "navigation"
           staff: false
         say:
-          usage: say <msg> or '<msg>
-          category: communication
+          usage: "say <msg> or '<msg>"
+          description: "Speak to the room"
+          category: "communication"
           staff: false
+          requiresTarget: true
         emote:
-          usage: emote <msg>
-          category: communication
+          usage: "emote <msg>"
+          description: "Perform an emote"
+          category: "communication"
           staff: false
+          requiresTarget: true
         pose:
-          usage: pose <msg>
-          category: communication
+          usage: "pose <msg>"
+          description: "Strike a pose"
+          category: "communication"
           staff: false
+          requiresTarget: true
         who:
-          usage: who
-          category: communication
+          usage: "who"
+          description: "List online players"
+          category: "communication"
           staff: false
         tell:
-          usage: tell/t <player> <msg>
-          category: communication
+          usage: "tell/t <player> <msg>"
+          description: "Private message a player"
+          category: "communication"
           staff: false
+          requiresTarget: true
         whisper:
-          usage: whisper/wh <player> <msg>
-          category: communication
+          usage: "whisper/wh <player> <msg>"
+          description: "Whisper to a player"
+          category: "communication"
           staff: false
+          requiresTarget: true
         gossip:
-          usage: gossip/gs <msg>
-          category: communication
+          usage: "gossip/gs <msg>"
+          description: "Global chat channel"
+          category: "communication"
           staff: false
+          requiresTarget: true
         shout:
-          usage: shout/sh <msg>
-          category: communication
+          usage: "shout/sh <msg>"
+          description: "Shout to your zone"
+          category: "communication"
           staff: false
+          requiresTarget: true
         ooc:
-          usage: ooc <msg>
-          category: communication
+          usage: "ooc <msg>"
+          description: "Out-of-character channel"
+          category: "communication"
           staff: false
+          requiresTarget: true
         inventory:
-          usage: inventory/inv/i
-          category: items
+          usage: "inventory/inv/i"
+          description: "View your inventory"
+          category: "items"
           staff: false
         equipment:
-          usage: equipment/eq
-          category: items
+          usage: "equipment/eq"
+          description: "View worn equipment"
+          category: "items"
           staff: false
         wear:
-          usage: wear/equip <item>
-          category: items
+          usage: "wear/equip <item>"
+          description: "Equip an item"
+          category: "items"
           staff: false
+          requiresTarget: true
         remove:
-          usage: remove/unequip <slot>
-          category: items
+          usage: "remove/unequip <slot>"
+          description: "Unequip from a slot"
+          category: "items"
           staff: false
+          requiresTarget: true
         get:
-          usage: get/take/pickup <item>
-          category: items
+          usage: "get/take/pickup <item>"
+          description: "Pick up an item"
+          category: "items"
           staff: false
+          requiresTarget: true
         drop:
-          usage: drop <item>
-          category: items
+          usage: "drop <item>"
+          description: "Drop an item"
+          category: "items"
           staff: false
+          requiresTarget: true
         use:
-          usage: use/eat/drink <item>
-          category: items
+          usage: "use/eat/drink <item>"
+          description: "Use a consumable item"
+          category: "items"
+          staff: false
+          requiresTarget: true
+        quickheal:
+          usage: "quickheal/qh"
+          description: "Auto-use best healing potion"
+          category: "combat"
+          staff: false
+        quickmana:
+          usage: "quickmana/qm"
+          description: "Auto-use best mana potion"
+          category: "combat"
           staff: false
         give:
-          usage: give <item> <player>
-          category: items
+          usage: "give <item> <player>"
+          description: "Give an item to a player"
+          category: "items"
           staff: false
+          requiresTarget: true
         talk:
-          usage: talk <npc>
-          category: social
+          usage: "talk <npc>"
+          description: "Start a conversation with an NPC"
+          category: "social"
+          staff: false
+          requiresTarget: true
+        bye:
+          usage: "bye/goodbye"
+          description: "End the current NPC conversation"
+          category: "social"
           staff: false
         kill:
-          usage: kill <mob>
-          category: combat
+          usage: "kill <mob>"
+          description: "Attack a mob"
+          category: "combat"
           staff: false
-        consider:
-          usage: consider/con <mob>
-          category: combat
-          staff: false
-        wimpy:
-          usage: wimpy [off | 0-95]
-          category: combat
-          staff: false
+          requiresTarget: true
         flee:
-          usage: flee
-          category: combat
+          usage: "flee"
+          description: "Attempt to flee combat"
+          category: "combat"
           staff: false
         cast:
-          usage: cast/c <spell> [target]
-          category: combat
+          usage: "cast/c <spell> [target]"
+          description: "Cast a spell or ability"
+          category: "combat"
           staff: false
+          requiresTarget: true
+        consider:
+          usage: "consider/con <mob>"
+          description: "Estimate your odds against a mob before attacking"
+          category: "combat"
+          staff: false
+          requiresTarget: true
+        wimpy:
+          usage: "wimpy [off | 0-95]"
+          description: "View or set the HP percent where you auto-flee combat"
+          category: "combat"
+          staff: false
+        duel:
+          usage: "duel <player> | duel accept | duel decline"
+          description: "Challenge another player to a PvP duel"
+          category: "combat"
+          staff: false
+          requiresTarget: true
         spells:
-          usage: spells/abilities/skills
-          category: progression
+          usage: "spells/abilities/skills"
+          description: "List your abilities"
+          category: "progression"
           staff: false
         effects:
-          usage: effects/buffs/debuffs
-          category: progression
+          usage: "effects/buffs/debuffs"
+          description: "View active status effects"
+          category: "progression"
           staff: false
         score:
-          usage: score/sc
-          category: progression
+          usage: "score/sc"
+          description: "View your character sheet"
+          category: "progression"
           staff: false
         balance:
-          usage: gold/balance
-          category: shops
+          usage: "gold/balance"
+          description: "Check the gold you are carrying"
+          category: "shops"
           staff: false
         currencies:
-          usage: currencies/currency/wallet
-          category: progression
+          usage: "currencies/currency/wallet"
+          description: "View secondary currencies"
+          category: "progression"
+          staff: false
+        reputation:
+          usage: "reputation/rep/factions"
+          description: "View your faction standings"
+          category: "progression"
           staff: false
         shop_list:
-          usage: list/shop
-          category: shops
+          usage: "list/shop"
+          description: "Browse a shop's wares"
+          category: "shops"
           staff: false
         buy:
-          usage: buy <item>
-          category: shops
+          usage: "buy <item>"
+          description: "Purchase from a shop"
+          category: "shops"
           staff: false
+          requiresTarget: true
         sell:
-          usage: sell <item>
-          category: shops
+          usage: "sell <item>"
+          description: "Sell to a shop"
+          category: "shops"
           staff: false
+          requiresTarget: true
+        bank:
+          usage: "bank"
+          description: "View bank balance and vault contents (requires a bank)"
+          category: "shops"
+          staff: false
+        deposit:
+          usage: "deposit <amount|item>"
+          description: "Deposit gold or an item into your bank vault"
+          category: "shops"
+          staff: false
+          requiresTarget: true
+        withdraw:
+          usage: "withdraw <amount|item>"
+          description: "Withdraw gold or an item from your bank vault"
+          category: "shops"
+          staff: false
+          requiresTarget: true
+        auction:
+          usage: "auction"
+          description: "Browse auction house listings"
+          category: "shops"
+          staff: false
+        auction_sell:
+          usage: "auction sell <item> <price>"
+          description: "List an item on the auction house"
+          category: "shops"
+          staff: false
+          requiresTarget: true
+        auction_buy:
+          usage: "auction buy <#>"
+          description: "Buy an auction listing by number"
+          category: "shops"
+          staff: false
+          requiresTarget: true
+        auction_cancel:
+          usage: "auction cancel <#>"
+          description: "Cancel your listing and reclaim the item"
+          category: "shops"
+          staff: false
+          requiresTarget: true
+        trade:
+          usage: "trade <player> | trade accept | trade cancel | trade status"
+          description: "Trade items and gold with another player"
+          category: "items"
+          staff: false
+          requiresTarget: true
+        trade_offer:
+          usage: "trade offer <item> | trade offer <amount> gold"
+          description: "Add an item or gold to the active trade"
+          category: "items"
+          staff: false
+          requiresTarget: true
+        trade_remove:
+          usage: "trade remove <item>"
+          description: "Remove an item from your trade offer"
+          category: "items"
+          staff: false
+          requiresTarget: true
         quest_log:
-          usage: quest log/list
-          category: quests
+          usage: "quest log/list"
+          description: "View active quests"
+          category: "quests"
           staff: false
         quest_info:
-          usage: quest info <name>
-          category: quests
+          usage: "quest info <name>"
+          description: "Quest details"
+          category: "quests"
           staff: false
+          requiresTarget: true
         quest_abandon:
-          usage: quest abandon <name>
-          category: quests
+          usage: "quest abandon <name>"
+          description: "Abandon a quest"
+          category: "quests"
           staff: false
+          requiresTarget: true
         quest_turnin:
-          usage: quest turnin <name>
-          category: quests
+          usage: "quest turnin <name>"
+          description: "Turn in a completed quest to its giver NPC"
+          category: "quests"
           staff: false
+          requiresTarget: true
         accept:
-          usage: accept <quest>
-          category: quests
+          usage: "accept <quest>"
+          description: "Accept a quest from an NPC"
+          category: "quests"
           staff: false
+          requiresTarget: true
         bounty:
-          usage: bounty / quest auto
-          category: quests
+          usage: "bounty / quest auto"
+          description: "Request an auto-generated bounty quest"
+          category: "quests"
           staff: false
         bounty_info:
-          usage: bounty info / quest auto info
-          category: quests
+          usage: "bounty info / quest auto info"
+          description: "View active bounty progress"
+          category: "quests"
           staff: false
         bounty_abandon:
-          usage: bounty abandon / quest auto abandon
-          category: quests
+          usage: "bounty abandon / quest auto abandon"
+          description: "Abandon active bounty"
+          category: "quests"
           staff: false
         achievements:
-          usage: achievements/ach
-          category: quests
+          usage: "achievements/ach"
+          description: "View achievements"
+          category: "quests"
           staff: false
         daily:
-          usage: daily/dailies
-          category: quests
+          usage: "daily/dailies"
+          description: "View daily quest board"
+          category: "quests"
           staff: false
         weekly:
-          usage: weekly
-          category: quests
+          usage: "weekly"
+          description: "View weekly quest board"
+          category: "quests"
           staff: false
         gquest:
-          usage: gquest/gq/global
-          category: quests
+          usage: "gquest/gq/global"
+          description: "View active global quest status"
+          category: "quests"
           staff: false
+        qoffers:
+          usage: "qoffers <mob>"
+          description: "List the quests an NPC has to offer"
+          category: "quests"
+          staff: false
+          requiresTarget: true
         group_invite:
-          usage: group invite <player>
-          category: groups
+          usage: "group invite <player>"
+          description: "Invite to your group"
+          category: "groups"
           staff: false
+          requiresTarget: true
         group_accept:
-          usage: group accept
-          category: groups
+          usage: "group accept"
+          description: "Accept a group invite"
+          category: "groups"
           staff: false
         group_leave:
-          usage: group leave
-          category: groups
+          usage: "group leave"
+          description: "Leave your group"
+          category: "groups"
           staff: false
         group_kick:
-          usage: group kick <player>
-          category: groups
+          usage: "group kick <player>"
+          description: "Kick from group"
+          category: "groups"
           staff: false
+          requiresTarget: true
         group_list:
-          usage: group list (or just 'group')
-          category: groups
+          usage: "group list (or just 'group')"
+          description: "List group members"
+          category: "groups"
           staff: false
         gtell:
-          usage: gtell/gt <message>
-          category: groups
+          usage: "gtell/gt <message>"
+          description: "Group chat"
+          category: "groups"
           staff: false
+          requiresTarget: true
         guild_create:
-          usage: guild create <name> <tag>
-          category: guilds
+          usage: "guild create <name> <tag>"
+          description: "Create a guild"
+          category: "guilds"
           staff: false
+          requiresTarget: true
         guild_disband:
-          usage: guild disband
-          category: guilds
+          usage: "guild disband"
+          description: "Disband your guild"
+          category: "guilds"
           staff: false
         guild_invite:
-          usage: guild invite <player>
-          category: guilds
+          usage: "guild invite <player>"
+          description: "Invite to guild"
+          category: "guilds"
           staff: false
+          requiresTarget: true
         guild_accept:
-          usage: guild accept
-          category: guilds
+          usage: "guild accept"
+          description: "Accept a guild invite"
+          category: "guilds"
           staff: false
         guild_leave:
-          usage: guild leave
-          category: guilds
+          usage: "guild leave"
+          description: "Leave your guild"
+          category: "guilds"
           staff: false
         guild_kick:
-          usage: guild kick <player>
-          category: guilds
+          usage: "guild kick <player>"
+          description: "Remove from guild"
+          category: "guilds"
           staff: false
+          requiresTarget: true
         guild_promote:
-          usage: guild promote <player>
-          category: guilds
+          usage: "guild promote <player>"
+          description: "Promote a member"
+          category: "guilds"
           staff: false
+          requiresTarget: true
         guild_demote:
-          usage: guild demote <player>
-          category: guilds
+          usage: "guild demote <player>"
+          description: "Demote a member"
+          category: "guilds"
           staff: false
+          requiresTarget: true
         guild_motd:
-          usage: guild motd <message>
-          category: guilds
+          usage: "guild motd <message>"
+          description: "Set guild message of the day"
+          category: "guilds"
           staff: false
+          requiresTarget: true
         guild_roster:
-          usage: guild roster
-          category: guilds
+          usage: "guild roster"
+          description: "View guild members"
+          category: "guilds"
           staff: false
         guild_info:
-          usage: guild info (or just 'guild')
-          category: guilds
+          usage: "guild info (or just 'guild')"
+          description: "Guild overview"
+          category: "guilds"
           staff: false
         gchat:
-          usage: gchat/g <message>
-          category: guilds
+          usage: "gchat/g <message>"
+          description: "Guild chat"
+          category: "guilds"
+          staff: false
+          requiresTarget: true
+        guild_hall:
+          usage: "guild hall [buy | expand <template> <direction> | enter | leave]"
+          description: "View, buy, expand, and visit your guild hall"
+          category: "guilds"
           staff: false
         gather:
-          usage: gather/harvest/mine <node>
-          category: crafting
+          usage: "gather/harvest/mine <node>"
+          description: "Gather from a resource node"
+          category: "crafting"
           staff: false
+          requiresTarget: true
         craft:
-          usage: craft/make <recipe>
-          category: crafting
+          usage: "craft/make <recipe>"
+          description: "Craft an item from a recipe"
+          category: "crafting"
           staff: false
+          requiresTarget: true
         recipes:
-          usage: recipes [filter]
-          category: crafting
+          usage: "recipes [filter]"
+          description: "Browse available recipes"
+          category: "crafting"
           staff: false
         craftskills:
-          usage: craftskills/professions
-          category: crafting
+          usage: "craftskills/professions"
+          description: "View crafting skill levels"
+          category: "crafting"
+          staff: false
+        specialize:
+          usage: "specialize/spec [profession]"
+          description: "View or choose a crafting specialization"
+          category: "crafting"
+          staff: false
+        enchant:
+          usage: "enchant <item> [enchantment]"
+          description: "Enchant an item with a known enchantment"
+          category: "crafting"
+          staff: false
+          requiresTarget: true
+        enchantments:
+          usage: "enchantments"
+          description: "List available enchantments"
+          category: "crafting"
           staff: false
         house:
-          usage: house [status]
-          category: housing
+          usage: "house [status]"
+          description: "View your house info"
+          category: "housing"
           staff: false
         house_list:
-          usage: house list
-          category: housing
+          usage: "house list"
+          description: "Browse available room templates"
+          category: "housing"
           staff: false
         house_buy:
-          usage: house buy
-          category: housing
+          usage: "house buy"
+          description: "Purchase your house (at broker)"
+          category: "housing"
           staff: false
         house_expand:
-          usage: house expand <template> <direction>
-          category: housing
+          usage: "house expand <template> <direction>"
+          description: "Add a room to your house"
+          category: "housing"
           staff: false
+          requiresTarget: true
         house_describe:
-          usage: house describe [title|desc] <text>
-          category: housing
+          usage: "house describe [title|desc] <text>"
+          description: "Customize room title or description"
+          category: "housing"
           staff: false
+          requiresTarget: true
         house_invite:
-          usage: house invite <player>
-          category: housing
+          usage: "house invite <player>"
+          description: "Invite a player to your house"
+          category: "housing"
           staff: false
+          requiresTarget: true
         house_kick:
-          usage: house kick <player>
-          category: housing
+          usage: "house kick <player>"
+          description: "Remove a visitor from your house"
+          category: "housing"
           staff: false
+          requiresTarget: true
         house_guests:
-          usage: house guests
-          category: housing
+          usage: "house guests"
+          description: "List visitors in your house"
+          category: "housing"
           staff: false
         open:
-          usage: open <door|container>
-          category: world
+          usage: "open <door|container>"
+          description: "Open a door or container"
+          category: "world"
           staff: false
+          requiresTarget: true
         close:
-          usage: close <door|container>
-          category: world
+          usage: "close <door|container>"
+          description: "Close a door or container"
+          category: "world"
           staff: false
+          requiresTarget: true
         unlock:
-          usage: unlock <door|container>
-          category: world
+          usage: "unlock <door|container>"
+          description: "Unlock with a key"
+          category: "world"
           staff: false
+          requiresTarget: true
         lock:
-          usage: lock <door|container>
-          category: world
+          usage: "lock <door|container>"
+          description: "Lock with a key"
+          category: "world"
           staff: false
+          requiresTarget: true
         search:
-          usage: search <container>
-          category: world
+          usage: "search <container>"
+          description: "Search a container for its contents"
+          category: "world"
           staff: false
+          requiresTarget: true
         get_from:
-          usage: get <item> from <container>
-          category: world
+          usage: "get <item> from <container>"
+          description: "Take an item from a container"
+          category: "world"
           staff: false
+          requiresTarget: true
         put_in:
-          usage: put <item> <container>
-          category: world
+          usage: "put <item> <container>"
+          description: "Place an item in a container"
+          category: "world"
           staff: false
+          requiresTarget: true
         pull:
-          usage: pull <lever>
-          category: world
+          usage: "pull <lever>"
+          description: "Pull a lever or object"
+          category: "world"
           staff: false
+          requiresTarget: true
         read:
-          usage: read <sign>
-          category: world
+          usage: "read <sign>"
+          description: "Read a sign or inscription"
+          category: "world"
           staff: false
+          requiresTarget: true
         answer:
-          usage: answer <text>
-          category: world
+          usage: "answer <text>"
+          description: "Answer a riddle in the room"
+          category: "world"
           staff: false
+          requiresTarget: true
+        dungeon:
+          usage: "dungeon enter <name> [difficulty] | dungeon leave"
+          description: "Enter or leave an instanced dungeon"
+          category: "world"
+          staff: false
+          requiresTarget: true
         title:
-          usage: title <titleName> | title clear
-          category: progression
+          usage: "title <titleName> | title clear"
+          description: "Set or clear your title"
+          category: "progression"
           staff: false
+          requiresTarget: true
         gender:
-          usage: gender <option>
-          category: progression
+          usage: "gender <option>"
+          description: "Set your gender"
+          category: "progression"
           staff: false
+          requiresTarget: true
         sprite:
-          usage: sprite list | set <id> | default
-          category: progression
+          usage: "sprite list | set <id> | default"
+          description: "Manage your character sprite"
+          category: "progression"
+          staff: false
+        describe:
+          usage: "describe <text> | describe clear | describe check <player>"
+          description: "Set, clear, or view a character description"
+          category: "progression"
+          staff: false
+          requiresTarget: true
+        train:
+          usage: "train [list] | train learn <ability> | train unlock <class> | train reset"
+          description: "Learn abilities, unlock classes, or respec at a class trainer"
+          category: "progression"
+          staff: false
+        prestige:
+          usage: "prestige | prestige info"
+          description: "Reset at max level for permanent prestige perks"
+          category: "progression"
+          staff: false
+        leaderboard:
+          usage: "leaderboard/top [category]"
+          description: "View player leaderboards"
+          category: "progression"
+          staff: false
+        stylist:
+          usage: "stylist"
+          description: "View race-change options and fee (requires a stylist)"
+          category: "progression"
+          staff: false
+        changerace:
+          usage: "changerace <race>"
+          description: "Pay the stylist to change your race"
+          category: "progression"
+          staff: false
+          requiresTarget: true
+        pet:
+          usage: "pet [status] | pet name <name> | pet skills | pet <skill> | pet dismiss"
+          description: "Manage your pet and trigger its skills"
+          category: "progression"
           staff: false
         friend:
-          usage: friend list | add <player> | remove <player>
-          category: social
+          usage: "friend list | add <player> | remove <player>"
+          description: "Manage your friends list"
+          category: "social"
           staff: false
         mail:
-          usage: mail list | read <n> | send <player> | delete <n>
-          category: social
+          usage: "mail list | read <n> | send <player> | delete <n>"
+          description: "Manage mail"
+          category: "social"
           staff: false
         lottery:
-          usage: lottery [info] | lottery buy [count] (buying requires a tavern)
-          category: social
+          usage: "lottery [info] | lottery buy [count]"
+          description: "View the lottery or buy tickets (buying requires a tavern)"
+          category: "social"
           staff: false
         gamble:
-          usage: gamble/dice <amount> (requires a tavern)
-          category: social
+          usage: "gamble/dice <amount>"
+          description: "Roll d100 against the house (requires a tavern)"
+          category: "social"
           staff: false
         ansi:
-          usage: ansi on/off
-          category: utility
+          usage: "ansi on/off"
+          description: "Toggle color output"
+          category: "utility"
           staff: false
         screenreader:
-          usage: screenreader [on/off]
-          category: utility
+          usage: "screenreader [on/off]"
+          description: "Toggle screen reader mode"
+          category: "utility"
           staff: false
         autoloot:
-          usage: autoloot on/off/status
-          category: utility
+          usage: "autoloot on/off/status"
+          description: "Auto-loot mob corpses when enabled"
+          category: "utility"
+          staff: false
+        autopeek:
+          usage: "autopeek on/off/status"
+          description: "Append adjacent room names below room descriptions"
+          category: "utility"
           staff: false
         colors:
-          usage: colors
-          category: utility
+          usage: "colors"
+          description: "Preview ANSI color palette"
+          category: "utility"
           staff: false
         clear:
-          usage: clear
-          category: utility
+          usage: "clear"
+          description: "Clear the terminal"
+          category: "utility"
           staff: false
         quit:
-          usage: quit/exit
-          category: utility
+          usage: "quit/exit"
+          description: "Disconnect"
+          category: "utility"
           staff: false
         phase:
-          usage: phase/layer [instance]
-          category: utility
+          usage: "phase/layer [instance]"
+          description: "Switch zone instance"
+          category: "utility"
+          staff: false
+        time:
+          usage: "time"
+          description: "Show the in-game time of day"
+          category: "utility"
+          staff: false
+        claim:
+          usage: "claim <password> | claim <newname> <password>"
+          description: "Save a demo character as a permanent account"
+          category: "utility"
           staff: false
         goto:
-          usage: goto <zone:room | room | zone:>
-          category: admin
+          usage: "goto <zone:room | room | zone:>"
+          description: "Teleport to a room"
+          category: "admin"
           staff: true
+          requiresTarget: true
         transfer:
-          usage: transfer <player> <room>
-          category: admin
+          usage: "transfer <player> <room>"
+          description: "Move a player"
+          category: "admin"
           staff: true
+          requiresTarget: true
         spawn:
-          usage: spawn <mob-template>
-          category: admin
+          usage: "spawn <mob-template>"
+          description: "Spawn a mob"
+          category: "admin"
           staff: true
+          requiresTarget: true
         smite:
-          usage: smite <player|mob>
-          category: admin
+          usage: "smite <player|mob>"
+          description: "Instantly kill a target"
+          category: "admin"
           staff: true
+          requiresTarget: true
         staff_kick:
-          usage: kick <player>
-          category: admin
+          usage: "kick <player>"
+          description: "Disconnect a player"
+          category: "admin"
           staff: true
+          requiresTarget: true
         dispel:
-          usage: dispel <player|mob>
-          category: admin
+          usage: "dispel <player|mob>"
+          description: "Remove all effects"
+          category: "admin"
           staff: true
+          requiresTarget: true
         setlevel:
-          usage: setlevel <player> <level>
-          category: admin
+          usage: "setlevel <player> <level>"
+          description: "Set a player's level"
+          category: "admin"
           staff: true
+          requiresTarget: true
         shutdown:
-          usage: shutdown
-          category: admin
+          usage: "shutdown"
+          description: "Shut down the server"
+          category: "admin"
           staff: true
         reload:
-          usage: reload [scope]
-          category: admin
+          usage: "reload [scope]"
+          description: "Reload world data"
+          category: "admin"
           staff: true
         possess:
-          usage: possess/switch <mob>
-          category: admin
+          usage: "possess/switch <mob>"
+          description: "Take control of a mob"
+          category: "admin"
           staff: true
+          requiresTarget: true
         return:
-          usage: return/unpossess
-          category: admin
+          usage: "return/unpossess"
+          description: "Release a possessed mob"
+          category: "admin"
           staff: true
         invis:
-          usage: invis
-          category: admin
+          usage: "invis"
+          description: "Toggle staff invisibility"
+          category: "admin"
           staff: true
         broadcast:
-          usage: broadcast <message>
-          category: admin
+          usage: "broadcast <message>"
+          description: "Send a server-wide announcement"
+          category: "admin"
           staff: true
+          requiresTarget: true
+        heal:
+          usage: "heal [player]"
+          description: "Fully restore a player's HP and mana"
+          category: "admin"
+          staff: true
+        pinfo:
+          usage: "pinfo <player>"
+          description: "Inspect a player's state"
+          category: "admin"
+          staff: true
+          requiresTarget: true
+        setstaff:
+          usage: "setstaff/grantstaff <player> | revokestaff <player>"
+          description: "Grant or revoke staff access"
+          category: "admin"
+          staff: true
+          requiresTarget: true
+        setgold:
+          usage: "setgold <player> <amount>"
+          description: "Set a player's gold"
+          category: "admin"
+          staff: true
+          requiresTarget: true
+        setrace:
+          usage: "setrace <player> <race>"
+          description: "Set a player's race"
+          category: "admin"
+          staff: true
+          requiresTarget: true
+        setclass:
+          usage: "setclass <player> <class>"
+          description: "Set a player's class"
+          category: "admin"
+          staff: true
+          requiresTarget: true
+        setgender:
+          usage: "setgender <player> <gender>"
+          description: "Set a player's gender"
+          category: "admin"
+          staff: true
+          requiresTarget: true
+        setxp:
+          usage: "setxp <player> <xp>"
+          description: "Set a player's XP"
+          category: "admin"
+          staff: true
+          requiresTarget: true
     group:
       maxSize: 5
       inviteTimeoutMs: 60000

--- a/src/test/kotlin/dev/ambon/config/CommandManifestSyncTest.kt
+++ b/src/test/kotlin/dev/ambon/config/CommandManifestSyncTest.kt
@@ -33,7 +33,7 @@ class CommandManifestSyncTest {
         require(!entriesNode.isMissingNode) { "commands.entries not found in application.yaml" }
 
         val yamlEntries = linkedMapOf<String, CommandMetadata>()
-        for ((key, node) in entriesNode.properties) {
+        for ((key, node) in entriesNode.properties()) {
             yamlEntries[key] = CommandMetadata(
                 usage = node.path("usage").asText(""),
                 description = node.path("description").asText(""),

--- a/src/test/kotlin/dev/ambon/config/CommandManifestSyncTest.kt
+++ b/src/test/kotlin/dev/ambon/config/CommandManifestSyncTest.kt
@@ -33,7 +33,7 @@ class CommandManifestSyncTest {
         require(!entriesNode.isMissingNode) { "commands.entries not found in application.yaml" }
 
         val yamlEntries = linkedMapOf<String, CommandMetadata>()
-        for ((key, node) in entriesNode.fields()) {
+        for ((key, node) in entriesNode.properties) {
             yamlEntries[key] = CommandMetadata(
                 usage = node.path("usage").asText(""),
                 description = node.path("description").asText(""),

--- a/src/test/kotlin/dev/ambon/config/CommandManifestSyncTest.kt
+++ b/src/test/kotlin/dev/ambon/config/CommandManifestSyncTest.kt
@@ -1,0 +1,89 @@
+package dev.ambon.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * `application.yaml` fully replaces [CommandsConfig.defaultCommandEntries] when
+ * it defines `commands.entries` — a key missing from the YAML silently vanishes
+ * from `help` and the web command palette, and a YAML entry that omits a field
+ * (e.g. `requiresTarget`) silently downgrades the default. That drift is how the
+ * auction/train/bank/rest family went undocumented for months.
+ *
+ * This test pins the two sources together. On mismatch it writes the
+ * regenerated YAML block (rendered from the code defaults, which are the source
+ * of truth) to `build/command-manifest.yaml` for copy-paste into
+ * `application.yaml`.
+ */
+class CommandManifestSyncTest {
+    private val repoRoot = File(System.getProperty("user.dir"))
+
+    @Test
+    fun `application yaml commands entries exactly match the code defaults`() {
+        val yamlFile = repoRoot.resolve("src/main/resources/application.yaml")
+        val entriesNode = ObjectMapper(YAMLFactory())
+            .readTree(yamlFile)
+            .path("ambonmud")
+            .path("engine")
+            .path("commands")
+            .path("entries")
+        require(!entriesNode.isMissingNode) { "commands.entries not found in application.yaml" }
+
+        val yamlEntries = linkedMapOf<String, CommandMetadata>()
+        for ((key, node) in entriesNode.fields()) {
+            yamlEntries[key] = CommandMetadata(
+                usage = node.path("usage").asText(""),
+                description = node.path("description").asText(""),
+                category = node.path("category").asText("general"),
+                staff = node.path("staff").asBoolean(false),
+                requiresTarget = node.path("requiresTarget").asBoolean(false),
+            )
+        }
+
+        val defaults = CommandsConfig.defaultCommandEntries()
+
+        // Always refresh the regeneration artifact so maintainers can copy-paste.
+        val artifact = repoRoot.resolve("build/command-manifest.yaml")
+        artifact.parentFile.mkdirs()
+        artifact.writeText(renderYamlBlock(defaults))
+
+        if (yamlEntries == defaults) return
+
+        val missing = defaults.keys - yamlEntries.keys
+        val extra = yamlEntries.keys - defaults.keys
+        val differing = (defaults.keys intersect yamlEntries.keys)
+            .filter { defaults[it] != yamlEntries[it] }
+        fail<Unit>(
+            buildString {
+                appendLine("application.yaml commands.entries is out of sync with CommandsConfig.defaultCommandEntries().")
+                if (missing.isNotEmpty()) appendLine("  Missing from YAML: ${missing.sorted()}")
+                if (extra.isNotEmpty()) appendLine("  Extra in YAML: ${extra.sorted()}")
+                for (key in differing) {
+                    appendLine("  Differs '$key':")
+                    appendLine("    default = ${defaults[key]}")
+                    appendLine("    yaml    = ${yamlEntries[key]}")
+                }
+                appendLine("Paste the regenerated block from build/command-manifest.yaml into application.yaml.")
+            },
+        )
+    }
+
+    /** Renders the canonical `commands:` block at application.yaml's indentation. */
+    private fun renderYamlBlock(entries: Map<String, CommandMetadata>): String = buildString {
+        appendLine("    commands:")
+        appendLine("      entries:")
+        for ((key, m) in entries) {
+            appendLine("        $key:")
+            appendLine("          usage: ${quote(m.usage)}")
+            if (m.description.isNotEmpty()) appendLine("          description: ${quote(m.description)}")
+            appendLine("          category: ${quote(m.category)}")
+            appendLine("          staff: ${m.staff}")
+            if (m.requiresTarget) appendLine("          requiresTarget: true")
+        }
+    }
+
+    private fun quote(s: String): String = "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+}

--- a/src/test/kotlin/dev/ambon/config/CommandsConfigHelpTest.kt
+++ b/src/test/kotlin/dev/ambon/config/CommandsConfigHelpTest.kt
@@ -1,0 +1,39 @@
+package dev.ambon.config
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CommandsConfigHelpTest {
+    @Test
+    fun `help groups by category and shows usage with description`() {
+        val config = CommandsConfig(
+            entries = linkedMapOf(
+                "look" to CommandMetadata("look/l", "Look around", "navigation"),
+                "mystery" to CommandMetadata("mystery <arg>", "From an unknown category", "experimental"),
+                "smite" to CommandMetadata("smite <target>", "Staff only", "admin", staff = true),
+            ),
+        )
+
+        val help = config.generateHelp(isStaff = false)
+        assertTrue(help.contains("[Navigation]"), "expected category header, got:\n$help")
+        assertTrue(help.contains("look/l — Look around"), "expected usage — description, got:\n$help")
+        assertTrue(help.contains("[Experimental]"), "unknown categories must not be dropped, got:\n$help")
+        assertTrue(help.contains("mystery <arg> — From an unknown category"))
+        assertFalse(help.contains("smite"), "staff commands must be hidden from players")
+
+        val staffHelp = config.generateHelp(isStaff = true)
+        assertTrue(staffHelp.contains("[Staff]"), "expected staff section, got:\n$staffHelp")
+        assertTrue(staffHelp.contains("smite <target> — Staff only"))
+    }
+
+    @Test
+    fun `every default manifest entry has a usage and a description`() {
+        val blank = CommandsConfig.defaultCommandEntries()
+            .filterValues { it.usage.isBlank() || it.description.isBlank() }
+            .keys
+        assertTrue(blank.isEmpty()) {
+            "Manifest entries must explain their command — blank usage/description for: ${blank.sorted()}"
+        }
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/WebClientParityTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/WebClientParityTest.kt
@@ -20,163 +20,308 @@ class WebClientParityTest {
     // -- Parser ↔ manifest parity ---------------------------------------------
 
     /**
-     * Every user-facing command recognized by [CommandParser] should have a
-     * corresponding entry in [CommandsConfig.defaultCommandEntries] so that
-     * `Server.Commands` GMCP includes it (command palette, help panel, autocomplete).
-     *
-     * Staff-only commands may be present; internal/meta commands (Noop, Invalid,
-     * Unknown) are excluded.
+     * Maps every Command subtype (by simple name; nested sealed members as
+     * `Parent.Child`) to the manifest key in
+     * [CommandsConfig.defaultCommandEntries] that documents it. The
+     * completeness test below scans CommandParser.kt and fails when a new
+     * Command is added without a row here — which forces a manifest entry too.
      */
+    private val parserToManifest = mapOf(
+        // Navigation
+        "Look" to "look",
+        "LookDir" to "look",
+        "LookAt" to "look",
+        "Move" to "move",
+        "Run" to "run",
+        "Areas" to "areas",
+        "Exits" to "exits",
+        "Recall" to "recall",
+        "Rest" to "rest",
+        "Depart" to "depart",
+        // Communication
+        "Say" to "say",
+        "Tell" to "tell",
+        "Whisper" to "whisper",
+        "Gossip" to "gossip",
+        "Shout" to "shout",
+        "Ooc" to "ooc",
+        "Emote" to "emote",
+        "Pose" to "pose",
+        "Who" to "who",
+        // Items
+        "Inventory" to "inventory",
+        "Equipment" to "equipment",
+        "Wear" to "wear",
+        "Remove" to "remove",
+        "Get" to "get",
+        "Drop" to "drop",
+        "Use" to "use",
+        "Give" to "give",
+        "QuickHeal" to "quickheal",
+        "QuickMana" to "quickmana",
+        // Trading
+        "TradeRequest" to "trade",
+        "TradeAccept" to "trade",
+        "TradeCancel" to "trade",
+        "TradeStatus" to "trade",
+        "TradeOffer" to "trade_offer",
+        "TradeOfferGold" to "trade_offer",
+        "TradeRemove" to "trade_remove",
+        // Auction house
+        "AuctionList" to "auction",
+        "AuctionSell" to "auction_sell",
+        "AuctionBuy" to "auction_buy",
+        "AuctionCancel" to "auction_cancel",
+        // World
+        "OpenFeature" to "open",
+        "CloseFeature" to "close",
+        "LockFeature" to "lock",
+        "UnlockFeature" to "unlock",
+        "SearchContainer" to "search",
+        "Pull" to "pull",
+        "ReadSign" to "read",
+        "Answer" to "answer",
+        "PutIn" to "put_in",
+        "GetFrom" to "get_from",
+        "DungeonEnter" to "dungeon",
+        "DungeonLeave" to "dungeon",
+        // Combat
+        "Kill" to "kill",
+        "Consider" to "consider",
+        "Flee" to "flee",
+        "Wimpy" to "wimpy",
+        "Cast" to "cast",
+        "Duel" to "duel",
+        "DuelAccept" to "duel",
+        "DuelDecline" to "duel",
+        // Progression
+        "Spells" to "spells",
+        "Effects" to "effects",
+        "Score" to "score",
+        "Reputation" to "reputation",
+        "Currencies" to "currencies",
+        "TitleSet" to "title",
+        "TitleClear" to "title",
+        "SetGender" to "gender",
+        "SpriteList" to "sprite",
+        "SpriteSet" to "sprite",
+        "SpriteDefault" to "sprite",
+        "Describe" to "describe",
+        "DescribeClear" to "describe",
+        "DescribeCheck" to "describe",
+        "Leaderboard" to "leaderboard",
+        "Prestige" to "prestige",
+        "PrestigeInfo" to "prestige",
+        // Pets
+        "PetStatus" to "pet",
+        "PetDismiss" to "pet",
+        "PetName" to "pet",
+        "PetSkills" to "pet",
+        "PetSkill" to "pet",
+        // Shops & economy
+        "ShopList" to "shop_list",
+        "Buy" to "buy",
+        "Sell" to "sell",
+        "Balance" to "balance",
+        "LotteryInfo" to "lottery",
+        "LotteryBuy" to "lottery",
+        "Gamble" to "gamble",
+        // Quests
+        "QuestLog" to "quest_log",
+        "QuestInfo" to "quest_info",
+        "QuestAbandon" to "quest_abandon",
+        "QuestTurnIn" to "quest_turnin",
+        "QuestTurnInById" to "quest_turnin",
+        "QuestAccept" to "accept",
+        "QuestAcceptById" to "accept",
+        "QuestOffers" to "qoffers",
+        "QuestAuto" to "bounty",
+        "QuestAutoInfo" to "bounty_info",
+        "QuestAutoAbandon" to "bounty_abandon",
+        "AchievementList" to "achievements",
+        "DailyQuests" to "daily",
+        "WeeklyQuests" to "weekly",
+        "GlobalQuestInfo" to "gquest",
+        // Social
+        "Talk" to "talk",
+        "DialogueChoice" to "talk",
+        "DialogueEnd" to "bye",
+        // Groups
+        "Gtell" to "gtell",
+        "Gchat" to "gchat",
+        // Crafting
+        "Gather" to "gather",
+        "Craft" to "craft",
+        "Recipes" to "recipes",
+        "CraftSkills" to "craftskills",
+        "Specialize" to "specialize",
+        "Enchant" to "enchant",
+        "Enchantments" to "enchantments",
+        // Utility
+        "Help" to "help",
+        "Claim" to "claim",
+        "Time" to "time",
+        "AnsiOn" to "ansi",
+        "AnsiOff" to "ansi",
+        "ScreenReaderOn" to "screenreader",
+        "ScreenReaderOff" to "screenreader",
+        "AutolootOn" to "autoloot",
+        "AutolootOff" to "autoloot",
+        "AutolootStatus" to "autoloot",
+        "AutopeekOn" to "autopeek",
+        "AutopeekOff" to "autopeek",
+        "AutopeekStatus" to "autopeek",
+        "Colors" to "colors",
+        "Clear" to "clear",
+        "Quit" to "quit",
+        "Phase" to "phase",
+        // Staff
+        "Goto" to "goto",
+        "Transfer" to "transfer",
+        "Spawn" to "spawn",
+        "Smite" to "smite",
+        "Kick" to "staff_kick",
+        "SetLevel" to "setlevel",
+        "SetStaff" to "setstaff",
+        "SetGold" to "setgold",
+        "SetRace" to "setrace",
+        "SetClass" to "setclass",
+        "StaffSetGender" to "setgender",
+        "SetXp" to "setxp",
+        "Heal" to "heal",
+        "Pinfo" to "pinfo",
+        "Dispel" to "dispel",
+        "Shutdown" to "shutdown",
+        "Reload" to "reload",
+        "Possess" to "possess",
+        "Return" to "return",
+        "Invis" to "invis",
+        "Broadcast" to "broadcast",
+    )
+
+    /** Nested sealed-family subcommands map to their parent manifest entries. */
+    private val sealedSubcommands = mapOf(
+        "GroupCmd.Invite" to "group_invite",
+        "GroupCmd.Accept" to "group_accept",
+        "GroupCmd.Decline" to "group_accept", // decline shares the group family
+        "GroupCmd.Leave" to "group_leave",
+        "GroupCmd.Kick" to "group_kick",
+        "GroupCmd.List" to "group_list",
+        "Guild.Create" to "guild_create",
+        "Guild.Disband" to "guild_disband",
+        "Guild.Invite" to "guild_invite",
+        "Guild.Accept" to "guild_accept",
+        "Guild.Decline" to "guild_accept", // decline shares the guild family
+        "Guild.Leave" to "guild_leave",
+        "Guild.Kick" to "guild_kick",
+        "Guild.Promote" to "guild_promote",
+        "Guild.Demote" to "guild_demote",
+        "Guild.Motd" to "guild_motd",
+        "Guild.Roster" to "guild_roster",
+        "Guild.Info" to "guild_info",
+        "Guild.Hall" to "guild_hall",
+        "Guild.HallBuy" to "guild_hall",
+        "Guild.HallExpand" to "guild_hall",
+        "Guild.HallEnter" to "guild_hall",
+        "Guild.HallLeave" to "guild_hall",
+        "Bank.DepositGold" to "deposit",
+        "Bank.DepositItem" to "deposit",
+        "Bank.WithdrawGold" to "withdraw",
+        "Bank.WithdrawItem" to "withdraw",
+        "Bank.Balance" to "bank",
+        "Stylist.List" to "stylist",
+        "Stylist.ChangeRace" to "changerace",
+        "Train.List" to "train",
+        "Train.Learn" to "train",
+        "Train.Unlock" to "train",
+        "Train.Reset" to "train",
+        "Friend.List" to "friend",
+        "Friend.Add" to "friend",
+        "Friend.Remove" to "friend",
+        "Mail.List" to "mail",
+        "Mail.Read" to "mail",
+        "Mail.Delete" to "mail",
+        "Mail.Send" to "mail",
+        "Mail.Abort" to "mail",
+        "House.Status" to "house",
+        "House.ListTemplates" to "house_list",
+        "House.Buy" to "house_buy",
+        "House.Expand" to "house_expand",
+        "House.SetTitle" to "house_describe",
+        "House.SetDescription" to "house_describe",
+        "House.Invite" to "house_invite",
+        "House.Kick" to "house_kick",
+        "House.Guests" to "house_guests",
+    )
+
+    /**
+     * Parser internals and deliberately undocumented commands. `Petition` is a
+     * hidden easter egg; the rest never reach a player's hands.
+     */
+    private val unmappedCommands = setOf("Noop", "Invalid", "Unknown", "Petition")
+
+    /** Every mapped command must point at a real manifest key. */
     @Test
     fun `every parser command has a manifest entry in defaultCommandEntries`() {
-        val manifest = CommandsConfig.defaultCommandEntries()
-        val manifestKeys = manifest.keys
-
-        // Map each meaningful Command subtype to the manifest key(s) it should match.
-        // This is the single source of truth for the parser → manifest mapping.
-        val parserToManifest = mapOf(
-            // Navigation
-            "Look" to "look",
-            "Move" to "move",
-            "Exits" to "exits",
-            "Recall" to "recall",
-            "LookDir" to "look",
-            "LookAt" to "look",
-            // Communication
-            "Say" to "say",
-            "Tell" to "tell",
-            "Whisper" to "whisper",
-            "Gossip" to "gossip",
-            "Shout" to "shout",
-            "Ooc" to "ooc",
-            "Emote" to "emote",
-            "Pose" to "pose",
-            "Who" to "who",
-            // Items
-            "Inventory" to "inventory",
-            "Equipment" to "equipment",
-            "Wear" to "wear",
-            "Remove" to "remove",
-            "Get" to "get",
-            "Drop" to "drop",
-            "Use" to "use",
-            "Give" to "give",
-            // World
-            "Open" to "open",
-            "Close" to "close",
-            "Lock" to "lock",
-            "Unlock" to "unlock",
-            "Search" to "search",
-            "Pull" to "pull",
-            "Read" to "read",
-            "Answer" to "answer",
-            "Put" to "put_in",
-            "GetFrom" to "get_from",
-            // Combat
-            "Kill" to "kill",
-            "Flee" to "flee",
-            "Cast" to "cast",
-            // Progression
-            "Spells" to "spells",
-            "Effects" to "effects",
-            "Score" to "score",
-            "Title" to "title",
-            "Gender" to "gender",
-            "Sprite" to "sprite",
-            // Shops
-            "ShopList" to "shop_list",
-            "Buy" to "buy",
-            "Sell" to "sell",
-            "Balance" to "balance",
-            // Quests
-            "QuestLog" to "quest_log",
-            "QuestInfo" to "quest_info",
-            "QuestAbandon" to "quest_abandon",
-            "QuestTurnIn" to "quest_turnin",
-            "QuestAuto" to "bounty",
-            "QuestAutoInfo" to "bounty_info",
-            "QuestAutoAbandon" to "bounty_abandon",
-            "Accept" to "accept",
-            "Achievements" to "achievements",
-            "DailyQuests" to "daily",
-            "WeeklyQuests" to "weekly",
-            // Social
-            "Talk" to "talk",
-            "DialogueChoice" to "talk",
-            "Friend" to "friend",
-            "Mail" to "mail",
-            // Groups
-            "Gtell" to "gtell",
-            "Gchat" to "gchat",
-            // Utility
-            "Help" to "help",
-            "AnsiOn" to "ansi",
-            "AnsiOff" to "ansi",
-            "ScreenReaderOn" to "screenreader",
-            "ScreenReaderOff" to "screenreader",
-            "AutolootOn" to "autoloot",
-            "AutolootOff" to "autoloot",
-            "AutolootStatus" to "autoloot",
-            "AutopeekOn" to "autopeek",
-            "AutopeekOff" to "autopeek",
-            "AutopeekStatus" to "autopeek",
-            "Colors" to "colors",
-            "Clear" to "clear",
-            "Quit" to "quit",
-            "Phase" to "phase",
-            "Gather" to "gather",
-            "Craft" to "craft",
-            "Recipes" to "recipes",
-            "CraftSkills" to "craftskills",
-            // Staff
-            "Goto" to "goto",
-            "Transfer" to "transfer",
-            "Spawn" to "spawn",
-            "Smite" to "smite",
-            "Kick" to "staff_kick",
-            "SetLevel" to "setlevel",
-            "Dispel" to "dispel",
-            "Shutdown" to "shutdown",
-            "Reload" to "reload",
-            "Possess" to "possess",
-            "Return" to "return",
-            "Invis" to "invis",
-            "Broadcast" to "broadcast",
-        )
-
-        // GroupCmd and Guild subcommands map to their parent manifest entries
-        val sealedSubcommands = mapOf(
-            "GroupCmd.Invite" to "group_invite",
-            "GroupCmd.Accept" to "group_accept",
-            "GroupCmd.Decline" to "group_accept", // decline shares the group family
-            "GroupCmd.Leave" to "group_leave",
-            "GroupCmd.Kick" to "group_kick",
-            "GroupCmd.List" to "group_list",
-            "Guild.Create" to "guild_create",
-            "Guild.Disband" to "guild_disband",
-            "Guild.Invite" to "guild_invite",
-            "Guild.Accept" to "guild_accept",
-            "Guild.Decline" to "guild_accept", // decline shares the guild family
-            "Guild.Leave" to "guild_leave",
-            "Guild.Kick" to "guild_kick",
-            "Guild.Promote" to "guild_promote",
-            "Guild.Demote" to "guild_demote",
-            "Guild.Motd" to "guild_motd",
-            "Guild.Roster" to "guild_roster",
-            "Guild.Info" to "guild_info",
-        )
-
-        val allMappings = parserToManifest + sealedSubcommands
-        val missing = mutableListOf<String>()
-
-        for ((commandName, manifestKey) in allMappings) {
-            if (manifestKey !in manifestKeys) {
-                missing += "Command.$commandName → expected manifest key '$manifestKey'"
-            }
-        }
+        val manifestKeys = CommandsConfig.defaultCommandEntries().keys
+        val missing = (parserToManifest + sealedSubcommands)
+            .filterValues { it !in manifestKeys }
+            .map { (commandName, manifestKey) -> "Command.$commandName → expected manifest key '$manifestKey'" }
 
         assertTrue(missing.isEmpty()) {
             "Parser commands missing from defaultCommandEntries() manifest:\n  ${missing.joinToString("\n  ")}"
+        }
+    }
+
+    /**
+     * Scans the Command sealed interface in CommandParser.kt and requires every
+     * declared subtype to appear in the mapping (or the explicit exclusion
+     * list), in both directions. Adding a Command without a manifest entry —
+     * how auction/train/bank went undocumented — now fails here.
+     */
+    @Test
+    fun `every Command subtype is mapped or explicitly excluded`() {
+        val source = repoRoot
+            .resolve("src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt")
+            .readText()
+
+        // Bound the scan to the Command interface body (it closes at the first
+        // column-zero brace before the CommandParser object).
+        val start = source.indexOf("sealed interface Command {")
+        require(start >= 0) { "Command interface not found" }
+        val end = source.indexOf("\n}", start)
+        require(end >= 0) { "Command interface closing brace not found" }
+        val body = source.substring(start, end)
+
+        val declared = mutableSetOf<String>()
+        var currentFamily: String? = null
+        for (line in body.lineSequence()) {
+            Regex("""^    sealed interface (\w+)""").find(line)?.let {
+                currentFamily = it.groupValues[1]
+                return@let
+            }
+            Regex("""^    data (?:class|object) (\w+)""").find(line)?.let {
+                currentFamily = null
+                declared += it.groupValues[1]
+            }
+            Regex("""^        data (?:class|object) (\w+)""").find(line)?.let {
+                val family = currentFamily
+                    ?: error("Nested command ${it.groupValues[1]} outside a sealed family")
+                declared += "$family.${it.groupValues[1]}"
+            }
+        }
+        require(declared.size > 100) { "Suspiciously few commands scanned (${declared.size}) — parser format changed?" }
+
+        val mapped = parserToManifest.keys + sealedSubcommands.keys
+        val unmapped = declared - mapped - unmappedCommands
+        val stale = (mapped + unmappedCommands) - declared
+
+        assertTrue(unmapped.isEmpty()) {
+            "Command subtypes with no manifest mapping (add to parserToManifest/sealedSubcommands " +
+                "and defaultCommandEntries):\n  ${unmapped.sorted().joinToString("\n  ")}"
+        }
+        assertTrue(stale.isEmpty()) {
+            "Mapping entries for Command subtypes that no longer exist:\n  ${stale.sorted().joinToString("\n  ")}"
         }
     }
 


### PR DESCRIPTION
Full audit of the in-game `help` / web command palette manifest, prompted by the live-playtest finding that auction, train, bank, rest, stylist, duel, pet, and `answer` were all undocumented. The audit found the problem was much wider than those, with four distinct root causes — each fixed with a guard so it can't regress.

## What was missing

**~40 player-facing commands** had no manifest entry at all: `auction` (4 forms), `trade` (3 forms), `bank`/`deposit`/`withdraw`, `duel`, `pet` (5 forms), `train` (4 forms), `prestige`, `leaderboard`, `stylist`/`changerace`, `dungeon`, `enchant`/`enchantments`, `rest`, `depart`, `consider`, `wimpy`*, `claim`, `reputation`, `describe`, `specialize`, `guild hall` (5 forms), `qoffers`, `bye`, `time`, `quickheal`/`quickmana`*, `run`*, `areas`* — plus 8 staff commands (`heal`, `pinfo`, `setstaff`, `setgold`, `setrace`, `setclass`, `setgender`, `setxp`).

\* present in only one of the two manifest sources — see root cause 2.

## Root causes and fixes

1. **`defaultCommandEntries()` lacked the entries.** Added all 47, with usage strings that spell out full subcommand syntax (`train [list] | train learn <ability> | train unlock <class> | train reset`) and descriptions that note room requirements ("requires a bank/tavern/stylist", "set by resting at an inn"). Existing vague wording clarified (`gamble` → "Roll d100 against the house (requires a tavern)").

2. **`application.yaml` wholesale-replaces the defaults, and they had drifted both ways.** The YAML was missing keys the defaults had (and vice versa — `rest`/`run`/`areas`/`consider`/`wimpy` existed *only* in YAML), carried almost no descriptions, and silently reset `requiresTarget` to false on every entry. The YAML block is now **regenerated verbatim from the code defaults**, and a new `CommandManifestSyncTest` pins the two equal — on any drift it fails with a field-level diff and writes the fresh block to `build/command-manifest.yaml` for copy-paste.

3. **`WebClientParityTest` only validated commands already in its hand-written map**, so unmapped commands escaped silently (and several map keys were dead names — `Accept`, `Achievements`, `Title`, `Open` don't exist as Command subtypes). The mapping now covers every `Command` subtype with its real name, and a new completeness test scans `CommandParser.kt`'s sealed hierarchy and fails **in both directions**: a new Command without a mapping+manifest entry, or a stale mapping for a removed Command. Exclusions are explicit and justified (`Noop`/`Invalid`/`Unknown` internals, `Petition` easter egg).

4. **`generateHelp()` silently dropped any category absent from its hardcoded order list and never showed descriptions.** `help` now renders category headers (`[Navigation]`), `usage — description` lines, and appends unknown categories instead of dropping them. `CommandsConfigHelpTest` covers the rendering and additionally requires every manifest entry to carry a non-blank usage *and* description.

## Sample of the new help output

```
Commands:
  [Navigation]
    look/l [target|direction] — Look around, at a target, or in a direction
    ...
    rest — Rest at an inn to make it your recall point.
  [Shops]
    bank — View bank balance and vault contents (requires a bank)
    auction sell <item> <price> — List an item on the auction house
```

`ktlintCheck`, full `test`, and `integrationTest` all pass. The richer descriptions also flow to the web palette via `Server.Commands` GMCP automatically.
