### PR TITLE
fix(abilities): non-combat NPCs refuse hostile casts (#1232)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -238,15 +238,7 @@ class CombatSystem(
         if (matches.isEmpty()) return "You don't see '$keyword' here."
 
         val mob = matches.first()
-        if (!mob.role.isCombatant) {
-            return when (mob.role) {
-                dev.ambon.domain.mob.MobRole.VENDOR -> "${mob.name} isn't interested in fighting — try the shop instead."
-                dev.ambon.domain.mob.MobRole.QUEST_GIVER -> "${mob.name} has no quarrel with you. Maybe they have work to offer?"
-                dev.ambon.domain.mob.MobRole.DIALOG -> "${mob.name} has no interest in fighting you."
-                dev.ambon.domain.mob.MobRole.PROP -> "${mob.name} is not something you can attack."
-                dev.ambon.domain.mob.MobRole.COMBAT -> error("unreachable")
-            }
-        }
+        nonCombatantRefusal(mob)?.let { return it }
 
         val now = clock.millis()
         registerCombatant(sessionId, mob.id, player, now)
@@ -256,6 +248,20 @@ class CombatSystem(
         broadcastToRoom(players, outbound, roomId, "${player.name} attacks ${mob.name}.", exclude = sessionId)
 
         return null
+    }
+
+    /**
+     * Player-facing refusal for attempting to fight [mob], or null when the mob
+     * is a combatant. Shared by the kill command and hostile ability casts so
+     * non-combat NPCs (vendors, quest givers, dialogue NPCs, props) refuse the
+     * spell exactly like they refuse the sword (#1232).
+     */
+    fun nonCombatantRefusal(mob: MobState): String? = when (mob.role) {
+        dev.ambon.domain.mob.MobRole.COMBAT -> null
+        dev.ambon.domain.mob.MobRole.VENDOR -> "${mob.name} isn't interested in fighting — try the shop instead."
+        dev.ambon.domain.mob.MobRole.QUEST_GIVER -> "${mob.name} has no quarrel with you. Maybe they have work to offer?"
+        dev.ambon.domain.mob.MobRole.DIALOG -> "${mob.name} has no interest in fighting you."
+        dev.ambon.domain.mob.MobRole.PROP -> "${mob.name} is not something you can attack."
     }
 
     /**

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
@@ -171,6 +171,11 @@ class AbilitySystem(
                     ?: return "Cast ${ability.displayName} on whom?"
             }
 
+        // Non-combat NPCs refuse spells exactly like they refuse `kill` —
+        // without this gate a targeted cast could destroy quest givers,
+        // vendors, and props without ever entering combat (#1232).
+        combat.nonCombatantRefusal(mob)?.let { return it }
+
         if (effects.any { it is AbilityEffect.AreaDamage } && mobs == null) {
             return "Area damage is not available."
         }

--- a/src/test/kotlin/dev/ambon/engine/abilities/AbilitySystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/abilities/AbilitySystemTest.kt
@@ -6,6 +6,7 @@ import dev.ambon.config.ProgressionConfig
 import dev.ambon.config.StatBindingsConfig
 import dev.ambon.domain.DamageRange
 import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.mob.MobRole
 import dev.ambon.domain.mob.MobState
 import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.DirtyNotifier
@@ -319,6 +320,46 @@ class AbilitySystemTest {
                     .filterIsInstance<OutboundEvent.SendText>()
                     .map { it.text }
             assertTrue(messages.any { it.contains("dies") })
+        }
+
+    @Test
+    fun `cast refuses non-combatant targets without spending mana or dealing damage`() =
+        runTest {
+            val h = buildSystem()
+            h.players.loginOrFail(sid, "Caster")
+            h.abilitySystem.syncAbilities(sid, 1)
+            val player = h.players.get(sid)!!
+
+            val nonCombatants = mapOf(
+                MobRole.VENDOR to "isn't interested in fighting",
+                MobRole.QUEST_GIVER to "has no quarrel with you",
+                MobRole.DIALOG to "has no interest in fighting you",
+                MobRole.PROP to "is not something you can attack",
+            )
+            for ((role, expectedRefusal) in nonCombatants) {
+                player.mana = 20
+                val mob = MobState(
+                    id = MobId("zone:npc_${role.name.lowercase()}"),
+                    name = "an innocent ${role.name.lowercase()}",
+                    roomId = roomId,
+                    hp = 20,
+                    maxHp = 20,
+                    role = role,
+                )
+                h.mobs.upsert(mob)
+
+                val err = h.abilitySystem.cast(sid, "magic_missile", role.name.lowercase())
+
+                assertNotNull(err, "$role should refuse a hostile cast")
+                assertTrue(
+                    err!!.contains(expectedRefusal),
+                    "$role refusal should match the kill command's wording, got: $err",
+                )
+                assertEquals(20, mob.hp, "$role must take no spell damage")
+                assertEquals(20, player.mana, "refused cast must not spend mana")
+                assertFalse(h.combat.isInCombat(sid), "refused cast must not start combat")
+                h.mobs.remove(mob.id)
+            }
         }
 
     @Test

--- a/web-v3/src/canvas/scenes/WorldScene.ts
+++ b/web-v3/src/canvas/scenes/WorldScene.ts
@@ -1730,10 +1730,19 @@ export class WorldScene {
       // Pulse targetable entities
       const isEnemy = pending.targetType === "ENEMY";
       const isAlly = pending.targetType === "ALLY";
+      // Hostile casts can only hit true combatants — vendors, quest givers,
+      // dialog NPCs, and props stay at rest with no crosshair so the overlay
+      // doesn't suggest they're valid targets (#1232). Absent info defaults
+      // to targetable (legacy mobs are COMBAT).
+      const mobInfo = gameStateRef.current.mobInfo;
+      const isTargetable = (ids: string[]): boolean => {
+        const info = mobInfo.find((m) => m.id === ids[0]);
+        return info ? info.combatant : true;
+      };
       if (!this.targetingActive) {
         // Set cursor once on targeting start
-        for (const { hitArea } of this.mobSprites.values()) {
-          if (isEnemy) hitArea.cursor = "crosshair";
+        for (const { hitArea, ids } of this.mobSprites.values()) {
+          if (isEnemy && isTargetable(ids)) hitArea.cursor = "crosshair";
         }
         for (const { hitArea } of this.playerSprites.values()) {
           if (isAlly) hitArea.cursor = "crosshair";
@@ -1741,8 +1750,8 @@ export class WorldScene {
         this.targetingActive = true;
       }
       // Animate alpha every frame
-      for (const { sprite } of this.mobSprites.values()) {
-        if (isEnemy) sprite.alpha = pulse;
+      for (const { sprite, ids } of this.mobSprites.values()) {
+        if (isEnemy && isTargetable(ids)) sprite.alpha = pulse;
       }
       for (const { sprite } of this.playerSprites.values()) {
         if (isAlly) sprite.alpha = pulse;
@@ -1848,7 +1857,14 @@ export class WorldScene {
 
       const mobData = mob;
       hitArea.on("pointerdown", () => {
-        if (pendingCastRef.current) {
+        const pendingCast = pendingCastRef.current;
+        if (pendingCast) {
+          // Hostile casts cannot target non-combat NPCs — the server refuses
+          // them too (#1232); don't consume the click as a target selection.
+          if (pendingCast.targetType === "ENEMY") {
+            const info = gameStateRef.current.mobInfo.find((m) => m.id === mobData.id) ?? null;
+            if (info && !info.combatant) return;
+          }
           canvasCallbacks.onTargetSelected?.(mobData.name);
           return;
         }


### PR DESCRIPTION
Closes #1232.

## Problem

`kill` checks `mob.role.isCombatant` and refuses with role-specific flavor — but targeted spell casts never did. Repro (as reported): press a skill hotkey out of combat, cursor becomes a crosshair, click a non-killable mob (quest giver / vendor / dialog NPC / prop) → `applySpellDamage` lands, `handleSpellKill` fires, and the NPC dies without combat ever starting. The earlier #1219 fix made hostile casts *engage* combat, but `engageMobCombat` deliberately no-ops for non-combatants — leaving the damage path itself ungated.

## Server fix (authoritative)

- The role-refusal messages move out of `startCombat` into a shared **`CombatSystem.nonCombatantRefusal(mob)`** (exhaustive `when` over `MobRole`, null for `COMBAT`).
- `AbilitySystem.handleEnemyCast` applies it immediately after target resolution — **before** mana deduction, cooldown, combat engagement, or any effect — so the spell gets exactly the same refusals as the sword:
  - "X isn't interested in fighting — try the shop instead." (vendor)
  - "X has no quarrel with you. Maybe they have work to offer?" (quest giver)
  - "X has no interest in fighting you." (dialog)
  - "X is not something you can attack." (prop)
- Covers DirectDamage, ApplyStatus (DoTs could also kill), and the single-target path generally. Area damage and taunts already only consider mobs *in combat*, which non-combatants can never be.

## Web client polish

The crosshair targeting overlay was advertising the broken behavior:
- ENEMY-targeted skills no longer pulse or show a crosshair over non-combatants (the `mobInfo.combatant` GMCP flag was already plumbed for the context-menu Attack gate).
- Clicking a non-combatant in target mode is ignored rather than consumed as a target selection — targeting stays active so the player can pick a real enemy.
- Absent mob info defaults to targetable, matching the existing legacy-mob convention.

## Tests

New `AbilitySystemTest` case iterates all four non-combat roles: cast refused with the kill-command wording, **zero damage, zero mana spent, no combat started**. Existing kill-command refusal coverage still passes against the extracted helper.

`ktlintCheck`, full `test`, `integrationTest`, `bun run lint`, and `buildWeb` all pass.
