### PR TITLE
feat(metrics): demo-account + post-setup system metrics, dashboard refresh, public Grafana (#1226)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,10 @@ services:
       - "3000:3000"
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=admin
+      # Mirror production: dashboards are anonymously viewable (read-only).
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
+      - GF_USERS_ALLOW_SIGN_UP=false
     volumes:
       - ./infra/grafana/provisioning:/etc/grafana/provisioning:ro
     depends_on:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -543,12 +543,39 @@ Trigger it manually from the Actions tab. After it finishes, run a staff
 new data to the running engine.
 
 
+### Public Grafana dashboards
+
+`/grafana/` is **deliberately un-gated**: Grafana serves anonymous read-only
+(Viewer role) access so visitors can browse the monitoring dashboards without
+credentials. The exposure is bounded:
+
+- Anonymous users are Viewers — no editing, no admin pages, sign-up disabled.
+- `GF_EXPLORE_ENABLED=false` — anonymous visitors can only read the
+  provisioned dashboards, not run ad-hoc PromQL against the datasource.
+- The Grafana **admin** login password is the SSM admin token (written to
+  `/etc/ambonmud/grafana.env` by `generate-grafana-env` at service start —
+  never the old hardcoded `admin`).
+- `/prometheus/` and `/admin/` remain behind nginx basic-auth.
+
+To apply this to an already-running instance without replacing it (user data
+only runs at first boot), via SSM shell:
+
+```bash
+sudo sed -i '/location \/grafana\/ {/,/}/ { /auth_basic/d }' /etc/nginx/conf.d/ambonmud.conf
+sudo nginx -t && sudo systemctl reload nginx
+# then update /etc/systemd/system/grafana.service to match infra/lib/ec2-stack.ts
+# (generate-grafana-env ExecStartPre + --env-file + the GF_* hardening vars),
+# write /usr/local/bin/generate-grafana-env, and:
+sudo systemctl daemon-reload && sudo systemctl restart grafana
+```
+
 ### Admin token (SSM Parameter Store)
 
-The admin API token used for nginx basic-auth on `/grafana/`, `/prometheus/`,
-and `/admin/` (and for the admin API itself) is stored in AWS SSM Parameter
-Store as a `SecureString`, NOT in the publicly-fetched lore overlay.
-This keeps the secret out of any file that's served over public HTTP.
+The admin API token used for nginx basic-auth on `/prometheus/` and
+`/admin/`, for the admin API itself, and as the Grafana admin login password
+is stored in AWS SSM Parameter Store as a `SecureString`, NOT in the
+publicly-fetched lore overlay. This keeps the secret out of any file that's
+served over public HTTP.
 
 **One-time setup:**
 

--- a/infra/grafana/provisioning/dashboards/ambon_gameplay.json
+++ b/infra/grafana/provisioning/dashboards/ambon_gameplay.json
@@ -4,16 +4,26 @@
   "schemaVersion": 38,
   "version": 1,
   "refresh": "15s",
-  "time": { "from": "now-15m", "to": "now" },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
   "panels": [
     {
       "id": 1,
       "title": "Players Online",
       "type": "stat",
-      "gridPos": { "x": 0, "y": 0, "w": 4, "h": 4 },
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus" },
+          "datasource": {
+            "type": "prometheus"
+          },
           "expr": "players_online",
           "legendFormat": "players"
         }
@@ -23,10 +33,17 @@
       "id": 2,
       "title": "Mobs Alive",
       "type": "stat",
-      "gridPos": { "x": 4, "y": 0, "w": 4, "h": 4 },
+      "gridPos": {
+        "x": 4,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus" },
+          "datasource": {
+            "type": "prometheus"
+          },
           "expr": "mobs_alive",
           "legendFormat": "mobs"
         }
@@ -36,10 +53,17 @@
       "id": 3,
       "title": "Rooms Occupied",
       "type": "stat",
-      "gridPos": { "x": 8, "y": 0, "w": 4, "h": 4 },
+      "gridPos": {
+        "x": 8,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus" },
+          "datasource": {
+            "type": "prometheus"
+          },
           "expr": "rooms_occupied",
           "legendFormat": "rooms"
         }
@@ -49,15 +73,24 @@
       "id": 4,
       "title": "Mob System Tick Duration (seconds)",
       "type": "timeseries",
-      "gridPos": { "x": 0, "y": 4, "w": 12, "h": 6 },
+      "gridPos": {
+        "x": 0,
+        "y": 4,
+        "w": 12,
+        "h": 6
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus" },
+          "datasource": {
+            "type": "prometheus"
+          },
           "expr": "histogram_quantile(0.50, rate(mob_system_tick_duration_seconds_bucket[1m]))",
           "legendFormat": "p50"
         },
         {
-          "datasource": { "type": "prometheus" },
+          "datasource": {
+            "type": "prometheus"
+          },
           "expr": "histogram_quantile(0.95, rate(mob_system_tick_duration_seconds_bucket[1m]))",
           "legendFormat": "p95"
         }
@@ -67,15 +100,24 @@
       "id": 5,
       "title": "Combat System Tick Duration (seconds)",
       "type": "timeseries",
-      "gridPos": { "x": 12, "y": 4, "w": 12, "h": 6 },
+      "gridPos": {
+        "x": 12,
+        "y": 4,
+        "w": 12,
+        "h": 6
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus" },
+          "datasource": {
+            "type": "prometheus"
+          },
           "expr": "histogram_quantile(0.50, rate(combat_system_tick_duration_seconds_bucket[1m]))",
           "legendFormat": "p50"
         },
         {
-          "datasource": { "type": "prometheus" },
+          "datasource": {
+            "type": "prometheus"
+          },
           "expr": "histogram_quantile(0.95, rate(combat_system_tick_duration_seconds_bucket[1m]))",
           "legendFormat": "p95"
         }
@@ -85,15 +127,24 @@
       "id": 6,
       "title": "Regen Tick Duration (seconds)",
       "type": "timeseries",
-      "gridPos": { "x": 0, "y": 10, "w": 12, "h": 6 },
+      "gridPos": {
+        "x": 0,
+        "y": 10,
+        "w": 12,
+        "h": 6
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus" },
+          "datasource": {
+            "type": "prometheus"
+          },
           "expr": "rate(regen_tick_duration_seconds_sum[1m]) / rate(regen_tick_duration_seconds_count[1m])",
           "legendFormat": "avg"
         },
         {
-          "datasource": { "type": "prometheus" },
+          "datasource": {
+            "type": "prometheus"
+          },
           "expr": "regen_tick_duration_seconds_max",
           "legendFormat": "max"
         }
@@ -103,10 +154,17 @@
       "id": 7,
       "title": "Mob Moves / sec",
       "type": "timeseries",
-      "gridPos": { "x": 12, "y": 10, "w": 6, "h": 6 },
+      "gridPos": {
+        "x": 12,
+        "y": 10,
+        "w": 6,
+        "h": 6
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus" },
+          "datasource": {
+            "type": "prometheus"
+          },
           "expr": "rate(mob_moves_total[1m])",
           "legendFormat": "moves/s"
         }
@@ -116,10 +174,17 @@
       "id": 8,
       "title": "Combats Processed / sec",
       "type": "timeseries",
-      "gridPos": { "x": 18, "y": 10, "w": 6, "h": 6 },
+      "gridPos": {
+        "x": 18,
+        "y": 10,
+        "w": 6,
+        "h": 6
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus" },
+          "datasource": {
+            "type": "prometheus"
+          },
           "expr": "rate(combats_processed_total[1m])",
           "legendFormat": "combats/s"
         }
@@ -129,10 +194,17 @@
       "id": 9,
       "title": "XP Awarded / sec",
       "type": "timeseries",
-      "gridPos": { "x": 0, "y": 16, "w": 12, "h": 6 },
+      "gridPos": {
+        "x": 0,
+        "y": 16,
+        "w": 12,
+        "h": 6
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus" },
+          "datasource": {
+            "type": "prometheus"
+          },
           "expr": "rate(xp_awarded_total[1m])",
           "legendFormat": "{{source}}"
         }
@@ -142,10 +214,17 @@
       "id": 10,
       "title": "Level Ups / sec",
       "type": "timeseries",
-      "gridPos": { "x": 12, "y": 16, "w": 6, "h": 6 },
+      "gridPos": {
+        "x": 12,
+        "y": 16,
+        "w": 6,
+        "h": 6
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus" },
+          "datasource": {
+            "type": "prometheus"
+          },
           "expr": "rate(level_ups_total[1m])",
           "legendFormat": "levelups/s"
         }
@@ -155,12 +234,199 @@
       "id": 11,
       "title": "Player Deaths / sec",
       "type": "timeseries",
-      "gridPos": { "x": 18, "y": 16, "w": 6, "h": 6 },
+      "gridPos": {
+        "x": 18,
+        "y": 16,
+        "w": 6,
+        "h": 6
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus" },
+          "datasource": {
+            "type": "prometheus"
+          },
           "expr": "rate(player_deaths_total[1m])",
           "legendFormat": "deaths/s"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "title": "Demo Players Online",
+      "type": "stat",
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "expr": "demo_players_online",
+          "legendFormat": "demo"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "title": "Demo Created (24h)",
+      "type": "stat",
+      "gridPos": {
+        "x": 16,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "expr": "increase(game_events_total{system=\"demo\",event=\"created\"}[24h])",
+          "legendFormat": "created"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "title": "Demo Claimed (24h)",
+      "type": "stat",
+      "gridPos": {
+        "x": 20,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "expr": "increase(game_events_total{system=\"demo\",event=\"claimed\"}[24h])",
+          "legendFormat": "claimed"
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "title": "Demo Account Events / hour",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 22,
+        "w": 12,
+        "h": 6
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "expr": "sum by (event) (increase(game_events_total{system=\"demo\"}[1h]))",
+          "legendFormat": "{{event}}"
+        }
+      ]
+    },
+    {
+      "id": 16,
+      "title": "Quest Events / hour",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 22,
+        "w": 12,
+        "h": 6
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "expr": "sum by (event) (increase(game_events_total{system=\"quest\"}[1h]))",
+          "legendFormat": "{{event}}"
+        }
+      ]
+    },
+    {
+      "id": 17,
+      "title": "Economy Events / hour",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 28,
+        "w": 12,
+        "h": 6
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "expr": "sum by (system, event) (increase(game_events_total{system=~\"auction|tavern|bank|trade\"}[1h]))",
+          "legendFormat": "{{system}}/{{event}}"
+        }
+      ]
+    },
+    {
+      "id": 18,
+      "title": "Crafting Events / hour",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 28,
+        "w": 12,
+        "h": 6
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "expr": "sum by (event) (increase(game_events_total{system=\"crafting\"}[1h]))",
+          "legendFormat": "{{event}}"
+        }
+      ]
+    },
+    {
+      "id": 19,
+      "title": "Adventure Events / hour",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 34,
+        "w": 12,
+        "h": 6
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "expr": "sum by (system, event) (increase(game_events_total{system=~\"dungeon|duel|puzzle|ability\"}[1h]))",
+          "legendFormat": "{{system}}/{{event}}"
+        }
+      ]
+    },
+    {
+      "id": 20,
+      "title": "Social & Progression Events / hour",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 34,
+        "w": 12,
+        "h": 6
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "expr": "sum by (system, event) (increase(game_events_total{system=~\"housing|stylist|prestige|pet|guild|mail\"}[1h]))",
+          "legendFormat": "{{system}}/{{event}}"
         }
       ]
     }

--- a/infra/lib/ec2-stack.ts
+++ b/infra/lib/ec2-stack.ts
@@ -424,7 +424,38 @@ export class Ec2Stack extends Stack {
       'WantedBy=multi-user.target',
       'PROM_SVC_END',
       '',
+      // ---- Grafana admin-password env helper -----------------------------------
+      // Grafana is PUBLIC (anonymous Viewer) — the nginx /grafana/ location has
+      // no basic-auth so resume visitors can browse the dashboards. That makes
+      // the old hardcoded GF_SECURITY_ADMIN_PASSWORD=admin a real login, so the
+      // admin password now comes from the same SSM admin token nginx uses.
+      // secrets.env is written by fetch-admin-token (an ambonmud.service
+      // ExecStartPre), which may not have run yet on first boot — so this
+      // helper re-runs the fetch itself when available and falls back to
+      // 'admin' only when no SSM token is configured (dev installs without
+      // a public hostname, where nginx isn't fronting Grafana anyway).
+      `cat > /usr/local/bin/generate-grafana-env << 'GRAF_ENV_END'`,
+      '#!/bin/bash',
+      'set -euo pipefail',
+      'if [ -x /usr/local/bin/fetch-admin-token ]; then',
+      '  /usr/local/bin/fetch-admin-token || true',
+      'fi',
+      'TOKEN=""',
+      'if [ -f /etc/ambonmud/secrets.env ]; then',
+      '  # shellcheck source=/dev/null',
+      '  . /etc/ambonmud/secrets.env',
+      '  TOKEN="${AMBONMUD_ADMIN_TOKEN:-}"',
+      'fi',
+      'umask 077',
+      'mkdir -p /etc/ambonmud',
+      'printf "GF_SECURITY_ADMIN_PASSWORD=%s\\n" "${TOKEN:-admin}" > /etc/ambonmud/grafana.env',
+      'GRAF_ENV_END',
+      'chmod +x /usr/local/bin/generate-grafana-env',
+      '',
       // ---- Grafana systemd service --------------------------------------------
+      // Anonymous access is read-only: Viewer role, sign-up disabled, and
+      // Explore off so anonymous visitors can only read the provisioned
+      // dashboards, not run ad-hoc PromQL against the datasource.
       `cat > /etc/systemd/system/grafana.service << 'GRAF_SVC_END'`,
       '[Unit]',
       'Description=Grafana',
@@ -434,15 +465,20 @@ export class Ec2Stack extends Stack {
       '[Service]',
       'Restart=always',
       'RestartSec=10',
+      'ExecStartPre=/usr/local/bin/generate-grafana-env',
       'ExecStartPre=-/usr/bin/docker rm -f grafana',
       'ExecStart=/usr/bin/docker run --name grafana \\',
       '  --network ambonmud-net \\',
       '  -p 3000:3000 \\',
-      '  -e GF_SECURITY_ADMIN_PASSWORD=admin \\',
+      '  --env-file /etc/ambonmud/grafana.env \\',
       `  -e GF_SERVER_ROOT_URL=https://${hostname || 'localhost'}/grafana/ \\`,
       '  -e GF_SERVER_SERVE_FROM_SUB_PATH=true \\',
       '  -e GF_AUTH_ANONYMOUS_ENABLED=true \\',
       '  -e GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer \\',
+      '  -e GF_USERS_ALLOW_SIGN_UP=false \\',
+      '  -e GF_EXPLORE_ENABLED=false \\',
+      '  -e GF_SECURITY_DISABLE_GRAVATAR=true \\',
+      '  -e GF_ANALYTICS_REPORTING_ENABLED=false \\',
       '  -v /app/grafana/provisioning:/etc/grafana/provisioning:ro \\',
       '  grafana/grafana:10.4.2',
       'ExecStop=/usr/bin/docker stop grafana',
@@ -773,9 +809,11 @@ export class Ec2Stack extends Stack {
         '        proxy_read_timeout 3600;',
         '    }',
         '',
+        '    # Deliberately un-gated: Grafana serves anonymous read-only Viewer',
+        '    # dashboards so visitors can see how the monitoring is set up.',
+        '    # Editing/admin still requires the Grafana admin login (SSM token),',
+        '    # and /prometheus/ + /admin/ below remain behind basic-auth.',
         '    location /grafana/ {',
-        '        auth_basic "AmbonMUD Admin";',
-        '        auth_basic_user_file /etc/nginx/.htpasswd;',
         '        proxy_pass http://localhost:3000/grafana/;',
         '        proxy_set_header Host $host;',
         '        proxy_set_header X-Real-IP $remote_addr;',

--- a/src/main/kotlin/dev/ambon/MudServer.kt
+++ b/src/main/kotlin/dev/ambon/MudServer.kt
@@ -454,6 +454,8 @@ class MudServer(
 
     private fun bindWorldStateGauges() {
         gameMetrics.bindPlayerRegistry { players.allPlayers().size }
+        // Unclaimed demo characters have no playerId until `claim` (#1226).
+        gameMetrics.bindDemoPlayersOnline { players.allPlayers().count { it.playerId == null } }
         gameMetrics.bindMobRegistry { mobs.all().size }
         gameMetrics.bindRoomsOccupied {
             players

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -847,6 +847,7 @@ class GameEngine(
             onCombatEvent = { sid, event -> gmcpEmitter.sendCombatEvent(sid, event) },
             onSummonPet = { sid, templateKey, durationMs ->
                 val player = players.get(sid) ?: return@AbilitySystem
+                metrics.onGameEvent("pet", "summoned")
                 // Snapshot existing pets before summon so we can broadcast their removal —
                 // summon() replaces the old pet internally but clients don't hear about it,
                 // leaving a ghost sprite until the owner moves rooms. See issue #1093.
@@ -1019,6 +1020,7 @@ class GameEngine(
         }
         // Single assignment: a second `onPvpKill =` would silently overwrite the first.
         combatSystem.onPvpKill = { killerSid ->
+            metrics.onGameEvent("duel", "completed")
             notifyDailyQuest(killerSid, "pvpKill")
             val killer = players.get(killerSid)
             if (killer != null &&
@@ -1036,7 +1038,10 @@ class GameEngine(
         }
         statusEffectSystem.onCombatEvent = { sid, event -> gmcpEmitter.sendCombatEvent(sid, event) }
 
+        questSystem.onQuestAccepted = { _, _ -> metrics.onGameEvent("quest", "accepted") }
+        questSystem.onQuestAbandoned = { _, _ -> metrics.onGameEvent("quest", "abandoned") }
         questSystem.onQuestCompleted = { sid, questId ->
+            metrics.onGameEvent("quest", "completed")
             achievementSystem.onQuestCompleted(sid, questId)
             val player = players.get(sid)
             if (player != null) {
@@ -1107,7 +1112,10 @@ class GameEngine(
             gmcpEmitter.sendCharItemsAdd(sid, item)
             questSystem.onItemCollected(sid, item)
         }
-        guildSystem?.onGuildCreated = { sid -> achievementSystem.onGuildCreated(sid) }
+        guildSystem?.onGuildCreated = { sid ->
+            metrics.onGameEvent("guild", "created")
+            achievementSystem.onGuildCreated(sid)
+        }
     }
 
     private val behaviorTreeSystem: BehaviorTreeSystem =
@@ -1224,6 +1232,7 @@ class GameEngine(
             puzzleSystem = puzzleSystem,
             bankConfig = engineConfig.bank,
             stylistConfig = engineConfig.stylist,
+            metrics = metrics,
         )
 
         // Push a fresh room look when a dead player respawns, so the web client
@@ -1361,6 +1370,7 @@ class GameEngine(
                 gatheringRegistry = gatheringRegistry,
                 markVitalsDirty = ::markVitalsDirty,
                 onItemCrafted = { sid ->
+                    metrics.onGameEvent("crafting", "craft")
                     achievementSystem.onItemCrafted(sid)
                     notifyDailyQuest(sid, "craft")
                     globalQuestSystem?.onEvent(sid, GlobalQuestObjectiveType.CRAFT)
@@ -1380,6 +1390,7 @@ class GameEngine(
                     }
                 },
                 onItemGathered = { sid, skill ->
+                    metrics.onGameEvent("crafting", "gather")
                     achievementSystem.onItemGathered(sid, skill)
                     notifyDailyQuest(sid, "gather")
                     globalQuestSystem?.onEvent(sid, GlobalQuestObjectiveType.GATHER)
@@ -1434,7 +1445,10 @@ class GameEngine(
             ClaimHandler(
                 ctx = ctx,
                 getEngineScope = { engineScope },
-                onClaimed = { sid -> issueAuthToken(sid) },
+                onClaimed = { sid ->
+                    metrics.onGameEvent("demo", "claimed")
+                    issueAuthToken(sid)
+                },
             ),
             HousingHandler(
                 ctx = ctx,
@@ -2807,6 +2821,7 @@ class GameEngine(
         val inst = dungeonManager.findInstanceByBossMob(mobId)
         if (inst == null || inst.completed) return
         dungeonManager.markComplete(inst)
+        metrics.onGameEvent("dungeon", "completed")
         val completionHeadline =
             "** The dungeon boss has been defeated! The ${inst.template.name} is complete! **"
         for (sid in inst.members) {

--- a/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
@@ -34,6 +34,12 @@ class QuestSystem(
     /** Invoked after a quest is successfully completed; used by AchievementSystem. */
     var onQuestCompleted: (suspend (SessionId, String) -> Unit)? = null
 
+    /** Invoked after a quest is accepted; used for metrics. */
+    var onQuestAccepted: (suspend (SessionId, String) -> Unit)? = null
+
+    /** Invoked after a quest is abandoned; used for metrics. */
+    var onQuestAbandoned: (suspend (SessionId, String) -> Unit)? = null
+
     /** Invoked to emit quest GMCP; set by GameEngine during wiring. */
     var onQuestListChanged: (suspend (SessionId) -> Unit)? = null
     var onQuestObjectiveUpdated: (suspend (SessionId, String, Int, Int, Int, Boolean) -> Unit)? = null
@@ -286,6 +292,7 @@ class QuestSystem(
             )
         ps.activeQuests = ps.activeQuests + (questId to state)
         players.persistPlayer(ps.sessionId)
+        onQuestAccepted?.invoke(sessionId, questId)
 
         outbound.send(OutboundEvent.SendInfo(sessionId, "Quest accepted: ${quest.name}"))
         val acceptHandler = completionHandlers.get(quest.completionType)
@@ -408,6 +415,7 @@ class QuestSystem(
         val quest = registry.get(questId)
         ps.activeQuests = ps.activeQuests - questId
         players.persistPlayer(ps.sessionId)
+        onQuestAbandoned?.invoke(sessionId, questId)
         outbound.send(OutboundEvent.SendInfo(sessionId, "Quest abandoned: ${quest?.name ?: questId}"))
         onQuestListChanged?.invoke(sessionId)
         return null

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/AuctionHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/AuctionHandler.kt
@@ -118,6 +118,7 @@ class AuctionHandler(
                 return
             }
 
+            ctx.metrics.onGameEvent("auction", "listed")
             val message = "Listed ${listing.item.item.displayName} for ${listing.price} gold (listing #${listing.id})."
             outbound.send(
                 OutboundEvent.SendInfo(
@@ -220,6 +221,7 @@ class AuctionHandler(
                 creditOfflineSellerGold(purchased.sellerName, purchased.price)
             }
 
+            ctx.metrics.onGameEvent("auction", "sold")
             val message = "You purchased ${purchased.item.item.displayName} for ${purchased.price} gold."
             outbound.send(OutboundEvent.SendInfo(sessionId, message))
             sendScopedFeedback(sessionId, gmcpEmitter, "success", message, "auction", code = "PURCHASE_COMPLETE", command = "buy")
@@ -260,6 +262,7 @@ class AuctionHandler(
             return
         }
 
+        ctx.metrics.onGameEvent("auction", "cancelled")
         val message = "Cancelled listing #${cancelled.id}. ${cancelled.item.item.displayName} returned to your inventory."
         outbound.send(
             OutboundEvent.SendInfo(

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/BankHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/BankHandler.kt
@@ -18,6 +18,7 @@ class BankHandler(
     private val items = ctx.items
     private val outbound = ctx.outbound
     private val gmcpEmitter = ctx.gmcpEmitter
+    private val metrics = ctx.metrics
 
     override fun register(router: CommandRouter) {
         router.on<Command.Bank.DepositGold> { sid, cmd -> handleDepositGold(sid, cmd) }
@@ -52,6 +53,7 @@ class BankHandler(
         me.gold -= amount
         me.bankGold += amount
         markVitalsDirty?.invoke(sessionId)
+        metrics.onGameEvent("bank", "deposit_gold")
         outbound.send(OutboundEvent.SendInfo(sessionId, "You deposit $amount gold. Bank balance: ${me.bankGold} gold."))
         emitBankState(sessionId, me)
     }
@@ -72,6 +74,7 @@ class BankHandler(
         me.bankGold -= amount
         me.gold += amount
         markVitalsDirty?.invoke(sessionId)
+        metrics.onGameEvent("bank", "withdraw_gold")
         outbound.send(OutboundEvent.SendInfo(sessionId, "You withdraw $amount gold. Bank balance: ${me.bankGold} gold."))
         emitBankState(sessionId, me)
     }
@@ -92,6 +95,7 @@ class BankHandler(
         }
 
         me.bankItems.add(removed)
+        metrics.onGameEvent("bank", "deposit_item")
         outbound.send(OutboundEvent.SendInfo(sessionId, "You deposit ${removed.item.displayName} into your bank vault."))
         syncItemsGmcp(sessionId, items, gmcpEmitter)
         emitBankState(sessionId, me)
@@ -112,6 +116,7 @@ class BankHandler(
 
         val withdrawn = me.bankItems.removeAt(idx)
         items.addToInventory(sessionId, withdrawn)
+        metrics.onGameEvent("bank", "withdraw_item")
         outbound.send(OutboundEvent.SendInfo(sessionId, "You withdraw ${withdrawn.item.displayName} from your bank vault."))
         syncItemsGmcp(sessionId, items, gmcpEmitter)
         emitBankState(sessionId, me)

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/CombatHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/CombatHandler.kt
@@ -27,6 +27,7 @@ class CombatHandler(
     private val combat = ctx.combat
     private val outbound = ctx.outbound
     private val gmcpEmitter = ctx.gmcpEmitter
+    private val metrics = ctx.metrics
     private val world: World = ctx.world
 
     override fun register(router: CommandRouter) {
@@ -158,6 +159,8 @@ class CombatHandler(
         outbound.sendIfError(sessionId, error)
         if (error != null) {
             gmcpEmitter?.sendUiFeedback(sessionId, "error", error, scope = "combat", command = "cast")
+        } else {
+            metrics.onGameEvent("ability", "cast")
         }
     }
 

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/DuelHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/DuelHandler.kt
@@ -129,6 +129,7 @@ class DuelHandler(
             return
         }
 
+        ctx.metrics.onGameEvent("duel", "started")
         outbound.send(
             OutboundEvent.SendInfo(duel.player1, "** ${me.name} accepts your duel challenge! Fight! **"),
         )

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/DungeonHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/DungeonHandler.kt
@@ -162,6 +162,7 @@ class DungeonHandler(
                 partyLevel = partyLevel,
                 returnRoom = returnRoom,
             )
+            ctx.metrics.onGameEvent("dungeon", "entered")
 
             // Teleport all members to the entrance
             val entrance = dm.entranceRoom(instance)

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/EnchantHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/EnchantHandler.kt
@@ -17,6 +17,7 @@ class EnchantHandler(
     private val outbound = ctx.outbound
     private val gmcpEmitter = ctx.gmcpEmitter
     private val items = ctx.items
+    private val metrics = ctx.metrics
 
     override fun register(router: CommandRouter) {
         router.on<Command.Enchant> { sid, cmd -> handleEnchant(sid, cmd) }
@@ -28,6 +29,7 @@ class EnchantHandler(
 
         when (val result = enchantSystem.enchant(sessionId, cmd.itemKeyword, cmd.enchantmentId, player.craftingSkills)) {
             is EnchantResult.Success -> {
+                metrics.onGameEvent("crafting", "enchant")
                 outbound.send(
                     OutboundEvent.SendInfo(
                         sessionId,

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/EngineContext.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/EngineContext.kt
@@ -22,6 +22,7 @@ import dev.ambon.engine.TrainerRegistry
 import dev.ambon.engine.WorldStateRegistry
 import dev.ambon.engine.crafting.GatheringRegistry
 import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.metrics.GameMetrics
 
 /**
  * Shared registries and services passed to every command handler.
@@ -55,4 +56,6 @@ data class EngineContext(
     val puzzleSystem: PuzzleSystem? = null,
     val bankConfig: BankConfig = BankConfig(),
     val stylistConfig: StylistConfig = StylistConfig(),
+    /** Gameplay metrics. Defaults to a no-op registry so tests need no wiring. */
+    val metrics: GameMetrics = GameMetrics.noop(),
 )

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HousingHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HousingHandler.kt
@@ -93,6 +93,7 @@ class HousingHandler(
             outbound.send(OutboundEvent.SendError(sessionId, err))
             gmcpEmitter?.sendUiFeedback(sessionId, "error", err, scope = "housing", command = "buy")
         } else {
+            ctx.metrics.onGameEvent("housing", "purchased")
             val msg = "Congratulations! You are now a homeowner."
             outbound.send(OutboundEvent.SendInfo(sessionId, msg))
             outbound.send(OutboundEvent.SendInfo(sessionId, "Use 'recall' to visit your house, or 'house status' to see your rooms."))
@@ -109,6 +110,7 @@ class HousingHandler(
             outbound.send(OutboundEvent.SendError(sessionId, err))
             gmcpEmitter?.sendUiFeedback(sessionId, "error", err, scope = "housing", command = "expand")
         } else {
+            ctx.metrics.onGameEvent("housing", "expanded")
             val name = template?.title ?: cmd.templateId
             val msg = "You've added a $name to the ${cmd.direction.name.lowercase()}."
             outbound.send(OutboundEvent.SendInfo(sessionId, msg))

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/LotteryHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/LotteryHandler.kt
@@ -92,6 +92,7 @@ class LotteryHandler(
 
             when (result) {
                 is LotteryBuyResult.Success -> {
+                    ctx.metrics.onGameEvent("tavern", "lottery_ticket", count = result.count.toLong())
                     val message =
                         "You purchased ${result.count} lottery ticket(s) for ${result.totalCost} gold. " +
                             "You now have ${result.totalTickets} ticket(s)."
@@ -191,6 +192,8 @@ class LotteryHandler(
 
             when (result) {
                 is GambleResult.Win -> {
+                    ctx.metrics.onGameEvent("tavern", "gamble")
+                    ctx.metrics.onGameEvent("tavern", "gamble_win")
                     me.gold = me.gold - result.bet + result.payout
                     outbound.send(
                         OutboundEvent.SendInfo(
@@ -216,6 +219,7 @@ class LotteryHandler(
                 }
 
                 is GambleResult.Lose -> {
+                    ctx.metrics.onGameEvent("tavern", "gamble")
                     me.gold -= result.bet
                     outbound.send(
                         OutboundEvent.SendInfo(

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/MailHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/MailHandler.kt
@@ -19,6 +19,7 @@ class MailHandler(
     private val players = ctx.players
     private val outbound = ctx.outbound
     private val gmcpEmitter = ctx.gmcpEmitter
+    private val metrics = ctx.metrics
 
     override fun register(router: CommandRouter) {
         router.on<Command.Mail.List> { sid, _ -> handleList(sid) }
@@ -165,6 +166,7 @@ class MailHandler(
         if (recipientOnline != null) {
             recipientOnline.inbox.add(message)
             players.persistPlayer(recipientOnline.sessionId)
+            metrics.onGameEvent("mail", "sent")
             outbound.send(OutboundEvent.SendInfo(sessionId, "Mail delivered to ${recipientOnline.name}."))
             if (recipientOnline.sessionId != sessionId) {
                 outbound.send(
@@ -189,6 +191,7 @@ class MailHandler(
                 outbound.send(OutboundEvent.SendPrompt(sessionId))
                 return
             }
+            metrics.onGameEvent("mail", "sent")
             outbound.send(OutboundEvent.SendInfo(sessionId, "Mail delivered to ${compose.recipientName}."))
         }
         outbound.send(OutboundEvent.SendPrompt(sessionId))

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/PrestigeHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/PrestigeHandler.kt
@@ -17,6 +17,7 @@ class PrestigeHandler(
     private val players = ctx.players
     private val outbound = ctx.outbound
     private val gmcpEmitter = ctx.gmcpEmitter
+    private val metrics = ctx.metrics
 
     override fun register(router: CommandRouter) {
         router.on<Command.Prestige> { sid, _ -> handlePrestige(sid) }
@@ -83,6 +84,7 @@ class PrestigeHandler(
             }
 
             val result = prestigeSystem.prestige(me, maxLevel) ?: return
+            metrics.onGameEvent("prestige", "prestiged")
             val perkDesc = result.perk?.description ?: "No perk"
             val message = "You have achieved Prestige Rank ${result.newRank}! Perk: $perkDesc"
             outbound.send(

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/PuzzleHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/PuzzleHandler.kt
@@ -62,6 +62,7 @@ class PuzzleHandler(
             val result = system.attemptRiddleAnswer(sessionId, puzzle, answerText)
             when (result) {
                 is PuzzleResult.Success -> {
+                    ctx.metrics.onGameEvent("puzzle", "solved")
                     outbound.send(OutboundEvent.SendInfo(sessionId, result.message))
                     grantReward(sessionId, result.reward)
                     // Refresh room state so newly-unlocked exits, minimap, and Puzzle.List
@@ -109,6 +110,7 @@ class PuzzleHandler(
 
         when (result) {
             is PuzzleResult.Success -> {
+                ctx.metrics.onGameEvent("puzzle", "solved")
                 outbound.send(OutboundEvent.SendInfo(sessionId, result.message))
                 grantReward(sessionId, result.reward)
                 // Refresh room state so newly-unlocked exits and Puzzle.List reach the client.

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/StylistHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/StylistHandler.kt
@@ -27,6 +27,7 @@ class StylistHandler(
     private val outbound = ctx.outbound
     private val gmcpEmitter = ctx.gmcpEmitter
     private val raceRegistry = ctx.raceRegistry
+    private val metrics = ctx.metrics
 
     override fun register(router: CommandRouter) {
         router.on<Command.Stylist.List> { sid, _ -> handleList(sid) }
@@ -120,6 +121,7 @@ class StylistHandler(
         markVitalsDirty?.invoke(sessionId)
         markStatsDirty?.invoke(sessionId)
 
+        metrics.onGameEvent("stylist", "race_change")
         outbound.send(
             OutboundEvent.SendInfo(
                 sessionId,

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/TradeHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/TradeHandler.kt
@@ -21,6 +21,7 @@ class TradeHandler(
     private val items = ctx.items
     private val outbound = ctx.outbound
     private val gmcpEmitter = ctx.gmcpEmitter
+    private val metrics = ctx.metrics
 
     override fun register(router: CommandRouter) {
         router.on<Command.TradeRequest> { sid, cmd -> handleTradeRequest(sid, cmd) }
@@ -224,6 +225,8 @@ class TradeHandler(
             }
             is TradeResult.Success -> { /* fall through to summary */ }
         }
+
+        metrics.onGameEvent("trade", "completed")
 
         // Build summary
         val initItemNames = session.initiatorItems.joinToString(", ") { it.item.displayName }.ifEmpty { "nothing" }

--- a/src/main/kotlin/dev/ambon/engine/events/LoginFlowHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/LoginFlowHandler.kt
@@ -519,6 +519,7 @@ internal class LoginFlowHandler(
                 )
                 when (createResult) {
                     dev.ambon.engine.CreateResult.Ok -> {
+                        metrics.onGameEvent("demo", "created")
                         outbound.send(
                             OutboundEvent.SendInfo(
                                 sid,

--- a/src/main/kotlin/dev/ambon/metrics/GameMetrics.kt
+++ b/src/main/kotlin/dev/ambon/metrics/GameMetrics.kt
@@ -231,6 +231,23 @@ class GameMetrics(
     private val schedulerActionsDroppedCounter =
         Counter.builder("scheduler_actions_dropped_total").register(registry)
 
+    /**
+     * Pre-registered gameplay event counters — bounded cardinality, one per
+     * (system, event) pair in [KNOWN_GAME_EVENTS]. Covers the systems added
+     * after the original dashboard setup (auction, tavern, bank, trade, duel,
+     * crafting, dungeons, housing, pets, prestige, puzzles, demo accounts).
+     */
+    private val gameEventCounters: Map<Pair<String, String>, Counter> =
+        KNOWN_GAME_EVENTS
+            .flatMap { (system, events) -> events.map { system to it } }
+            .associateWith { (system, event) ->
+                Counter
+                    .builder("game_events_total")
+                    .tag("system", system)
+                    .tag("event", event)
+                    .register(registry)
+            }
+
     private val xpAwardedKillCounter =
         Counter.builder("xp_awarded_total").tag("source", "kill").register(registry)
     private val xpAwardedQuestCounter =
@@ -378,6 +395,25 @@ class GameMetrics(
 
     fun onLevelUp() = levelUpsCounter.increment()
 
+    /**
+     * Increments `game_events_total{system, event}`. Only pairs declared in
+     * [KNOWN_GAME_EVENTS] are accepted — unknown pairs are logged and dropped
+     * to prevent metric cardinality explosion (same contract as
+     * [recordTickPhase]).
+     */
+    fun onGameEvent(
+        system: String,
+        event: String,
+        count: Long = 1L,
+    ) {
+        val counter = gameEventCounters[system to event]
+        if (counter == null) {
+            log.warn { "Unknown game event '$system/$event' — dropping metric to prevent cardinality explosion" }
+            return
+        }
+        counter.increment(count.toDouble())
+    }
+
     fun onPlayerDeath() = playerDeathsCounter.increment()
 
     fun onPlayerSave() = playerSavesCounter.increment()
@@ -451,6 +487,14 @@ class GameMetrics(
         Gauge.builder("players_online") { supplier().toDouble() }.register(registry)
     }
 
+    /**
+     * Online players still on an unclaimed demo character (#1226). Together
+     * with `players_online` this splits traffic into demo vs registered.
+     */
+    fun bindDemoPlayersOnline(supplier: () -> Int) {
+        Gauge.builder("demo_players_online") { supplier().toDouble() }.register(registry)
+    }
+
     fun bindMobRegistry(supplier: () -> Int) {
         Gauge.builder("mobs_alive") { supplier().toDouble() }.register(registry)
     }
@@ -512,6 +556,30 @@ class GameMetrics(
             "simulation",
             "gmcp_flush",
             "outbound_flush",
+        )
+
+        /**
+         * Pre-registered (system → events) pairs accepted by [onGameEvent].
+         * Add new systems/events here — anything else is dropped at runtime.
+         */
+        val KNOWN_GAME_EVENTS: Map<String, Set<String>> = mapOf(
+            "demo" to setOf("created", "claimed"),
+            "quest" to setOf("accepted", "completed", "abandoned"),
+            "crafting" to setOf("craft", "gather", "enchant"),
+            "auction" to setOf("listed", "sold", "cancelled"),
+            "tavern" to setOf("lottery_ticket", "gamble", "gamble_win"),
+            "bank" to setOf("deposit_gold", "withdraw_gold", "deposit_item", "withdraw_item"),
+            "trade" to setOf("completed"),
+            "duel" to setOf("started", "completed"),
+            "dungeon" to setOf("entered", "completed"),
+            "puzzle" to setOf("solved"),
+            "housing" to setOf("purchased", "expanded"),
+            "stylist" to setOf("race_change"),
+            "prestige" to setOf("prestiged"),
+            "pet" to setOf("summoned"),
+            "guild" to setOf("created"),
+            "mail" to setOf("sent"),
+            "ability" to setOf("cast"),
         )
 
         fun noop(): GameMetrics = GameMetrics(SimpleMeterRegistry(), bindJvmMetrics = false)

--- a/src/test/kotlin/dev/ambon/metrics/GameMetricsTest.kt
+++ b/src/test/kotlin/dev/ambon/metrics/GameMetricsTest.kt
@@ -290,4 +290,50 @@ class GameMetricsTest {
         val timer = registry.get("outbound_event_queue_age_seconds").timer()
         assertEquals(2L, timer.count())
     }
+
+    @Test
+    fun `onGameEvent increments the tagged counter`() {
+        metrics.onGameEvent("demo", "created")
+        metrics.onGameEvent("demo", "created")
+        metrics.onGameEvent("demo", "claimed")
+        metrics.onGameEvent("tavern", "lottery_ticket", count = 5L)
+
+        assertEquals(2.0, registry.counter("game_events_total", "system", "demo", "event", "created").count())
+        assertEquals(1.0, registry.counter("game_events_total", "system", "demo", "event", "claimed").count())
+        assertEquals(5.0, registry.counter("game_events_total", "system", "tavern", "event", "lottery_ticket").count())
+    }
+
+    @Test
+    fun `onGameEvent drops unknown pairs to bound cardinality`() {
+        metrics.onGameEvent("demo", "nonsense")
+        metrics.onGameEvent("nonsense", "created")
+
+        // No counter is created for unknown pairs — only the pre-registered
+        // whitelist exists, all still at zero except what tests above touched.
+        val unknown = registry.find("game_events_total").tag("system", "nonsense").counter()
+        assertEquals(null, unknown)
+    }
+
+    @Test
+    fun `every whitelisted game event pair is pre-registered`() {
+        for ((system, events) in GameMetrics.KNOWN_GAME_EVENTS) {
+            for (event in events) {
+                metrics.onGameEvent(system, event)
+                assertEquals(
+                    1.0,
+                    registry.counter("game_events_total", "system", system, "event", event).count(),
+                    "expected pre-registered counter for $system/$event",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `demo players gauge reflects supplier`() {
+        var demoCount = 3
+        metrics.bindDemoPlayersOnline { demoCount }
+        assertEquals(3.0, registry.get("demo_players_online").gauge().value())
+        demoCount = 1
+        assertEquals(1.0, registry.get("demo_players_online").gauge().value())
+    }
 }


### PR DESCRIPTION
Closes #1226, plus the two related asks: a metrics audit covering everything added since the original Grafana setup, and public read-only dashboards.

## Metrics audit

The gameplay metrics were frozen at initial-setup vintage — XP, level-ups, deaths, combat ticks, mobs, zones. **Nothing** for auction, lottery, gambling, trade, duels, bank, crafting, enchanting, dungeons, housing, pets, prestige, puzzles, guilds, mail, or demo accounts.

## New instrumentation (commit 1)

One bounded-cardinality counter family — `game_events_total{system, event}` — using the same whitelist pattern as `KNOWN_TICK_PHASES` (unknown pairs are logged and dropped, all whitelisted pairs pre-registered so they exist at scrape time even at zero). Wired at the success point of each system:

| system | events |
|---|---|
| **demo** (#1226) | created, claimed |
| quest | accepted, completed, abandoned |
| crafting | craft, gather, enchant |
| auction | listed, sold, cancelled |
| tavern | lottery_ticket (by count), gamble, gamble_win |
| bank | deposit_gold, withdraw_gold, deposit_item, withdraw_item |
| trade / duel / dungeon | completed / started+completed / entered+completed |
| puzzle / housing / stylist / prestige / pet / guild / mail / ability | solved / purchased+expanded / race_change / prestiged / summoned / created / sent / cast |

Plus **`demo_players_online`** — online players with no `playerId`, i.e. unclaimed demo characters — so `players_online` splits into demo vs registered traffic.

Plumbing: `EngineContext` gains a `metrics` field (defaults to `GameMetrics.noop()`, so no test harness changes); GameEngine wires the callback-based systems; `QuestSystem` gains `onQuestAccepted`/`onQuestAbandoned` hooks in its existing callback style. Tests cover increment, count-weighted increment, unknown-pair dropping, full-whitelist pre-registration, and the demo gauge.

## Dashboards (commit 2)

`ambon_gameplay.json` gains: **Demo Players Online / Demo Created (24h) / Demo Claimed (24h)** stats, and six hourly timeseries — demo, quest, economy (auction/tavern/bank/trade), crafting, adventure (dungeon/duel/puzzle/ability), social & progression. Hourly `increase()` rather than per-second `rate()` because the demo's traffic rounds to zero at per-second resolution.

## Public Grafana (commit 3)

- nginx: `/grafana/` basic-auth **removed** (with an in-config comment explaining the deliberate exposure); `/prometheus/` and `/admin/` stay gated.
- The container already had anonymous Viewer enabled — but un-gating nginx would have exposed the hardcoded `GF_SECURITY_ADMIN_PASSWORD=admin` as a working login. A new `generate-grafana-env` ExecStartPre derives the admin password from the **SSM admin token** (re-running `fetch-admin-token` itself, since `secrets.env` is otherwise only written when `ambonmud.service` first starts); the `admin` fallback only applies to dev installs with no SSM parameter, where nginx isn't fronting Grafana at all.
- Hardening: sign-up disabled, `GF_EXPLORE_ENABLED=false` (anonymous = provisioned dashboards only, no ad-hoc PromQL), gravatar/analytics off.
- Local `docker-compose.yml` mirrors the anonymous-viewer settings; `DEPLOYMENT.md` documents the rationale and the SSM-shell steps to apply this to the running instance (user data only executes at first boot — **the live box needs either an instance refresh or the documented manual steps**).

## Verification

`ktlintCheck`, full `test`, `integrationTest` pass; `npx tsc --noEmit` clean on the CDK app; dashboard JSON validated.
