### PR TITLE
ci(docker): use larger ARM runner to fix Kotlin compile OOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,12 @@ jobs:
     # Build and push to ECR on every push to main after tests pass.
     # Runs on a native ARM64 runner to match the t4g.nano demo instance —
     # avoids slow QEMU emulation while producing a correct linux/arm64 image.
+    # Uses the 8-core (~32 GB) larger runner: the in-process Kotlin compiler
+    # requests a 6g heap (gradle.properties) which OOMs the standard 16 GB
+    # ubuntu-24.04-arm runner during `shadowJar`. Revisit if the heap is lowered.
     needs: [test, frontend]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-24.04-arm-8core
     outputs:
       image-tag: ${{ steps.meta.outputs.tag }}
     steps:


### PR DESCRIPTION
## Problem

The `docker` job's image build fails with:

> Not enough memory to run compilation. Try to increase it via 'gradle.properties': `kotlin.daemon.jvmargs=-Xmx<size>`

This is a **resource mismatch**, not an under-allocation. `gradle.properties` requests a 6g heap (`org.gradle.jvmargs=-Xmx6g`, `kotlin.daemon.jvmargs=-Xmx6g`) and uses `kotlin.compiler.execution.strategy=in-process`, so the Kotlin compiler runs inside the Gradle JVM and needs the full 6g during `shadowJar`. The standard `ubuntu-24.04-arm` runner (~16 GB, shared with the OS + Docker daemon) OOM-kills it.

## Fix

Move the `docker` job to `ubuntu-24.04-arm-8core` (~32 GB, 8 vCPU). Stays on **ARM** deliberately — the job builds a native `linux/arm64` image for the `t4g` demo instance, and switching to x64 would force slow QEMU emulation or a wrong-arch image.

## Tradeoff / follow-up

The larger runner is billed at a higher per-minute multiplier and the `docker` job runs on every push to `main`. The cost-free alternative is lowering the heap in `gradle.properties` (the 6g value looks like a local-dev default; the build very likely fits in 3–4g). This PR takes the runner-upgrade path to unblock the demo deploy now; lowering the heap can follow once the floor is confirmed with a capped build.