### PR TITLE
ci(docker): cap build heap at 4g instead of larger runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,12 +61,13 @@ jobs:
     # Build and push to ECR on every push to main after tests pass.
     # Runs on a native ARM64 runner to match the t4g.nano demo instance —
     # avoids slow QEMU emulation while producing a correct linux/arm64 image.
-    # Uses the 8-core (~32 GB) larger runner: the in-process Kotlin compiler
-    # requests a 6g heap (gradle.properties) which OOMs the standard 16 GB
-    # ubuntu-24.04-arm runner during `shadowJar`. Revisit if the heap is lowered.
+    # The Docker build caps the Kotlin/Gradle heap (see Dockerfile) so the
+    # in-process compiler fits this standard ~16 GB runner during `shadowJar`.
+    # Larger hosted runners aren't available on this personal account, so the
+    # heap is sized down rather than the runner sized up.
     needs: [test, frontend]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    runs-on: ubuntu-24.04-arm-8core
+    runs-on: ubuntu-24.04-arm
     outputs:
       image-tag: ${{ steps.meta.outputs.tag }}
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,15 @@ COPY src/main/proto/ src/main/proto/
 # Resolve dependencies (cached layer if build files unchanged)
 RUN chmod +x ./gradlew && ./gradlew dependencies --no-daemon -q
 
-# Copy source, inject the built frontend, then build the fat JAR
+# Copy source, inject the built frontend, then build the fat JAR.
+# Cap the Gradle launcher JVM and the in-process Kotlin compiler at 4g: the
+# repo's gradle.properties requests 6g (a local-dev default) which OOMs the
+# ~16 GB CI runner during compilation. GRADLE_OPTS overrides those values for
+# the container build only, leaving local builds untouched.
 COPY src/ src/
 COPY --from=frontend /build/src/main/resources/web-v3/ src/main/resources/web-v3/
-RUN ./gradlew shadowJar --no-daemon -x test
+RUN GRADLE_OPTS="-Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvmargs=-Xmx4g" \
+    ./gradlew shadowJar --no-daemon -x test
 
 # Stage 3: minimal JRE runtime
 FROM eclipse-temurin:21-jre AS runtime


### PR DESCRIPTION
## Why

#1236 switched the `docker` job to `ubuntu-24.04-arm-8core` to fix the Kotlin compile OOM. But **larger hosted runners aren't available on a personal (User) account** — only Team/Enterprise orgs get them. The result: the job queued for 18+ minutes and never picked up a runner (had to be cancelled).

## Fix

- Revert `runs-on` back to the free `ubuntu-24.04-arm`.
- Cap the Kotlin/Gradle heap at **4g** via `GRADLE_OPTS` in the Dockerfile builder stage. The repo's `gradle.properties` requests 6g (a local-dev default) which OOMs the ~16 GB runner during `shadowJar`. 4g fits with headroom and is above the build's real floor.
- The override is scoped to the **container build only** — local builds keep their 6g heap.

## Net effect

Same goal as #1236 (unblock the image build + demo deploy), but using a path that's actually available on this account and costs nothing.