### PR TITLE
fix(web): stop cutting off dialogue voice-over for no-choice NPCs

### DIFF
--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -567,8 +567,17 @@ function App() {
   // Audio for room music/ambient
   useEffect(() => { audio.playMusic(state.room.music ?? null); }, [state.room.music]); // eslint-disable-line react-hooks/exhaustive-deps
   useEffect(() => { audio.playAmbient(state.room.ambient ?? null); }, [state.room.ambient]); // eslint-disable-line react-hooks/exhaustive-deps
-  // Dialogue voice-over: play the current node's clip, stop when dialogue clears
-  useEffect(() => { audio.playVoice(state.dialogue?.voiceUrl ?? null); }, [state.dialogue?.voiceUrl]); // eslint-disable-line react-hooks/exhaustive-deps
+  // Dialogue voice-over: play the current node's clip as a one-shot. Deliberately
+  // does NOT stop when the dialogue clears — a short voice line should finish even
+  // when the overlay closes (conversation ended, dismissed, walked away). Otherwise
+  // ending a single-exchange conversation (e.g. clicking a terminal choice, which
+  // makes the server send Dialogue.End) cuts the clip after only its first few
+  // words. A new node's clip still supersedes the previous one via playVoice's
+  // internal stop, so mid-conversation node changes interrupt as expected.
+  useEffect(() => {
+    const url = state.dialogue?.voiceUrl ?? null;
+    if (url) audio.playVoice(url);
+  }, [state.dialogue?.voiceUrl]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Combat audio
   const hpPercent = state.vitals.maxHp > 0 ? state.vitals.hp / state.vitals.maxHp : 1;

--- a/web-v3/src/components/panels/MonsterManualPanel.tsx
+++ b/web-v3/src/components/panels/MonsterManualPanel.tsx
@@ -105,21 +105,24 @@ export function MonsterManualPanel({
     if (view === "dialog") dialogueSeenRef.current = false;
   }, [view]);
 
-  // Return to the entry when a conversation ends — whether the server sends a
-  // terminal node (no choices; show its closing line briefly) or just clears
-  // the dialogue (e.g. "Maybe later"). The initial "…" wait is ignored.
+  // Auto-return to the entry only when the conversation ends with nothing left to
+  // read — i.e. the server cleared the dialogue outright (a terminal "Maybe
+  // later"-style choice, walking away, entering combat). A terminal *node* (the
+  // NPC's final line, which has no choices) is deliberately KEPT on screen so its
+  // voice-over can play to the end and the player can read it at their own pace;
+  // they dismiss it with the Farewell button, the Entry button, or by closing the
+  // manual. Auto-closing it on a fixed timer (the old behaviour) cut the voice off
+  // after a few words and yanked dialogue-only NPCs back to the description.
   useEffect(() => {
     if (view !== "dialog") return;
-    if (dialogue) dialogueSeenRef.current = true;
-    const endedWithNode = dialogue && dialogue.choices.length === 0;
-    const endedByClear = !dialogue && dialogueSeenRef.current;
-    if (!endedWithNode && !endedByClear) return;
-    const t = window.setTimeout(() => {
-      if (dialogue) onDialogueEnd();
-      setView("info");
-    }, endedWithNode ? 1700 : 150);
+    if (dialogue) {
+      dialogueSeenRef.current = true;
+      return;
+    }
+    if (!dialogueSeenRef.current) return; // still waiting for the first node ("…")
+    const t = window.setTimeout(() => setView("info"), 150);
     return () => window.clearTimeout(t);
-  }, [view, dialogue]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [view, dialogue]);
 
   const { info, name } = monster;
   const skinned = !!bg; // a monster_manual_bg frame is registered
@@ -252,7 +255,7 @@ export function MonsterManualPanel({
               {dialogue ? (
                 <>
                   <p className="mm-dialog-text">{dialogue.text}</p>
-                  {dialogue.choices.length > 0 && (
+                  {dialogue.choices.length > 0 ? (
                     <ul className="mm-dialog-choices">
                       {dialogue.choices.map((ch) => (
                         <li key={ch.index}>
@@ -261,6 +264,16 @@ export function MonsterManualPanel({
                           </button>
                         </li>
                       ))}
+                    </ul>
+                  ) : (
+                    // Terminal node: no further choices. Let the player linger on
+                    // the line (and its voice-over) and leave on their own terms.
+                    <ul className="mm-dialog-choices">
+                      <li>
+                        <button type="button" className="mm-dialog-choice" onClick={() => { onDialogueEnd(); setView("info"); }}>
+                          Farewell.
+                        </button>
+                      </li>
                     </ul>
                   )}
                 </>


### PR DESCRIPTION
## Problem

Talking to a dialogue-only (flavor) NPC played only the **first few words** of the voice-over, then the dialogue instantly closed and snapped back to the mob description. The audible length varied slightly each time ("a word more or less"), which (correctly) suggested the audio file wasn't the issue.

## Root cause

Not the audio engine, and not a user-clicked choice. The mob's field-manual panel (`MonsterManualPanel`) had a fixed **1700ms auto-close timer**:

```tsx
const endedWithNode = dialogue && dialogue.choices.length === 0; // true for flavor NPCs
setTimeout(() => { onDialogueEnd(); setView("info"); }, endedWithNode ? 1700 : 150);
```

A dialogue-only NPC's single line is a node with **no choices**, so it was treated as "conversation over — flash briefly, then return to the entry." After ~1.7s the dialogue was cleared and the view reverted — well before the voice-over finished reading the line. The variance was just the clip's fetch/decode latency landing at different points inside that fixed window.

## Fix

- **`MonsterManualPanel.tsx`** (primary): keep a terminal (no-choice) node on screen instead of auto-closing it. The conversation has already ended server-side, so the player reads the line, hears the full voice-over, and leaves on their own terms via a new **"Farewell."** button, the **Entry** button, or by closing the manual. The 150ms auto-return now applies only when the server clears the dialogue outright (e.g. a "Maybe later" choice), where there's nothing left to display.
- **`App.tsx`** (complementary): make the dialogue voice-over a true one-shot — let it finish naturally rather than stopping the instant `dialogue` state clears. Dismissing mid-line (or walking away / entering combat) no longer cuts it; a new node's clip still supersedes the previous one.

## Testing

- `bun run lint` — clean
- `bunx tsc -b` — clean
- No existing tests covered the old timer behavior.

Manual verification against the auringold zone with real voice clips still recommended (requires the clips + a click-through).