### PR TITLE
fix(web): don't flash the login screen after token auth

### DIFF
--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -1672,8 +1672,15 @@ export function applyGmcpPackage(
     case "Session.AuthResult": {
       const packet = data as { success?: boolean; message?: string };
       if (packet.success) {
-        // Auth succeeded — server will send full state sync
+        // Auth succeeded — server will send full state sync. Clear the stale
+        // "name" login prompt left over from the initial Login.Prompt (it set
+        // both the character picker and loginPrompt). Otherwise, the instant we
+        // drop `reconnecting`, the modal gate (loginPrompt && !reconnecting &&
+        // no saved characters) briefly flashes the "Enter your name" screen
+        // until Char.Name arrives and clears it.
         ctx.setReconnecting(false);
+        ctx.setLoginPrompt(null);
+        ctx.setLoginError(null);
         ctx.pendingAuthCharRef.current = null;
       } else {
         // Auth failed — remove the stale token. The server will follow up with


### PR DESCRIPTION
## Problem

When a returning player logs in with a saved auth token, the **"DEMO / Enter your name"** login screen briefly flashes up before the game world loads.

## Root cause

A state race in the auth-token login path:

1. `Login.Prompt("name")` arrives → the handler sets **both** `savedCharacters` and `loginPrompt = {state:"name"}` → the **CharacterPicker** shows.
2. Player picks their character → `savedCharacters=[]`, `reconnecting=true` → "Reconnecting…" shows, no login UI.
3. `Session.AuthResult(success)` → `setReconnecting(false)` — but `loginPrompt` is **still** the stale `{state:"name"}` packet from step 1.
4. For the brief window until the full state sync + `Char.Name` arrives (which clears `loginPrompt`), the modal gate `loginPrompt && !reconnecting && savedCharacters.length === 0` is **true** → the LoginModal "name" screen flashes.

The resume-token path doesn't hit this because it never sets `loginPrompt`.

## Fix

Clear `loginPrompt` (and `loginError`) on `Session.AuthResult` success, so the login modal can't reappear between authentication and the full state sync. One-line behavioral change in the success branch; nothing else in the flow depends on `loginPrompt` lingering after a successful auth.

## Testing

- `bun run lint` — clean
- `bunx tsc -b` — clean

Manual verification (log in as a returning player with a remembered character and confirm no "Enter your name" flash) recommended.