### PR TITLE
feat(web): abbreviate large vitals numbers in the decorative HUD

### DIFF
--- a/web-v3/src/components/CanvasVitalsHud.tsx
+++ b/web-v3/src/components/CanvasVitalsHud.tsx
@@ -2,7 +2,7 @@ import type { ItemSummary, Vitals } from "../types";
 import type { AudioEngine } from "../hooks/useAudioEngine";
 import { AudioControls } from "./AudioControls";
 import { selectQuickPotion } from "../combat/quickPotion";
-import { percent } from "../utils";
+import { formatCompact, percent } from "../utils";
 
 interface CanvasVitalsHudProps {
   vitals: Vitals;
@@ -50,9 +50,9 @@ export function CanvasVitalsHud({ vitals, inventory, serverAssets, onCommand, au
           <div className="vskin-slot vskin-slot-mp" title={`MP: ${vitals.mana}/${vitals.maxMana}`}>
             <span className="vskin-drain" style={{ left: `${mpPct}%` }} />
           </div>
-          <span className="vskin-num vskin-num-hp">{vitals.hp}/{vitals.maxHp}</span>
-          <span className="vskin-num vskin-num-mp">{vitals.mana}/{vitals.maxMana}</span>
-          <span className="vskin-num vskin-num-gold">{vitals.gold.toLocaleString()}</span>
+          <span className="vskin-num vskin-num-hp" title={`HP: ${vitals.hp}/${vitals.maxHp}`}>{formatCompact(vitals.hp)}/{formatCompact(vitals.maxHp)}</span>
+          <span className="vskin-num vskin-num-mp" title={`MP: ${vitals.mana}/${vitals.maxMana}`}>{formatCompact(vitals.mana)}/{formatCompact(vitals.maxMana)}</span>
+          <span className="vskin-num vskin-num-gold" title={`Gold: ${vitals.gold.toLocaleString()}`}>{formatCompact(vitals.gold)}</span>
           <button
             type="button"
             className="vskin-hotspot vskin-heal"
@@ -98,7 +98,7 @@ export function CanvasVitalsHud({ vitals, inventory, serverAssets, onCommand, au
         <div className="vbar-vital-track">
           <span className="vbar-vital-fill vbar-vital-hp" style={{ width: `${percent(vitals.hp, vitals.maxHp)}%` }} />
         </div>
-        <span className="vbar-vital-text">{vitals.hp}/{vitals.maxHp}</span>
+        <span className="vbar-vital-text">{formatCompact(vitals.hp)}/{formatCompact(vitals.maxHp)}</span>
       </div>
       <button
         type="button"
@@ -116,7 +116,7 @@ export function CanvasVitalsHud({ vitals, inventory, serverAssets, onCommand, au
         <div className="vbar-vital-track">
           <span className="vbar-vital-fill vbar-vital-mp" style={{ width: `${percent(vitals.mana, vitals.maxMana)}%` }} />
         </div>
-        <span className="vbar-vital-text">{vitals.mana}/{vitals.maxMana}</span>
+        <span className="vbar-vital-text">{formatCompact(vitals.mana)}/{formatCompact(vitals.maxMana)}</span>
       </div>
       <button
         type="button"
@@ -129,9 +129,9 @@ export function CanvasVitalsHud({ vitals, inventory, serverAssets, onCommand, au
         <span className="vbar-quick-potion-icon" aria-hidden="true">+</span>
         <span className="vbar-quick-potion-label">Mana</span>
       </button>
-      <div className="vbar-gold">
+      <div className="vbar-gold" title={`Gold: ${vitals.gold.toLocaleString()}`}>
         <span className="vbar-gold-coin" />
-        <span className="vbar-gold-text">{vitals.gold.toLocaleString()}</span>
+        <span className="vbar-gold-text">{formatCompact(vitals.gold)}</span>
       </div>
       <AudioControls audio={audio} />
     </div>

--- a/web-v3/src/utils.ts
+++ b/web-v3/src/utils.ts
@@ -9,6 +9,35 @@ export function percent(current: number, max: number): number {
   return Math.max(0, Math.min(100, Math.round((current / max) * 100)));
 }
 
+/**
+ * Abbreviate a large number for compact, decorative display: 850 → "850",
+ * 1800 → "1.8K", 1_825_461 → "1.8M", 1_000_000 → "1M", 3_100_000_000 → "3.1B".
+ * One decimal is kept only when the scaled value is under 10 (so "1.8M" but
+ * "601K"), and a trailing ".0" is dropped ("1M", not "1.0M"). Exact values are
+ * still surfaced elsewhere (combat bar, score, character panel) and on hover.
+ */
+export function formatCompact(value: number): string {
+  if (!Number.isFinite(value)) return "0";
+  const abs = Math.abs(value);
+  if (abs < 1000) return String(Math.round(value));
+  const units: Array<[number, string]> = [
+    [1e9, "B"],
+    [1e6, "M"],
+    [1e3, "K"],
+  ];
+  for (const [factor, suffix] of units) {
+    if (abs >= factor) {
+      const scaled = value / factor;
+      const text =
+        Math.abs(scaled) < 10
+          ? scaled.toFixed(1).replace(/\.0$/, "")
+          : String(Math.round(scaled));
+      return text + suffix;
+    }
+  }
+  return String(Math.round(value));
+}
+
 export function titleCaseWords(value: string): string {
   return value
     .split(/[\s_-]+/)


### PR DESCRIPTION
## Problem

At high levels the ornate top HUD overflowed with raw values — e.g. `1825461/1825461` for HP and `3129992/3129992` for mana — which spill out of the carved slots.

## Change

Format HP / Mana / Gold in the decorative HUD as compact magnitudes:

| Raw | Shown |
|-----|-------|
| 1,825,461 | **1.8M** |
| 3,129,992 | **3.1M** |
| 1,000,000 | **1M** |
| 600,539 | **601K** |
| 1,800 | **1.8K** |

- New `formatCompact()` in `utils.ts`: `x` / `xK` / `xM` / `xB`. One decimal only when the scaled value is under 10 (so `1.8M` but `601K`), and a trailing `.0` is dropped (`1M`, not `1.0M`).
- Applied in `CanvasVitalsHud` for HP / Mana / Gold across both the skinned bar and its unskinned fallback. **Exact values are preserved on the hover `title`** of each number.

The decorative bar doesn't need exact figures — those remain in full in the combat bar, score, and character panel, as before.

## Testing

- `bun run lint` — clean
- `bunx tsc -b` — clean
- Spot-checked `formatCompact` across `0, 850, 1.8K, 12K, 601K, 1M, 1.8M, 3.1M, 9.9M, 3.1B`.

No tests added — `web-v3` has no test suite yet, so this avoids introducing the first-ever test file in a small QoL change.