### PR TITLE
feat(web): make mob dialogue/quest indicators deep-link to the manual

### DIFF
--- a/web-v3/src/canvas/scenes/WorldScene.ts
+++ b/web-v3/src/canvas/scenes/WorldScene.ts
@@ -134,6 +134,10 @@ export class WorldScene {
   private questAvailableIcons: Map<string, Sprite> = new Map();
   private questCompleteTexture: Texture | null = null;
   private questCompleteIcons: Map<string, Sprite> = new Map();
+  // Representative mob data (rep id → fields needed to open the field manual),
+  // so a click on a floating dialogue/quest indicator can build the same panel
+  // entry as a click on the mob sprite. Rebuilt alongside the mob sprites.
+  private mobDataById = new Map<string, { id: string; name: string; description?: string; image?: string | null; video?: string | null }>();
 
   private shopBadge: Container;
   private shopSprite: Sprite | null = null;
@@ -1809,6 +1813,7 @@ export class WorldScene {
     }
     this.questCompleteIcons.clear();
     this.mobSprites.clear();
+    this.mobDataById.clear();
 
     // Group mobs by templateKey — every spawn of the same template renders
     // as a single sprite with a "(N)" count suffix. Two mobs that share a
@@ -1868,25 +1873,7 @@ export class WorldScene {
           canvasCallbacks.onTargetSelected?.(mobData.name);
           return;
         }
-        const info = gameStateRef.current.mobInfo.find((m) => m.id === mobData.id) ?? null;
-        const isStaff = gameStateRef.current.character.isStaff;
-        // Attackable only for true combatants (role COMBAT). Vendors, quest-givers,
-        // dialog NPCs and props are not — props get neither Attack nor a threat
-        // line. Absent info defaults to attackable (legacy mobs are COMBAT).
-        const canAttack = info ? info.combatant : true;
-        canvasCallbacks.openMonsterManual?.({
-          id: mobData.id,
-          name: mobData.name,
-          description: mobData.description ?? null,
-          image: mobData.image ?? null,
-          video: mobData.video ?? null,
-          level: info?.level ?? null,
-          info,
-          isStaff,
-          canAttack,
-        });
-        // Auto-fetch the threat assessment so the manual fills in its stats.
-        if (canAttack) canvasCallbacks.sendCommand?.(`consider ${mobData.name}`);
+        this.openMobManual(mobData.id);
       });
 
       this.container.addChild(sprite);
@@ -1894,6 +1881,7 @@ export class WorldScene {
       this.container.addChild(label);
       this.container.addChild(hitArea);
       this.mobSprites.set(groupKey, { sprite, label, labelBg, hitArea, name: mob.name, count, ids });
+      this.mobDataById.set(mob.id, mob);
     }
   }
 
@@ -2548,7 +2536,13 @@ export class WorldScene {
     if (!icon) {
       icon = new Sprite(this.dialogueTexture);
       icon.anchor.set(0.5);
-      icon.eventMode = "none";
+      // Clickable: jump straight to the dialogue subpanel of the field manual.
+      icon.eventMode = "static";
+      icon.cursor = "pointer";
+      icon.on("pointerdown", (e) => {
+        e.stopPropagation();
+        this.openMobManual(mobId, "talk");
+      });
       this.dialogueIcons.set(mobId, icon);
       this.container.addChild(icon);
     }
@@ -2601,7 +2595,13 @@ export class WorldScene {
     if (!icon) {
       icon = new Sprite(texture);
       icon.anchor.set(0.5);
-      icon.eventMode = "none";
+      // Clickable: jump straight to the quest subpanel of the field manual.
+      icon.eventMode = "static";
+      icon.cursor = "pointer";
+      icon.on("pointerdown", (e) => {
+        e.stopPropagation();
+        this.openMobManual(mobId, "quest");
+      });
       map.set(mobId, icon);
       this.container.addChild(icon);
     }
@@ -2610,6 +2610,36 @@ export class WorldScene {
     icon.height = size;
     icon.x = cx;
     icon.y = cy - mobSize / 2 - size / 2 - 4;
+  }
+
+  /**
+   * Open the field manual for a mob, optionally deep-linking to a subpanel.
+   * Shared by the mob sprite (plain info view) and its floating dialogue/quest
+   * indicators ("talk"/"quest" intents), so all three build an identical entry.
+   */
+  private openMobManual(repId: string, intent?: "talk" | "quest") {
+    const mob = this.mobDataById.get(repId);
+    if (!mob) return;
+    const info = gameStateRef.current.mobInfo.find((m) => m.id === repId) ?? null;
+    const isStaff = gameStateRef.current.character.isStaff;
+    // Attackable only for true combatants (role COMBAT). Vendors, quest-givers,
+    // dialog NPCs and props are not. Absent info defaults to attackable
+    // (legacy mobs are COMBAT).
+    const canAttack = info ? info.combatant : true;
+    canvasCallbacks.openMonsterManual?.({
+      id: mob.id,
+      name: mob.name,
+      description: mob.description ?? null,
+      image: mob.image ?? null,
+      video: mob.video ?? null,
+      level: info?.level ?? null,
+      info,
+      isStaff,
+      canAttack,
+      intent,
+    });
+    // Auto-fetch the threat assessment so the manual fills in its stats.
+    if (canAttack) canvasCallbacks.sendCommand?.(`consider ${mob.name}`);
   }
 
   private pruneIcons(map: Map<string, Sprite>, active: Set<string>) {

--- a/web-v3/src/components/panels/MonsterManualPanel.tsx
+++ b/web-v3/src/components/panels/MonsterManualPanel.tsx
@@ -77,10 +77,31 @@ export function MonsterManualPanel({
   onShop,
   onVideo,
 }: MonsterManualPanelProps) {
-  const [view, setView] = useState<ManualView>("info");
+  // Deep-link: clicking a creature's floating indicator opens the manual
+  // straight to the matching subpanel (dialogue → Talk, quest → Quest). The
+  // panel is keyed by creature id in App, so this lazy initializer runs fresh
+  // per creature and there's no flash of the info page first.
+  const [view, setView] = useState<ManualView>(() =>
+    monster.intent === "talk" ? "dialog" : monster.intent === "quest" ? "quest" : "info",
+  );
   // Tracks whether the current conversation has produced any node yet, so the
   // initial "…" wait isn't mistaken for the conversation having ended.
   const dialogueSeenRef = useRef(false);
+
+  // Fire the matching fetch when deep-linked from an indicator. The initial
+  // `view` (above) already shows the right subpanel; the setView calls here
+  // also cover the rare case where the same creature's intent changes without
+  // a remount.
+  useEffect(() => {
+    if (monster.intent === "talk") {
+      onCommand(`talk ${monster.name}`);
+      setView("dialog");
+    } else if (monster.intent === "quest") {
+      onQuest(monster.name);
+      setView("quest");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [monster.id, monster.intent]);
 
   // Closing mid-conversation should also end the dialogue (so the in-canvas
   // overlay doesn't resurface once the manual is gone).

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -487,6 +487,12 @@ export interface MonsterEntry {
   isStaff: boolean;
   /** Whether an Attack button + threat assessment apply (false for pets). */
   canAttack: boolean;
+  /**
+   * Deep-link the manual straight to a subpanel when opened from one of the
+   * creature's floating indicators: "talk" → dialogue view, "quest" → quest
+   * view. Undefined (a plain click) opens the info page.
+   */
+  intent?: "talk" | "quest";
 }
 
 /** A clicked room item, surfaced in the parchment item card (analogous to the


### PR DESCRIPTION
## Idea

Clicking a creature opens its field manual on the **info** page. This makes the floating indicators above a creature into clickable shortcuts:

- **Dialogue bubble** → opens the manual straight to the **Talk** view and starts the conversation.
- **Quest marker** (available or complete) → opens the manual straight to the **Quest** view.
- Clicking the creature body itself is unchanged (info page).

So the flow in the screenshots — click creature → info manual, but click the speech-bubble indicator → jump right into the dialogue — now works in one click.

## Changes

- **`WorldScene.ts`**
  - The dialogue and quest indicator sprites become interactive (`eventMode: "static"`, pointer cursor).
  - A pointerdown on an indicator routes through a new shared `openMobManual(repId, intent?)` that builds the **same** panel entry a mob-sprite click builds (resolved via a new rep-id → mob-data map). It opens the manual with a `"talk"` or `"quest"` intent and `stopPropagation()`s so it never doubles as a body click.
  - The mob sprite's own handler now calls the same helper (no behavior change — just deduped).
- **`MonsterManualPanel.tsx`** — honors the new `MonsterEntry.intent`: the `view` lazy-initializer opens the requested subpanel directly (no flash of the info page, since the panel is keyed per-creature and remounts), and an effect fires the matching fetch (`talk` / `qoffers`).
- **`types.ts`** — optional `intent?: "talk" | "quest"` on `MonsterEntry`.

Aggro indicators stay non-interactive (out of scope).

## Testing

- `bun run lint` — clean
- `bunx tsc -b` — clean
- `bun run build` — succeeds

Worth a manual click-through: open a creature with a dialogue bubble and one with a quest marker, confirm each indicator deep-links to the right subpanel and that clicking the creature body still lands on the info page.