### PR TITLE
feat(web): add a canvas badge for readable signs

### DIFF
--- a/web-v3/src/canvas/scenes/WorldScene.ts
+++ b/web-v3/src/canvas/scenes/WorldScene.ts
@@ -278,6 +278,14 @@ export class WorldScene {
   private leverVisible = false;
   private leverCount = 0;
 
+  private signBadge: Container | null = null;
+  private signSprite: Sprite | null = null;
+  private signLabel: Text | null = null;
+  private signLabelBg = new Graphics();
+  private signHitArea = new Graphics();
+  private signVisible = false;
+  private signCount = 0;
+
   private lastMobsKey = "";
   private lastPetsKey = "";
   private lastItemsKey = "";
@@ -801,6 +809,35 @@ export class WorldScene {
     this.leverBadge.addChild(this.leverLabelBg);
     this.leverBadge.addChild(this.leverLabel);
 
+    // Sign badge — readable placard/sign quick access
+    this.signBadge = new Container();
+    this.signBadge.visible = false;
+    this.signBadge.eventMode = "static";
+    this.signBadge.cursor = "pointer";
+    this.signBadge.on("pointerdown", () => {
+      canvasCallbacks.openFeatures?.("sign");
+    });
+    this.signBadge.on("pointerover", () => {
+      if (this.signSprite) this.signSprite.alpha = 1;
+    });
+    this.signBadge.on("pointerout", () => {
+      if (this.signSprite) this.signSprite.alpha = 0.85;
+    });
+    this.signHitArea.rect(-hs / 2, -hs / 2, hs, hs + 20);
+    this.signHitArea.fill({ color: 0x000000, alpha: 0.001 });
+    this.signHitArea.eventMode = "auto";
+    this.signBadge.addChild(this.signHitArea);
+    this.signLabel = new Text({
+      text: "Sign",
+      style: { fontFamily: "JetBrains Mono, Cascadia Mono, monospace", fontSize: 11, fill: "#cdbd9a", dropShadow: { color: 0x000000, alpha: 1, blur: 4, distance: 0 } },
+    });
+    this.signLabel.anchor.set(0.5, 0);
+    this.signLabel.y = hs / 2 + 2;
+    this.signLabel.eventMode = "none";
+    this.signLabelBg.eventMode = "none";
+    this.signBadge.addChild(this.signLabelBg);
+    this.signBadge.addChild(this.signLabel);
+
     // Recall button
     this.recallBtn = this.buildActionButton("Recall", 0xb9aed8, 0x2a2845, () => {
       canvasCallbacks.sendCommand?.("recall");
@@ -838,6 +875,7 @@ export class WorldScene {
     this.container.addChild(this.doorBadge!);
     this.container.addChild(this.containerBadge!);
     this.container.addChild(this.leverBadge!);
+    this.container.addChild(this.signBadge!);
     this.container.addChild(this.recallBtn);
     this.container.addChild(this.departBtn);
     this.container.addChild(this.backdropHit);
@@ -889,6 +927,7 @@ export class WorldScene {
       this.loadDoorIcon();
       this.loadContainerIcon();
       this.loadLeverIcon();
+      this.loadSignIcon();
       this.loadDialogueTexture();
       this.loadAggroTexture();
       this.loadQuestTextures();
@@ -1160,6 +1199,15 @@ export class WorldScene {
       if (this.leverLabel) this.leverLabel.text = featureCountLabel(leverCount, "Lever", "Levers");
     }
 
+    const signCount = state.roomFeatures.filter((feature) => feature.type === "sign").length;
+    const hasSigns = signCount > 0;
+    if (hasSigns !== this.signVisible || signCount !== this.signCount) {
+      this.signVisible = hasSigns;
+      this.signCount = signCount;
+      if (this.signBadge) this.signBadge.visible = hasSigns;
+      if (this.signLabel) this.signLabel.text = featureCountLabel(signCount, "Sign", "Signs");
+    }
+
     // Recall button visibility — show when logged in and not in combat
     const loggedIn = state.character.name !== "-";
     const showRecall = loggedIn && !state.vitals.inCombat;
@@ -1241,6 +1289,7 @@ export class WorldScene {
     if (this.doorBadge) this.doorBadge.visible = this.doorVisible && !stripMode;
     if (this.containerBadge) this.containerBadge.visible = this.containerVisible && !stripMode;
     if (this.leverBadge) this.leverBadge.visible = this.leverVisible && !stripMode;
+    if (this.signBadge) this.signBadge.visible = this.signVisible && !stripMode;
     this.recallBtn.visible = this.recallBtn.visible && !stripMode;
     this.departBtn.visible = this.departBtn.visible && !stripMode;
 
@@ -1498,7 +1547,7 @@ export class WorldScene {
       this.mailBadge?.visible,
       this.duelBadge?.visible, this.puzzleBadge?.visible,
       this.doorBadge?.visible, this.containerBadge?.visible,
-      this.leverBadge?.visible,
+      this.leverBadge?.visible, this.signBadge?.visible,
     ].filter(Boolean).length;
     const availableHeight = h * 0.58; // from 35% to ~93% of viewport
     // Minimum spacing must clear the full badge footprint (icon + label pill + gap)
@@ -1626,6 +1675,13 @@ export class WorldScene {
       this.leverBadge.x = badgeX;
       this.leverBadge.y = badgeStartY + badgeSlot * badgeSpacing;
       drawLabelPill(this.leverLabelBg, this.leverLabel!);
+      badgeSlot++;
+    }
+
+    if (this.signBadge?.visible) {
+      this.signBadge.x = badgeX;
+      this.signBadge.y = badgeStartY + badgeSlot * badgeSpacing;
+      drawLabelPill(this.signLabelBg, this.signLabel!);
       badgeSlot++;
     }
 
@@ -2521,6 +2577,22 @@ export class WorldScene {
       sprite.eventMode = "none";
       this.leverSprite = sprite;
       this.leverBadge?.addChild(sprite);
+    } catch {
+      // Fallback: text-only label still works
+    }
+  }
+
+  private async loadSignIcon() {
+    try {
+      const texture = await Assets.load(assetUrl("feature_sign", "feature_sign.png"));
+      const sprite = new Sprite(texture);
+      sprite.width = SHOP_BADGE_SIZE;
+      sprite.height = SHOP_BADGE_SIZE;
+      sprite.anchor.set(0.5);
+      sprite.alpha = 0.85;
+      sprite.eventMode = "none";
+      this.signSprite = sprite;
+      this.signBadge?.addChild(sprite);
     } catch {
       // Fallback: text-only label still works
     }

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -3,7 +3,7 @@ export type SystemPanelView = "dungeon" | "duel" | "lottery" | "pet" | "prestige
 export type ChatChannel = "say" | "tell" | "gossip" | "shout" | "ooc" | "gtell" | "gchat";
 export type SocialTab = "chat" | "friends" | "guild" | "group" | "who";
 export type RoomFeatureType = "door" | "container" | "lever" | "sign";
-export type FeaturePopoutFocus = Exclude<RoomFeatureType, "sign"> | null;
+export type FeaturePopoutFocus = RoomFeatureType | null;
 
 export interface WorldTime {
   period: string;


### PR DESCRIPTION
## Problem

Rooms can expose **sign/placard** features (`Room.Features` type `"sign"`), and the features popout already fully supports them (a Signs tab with the sign text + a Read action). But the canvas only rendered **door / container / lever** badges — so a sign was effectively invisible unless the room *also* had another feature whose badge happened to open the popout.

In the screenshot room ("The Cabinet of Curiosities"), the description calls out "a softly glowing placard that very much wants to be read," but only the Container and Lever badges appear on the canvas.

## Fix

Add a dedicated **Sign(s)** badge to the left kiosk column, mirroring the existing lever/container badges:

- Appears whenever the room has one or more `sign` features.
- Opens the features popout focused on the **Signs** tab (text + Read already render there).
- Falls back to a text-only label if the optional `feature_sign` art isn't registered, exactly like the other feature badges.

### Changes
- **`WorldScene.ts`** — sign badge wiring: fields, constructor block, scene attach, `loadSignIcon()` loader, visibility driven by the sign feature count, strip-mode handling, and a kiosk-column layout slot.
- **`types.ts`** — widen `FeaturePopoutFocus` to include `"sign"`. It was previously `Exclude<RoomFeatureType, "sign">` only because nothing could focus the Signs tab; now the badge can deep-link to it.

## Testing

- `bun run lint` — clean
- `bunx tsc -b` — clean

Manual check recommended: enter a room with a sign feature and confirm the Sign badge appears and opens the popout on the Signs tab.