### PR TITLE
feat: lever art (custom + global defaults) and richer world-feature feedback

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -3036,6 +3036,11 @@ data class ImagesConfig(
             "feature_door" to "global_assets/feature_door.png",
             "feature_container" to "global_assets/feature_container.png",
             "feature_lever" to "global_assets/feature_lever.png",
+            // Server-wide default lever art (plate + rotating handle). Used for levers
+            // that don't author their own plateImage/handleImage; falls back further to
+            // the built-in vector lever when these aren't present either.
+            "lever_plate" to "global_assets/lever_plate.png",
+            "lever_handle" to "global_assets/lever_handle.png",
             "dialog_indicator" to "global_assets/dialog_indicator.png",
             "aggro_indicator" to "global_assets/aggro_indicator.png",
             "quest_available_indicator" to "global_assets/quest_available_indicator.png",

--- a/src/main/kotlin/dev/ambon/domain/world/RoomFeature.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/RoomFeature.kt
@@ -56,7 +56,25 @@ sealed class RoomFeature {
         val resetWithZone: Boolean,
         /** Seconds out of [initialState] before the lever snaps back. Null = zone reset only. */
         val respawnSeconds: Long? = null,
+        /**
+         * Optional custom artwork: a static base plate plus a handle that rotates
+         * around [leverPivot] between [upAngle] and [downAngle]. Image refs are
+         * content-addressed filenames resolved against the world image base, like
+         * room/mob/item art. When [handleImage] is absent the client renders its
+         * built-in vector lever (full backward compatibility).
+         */
+        val plateImage: String? = null,
+        val handleImage: String? = null,
+        val leverPivot: LeverPivot? = null,
+        val upAngle: Double? = null,
+        val downAngle: Double? = null,
     ) : RoomFeature()
+
+    /** Handle pivot as fractions (0..1) of the handle sprite box. */
+    data class LeverPivot(
+        val x: Double,
+        val y: Double,
+    )
 
     data class Sign(
         override val id: String,

--- a/src/main/kotlin/dev/ambon/domain/world/data/FeatureFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/FeatureFile.kt
@@ -23,4 +23,20 @@ data class FeatureFile(
     val items: List<String> = emptyList(),
     /** Text content. Only applies to SIGN type. */
     val text: String? = null,
+    /** Static base-plate art (content-addressed filename), drawn behind the handle. LEVER only. */
+    val plateImage: String? = null,
+    /** Rotating handle art (content-addressed filename), neutral upright pose. LEVER only. */
+    val handleImage: String? = null,
+    /** Handle pivot as a fraction of the handle sprite. LEVER only. Defaults to {0.5, 0.85}. */
+    val leverPivot: LeverPivotFile? = null,
+    /** Handle rotation in degrees when state = up. LEVER only. Default -28. */
+    val upAngle: Double? = null,
+    /** Handle rotation in degrees when state = down. LEVER only. Default 28. */
+    val downAngle: Double? = null,
+)
+
+/** Handle pivot as fractions (0..1) of the handle sprite box. */
+data class LeverPivotFile(
+    val x: Double = 0.5,
+    val y: Double = 0.85,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -329,7 +329,7 @@ object WorldLoader {
                 val featList = allRoomFeatures.getOrPut(fromId) { mutableListOf() }
                 for ((featLocalId, ff) in rf.features) {
                     val featId = "${fromId.value}/$featLocalId"
-                    featList.add(parseFeatureFile(featId, fromId, zone, ff))
+                    featList.add(parseFeatureFile(featId, fromId, zone, ff, imagesBase))
                 }
             }
 
@@ -1541,6 +1541,7 @@ object WorldLoader {
         roomId: RoomId,
         zone: String,
         ff: FeatureFile,
+        imagesBase: String,
     ): RoomFeature {
         val type = ff.type.trim().uppercase()
         val displayName = requireNonBlank(ff.displayName) {
@@ -1590,6 +1591,13 @@ object WorldLoader {
                     initialState = initialState,
                     resetWithZone = ff.resetWithZone,
                     respawnSeconds = respawnSeconds,
+                    // Optional custom art. Image refs are content-addressed filenames
+                    // resolved against the world image base, exactly like room/mob/item art.
+                    plateImage = ff.plateImage?.trim()?.takeUnless { it.isEmpty() }?.let { "$imagesBase$it" },
+                    handleImage = ff.handleImage?.trim()?.takeUnless { it.isEmpty() }?.let { "$imagesBase$it" },
+                    leverPivot = ff.leverPivot?.let { RoomFeature.LeverPivot(it.x, it.y) },
+                    upAngle = ff.upAngle,
+                    downAngle = ff.downAngle,
                 )
             }
             "SIGN" -> {

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -3133,6 +3133,17 @@ class GmcpEmitter(
         val locked: Boolean? = null,
         val keyRequired: Boolean? = null,
         val text: String? = null,
+        // Optional custom lever art (static per-lever; rides along with the feature).
+        val plateImage: String? = null,
+        val handleImage: String? = null,
+        val leverPivot: LeverPivotPayload? = null,
+        val upAngle: Double? = null,
+        val downAngle: Double? = null,
+    )
+
+    data class LeverPivotPayload(
+        val x: Double,
+        val y: Double,
     )
 
     data class ContainerItemPayload(

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -593,6 +593,11 @@ internal fun buildFeaturePayload(
             keyword = feature.keyword,
             type = "lever",
             state = state.name.lowercase(),
+            plateImage = feature.plateImage,
+            handleImage = feature.handleImage,
+            leverPivot = feature.leverPivot?.let { GmcpEmitter.LeverPivotPayload(it.x, it.y) },
+            upAngle = feature.upAngle,
+            downAngle = feature.downAngle,
         )
     }
     is RoomFeature.Sign -> GmcpEmitter.RoomFeaturePayload(

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldFeaturesHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldFeaturesHandler.kt
@@ -207,7 +207,12 @@ class WorldFeaturesHandler(
         val state = worldState?.getLeverState(feature.id) ?: feature.initialState
         val newState = if (state == LeverState.UP) LeverState.DOWN else LeverState.UP
         worldState?.setLeverState(feature.id, newState)
-        outbound.send(OutboundEvent.SendInfo(sessionId, "You pull ${the(feature.displayName)}. It moves ${newState.name.lowercase()}."))
+        val pullMessage = "You pull ${the(feature.displayName)}. It moves ${newState.name.lowercase()}."
+        outbound.send(OutboundEvent.SendInfo(sessionId, pullMessage))
+        // Web clients drop plain text — surface the result via UI.Feedback so the
+        // pull isn't just a silent state flip on the canvas (telnet still gets the
+        // SendInfo above).
+        gmcpEmitter?.sendUiFeedback(sessionId, "success", pullMessage, scope = "features", command = "pull")
         broadcastToRoomExcept(me.roomId, sessionId, "${me.name} pulls ${the(feature.displayName)}.", players, outbound)
         emitRoomFeatures(room)
         // Notify puzzle system of the lever interaction

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldFeaturesHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldFeaturesHandler.kt
@@ -57,7 +57,9 @@ class WorldFeaturesHandler(
             LockableState.OPEN -> outbound.send(OutboundEvent.SendError(sessionId, "${theCap(lockable.displayName)} is already open."))
             LockableState.CLOSED -> {
                 lockable.applyState(LockableState.OPEN)
-                outbound.send(OutboundEvent.SendInfo(sessionId, "You open ${the(lockable.displayName)}."))
+                val msg = "You open ${the(lockable.displayName)}."
+                outbound.send(OutboundEvent.SendInfo(sessionId, msg))
+                gmcpEmitter?.sendUiFeedback(sessionId, "success", msg, scope = "features", command = "open")
                 broadcastToRoomExcept(me.roomId, sessionId, "${me.name} opens ${the(lockable.displayName)}.", players, outbound)
                 world.rooms[me.roomId]?.let { emitRoomFeatures(it) }
             }
@@ -71,7 +73,9 @@ class WorldFeaturesHandler(
         when (lockable.state) {
             LockableState.OPEN -> {
                 lockable.applyState(LockableState.CLOSED)
-                outbound.send(OutboundEvent.SendInfo(sessionId, "You close ${the(lockable.displayName)}."))
+                val msg = "You close ${the(lockable.displayName)}."
+                outbound.send(OutboundEvent.SendInfo(sessionId, msg))
+                gmcpEmitter?.sendUiFeedback(sessionId, "success", msg, scope = "features", command = "close")
                 broadcastToRoomExcept(me.roomId, sessionId, "${me.name} closes ${the(lockable.displayName)}.", players, outbound)
                 world.rooms[me.roomId]?.let { emitRoomFeatures(it) }
             }
@@ -229,6 +233,7 @@ class WorldFeaturesHandler(
             return
         }
         outbound.send(OutboundEvent.SendInfo(sessionId, feature.text))
+        gmcpEmitter?.sendUiFeedback(sessionId, "info", feature.text, scope = "features", command = "read")
     }
 
     private suspend fun applyKeyAction(
@@ -245,7 +250,9 @@ class WorldFeaturesHandler(
         } else {
             lockable.applyState(newState)
             if (lockable.keyConsumed) items.removeFromInventory(sessionId, key.item.keyword)
-            outbound.send(OutboundEvent.SendInfo(sessionId, "You $verb ${the(lockable.displayName)}."))
+            val msg = "You $verb ${the(lockable.displayName)}."
+            outbound.send(OutboundEvent.SendInfo(sessionId, msg))
+            gmcpEmitter?.sendUiFeedback(sessionId, "success", msg, scope = "features", command = verb)
             broadcastToRoomExcept(
                 me.roomId,
                 sessionId,

--- a/src/test/kotlin/dev/ambon/world/load/WorldLoaderFeaturesTest.kt
+++ b/src/test/kotlin/dev/ambon/world/load/WorldLoaderFeaturesTest.kt
@@ -64,6 +64,29 @@ class WorldLoaderFeaturesTest {
         assertEquals("lever", lever.keyword)
         assertEquals(LeverState.UP, lever.initialState)
         assertTrue(lever.resetWithZone)
+        // No custom art authored — fields stay null so the client renders its
+        // built-in vector lever (backward compatibility).
+        assertNull(lever.plateImage)
+        assertNull(lever.handleImage)
+        assertNull(lever.leverPivot)
+        assertNull(lever.upAngle)
+        assertNull(lever.downAngle)
+    }
+
+    @Test
+    fun `lever with custom art is parsed and image refs are resolved`() {
+        val world = dev.ambon.test.TestWorlds.okFeatures
+        val entrance = world.rooms.getValue(RoomId("ok_features:entrance"))
+
+        val lever = entrance.features.filterIsInstance<RoomFeature.Lever>().single { it.keyword == "brass" }
+        assertEquals("an ostentatious brass lever", lever.displayName)
+        assertEquals(LeverState.DOWN, lever.initialState)
+        // Image refs are content-addressed filenames resolved against the image base.
+        assertTrue(lever.plateImage!!.endsWith("plate123.webp"), "got=${lever.plateImage}")
+        assertTrue(lever.handleImage!!.endsWith("handle456.webp"), "got=${lever.handleImage}")
+        assertEquals(RoomFeature.LeverPivot(0.4, 0.9), lever.leverPivot)
+        assertEquals(-30.0, lever.upAngle)
+        assertEquals(35.0, lever.downAngle)
     }
 
     @Test

--- a/src/test/resources/world/ok_features.yaml
+++ b/src/test/resources/world/ok_features.yaml
@@ -30,6 +30,16 @@ rooms:
         displayName: "a notice board"
         keyword: board
         text: "Welcome to the test zone."
+      brass_lever:
+        type: LEVER
+        displayName: "an ostentatious brass lever"
+        keyword: brass
+        initialState: down
+        plateImage: "plate123.webp"
+        handleImage: "handle456.webp"
+        leverPivot: { x: 0.4, y: 0.9 }
+        upAngle: -30
+        downAngle: 35
 
   vault:
     title: "Vault"

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -1098,6 +1098,7 @@ function App() {
             roomFeatures={state.roomFeatures}
             containerContents={state.containerContents}
             preferredType={featureFocus}
+            serverAssets={state.serverAssets}
             onCommand={sendCommand}
           />
         )}

--- a/web-v3/src/components/WorldFeaturesPopout.tsx
+++ b/web-v3/src/components/WorldFeaturesPopout.tsx
@@ -8,6 +8,8 @@ interface WorldFeaturesPopoutProps {
   roomFeatures: RoomFeature[];
   containerContents: ContainerContents | null;
   preferredType: FeaturePopoutFocus;
+  /** Resolved server assets — supplies the global default lever plate/handle art. */
+  serverAssets: Record<string, string>;
   onCommand: (command: string) => void;
 }
 
@@ -38,58 +40,89 @@ function stateLabel(feature: RoomFeature): string | null {
 
 function LeverWidget({
   feature,
+  serverAssets,
   onCommand,
 }: {
   feature: RoomFeature;
+  serverAssets: Record<string, string>;
   onCommand: (cmd: string) => void;
 }) {
   const isUp = feature.state === "up";
   const label = isUp ? "Ready" : "Pulled";
 
+  // Custom art (authored in Arcanum): a static plate plus a handle sprite that
+  // rotates around its pivot between the up/down angles. Per-lever art wins;
+  // otherwise the server-wide default plate/handle; otherwise the hand-drawn
+  // vector lever.
+  const px = feature.leverPivot?.x ?? 0.5;
+  const py = feature.leverPivot?.y ?? 0.85;
+  const angle = isUp ? (feature.upAngle ?? -28) : (feature.downAngle ?? 28);
+  const handleSrc = feature.handleImage ?? serverAssets["lever_handle"] ?? null;
+  const plateSrc = feature.plateImage ?? serverAssets["lever_plate"] ?? null;
+
   return (
     <div className="lever-widget" onClick={() => onCommand(`pull ${feature.keyword}`)}>
-      <div className="lever-widget-plate">
-        <svg
-          className="lever-widget-svg"
-          viewBox="0 0 64 96"
-          aria-label={`${feature.name}: ${label}`}
-        >
-          {/* Base plate arc */}
-          <path
-            d="M12 78 Q32 86 52 78"
-            fill="none"
-            stroke="rgb(180 150 210 / 40%)"
-            strokeWidth="2"
-            strokeLinecap="round"
+      {handleSrc ? (
+        <div className="lever-widget-art" aria-label={`${feature.name}: ${label}`} role="img">
+          {plateSrc && (
+            <img className="lever-widget-art-plate" src={plateSrc} alt="" aria-hidden="true" draggable={false} />
+          )}
+          <img
+            className="lever-widget-art-handle"
+            src={handleSrc}
+            alt=""
+            aria-hidden="true"
+            draggable={false}
+            style={{
+              transformOrigin: `${px * 100}% ${py * 100}%`,
+              transform: `translate(${(0.5 - px) * 100}%, ${(0.5 - py) * 100}%) rotate(${angle}deg)`,
+            }}
           />
-          {/* Pivot point */}
-          <circle cx="32" cy="72" r="6" className="lever-widget-pivot" />
-          {/* Handle shaft */}
-          <line
-            x1="32"
-            y1="72"
-            x2={isUp ? "32" : "46"}
-            y2={isUp ? "22" : "32"}
-            className="lever-widget-shaft"
-            strokeWidth="4"
-            strokeLinecap="round"
-          />
-          {/* Handle grip */}
-          <circle
-            cx={isUp ? "32" : "46"}
-            cy={isUp ? "18" : "28"}
-            r="7"
-            className="lever-widget-grip"
-          />
-          {/* Glow on grip */}
-          <circle
-            cx={isUp ? "32" : "46"}
-            cy={isUp ? "18" : "28"}
-            r="4"
-            className="lever-widget-glow"
-          />
-        </svg>
-      </div>
+        </div>
+      ) : (
+        <div className="lever-widget-plate">
+          <svg
+            className="lever-widget-svg"
+            viewBox="0 0 64 96"
+            aria-label={`${feature.name}: ${label}`}
+          >
+            {/* Base plate arc */}
+            <path
+              d="M12 78 Q32 86 52 78"
+              fill="none"
+              stroke="rgb(180 150 210 / 40%)"
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+            {/* Pivot point */}
+            <circle cx="32" cy="72" r="6" className="lever-widget-pivot" />
+            {/* Handle shaft */}
+            <line
+              x1="32"
+              y1="72"
+              x2={isUp ? "32" : "46"}
+              y2={isUp ? "22" : "32"}
+              className="lever-widget-shaft"
+              strokeWidth="4"
+              strokeLinecap="round"
+            />
+            {/* Handle grip */}
+            <circle
+              cx={isUp ? "32" : "46"}
+              cy={isUp ? "18" : "28"}
+              r="7"
+              className="lever-widget-grip"
+            />
+            {/* Glow on grip */}
+            <circle
+              cx={isUp ? "32" : "46"}
+              cy={isUp ? "18" : "28"}
+              r="4"
+              className="lever-widget-glow"
+            />
+          </svg>
+        </div>
+      )}
       <div className="lever-widget-info">
         <span className="lever-widget-name">{feature.name}</span>
         <span className={`lever-widget-state lever-widget-state-${isUp ? "up" : "down"}`}>
@@ -290,6 +323,7 @@ export function WorldFeaturesPopout({
   roomFeatures,
   containerContents,
   preferredType,
+  serverAssets,
   onCommand,
 }: WorldFeaturesPopoutProps) {
   const groupedFeatures = useMemo(
@@ -397,7 +431,7 @@ export function WorldFeaturesPopout({
       <div className={`feature-popout-grid${activeTab === "lever" ? " feature-popout-grid-levers" : ""}`}>
         {visibleFeatures.map((feature) => {
           if (feature.type === "lever") {
-            return <LeverWidget key={feature.id} feature={feature} onCommand={onCommand} />;
+            return <LeverWidget key={feature.id} feature={feature} serverAssets={serverAssets} onCommand={onCommand} />;
           }
 
           if (

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -1723,6 +1723,11 @@ export function applyGmcpPackage(
       if (packet.code === "DEMO_CHARACTER" && packet.message) {
         ctx.setToast(packet.message);
       }
+      // Room-feature actions (e.g. pulling a lever) have no dedicated panel feed,
+      // so toast their result — otherwise a pull is just a silent state flip.
+      if (packet.scope === "features" && packet.message) {
+        ctx.setToast(packet.message);
+      }
       break;
     }
 

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -1427,6 +1427,17 @@ export function applyGmcpPackage(
             locked: typeof e.locked === "boolean" ? e.locked : null,
             keyRequired: typeof e.keyRequired === "boolean" ? e.keyRequired : null,
             text: typeof e.text === "string" ? e.text : null,
+            plateImage: typeof e.plateImage === "string" ? e.plateImage : null,
+            handleImage: typeof e.handleImage === "string" ? e.handleImage : null,
+            leverPivot:
+              e.leverPivot && typeof e.leverPivot === "object"
+                ? {
+                    x: typeof (e.leverPivot as Record<string, unknown>).x === "number" ? (e.leverPivot as Record<string, number>).x : 0.5,
+                    y: typeof (e.leverPivot as Record<string, unknown>).y === "number" ? (e.leverPivot as Record<string, number>).y : 0.85,
+                  }
+                : null,
+            upAngle: typeof e.upAngle === "number" ? e.upAngle : null,
+            downAngle: typeof e.downAngle === "number" ? e.downAngle : null,
           })),
       );
       break;

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -3381,6 +3381,28 @@ body {
   overflow: visible;
 }
 
+/* Custom lever art — a square box; the plate + pivoting handle overlay it. */
+.lever-widget-art {
+  position: relative;
+  width: 88px;
+  height: 88px;
+}
+
+.lever-widget-art-plate,
+.lever-widget-art-handle {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  pointer-events: none;
+  user-select: none;
+}
+
+.lever-widget-art-handle {
+  transition: transform 0.45s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
 .lever-widget-svg line,
 .lever-widget-svg circle {
   transition:
@@ -3485,7 +3507,8 @@ body {
   }
 
   .lever-widget,
-  .lever-widget-pull {
+  .lever-widget-pull,
+  .lever-widget-art-handle {
     transition: none;
   }
 

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -680,6 +680,16 @@ export interface RoomFeature {
   locked: boolean | null;
   keyRequired: boolean | null;
   text: string | null;
+  /**
+   * Optional custom lever art (LEVER only): a static plate plus a handle that
+   * rotates around {@link leverPivot} between {@link upAngle}/{@link downAngle}.
+   * Image fields are fully-resolved URLs. Absent → the built-in vector lever.
+   */
+  plateImage: string | null;
+  handleImage: string | null;
+  leverPivot: { x: number; y: number } | null;
+  upAngle: number | null;
+  downAngle: number | null;
 }
 
 export interface ContainerContents {


### PR DESCRIPTION
Expands the original lever-pull feedback into the full feature set you asked for.

## 1. Lever-pull feedback → all feature actions
`WorldFeaturesHandler` only spoke to telnet (`SendInfo`), so feature actions were silent on the web client. It now also emits `UI.Feedback` (`scope: "features"`), and the client toasts that scope, for:
- **pull** (lever), **open**, **close**, **lock**, **unlock**, **read** (sign)

No double-display: panels filter the feedback feed by their own scope, and `features` has no panel feed.

## 2. Custom lever artwork (Arcanum → MUD contract)
A lever can author a two-layer sprite — a static **plate** plus a **handle** that rotates around a pivot between an up and a down angle. Engine state is unchanged (`LeverState UP/DOWN`); the swing is pure CSS.

New optional `LEVER` fields flow **YAML → domain → GMCP → client**:
`plateImage`, `handleImage`, `leverPivot {x,y}`, `upAngle`, `downAngle`. Image refs are content-addressed filenames resolved against the world image base (same scheme as room/mob/item art). Defaults match the contract: pivot `{0.5, 0.85}`, up `-28°`, down `28°`.

The `LeverWidget` renders the layered sprite (handle `transform-origin` at the pivot, translated to box-center, then rotated, with a springy transition) and **falls back to the built-in vector lever** when no handle art applies.

## 3. Server-wide default lever art
Registered `lever_plate` / `lever_handle` global assets. Resolution order per lever:
**per-lever art → global default art → built-in vector lever.**

## Files
- Server: `FeatureFile`, `RoomFeature`, `WorldLoader`, `GmcpEmitter`, `HandlerHelpers` (payload), `WorldFeaturesHandler` (feedback), `AppConfig` (global assets)
- Web: `types.ts`, `applyGmcpPackage.ts`, `WorldFeaturesPopout.tsx` (LeverWidget), `App.tsx`, `styles.css`

## Testing
- `WorldLoaderFeaturesTest`: new coverage for the no-art (null fields, backward compatible) and custom-art (parsed + image refs resolved) cases; `ok_features` fixture gains an art-bearing lever.
- `./gradlew ktlintMainSourceSetCheck ktlintTestSourceSetCheck compileKotlin` + WorldLoader/GmcpEmitter/feature tests — green.
- Web `bun run lint`, `bunx tsc -b`, `bun run build` — green.

## Notes
- Global default art keys point at `global_assets/lever_plate.png` / `lever_handle.png` — those image files need to exist in the global asset bucket for the default to render; until then levers fall through to the vector SVG (no breakage).