### PR TITLE
feat(web): art-forward container/sign/lever cards + backdrop assets

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -3041,6 +3041,12 @@ data class ImagesConfig(
             // the built-in vector lever when these aren't present either.
             "lever_plate" to "global_assets/lever_plate.png",
             "lever_handle" to "global_assets/lever_handle.png",
+            // Server-wide default backdrops for the World Features modal. Used when a
+            // feature doesn't author its own backgroundImage; the client falls back
+            // further to a polished CSS treatment when these aren't present either.
+            "container_bg" to "global_assets/container_bg.png",
+            "sign_bg" to "global_assets/sign_bg.png",
+            "lever_bg" to "global_assets/lever_bg.png",
             "dialog_indicator" to "global_assets/dialog_indicator.png",
             "aggro_indicator" to "global_assets/aggro_indicator.png",
             "quest_available_indicator" to "global_assets/quest_available_indicator.png",

--- a/src/main/kotlin/dev/ambon/domain/world/RoomFeature.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/RoomFeature.kt
@@ -45,6 +45,12 @@ sealed class RoomFeature {
          * container reverts and refills [initialItems]. Null = zone reset only.
          */
         val respawnSeconds: Long? = null,
+        /**
+         * Optional open-chest backdrop art (resolved URL) for the web client's
+         * World Features modal. Absent → the `container_bg` global default, then
+         * a built-in CSS treatment.
+         */
+        val backgroundImage: String? = null,
     ) : RoomFeature()
 
     data class Lever(
@@ -68,6 +74,12 @@ sealed class RoomFeature {
         val leverPivot: LeverPivot? = null,
         val upAngle: Double? = null,
         val downAngle: Double? = null,
+        /**
+         * Optional backdrop "box" art (resolved URL) the lever sits inside;
+         * the plate + handle render on top. Absent → the `lever_bg` global
+         * default, then a built-in CSS treatment.
+         */
+        val backgroundImage: String? = null,
     ) : RoomFeature()
 
     /** Handle pivot as fractions (0..1) of the handle sprite box. */
@@ -82,5 +94,11 @@ sealed class RoomFeature {
         override val displayName: String,
         override val keyword: String,
         val text: String,
+        /**
+         * Optional sign-board backdrop art (resolved URL) for the web client's
+         * World Features modal. Absent → the `sign_bg` global default, then a
+         * built-in CSS treatment.
+         */
+        val backgroundImage: String? = null,
     ) : RoomFeature()
 }

--- a/src/main/kotlin/dev/ambon/domain/world/data/FeatureFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/FeatureFile.kt
@@ -23,6 +23,14 @@ data class FeatureFile(
     val items: List<String> = emptyList(),
     /** Text content. Only applies to SIGN type. */
     val text: String? = null,
+    /**
+     * Optional backdrop art (content-addressed filename) for the World Features
+     * modal, resolved against the world image base like room/mob/item art.
+     * CONTAINER → open-chest backdrop; SIGN → sign-board backdrop; LEVER → the
+     * box the lever sits inside. Absent → the server-wide `<type>_bg` default,
+     * then a built-in CSS treatment. Valid for CONTAINER, SIGN, and LEVER.
+     */
+    val backgroundImage: String? = null,
     /** Static base-plate art (content-addressed filename), drawn behind the handle. LEVER only. */
     val plateImage: String? = null,
     /** Rotating handle art (content-addressed filename), neutral upright pose. LEVER only. */

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -1579,6 +1579,7 @@ object WorldLoader {
                     resetWithZone = ff.resetWithZone,
                     initialItems = initialItems,
                     respawnSeconds = respawnSeconds,
+                    backgroundImage = ff.backgroundImage?.trim()?.takeUnless { it.isEmpty() }?.let { "$imagesBase$it" },
                 )
             }
             "LEVER" -> {
@@ -1598,6 +1599,7 @@ object WorldLoader {
                     leverPivot = ff.leverPivot?.let { RoomFeature.LeverPivot(it.x, it.y) },
                     upAngle = ff.upAngle,
                     downAngle = ff.downAngle,
+                    backgroundImage = ff.backgroundImage?.trim()?.takeUnless { it.isEmpty() }?.let { "$imagesBase$it" },
                 )
             }
             "SIGN" -> {
@@ -1611,6 +1613,7 @@ object WorldLoader {
                     displayName = displayName,
                     keyword = keyword,
                     text = text,
+                    backgroundImage = ff.backgroundImage?.trim()?.takeUnless { it.isEmpty() }?.let { "$imagesBase$it" },
                 )
             }
             else -> throw WorldLoadException(

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -3133,6 +3133,9 @@ class GmcpEmitter(
         val locked: Boolean? = null,
         val keyRequired: Boolean? = null,
         val text: String? = null,
+        // Optional per-feature backdrop art for the World Features modal.
+        // CONTAINER → chest, SIGN → board, LEVER → the box the lever sits inside.
+        val backgroundImage: String? = null,
         // Optional custom lever art (static per-lever; rides along with the feature).
         val plateImage: String? = null,
         val handleImage: String? = null,

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -583,6 +583,7 @@ internal fun buildFeaturePayload(
             state = state.name.lowercase(),
             locked = state == LockableState.LOCKED,
             keyRequired = feature.keyItemId != null,
+            backgroundImage = feature.backgroundImage,
         )
     }
     is RoomFeature.Lever -> {
@@ -593,6 +594,7 @@ internal fun buildFeaturePayload(
             keyword = feature.keyword,
             type = "lever",
             state = state.name.lowercase(),
+            backgroundImage = feature.backgroundImage,
             plateImage = feature.plateImage,
             handleImage = feature.handleImage,
             leverPivot = feature.leverPivot?.let { GmcpEmitter.LeverPivotPayload(it.x, it.y) },
@@ -606,6 +608,7 @@ internal fun buildFeaturePayload(
         keyword = feature.keyword,
         type = "sign",
         text = feature.text,
+        backgroundImage = feature.backgroundImage,
     )
 }
 

--- a/src/test/kotlin/dev/ambon/world/load/WorldLoaderFeaturesTest.kt
+++ b/src/test/kotlin/dev/ambon/world/load/WorldLoaderFeaturesTest.kt
@@ -52,6 +52,8 @@ class WorldLoaderFeaturesTest {
         assertTrue(container.resetWithZone)
         assertEquals(listOf(ItemId("ok_features:silver_coin")), container.initialItems)
         assertEquals(RoomId("ok_features:storeroom"), container.roomId)
+        // Backdrop art is a content-addressed filename resolved against the image base.
+        assertTrue(container.backgroundImage!!.endsWith("chestbg111.webp"), "got=${container.backgroundImage}")
     }
 
     @Test
@@ -71,6 +73,7 @@ class WorldLoaderFeaturesTest {
         assertNull(lever.leverPivot)
         assertNull(lever.upAngle)
         assertNull(lever.downAngle)
+        assertNull(lever.backgroundImage)
     }
 
     @Test
@@ -87,6 +90,7 @@ class WorldLoaderFeaturesTest {
         assertEquals(RoomFeature.LeverPivot(0.4, 0.9), lever.leverPivot)
         assertEquals(-30.0, lever.upAngle)
         assertEquals(35.0, lever.downAngle)
+        assertTrue(lever.backgroundImage!!.endsWith("leverbox222.webp"), "got=${lever.backgroundImage}")
     }
 
     @Test
@@ -98,6 +102,7 @@ class WorldLoaderFeaturesTest {
         assertEquals("a notice board", sign.displayName)
         assertEquals("board", sign.keyword)
         assertEquals("Welcome to the test zone.", sign.text)
+        assertTrue(sign.backgroundImage!!.endsWith("signbg789.webp"), "got=${sign.backgroundImage}")
     }
 
     @Test

--- a/src/test/resources/world/ok_features.yaml
+++ b/src/test/resources/world/ok_features.yaml
@@ -30,11 +30,13 @@ rooms:
         displayName: "a notice board"
         keyword: board
         text: "Welcome to the test zone."
+        backgroundImage: "signbg789.webp"
       brass_lever:
         type: LEVER
         displayName: "an ostentatious brass lever"
         keyword: brass
         initialState: down
+        backgroundImage: "leverbox222.webp"
         plateImage: "plate123.webp"
         handleImage: "handle456.webp"
         leverPivot: { x: 0.4, y: 0.9 }
@@ -68,5 +70,6 @@ rooms:
         keyItemId: null
         keyConsumed: false
         resetWithZone: true
+        backgroundImage: "chestbg111.webp"
         items:
           - silver_coin

--- a/web-v3/src/components/WorldFeaturesPopout.tsx
+++ b/web-v3/src/components/WorldFeaturesPopout.tsx
@@ -59,9 +59,18 @@ function LeverWidget({
   const angle = isUp ? (feature.upAngle ?? -28) : (feature.downAngle ?? 28);
   const handleSrc = feature.handleImage ?? serverAssets["lever_handle"] ?? null;
   const plateSrc = feature.plateImage ?? serverAssets["lever_plate"] ?? null;
+  // Optional backdrop "box" the lever sits inside; the plate + handle ride on
+  // top. Per-feature art wins, then the server-wide default, then a CSS frame.
+  const boxSrc = feature.backgroundImage ?? serverAssets["lever_bg"] ?? null;
 
   return (
-    <div className="lever-widget" onClick={() => onCommand(`pull ${feature.keyword}`)}>
+    <div
+      className={`lever-widget${boxSrc ? " lever-widget-boxed" : ""}`}
+      onClick={() => onCommand(`pull ${feature.keyword}`)}
+    >
+      {boxSrc && (
+        <img className="lever-widget-box" src={boxSrc} alt="" aria-hidden="true" draggable={false} />
+      )}
       {handleSrc ? (
         <div className="lever-widget-art" aria-label={`${feature.name}: ${label}`} role="img">
           {plateSrc && (
@@ -140,6 +149,181 @@ function LeverWidget({
         Pull
       </button>
     </div>
+  );
+}
+
+/** Stylized open-chest used as the container backdrop when no art is shipped. */
+function ChestGlyph() {
+  return (
+    <svg className="fcard-glyph fcard-glyph-chest" viewBox="0 0 160 120" aria-hidden="true">
+      {/* open lid, tilted back */}
+      <path
+        d="M30 52 Q80 6 130 52 L130 60 Q80 22 30 60 Z"
+        fill="currentColor"
+        opacity="0.22"
+      />
+      <path
+        d="M30 52 Q80 6 130 52"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="3"
+        strokeLinecap="round"
+        opacity="0.5"
+      />
+      {/* chest body */}
+      <path d="M26 58 H134 V104 a8 8 0 0 1-8 8 H34 a8 8 0 0 1-8-8 Z" fill="currentColor" opacity="0.16" />
+      <path
+        d="M26 58 H134 V104 a8 8 0 0 1-8 8 H34 a8 8 0 0 1-8-8 Z"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="3"
+        opacity="0.45"
+      />
+      {/* horizontal band + lock */}
+      <line x1="26" y1="78" x2="134" y2="78" stroke="currentColor" strokeWidth="3" opacity="0.4" />
+      <rect x="72" y="72" width="16" height="16" rx="3" fill="currentColor" opacity="0.55" />
+      <circle cx="80" cy="80" r="2.4" fill="rgb(20 22 34)" opacity="0.7" />
+    </svg>
+  );
+}
+
+/** Stylized hanging placard used as the sign backdrop when no art is shipped. */
+function SignGlyph() {
+  return (
+    <svg className="fcard-glyph fcard-glyph-sign" viewBox="0 0 160 120" aria-hidden="true">
+      {/* top rail + ropes */}
+      <line x1="40" y1="16" x2="120" y2="16" stroke="currentColor" strokeWidth="3" opacity="0.4" />
+      <line x1="52" y1="16" x2="46" y2="34" stroke="currentColor" strokeWidth="2.5" opacity="0.4" />
+      <line x1="108" y1="16" x2="114" y2="34" stroke="currentColor" strokeWidth="2.5" opacity="0.4" />
+      {/* board */}
+      <rect x="30" y="32" width="100" height="60" rx="9" fill="currentColor" opacity="0.16" />
+      <rect
+        x="30"
+        y="32"
+        width="100"
+        height="60"
+        rx="9"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="3"
+        opacity="0.45"
+      />
+      {/* inked lines */}
+      <line x1="46" y1="52" x2="114" y2="52" stroke="currentColor" strokeWidth="3" opacity="0.32" />
+      <line x1="46" y1="64" x2="114" y2="64" stroke="currentColor" strokeWidth="3" opacity="0.32" />
+      <line x1="46" y1="76" x2="94" y2="76" stroke="currentColor" strokeWidth="3" opacity="0.32" />
+    </svg>
+  );
+}
+
+function ContainerCard({
+  feature,
+  contents,
+  serverAssets,
+  onCommand,
+}: {
+  feature: RoomFeature;
+  contents: ContainerContents | null;
+  serverAssets: Record<string, string>;
+  onCommand: (cmd: string) => void;
+}) {
+  const bgSrc = feature.backgroundImage ?? serverAssets["container_bg"] ?? null;
+  const isOpen = feature.state === "open";
+  const stateClass = isOpen ? "is-open" : feature.state === "locked" ? "is-locked" : "is-closed";
+  const actions = featureActions(feature);
+  const items = isOpen && contents?.featureId === feature.id ? contents.items : null;
+
+  return (
+    <article
+      className={`fcard fcard-container ${stateClass}${bgSrc ? " has-art" : ""}`}
+      style={bgSrc ? { ["--fcard-art" as string]: `url("${bgSrc}")` } : undefined}
+    >
+      <div className="fcard-bg" aria-hidden="true">{!bgSrc && <ChestGlyph />}</div>
+      <div className="fcard-body">
+        <header className="fcard-head">
+          <span className="fcard-eyebrow fcard-eyebrow-container">Container</span>
+          <h4 className="fcard-title">{feature.name}</h4>
+          <p className="fcard-sub">
+            {feature.state === "locked"
+              ? feature.keyRequired
+                ? "Locked — a key is required."
+                : "Locked tight."
+              : isOpen
+                ? "Open"
+                : "Closed"}
+          </p>
+        </header>
+
+        <div className="fcard-foot">
+          {isOpen && items !== null && (
+            items.length === 0 ? (
+              <p className="fcard-empty">Nothing inside.</p>
+            ) : (
+              <ul className="fcard-loot" role="list">
+                {items.map((item, index) => (
+                  <li key={`${item.keyword}-${index}`} className="fcard-loot-row">
+                    <span className="fcard-loot-name">{item.name}</span>
+                    <button
+                      type="button"
+                      className="fcard-take"
+                      onClick={() => onCommand(`get ${item.keyword} from ${feature.keyword}`)}
+                    >
+                      Take
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )
+          )}
+          {actions.length > 0 && (
+            <div className="fcard-actions">
+              {actions.map((action) => (
+                <button
+                  key={`${feature.id}-${action.command}`}
+                  type="button"
+                  className={`fcard-btn${action.label === "Open" || action.label === "Unlock" ? " fcard-btn-primary" : ""}`}
+                  onClick={() => onCommand(action.command)}
+                >
+                  {action.label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function SignCard({
+  feature,
+  serverAssets,
+  onCommand,
+}: {
+  feature: RoomFeature;
+  serverAssets: Record<string, string>;
+  onCommand: (cmd: string) => void;
+}) {
+  const bgSrc = feature.backgroundImage ?? serverAssets["sign_bg"] ?? null;
+
+  return (
+    <article
+      className={`fcard fcard-sign${bgSrc ? " has-art" : ""}`}
+      style={bgSrc ? { ["--fcard-art" as string]: `url("${bgSrc}")` } : undefined}
+    >
+      <div className="fcard-bg" aria-hidden="true">{!bgSrc && <SignGlyph />}</div>
+      <div className="fcard-body fcard-sign-body">
+        <span className="fcard-eyebrow fcard-eyebrow-sign">{feature.name}</span>
+        {feature.text && <p className="fcard-sign-text">{feature.text}</p>}
+        <button
+          type="button"
+          className="fcard-sign-read"
+          onClick={() => onCommand(`read ${feature.keyword}`)}
+        >
+          Read aloud
+        </button>
+      </div>
+    </article>
   );
 }
 
@@ -434,25 +618,31 @@ export function WorldFeaturesPopout({
             return <LeverWidget key={feature.id} feature={feature} serverAssets={serverAssets} onCommand={onCommand} />;
           }
 
-          if (
-            feature.type === "container" &&
-            feature.state === "locked" &&
-            visibleFeatures.length === 1
-          ) {
-            return <LockedContainerHero key={feature.id} feature={feature} onCommand={onCommand} />;
+          if (feature.type === "container") {
+            if (feature.state === "locked" && visibleFeatures.length === 1) {
+              return <LockedContainerHero key={feature.id} feature={feature} onCommand={onCommand} />;
+            }
+            const contents = containerContents?.featureId === feature.id ? containerContents : null;
+            return (
+              <ContainerCard
+                key={feature.id}
+                feature={feature}
+                contents={contents}
+                serverAssets={serverAssets}
+                onCommand={onCommand}
+              />
+            );
           }
 
-          if (
-            feature.type === "door" &&
-            feature.state === "locked" &&
-            visibleFeatures.length === 1
-          ) {
+          if (feature.type === "sign") {
+            return <SignCard key={feature.id} feature={feature} serverAssets={serverAssets} onCommand={onCommand} />;
+          }
+
+          // Doors — generic card.
+          if (feature.state === "locked" && visibleFeatures.length === 1) {
             return <LockedDoorHero key={feature.id} feature={feature} onCommand={onCommand} />;
           }
 
-          const contents = feature.type === "container" && containerContents?.featureId === feature.id
-            ? containerContents
-            : null;
           const actions = featureActions(feature);
           const label = stateLabel(feature);
 
@@ -486,10 +676,6 @@ export function WorldFeaturesPopout({
                 <span className="feature-card-detail-chip">Keyword: {feature.keyword}</span>
               </div>
 
-              {feature.type === "sign" && feature.text && (
-                <p className="feature-card-sign-text">{feature.text}</p>
-              )}
-
               {actions.length > 0 && (
                 <div className="feature-card-actions">
                   {actions.map((action) => (
@@ -502,33 +688,6 @@ export function WorldFeaturesPopout({
                       {action.label}
                     </button>
                   ))}
-                </div>
-              )}
-
-              {feature.type === "container" && contents && (
-                <div className="feature-card-contents">
-                  <div className="feature-card-contents-header">
-                    <span>Inside {contents.name}</span>
-                    <span>{contents.items.length} item{contents.items.length === 1 ? "" : "s"}</span>
-                  </div>
-                  {contents.items.length === 0 ? (
-                    <p className="feature-card-empty">Nothing is inside right now.</p>
-                  ) : (
-                    <ul className="feature-card-item-list" role="list">
-                      {contents.items.map((item, index) => (
-                        <li key={`${item.keyword}-${index}`} className="feature-card-item">
-                          <span>{item.name}</span>
-                          <button
-                            type="button"
-                            className="feature-card-inline-action"
-                            onClick={() => onCommand(`get ${item.keyword} from ${contents.keyword}`)}
-                          >
-                            Take
-                          </button>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
                 </div>
               )}
             </article>

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -1427,6 +1427,7 @@ export function applyGmcpPackage(
             locked: typeof e.locked === "boolean" ? e.locked : null,
             keyRequired: typeof e.keyRequired === "boolean" ? e.keyRequired : null,
             text: typeof e.text === "string" ? e.text : null,
+            backgroundImage: typeof e.backgroundImage === "string" ? e.backgroundImage : null,
             plateImage: typeof e.plateImage === "string" ? e.plateImage : null,
             handleImage: typeof e.handleImage === "string" ? e.handleImage : null,
             leverPivot:

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -3325,12 +3325,6 @@ body {
     linear-gradient(145deg, rgb(62 73 108 / 92%), rgb(47 58 87 / 88%));
 }
 
-.feature-card-container {
-  background:
-    radial-gradient(circle at top right, rgb(212 178 110 / 14%), transparent 28%),
-    linear-gradient(145deg, rgb(72 68 92 / 92%), rgb(57 55 78 / 88%));
-}
-
 .feature-card-lever {
   background:
     radial-gradient(circle at top right, rgb(204 154 216 / 14%), transparent 28%),
@@ -3344,6 +3338,8 @@ body {
 
 /* ── Graphical lever widget ─────────────────────────────── */
 .lever-widget {
+  position: relative;
+  isolation: isolate;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -3359,6 +3355,26 @@ body {
     border-color 200ms var(--ease-out-soft),
     transform 200ms var(--ease-out-soft),
     box-shadow 200ms var(--ease-out-soft);
+}
+
+/* Optional backdrop "box" art (lever_bg / per-feature). Fills the card; the
+   plate + handle render on top. When present we drop the CSS frame so only the
+   authored art shows. */
+.lever-widget-box {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: var(--radius-lg);
+  pointer-events: none;
+  user-select: none;
+}
+
+.lever-widget-boxed {
+  border-color: transparent;
+  background: none;
 }
 
 .lever-widget:hover {
@@ -3517,12 +3533,6 @@ body {
   }
 }
 
-.feature-card-sign {
-  background:
-    radial-gradient(circle at top right, rgb(148 188 160 / 12%), transparent 28%),
-    linear-gradient(145deg, rgb(61 74 95 / 92%), rgb(49 62 82 / 88%));
-}
-
 .feature-card-header {
   display: flex;
   justify-content: space-between;
@@ -3606,30 +3616,13 @@ body {
   gap: 8px;
 }
 
-.feature-card-sign-text,
-.feature-card-empty {
-  margin: 0;
-  color: var(--text-secondary);
-  line-height: 1.5;
-}
-
-.feature-card-sign-text {
-  padding: 12px 14px;
-  border-radius: var(--radius-md);
-  background: rgb(10 12 22 / 22%);
-  color: var(--text-primary);
-  font-style: italic;
-  white-space: pre-wrap;
-}
-
 .feature-card-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
 }
 
-.feature-card-action,
-.feature-card-inline-action {
+.feature-card-action {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -3648,51 +3641,280 @@ body {
     background 150ms var(--ease-out-soft);
 }
 
-.feature-card-inline-action {
-  padding: 6px 10px;
-  font-size: 0.78rem;
-}
-
-.feature-card-action:hover,
-.feature-card-inline-action:hover {
+.feature-card-action:hover {
   transform: translateY(-1px);
   border-color: rgb(216 197 232 / 34%);
   background: linear-gradient(135deg, rgb(102 117 162 / 72%), rgb(76 91 132 / 68%));
 }
 
-.feature-card-contents {
-  display: grid;
-  gap: 8px;
-  padding: 12px 14px;
-  border-radius: var(--radius-md);
-  background: rgb(9 12 22 / 24%);
-  border: 1px solid rgb(255 255 255 / 8%);
+/* ───────────────────────────────────────────────────────────────────────
+   Container & Sign cards (fcard) — art-forward, no boxy chrome.
+   A full-bleed backdrop layer (authored art via --fcard-art, or a stylized
+   CSS/SVG fallback) sits behind a body that floats its content over the art.
+   ─────────────────────────────────────────────────────────────────────── */
+.fcard {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--line-soft);
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 8%),
+    0 10px 26px rgb(8 10 20 / 26%);
 }
 
-.feature-card-contents-header {
+.fcard-bg {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
   display: flex;
-  justify-content: space-between;
-  gap: var(--space-2);
-  color: var(--text-primary);
-  font-size: 0.84rem;
-  font-weight: 700;
+  align-items: center;
+  justify-content: center;
 }
 
-.feature-card-item-list {
+/* Authored art fills the card; a scrim keeps overlaid text legible. */
+.fcard.has-art .fcard-bg {
+  background-image: var(--fcard-art);
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.fcard.has-art .fcard-bg::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgb(12 14 24 / 20%) 0%, rgb(12 14 24 / 18%) 42%, rgb(10 12 20 / 78%) 100%);
+}
+
+/* Stylized SVG fallback glyph (no art shipped yet). */
+.fcard-glyph {
+  width: min(58%, 320px);
+  height: auto;
+  opacity: 0.9;
+}
+
+.fcard-body {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-height: 168px;
+  padding: 16px 18px;
+}
+
+.fcard-head {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.fcard-eyebrow {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.fcard-eyebrow-container {
+  color: #e1c17c;
+}
+
+.fcard-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.16rem;
+  color: var(--text-heading);
+  text-shadow: 0 1px 8px rgb(8 10 18 / 55%);
+}
+
+.fcard-sub {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+}
+
+/* Container contents + actions sit in the lower half (the open chest's cavity). */
+.fcard-foot {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.fcard-loot {
   list-style: none;
   margin: 0;
   padding: 0;
-  display: grid;
-  gap: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
-.feature-card-item {
+.fcard-loot-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--space-2);
+  padding: 7px 4px 7px 2px;
+  border-bottom: 1px solid rgb(255 255 255 / 8%);
+}
+
+.fcard-loot-row:last-child {
+  border-bottom: none;
+}
+
+.fcard-loot-name {
   color: var(--text-primary);
+  font-size: 0.88rem;
+}
+
+.fcard-take {
+  flex-shrink: 0;
+  padding: 4px 12px;
+  border: 1px solid rgb(226 198 134 / 28%);
+  border-radius: 999px;
+  background: rgb(226 198 134 / 12%);
+  color: #ecd6a0;
+  font-family: var(--font-body);
+  font-size: 0.78rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    background 150ms var(--ease-out-soft),
+    border-color 150ms var(--ease-out-soft),
+    transform 150ms var(--ease-out-soft);
+}
+
+.fcard-take:hover {
+  background: rgb(226 198 134 / 22%);
+  border-color: rgb(240 214 150 / 55%);
+  transform: translateY(-1px);
+}
+
+.fcard-empty {
+  margin: 0;
+  color: var(--text-muted);
   font-size: 0.84rem;
+  font-style: italic;
+}
+
+.fcard-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.fcard-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 16px;
+  border: 1px solid rgb(255 255 255 / 14%);
+  border-radius: var(--radius-md);
+  background: rgb(18 22 34 / 52%);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 0.84rem;
+  font-weight: 700;
+  cursor: pointer;
+  backdrop-filter: blur(2px);
+  transition:
+    transform 150ms var(--ease-out-soft),
+    border-color 150ms var(--ease-out-soft),
+    background 150ms var(--ease-out-soft);
+}
+
+.fcard-btn:hover {
+  transform: translateY(-1px);
+  border-color: rgb(216 197 232 / 38%);
+  background: rgb(28 34 50 / 62%);
+}
+
+.fcard-btn-primary {
+  border-color: rgb(226 198 134 / 46%);
+  background: linear-gradient(135deg, rgb(164 136 82 / 64%), rgb(124 102 62 / 58%));
+  color: #f3e4bf;
+}
+
+.fcard-btn-primary:hover {
+  border-color: rgb(240 214 150 / 70%);
+  background: linear-gradient(135deg, rgb(188 158 100 / 76%), rgb(142 118 74 / 68%));
+}
+
+/* Container card tinting */
+.fcard-container {
+  border-color: rgb(212 178 110 / 24%);
+}
+
+.fcard-container .fcard-bg {
+  color: #e6c587;
+  background:
+    radial-gradient(ellipse at 50% 8%, rgb(226 198 134 / 16%), transparent 58%),
+    linear-gradient(165deg, rgb(74 66 86 / 96%), rgb(50 46 66 / 94%));
+}
+
+.fcard-container.is-closed .fcard-glyph,
+.fcard-container.is-locked .fcard-glyph {
+  opacity: 0.6;
+}
+
+/* Sign card */
+.fcard-sign {
+  border-color: rgb(148 188 160 / 24%);
+}
+
+.fcard-sign .fcard-bg {
+  color: #bcdcc4;
+  background:
+    radial-gradient(ellipse at 50% 0%, rgb(168 204 178 / 14%), transparent 60%),
+    linear-gradient(165deg, rgb(60 74 92 / 96%), rgb(47 60 78 / 94%));
+}
+
+.fcard-sign-body {
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  text-align: center;
+}
+
+.fcard-eyebrow-sign {
+  color: #b9d6be;
+}
+
+.fcard-sign-text {
+  margin: 0;
+  max-width: 62ch;
+  color: var(--text-bright);
+  font-family: var(--font-display);
+  font-size: 1.04rem;
+  font-style: italic;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  text-shadow: 0 1px 10px rgb(8 10 18 / 60%);
+}
+
+.fcard-sign-read {
+  padding: 6px 16px;
+  border: 1px solid rgb(185 214 190 / 30%);
+  border-radius: 999px;
+  background: rgb(185 214 190 / 10%);
+  color: #cfe6d4;
+  font-family: var(--font-body);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition:
+    background 150ms var(--ease-out-soft),
+    border-color 150ms var(--ease-out-soft),
+    transform 150ms var(--ease-out-soft);
+}
+
+.fcard-sign-read:hover {
+  background: rgb(185 214 190 / 20%);
+  border-color: rgb(205 230 212 / 55%);
+  transform: translateY(-1px);
 }
 
 /* Hero treatment for a single locked feature (container or door) — bigger,

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -687,6 +687,13 @@ export interface RoomFeature {
   keyRequired: boolean | null;
   text: string | null;
   /**
+   * Optional per-feature backdrop art (fully-resolved URL) for the World
+   * Features modal. CONTAINER → open chest, SIGN → sign board, LEVER → the box
+   * the lever sits inside. Absent → the `<type>_bg` server default, then a
+   * built-in CSS treatment.
+   */
+  backgroundImage: string | null;
+  /**
    * Optional custom lever art (LEVER only): a static plate plus a handle that
    * rotates around {@link leverPivot} between {@link upAngle}/{@link downAngle}.
    * Image fields are fully-resolved URLs. Absent → the built-in vector lever.


### PR DESCRIPTION
## Summary

Reskins the **World Features** modal so containers, signs, and levers are each their own art-forward card instead of sharing the generic chip-and-box `feature-card` treatment. Doors are untouched.

| Type | Before | After |
|---|---|---|
| **Container** | chips (Locked / Key / Keyword) + nested bordered contents box | open-chest backdrop; title up top, **loot list + actions in the lower half** (the chest cavity); clean hairline rows with gold ghost "Take" pills |
| **Sign** | kind badge + keyword chip + boxed text | sign-board backdrop with the text shown prominently (display serif, legibility scrim); subtle "Read aloud" action |
| **Lever** | plate + handle on a CSS gradient card | same, now with an **optional backdrop box** behind it |

Each card ships a polished **CSS + inline-SVG fallback** (stylized chest / placard glyph, gold/teal tint) so it looks finished today — before any art lands. When art ships it takes over automatically.

## Asset contract (for parallel Arcanum-side work)

New global asset keys (server defaults in `AppConfig`):

| Key | Default path | Art |
|---|---|---|
| `container_bg` | `global_assets/container_bg.png` | open chest, interior cavity in lower ~55% |
| `sign_bg` | `global_assets/sign_bg.png` | sign board with a central text-safe area |
| `lever_bg` | `global_assets/lever_bg.png` | the box the lever sits inside |

New optional per-feature YAML override (CONTAINER / SIGN / LEVER), mirroring the existing lever `plateImage`/`handleImage`:

```yaml
- type: CONTAINER   # or SIGN / LEVER
  backgroundImage: ornate_curio_chest.webp
```

Resolved against the world image base and carried in the `Room.Features` GMCP payload. **Resolution order per feature:** `backgroundImage` → `<type>_bg` global → CSS fallback. Everything is optional and degrades gracefully.

## Changes

**Backend** — `AppConfig` (3 keys), `FeatureFile` + `RoomFeature` (`backgroundImage` on Container/Sign/Lever), `WorldLoader` (resolution), `GmcpEmitter.RoomFeaturePayload` + `HandlerHelpers` (payload mapping).

**Client** — `types.ts` + `applyGmcpPackage.ts` (parse field); `WorldFeaturesPopout.tsx` (new `ContainerCard` / `SignCard`, lever backdrop); `styles.css` (new `.fcard*` system, removed dead container/sign box rules).

## Tests

Extended `ok_features.yaml` + `WorldLoaderFeaturesTest` to assert `backgroundImage` resolution on all three types (and null when unauthored).

Verified: `eslint` ✓ · `tsc -b` ✓ · `vite build` ✓ · `ktlintCheck` ✓ · `WorldLoaderFeaturesTest` + `CommandRouterFeaturesTest` ✓.

> Note: backdrop art (`container_bg` / `sign_bg` / `lever_bg`) is not in this PR — it's authored separately on the Arcanum side. Until it ships, the CSS/SVG fallbacks render.