### PR TITLE
feat(web): strip World Features chrome — let the art lead

### DIFF
--- a/web-v3/src/components/WorldFeaturesPopout.tsx
+++ b/web-v3/src/components/WorldFeaturesPopout.tsx
@@ -50,105 +50,68 @@ function LeverWidget({
   const isUp = feature.state === "up";
   const label = isUp ? "Ready" : "Pulled";
 
-  // Custom art (authored in Arcanum): a static plate plus a handle sprite that
-  // rotates around its pivot between the up/down angles. Per-lever art wins;
-  // otherwise the server-wide default plate/handle; otherwise the hand-drawn
-  // vector lever.
+  // Composed art: an optional backdrop "box" with the plate + rotating handle on
+  // top. Per-feature art wins, then the server-wide default, then a vector lever.
+  // We show only the lever itself — the whole tile is the click target.
   const px = feature.leverPivot?.x ?? 0.5;
   const py = feature.leverPivot?.y ?? 0.85;
   const angle = isUp ? (feature.upAngle ?? -28) : (feature.downAngle ?? 28);
   const handleSrc = feature.handleImage ?? serverAssets["lever_handle"] ?? null;
   const plateSrc = feature.plateImage ?? serverAssets["lever_plate"] ?? null;
-  // Optional backdrop "box" the lever sits inside; the plate + handle ride on
-  // top. Per-feature art wins, then the server-wide default, then a CSS frame.
   const boxSrc = feature.backgroundImage ?? serverAssets["lever_bg"] ?? null;
+  const hasArt = Boolean(boxSrc || handleSrc);
 
   return (
-    <div
-      className={`lever-widget${boxSrc ? " lever-widget-boxed" : ""}`}
+    <button
+      type="button"
+      className={`lever-tile${hasArt ? " has-art" : ""}${boxSrc ? " has-box" : ""}`}
       onClick={() => onCommand(`pull ${feature.keyword}`)}
+      aria-label={`Pull ${feature.name} (${label})`}
+      title={`Pull ${feature.name}`}
     >
-      {boxSrc && (
-        <img className="lever-widget-box" src={boxSrc} alt="" aria-hidden="true" draggable={false} />
-      )}
-      {handleSrc ? (
-        <div className="lever-widget-art" aria-label={`${feature.name}: ${label}`} role="img">
-          {plateSrc && (
-            <img className="lever-widget-art-plate" src={plateSrc} alt="" aria-hidden="true" draggable={false} />
-          )}
-          <img
-            className="lever-widget-art-handle"
-            src={handleSrc}
-            alt=""
-            aria-hidden="true"
-            draggable={false}
-            style={{
-              transformOrigin: `${px * 100}% ${py * 100}%`,
-              transform: `translate(${(0.5 - px) * 100}%, ${(0.5 - py) * 100}%) rotate(${angle}deg)`,
-            }}
-          />
-        </div>
-      ) : (
-        <div className="lever-widget-plate">
-          <svg
-            className="lever-widget-svg"
-            viewBox="0 0 64 96"
-            aria-label={`${feature.name}: ${label}`}
-          >
-            {/* Base plate arc */}
-            <path
-              d="M12 78 Q32 86 52 78"
-              fill="none"
-              stroke="rgb(180 150 210 / 40%)"
-              strokeWidth="2"
-              strokeLinecap="round"
+      <span className="lever-tile-stage">
+        {boxSrc && (
+          <img className="lever-tile-box" src={boxSrc} alt="" aria-hidden="true" draggable={false} />
+        )}
+        {handleSrc ? (
+          <span className="lever-tile-lever">
+            {plateSrc && (
+              <img className="lever-tile-plate" src={plateSrc} alt="" aria-hidden="true" draggable={false} />
+            )}
+            <img
+              className="lever-tile-handle"
+              src={handleSrc}
+              alt=""
+              aria-hidden="true"
+              draggable={false}
+              style={{
+                transformOrigin: `${px * 100}% ${py * 100}%`,
+                transform: `translate(${(0.5 - px) * 100}%, ${(0.5 - py) * 100}%) rotate(${angle}deg)`,
+              }}
             />
-            {/* Pivot point */}
-            <circle cx="32" cy="72" r="6" className="lever-widget-pivot" />
-            {/* Handle shaft */}
-            <line
-              x1="32"
-              y1="72"
-              x2={isUp ? "32" : "46"}
-              y2={isUp ? "22" : "32"}
-              className="lever-widget-shaft"
-              strokeWidth="4"
-              strokeLinecap="round"
-            />
-            {/* Handle grip */}
-            <circle
-              cx={isUp ? "32" : "46"}
-              cy={isUp ? "18" : "28"}
-              r="7"
-              className="lever-widget-grip"
-            />
-            {/* Glow on grip */}
-            <circle
-              cx={isUp ? "32" : "46"}
-              cy={isUp ? "18" : "28"}
-              r="4"
-              className="lever-widget-glow"
-            />
-          </svg>
-        </div>
-      )}
-      <div className="lever-widget-info">
-        <span className="lever-widget-name">{feature.name}</span>
-        <span className={`lever-widget-state lever-widget-state-${isUp ? "up" : "down"}`}>
-          {label}
-        </span>
-      </div>
-      <button
-        type="button"
-        className="lever-widget-pull"
-        onClick={(e) => {
-          e.stopPropagation();
-          onCommand(`pull ${feature.keyword}`);
-        }}
-      >
-        Pull
-      </button>
-    </div>
+          </span>
+        ) : (
+          <span className="lever-tile-lever">
+            <svg className="lever-tile-svg" viewBox="0 0 64 96" aria-hidden="true">
+              {/* Base plate arc */}
+              <path d="M12 78 Q32 86 52 78" fill="none" stroke="rgb(180 150 210 / 40%)" strokeWidth="2" strokeLinecap="round" />
+              {/* Pivot point */}
+              <circle cx="32" cy="72" r="6" className="lever-tile-pivot" />
+              {/* Handle shaft */}
+              <line x1="32" y1="72" x2={isUp ? "32" : "46"} y2={isUp ? "22" : "32"} className="lever-tile-shaft" strokeWidth="4" strokeLinecap="round" />
+              {/* Handle grip */}
+              <circle cx={isUp ? "32" : "46"} cy={isUp ? "18" : "28"} r="7" className="lever-tile-grip" />
+              {/* Glow on grip */}
+              <circle cx={isUp ? "32" : "46"} cy={isUp ? "18" : "28"} r="4" className="lever-tile-glow" />
+            </svg>
+          </span>
+        )}
+      </span>
+      <span className="lever-tile-caption">
+        <span className="lever-tile-name">{feature.name}</span>
+        <span className={`lever-tile-state lever-tile-state-${isUp ? "up" : "down"}`}>{label}</span>
+      </span>
+    </button>
   );
 }
 
@@ -240,19 +203,7 @@ function ContainerCard({
     >
       <div className="fcard-bg" aria-hidden="true">{!bgSrc && <ChestGlyph />}</div>
       <div className="fcard-body">
-        <header className="fcard-head">
-          <span className="fcard-eyebrow fcard-eyebrow-container">Container</span>
-          <h4 className="fcard-title">{feature.name}</h4>
-          <p className="fcard-sub">
-            {feature.state === "locked"
-              ? feature.keyRequired
-                ? "Locked — a key is required."
-                : "Locked tight."
-              : isOpen
-                ? "Open"
-                : "Closed"}
-          </p>
-        </header>
+        <h4 className="fcard-title">{feature.name}</h4>
 
         <div className="fcard-foot">
           {isOpen && items !== null && (
@@ -298,11 +249,9 @@ function ContainerCard({
 function SignCard({
   feature,
   serverAssets,
-  onCommand,
 }: {
   feature: RoomFeature;
   serverAssets: Record<string, string>;
-  onCommand: (cmd: string) => void;
 }) {
   const bgSrc = feature.backgroundImage ?? serverAssets["sign_bg"] ?? null;
 
@@ -310,18 +259,11 @@ function SignCard({
     <article
       className={`fcard fcard-sign${bgSrc ? " has-art" : ""}`}
       style={bgSrc ? { ["--fcard-art" as string]: `url("${bgSrc}")` } : undefined}
+      aria-label={feature.name}
     >
       <div className="fcard-bg" aria-hidden="true">{!bgSrc && <SignGlyph />}</div>
       <div className="fcard-body fcard-sign-body">
-        <span className="fcard-eyebrow fcard-eyebrow-sign">{feature.name}</span>
         {feature.text && <p className="fcard-sign-text">{feature.text}</p>}
-        <button
-          type="button"
-          className="fcard-sign-read"
-          onClick={() => onCommand(`read ${feature.keyword}`)}
-        >
-          Read aloud
-        </button>
       </div>
     </article>
   );
@@ -450,13 +392,6 @@ function LockedDoorHero({
   );
 }
 
-function featureSummary(features: RoomFeature[], type: RoomFeatureType): string {
-  const count = features.filter((feature) => feature.type === type).length;
-  if (count === 0) return `No ${FEATURE_LABELS[type].plural.toLowerCase()}`;
-  if (count === 1) return `1 ${FEATURE_LABELS[type].singular.toLowerCase()}`;
-  return `${count} ${FEATURE_LABELS[type].plural.toLowerCase()}`;
-}
-
 function featureActions(feature: RoomFeature): Array<{ label: string; command: string }> {
   if (feature.type === "door") {
     const actions: Array<{ label: string; command: string }> = [];
@@ -579,38 +514,23 @@ export function WorldFeaturesPopout({
 
   return (
     <div className="feature-popout">
-      <header className="feature-popout-hero">
-        <div className="feature-popout-hero-copy">
-          <h3>{roomTitle}</h3>
+      {availableTabs.length > 1 && (
+        <div className="feature-popout-tabs" role="tablist" aria-label="Feature categories">
+          {availableTabs.map((type) => (
+            <button
+              key={type}
+              type="button"
+              role="tab"
+              className={`feature-popout-tab feature-popout-tab-${type}${activeTab === type ? " feature-popout-tab-active" : ""}`}
+              aria-selected={activeTab === type}
+              onClick={() => setManualTab(type)}
+            >
+              {FEATURE_LABELS[type].plural}
+              <span className="feature-popout-tab-count">{groupedFeatures[type].length}</span>
+            </button>
+          ))}
         </div>
-        <div className="feature-popout-summary" aria-label="Feature summary">
-          <span className="feature-popout-summary-pill feature-popout-summary-door">
-            {featureSummary(roomFeatures, "door")}
-          </span>
-          <span className="feature-popout-summary-pill feature-popout-summary-container">
-            {featureSummary(roomFeatures, "container")}
-          </span>
-          <span className="feature-popout-summary-pill feature-popout-summary-lever">
-            {featureSummary(roomFeatures, "lever")}
-          </span>
-        </div>
-      </header>
-
-      <div className="feature-popout-tabs" role="tablist" aria-label="Feature categories">
-        {availableTabs.map((type) => (
-          <button
-            key={type}
-            type="button"
-            role="tab"
-            className={`feature-popout-tab feature-popout-tab-${type}${activeTab === type ? " feature-popout-tab-active" : ""}`}
-            aria-selected={activeTab === type}
-            onClick={() => setManualTab(type)}
-          >
-            {FEATURE_LABELS[type].plural}
-            <span className="feature-popout-tab-count">{groupedFeatures[type].length}</span>
-          </button>
-        ))}
-      </div>
+      )}
 
       <div className={`feature-popout-grid${activeTab === "lever" ? " feature-popout-grid-levers" : ""}`}>
         {visibleFeatures.map((feature) => {
@@ -635,7 +555,7 @@ export function WorldFeaturesPopout({
           }
 
           if (feature.type === "sign") {
-            return <SignCard key={feature.id} feature={feature} serverAssets={serverAssets} onCommand={onCommand} />;
+            return <SignCard key={feature.id} feature={feature} serverAssets={serverAssets} />;
           }
 
           // Doors — generic card.

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -3208,100 +3208,67 @@ body {
 }
 
 
-.feature-popout-summary {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2);
-}
-
-.feature-popout-summary-pill {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 32px;
-  padding: 6px 12px;
-  border-radius: 999px;
-  border: 1px solid rgb(255 255 255 / 10%);
-  font-size: 0.82rem;
-  font-weight: 700;
-  color: var(--text-primary);
-  background: rgb(18 22 34 / 42%);
-}
-
-.feature-popout-summary-door {
-  color: #bdd8ee;
-}
-
-.feature-popout-summary-container {
-  color: #e1c17c;
-}
-
-.feature-popout-summary-lever {
-  color: #d3abdf;
-}
-
+/* Quiet text tabs — only shown when a room has more than one feature type.
+   No pill boxes; the active category brightens with a soft underline. */
 .feature-popout-tabs {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 4px;
+  margin: -2px 0 2px;
 }
 
 .feature-popout-tab {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 14px;
-  border: 1px solid var(--line-soft);
-  border-radius: 999px;
-  background: linear-gradient(135deg, rgb(72 83 117 / 76%), rgb(57 69 101 / 72%));
-  color: var(--text-secondary);
+  gap: 6px;
+  padding: 6px 4px;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: none;
+  color: var(--text-muted);
   font-family: var(--font-body);
-  font-size: 0.84rem;
+  font-size: 0.86rem;
   font-weight: 700;
+  letter-spacing: 0.01em;
   cursor: pointer;
   transition:
-    transform 160ms var(--ease-out-soft),
-    border-color 160ms var(--ease-out-soft),
     color 160ms var(--ease-out-soft),
-    background 160ms var(--ease-out-soft);
+    border-color 160ms var(--ease-out-soft);
+}
+
+.feature-popout-tab + .feature-popout-tab {
+  margin-left: 12px;
 }
 
 .feature-popout-tab:hover {
-  transform: translateY(-1px);
   color: var(--text-primary);
-  border-color: rgb(216 197 232 / 34%);
 }
 
 .feature-popout-tab-active {
   color: var(--text-bright);
-  border-color: rgb(216 197 232 / 44%);
-  background: linear-gradient(135deg, rgb(96 82 120 / 84%), rgb(73 95 131 / 78%));
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 12%), 0 10px 20px rgb(10 12 22 / 18%);
+  border-bottom-color: rgb(216 197 232 / 70%);
 }
 
 .feature-popout-tab-door.feature-popout-tab-active {
-  border-color: rgb(156 190 228 / 42%);
+  border-bottom-color: rgb(156 190 228 / 75%);
 }
 
 .feature-popout-tab-container.feature-popout-tab-active {
-  border-color: rgb(223 191 116 / 42%);
+  border-bottom-color: rgb(223 191 116 / 78%);
 }
 
 .feature-popout-tab-lever.feature-popout-tab-active {
-  border-color: rgb(211 171 223 / 42%);
+  border-bottom-color: rgb(211 171 223 / 78%);
+}
+
+.feature-popout-tab-sign.feature-popout-tab-active {
+  border-bottom-color: rgb(168 204 178 / 78%);
 }
 
 .feature-popout-tab-count {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 22px;
-  min-height: 22px;
-  padding: 0 6px;
-  border-radius: 999px;
-  background: rgb(15 18 29 / 45%);
-  color: currentColor;
   font-size: 0.74rem;
+  font-weight: 700;
+  opacity: 0.7;
 }
 
 .feature-popout-grid {
@@ -3331,81 +3298,72 @@ body {
     linear-gradient(145deg, rgb(73 64 102 / 92%), rgb(55 49 81 / 88%));
 }
 
-/* Lever grid lays out widgets in a compact row-wrap */
+/* Lever tiles lay out in a compact row-wrap, each a fixed-ish width so a lone
+   lever stays small rather than stretching across the modal. */
 .feature-popout-grid-levers {
-  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(150px, 180px));
+  justify-content: start;
 }
 
-/* ── Graphical lever widget ─────────────────────────────── */
-.lever-widget {
-  position: relative;
-  isolation: isolate;
+/* ── Lever tile — just the lever art, click to pull ───────── */
+.lever-tile {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
   gap: 8px;
-  padding: 14px 12px 12px;
-  border: 1px solid rgb(211 171 223 / 18%);
-  border-radius: var(--radius-lg);
-  background:
-    radial-gradient(circle at 50% 20%, rgb(204 154 216 / 12%), transparent 60%),
-    linear-gradient(160deg, rgb(66 58 94 / 92%), rgb(50 44 74 / 90%));
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
   cursor: pointer;
-  transition:
-    border-color 200ms var(--ease-out-soft),
-    transform 200ms var(--ease-out-soft),
-    box-shadow 200ms var(--ease-out-soft);
 }
 
-/* Optional backdrop "box" art (lever_bg / per-feature). Fills the card; the
-   plate + handle render on top. When present we drop the CSS frame so only the
-   authored art shows. */
-.lever-widget-box {
+.lever-tile:focus-visible {
+  outline: 2px solid rgb(216 197 232 / 70%);
+  outline-offset: 4px;
+  border-radius: var(--radius-md);
+}
+
+/* The art stage holds the box (decorative frame) filling it, with the lever
+   (plate + pivoting handle, or vector fallback) riding on top. No card chrome. */
+.lever-tile-stage {
+  display: block;
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 5;
+  transition:
+    transform 200ms var(--ease-out-soft),
+    filter 200ms var(--ease-out-soft);
+}
+
+.lever-tile-box {
   position: absolute;
   inset: 0;
-  z-index: -1;
   width: 100%;
   height: 100%;
   object-fit: cover;
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   pointer-events: none;
   user-select: none;
 }
 
-.lever-widget-boxed {
-  border-color: transparent;
-  background: none;
+/* The lever itself. With a box it sits in the box's socket (upper-centre, about
+   half width); without a box it fills the stage. The plate + handle share this
+   frame so the handle pivots correctly. */
+.lever-tile-lever {
+  position: absolute;
+  inset: 0;
 }
 
-.lever-widget:hover {
-  border-color: rgb(211 171 223 / 38%);
-  transform: translateY(-2px);
-  box-shadow: 0 8px 20px rgb(10 8 18 / 30%);
+.lever-tile.has-box .lever-tile-lever {
+  inset: 8% 27% auto 27%;
+  aspect-ratio: 1;
 }
 
-.lever-widget-plate {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 72px;
-  height: 96px;
-}
-
-.lever-widget-svg {
-  width: 64px;
-  height: 96px;
-  overflow: visible;
-}
-
-/* Custom lever art — a square box; the plate + pivoting handle overlay it. */
-.lever-widget-art {
-  position: relative;
-  width: 88px;
-  height: 88px;
-}
-
-.lever-widget-art-plate,
-.lever-widget-art-handle {
+.lever-tile-plate,
+.lever-tile-handle,
+.lever-tile-svg {
   position: absolute;
   inset: 0;
   width: 100%;
@@ -3413,14 +3371,25 @@ body {
   object-fit: contain;
   pointer-events: none;
   user-select: none;
+  overflow: visible;
 }
 
-.lever-widget-art-handle {
+.lever-tile-handle {
   transition: transform 0.45s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
-.lever-widget-svg line,
-.lever-widget-svg circle {
+.lever-tile:hover .lever-tile-stage {
+  transform: translateY(-3px) scale(1.03);
+  filter: drop-shadow(0 10px 22px rgb(10 8 18 / 45%));
+}
+
+.lever-tile:active .lever-tile-stage {
+  transform: translateY(-1px) scale(1.01);
+}
+
+/* Vector fallback colors (no art shipped) */
+.lever-tile-svg line,
+.lever-tile-svg circle {
   transition:
     cx 400ms var(--ease-in-out-smooth),
     cy 400ms var(--ease-in-out-smooth),
@@ -3430,101 +3399,66 @@ body {
     y2 400ms var(--ease-in-out-smooth);
 }
 
-.lever-widget-pivot {
+.lever-tile-pivot {
   fill: rgb(80 70 110);
   stroke: rgb(160 140 190 / 50%);
   stroke-width: 1.5;
 }
 
-.lever-widget-shaft {
+.lever-tile-shaft {
   stroke: rgb(190 165 220);
   filter: drop-shadow(0 0 3px rgb(190 165 220 / 30%));
 }
 
-.lever-widget-grip {
+.lever-tile-grip {
   fill: rgb(100 85 135);
   stroke: rgb(210 185 240 / 60%);
   stroke-width: 1.5;
 }
 
-.lever-widget-glow {
+.lever-tile-glow {
   fill: rgb(220 195 250 / 50%);
   filter: blur(2px);
   pointer-events: none;
 }
 
-/* Info below lever */
-.lever-widget-info {
+/* Readable caption beneath the art (never overlaid on it) */
+.lever-tile-caption {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2px;
+  gap: 1px;
   text-align: center;
 }
 
-.lever-widget-name {
+.lever-tile-name {
   font-size: 0.84rem;
   font-weight: 700;
   color: var(--text-primary);
   line-height: 1.2;
 }
 
-.lever-widget-state {
-  font-size: 0.72rem;
+.lever-tile-state {
+  font-size: 0.7rem;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  font-weight: 600;
-}
-
-.lever-widget-state-up {
-  color: rgb(180 210 160);
-}
-
-.lever-widget-state-down {
-  color: rgb(220 180 130);
-}
-
-/* Pull button */
-.lever-widget-pull {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  padding: 6px 0;
-  border: 1px solid rgb(211 171 223 / 22%);
-  border-radius: var(--radius-md);
-  background: linear-gradient(135deg, rgb(100 85 140 / 60%), rgb(80 68 118 / 56%));
-  color: var(--text-primary);
-  font-family: var(--font-body);
-  font-size: 0.8rem;
+  letter-spacing: 0.07em;
   font-weight: 700;
-  cursor: pointer;
-  transition:
-    background 150ms var(--ease-out-soft),
-    border-color 150ms var(--ease-out-soft),
-    transform 150ms var(--ease-out-soft);
 }
 
-.lever-widget-pull:hover {
-  background: linear-gradient(135deg, rgb(120 100 165 / 72%), rgb(95 82 140 / 68%));
-  border-color: rgb(211 171 223 / 40%);
-  transform: translateY(-1px);
+.lever-tile-state-up {
+  color: rgb(150 200 130);
 }
 
-.lever-widget-pull:active {
-  transform: translateY(0);
+.lever-tile-state-down {
+  color: rgb(220 175 120);
 }
 
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce) {
-  .lever-widget-svg line,
-  .lever-widget-svg circle {
-    transition: none;
-  }
-
-  .lever-widget,
-  .lever-widget-pull,
-  .lever-widget-art-handle {
+  .lever-tile-svg line,
+  .lever-tile-svg circle,
+  .lever-tile-art,
+  .lever-tile-handle {
     transition: none;
   }
 
@@ -3684,7 +3618,7 @@ body {
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(180deg, rgb(12 14 24 / 20%) 0%, rgb(12 14 24 / 18%) 42%, rgb(10 12 20 / 78%) 100%);
+  background: linear-gradient(180deg, rgb(10 12 20 / 26%) 0%, rgb(10 12 20 / 12%) 45%, rgb(10 12 20 / 46%) 100%);
 }
 
 /* Stylized SVG fallback glyph (no art shipped yet). */
@@ -3703,35 +3637,14 @@ body {
   padding: 16px 18px;
 }
 
-.fcard-head {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-}
-
-.fcard-eyebrow {
-  font-size: 0.7rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-}
-
-.fcard-eyebrow-container {
-  color: #e1c17c;
-}
-
 .fcard-title {
   margin: 0;
   font-family: var(--font-display);
   font-size: 1.16rem;
-  color: var(--text-heading);
-  text-shadow: 0 1px 8px rgb(8 10 18 / 55%);
-}
-
-.fcard-sub {
-  margin: 0;
-  font-size: 0.82rem;
-  color: var(--text-secondary);
+  color: var(--text-bright);
+  text-shadow:
+    0 1px 2px rgb(0 0 0 / 70%),
+    0 1px 14px rgb(0 0 0 / 55%);
 }
 
 /* Container contents + actions sit in the lower half (the open chest's cavity). */
@@ -3756,8 +3669,8 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: var(--space-2);
-  padding: 7px 4px 7px 2px;
-  border-bottom: 1px solid rgb(255 255 255 / 8%);
+  padding: 8px 0;
+  border-bottom: 1px solid rgb(255 255 255 / 12%);
 }
 
 .fcard-loot-row:last-child {
@@ -3765,21 +3678,23 @@ body {
 }
 
 .fcard-loot-name {
-  color: var(--text-primary);
-  font-size: 0.88rem;
+  color: var(--text-bright);
+  font-size: 0.9rem;
+  text-shadow: 0 1px 6px rgb(0 0 0 / 65%);
 }
 
 .fcard-take {
   flex-shrink: 0;
-  padding: 4px 12px;
-  border: 1px solid rgb(226 198 134 / 28%);
+  padding: 5px 14px;
+  border: 1px solid rgb(240 214 150 / 50%);
   border-radius: 999px;
-  background: rgb(226 198 134 / 12%);
-  color: #ecd6a0;
+  background: rgb(60 48 24 / 62%);
+  color: #f4e2b2;
   font-family: var(--font-body);
   font-size: 0.78rem;
   font-weight: 700;
   cursor: pointer;
+  backdrop-filter: blur(2px);
   transition:
     background 150ms var(--ease-out-soft),
     border-color 150ms var(--ease-out-soft),
@@ -3787,8 +3702,8 @@ body {
 }
 
 .fcard-take:hover {
-  background: rgb(226 198 134 / 22%);
-  border-color: rgb(240 214 150 / 55%);
+  background: rgb(86 68 32 / 78%);
+  border-color: rgb(248 226 168 / 80%);
   transform: translateY(-1px);
 }
 
@@ -3842,9 +3757,18 @@ body {
   background: linear-gradient(135deg, rgb(188 158 100 / 76%), rgb(142 118 74 / 68%));
 }
 
+/* Art bleeds — only a whisper of an edge so the card reads as the art, not a box. */
+.fcard.has-art {
+  border-color: rgb(255 255 255 / 7%);
+}
+
 /* Container card tinting */
 .fcard-container {
   border-color: rgb(212 178 110 / 24%);
+}
+
+.fcard-container .fcard-body {
+  min-height: 210px;
 }
 
 .fcard-container .fcard-bg {
@@ -3852,6 +3776,22 @@ body {
   background:
     radial-gradient(ellipse at 50% 8%, rgb(226 198 134 / 16%), transparent 58%),
     linear-gradient(165deg, rgb(74 66 86 / 96%), rgb(50 46 66 / 94%));
+}
+
+/* The open chest's interior is bright — a soft gradient (not a panel) sits behind
+   the title + loot so light text stays legible. */
+.fcard-container.has-art .fcard-body::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background: linear-gradient(
+    to top,
+    rgb(6 7 13 / 82%) 0%,
+    rgb(6 7 13 / 58%) 26%,
+    rgb(6 7 13 / 16%) 54%,
+    transparent 76%
+  );
 }
 
 .fcard-container.is-closed .fcard-glyph,
@@ -3874,47 +3814,21 @@ body {
 .fcard-sign-body {
   align-items: center;
   justify-content: center;
-  gap: 12px;
   text-align: center;
-}
-
-.fcard-eyebrow-sign {
-  color: #b9d6be;
 }
 
 .fcard-sign-text {
   margin: 0;
-  max-width: 62ch;
+  max-width: 58ch;
   color: var(--text-bright);
   font-family: var(--font-display);
-  font-size: 1.04rem;
+  font-size: 1.06rem;
   font-style: italic;
-  line-height: 1.55;
+  line-height: 1.6;
   white-space: pre-wrap;
-  text-shadow: 0 1px 10px rgb(8 10 18 / 60%);
-}
-
-.fcard-sign-read {
-  padding: 6px 16px;
-  border: 1px solid rgb(185 214 190 / 30%);
-  border-radius: 999px;
-  background: rgb(185 214 190 / 10%);
-  color: #cfe6d4;
-  font-family: var(--font-body);
-  font-size: 0.78rem;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  cursor: pointer;
-  transition:
-    background 150ms var(--ease-out-soft),
-    border-color 150ms var(--ease-out-soft),
-    transform 150ms var(--ease-out-soft);
-}
-
-.fcard-sign-read:hover {
-  background: rgb(185 214 190 / 20%);
-  border-color: rgb(205 230 212 / 55%);
-  transform: translateY(-1px);
+  text-shadow:
+    0 1px 2px rgb(0 0 0 / 60%),
+    0 1px 12px rgb(0 0 0 / 50%);
 }
 
 /* Hero treatment for a single locked feature (container or door) — bigger,


### PR DESCRIPTION
## Summary

Follow-up to #1246. The backdrop art landed and looks great — this pass removes the boxes stacked **above and around** the feature art so the art itself is the focus. Pure UI/CSS; no data or GMCP-contract changes.

### Before → after
- **Header chrome gone.** Dropped the room-title hero panel and the "N container / N lever" summary pills.
- **Tabs are quiet now.** Underlined text labels instead of filled pills, and they only appear when a room has more than one feature type.
- **Containers.** Removed the "CONTAINER" eyebrow and the "Open" sub-line — just a readable title. Added a soft bottom scrim + text shadows so the loot list and **Take** buttons read clearly over the bright chest interior; aligned the loot rows with the title; made the Take buttons solid enough to actually see.
- **Levers.** Dropped the purple card, the overlaid name, and the separate **Pull** button. Now it's just the lever in its box — the box fills the tile, the plate/handle ride in the socket as before, the whole tile is the click-to-pull target, and the name + state moved to a readable caption **beneath** the art.
- **Signs.** Dropped the name eyebrow and the **Read aloud** button. (That button only re-ran the `read` command — there's no text-to-speech, and the text is already on the placard, so it was dead weight.)

### Notes
- No changes to asset keys, the `backgroundImage` field, or the GMCP payload.
- The lever keeps the existing box + plate/handle composition (box fills the tile, lever sprite in the upper-centre socket). If the brass arm looks off-scale now that the card is gone, it's a one-line tweak to the socket inset — flag a screenshot.

Verified: `eslint` ✓ · `tsc -b` ✓ · `vite build` ✓.