### PR TITLE
feat: full-bleed feature panels + grimoire puzzle (inscribe → flame)

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -3047,6 +3047,10 @@ data class ImagesConfig(
             "container_bg" to "global_assets/container_bg.png",
             "sign_bg" to "global_assets/sign_bg.png",
             "lever_bg" to "global_assets/lever_bg.png",
+            // Server-wide default backdrop for the puzzle (grimoire/parchment) panel.
+            // Used when a puzzle doesn't author its own backgroundImage; falls back
+            // further to a CSS tome treatment when this isn't present either.
+            "puzzle_bg" to "global_assets/puzzle_bg.png",
             "dialog_indicator" to "global_assets/dialog_indicator.png",
             "aggro_indicator" to "global_assets/aggro_indicator.png",
             "quest_available_indicator" to "global_assets/quest_available_indicator.png",

--- a/src/main/kotlin/dev/ambon/domain/puzzle/PuzzleDef.kt
+++ b/src/main/kotlin/dev/ambon/domain/puzzle/PuzzleDef.kt
@@ -27,6 +27,12 @@ data class PuzzleDef(
     val cooldownMs: Long = 0L,
     /** Whether a failed sequence resets to the beginning. */
     val resetOnFail: Boolean = true,
+    /**
+     * Optional parchment/grimoire backdrop art (resolved URL) for the web
+     * client's puzzle panel. Absent → the `puzzle_bg` global default, then a
+     * built-in CSS treatment.
+     */
+    val backgroundImage: String? = null,
 )
 
 enum class PuzzleType {

--- a/src/main/kotlin/dev/ambon/domain/world/data/PuzzleFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/PuzzleFile.kt
@@ -31,6 +31,13 @@ data class PuzzleFile(
     val cooldownMs: Long = 0L,
     /** Whether a failed sequence resets to the beginning (sequence type only). */
     val resetOnFail: Boolean = true,
+    /**
+     * Optional grimoire/parchment backdrop art (content-addressed filename) for
+     * the web client's puzzle panel, resolved against the world image base like
+     * room/mob/item art. Absent → the `puzzle_bg` global default, then a built-in
+     * CSS tome treatment.
+     */
+    val backgroundImage: String? = null,
 )
 
 /** A single step in a sequence puzzle. */

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -958,6 +958,7 @@ object WorldLoader {
                         successMessage = puzzleFile.successMessage,
                         cooldownMs = puzzleFile.cooldownMs,
                         resetOnFail = puzzleFile.resetOnFail,
+                        backgroundImage = puzzleFile.backgroundImage?.trim()?.takeUnless { it.isEmpty() }?.let { "$imagesBase$it" },
                     ),
                 )
             }

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -2204,6 +2204,25 @@ class GmcpEmitter(
         emitRaw(sessionId, "Puzzle.Close", "{}", supportCheck = "Puzzle")
     }
 
+    /**
+     * Result of a riddle answer attempt. The web client uses this to play the
+     * inscribe → puff-of-flame beat (gold flare on [correct], ash scatter
+     * otherwise) and surface [message] on the page.
+     */
+    suspend fun sendPuzzleResult(
+        sessionId: SessionId,
+        id: String,
+        correct: Boolean,
+        message: String,
+    ) {
+        emit(
+            sessionId,
+            "Puzzle.Result",
+            PuzzleResultPayload(id = id, correct = correct, message = message),
+            supportCheck = "Puzzle",
+        )
+    }
+
     // ---------- look target ----------
 
     suspend fun sendLookTarget(
@@ -3353,6 +3372,15 @@ class GmcpEmitter(
         val currentStep: Int?,
         /** True if the player has already solved this puzzle. */
         val solved: Boolean,
+        /** Optional parchment/grimoire backdrop art (resolved URL), or null. */
+        val backgroundImage: String? = null,
+    )
+
+    /** Result of a riddle answer attempt — drives the client's inscribe/flame beat. */
+    private data class PuzzleResultPayload(
+        val id: String,
+        val correct: Boolean,
+        val message: String,
     )
 
     internal companion object {

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -234,6 +234,7 @@ internal suspend fun EngineContext.emitPuzzleGmcp(sessionId: SessionId) {
             totalSteps = if (isRiddle) null else p.steps.size,
             currentStep = if (isRiddle) null else system.sequenceStep(sessionId, p.id),
             solved = system.isSolved(sessionId, p.id),
+            backgroundImage = p.backgroundImage,
         )
     }
     emitter.sendPuzzleList(sessionId, payloads)

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/PuzzleHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/PuzzleHandler.kt
@@ -58,12 +58,16 @@ class PuzzleHandler(
         // Try each riddle in the room — if any succeeds, stop immediately.
         // Otherwise, show the fail message from the last attempted riddle.
         var lastFailMessage: String? = null
+        var lastFailPuzzleId: String? = null
         for (puzzle in riddles) {
             val result = system.attemptRiddleAnswer(sessionId, puzzle, answerText)
             when (result) {
                 is PuzzleResult.Success -> {
                     ctx.metrics.onGameEvent("puzzle", "solved")
                     outbound.send(OutboundEvent.SendInfo(sessionId, result.message))
+                    // Drives the web client's inscribe → gold-flame beat before the
+                    // room refresh marks the puzzle solved.
+                    gmcpEmitter?.sendPuzzleResult(sessionId, puzzle.id, correct = true, message = result.message)
                     grantReward(sessionId, result.reward)
                     // Refresh room state so newly-unlocked exits, minimap, and Puzzle.List
                     // (marking the puzzle as solved) reach the client immediately.
@@ -72,6 +76,7 @@ class PuzzleHandler(
                 }
                 is PuzzleResult.Failure -> {
                     lastFailMessage = result.message
+                    lastFailPuzzleId = puzzle.id
                     // Continue to try next riddle
                 }
                 is PuzzleResult.AlreadySolved -> {
@@ -89,6 +94,8 @@ class PuzzleHandler(
         // No riddle succeeded — show last fail or generic message
         if (lastFailMessage != null) {
             outbound.send(OutboundEvent.SendError(sessionId, lastFailMessage))
+            // Drives the web client's ash-scatter beat with the riddle's fail message.
+            gmcpEmitter?.sendPuzzleResult(sessionId, lastFailPuzzleId ?: riddles.first().id, correct = false, message = lastFailMessage)
         } else {
             outbound.send(OutboundEvent.SendInfo(sessionId, "You have already solved this puzzle."))
         }

--- a/src/test/kotlin/dev/ambon/engine/commands/PuzzleSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/PuzzleSystemTest.kt
@@ -80,12 +80,16 @@ class PuzzleSystemTest {
         assertEquals("ok_puzzles:sphinx", riddle.mobId)
         assertTrue(riddle.acceptableAnswers.contains("mountain"))
         assertTrue(riddle.acceptableAnswers.contains("a mountain"))
+        // Optional grimoire backdrop art resolves against the world image base.
+        assertTrue(riddle.backgroundImage!!.endsWith("sphinx_tome.webp"), "got=${riddle.backgroundImage}")
 
         val sequence = puzzles.first { it.id == "ok_puzzles:lever_sequence" }
         assertEquals(PuzzleType.SEQUENCE, sequence.type)
         assertEquals(3, sequence.steps.size)
         assertEquals("red", sequence.steps[0].featureKeyword)
         assertEquals("pull", sequence.steps[0].action)
+        // No art authored — stays null (client falls back to puzzle_bg, then CSS).
+        assertNull(sequence.backgroundImage)
     }
 
     // ---- Riddle tests ----

--- a/src/test/resources/world/ok_puzzles.yaml
+++ b/src/test/resources/world/ok_puzzles.yaml
@@ -80,6 +80,7 @@ puzzles:
     question: "What has roots that nobody sees, is taller than trees, up it goes, and yet never grows?"
     answer: "mountain"
     acceptableAnswers: ["mountain", "a mountain", "the mountain"]
+    backgroundImage: "sphinx_tome.webp"
     reward:
       type: unlock_exit
       exitDirection: north

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -921,7 +921,9 @@ function App() {
         title={drawerTitle}
         onClose={closeDrawer}
         variant={
-          drawerPanel === "features"
+          drawerPanel === "puzzle"
+            ? "tome"
+            : drawerPanel === "features"
             ? "feature"
             : drawerPanel === "inventory"
             ? "satchel"
@@ -944,7 +946,10 @@ function App() {
                             : "default"
         }
         skinBg={
-          drawerPanel === "features"
+          drawerPanel === "puzzle"
+            ? (state.puzzle?.puzzles.find((p) => p.backgroundImage)?.backgroundImage
+                ?? state.serverAssets["puzzle_bg"])
+            : drawerPanel === "features"
             ? (featurePanelFeature && featurePanelFeature.type !== "lever"
                 ? (featureArt(featurePanelFeature, state.serverAssets) ?? undefined)
                 : undefined)
@@ -1103,7 +1108,12 @@ function App() {
         )}
 
         {drawerPanel === "puzzle" && state.puzzle && (
-          <PuzzlePopout puzzle={state.puzzle} onCommand={sendCommand} />
+          <PuzzlePopout
+            puzzle={state.puzzle}
+            puzzleResult={state.puzzleResult}
+            serverAssets={state.serverAssets}
+            onCommand={sendCommand}
+          />
         )}
 
         {drawerPanel === "features" && (

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -8,6 +8,7 @@ import { ShopPopout } from "./components/ShopPopout";
 import { TrainerPanel } from "./components/TrainerPanel";
 import { TradePanel } from "./components/TradePanel";
 import { WorldFeaturesPopout } from "./components/WorldFeaturesPopout";
+import { featureArt, pickFocusedFeature } from "./components/worldFeatures";
 import { ChatPanel } from "./components/panels/ChatPanel";
 import { CharacterPanel } from "./components/panels/CharacterPanel";
 import { SpellbookPanel } from "./components/SpellbookPanel";
@@ -827,6 +828,13 @@ function App() {
     return () => canvas.removeEventListener("wheel", stop);
   }, [drawerPanel]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // The single feature a freshly-opened features panel shows — drives the Drawer
+  // title and skin background so the chrome matches what WorldFeaturesPopout renders.
+  const featurePanelFeature = useMemo(
+    () => (drawerPanel === "features" ? pickFocusedFeature(state.roomFeatures, featureFocus) : null),
+    [drawerPanel, state.roomFeatures, featureFocus],
+  );
+
   const drawerTitle = useMemo(() => {
     switch (drawerPanel) {
       case "character": return "Character";
@@ -838,7 +846,7 @@ function App() {
       case "chat": return "Social";
       case "shop": return state.shop?.name ?? "Shop";
       case "puzzle": return "Puzzle";
-      case "features": return "World Features";
+      case "features": return featurePanelFeature ? featurePanelFeature.name : "Interactive Feature";
       case "trainer": return "Trainer";
       case "mail": return "Mail";
       case "crafting": return "Crafting";
@@ -858,7 +866,7 @@ function App() {
       case "map": return "World Map";
       default: return "";
     }
-  }, [drawerPanel, state.shop?.name, state.room.title]);
+  }, [drawerPanel, state.shop?.name, state.room.title, featurePanelFeature]);
 
   const sortedExits = useMemo(() => sortExits(state.room.exits), [state.room.exits]);
   const questMarkerCount = useMemo(
@@ -913,7 +921,9 @@ function App() {
         title={drawerTitle}
         onClose={closeDrawer}
         variant={
-          drawerPanel === "inventory"
+          drawerPanel === "features"
+            ? "feature"
+            : drawerPanel === "inventory"
             ? "satchel"
             : drawerPanel === "equipment"
               ? "equipment"
@@ -934,7 +944,11 @@ function App() {
                             : "default"
         }
         skinBg={
-          drawerPanel === "inventory"
+          drawerPanel === "features"
+            ? (featurePanelFeature && featurePanelFeature.type !== "lever"
+                ? (featureArt(featurePanelFeature, state.serverAssets) ?? undefined)
+                : undefined)
+            : drawerPanel === "inventory"
             ? state.serverAssets["inventory_satchel_bg"]
             : drawerPanel === "equipment"
               ? state.serverAssets["equipment_bg"]
@@ -1094,7 +1108,6 @@ function App() {
 
         {drawerPanel === "features" && (
           <WorldFeaturesPopout
-            roomTitle={state.room.title !== "-" ? state.room.title : "Current Room"}
             roomFeatures={state.roomFeatures}
             containerContents={state.containerContents}
             preferredType={featureFocus}

--- a/web-v3/src/components/Drawer.tsx
+++ b/web-v3/src/components/Drawer.tsx
@@ -9,7 +9,7 @@ interface DrawerProps {
   /** Visual skin for the sheet chrome: warm leather (satchel), a dim
    *  dressing-chamber (equipment), a merchant cart (shop), a chalkboard
    *  (trainer), a parchment journal (combat log), or a cork quest board. */
-  variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "desk" | "mail" | "feature";
+  variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "desk" | "mail" | "feature" | "tome";
   /** Optional background art for a skinned variant (server asset). */
   skinBg?: string;
 }

--- a/web-v3/src/components/Drawer.tsx
+++ b/web-v3/src/components/Drawer.tsx
@@ -9,7 +9,7 @@ interface DrawerProps {
   /** Visual skin for the sheet chrome: warm leather (satchel), a dim
    *  dressing-chamber (equipment), a merchant cart (shop), a chalkboard
    *  (trainer), a parchment journal (combat log), or a cork quest board. */
-  variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "desk" | "mail";
+  variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "desk" | "mail" | "feature";
   /** Optional background art for a skinned variant (server asset). */
   skinBg?: string;
 }

--- a/web-v3/src/components/PuzzlePopout.tsx
+++ b/web-v3/src/components/PuzzlePopout.tsx
@@ -1,132 +1,152 @@
-import { useState } from "react";
-import type { PuzzleItem, PuzzleState } from "../types";
+import { useEffect, useRef, useState } from "react";
+import type { PuzzleItem, PuzzleResult, PuzzleState } from "../types";
 
 interface PuzzlePopoutProps {
   puzzle: PuzzleState;
+  puzzleResult: PuzzleResult | null;
+  serverAssets: Record<string, string>;
   onCommand: (command: string) => void;
 }
 
 function SequenceDots({ currentStep, totalSteps }: { currentStep: number; totalSteps: number }) {
   return (
-    <div className="puzzle-sequence-dots" aria-label={`Step ${currentStep} of ${totalSteps}`}>
+    <div className="puzzle-seq-dots" aria-label={`Step ${currentStep} of ${totalSteps}`}>
       {Array.from({ length: totalSteps }, (_, i) => (
         <span
           key={i}
-          className={`puzzle-sequence-dot${i < currentStep ? " puzzle-sequence-dot-done" : ""}${i === currentStep ? " puzzle-sequence-dot-next" : ""}`}
+          className={`puzzle-seq-dot${i < currentStep ? " is-done" : ""}${i === currentStep ? " is-next" : ""}`}
         />
       ))}
     </div>
   );
 }
 
-function RiddleCard({ puzzle }: { puzzle: PuzzleItem }) {
+function RiddleBlock({ puzzle }: { puzzle: PuzzleItem }) {
   return (
-    <article className={`puzzle-card puzzle-card-riddle${puzzle.solved ? " puzzle-card-solved" : ""}`}>
-      <div className="puzzle-card-icon">
-        <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
-          <path
-            d="M12 2C8.13 2 5 5.13 5 9c0 2.38 1.19 4.47 3 5.74V17a1 1 0 001 1h6a1 1 0 001-1v-2.26c1.81-1.27 3-3.36 3-5.74 0-3.87-3.13-7-7-7z"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-          <path d="M9 21h6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-          <path d="M10 17v4M14 17v4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-        </svg>
-      </div>
-      <div className="puzzle-card-body">
-        <div className="puzzle-card-top">
-          <span className="puzzle-card-label">Riddle</span>
-          {puzzle.solved && <span className="puzzle-card-badge">Solved</span>}
-        </div>
-        <p className="puzzle-card-question">
-          {puzzle.question ?? "An ancient riddle awaits your answer."}
-        </p>
-      </div>
-    </article>
+    <div className={`puzzle-riddle${puzzle.solved ? " is-solved" : ""}`}>
+      <span className="puzzle-eyebrow">A Riddle</span>
+      <p className="puzzle-riddle-text">
+        {puzzle.question ?? "An ancient riddle awaits your answer."}
+      </p>
+      {puzzle.solved && <span className="puzzle-seal">Solved</span>}
+    </div>
   );
 }
 
-function SequenceCard({ puzzle }: { puzzle: PuzzleItem }) {
+function SequenceBlock({ puzzle }: { puzzle: PuzzleItem }) {
   return (
-    <article className={`puzzle-card puzzle-card-sequence${puzzle.solved ? " puzzle-card-solved" : ""}`}>
-      <div className="puzzle-card-icon puzzle-card-icon-sequence">
-        <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
-          <circle cx="5" cy="12" r="2" stroke="currentColor" strokeWidth="1.5" />
-          <circle cx="12" cy="12" r="2" stroke="currentColor" strokeWidth="1.5" />
-          <circle cx="19" cy="12" r="2" stroke="currentColor" strokeWidth="1.5" />
-          <path d="M7 12h3M14 12h3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-        </svg>
-      </div>
-      <div className="puzzle-card-body">
-        <div className="puzzle-card-top">
-          <span className="puzzle-card-label">Sequence</span>
-          {puzzle.solved && <span className="puzzle-card-badge">Solved</span>}
-        </div>
-        <p className="puzzle-card-hint">
-          Interact with features in the correct order.
-        </p>
-        {puzzle.totalSteps != null && puzzle.currentStep != null && (
-          <SequenceDots currentStep={puzzle.currentStep} totalSteps={puzzle.totalSteps} />
-        )}
-      </div>
-    </article>
+    <div className={`puzzle-riddle${puzzle.solved ? " is-solved" : ""}`}>
+      <span className="puzzle-eyebrow">A Sequence</span>
+      <p className="puzzle-riddle-text">Work the room's features in the right order.</p>
+      {puzzle.totalSteps != null && puzzle.currentStep != null && (
+        <SequenceDots currentStep={puzzle.currentStep} totalSteps={puzzle.totalSteps} />
+      )}
+      {puzzle.solved && <span className="puzzle-seal">Solved</span>}
+    </div>
   );
 }
 
-export function PuzzlePopout({ puzzle, onCommand }: PuzzlePopoutProps) {
+export function PuzzlePopout({ puzzle, puzzleResult, serverAssets, onCommand }: PuzzlePopoutProps) {
   const [answer, setAnswer] = useState("");
+  const [burn, setBurn] = useState<{ correct: boolean; text: string; message: string } | null>(null);
+  const [seenResult, setSeenResult] = useState<PuzzleResult | null>(puzzleResult);
+  const [pendingText, setPendingText] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const hasArt =
+    (puzzle.puzzles.find((p) => p.backgroundImage)?.backgroundImage ?? serverAssets["puzzle_bg"]) != null;
+  const hasUnsolvedRiddle = puzzle.puzzles.some((p) => p.type === "riddle" && !p.solved);
+
+  // A fresh Puzzle.Result ignites the ink: gold flare if correct, ash scatter if
+  // not. Derived during render (the blessed "adjust state on prop change" form)
+  // so we react the instant the result lands, showing what was just inscribed.
+  if (puzzleResult !== seenResult) {
+    setSeenResult(puzzleResult);
+    if (puzzleResult) {
+      setBurn({
+        correct: puzzleResult.correct,
+        text: pendingText,
+        message: puzzleResult.message,
+      });
+      setAnswer("");
+    }
+  }
 
   const submit = () => {
     const trimmed = answer.trim();
-    if (trimmed.length === 0) return;
+    if (trimmed.length === 0 || burn) return;
+    setPendingText(trimmed);
     onCommand(`answer ${trimmed}`);
-    setAnswer("");
   };
 
-  const hasUnsolvedRiddle = puzzle.puzzles.some((p) => p.type === "riddle" && !p.solved);
+  // Clear the flame once it's burned out; re-arm the page for another attempt
+  // when the answer was wrong.
+  useEffect(() => {
+    if (!burn) return;
+    const wasWrong = !burn.correct;
+    const timer = setTimeout(() => {
+      setBurn(null);
+      if (wasWrong) inputRef.current?.focus();
+    }, 1500);
+    return () => clearTimeout(timer);
+  }, [burn]);
 
   return (
-    <div className="puzzle-popout">
-      {puzzle.puzzles.map((p) =>
-        p.type === "riddle" ? (
-          <RiddleCard key={p.id} puzzle={p} />
-        ) : (
-          <SequenceCard key={p.id} puzzle={p} />
-        ),
-      )}
+    <div className="puzzle-tome">
+      <div className={`puzzle-page${hasArt ? " on-art" : " on-css"}`}>
+        {puzzle.puzzles.map((p) =>
+          p.type === "riddle" ? (
+            <RiddleBlock key={p.id} puzzle={p} />
+          ) : (
+            <SequenceBlock key={p.id} puzzle={p} />
+          ),
+        )}
 
-      {hasUnsolvedRiddle && (
-        <form
-          className="puzzle-answer-bar"
-          onSubmit={(e) => {
-            e.preventDefault();
-            submit();
-          }}
-        >
-          <label htmlFor="puzzle-answer-input" className="sr-only">
-            Your answer
-          </label>
-          <input
-            id="puzzle-answer-input"
-            type="text"
-            className="puzzle-answer-input"
-            placeholder="Speak your answer..."
-            value={answer}
-            onChange={(e) => setAnswer(e.target.value)}
-            autoComplete="off"
-            spellCheck={false}
-          />
-          <button
-            type="submit"
-            className="puzzle-answer-submit"
-            disabled={answer.trim().length === 0}
+        {(hasUnsolvedRiddle || burn) && (
+          <form
+            className="puzzle-inscribe"
+            onSubmit={(e) => {
+              e.preventDefault();
+              submit();
+            }}
           >
-            Answer
-          </button>
-        </form>
-      )}
+            <div className={`puzzle-inscribe-field${burn ? (burn.correct ? " is-success" : " is-fail") : ""}`}>
+              <input
+                ref={inputRef}
+                id="puzzle-answer-input"
+                type="text"
+                className="puzzle-inscribe-input"
+                placeholder="Inscribe your answer…"
+                value={answer}
+                onChange={(e) => setAnswer(e.target.value)}
+                autoComplete="off"
+                spellCheck={false}
+                disabled={burn != null}
+                aria-label="Your answer"
+              />
+              {burn && (
+                <div className={`puzzle-burn${burn.correct ? " is-success" : " is-fail"}`} aria-hidden="true">
+                  <span className="puzzle-burn-text">{burn.text}</span>
+                  <span className="puzzle-flame" />
+                  <span className="puzzle-flame puzzle-flame-2" />
+                </div>
+              )}
+            </div>
+            <button
+              type="submit"
+              className="puzzle-inscribe-submit"
+              disabled={answer.trim().length === 0 || burn != null}
+            >
+              Inscribe
+            </button>
+            {burn && (
+              <p className={`puzzle-verdict${burn.correct ? " is-success" : " is-fail"}`} role="status">
+                {burn.message}
+              </p>
+            )}
+          </form>
+        )}
+      </div>
     </div>
   );
 }

--- a/web-v3/src/components/WorldFeaturesPopout.tsx
+++ b/web-v3/src/components/WorldFeaturesPopout.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import type { ReactNode } from "react";
-import type { ContainerContents, FeaturePopoutFocus, RoomFeature, RoomFeatureType } from "../types";
+import { useEffect, useRef } from "react";
+import type { ContainerContents, FeaturePopoutFocus, RoomFeature } from "../types";
 import { DirectionIcon } from "./Icons";
+import { featureArt, pickFocusedFeature } from "./worldFeatures";
 
 interface WorldFeaturesPopoutProps {
-  roomTitle: string;
   roomFeatures: RoomFeature[];
   containerContents: ContainerContents | null;
   preferredType: FeaturePopoutFocus;
@@ -12,15 +11,6 @@ interface WorldFeaturesPopoutProps {
   serverAssets: Record<string, string>;
   onCommand: (command: string) => void;
 }
-
-const FEATURE_ORDER: RoomFeatureType[] = ["door", "container", "lever", "sign"];
-
-const FEATURE_LABELS: Record<RoomFeatureType, { singular: string; plural: string }> = {
-  door: { singular: "Door", plural: "Doors" },
-  container: { singular: "Container", plural: "Containers" },
-  lever: { singular: "Lever", plural: "Levers" },
-  sign: { singular: "Sign", plural: "Signs" },
-};
 
 function titleCase(value: string | null | undefined): string {
   if (!value) return "";
@@ -30,15 +20,156 @@ function titleCase(value: string | null | undefined): string {
     .join(" ");
 }
 
-function stateLabel(feature: RoomFeature): string | null {
-  if (!feature.state) return null;
-  if (feature.type === "lever") {
-    return feature.state === "up" ? "Ready" : "Pulled";
+function featureActions(feature: RoomFeature): Array<{ label: string; command: string; primary?: boolean }> {
+  if (feature.type === "door") {
+    const actions: Array<{ label: string; command: string; primary?: boolean }> = [];
+    if (feature.state === "open") {
+      if (feature.direction) {
+        actions.push({ label: `Go ${titleCase(feature.direction)}`, command: feature.direction, primary: true });
+      }
+      actions.push({ label: "Close", command: `close ${feature.keyword}` });
+    } else if (feature.state === "closed") {
+      actions.push({ label: "Open", command: `open ${feature.keyword}`, primary: true });
+      if (feature.locked === false) {
+        actions.push({ label: "Lock", command: `lock ${feature.keyword}` });
+      }
+    } else if (feature.state === "locked") {
+      actions.push({ label: "Unlock", command: `unlock ${feature.keyword}`, primary: true });
+    }
+    return actions;
   }
-  return titleCase(feature.state);
+
+  if (feature.type === "container") {
+    const actions: Array<{ label: string; command: string; primary?: boolean }> = [];
+    if (feature.state === "open") {
+      actions.push({ label: "Close", command: `close ${feature.keyword}` });
+    } else if (feature.state === "closed") {
+      actions.push({ label: "Open", command: `open ${feature.keyword}`, primary: true });
+      if (feature.locked === false) {
+        actions.push({ label: "Lock", command: `lock ${feature.keyword}` });
+      }
+    } else if (feature.state === "locked") {
+      actions.push({ label: "Unlock", command: `unlock ${feature.keyword}`, primary: true });
+    }
+    return actions;
+  }
+
+  return [];
 }
 
-function LeverWidget({
+/** Stylized open-chest, shown faintly behind a container with no art yet. */
+function ChestGlyph() {
+  return (
+    <svg className="feat-glyph feat-glyph-chest" viewBox="0 0 160 120" aria-hidden="true">
+      <path d="M30 52 Q80 6 130 52 L130 60 Q80 22 30 60 Z" fill="currentColor" opacity="0.22" />
+      <path d="M30 52 Q80 6 130 52" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" opacity="0.5" />
+      <path d="M26 58 H134 V104 a8 8 0 0 1-8 8 H34 a8 8 0 0 1-8-8 Z" fill="currentColor" opacity="0.16" />
+      <path d="M26 58 H134 V104 a8 8 0 0 1-8 8 H34 a8 8 0 0 1-8-8 Z" fill="none" stroke="currentColor" strokeWidth="3" opacity="0.45" />
+      <line x1="26" y1="78" x2="134" y2="78" stroke="currentColor" strokeWidth="3" opacity="0.4" />
+      <rect x="72" y="72" width="16" height="16" rx="3" fill="currentColor" opacity="0.55" />
+      <circle cx="80" cy="80" r="2.4" fill="rgb(20 22 34)" opacity="0.7" />
+    </svg>
+  );
+}
+
+/** Stylized placard, shown faintly behind a sign with no art yet. */
+function SignGlyph() {
+  return (
+    <svg className="feat-glyph feat-glyph-sign" viewBox="0 0 160 120" aria-hidden="true">
+      <line x1="40" y1="16" x2="120" y2="16" stroke="currentColor" strokeWidth="3" opacity="0.4" />
+      <line x1="52" y1="16" x2="46" y2="34" stroke="currentColor" strokeWidth="2.5" opacity="0.4" />
+      <line x1="108" y1="16" x2="114" y2="34" stroke="currentColor" strokeWidth="2.5" opacity="0.4" />
+      <rect x="30" y="32" width="100" height="60" rx="9" fill="currentColor" opacity="0.16" />
+      <rect x="30" y="32" width="100" height="60" rx="9" fill="none" stroke="currentColor" strokeWidth="3" opacity="0.45" />
+      <line x1="46" y1="52" x2="114" y2="52" stroke="currentColor" strokeWidth="3" opacity="0.32" />
+      <line x1="46" y1="64" x2="114" y2="64" stroke="currentColor" strokeWidth="3" opacity="0.32" />
+      <line x1="46" y1="76" x2="94" y2="76" stroke="currentColor" strokeWidth="3" opacity="0.32" />
+    </svg>
+  );
+}
+
+function SignPanel({
+  feature,
+  serverAssets,
+}: {
+  feature: RoomFeature;
+  serverAssets: Record<string, string>;
+}) {
+  const hasArt = featureArt(feature, serverAssets) !== null;
+  return (
+    <div className={`feat-panel feat-sign${hasArt ? " has-art" : ""}`}>
+      {!hasArt && <div className="feat-fallback feat-fallback-sign" aria-hidden="true"><SignGlyph /></div>}
+      {feature.text && <p className="feat-sign-text">{feature.text}</p>}
+    </div>
+  );
+}
+
+function ContainerPanel({
+  feature,
+  contents,
+  serverAssets,
+  onCommand,
+}: {
+  feature: RoomFeature;
+  contents: ContainerContents | null;
+  serverAssets: Record<string, string>;
+  onCommand: (cmd: string) => void;
+}) {
+  const hasArt = featureArt(feature, serverAssets) !== null;
+  const isOpen = feature.state === "open";
+  const items = isOpen && contents?.featureId === feature.id ? contents.items : null;
+  const actions = featureActions(feature);
+
+  return (
+    <div className={`feat-panel feat-container${hasArt ? " has-art" : ""}`}>
+      {!hasArt && <div className="feat-fallback feat-fallback-container" aria-hidden="true"><ChestGlyph /></div>}
+      <div className="feat-container-inner">
+        <h3 className="feat-container-title">{feature.name}</h3>
+        {feature.state === "locked" && (
+          <p className="feat-container-note">
+            {feature.keyRequired ? "Locked — a key is required." : "Locked tight."}
+          </p>
+        )}
+        {isOpen && items !== null && (
+          items.length === 0 ? (
+            <p className="feat-empty">Nothing inside.</p>
+          ) : (
+            <ul className="feat-loot" role="list">
+              {items.map((item, index) => (
+                <li key={`${item.keyword}-${index}`} className="feat-loot-row">
+                  <span className="feat-loot-name">{item.name}</span>
+                  <button
+                    type="button"
+                    className="feat-take"
+                    onClick={() => onCommand(`get ${item.keyword} from ${feature.keyword}`)}
+                  >
+                    Take
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )
+        )}
+        {actions.length > 0 && (
+          <div className="feat-actions">
+            {actions.map((action) => (
+              <button
+                key={`${feature.id}-${action.command}`}
+                type="button"
+                className={`feat-btn${action.primary ? " feat-btn-primary" : ""}`}
+                onClick={() => onCommand(action.command)}
+              >
+                {action.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function LeverPanel({
   feature,
   serverAssets,
   onCommand,
@@ -49,37 +180,32 @@ function LeverWidget({
 }) {
   const isUp = feature.state === "up";
   const label = isUp ? "Ready" : "Pulled";
-
-  // Composed art: an optional backdrop "box" with the plate + rotating handle on
-  // top. Per-feature art wins, then the server-wide default, then a vector lever.
-  // We show only the lever itself — the whole tile is the click target.
   const px = feature.leverPivot?.x ?? 0.5;
   const py = feature.leverPivot?.y ?? 0.85;
   const angle = isUp ? (feature.upAngle ?? -28) : (feature.downAngle ?? 28);
   const handleSrc = feature.handleImage ?? serverAssets["lever_handle"] ?? null;
   const plateSrc = feature.plateImage ?? serverAssets["lever_plate"] ?? null;
   const boxSrc = feature.backgroundImage ?? serverAssets["lever_bg"] ?? null;
-  const hasArt = Boolean(boxSrc || handleSrc);
 
   return (
-    <button
-      type="button"
-      className={`lever-tile${hasArt ? " has-art" : ""}${boxSrc ? " has-box" : ""}`}
-      onClick={() => onCommand(`pull ${feature.keyword}`)}
-      aria-label={`Pull ${feature.name} (${label})`}
-      title={`Pull ${feature.name}`}
-    >
-      <span className="lever-tile-stage">
+    <div className="feat-panel feat-lever">
+      <button
+        type="button"
+        className={`feat-lever-stage${boxSrc ? " has-box" : ""}`}
+        onClick={() => onCommand(`pull ${feature.keyword}`)}
+        aria-label={`Pull ${feature.name} (${label})`}
+        title={`Pull ${feature.name}`}
+      >
         {boxSrc && (
-          <img className="lever-tile-box" src={boxSrc} alt="" aria-hidden="true" draggable={false} />
+          <img className="feat-lever-box" src={boxSrc} alt="" aria-hidden="true" draggable={false} />
         )}
         {handleSrc ? (
-          <span className="lever-tile-lever">
+          <span className="feat-lever-lever">
             {plateSrc && (
-              <img className="lever-tile-plate" src={plateSrc} alt="" aria-hidden="true" draggable={false} />
+              <img className="feat-lever-plate" src={plateSrc} alt="" aria-hidden="true" draggable={false} />
             )}
             <img
-              className="lever-tile-handle"
+              className="feat-lever-handle"
               src={handleSrc}
               alt=""
               aria-hidden="true"
@@ -91,529 +217,123 @@ function LeverWidget({
             />
           </span>
         ) : (
-          <span className="lever-tile-lever">
-            <svg className="lever-tile-svg" viewBox="0 0 64 96" aria-hidden="true">
-              {/* Base plate arc */}
+          <span className="feat-lever-lever">
+            <svg className="feat-lever-svg" viewBox="0 0 64 96" aria-hidden="true">
               <path d="M12 78 Q32 86 52 78" fill="none" stroke="rgb(180 150 210 / 40%)" strokeWidth="2" strokeLinecap="round" />
-              {/* Pivot point */}
-              <circle cx="32" cy="72" r="6" className="lever-tile-pivot" />
-              {/* Handle shaft */}
-              <line x1="32" y1="72" x2={isUp ? "32" : "46"} y2={isUp ? "22" : "32"} className="lever-tile-shaft" strokeWidth="4" strokeLinecap="round" />
-              {/* Handle grip */}
-              <circle cx={isUp ? "32" : "46"} cy={isUp ? "18" : "28"} r="7" className="lever-tile-grip" />
-              {/* Glow on grip */}
-              <circle cx={isUp ? "32" : "46"} cy={isUp ? "18" : "28"} r="4" className="lever-tile-glow" />
+              <circle cx="32" cy="72" r="6" className="feat-lever-pivot" />
+              <line x1="32" y1="72" x2={isUp ? "32" : "46"} y2={isUp ? "22" : "32"} className="feat-lever-shaft" strokeWidth="4" strokeLinecap="round" />
+              <circle cx={isUp ? "32" : "46"} cy={isUp ? "18" : "28"} r="7" className="feat-lever-grip" />
+              <circle cx={isUp ? "32" : "46"} cy={isUp ? "18" : "28"} r="4" className="feat-lever-glow" />
             </svg>
           </span>
         )}
+      </button>
+      <span className="feat-lever-caption">
+        <span className="feat-lever-name">{feature.name}</span>
+        <span className={`feat-lever-state feat-lever-state-${isUp ? "up" : "down"}`}>{label}</span>
       </span>
-      <span className="lever-tile-caption">
-        <span className="lever-tile-name">{feature.name}</span>
-        <span className={`lever-tile-state lever-tile-state-${isUp ? "up" : "down"}`}>{label}</span>
-      </span>
-    </button>
+    </div>
   );
 }
 
-/** Stylized open-chest used as the container backdrop when no art is shipped. */
-function ChestGlyph() {
-  return (
-    <svg className="fcard-glyph fcard-glyph-chest" viewBox="0 0 160 120" aria-hidden="true">
-      {/* open lid, tilted back */}
-      <path
-        d="M30 52 Q80 6 130 52 L130 60 Q80 22 30 60 Z"
-        fill="currentColor"
-        opacity="0.22"
-      />
-      <path
-        d="M30 52 Q80 6 130 52"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="3"
-        strokeLinecap="round"
-        opacity="0.5"
-      />
-      {/* chest body */}
-      <path d="M26 58 H134 V104 a8 8 0 0 1-8 8 H34 a8 8 0 0 1-8-8 Z" fill="currentColor" opacity="0.16" />
-      <path
-        d="M26 58 H134 V104 a8 8 0 0 1-8 8 H34 a8 8 0 0 1-8-8 Z"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="3"
-        opacity="0.45"
-      />
-      {/* horizontal band + lock */}
-      <line x1="26" y1="78" x2="134" y2="78" stroke="currentColor" strokeWidth="3" opacity="0.4" />
-      <rect x="72" y="72" width="16" height="16" rx="3" fill="currentColor" opacity="0.55" />
-      <circle cx="80" cy="80" r="2.4" fill="rgb(20 22 34)" opacity="0.7" />
-    </svg>
-  );
-}
-
-/** Stylized hanging placard used as the sign backdrop when no art is shipped. */
-function SignGlyph() {
-  return (
-    <svg className="fcard-glyph fcard-glyph-sign" viewBox="0 0 160 120" aria-hidden="true">
-      {/* top rail + ropes */}
-      <line x1="40" y1="16" x2="120" y2="16" stroke="currentColor" strokeWidth="3" opacity="0.4" />
-      <line x1="52" y1="16" x2="46" y2="34" stroke="currentColor" strokeWidth="2.5" opacity="0.4" />
-      <line x1="108" y1="16" x2="114" y2="34" stroke="currentColor" strokeWidth="2.5" opacity="0.4" />
-      {/* board */}
-      <rect x="30" y="32" width="100" height="60" rx="9" fill="currentColor" opacity="0.16" />
-      <rect
-        x="30"
-        y="32"
-        width="100"
-        height="60"
-        rx="9"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="3"
-        opacity="0.45"
-      />
-      {/* inked lines */}
-      <line x1="46" y1="52" x2="114" y2="52" stroke="currentColor" strokeWidth="3" opacity="0.32" />
-      <line x1="46" y1="64" x2="114" y2="64" stroke="currentColor" strokeWidth="3" opacity="0.32" />
-      <line x1="46" y1="76" x2="94" y2="76" stroke="currentColor" strokeWidth="3" opacity="0.32" />
-    </svg>
-  );
-}
-
-function ContainerCard({
+function DoorPanel({
   feature,
-  contents,
-  serverAssets,
   onCommand,
 }: {
   feature: RoomFeature;
-  contents: ContainerContents | null;
-  serverAssets: Record<string, string>;
   onCommand: (cmd: string) => void;
 }) {
-  const bgSrc = feature.backgroundImage ?? serverAssets["container_bg"] ?? null;
-  const isOpen = feature.state === "open";
-  const stateClass = isOpen ? "is-open" : feature.state === "locked" ? "is-locked" : "is-closed";
   const actions = featureActions(feature);
-  const items = isOpen && contents?.featureId === feature.id ? contents.items : null;
-
   return (
-    <article
-      className={`fcard fcard-container ${stateClass}${bgSrc ? " has-art" : ""}`}
-      style={bgSrc ? { ["--fcard-art" as string]: `url("${bgSrc}")` } : undefined}
-    >
-      <div className="fcard-bg" aria-hidden="true">{!bgSrc && <ChestGlyph />}</div>
-      <div className="fcard-body">
-        <h4 className="fcard-title">{feature.name}</h4>
-
-        <div className="fcard-foot">
-          {isOpen && items !== null && (
-            items.length === 0 ? (
-              <p className="fcard-empty">Nothing inside.</p>
-            ) : (
-              <ul className="fcard-loot" role="list">
-                {items.map((item, index) => (
-                  <li key={`${item.keyword}-${index}`} className="fcard-loot-row">
-                    <span className="fcard-loot-name">{item.name}</span>
-                    <button
-                      type="button"
-                      className="fcard-take"
-                      onClick={() => onCommand(`get ${item.keyword} from ${feature.keyword}`)}
-                    >
-                      Take
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            )
+    <div className="feat-panel feat-door">
+      <div className="feat-door-card">
+        <h3 className="feat-door-title">{feature.name}</h3>
+        <div className="feat-door-meta">
+          {feature.direction && (
+            <span className="feat-door-direction">
+              <DirectionIcon
+                direction={feature.direction as "north" | "east" | "south" | "west" | "up" | "down"}
+                className="feat-door-direction-icon"
+              />
+              Leads {titleCase(feature.direction)}
+            </span>
           )}
-          {actions.length > 0 && (
-            <div className="fcard-actions">
-              {actions.map((action) => (
-                <button
-                  key={`${feature.id}-${action.command}`}
-                  type="button"
-                  className={`fcard-btn${action.label === "Open" || action.label === "Unlock" ? " fcard-btn-primary" : ""}`}
-                  onClick={() => onCommand(action.command)}
-                >
-                  {action.label}
-                </button>
-              ))}
-            </div>
+          {feature.state === "locked" && (
+            <span className="feat-door-chip">
+              {feature.keyRequired ? "Locked — key required" : "Locked"}
+            </span>
           )}
         </div>
+        {actions.length > 0 && (
+          <div className="feat-actions">
+            {actions.map((action) => (
+              <button
+                key={`${feature.id}-${action.command}`}
+                type="button"
+                className={`feat-btn${action.primary ? " feat-btn-primary" : ""}`}
+                onClick={() => onCommand(action.command)}
+              >
+                {action.label}
+              </button>
+            ))}
+          </div>
+        )}
       </div>
-    </article>
+    </div>
   );
-}
-
-function SignCard({
-  feature,
-  serverAssets,
-}: {
-  feature: RoomFeature;
-  serverAssets: Record<string, string>;
-}) {
-  const bgSrc = feature.backgroundImage ?? serverAssets["sign_bg"] ?? null;
-
-  return (
-    <article
-      className={`fcard fcard-sign${bgSrc ? " has-art" : ""}`}
-      style={bgSrc ? { ["--fcard-art" as string]: `url("${bgSrc}")` } : undefined}
-      aria-label={feature.name}
-    >
-      <div className="fcard-bg" aria-hidden="true">{!bgSrc && <SignGlyph />}</div>
-      <div className="fcard-body fcard-sign-body">
-        {feature.text && <p className="fcard-sign-text">{feature.text}</p>}
-      </div>
-    </article>
-  );
-}
-
-function LockedFeatureHero({
-  feature,
-  kindLabel,
-  kindClass,
-  heroVariantClass,
-  subtitle,
-  extraContent,
-  onCommand,
-}: {
-  feature: RoomFeature;
-  kindLabel: string;
-  kindClass: string;
-  heroVariantClass: string;
-  subtitle: string;
-  extraContent?: ReactNode;
-  onCommand: (cmd: string) => void;
-}) {
-  return (
-    <article
-      className={`feature-card feature-card-${feature.type} feature-card-hero-locked ${heroVariantClass}`}
-    >
-      <div className="feature-card-hero-lock" aria-hidden="true">
-        <svg viewBox="0 0 64 80" className="feature-card-hero-lock-svg">
-          <path
-            d="M20 34 V24 a12 12 0 0 1 24 0 V34"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="4"
-            strokeLinecap="round"
-          />
-          <rect
-            x="12"
-            y="34"
-            width="40"
-            height="34"
-            rx="5"
-            fill="currentColor"
-            opacity="0.18"
-            stroke="currentColor"
-            strokeWidth="2.5"
-          />
-          <circle cx="32" cy="48" r="4" fill="currentColor" />
-          <path
-            d="M32 52 V58"
-            stroke="currentColor"
-            strokeWidth="3"
-            strokeLinecap="round"
-          />
-        </svg>
-      </div>
-      <div className="feature-card-hero-copy">
-        <span className={`feature-card-kind ${kindClass}`}>{kindLabel}</span>
-        <h4>{feature.name}</h4>
-        <p className="feature-card-hero-subtitle">{subtitle}</p>
-        {extraContent}
-      </div>
-      <div className="feature-card-hero-actions">
-        <button
-          type="button"
-          className="feature-card-action feature-card-action-primary"
-          onClick={() => onCommand(`unlock ${feature.keyword}`)}
-        >
-          Unlock
-        </button>
-      </div>
-    </article>
-  );
-}
-
-function LockedContainerHero({
-  feature,
-  onCommand,
-}: {
-  feature: RoomFeature;
-  onCommand: (cmd: string) => void;
-}) {
-  return (
-    <LockedFeatureHero
-      feature={feature}
-      kindLabel="Container"
-      kindClass="feature-card-kind-container"
-      heroVariantClass="feature-card-hero-locked-container"
-      subtitle={feature.keyRequired ? "A key is required to unlock this." : "Locked tight."}
-      onCommand={onCommand}
-    />
-  );
-}
-
-function LockedDoorHero({
-  feature,
-  onCommand,
-}: {
-  feature: RoomFeature;
-  onCommand: (cmd: string) => void;
-}) {
-  const direction = feature.direction ? titleCase(feature.direction) : null;
-  return (
-    <LockedFeatureHero
-      feature={feature}
-      kindLabel="Door"
-      kindClass="feature-card-kind-door"
-      heroVariantClass="feature-card-hero-locked-door"
-      subtitle={
-        feature.keyRequired
-          ? "A key is required to pass through."
-          : "The way is barred."
-      }
-      extraContent={
-        direction ? (
-          <span className="feature-card-hero-direction">
-            <DirectionIcon
-              direction={feature.direction as "north" | "east" | "south" | "west" | "up" | "down"}
-              className="feature-card-direction-icon"
-            />
-            Leads {direction}
-          </span>
-        ) : null
-      }
-      onCommand={onCommand}
-    />
-  );
-}
-
-function featureActions(feature: RoomFeature): Array<{ label: string; command: string }> {
-  if (feature.type === "door") {
-    const actions: Array<{ label: string; command: string }> = [];
-    if (feature.state === "open") {
-      if (feature.direction) {
-        actions.push({ label: `Go ${feature.direction}`, command: feature.direction });
-      }
-      actions.push({ label: "Close", command: `close ${feature.keyword}` });
-    } else if (feature.state === "closed") {
-      actions.push({ label: "Open", command: `open ${feature.keyword}` });
-      if (feature.locked === false) {
-        actions.push({ label: "Lock", command: `lock ${feature.keyword}` });
-      }
-    } else if (feature.state === "locked") {
-      actions.push({ label: "Unlock", command: `unlock ${feature.keyword}` });
-    }
-    return actions;
-  }
-
-  if (feature.type === "container") {
-    const actions: Array<{ label: string; command: string }> = [];
-    if (feature.state === "open") {
-      actions.push({ label: "Close", command: `close ${feature.keyword}` });
-    } else if (feature.state === "closed") {
-      actions.push({ label: "Open", command: `open ${feature.keyword}` });
-      if (feature.locked === false) {
-        actions.push({ label: "Lock", command: `lock ${feature.keyword}` });
-      }
-    } else if (feature.state === "locked") {
-      actions.push({ label: "Unlock", command: `unlock ${feature.keyword}` });
-    }
-    return actions;
-  }
-
-  if (feature.type === "lever") {
-    return [{ label: "Pull", command: `pull ${feature.keyword}` }];
-  }
-
-  if (feature.type === "sign") {
-    return [{ label: "Read", command: `read ${feature.keyword}` }];
-  }
-
-  return [];
 }
 
 export function WorldFeaturesPopout({
-  roomTitle,
   roomFeatures,
   containerContents,
   preferredType,
   serverAssets,
   onCommand,
 }: WorldFeaturesPopoutProps) {
-  const groupedFeatures = useMemo(
-    () => ({
-      door: roomFeatures.filter((feature) => feature.type === "door"),
-      container: roomFeatures.filter((feature) => feature.type === "container"),
-      lever: roomFeatures.filter((feature) => feature.type === "lever"),
-      sign: roomFeatures.filter((feature) => feature.type === "sign"),
-    }),
-    [roomFeatures],
-  );
+  const feature = pickFocusedFeature(roomFeatures, preferredType);
 
-  const availableTabs = useMemo(
-    () => FEATURE_ORDER.filter((type) => groupedFeatures[type].length > 0),
-    [groupedFeatures],
-  );
-
-  const [manualTab, setManualTab] = useState<RoomFeatureType | null>(null);
-
-  // Auto-search containers once they become open so their contents render
-  // without an extra click. A ref tracks which feature ids we've already
-  // requested, scoped to the current "open" session — if a container closes
-  // or disappears, its id is dropped so reopening triggers a fresh search.
-  const autoSearchedRef = useRef<Set<string>>(new Set());
+  // Auto-search the focused container once it's open so its contents render
+  // without an extra click. Track the id we've requested for the current "open"
+  // session so a close/reopen triggers a fresh search.
+  const autoSearchedRef = useRef<string | null>(null);
   useEffect(() => {
-    const openIds = new Set(
-      roomFeatures
-        .filter((f) => f.type === "container" && f.state === "open")
-        .map((f) => f.id),
-    );
-    for (const id of Array.from(autoSearchedRef.current)) {
-      if (!openIds.has(id)) autoSearchedRef.current.delete(id);
+    if (!feature || feature.type !== "container") {
+      autoSearchedRef.current = null;
+      return;
     }
-    for (const feature of roomFeatures) {
-      if (
-        feature.type === "container" &&
-        feature.state === "open" &&
-        !autoSearchedRef.current.has(feature.id) &&
-        containerContents?.featureId !== feature.id
-      ) {
-        autoSearchedRef.current.add(feature.id);
-        onCommand(`search ${feature.keyword}`);
-      }
+    if (feature.state !== "open") {
+      autoSearchedRef.current = null;
+      return;
     }
-  }, [roomFeatures, containerContents, onCommand]);
+    if (autoSearchedRef.current !== feature.id && containerContents?.featureId !== feature.id) {
+      autoSearchedRef.current = feature.id;
+      onCommand(`search ${feature.keyword}`);
+    }
+  }, [feature, containerContents, onCommand]);
 
-  if (roomFeatures.length === 0) {
+  if (!feature) {
     return (
-      <div className="feature-popout feature-popout-empty">
-        <div className="feature-popout-hero feature-popout-hero-empty">
-          <p className="feature-popout-eyebrow">Room Features</p>
-          <h3>{roomTitle}</h3>
-          <p>
-            This room does not currently expose any doors, containers, levers, or signs to the web client.
-            When Arcanum authors them into the world, they will appear here automatically.
-          </p>
-        </div>
+      <div className="feat-panel feat-empty-panel">
+        <p>This room exposes no interactive features to the web client yet.</p>
       </div>
     );
   }
 
-  const activeTab =
-    (preferredType && groupedFeatures[preferredType].length > 0 ? preferredType : null) ??
-    (manualTab && availableTabs.includes(manualTab) ? manualTab : null) ??
-    availableTabs[0] ??
-    "door";
-
-  const visibleFeatures = groupedFeatures[activeTab];
-
-  return (
-    <div className="feature-popout">
-      {availableTabs.length > 1 && (
-        <div className="feature-popout-tabs" role="tablist" aria-label="Feature categories">
-          {availableTabs.map((type) => (
-            <button
-              key={type}
-              type="button"
-              role="tab"
-              className={`feature-popout-tab feature-popout-tab-${type}${activeTab === type ? " feature-popout-tab-active" : ""}`}
-              aria-selected={activeTab === type}
-              onClick={() => setManualTab(type)}
-            >
-              {FEATURE_LABELS[type].plural}
-              <span className="feature-popout-tab-count">{groupedFeatures[type].length}</span>
-            </button>
-          ))}
-        </div>
-      )}
-
-      <div className={`feature-popout-grid${activeTab === "lever" ? " feature-popout-grid-levers" : ""}`}>
-        {visibleFeatures.map((feature) => {
-          if (feature.type === "lever") {
-            return <LeverWidget key={feature.id} feature={feature} serverAssets={serverAssets} onCommand={onCommand} />;
-          }
-
-          if (feature.type === "container") {
-            if (feature.state === "locked" && visibleFeatures.length === 1) {
-              return <LockedContainerHero key={feature.id} feature={feature} onCommand={onCommand} />;
-            }
-            const contents = containerContents?.featureId === feature.id ? containerContents : null;
-            return (
-              <ContainerCard
-                key={feature.id}
-                feature={feature}
-                contents={contents}
-                serverAssets={serverAssets}
-                onCommand={onCommand}
-              />
-            );
-          }
-
-          if (feature.type === "sign") {
-            return <SignCard key={feature.id} feature={feature} serverAssets={serverAssets} />;
-          }
-
-          // Doors — generic card.
-          if (feature.state === "locked" && visibleFeatures.length === 1) {
-            return <LockedDoorHero key={feature.id} feature={feature} onCommand={onCommand} />;
-          }
-
-          const actions = featureActions(feature);
-          const label = stateLabel(feature);
-
-          return (
-            <article key={feature.id} className={`feature-card feature-card-${feature.type}`}>
-              <header className="feature-card-header">
-                <div className="feature-card-heading">
-                  <span className={`feature-card-kind feature-card-kind-${feature.type}`}>
-                    {FEATURE_LABELS[feature.type].singular}
-                  </span>
-                  <h4>{feature.name}</h4>
-                </div>
-                <div className="feature-card-meta">
-                  {label && <span className="feature-card-state">{label}</span>}
-                  {feature.direction && (
-                    <span className="feature-card-direction">
-                      <DirectionIcon direction={feature.direction as "north" | "east" | "south" | "west" | "up" | "down"} className="feature-card-direction-icon" />
-                      {titleCase(feature.direction)}
-                    </span>
-                  )}
-                </div>
-              </header>
-
-              <div className="feature-card-details">
-                {feature.locked === true && (
-                  <span className="feature-card-detail-chip">Locked</span>
-                )}
-                {feature.keyRequired && (
-                  <span className="feature-card-detail-chip">Key required</span>
-                )}
-                <span className="feature-card-detail-chip">Keyword: {feature.keyword}</span>
-              </div>
-
-              {actions.length > 0 && (
-                <div className="feature-card-actions">
-                  {actions.map((action) => (
-                    <button
-                      key={`${feature.id}-${action.command}`}
-                      type="button"
-                      className="feature-card-action"
-                      onClick={() => onCommand(action.command)}
-                    >
-                      {action.label}
-                    </button>
-                  ))}
-                </div>
-              )}
-            </article>
-          );
-        })}
-      </div>
-    </div>
-  );
+  switch (feature.type) {
+    case "sign":
+      return <SignPanel feature={feature} serverAssets={serverAssets} />;
+    case "lever":
+      return <LeverPanel feature={feature} serverAssets={serverAssets} onCommand={onCommand} />;
+    case "container":
+      return (
+        <ContainerPanel
+          feature={feature}
+          contents={containerContents?.featureId === feature.id ? containerContents : null}
+          serverAssets={serverAssets}
+          onCommand={onCommand}
+        />
+      );
+    default:
+      return <DoorPanel feature={feature} onCommand={onCommand} />;
+  }
 }

--- a/web-v3/src/components/worldFeatures.ts
+++ b/web-v3/src/components/worldFeatures.ts
@@ -1,0 +1,38 @@
+import type { FeaturePopoutFocus, RoomFeature, RoomFeatureType } from "../types";
+
+const FEATURE_ORDER: RoomFeatureType[] = ["door", "container", "lever", "sign"];
+
+/**
+ * The feature a freshly-opened panel should show. A panel is opened against a
+ * specific feature (the canvas badge / room list passes its type), so we prefer
+ * the first feature of that type; otherwise the first feature in display order.
+ * Shared so App keeps the Drawer title + skin background in sync with the panel.
+ */
+export function pickFocusedFeature(
+  features: RoomFeature[],
+  preferred: FeaturePopoutFocus,
+): RoomFeature | null {
+  if (features.length === 0) return null;
+  if (preferred) {
+    const match = features.find((f) => f.type === preferred);
+    if (match) return match;
+  }
+  for (const type of FEATURE_ORDER) {
+    const match = features.find((f) => f.type === type);
+    if (match) return match;
+  }
+  return features[0];
+}
+
+/**
+ * Fully-resolved backdrop art URL for a feature (per-feature override → global
+ * `<type>_bg` default), or null when none is shipped yet. Levers compose their
+ * own art in-panel, so this is used by App for the sign/container drawer skin.
+ */
+export function featureArt(
+  feature: RoomFeature | null,
+  serverAssets: Record<string, string>,
+): string | null {
+  if (!feature) return null;
+  return feature.backgroundImage ?? serverAssets[`${feature.type}_bg`] ?? null;
+}

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -60,6 +60,7 @@ import type {
   StaffWorldZone,
   ShopState,
   PuzzleItem,
+  PuzzleResult,
   PuzzleState,
   SkillSummary,
   SpriteEntry,
@@ -157,6 +158,7 @@ interface GmcpContext {
   setCombatTarget: Dispatch<SetStateAction<CombatTarget | null>>;
   setShop: Dispatch<SetStateAction<ShopState | null>>;
   setPuzzle: Dispatch<SetStateAction<PuzzleState | null>>;
+  setPuzzleResult: Dispatch<SetStateAction<PuzzleResult | null>>;
   setChatByChannel: Dispatch<SetStateAction<Record<ChatChannel, ChatMessage[]>>>;
   updateMap: (roomId: string, exits: Record<string, string>, title: string, image: string | null, mapX: number, mapY: number, housing?: boolean, terrain?: string | null) => void;
   loadZoneMap: (zone: string, rooms: Array<{ id: string; x: number; y: number; exits: Record<string, string> }>) => void;
@@ -1504,11 +1506,22 @@ export function applyGmcpPackage(
                 totalSteps: typeof p.totalSteps === "number" ? p.totalSteps : null,
                 currentStep: typeof p.currentStep === "number" ? p.currentStep : null,
                 solved: p.solved === true,
+                backgroundImage: typeof p.backgroundImage === "string" ? p.backgroundImage : null,
               } satisfies PuzzleItem;
             })
             .filter((p) => p.id.length > 0)
         : [];
       ctx.setPuzzle(puzzles.length > 0 ? { puzzles } : null);
+      break;
+    }
+
+    case "Puzzle.Result": {
+      const packet = data as Partial<Record<string, unknown>>;
+      ctx.setPuzzleResult({
+        id: typeof packet.id === "string" ? packet.id : "",
+        correct: packet.correct === true,
+        message: typeof packet.message === "string" ? packet.message : "",
+      });
       break;
     }
 

--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -79,6 +79,7 @@ import type {
   RoomPlayer,
   RoomState,
   PuzzleState,
+  PuzzleResult,
   ServerFeatures,
   ShopState,
   SkillSummary,
@@ -269,6 +270,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
   // ── Economy ───────────────────────────────────────
   const [shop, setShop] = useState<ShopState | null>(null);
   const [puzzle, setPuzzle] = useState<PuzzleState | null>(null);
+  const [puzzleResult, setPuzzleResult] = useState<PuzzleResult | null>(null);
   const [auctionListings, setAuctionListings] = useState<AuctionListing[]>([]);
   const [currencies, setCurrencies] = useState<CurrencyBalance[]>([]);
   const [bankState, setBankState] = useState<BankState | null>(null);
@@ -572,8 +574,12 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
         },
         setPuzzle: (value) => {
           setPuzzle(value);
-          if (!value) setActivePopout((prev) => prev === "puzzle" ? null : prev);
+          if (!value) {
+            setPuzzleResult(null);
+            setActivePopout((prev) => prev === "puzzle" ? null : prev);
+          }
         },
+        setPuzzleResult,
         setFriends,
         pushFriendNotification,
         setChatByChannel,
@@ -702,6 +708,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     setContainerContents(null);
     setShop(null);
     setPuzzle(null);
+    setPuzzleResult(null);
     setQuestNotifications([]);
     setCombatVictoryNotifications([]);
     setFleeNotifications([]);
@@ -774,7 +781,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     quests, questsAvailable, questNotifications, setQuestNotifications,
     dailyQuests, weeklyQuests, autoQuest, globalQuest,
     // Economy
-    shop, puzzle, auctionListings, currencies, currencyActivity, bankState, stylistState, recallState, lotteryInfo, diceResult,
+    shop, puzzle, puzzleResult, auctionListings, currencies, currencyActivity, bankState, stylistState, recallState, lotteryInfo, diceResult,
     // Crafting
     craftingSkills, craftingRecipes, craftingNodes, gatherCooldownUntilMs,
     // World

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -3164,206 +3164,308 @@ body {
   cursor: default;
 }
 
-.feature-popout {
+/* ════════════════════════════════════════════════════════════════════════
+   World feature panels — each interactive feature opens as its own full-bleed
+   Drawer panel (like Inventory/Equipment): the art is the panel background, the
+   feature name is the title, the content floats over the art. No tabs, no
+   "World Features" wrapper, no inner bounding box.
+   ════════════════════════════════════════════════════════════════════════ */
+
+/* Sign + container use the feature art as the full sheet background (behind the
+   header too). Levers compose their art in-panel and keep the default dark sheet. */
+.drawer-sheet.drawer-sheet-feature {
+  background-image:
+    var(--skin-bg, none),
+    linear-gradient(180deg, rgb(43 53 79 / 98%), rgb(34 41 64 / 98%));
+  background-size: cover, auto;
+  background-position: center, center;
+  background-repeat: no-repeat, no-repeat;
+}
+
+.drawer-sheet-feature .drawer-title {
+  text-shadow: 0 1px 2px rgb(0 0 0 / 72%), 0 1px 12px rgb(0 0 0 / 55%);
+}
+
+/* Soft top scrim keeps the title + close legible over bright art, without a
+   hard band (fades to transparent). */
+.drawer-sheet-feature .drawer-header {
+  border-bottom-color: transparent;
+  background: linear-gradient(to bottom, rgb(8 10 18 / 52%), transparent);
+}
+
+/* The body is just the foreground content floating over the sheet art. */
+.drawer-sheet-feature .drawer-body {
+  padding: 0;
   display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
 }
 
-.feature-popout-hero {
-  display: grid;
-  gap: var(--space-3);
-  padding: 16px 18px;
-  border: 1px solid var(--line-soft);
-  border-radius: var(--radius-lg);
-  background:
-    radial-gradient(circle at top right, rgb(156 190 228 / 14%), transparent 32%),
-    radial-gradient(circle at bottom left, rgb(212 178 110 / 14%), transparent 35%),
-    linear-gradient(145deg, rgb(71 81 113 / 92%), rgb(52 63 94 / 88%));
-}
-
-.feature-popout-hero-empty {
-  background:
-    radial-gradient(circle at top right, rgb(196 168 232 / 12%), transparent 30%),
-    linear-gradient(145deg, rgb(65 74 104 / 92%), rgb(48 58 86 / 88%));
-}
-
-.feature-popout-hero-copy {
+.feat-panel {
+  position: relative;
+  flex: 1;
   display: flex;
-  flex-direction: column;
-  gap: 6px;
+  min-height: 0;
 }
 
-.feature-popout-hero-copy > h3 {
+/* Fallback art (no asset shipped yet) — a faint glyph on a tinted gradient. */
+.feat-fallback {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.feat-glyph {
+  width: min(46%, 280px);
+  height: auto;
+  opacity: 0.85;
+}
+
+.feat-fallback-sign {
+  color: #bcdcc4;
+  background: linear-gradient(165deg, rgb(60 74 92 / 96%), rgb(47 60 78 / 94%));
+}
+
+.feat-fallback-container {
+  color: #e6c587;
+  background: linear-gradient(165deg, rgb(74 66 86 / 96%), rgb(50 46 66 / 94%));
+}
+
+/* ── Sign ─────────────────────────────────────────────────── */
+.feat-sign {
+  align-items: center;
+  justify-content: center;
+  padding: clamp(28px, 7vw, 72px) clamp(32px, 9vw, 120px);
+  min-height: 46vh;
+}
+
+.feat-sign-text {
+  position: relative;
   margin: 0;
+  max-width: 56ch;
+  text-align: center;
+  color: var(--text-bright);
   font-family: var(--font-display);
-  font-size: clamp(1.3rem, 2vw, 1.65rem);
-  color: var(--text-heading);
+  font-size: clamp(1rem, 1.5vw, 1.2rem);
+  font-style: italic;
+  line-height: 1.62;
+  white-space: pre-wrap;
+  text-shadow: 0 1px 2px rgb(0 0 0 / 64%), 0 1px 14px rgb(0 0 0 / 50%);
 }
 
-.feature-popout-hero-copy > p {
+/* ── Container ────────────────────────────────────────────── */
+.feat-container {
+  align-items: stretch;
+  justify-content: flex-end;
+  min-height: 44vh;
+}
+
+/* Soft bottom scrim so loot reads over the bright chest interior. */
+.feat-container.has-art::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background: linear-gradient(
+    to top,
+    rgb(6 7 13 / 86%) 0%,
+    rgb(6 7 13 / 55%) 26%,
+    rgb(6 7 13 / 12%) 52%,
+    transparent 72%
+  );
+}
+
+.feat-container-inner {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: clamp(16px, 4vw, 28px) clamp(18px, 4vw, 32px) clamp(16px, 3vw, 24px);
+}
+
+.feat-container-title {
+  margin: 0 0 2px;
+  font-family: var(--font-display);
+  font-size: 1.2rem;
+  color: var(--text-bright);
+  text-shadow: 0 1px 2px rgb(0 0 0 / 72%), 0 1px 14px rgb(0 0 0 / 55%);
+}
+
+.feat-container-note {
   margin: 0;
   color: var(--text-secondary);
-  line-height: 1.55;
-}
-
-
-/* Quiet text tabs — only shown when a room has more than one feature type.
-   No pill boxes; the active category brightens with a soft underline. */
-.feature-popout-tabs {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  margin: -2px 0 2px;
-}
-
-.feature-popout-tab {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 4px;
-  border: none;
-  border-bottom: 2px solid transparent;
-  background: none;
-  color: var(--text-muted);
-  font-family: var(--font-body);
   font-size: 0.86rem;
-  font-weight: 700;
-  letter-spacing: 0.01em;
-  cursor: pointer;
-  transition:
-    color 160ms var(--ease-out-soft),
-    border-color 160ms var(--ease-out-soft);
 }
 
-.feature-popout-tab + .feature-popout-tab {
-  margin-left: 12px;
-}
-
-.feature-popout-tab:hover {
-  color: var(--text-primary);
-}
-
-.feature-popout-tab-active {
-  color: var(--text-bright);
-  border-bottom-color: rgb(216 197 232 / 70%);
-}
-
-.feature-popout-tab-door.feature-popout-tab-active {
-  border-bottom-color: rgb(156 190 228 / 75%);
-}
-
-.feature-popout-tab-container.feature-popout-tab-active {
-  border-bottom-color: rgb(223 191 116 / 78%);
-}
-
-.feature-popout-tab-lever.feature-popout-tab-active {
-  border-bottom-color: rgb(211 171 223 / 78%);
-}
-
-.feature-popout-tab-sign.feature-popout-tab-active {
-  border-bottom-color: rgb(168 204 178 / 78%);
-}
-
-.feature-popout-tab-count {
-  font-size: 0.74rem;
-  font-weight: 700;
-  opacity: 0.7;
-}
-
-.feature-popout-grid {
-  display: grid;
-  gap: var(--space-3);
-}
-
-.feature-card {
-  display: grid;
-  gap: var(--space-2);
-  padding: 16px;
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--line-soft);
-  background: linear-gradient(145deg, rgb(63 73 105 / 92%), rgb(50 60 89 / 88%));
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 10%);
-}
-
-.feature-card-door {
-  background:
-    radial-gradient(circle at top right, rgb(146 184 223 / 14%), transparent 28%),
-    linear-gradient(145deg, rgb(62 73 108 / 92%), rgb(47 58 87 / 88%));
-}
-
-.feature-card-lever {
-  background:
-    radial-gradient(circle at top right, rgb(204 154 216 / 14%), transparent 28%),
-    linear-gradient(145deg, rgb(73 64 102 / 92%), rgb(55 49 81 / 88%));
-}
-
-/* Lever tiles lay out in a compact row-wrap, each a fixed-ish width so a lone
-   lever stays small rather than stretching across the modal. */
-.feature-popout-grid-levers {
-  grid-template-columns: repeat(auto-fill, minmax(150px, 180px));
-  justify-content: start;
-}
-
-/* ── Lever tile — just the lever art, click to pull ───────── */
-.lever-tile {
+.feat-loot {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
-  align-items: stretch;
+}
+
+.feat-loot-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: 9px 0;
+  border-bottom: 1px solid rgb(255 255 255 / 14%);
+}
+
+.feat-loot-row:last-child {
+  border-bottom: none;
+}
+
+.feat-loot-name {
+  color: var(--text-bright);
+  font-size: 0.95rem;
+  text-shadow: 0 1px 6px rgb(0 0 0 / 70%);
+}
+
+.feat-take {
+  flex-shrink: 0;
+  padding: 6px 16px;
+  border: 1px solid rgb(240 214 150 / 52%);
+  border-radius: 999px;
+  background: rgb(60 48 24 / 66%);
+  color: #f4e2b2;
+  font-family: var(--font-body);
+  font-size: 0.8rem;
+  font-weight: 700;
+  cursor: pointer;
+  backdrop-filter: blur(2px);
+  transition:
+    background 150ms var(--ease-out-soft),
+    border-color 150ms var(--ease-out-soft),
+    transform 150ms var(--ease-out-soft);
+}
+
+.feat-take:hover {
+  background: rgb(86 68 32 / 80%);
+  border-color: rgb(248 226 168 / 82%);
+  transform: translateY(-1px);
+}
+
+.feat-empty {
+  margin: 0;
+  color: var(--text-secondary);
+  font-style: italic;
+  text-shadow: 0 1px 6px rgb(0 0 0 / 60%);
+}
+
+.feat-actions {
+  display: flex;
+  flex-wrap: wrap;
   gap: 8px;
+  margin-top: 4px;
+}
+
+.feat-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 18px;
+  border: 1px solid rgb(255 255 255 / 16%);
+  border-radius: var(--radius-md);
+  background: rgb(16 20 32 / 60%);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  font-weight: 700;
+  cursor: pointer;
+  backdrop-filter: blur(3px);
+  transition:
+    transform 150ms var(--ease-out-soft),
+    border-color 150ms var(--ease-out-soft),
+    background 150ms var(--ease-out-soft);
+}
+
+.feat-btn:hover {
+  transform: translateY(-1px);
+  border-color: rgb(216 197 232 / 40%);
+  background: rgb(26 32 48 / 72%);
+}
+
+.feat-btn-primary {
+  border-color: rgb(226 198 134 / 50%);
+  background: linear-gradient(135deg, rgb(164 136 82 / 70%), rgb(124 102 62 / 64%));
+  color: #f3e4bf;
+}
+
+.feat-btn-primary:hover {
+  border-color: rgb(240 214 150 / 75%);
+  background: linear-gradient(135deg, rgb(188 158 100 / 82%), rgb(142 118 74 / 74%));
+}
+
+/* ── Lever — a tall vertical box with the lever in the centre ── */
+.feat-lever {
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: clamp(20px, 4vw, 36px) 16px clamp(18px, 3vw, 28px);
+}
+
+.feat-lever-stage {
+  position: relative;
+  width: min(340px, 74vw);
+  margin: 0 auto;
   padding: 0;
   border: none;
   background: none;
-  color: inherit;
-  font: inherit;
   cursor: pointer;
+  transition:
+    transform 220ms var(--ease-out-soft),
+    filter 220ms var(--ease-out-soft);
 }
 
-.lever-tile:focus-visible {
+.feat-lever-stage:not(.has-box) {
+  aspect-ratio: 3 / 4;
+}
+
+.feat-lever-stage:hover {
+  transform: translateY(-3px) scale(1.02);
+  filter: drop-shadow(0 12px 28px rgb(8 6 16 / 50%));
+}
+
+.feat-lever-stage:active {
+  transform: translateY(-1px) scale(1.01);
+}
+
+.feat-lever-stage:focus-visible {
   outline: 2px solid rgb(216 197 232 / 70%);
-  outline-offset: 4px;
+  outline-offset: 6px;
   border-radius: var(--radius-md);
 }
 
-/* The art stage holds the box (decorative frame) filling it, with the lever
-   (plate + pivoting handle, or vector fallback) riding on top. No card chrome. */
-.lever-tile-stage {
+.feat-lever-box {
   display: block;
-  position: relative;
   width: 100%;
-  aspect-ratio: 4 / 5;
-  transition:
-    transform 200ms var(--ease-out-soft),
-    filter 200ms var(--ease-out-soft);
-}
-
-.lever-tile-box {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+  height: auto;
   border-radius: var(--radius-md);
   pointer-events: none;
   user-select: none;
 }
 
-/* The lever itself. With a box it sits in the box's socket (upper-centre, about
-   half width); without a box it fills the stage. The plate + handle share this
-   frame so the handle pivots correctly. */
-.lever-tile-lever {
+/* The lever (plate + handle / vector) sits in the vertical centre of the box. */
+.feat-lever-lever {
   position: absolute;
-  inset: 0;
-}
-
-.lever-tile.has-box .lever-tile-lever {
-  inset: 8% 27% auto 27%;
+  top: 50%;
+  left: 50%;
+  width: 52%;
   aspect-ratio: 1;
+  transform: translate(-50%, -50%);
 }
 
-.lever-tile-plate,
-.lever-tile-handle,
-.lever-tile-svg {
+.feat-lever-plate,
+.feat-lever-handle,
+.feat-lever-svg {
   position: absolute;
   inset: 0;
   width: 100%;
@@ -3374,22 +3476,12 @@ body {
   overflow: visible;
 }
 
-.lever-tile-handle {
+.feat-lever-handle {
   transition: transform 0.45s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
-.lever-tile:hover .lever-tile-stage {
-  transform: translateY(-3px) scale(1.03);
-  filter: drop-shadow(0 10px 22px rgb(10 8 18 / 45%));
-}
-
-.lever-tile:active .lever-tile-stage {
-  transform: translateY(-1px) scale(1.01);
-}
-
-/* Vector fallback colors (no art shipped) */
-.lever-tile-svg line,
-.lever-tile-svg circle {
+.feat-lever-svg line,
+.feat-lever-svg circle {
   transition:
     cx 400ms var(--ease-in-out-smooth),
     cy 400ms var(--ease-in-out-smooth),
@@ -3399,31 +3491,30 @@ body {
     y2 400ms var(--ease-in-out-smooth);
 }
 
-.lever-tile-pivot {
+.feat-lever-pivot {
   fill: rgb(80 70 110);
   stroke: rgb(160 140 190 / 50%);
   stroke-width: 1.5;
 }
 
-.lever-tile-shaft {
+.feat-lever-shaft {
   stroke: rgb(190 165 220);
   filter: drop-shadow(0 0 3px rgb(190 165 220 / 30%));
 }
 
-.lever-tile-grip {
+.feat-lever-grip {
   fill: rgb(100 85 135);
   stroke: rgb(210 185 240 / 60%);
   stroke-width: 1.5;
 }
 
-.lever-tile-glow {
+.feat-lever-glow {
   fill: rgb(220 195 250 / 50%);
   filter: blur(2px);
   pointer-events: none;
 }
 
-/* Readable caption beneath the art (never overlaid on it) */
-.lever-tile-caption {
+.feat-lever-caption {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -3431,535 +3522,95 @@ body {
   text-align: center;
 }
 
-.lever-tile-name {
-  font-size: 0.84rem;
+.feat-lever-name {
+  font-size: 0.96rem;
   font-weight: 700;
-  color: var(--text-primary);
-  line-height: 1.2;
+  color: var(--text-bright);
 }
 
-.lever-tile-state {
-  font-size: 0.7rem;
+.feat-lever-state {
+  font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.07em;
   font-weight: 700;
 }
 
-.lever-tile-state-up {
+.feat-lever-state-up {
   color: rgb(150 200 130);
 }
 
-.lever-tile-state-down {
+.feat-lever-state-down {
   color: rgb(220 175 120);
 }
 
-/* Reduced motion */
-@media (prefers-reduced-motion: reduce) {
-  .lever-tile-svg line,
-  .lever-tile-svg circle,
-  .lever-tile-art,
-  .lever-tile-handle {
-    transition: none;
-  }
-
-  .puzzle-sequence-dot-next {
-    animation: none;
-  }
-}
-
-.feature-card-header {
-  display: flex;
-  justify-content: space-between;
-  gap: var(--space-3);
-  align-items: flex-start;
-}
-
-.feature-card-heading {
-  display: grid;
-  gap: 4px;
-}
-
-.feature-card-heading > h4 {
-  margin: 0;
-  font-size: 1rem;
-  color: var(--text-primary);
-}
-
-.feature-card-kind {
-  display: inline-flex;
+/* ── Door (no art — a tidy centred card) ──────────────────── */
+.feat-door {
   align-items: center;
-  width: fit-content;
-  padding: 4px 9px;
-  border-radius: 999px;
-  font-size: 0.72rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-weight: 700;
-  background: rgb(14 17 27 / 42%);
+  justify-content: center;
+  padding: clamp(24px, 5vw, 44px);
 }
 
-.feature-card-kind-door {
-  color: #bdd8ee;
+.feat-door-card {
+  width: min(440px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 22px 24px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgb(146 184 223 / 26%);
+  background:
+    radial-gradient(circle at 50% 0%, rgb(146 184 223 / 16%), transparent 60%),
+    linear-gradient(160deg, rgb(62 73 108 / 94%), rgb(45 56 86 / 92%));
 }
 
-.feature-card-kind-container {
-  color: #e1c17c;
+.feat-door-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.18rem;
+  color: var(--text-bright);
 }
 
-.feature-card-kind-lever {
-  color: #d9b3e2;
-}
-
-.feature-card-kind-sign {
-  color: #b9d6be;
-}
-
-.feature-card-meta {
+.feat-door-meta {
   display: flex;
   flex-wrap: wrap;
-  justify-content: flex-end;
   gap: 8px;
 }
 
-.feature-card-state,
-.feature-card-direction,
-.feature-card-detail-chip {
+.feat-door-direction,
+.feat-door-chip {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  min-height: 28px;
-  padding: 4px 10px;
+  padding: 4px 12px;
   border-radius: 999px;
-  background: rgb(10 12 22 / 34%);
-  color: var(--text-secondary);
-  font-size: 0.8rem;
-}
-
-.feature-card-direction {
+  background: rgb(10 12 22 / 38%);
   color: var(--text-primary);
+  font-size: 0.82rem;
 }
 
-.feature-card-direction-icon {
+.feat-door-direction-icon {
   width: 16px;
   height: 16px;
 }
 
-.feature-card-details {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.feature-card-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.feature-card-action {
-  display: inline-flex;
+.feat-empty-panel {
   align-items: center;
   justify-content: center;
-  padding: 8px 13px;
-  border: 1px solid rgb(255 255 255 / 12%);
-  border-radius: var(--radius-md);
-  background: linear-gradient(135deg, rgb(87 101 140 / 62%), rgb(65 78 114 / 58%));
-  color: var(--text-primary);
-  font-family: var(--font-body);
-  font-size: 0.84rem;
-  font-weight: 700;
-  cursor: pointer;
-  transition:
-    transform 150ms var(--ease-out-soft),
-    border-color 150ms var(--ease-out-soft),
-    background 150ms var(--ease-out-soft);
-}
-
-.feature-card-action:hover {
-  transform: translateY(-1px);
-  border-color: rgb(216 197 232 / 34%);
-  background: linear-gradient(135deg, rgb(102 117 162 / 72%), rgb(76 91 132 / 68%));
-}
-
-/* ───────────────────────────────────────────────────────────────────────
-   Container & Sign cards (fcard) — art-forward, no boxy chrome.
-   A full-bleed backdrop layer (authored art via --fcard-art, or a stylized
-   CSS/SVG fallback) sits behind a body that floats its content over the art.
-   ─────────────────────────────────────────────────────────────────────── */
-.fcard {
-  position: relative;
-  isolation: isolate;
-  overflow: hidden;
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--line-soft);
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 8%),
-    0 10px 26px rgb(8 10 20 / 26%);
-}
-
-.fcard-bg {
-  position: absolute;
-  inset: 0;
-  z-index: -1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-/* Authored art fills the card; a scrim keeps overlaid text legible. */
-.fcard.has-art .fcard-bg {
-  background-image: var(--fcard-art);
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
-}
-
-.fcard.has-art .fcard-bg::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(180deg, rgb(10 12 20 / 26%) 0%, rgb(10 12 20 / 12%) 45%, rgb(10 12 20 / 46%) 100%);
-}
-
-/* Stylized SVG fallback glyph (no art shipped yet). */
-.fcard-glyph {
-  width: min(58%, 320px);
-  height: auto;
-  opacity: 0.9;
-}
-
-.fcard-body {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-  min-height: 168px;
-  padding: 16px 18px;
-}
-
-.fcard-title {
-  margin: 0;
-  font-family: var(--font-display);
-  font-size: 1.16rem;
-  color: var(--text-bright);
-  text-shadow:
-    0 1px 2px rgb(0 0 0 / 70%),
-    0 1px 14px rgb(0 0 0 / 55%);
-}
-
-/* Container contents + actions sit in the lower half (the open chest's cavity). */
-.fcard-foot {
-  margin-top: auto;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.fcard-loot {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.fcard-loot-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-2);
-  padding: 8px 0;
-  border-bottom: 1px solid rgb(255 255 255 / 12%);
-}
-
-.fcard-loot-row:last-child {
-  border-bottom: none;
-}
-
-.fcard-loot-name {
-  color: var(--text-bright);
-  font-size: 0.9rem;
-  text-shadow: 0 1px 6px rgb(0 0 0 / 65%);
-}
-
-.fcard-take {
-  flex-shrink: 0;
-  padding: 5px 14px;
-  border: 1px solid rgb(240 214 150 / 50%);
-  border-radius: 999px;
-  background: rgb(60 48 24 / 62%);
-  color: #f4e2b2;
-  font-family: var(--font-body);
-  font-size: 0.78rem;
-  font-weight: 700;
-  cursor: pointer;
-  backdrop-filter: blur(2px);
-  transition:
-    background 150ms var(--ease-out-soft),
-    border-color 150ms var(--ease-out-soft),
-    transform 150ms var(--ease-out-soft);
-}
-
-.fcard-take:hover {
-  background: rgb(86 68 32 / 78%);
-  border-color: rgb(248 226 168 / 80%);
-  transform: translateY(-1px);
-}
-
-.fcard-empty {
-  margin: 0;
-  color: var(--text-muted);
-  font-size: 0.84rem;
-  font-style: italic;
-}
-
-.fcard-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.fcard-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 8px 16px;
-  border: 1px solid rgb(255 255 255 / 14%);
-  border-radius: var(--radius-md);
-  background: rgb(18 22 34 / 52%);
-  color: var(--text-primary);
-  font-family: var(--font-body);
-  font-size: 0.84rem;
-  font-weight: 700;
-  cursor: pointer;
-  backdrop-filter: blur(2px);
-  transition:
-    transform 150ms var(--ease-out-soft),
-    border-color 150ms var(--ease-out-soft),
-    background 150ms var(--ease-out-soft);
-}
-
-.fcard-btn:hover {
-  transform: translateY(-1px);
-  border-color: rgb(216 197 232 / 38%);
-  background: rgb(28 34 50 / 62%);
-}
-
-.fcard-btn-primary {
-  border-color: rgb(226 198 134 / 46%);
-  background: linear-gradient(135deg, rgb(164 136 82 / 64%), rgb(124 102 62 / 58%));
-  color: #f3e4bf;
-}
-
-.fcard-btn-primary:hover {
-  border-color: rgb(240 214 150 / 70%);
-  background: linear-gradient(135deg, rgb(188 158 100 / 76%), rgb(142 118 74 / 68%));
-}
-
-/* Art bleeds — only a whisper of an edge so the card reads as the art, not a box. */
-.fcard.has-art {
-  border-color: rgb(255 255 255 / 7%);
-}
-
-/* Container card tinting */
-.fcard-container {
-  border-color: rgb(212 178 110 / 24%);
-}
-
-.fcard-container .fcard-body {
-  min-height: 210px;
-}
-
-.fcard-container .fcard-bg {
-  color: #e6c587;
-  background:
-    radial-gradient(ellipse at 50% 8%, rgb(226 198 134 / 16%), transparent 58%),
-    linear-gradient(165deg, rgb(74 66 86 / 96%), rgb(50 46 66 / 94%));
-}
-
-/* The open chest's interior is bright — a soft gradient (not a panel) sits behind
-   the title + loot so light text stays legible. */
-.fcard-container.has-art .fcard-body::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  z-index: -1;
-  background: linear-gradient(
-    to top,
-    rgb(6 7 13 / 82%) 0%,
-    rgb(6 7 13 / 58%) 26%,
-    rgb(6 7 13 / 16%) 54%,
-    transparent 76%
-  );
-}
-
-.fcard-container.is-closed .fcard-glyph,
-.fcard-container.is-locked .fcard-glyph {
-  opacity: 0.6;
-}
-
-/* Sign card */
-.fcard-sign {
-  border-color: rgb(148 188 160 / 24%);
-}
-
-.fcard-sign .fcard-bg {
-  color: #bcdcc4;
-  background:
-    radial-gradient(ellipse at 50% 0%, rgb(168 204 178 / 14%), transparent 60%),
-    linear-gradient(165deg, rgb(60 74 92 / 96%), rgb(47 60 78 / 94%));
-}
-
-.fcard-sign-body {
-  align-items: center;
-  justify-content: center;
+  padding: 40px;
+  color: var(--text-secondary);
   text-align: center;
 }
 
-.fcard-sign-text {
-  margin: 0;
-  max-width: 58ch;
-  color: var(--text-bright);
-  font-family: var(--font-display);
-  font-size: 1.06rem;
-  font-style: italic;
-  line-height: 1.6;
-  white-space: pre-wrap;
-  text-shadow:
-    0 1px 2px rgb(0 0 0 / 60%),
-    0 1px 12px rgb(0 0 0 / 50%);
-}
-
-/* Hero treatment for a single locked feature (container or door) — bigger,
-   centered, with a prominent lock glyph and a primary Unlock action. Variant
-   classes re-tint the card (gold for containers, cool blue for doors) while
-   the layout and glyph stay consistent. */
-.feature-card-hero-locked {
-  grid-column: 1 / -1;
-  justify-self: center;
-  max-width: 420px;
-  width: 100%;
-  gap: 14px;
-  padding: 28px 24px 24px;
-  align-items: center;
-  text-align: center;
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 10%),
-    0 12px 32px rgb(10 8 18 / 34%);
-}
-
-.feature-card-hero-locked-container {
-  background:
-    radial-gradient(circle at 50% 0%, rgb(212 178 110 / 18%), transparent 60%),
-    linear-gradient(160deg, rgb(72 68 92 / 94%), rgb(52 50 74 / 92%));
-  border-color: rgb(212 178 110 / 28%);
-}
-
-.feature-card-hero-locked-door {
-  background:
-    radial-gradient(circle at 50% 0%, rgb(146 184 223 / 20%), transparent 60%),
-    linear-gradient(160deg, rgb(62 73 108 / 94%), rgb(45 56 86 / 92%));
-  border-color: rgb(146 184 223 / 30%);
-}
-
-.feature-card-hero-lock {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 96px;
-  height: 96px;
-  animation: hero-lock-breathe 4s var(--ease-in-out-smooth) infinite;
-}
-
-.feature-card-hero-locked-container .feature-card-hero-lock {
-  color: rgb(226 198 134);
-  filter: drop-shadow(0 0 10px rgb(226 198 134 / 24%));
-}
-
-.feature-card-hero-locked-door .feature-card-hero-lock {
-  color: rgb(189 216 238);
-  filter: drop-shadow(0 0 10px rgb(189 216 238 / 28%));
-}
-
-.feature-card-hero-lock-svg {
-  width: 72px;
-  height: 90px;
-}
-
-@keyframes hero-lock-breathe {
-  0%, 100% { transform: scale(1); opacity: 0.92; }
-  50% { transform: scale(1.04); opacity: 1; }
-}
-
+/* Reduced motion */
 @media (prefers-reduced-motion: reduce) {
-  .feature-card-hero-lock {
-    animation: none;
+  .feat-lever-stage,
+  .feat-lever-handle,
+  .feat-lever-svg line,
+  .feat-lever-svg circle {
+    transition: none;
   }
 }
 
-.feature-card-hero-copy {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-}
-
-.feature-card-hero-copy > h4 {
-  margin: 0;
-  font-family: var(--font-display);
-  font-size: 1.18rem;
-  color: var(--text-primary);
-}
-
-.feature-card-hero-subtitle {
-  margin: 0;
-  color: var(--text-muted);
-  font-size: 0.86rem;
-}
-
-.feature-card-hero-direction {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  margin-top: 4px;
-  padding: 4px 10px;
-  border-radius: 999px;
-  background: rgb(10 12 22 / 34%);
-  color: var(--text-primary);
-  font-size: 0.8rem;
-}
-
-.feature-card-hero-actions {
-  display: flex;
-  justify-content: center;
-  margin-top: 4px;
-}
-
-.feature-card-action-primary {
-  padding: 10px 22px;
-  font-size: 0.9rem;
-}
-
-.feature-card-hero-locked-container .feature-card-action-primary {
-  border-color: rgb(226 198 134 / 46%);
-  background: linear-gradient(135deg, rgb(164 136 82 / 70%), rgb(124 102 62 / 64%));
-}
-
-.feature-card-hero-locked-container .feature-card-action-primary:hover {
-  border-color: rgb(240 214 150 / 70%);
-  background: linear-gradient(135deg, rgb(188 158 100 / 80%), rgb(142 118 74 / 72%));
-}
-
-.feature-card-hero-locked-door .feature-card-action-primary {
-  border-color: rgb(156 190 228 / 50%);
-  background: linear-gradient(135deg, rgb(88 120 168 / 72%), rgb(66 92 136 / 66%));
-}
-
-.feature-card-hero-locked-door .feature-card-action-primary:hover {
-  border-color: rgb(186 214 240 / 70%);
-  background: linear-gradient(135deg, rgb(110 144 196 / 82%), rgb(82 112 160 / 74%));
-}
 
 .skills-combat-panel {
   display: grid;
@@ -10429,26 +10080,10 @@ body {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .feature-popout-tab,
-  .feature-card-action,
-  .feature-card-inline-action,
   .room-feature-item,
   .room-feature-btn,
   .room-exit-btn {
     transition: none;
-  }
-}
-
-@media (max-width: 720px) {
-  .feature-card-header,
-  .feature-card-contents-header,
-  .feature-card-item {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .feature-card-meta {
-    justify-content: flex-start;
   }
 }
 

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -2978,190 +2978,331 @@ body {
   50% { box-shadow: 0 0 12px rgb(190 168 115 / 50%); }
 }
 
-/* ── Puzzle popout ─────────────────────────────────────── */
-.puzzle-popout {
+/* ── Puzzle: the grimoire / parchment tome ─────────────────
+   Each puzzle opens as a full-bleed Drawer panel whose background is an open
+   grimoire spread (puzzle_bg / per-puzzle backgroundImage). You inscribe your
+   answer on the page; on submit the ink combusts — gold flare if correct, ash
+   scatter if not. */
+
+.drawer-sheet.drawer-sheet-tome {
+  background-image:
+    var(--skin-bg, none),
+    linear-gradient(180deg, rgb(43 53 79 / 98%), rgb(34 41 64 / 98%));
+  background-size: cover, auto;
+  background-position: center, center;
+  background-repeat: no-repeat, no-repeat;
+}
+
+.drawer-sheet-tome .drawer-title {
+  color: #f3e7cf;
+  text-shadow: 0 1px 2px rgb(0 0 0 / 72%), 0 1px 12px rgb(0 0 0 / 55%);
+}
+
+.drawer-sheet-tome .drawer-header {
+  border-bottom-color: transparent;
+  background: linear-gradient(to bottom, rgb(8 10 18 / 50%), transparent);
+}
+
+.drawer-sheet-tome .drawer-body {
+  padding: 0;
   display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
 }
 
-/* Shared puzzle card — compact row layout with icon */
-.puzzle-card {
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
-  padding: 12px 14px;
-  border: 1px solid var(--line-soft);
-  border-radius: var(--radius-md);
-  background: linear-gradient(135deg, rgb(196 168 232 / 8%), rgb(140 110 190 / 4%));
-  transition: border-color 200ms var(--ease-out-soft), background 200ms var(--ease-out-soft);
-}
-
-.puzzle-card:hover {
-  border-color: rgb(196 168 232 / 36%);
-}
-
-.puzzle-card-solved {
-  opacity: 0.6;
-}
-
-.puzzle-card-solved .puzzle-card-question,
-.puzzle-card-solved .puzzle-card-hint {
-  text-decoration: line-through;
-  text-decoration-color: rgb(255 255 255 / 18%);
-}
-
-/* Icon circle */
-.puzzle-card-icon {
-  flex-shrink: 0;
+.puzzle-tome {
+  position: relative;
+  flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  background: rgb(196 168 232 / 14%);
-  color: #d9b3e2;
+  min-height: 0;
 }
 
-.puzzle-card-icon > svg {
-  width: 20px;
-  height: 20px;
-}
-
-.puzzle-card-icon-sequence {
-  background: rgb(156 190 228 / 14%);
-  color: #bdd8ee;
-}
-
-/* Card body */
-.puzzle-card-body {
-  flex: 1;
-  min-width: 0;
+.puzzle-page {
+  position: relative;
+  z-index: 1;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  align-items: center;
+  gap: 18px;
+  width: 100%;
+  max-width: 560px;
+  padding: clamp(30px, 6vw, 60px) clamp(28px, 7vw, 76px);
+  text-align: center;
 }
 
-.puzzle-card-top {
+/* No art shipped — render a parchment card so the ink reads. */
+.puzzle-page.on-css {
+  max-width: 520px;
+  margin: clamp(16px, 4vw, 32px);
+  border-radius: 14px;
+  background: linear-gradient(160deg, #efe3c6, #e2d1ab);
+  border: 1px solid #b89b6a;
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 40%),
+    0 14px 36px rgb(20 14 6 / 42%);
+}
+
+.puzzle-riddle {
+  position: relative;
   display: flex;
+  flex-direction: column;
   align-items: center;
+  gap: 10px;
+}
+
+.puzzle-eyebrow {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-weight: 700;
+  color: #8a6a3a;
+}
+
+.puzzle-riddle-text {
+  margin: 0;
+  max-width: 46ch;
+  font-family: var(--font-display);
+  font-size: clamp(1.05rem, 1.7vw, 1.34rem);
+  line-height: 1.55;
+  color: #3f2e18;
+}
+
+.puzzle-riddle.is-solved .puzzle-riddle-text {
+  opacity: 0.6;
+}
+
+.puzzle-seal {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 14px;
+  border-radius: 999px;
+  background: radial-gradient(circle at 32% 28%, #c0532f, #8a2d18);
+  color: #f3dcc0;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  box-shadow: 0 2px 6px rgb(60 20 10 / 40%), inset 0 1px 0 rgb(255 255 255 / 22%);
+}
+
+.puzzle-seq-dots {
+  display: flex;
   gap: 8px;
 }
 
-.puzzle-card-label {
-  font-size: 0.72rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--text-secondary);
-  font-weight: 700;
-}
-
-.puzzle-card-badge {
-  font-size: 0.68rem;
-  padding: 1px 7px;
-  border-radius: 999px;
-  background: rgb(140 174 123 / 22%);
-  color: rgb(180 210 160);
-  font-weight: 600;
-}
-
-.puzzle-card-question {
-  margin: 0;
-  font-size: 0.92rem;
-  line-height: 1.45;
-  color: var(--text-primary);
-  font-style: italic;
-  font-family: var(--font-display);
-}
-
-.puzzle-card-hint {
-  margin: 0;
-  font-size: 0.82rem;
-  line-height: 1.4;
-  color: var(--text-secondary);
-}
-
-/* Sequence progress dots */
-.puzzle-sequence-dots {
-  display: flex;
-  gap: 6px;
-  padding-top: 4px;
-}
-
-.puzzle-sequence-dot {
-  width: 10px;
-  height: 10px;
+.puzzle-seq-dot {
+  width: 9px;
+  height: 9px;
   border-radius: 50%;
-  background: rgb(255 255 255 / 10%);
-  border: 1.5px solid rgb(255 255 255 / 18%);
-  transition: background 300ms var(--ease-out-soft), border-color 300ms var(--ease-out-soft), box-shadow 300ms var(--ease-out-soft);
+  border: 1.5px solid rgb(80 60 30 / 45%);
+  background: rgb(80 60 30 / 12%);
 }
 
-.puzzle-sequence-dot-done {
-  background: rgb(140 174 123 / 70%);
-  border-color: rgb(140 174 123 / 50%);
+.puzzle-seq-dot.is-done {
+  background: #8a6a3a;
+  border-color: #8a6a3a;
 }
 
-.puzzle-sequence-dot-next {
-  background: rgb(196 168 232 / 30%);
-  border-color: rgb(196 168 232 / 50%);
-  box-shadow: 0 0 6px rgb(196 168 232 / 40%);
-  animation: dot-pulse 2s var(--ease-in-out-smooth) infinite;
+.puzzle-seq-dot.is-next {
+  border-color: #b6831f;
+  box-shadow: 0 0 6px rgb(182 131 31 / 50%);
+  animation: dot-pulse-ink 2s var(--ease-in-out-smooth) infinite;
 }
 
-@keyframes dot-pulse {
-  0%, 100% { box-shadow: 0 0 6px rgb(196 168 232 / 40%); }
-  50% { box-shadow: 0 0 12px rgb(196 168 232 / 65%); }
+@keyframes dot-pulse-ink {
+  0%, 100% { box-shadow: 0 0 5px rgb(182 131 31 / 40%); }
+  50% { box-shadow: 0 0 11px rgb(182 131 31 / 70%); }
 }
 
-/* Answer bar — slim inline form */
-.puzzle-answer-bar {
+/* ── Inscribe row ─────────────────────────────────────────── */
+.puzzle-inscribe {
+  width: min(440px, 100%);
   display: flex;
-  gap: var(--space-2);
-  padding-top: 2px;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  margin-top: 4px;
 }
 
-.puzzle-answer-input {
-  flex: 1;
-  padding: 8px 12px;
-  border: 1px solid var(--line-soft);
-  border-radius: var(--radius-md);
-  background: var(--surface-chip);
-  color: var(--text-primary);
-  font-size: 0.88rem;
-  font-family: inherit;
-  transition: border-color 150ms, background 150ms;
+.puzzle-inscribe-field {
+  position: relative;
+  width: 100%;
+  min-height: 2.6em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.puzzle-answer-input:focus {
+.puzzle-inscribe-input {
+  width: 100%;
+  text-align: center;
+  padding: 6px 4px;
+  border: none;
+  border-bottom: 2px solid rgb(90 64 28 / 50%);
+  background: transparent;
+  color: #3f2e18;
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 1.12rem;
+  transition: border-color 150ms var(--ease-out-soft), opacity 200ms var(--ease-out-soft);
+}
+
+.puzzle-inscribe-input::placeholder {
+  color: rgb(90 64 28 / 50%);
+  font-style: italic;
+}
+
+.puzzle-inscribe-input:focus {
   outline: none;
-  border-color: rgb(196 168 232 / 55%);
-  background: rgb(255 255 255 / 5%);
+  border-bottom-color: #b6831f;
 }
 
-.puzzle-answer-submit {
-  padding: 8px 14px;
-  white-space: nowrap;
-  border: 1px solid rgb(196 168 232 / 28%);
-  border-radius: var(--radius-md);
-  background: linear-gradient(135deg, rgb(196 168 232 / 50%), rgb(160 130 200 / 44%));
-  color: var(--text-primary);
+.puzzle-inscribe-field.is-success .puzzle-inscribe-input,
+.puzzle-inscribe-field.is-fail .puzzle-inscribe-input {
+  opacity: 0;
+}
+
+.puzzle-inscribe-submit {
+  padding: 8px 24px;
+  border: 1px solid rgb(150 107 30 / 60%);
+  border-radius: 999px;
+  background: linear-gradient(135deg, #b98a3e, #8a5a1e);
+  color: #fff4dc;
   font-family: var(--font-body);
-  font-size: 0.84rem;
+  font-size: 0.85rem;
   font-weight: 700;
+  letter-spacing: 0.04em;
   cursor: pointer;
-  transition: background 150ms var(--ease-out-soft), transform 150ms var(--ease-out-soft);
+  box-shadow: 0 2px 8px rgb(60 40 10 / 30%);
+  transition: transform 150ms var(--ease-out-soft), filter 150ms var(--ease-out-soft);
 }
 
-.puzzle-answer-submit:not(:disabled):hover {
-  background: linear-gradient(135deg, rgb(210 182 246 / 66%), rgb(174 144 214 / 62%));
+.puzzle-inscribe-submit:not(:disabled):hover {
   transform: translateY(-1px);
+  filter: brightness(1.08);
 }
 
-.puzzle-answer-submit:disabled {
-  opacity: 0.45;
+.puzzle-inscribe-submit:disabled {
+  opacity: 0.5;
   cursor: default;
+}
+
+/* ── The puff of flame ────────────────────────────────────── */
+.puzzle-burn {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.puzzle-burn-text {
+  position: relative;
+  z-index: 1;
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 1.12rem;
+  color: #3f2e18;
+}
+
+.puzzle-burn.is-success .puzzle-burn-text {
+  animation: burn-gold 1.15s ease-in forwards;
+}
+
+.puzzle-burn.is-fail .puzzle-burn-text {
+  animation: burn-ash 1.15s ease-in forwards;
+}
+
+@keyframes burn-gold {
+  0% { color: #3f2e18; text-shadow: none; transform: translateY(0); opacity: 1; filter: blur(0); }
+  35% { color: #eab53c; text-shadow: 0 0 10px #ffb43a, 0 0 24px #ff8a1a; }
+  100% { color: #6b3a12; opacity: 0; transform: translateY(-18px); filter: blur(3px); }
+}
+
+@keyframes burn-ash {
+  0% { color: #3f2e18; opacity: 1; transform: translateY(0); filter: blur(0); letter-spacing: normal; }
+  40% { color: #8a7d6a; text-shadow: 0 0 8px rgb(120 70 40 / 50%); }
+  100% { color: #4a4640; opacity: 0; transform: translateY(10px) scale(0.97); filter: blur(2px); letter-spacing: 0.25em; }
+}
+
+.puzzle-flame {
+  position: absolute;
+  left: 50%;
+  bottom: -10%;
+  width: 56%;
+  height: 130%;
+  transform: translateX(-50%);
+  background: radial-gradient(
+    ellipse at 50% 100%,
+    rgb(255 214 96 / 92%),
+    rgb(255 142 32 / 60%) 34%,
+    rgb(198 60 20 / 22%) 60%,
+    transparent 72%
+  );
+  filter: blur(3px);
+  mix-blend-mode: screen;
+  opacity: 0;
+  animation: flame-rise 1.1s ease-out forwards;
+}
+
+.puzzle-flame-2 {
+  width: 36%;
+  animation-delay: 0.12s;
+}
+
+.puzzle-burn.is-fail .puzzle-flame {
+  background: radial-gradient(
+    ellipse at 50% 100%,
+    rgb(140 104 78 / 72%),
+    rgb(88 66 52 / 42%) 42%,
+    transparent 70%
+  );
+}
+
+@keyframes flame-rise {
+  0% { opacity: 0; transform: translateX(-50%) scaleY(0.4) translateY(16%); }
+  25% { opacity: 0.95; }
+  100% { opacity: 0; transform: translateX(-50%) scaleY(1.28) translateY(-42%); }
+}
+
+.puzzle-verdict {
+  margin: 0;
+  font-size: 0.88rem;
+  font-weight: 700;
+  opacity: 0;
+  animation: verdict-in 0.4s var(--ease-out-soft) 0.18s forwards;
+}
+
+.puzzle-verdict.is-success {
+  color: #9a6b1e;
+}
+
+.puzzle-verdict.is-fail {
+  color: #8a3a1e;
+}
+
+@keyframes verdict-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .puzzle-flame,
+  .puzzle-verdict,
+  .puzzle-seq-dot.is-next {
+    animation: none;
+  }
+
+  .puzzle-verdict {
+    opacity: 1;
+  }
+
+  .puzzle-burn.is-success .puzzle-burn-text,
+  .puzzle-burn.is-fail .puzzle-burn-text {
+    animation: none;
+    opacity: 0;
+  }
 }
 
 /* ════════════════════════════════════════════════════════════════════════

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -331,10 +331,19 @@ export interface PuzzleItem {
   currentStep: number | null;
   /** True if the player has already solved this puzzle. */
   solved: boolean;
+  /** Fully-resolved parchment/grimoire backdrop art URL, or null. */
+  backgroundImage: string | null;
 }
 
 export interface PuzzleState {
   puzzles: PuzzleItem[];
+}
+
+/** Result of a riddle answer attempt — drives the inscribe → puff-of-flame beat. */
+export interface PuzzleResult {
+  id: string;
+  correct: boolean;
+  message: string;
 }
 
 export interface RoomItem {


### PR DESCRIPTION
## Summary

Two related web-client passes, both following the art contract from the merged feature work (global default + per-feature/per-puzzle `backgroundImage` override, resolving `override → global → CSS fallback`).

### 1. Feature panels go full-bleed (one panel per feature)

Addresses the "rid of all the boxes" feedback. The tabbed **World Features** modal is gone — each interactive feature now opens as its **own full-bleed Drawer panel**, exactly like the Inventory/Equipment panels: the feature's art is the panel background, the feature's name is the title, content floats over the art. No tabs, no summary pills, no inner bounding box.

- New Drawer variant `feature`: sign + container use the art as the whole sheet background (behind the header); legibility shadow on the title.
- App picks the focused feature (by the type the canvas badge passed) and drives the Drawer title + skin from it, so chrome always matches content.
- **Sign**: just the text, centred on the placard.
- **Container**: title + loot + actions over the chest art, with a soft bottom scrim so loot reads over the bright interior.
- **Lever**: a tall vertical box with the lever art and the plate/handle composed in the **vertical centre** (was pinned too high); the whole tile is click-to-pull, name/state caption beneath.
- **Door**: tidy centred card (no art).

### 2. Puzzle becomes a grimoire — inscribe your answer, the ink combusts

New: the puzzle popout is a full-bleed parchment **tome**. Solving is one gesture — you inscribe your answer on the page and the ink burns off: a **gold flare** on success, an **ash scatter** on a wrong answer, then the page opens or not (with the riddle's fail message).

- New global asset **`puzzle_bg`** (open grimoire spread) + optional per-puzzle **`backgroundImage`** override on `PuzzleFile`/`PuzzleDef`, resolved in `WorldLoader`, carried in `Puzzle.List`.
- New **`Puzzle.Result`** GMCP (under the existing "Puzzle" family) emitted from `PuzzleHandler` on a riddle answer — `{ id, correct, message }` — so the client can drive the flame and show the verdict. Telnet feed (`SendInfo`/`SendError`) is unchanged.
- `PuzzlePopout` reskinned to the tome (Drawer `tome` variant using the puzzle art as skin; CSS parchment fallback when no art); inscribe input + flame animation; input re-arms on a wrong answer.

## Asset contract (for parallel Arcanum work)

| Key | Default path | Art |
|---|---|---|
| `puzzle_bg` | `global_assets/puzzle_bg.png` | open grimoire / parchment spread with a blank writable page |

Per-puzzle override: `backgroundImage: <filename>` on a puzzle (same as the lever/feature `backgroundImage`).

## Tests
- `PuzzleSystemTest`: `backgroundImage` resolution (riddle) + null (sequence).
- Verified: `eslint` ✓ · `tsc -b` ✓ · `vite build` ✓ · `ktlintCheck` ✓ · puzzle + feature loader tests ✓.

> Art (`puzzle_bg`) is authored separately; until it ships the CSS parchment fallback renders. The lever socket position (`inset` for the plate/handle) is a best guess — easy one-line tweak once you eyeball it live.