### PR TITLE
fix(web): tighten feature + puzzle panels (lines, lever, sign, puzzle verdict)

### DIFF
--- a/web-v3/src/components/PuzzlePopout.tsx
+++ b/web-v3/src/components/PuzzlePopout.tsx
@@ -48,7 +48,8 @@ function SequenceBlock({ puzzle }: { puzzle: PuzzleItem }) {
 
 export function PuzzlePopout({ puzzle, puzzleResult, serverAssets, onCommand }: PuzzlePopoutProps) {
   const [answer, setAnswer] = useState("");
-  const [burn, setBurn] = useState<{ correct: boolean; text: string; message: string } | null>(null);
+  const [burn, setBurn] = useState<{ correct: boolean; text: string } | null>(null);
+  const [verdict, setVerdict] = useState<{ correct: boolean; message: string } | null>(null);
   const [seenResult, setSeenResult] = useState<PuzzleResult | null>(puzzleResult);
   const [pendingText, setPendingText] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
@@ -60,14 +61,12 @@ export function PuzzlePopout({ puzzle, puzzleResult, serverAssets, onCommand }: 
   // A fresh Puzzle.Result ignites the ink: gold flare if correct, ash scatter if
   // not. Derived during render (the blessed "adjust state on prop change" form)
   // so we react the instant the result lands, showing what was just inscribed.
+  // The flame (`burn`) is brief; the verdict message stays so it can be read.
   if (puzzleResult !== seenResult) {
     setSeenResult(puzzleResult);
     if (puzzleResult) {
-      setBurn({
-        correct: puzzleResult.correct,
-        text: pendingText,
-        message: puzzleResult.message,
-      });
+      setBurn({ correct: puzzleResult.correct, text: pendingText });
+      setVerdict({ correct: puzzleResult.correct, message: puzzleResult.message });
       setAnswer("");
     }
   }
@@ -76,18 +75,19 @@ export function PuzzlePopout({ puzzle, puzzleResult, serverAssets, onCommand }: 
     const trimmed = answer.trim();
     if (trimmed.length === 0 || burn) return;
     setPendingText(trimmed);
+    setVerdict(null);
     onCommand(`answer ${trimmed}`);
   };
 
   // Clear the flame once it's burned out; re-arm the page for another attempt
-  // when the answer was wrong.
+  // when the answer was wrong. The verdict message persists.
   useEffect(() => {
     if (!burn) return;
     const wasWrong = !burn.correct;
     const timer = setTimeout(() => {
       setBurn(null);
       if (wasWrong) inputRef.current?.focus();
-    }, 1500);
+    }, 1200);
     return () => clearTimeout(timer);
   }, [burn]);
 
@@ -139,12 +139,13 @@ export function PuzzlePopout({ puzzle, puzzleResult, serverAssets, onCommand }: 
             >
               Inscribe
             </button>
-            {burn && (
-              <p className={`puzzle-verdict${burn.correct ? " is-success" : " is-fail"}`} role="status">
-                {burn.message}
-              </p>
-            )}
           </form>
+        )}
+
+        {verdict && (
+          <p className={`puzzle-verdict${verdict.correct ? " is-success" : " is-fail"}`} role="status">
+            {verdict.message}
+          </p>
         )}
       </div>
     </div>

--- a/web-v3/src/components/WorldFeaturesPopout.tsx
+++ b/web-v3/src/components/WorldFeaturesPopout.tsx
@@ -228,10 +228,6 @@ function LeverPanel({
           </span>
         )}
       </button>
-      <span className="feat-lever-caption">
-        <span className="feat-lever-name">{feature.name}</span>
-        <span className={`feat-lever-state feat-lever-state-${isUp ? "up" : "down"}`}>{label}</span>
-      </span>
     </div>
   );
 }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -2999,8 +2999,8 @@ body {
 }
 
 .drawer-sheet-tome .drawer-header {
-  border-bottom-color: transparent;
-  background: linear-gradient(to bottom, rgb(8 10 18 / 50%), transparent);
+  border-bottom: none;
+  background: none;
 }
 
 .drawer-sheet-tome .drawer-body {
@@ -3050,21 +3050,33 @@ body {
   gap: 10px;
 }
 
+/* A soft cream glow lifts the ink off the parchment (and over the book's gutter)
+   for even legibility regardless of the underlying art — not a hard panel. */
+.puzzle-riddle::before {
+  content: "";
+  position: absolute;
+  inset: -14% -10%;
+  z-index: -1;
+  background: radial-gradient(ellipse at center, rgb(248 240 218 / 66%), rgb(248 240 218 / 0%) 72%);
+  filter: blur(10px);
+}
+
 .puzzle-eyebrow {
   font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-weight: 700;
-  color: #8a6a3a;
+  color: #7a5326;
 }
 
 .puzzle-riddle-text {
   margin: 0;
-  max-width: 46ch;
+  max-width: 42ch;
   font-family: var(--font-display);
-  font-size: clamp(1.05rem, 1.7vw, 1.34rem);
+  font-size: clamp(1.08rem, 1.7vw, 1.36rem);
   line-height: 1.55;
-  color: #3f2e18;
+  color: #2c1d0c;
+  text-shadow: 0 1px 1px rgb(250 244 226 / 70%);
 }
 
 .puzzle-riddle.is-solved .puzzle-riddle-text {
@@ -3327,11 +3339,11 @@ body {
   text-shadow: 0 1px 2px rgb(0 0 0 / 72%), 0 1px 12px rgb(0 0 0 / 55%);
 }
 
-/* Soft top scrim keeps the title + close legible over bright art, without a
-   hard band (fades to transparent). */
+/* No divider, no scrim band — the title rides directly on the art (legibility
+   comes from its text-shadow). */
 .drawer-sheet-feature .drawer-header {
-  border-bottom-color: transparent;
-  background: linear-gradient(to bottom, rgb(8 10 18 / 52%), transparent);
+  border-bottom: none;
+  background: none;
 }
 
 /* The body is just the foreground content floating over the sheet art. */
@@ -3374,10 +3386,12 @@ body {
 }
 
 /* ── Sign ─────────────────────────────────────────────────── */
+/* The placard art sits in the upper-centre of the spread, so we bias the text
+   upward (heavier bottom padding) to land it on the board rather than the grass. */
 .feat-sign {
   align-items: center;
   justify-content: center;
-  padding: clamp(28px, 7vw, 72px) clamp(32px, 9vw, 120px);
+  padding: clamp(20px, 4vh, 44px) clamp(32px, 9vw, 120px) clamp(80px, 22vh, 220px);
   min-height: 46vh;
 }
 
@@ -3544,18 +3558,25 @@ body {
   background: linear-gradient(135deg, rgb(188 158 100 / 82%), rgb(142 118 74 / 74%));
 }
 
-/* ── Lever — a tall vertical box with the lever in the centre ── */
+/* ── Lever — a tall vertical box; the art fills the panel ────── */
+/* Levers are portrait, so give their panel a narrow, tall footprint — the art
+   fills it instead of floating in a wide, empty modal. */
+@media (min-width: 600px) {
+  .drawer-sheet:has(.feat-lever) {
+    width: min(460px, 92vw);
+  }
+}
+
 .feat-lever {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 12px;
-  padding: clamp(20px, 4vw, 36px) 16px clamp(18px, 3vw, 28px);
+  padding: clamp(14px, 2.5vh, 26px) 16px;
 }
 
 .feat-lever-stage {
   position: relative;
-  width: min(340px, 74vw);
+  width: min(400px, 86vw);
   margin: 0 auto;
   padding: 0;
   border: none;
@@ -3653,35 +3674,6 @@ body {
   fill: rgb(220 195 250 / 50%);
   filter: blur(2px);
   pointer-events: none;
-}
-
-.feat-lever-caption {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1px;
-  text-align: center;
-}
-
-.feat-lever-name {
-  font-size: 0.96rem;
-  font-weight: 700;
-  color: var(--text-bright);
-}
-
-.feat-lever-state {
-  font-size: 0.72rem;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  font-weight: 700;
-}
-
-.feat-lever-state-up {
-  color: rgb(150 200 130);
-}
-
-.feat-lever-state-down {
-  color: rgb(220 175 120);
 }
 
 /* ── Door (no art — a tidy centred card) ──────────────────── */


### PR DESCRIPTION
Follow-up polish on the full-bleed feature/puzzle panels, from live feedback. Client-only (CSS + two components).

- **Header line gone.** The dark scrim-gradient I'd put behind the panel title was reading as a divider line over bright art. Removed it on both the `feature` and `tome` panels — the title rides directly on the art now (its text-shadow keeps it legible).
- **Lever.** Dropped the redundant name/state caption under the art (the panel title already names it; the handle pose shows ready/pulled), and gave the lever panel a **narrow, tall footprint** (`:has(.feat-lever)` width override) so the portrait art fills it instead of floating in a wide "purple box".
- **Sign.** Biased the text upward so it lands on the placard board rather than the grass at the bottom; and the header line is gone here too.
- **Puzzle readability.** Darker ink + a soft cream glow behind the riddle text so it reads cleanly over the parchment and the book's centre gutter.
- **Puzzle verdict persists.** The success/fail message was vanishing in ~0.5s (couldn't finish reading it). The flame is still brief, but the verdict message now **stays** until the next attempt.

Verified: `eslint` ✓ · `tsc -b` ✓ · `vite build` ✓.