### PR TITLE
fix(web): stop dialogue voice-over when the window closes (#1249)

### DIFF
--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -568,17 +568,19 @@ function App() {
   // Audio for room music/ambient
   useEffect(() => { audio.playMusic(state.room.music ?? null); }, [state.room.music]); // eslint-disable-line react-hooks/exhaustive-deps
   useEffect(() => { audio.playAmbient(state.room.ambient ?? null); }, [state.room.ambient]); // eslint-disable-line react-hooks/exhaustive-deps
-  // Dialogue voice-over: play the current node's clip as a one-shot. Deliberately
-  // does NOT stop when the dialogue clears — a short voice line should finish even
-  // when the overlay closes (conversation ended, dismissed, walked away). Otherwise
-  // ending a single-exchange conversation (e.g. clicking a terminal choice, which
-  // makes the server send Dialogue.End) cuts the clip after only its first few
-  // words. A new node's clip still supersedes the previous one via playVoice's
-  // internal stop, so mid-conversation node changes interrupt as expected.
+  // Dialogue voice-over: play the current node's clip when it changes (a new node
+  // supersedes the previous one via playVoice's internal stop).
   useEffect(() => {
     const url = state.dialogue?.voiceUrl ?? null;
     if (url) audio.playVoice(url);
   }, [state.dialogue?.voiceUrl]); // eslint-disable-line react-hooks/exhaustive-deps
+  // ...and stop it the instant the dialogue window closes — the conversation
+  // ended, was dismissed, or the player left the room (issue #1249). The voice
+  // should only play while the window is open.
+  const dialogueOpen = state.dialogue !== null;
+  useEffect(() => {
+    if (!dialogueOpen) audio.playVoice(null);
+  }, [dialogueOpen]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Combat audio
   const hpPercent = state.vitals.maxHp > 0 ? state.vitals.hp / state.vitals.maxHp : 1;


### PR DESCRIPTION
Closes #1249.

**Bug:** A dialogue voice clip kept playing to its end even after the conversation closed, the player dismissed it, or walked out of the room.

**Cause:** The voice-over effect depended only on `state.dialogue?.voiceUrl`. By the time `dialogue` is cleared to `null`, the URL is already `null`, so the effect never re-fires — and it had no stop branch (it only ever called `playVoice(url)`, never `playVoice(null)`). `playVoice(null)` already stops the current clip; it just was never invoked on close.

**Fix:** Keep the existing play-on-node-change effect, and add a second effect that watches whether the dialogue window is open and stops the voice the moment it closes:

```ts
const dialogueOpen = state.dialogue !== null;
useEffect(() => {
  if (!dialogueOpen) audio.playVoice(null);
}, [dialogueOpen]);
```

Now the voice only plays while the dialogue window is open. Mid-conversation node changes still supersede the previous clip as before; closing (Dialogue.End), dismissing (`bye`/Escape), and leaving the room all clear `dialogue` → the clip stops immediately.

Verified: `eslint` ✓ · `tsc -b` ✓ · `vite build` ✓.