### PR TITLE
feat: door art (frame + swinging leaf, warded seal, key) + container polish

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -3047,6 +3047,14 @@ data class ImagesConfig(
             "container_bg" to "global_assets/container_bg.png",
             "sign_bg" to "global_assets/sign_bg.png",
             "lever_bg" to "global_assets/lever_bg.png",
+            // Server-wide default door art: a static frame + a swinging leaf (mirrors
+            // the lever plate/handle), the warded-seal lock overlay (glows when locked,
+            // shatters on unlock), and the card backdrop. Doors that don't author their
+            // own frameImage/leafImage use these; everything degrades to a CSS door.
+            "door_frame" to "global_assets/door_frame.png",
+            "door_leaf" to "global_assets/door_leaf.png",
+            "door_lock" to "global_assets/door_lock.png",
+            "door_bg" to "global_assets/door_bg.png",
             // Server-wide default backdrop for the puzzle (grimoire/parchment) panel.
             // Used when a puzzle doesn't author its own backgroundImage; falls back
             // further to a CSS tome treatment when this isn't present either.

--- a/src/main/kotlin/dev/ambon/domain/world/RoomFeature.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/RoomFeature.kt
@@ -28,6 +28,16 @@ sealed class RoomFeature {
         val resetWithZone: Boolean,
         /** Seconds out of [initialState] before the door reverts on its own. Null = zone reset only. */
         val respawnSeconds: Long? = null,
+        /**
+         * Optional custom door art (resolved URLs): a static [frameImage] and a
+         * swinging [leafImage] that pivots on [hinge] ("left"/"right") between 0°
+         * (closed) and [openAngle] (open). Absent → the `door_frame`/`door_leaf`
+         * global defaults, then a built-in CSS door.
+         */
+        val frameImage: String? = null,
+        val leafImage: String? = null,
+        val hinge: String? = null,
+        val openAngle: Double? = null,
     ) : RoomFeature()
 
     data class Container(

--- a/src/main/kotlin/dev/ambon/domain/world/RoomFeature.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/RoomFeature.kt
@@ -38,6 +38,10 @@ sealed class RoomFeature {
         val leafImage: String? = null,
         val hinge: String? = null,
         val openAngle: Double? = null,
+        /** Leaf size as a fraction of the frame box (fits it inside the opening). Default 0.76. */
+        val leafScale: Double? = null,
+        /** Vertical placement of the leaf within the frame (fraction; + = down). Default 0.09. */
+        val leafOffsetY: Double? = null,
     ) : RoomFeature()
 
     data class Container(

--- a/src/main/kotlin/dev/ambon/domain/world/data/DoorFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/DoorFile.kt
@@ -18,8 +18,12 @@ data class DoorFile(
      */
     val frameImage: String? = null,
     val leafImage: String? = null,
-    /** Which edge the leaf pivots on: "left" or "right". Default "left". */
+    /** Fixed edge the leaf is hinged on: "left" or "right". Default "right". */
     val hinge: String? = null,
-    /** Leaf swing angle (degrees) when open; closed is always 0. Default ~100. */
+    /** Leaf swing angle (degrees, unsigned) when open; closed is always 0. Default ~60. */
     val openAngle: Double? = null,
+    /** Leaf size as a fraction of the frame box, to fit it inside the opening. Default 0.76. */
+    val leafScale: Double? = null,
+    /** Vertical placement of the leaf within the frame (fraction; + = down). Default 0.09. */
+    val leafOffsetY: Double? = null,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/data/DoorFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/DoorFile.kt
@@ -10,4 +10,16 @@ data class DoorFile(
      * (e.g. an opened door re-closes/re-locks). Null = zone reset only.
      */
     val respawnSeconds: Long? = null,
+    /**
+     * Optional custom door art for the web client (content-addressed filenames,
+     * resolved against the world image base like the lever plate/handle).
+     * [frameImage] is the static frame/portal; [leafImage] is the swinging leaf.
+     * Absent → the `door_frame`/`door_leaf` global defaults, then a CSS door.
+     */
+    val frameImage: String? = null,
+    val leafImage: String? = null,
+    /** Which edge the leaf pivots on: "left" or "right". Default "left". */
+    val hinge: String? = null,
+    /** Leaf swing angle (degrees) when open; closed is always 0. Default ~100. */
+    val openAngle: Double? = null,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -311,6 +311,10 @@ object WorldLoader {
                                         keyConsumed = doorFile.keyConsumed,
                                         resetWithZone = doorFile.resetWithZone,
                                         respawnSeconds = doorRespawn,
+                                        frameImage = doorFile.frameImage?.trim()?.takeUnless { it.isEmpty() }?.let { "$imagesBase$it" },
+                                        leafImage = doorFile.leafImage?.trim()?.takeUnless { it.isEmpty() }?.let { "$imagesBase$it" },
+                                        hinge = doorFile.hinge?.trim()?.lowercase()?.takeIf { it == "left" || it == "right" },
+                                        openAngle = doorFile.openAngle,
                                     ),
                                 )
                             }

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -315,6 +315,8 @@ object WorldLoader {
                                         leafImage = doorFile.leafImage?.trim()?.takeUnless { it.isEmpty() }?.let { "$imagesBase$it" },
                                         hinge = doorFile.hinge?.trim()?.lowercase()?.takeIf { it == "left" || it == "right" },
                                         openAngle = doorFile.openAngle,
+                                        leafScale = doorFile.leafScale,
+                                        leafOffsetY = doorFile.leafOffsetY,
                                     ),
                                 )
                             }

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -3161,6 +3161,15 @@ class GmcpEmitter(
         val leverPivot: LeverPivotPayload? = null,
         val upAngle: Double? = null,
         val downAngle: Double? = null,
+        // Optional custom door art (DOOR only): a static frame + a swinging leaf
+        // that pivots on `hinge` between 0° (closed) and `openAngle` (open).
+        val frameImage: String? = null,
+        val leafImage: String? = null,
+        val hinge: String? = null,
+        val openAngle: Double? = null,
+        // The key that locks/unlocks this door (DOOR only), for the lock UI.
+        val keyImage: String? = null,
+        val keyName: String? = null,
     )
 
     data class LeverPivotPayload(

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -3167,6 +3167,8 @@ class GmcpEmitter(
         val leafImage: String? = null,
         val hinge: String? = null,
         val openAngle: Double? = null,
+        val leafScale: Double? = null,
+        val leafOffsetY: Double? = null,
         // The key that locks/unlocks this door (DOOR only), for the lock UI.
         val keyImage: String? = null,
         val keyName: String? = null,

--- a/src/main/kotlin/dev/ambon/engine/TimedRespawnHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/TimedRespawnHandler.kt
@@ -160,7 +160,7 @@ internal class TimedRespawnHandler(
     private suspend fun emitRoomFeatures(roomId: RoomId) {
         val emitter = gmcpEmitter ?: return
         val room = world.rooms[roomId] ?: return
-        val payloads = room.features.map { buildFeaturePayload(it, worldState) }
+        val payloads = room.features.map { buildFeaturePayload(it, worldState, items) }
         for (p in players.playersInRoom(roomId)) {
             emitter.sendRoomFeatures(p.sessionId, payloads)
         }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -552,7 +552,7 @@ internal suspend fun sendLook(
     gmcpEmitter?.sendRoomFeatures(
         sessionId,
         room.features.map { feature ->
-            buildFeaturePayload(feature, worldState)
+            buildFeaturePayload(feature, worldState, items)
         },
     )
 }
@@ -560,9 +560,11 @@ internal suspend fun sendLook(
 internal fun buildFeaturePayload(
     feature: RoomFeature,
     worldState: WorldStateRegistry?,
+    items: ItemRegistry? = null,
 ): GmcpEmitter.RoomFeaturePayload = when (feature) {
     is RoomFeature.Door -> {
         val state = worldState?.getDoorState(feature.id) ?: feature.initialState
+        val keyTemplate = feature.keyItemId?.let { items?.getTemplate(it) }
         GmcpEmitter.RoomFeaturePayload(
             id = feature.id,
             name = feature.displayName,
@@ -572,6 +574,12 @@ internal fun buildFeaturePayload(
             direction = feature.direction.name.lowercase(),
             locked = state == LockableState.LOCKED,
             keyRequired = feature.keyItemId != null,
+            frameImage = feature.frameImage,
+            leafImage = feature.leafImage,
+            hinge = feature.hinge,
+            openAngle = feature.openAngle,
+            keyImage = keyTemplate?.image,
+            keyName = keyTemplate?.displayName,
         )
     }
     is RoomFeature.Container -> {

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -578,6 +578,8 @@ internal fun buildFeaturePayload(
             leafImage = feature.leafImage,
             hinge = feature.hinge,
             openAngle = feature.openAngle,
+            leafScale = feature.leafScale,
+            leafOffsetY = feature.leafOffsetY,
             keyImage = keyTemplate?.image,
             keyName = keyTemplate?.displayName,
         )

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldFeaturesHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldFeaturesHandler.kt
@@ -266,7 +266,7 @@ class WorldFeaturesHandler(
 
     private suspend fun emitRoomFeatures(room: Room) {
         val emitter = gmcpEmitter ?: return
-        val payloads = room.features.map { feature -> buildFeaturePayload(feature, worldState) }
+        val payloads = room.features.map { feature -> buildFeaturePayload(feature, worldState, items) }
         for (p in players.playersInRoom(room.id)) {
             emitter.sendRoomFeatures(p.sessionId, payloads)
         }

--- a/src/test/kotlin/dev/ambon/world/load/WorldLoaderFeaturesTest.kt
+++ b/src/test/kotlin/dev/ambon/world/load/WorldLoaderFeaturesTest.kt
@@ -41,6 +41,8 @@ class WorldLoaderFeaturesTest {
         assertTrue(door.leafImage!!.endsWith("doorleaf.webp"), "got=${door.leafImage}")
         assertEquals("right", door.hinge)
         assertEquals(95.0, door.openAngle)
+        assertEquals(0.8, door.leafScale)
+        assertEquals(0.06, door.leafOffsetY)
     }
 
     @Test

--- a/src/test/kotlin/dev/ambon/world/load/WorldLoaderFeaturesTest.kt
+++ b/src/test/kotlin/dev/ambon/world/load/WorldLoaderFeaturesTest.kt
@@ -36,6 +36,11 @@ class WorldLoaderFeaturesTest {
         assertFalse(door.keyConsumed)
         assertTrue(door.resetWithZone)
         assertEquals(RoomId("ok_features:entrance"), door.roomId)
+        // Custom door art: frame + leaf image refs resolve against the image base.
+        assertTrue(door.frameImage!!.endsWith("doorframe.webp"), "got=${door.frameImage}")
+        assertTrue(door.leafImage!!.endsWith("doorleaf.webp"), "got=${door.leafImage}")
+        assertEquals("right", door.hinge)
+        assertEquals(95.0, door.openAngle)
     }
 
     @Test

--- a/src/test/resources/world/ok_features.yaml
+++ b/src/test/resources/world/ok_features.yaml
@@ -27,6 +27,8 @@ rooms:
           leafImage: "doorleaf.webp"
           hinge: right
           openAngle: 95
+          leafScale: 0.8
+          leafOffsetY: 0.06
       east: storeroom
     features:
       notice_board:

--- a/src/test/resources/world/ok_features.yaml
+++ b/src/test/resources/world/ok_features.yaml
@@ -23,6 +23,10 @@ rooms:
           keyItemId: brass_key
           keyConsumed: false
           resetWithZone: true
+          frameImage: "doorframe.webp"
+          leafImage: "doorleaf.webp"
+          hinge: right
+          openAngle: 95
       east: storeroom
     features:
       notice_board:

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -848,7 +848,9 @@ function App() {
       case "chat": return "Social";
       case "shop": return state.shop?.name ?? "Shop";
       case "puzzle": return "Puzzle";
-      case "features": return featurePanelFeature ? featurePanelFeature.name : "Interactive Feature";
+      case "features": return featurePanelFeature
+        ? (featurePanelFeature.type === "container" ? "" : featurePanelFeature.name)
+        : "Interactive Feature";
       case "trainer": return "Trainer";
       case "mail": return "Mail";
       case "crafting": return "Crafting";

--- a/web-v3/src/components/WorldFeaturesPopout.tsx
+++ b/web-v3/src/components/WorldFeaturesPopout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { ContainerContents, FeaturePopoutFocus, RoomFeature } from "../types";
 import { DirectionIcon } from "./Icons";
 import { featureArt, pickFocusedFeature } from "./worldFeatures";
@@ -124,7 +124,6 @@ function ContainerPanel({
     <div className={`feat-panel feat-container${hasArt ? " has-art" : ""}`}>
       {!hasArt && <div className="feat-fallback feat-fallback-container" aria-hidden="true"><ChestGlyph /></div>}
       <div className="feat-container-inner">
-        <h3 className="feat-container-title">{feature.name}</h3>
         {feature.state === "locked" && (
           <p className="feat-container-note">
             {feature.keyRequired ? "Locked — a key is required." : "Locked tight."}
@@ -234,32 +233,92 @@ function LeverPanel({
 
 function DoorPanel({
   feature,
+  serverAssets,
   onCommand,
 }: {
   feature: RoomFeature;
+  serverAssets: Record<string, string>;
   onCommand: (cmd: string) => void;
 }) {
+  const isOpen = feature.state === "open";
+  const isLocked = feature.state === "locked";
+  const dir = feature.direction as "north" | "east" | "south" | "west" | "up" | "down" | null;
+  const frameSrc = feature.frameImage ?? serverAssets["door_frame"] ?? null;
+  const leafSrc = feature.leafImage ?? serverAssets["door_leaf"] ?? null;
+  const lockSrc = serverAssets["door_lock"] ?? null;
+  const hinge = feature.hinge === "right" ? "right" : "left";
+  const openAngle = feature.openAngle ?? 100;
+  const leafAngle = isOpen ? (hinge === "right" ? openAngle : -openAngle) : 0;
   const actions = featureActions(feature);
+
+  // Track the door's state so the warded seal can shatter the instant it unlocks.
+  const [seenState, setSeenState] = useState<string | null>(feature.state);
+  const [shatter, setShatter] = useState(false);
+  if (feature.state !== seenState) {
+    const wasLocked = seenState === "locked";
+    setSeenState(feature.state);
+    if (wasLocked && feature.state !== "locked") setShatter(true);
+  }
+  useEffect(() => {
+    if (!shatter) return;
+    const timer = setTimeout(() => setShatter(false), 850);
+    return () => clearTimeout(timer);
+  }, [shatter]);
+
+  const showLock = isLocked || shatter;
+  const showKey = Boolean(feature.keyRequired && feature.keyImage && (isLocked || shatter));
+
   return (
     <div className="feat-panel feat-door">
-      <div className="feat-door-card">
-        <h3 className="feat-door-title">{feature.name}</h3>
-        <div className="feat-door-meta">
-          {feature.direction && (
-            <span className="feat-door-direction">
-              <DirectionIcon
-                direction={feature.direction as "north" | "east" | "south" | "west" | "up" | "down"}
-                className="feat-door-direction-icon"
-              />
-              Leads {titleCase(feature.direction)}
-            </span>
-          )}
-          {feature.state === "locked" && (
-            <span className="feat-door-chip">
-              {feature.keyRequired ? "Locked — key required" : "Locked"}
+      <div className={`feat-door-stage hinge-${hinge}${isOpen ? " is-open" : ""}`}>
+        <div className="feat-door-portal" aria-hidden="true">
+          {dir && (
+            <span className="feat-door-peek">
+              <DirectionIcon direction={dir} className="feat-door-peek-icon" />
+              {titleCase(dir)}
             </span>
           )}
         </div>
+        {leafSrc ? (
+          <img
+            className="feat-door-leaf"
+            src={leafSrc}
+            alt=""
+            aria-hidden="true"
+            draggable={false}
+            style={{ transform: `rotateY(${leafAngle}deg)` }}
+          />
+        ) : (
+          <div className="feat-door-leaf feat-door-leaf-css" style={{ transform: `rotateY(${leafAngle}deg)` }} aria-hidden="true" />
+        )}
+        {frameSrc ? (
+          <img className="feat-door-frame" src={frameSrc} alt="" aria-hidden="true" draggable={false} />
+        ) : (
+          <div className="feat-door-frame feat-door-frame-css" aria-hidden="true" />
+        )}
+        {showLock && (
+          <div className={`feat-door-seal${isLocked ? " is-locked" : ""}${shatter ? " is-shatter" : ""}`} aria-hidden="true">
+            {lockSrc ? (
+              <img className="feat-door-seal-img" src={lockSrc} alt="" draggable={false} />
+            ) : (
+              <span className="feat-door-seal-css" />
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="feat-door-info">
+        <p className="feat-door-line">
+          {dir ? <>Leads <strong>{titleCase(dir)}</strong></> : "A doorway."}
+          {isLocked && (feature.keyRequired ? " · sealed" : " · barred")}
+          {isOpen && " · open"}
+        </p>
+        {showKey && (
+          <div className={`feat-door-key${shatter ? " is-using" : ""}`}>
+            <img className="feat-door-key-img" src={feature.keyImage ?? ""} alt={feature.keyName ?? "key"} draggable={false} />
+            <span className="feat-door-key-name">{feature.keyName ?? "a key"}</span>
+          </div>
+        )}
         {actions.length > 0 && (
           <div className="feat-actions">
             {actions.map((action) => (
@@ -330,6 +389,6 @@ export function WorldFeaturesPopout({
         />
       );
     default:
-      return <DoorPanel feature={feature} onCommand={onCommand} />;
+      return <DoorPanel feature={feature} serverAssets={serverAssets} onCommand={onCommand} />;
   }
 }

--- a/web-v3/src/components/WorldFeaturesPopout.tsx
+++ b/web-v3/src/components/WorldFeaturesPopout.tsx
@@ -246,9 +246,25 @@ function DoorPanel({
   const frameSrc = feature.frameImage ?? serverAssets["door_frame"] ?? null;
   const leafSrc = feature.leafImage ?? serverAssets["door_leaf"] ?? null;
   const lockSrc = serverAssets["door_lock"] ?? null;
-  const hinge = feature.hinge === "right" ? "right" : "left";
-  const openAngle = feature.openAngle ?? 100;
+  const hinge = feature.hinge === "left" ? "left" : "right";
+  const openAngle = feature.openAngle ?? 60;
+  // Door opens toward the viewer; swing direction comes from the hinge, not the
+  // angle's sign (left hinge → right edge swings out = negative rotateY).
   const leafAngle = isOpen ? (hinge === "right" ? openAngle : -openAngle) : 0;
+  // Fit the leaf inside the frame's opening: leafScale (fraction of the box) +
+  // leafOffsetY (vertical nudge, + = down). Pivot on the hinge edge. Defaults
+  // match the bundled default door art.
+  const leafScale = feature.leafScale ?? 0.76;
+  const leafOffsetY = feature.leafOffsetY ?? 0.09;
+  const leafInset = (1 - leafScale) / 2;
+  const leafStyle = {
+    left: `${leafInset * 100}%`,
+    top: `${(leafInset + leafOffsetY) * 100}%`,
+    width: `${leafScale * 100}%`,
+    height: `${leafScale * 100}%`,
+    transformOrigin: hinge === "right" ? "right center" : "left center",
+    transform: `rotateY(${leafAngle}deg)`,
+  };
   const actions = featureActions(feature);
 
   // Track the door's state so the warded seal can shatter the instant it unlocks.
@@ -279,22 +295,18 @@ function DoorPanel({
             </span>
           )}
         </div>
-        {leafSrc ? (
-          <img
-            className="feat-door-leaf"
-            src={leafSrc}
-            alt=""
-            aria-hidden="true"
-            draggable={false}
-            style={{ transform: `rotateY(${leafAngle}deg)` }}
-          />
-        ) : (
-          <div className="feat-door-leaf feat-door-leaf-css" style={{ transform: `rotateY(${leafAngle}deg)` }} aria-hidden="true" />
-        )}
         {frameSrc ? (
           <img className="feat-door-frame" src={frameSrc} alt="" aria-hidden="true" draggable={false} />
         ) : (
           <div className="feat-door-frame feat-door-frame-css" aria-hidden="true" />
+        )}
+        {leafSrc ? (
+          <img className="feat-door-leaf" src={leafSrc} alt="" aria-hidden="true" draggable={false} style={leafStyle} />
+        ) : (
+          <div className="feat-door-leaf feat-door-leaf-css" style={leafStyle} aria-hidden="true" />
+        )}
+        {feature.keyRequired && feature.state === "closed" && (
+          <span className="feat-door-keyhole" aria-hidden="true" />
         )}
         {showLock && (
           <div className={`feat-door-seal${isLocked ? " is-locked" : ""}${shatter ? " is-shatter" : ""}`} aria-hidden="true">

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -1445,6 +1445,8 @@ export function applyGmcpPackage(
             leafImage: typeof e.leafImage === "string" ? e.leafImage : null,
             hinge: e.hinge === "left" || e.hinge === "right" ? e.hinge : null,
             openAngle: typeof e.openAngle === "number" ? e.openAngle : null,
+            leafScale: typeof e.leafScale === "number" ? e.leafScale : null,
+            leafOffsetY: typeof e.leafOffsetY === "number" ? e.leafOffsetY : null,
             keyImage: typeof e.keyImage === "string" ? e.keyImage : null,
             keyName: typeof e.keyName === "string" ? e.keyName : null,
           })),

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -1441,6 +1441,12 @@ export function applyGmcpPackage(
                 : null,
             upAngle: typeof e.upAngle === "number" ? e.upAngle : null,
             downAngle: typeof e.downAngle === "number" ? e.downAngle : null,
+            frameImage: typeof e.frameImage === "string" ? e.frameImage : null,
+            leafImage: typeof e.leafImage === "string" ? e.leafImage : null,
+            hinge: e.hinge === "left" || e.hinge === "right" ? e.hinge : null,
+            openAngle: typeof e.openAngle === "number" ? e.openAngle : null,
+            keyImage: typeof e.keyImage === "string" ? e.keyImage : null,
+            keyName: typeof e.keyName === "string" ? e.keyName : null,
           })),
       );
       break;

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -3411,43 +3411,32 @@ body {
 
 /* ── Container ────────────────────────────────────────────── */
 .feat-container {
-  align-items: stretch;
-  justify-content: flex-end;
-  min-height: 44vh;
+  align-items: center;
+  justify-content: center;
+  min-height: 46vh;
 }
 
-/* Soft bottom scrim so loot reads over the bright chest interior. */
-.feat-container.has-art::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  z-index: 0;
-  pointer-events: none;
-  background: linear-gradient(
-    to top,
-    rgb(6 7 13 / 86%) 0%,
-    rgb(6 7 13 / 55%) 26%,
-    rgb(6 7 13 / 12%) 52%,
-    transparent 72%
-  );
-}
-
+/* The controls live in the chest's dark central cavity — constrain + centre them
+   there (rather than spanning the ornate frame), with a soft scrim behind so the
+   loot reads over whatever interior art is shipped. */
 .feat-container-inner {
   position: relative;
   z-index: 1;
-  width: 100%;
+  width: min(560px, 62%);
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: clamp(16px, 4vw, 28px) clamp(18px, 4vw, 32px) clamp(16px, 3vw, 24px);
+  gap: 6px;
+  padding: clamp(12px, 2.5vw, 22px) clamp(14px, 3vw, 26px);
 }
 
-.feat-container-title {
-  margin: 0 0 2px;
-  font-family: var(--font-display);
-  font-size: 1.2rem;
-  color: var(--text-bright);
-  text-shadow: 0 1px 2px rgb(0 0 0 / 72%), 0 1px 14px rgb(0 0 0 / 55%);
+.feat-container.has-art .feat-container-inner::before {
+  content: "";
+  position: absolute;
+  inset: -10% -8%;
+  z-index: -1;
+  border-radius: 18px;
+  background: radial-gradient(ellipse at center, rgb(6 7 13 / 64%), rgb(6 7 13 / 0%) 76%);
+  filter: blur(10px);
 }
 
 .feat-container-note {
@@ -3676,54 +3665,244 @@ body {
   pointer-events: none;
 }
 
-/* ── Door (no art — a tidy centred card) ──────────────────── */
+/* ── Door — a frame with a swinging leaf + warded seal ─────── */
 .feat-door {
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: clamp(24px, 5vw, 44px);
+  gap: 14px;
+  padding: clamp(20px, 4vh, 36px) 16px;
 }
 
-.feat-door-card {
-  width: min(440px, 100%);
+.feat-door-stage {
+  position: relative;
+  width: min(300px, 56vw);
+  aspect-ratio: 3 / 4;
+  perspective: 1000px;
+}
+
+/* The doorway behind the leaf — revealed when the leaf swings open. */
+.feat-door-portal {
+  position: absolute;
+  inset: 8%;
+  z-index: 0;
   display: flex;
-  flex-direction: column;
-  gap: 12px;
-  padding: 22px 24px;
-  border-radius: var(--radius-lg);
-  border: 1px solid rgb(146 184 223 / 26%);
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
   background:
-    radial-gradient(circle at 50% 0%, rgb(146 184 223 / 16%), transparent 60%),
-    linear-gradient(160deg, rgb(62 73 108 / 94%), rgb(45 56 86 / 92%));
+    radial-gradient(ellipse at 50% 42%, rgb(120 150 210 / 35%), transparent 60%),
+    radial-gradient(ellipse at 50% 100%, rgb(40 50 82 / 60%), rgb(6 8 16 / 94%) 78%);
+  box-shadow: inset 0 0 36px rgb(0 0 0 / 70%);
 }
 
-.feat-door-title {
-  margin: 0;
-  font-family: var(--font-display);
-  font-size: 1.18rem;
-  color: var(--text-bright);
-}
-
-.feat-door-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.feat-door-direction,
-.feat-door-chip {
+.feat-door-peek {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 12px;
-  border-radius: 999px;
-  background: rgb(10 12 22 / 38%);
-  color: var(--text-primary);
-  font-size: 0.82rem;
+  opacity: 0;
+  color: rgb(206 224 246 / 92%);
+  font-size: 0.86rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-shadow: 0 0 10px rgb(120 160 220 / 70%), 0 1px 3px rgb(0 0 0 / 70%);
+  transition: opacity 300ms var(--ease-out-soft) 250ms;
 }
 
-.feat-door-direction-icon {
-  width: 16px;
-  height: 16px;
+.feat-door-peek-icon {
+  width: 18px;
+  height: 18px;
+}
+
+.feat-door-stage.is-open .feat-door-peek {
+  opacity: 1;
+}
+
+/* The swinging leaf — pivots on its hinge edge between 0° and the open angle. */
+.feat-door-leaf {
+  position: absolute;
+  inset: 8%;
+  z-index: 1;
+  width: 84%;
+  height: 84%;
+  object-fit: fill;
+  backface-visibility: hidden;
+  transition: transform 0.6s cubic-bezier(0.45, 0.05, 0.3, 1);
+  pointer-events: none;
+  user-select: none;
+}
+
+.feat-door-stage.hinge-left .feat-door-leaf {
+  transform-origin: left center;
+}
+
+.feat-door-stage.hinge-right .feat-door-leaf {
+  transform-origin: right center;
+}
+
+.feat-door-leaf-css {
+  border-radius: 6px;
+  background:
+    linear-gradient(100deg, rgb(96 70 44 / 96%), rgb(72 50 30 / 96%)),
+    repeating-linear-gradient(90deg, rgb(0 0 0 / 10%) 0 2px, transparent 2px 28px);
+  box-shadow: inset 0 0 0 2px rgb(40 28 16 / 80%), inset 0 2px 10px rgb(0 0 0 / 40%);
+}
+
+.feat-door-leaf-css::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 12%;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, #f0d98a, #9a6b1e);
+  box-shadow: 0 0 6px rgb(240 217 138 / 50%);
+  transform: translateY(-50%);
+}
+
+/* Static frame, on top of the leaf (authored art has a transparent opening). */
+.feat-door-frame {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  pointer-events: none;
+  user-select: none;
+}
+
+.feat-door-frame-css {
+  inset: 0;
+  border: 7px solid;
+  border-image: linear-gradient(160deg, rgb(150 120 80), rgb(96 74 46)) 1;
+  border-bottom-width: 10px;
+  border-radius: 12px 12px 4px 4px;
+  background: transparent;
+  box-shadow: inset 0 0 0 2px rgb(30 22 12 / 60%);
+}
+
+/* The warded seal — glows while locked, shatters on unlock. */
+.feat-door-seal {
+  position: absolute;
+  top: 46%;
+  left: 50%;
+  z-index: 3;
+  width: 44%;
+  transform: translate(-50%, -50%);
+}
+
+.feat-door-seal-img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.feat-door-seal-css {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 50% 50%, rgb(255 226 150 / 20%), transparent 62%),
+    conic-gradient(from 0deg, #caa24a, #8a5a1e, #caa24a, #8a5a1e, #caa24a);
+  box-shadow: inset 0 0 0 2px rgb(60 40 12 / 70%), 0 0 12px rgb(226 180 90 / 50%);
+}
+
+.feat-door-seal-css::after {
+  content: "";
+  position: absolute;
+  inset: 26%;
+  border-radius: 50%;
+  border: 2px solid rgb(255 234 170 / 70%);
+  box-shadow: 0 0 8px rgb(255 220 140 / 60%);
+}
+
+.feat-door-seal.is-locked {
+  animation: door-seal-pulse 2.4s var(--ease-in-out-smooth) infinite;
+}
+
+.feat-door-seal.is-shatter {
+  animation: door-seal-shatter 0.85s ease-out forwards;
+}
+
+@keyframes door-seal-pulse {
+  0%, 100% { filter: drop-shadow(0 0 5px rgb(226 180 90 / 55%)); transform: translate(-50%, -50%) scale(1); }
+  50% { filter: drop-shadow(0 0 16px rgb(255 210 120 / 85%)); transform: translate(-50%, -50%) scale(1.04); }
+}
+
+@keyframes door-seal-shatter {
+  0% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+  28% { opacity: 1; filter: brightness(1.7) drop-shadow(0 0 22px rgb(255 220 140 / 90%)); transform: translate(-50%, -50%) scale(1.16); }
+  100% { opacity: 0; filter: blur(3px) brightness(1.3); transform: translate(-50%, -50%) scale(1.55) rotate(9deg); }
+}
+
+/* Info + actions below the door */
+.feat-door-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  text-align: center;
+}
+
+.feat-door-line {
+  margin: 0;
+  color: var(--text-bright);
+  font-size: 0.95rem;
+  text-shadow: 0 1px 2px rgb(0 0 0 / 60%), 0 1px 10px rgb(0 0 0 / 45%);
+}
+
+.feat-door-line strong {
+  font-weight: 700;
+}
+
+/* The key that locks/unlocks this door — surfaced during the locked/unlock beat. */
+.feat-door-key {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 12px 5px 8px;
+  border-radius: 999px;
+  border: 1px solid rgb(226 198 134 / 36%);
+  background: rgb(10 12 22 / 50%);
+  backdrop-filter: blur(2px);
+}
+
+.feat-door-key-img {
+  width: 26px;
+  height: 26px;
+  object-fit: contain;
+  filter: drop-shadow(0 0 5px rgb(226 198 134 / 45%));
+}
+
+.feat-door-key-name {
+  font-size: 0.8rem;
+  color: #ecd6a0;
+}
+
+.feat-door-key.is-using .feat-door-key-img {
+  animation: door-key-use 0.85s var(--ease-out-soft);
+}
+
+@keyframes door-key-use {
+  0% { transform: rotate(0) scale(1); }
+  40% { transform: rotate(-16deg) scale(1.15); filter: drop-shadow(0 0 10px rgb(255 220 140 / 90%)); }
+  100% { transform: rotate(0) scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .feat-door-leaf,
+  .feat-door-peek {
+    transition: none;
+  }
+
+  .feat-door-seal.is-locked,
+  .feat-door-seal.is-shatter,
+  .feat-door-key.is-using .feat-door-key-img {
+    animation: none;
+  }
 }
 
 .feat-empty-panel {

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -3719,25 +3719,16 @@ body {
 }
 
 /* The swinging leaf — pivots on its hinge edge between 0° and the open angle. */
+/* The leaf sits in front of the frame (the door opens toward the viewer); its
+   box (size/position/pivot) is set inline from leafScale + leafOffsetY + hinge. */
 .feat-door-leaf {
   position: absolute;
-  inset: 8%;
-  z-index: 1;
-  width: 84%;
-  height: 84%;
+  z-index: 2;
   object-fit: fill;
   backface-visibility: hidden;
   transition: transform 0.6s cubic-bezier(0.45, 0.05, 0.3, 1);
   pointer-events: none;
   user-select: none;
-}
-
-.feat-door-stage.hinge-left .feat-door-leaf {
-  transform-origin: left center;
-}
-
-.feat-door-stage.hinge-right .feat-door-leaf {
-  transform-origin: right center;
 }
 
 .feat-door-leaf-css {
@@ -3761,16 +3752,36 @@ body {
   transform: translateY(-50%);
 }
 
-/* Static frame, on top of the leaf (authored art has a transparent opening). */
+/* Static frame, behind the leaf (the door opens toward the viewer). */
 .feat-door-frame {
   position: absolute;
   inset: 0;
-  z-index: 2;
+  z-index: 1;
   width: 100%;
   height: 100%;
   object-fit: contain;
   pointer-events: none;
   user-select: none;
+}
+
+/* Keyhole glow — a small warded glint on the closed leaf when a key is needed. */
+.feat-door-keyhole {
+  position: absolute;
+  top: 54%;
+  left: 50%;
+  z-index: 3;
+  width: 10px;
+  height: 14px;
+  transform: translate(-50%, -50%);
+  border-radius: 50% 50% 40% 40%;
+  background: radial-gradient(circle at 50% 34%, rgb(255 226 150 / 95%), rgb(190 140 50 / 70%) 60%, transparent 72%);
+  box-shadow: 0 0 10px rgb(255 210 120 / 75%), 0 0 22px rgb(255 190 90 / 45%);
+  animation: door-keyhole-glow 2.6s var(--ease-in-out-smooth) infinite;
+}
+
+@keyframes door-keyhole-glow {
+  0%, 100% { opacity: 0.65; }
+  50% { opacity: 1; }
 }
 
 .feat-door-frame-css {
@@ -3900,6 +3911,7 @@ body {
 
   .feat-door-seal.is-locked,
   .feat-door-seal.is-shatter,
+  .feat-door-keyhole,
   .feat-door-key.is-using .feat-door-key-img {
     animation: none;
   }

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -712,6 +712,19 @@ export interface RoomFeature {
   leverPivot: { x: number; y: number } | null;
   upAngle: number | null;
   downAngle: number | null;
+  /**
+   * Optional custom door art (DOOR only): a static {@link frameImage} and a
+   * swinging {@link leafImage} that pivots on {@link hinge} ("left"/"right")
+   * between 0° (closed) and {@link openAngle} (open). Fully-resolved URLs;
+   * absent → the `door_frame`/`door_leaf` defaults, then a built-in CSS door.
+   */
+  frameImage: string | null;
+  leafImage: string | null;
+  hinge: "left" | "right" | null;
+  openAngle: number | null;
+  /** The key that locks/unlocks this door (DOOR only) — image + name for the lock UI. */
+  keyImage: string | null;
+  keyName: string | null;
 }
 
 export interface ContainerContents {

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -722,6 +722,10 @@ export interface RoomFeature {
   leafImage: string | null;
   hinge: "left" | "right" | null;
   openAngle: number | null;
+  /** Leaf size as a fraction of the frame box (fits it inside the opening). Default 0.72. */
+  leafScale: number | null;
+  /** Vertical placement of the leaf within the frame (fraction; + = down). Default 0.04. */
+  leafOffsetY: number | null;
   /** The key that locks/unlocks this door (DOOR only) — image + name for the lock UI. */
   keyImage: string | null;
   keyName: string | null;


### PR DESCRIPTION
Door redo, mirroring the lever/feature art contract. My side = the AmbonMUD server wiring + the web-client door panel; the Arcanum authoring half (DoorArtEditor, requiredGlobalAssets, assetRefs, sanitize) is the parallel PR.

## Asset contract

**Per-door art** (DoorFile, all optional):

| Field | Type | Purpose |
|---|---|---|
| `frameImage` | string | Static frame/portal sprite (= lever plateImage) |
| `leafImage` | string | Swinging door leaf (= lever handleImage) |
| `hinge` | `"left"`\|`"right"` | Which edge the leaf pivots on (default left) |
| `openAngle` | number | Leaf swing angle when open (default ~100°); closed is 0° |

**New global defaults:** `door_frame`, `door_leaf`, `door_lock` (warded-seal overlay), `door_bg` (card backdrop).

Resolution per door: `frameImage → door_frame → CSS`; `leafImage → door_leaf → CSS`; lock/bg are global. Everything degrades to a built-in CSS door. Lock kept global-only (locks are world-uniform), so the per-door surface stays frame + leaf + tuning — clean parity with the lever.

## Server
- AppConfig keys; `DoorFile` + `RoomFeature.Door` fields; `WorldLoader` resolves frame/leaf against the image base and normalises hinge/openAngle.
- `RoomFeaturePayload` carries frame/leaf/hinge/openAngle **plus the door's key image + name** — resolved from the item registry (threaded into `buildFeaturePayload`, all three callers updated) so the lock UI can show the specific key.

## Web client
- `DoorPanel` is now a full-bleed panel over `door_bg`: a static frame with a leaf that **swings on its hinge** (3D `rotateY`) between closed/open, a doorway that **peeks the destination direction** through the open leaf, and a **warded seal** that glows while locked and **shatters the instant it unlocks**.
- **Key image** (your request): when a key is required, that specific key item's image is surfaced during the locked/unlock beat, with a little flourish as it's "used".

## Container polish (folded in, unrelated)
- The chest name no longer shows in **either** place — header title blanked for containers, in-body title removed.
- The controls (loot + Close) are constrained and **centred into the chest's dark central cavity** with a soft scrim, instead of spanning the ornate frame.

## Tests
`WorldLoaderFeaturesTest` covers frame/leaf/hinge/openAngle resolution. Verified: `eslint` ✓ · `tsc -b` ✓ · `vite build` ✓ · `ktlintCheck` ✓ · feature loader + command-router tests ✓.

> Door art (`door_frame`/`door_leaf`/`door_lock`/`door_bg`) is authored separately; until it ships the CSS door + dark sheet render, and the swing/seal/peek/key beats all work off the existing door state.