### PR TITLE
fix(door): drop the dark portal recess (black box over door_bg)

### DIFF
--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -3681,19 +3681,15 @@ body {
   perspective: 1000px;
 }
 
-/* The doorway behind the leaf — revealed when the leaf swings open. */
+/* Holds the destination peek label, centred in the doorway. Transparent — the
+   frame art paints its own opening, so no recess fill (that read as a black box). */
 .feat-door-portal {
   position: absolute;
-  inset: 8%;
+  inset: 0;
   z-index: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 8px;
-  background:
-    radial-gradient(ellipse at 50% 42%, rgb(120 150 210 / 35%), transparent 60%),
-    radial-gradient(ellipse at 50% 100%, rgb(40 50 82 / 60%), rgb(6 8 16 / 94%) 78%);
-  box-shadow: inset 0 0 36px rgb(0 0 0 / 70%);
 }
 
 .feat-door-peek {


### PR DESCRIPTION
Follow-up to the merged door PR (#1252).

The door panel had a dark "doorway recess" layer (`.feat-door-portal`) drawn behind the frame to fake depth. But the `door_frame` art has a transparent opening, and `door_bg` already paints the destination view (the sunny path/landscape through the archway) — so that dark layer just showed as a **black box** around/behind the frame.

Fix: make the portal a transparent container for the "→ direction" peek label only. The frame's opening now shows the `door_bg` landscape through it (the real peek-through), and the label still floats over it.

Verified: `eslint` ✓ · `tsc -b` ✓ · `vite build` ✓.