### PR TITLE
feat(web): bank "The Vault" reskin + auto-close empty features panel

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -3059,6 +3059,9 @@ data class ImagesConfig(
             // Used when a puzzle doesn't author its own backgroundImage; falls back
             // further to a CSS tome treatment when this isn't present either.
             "puzzle_bg" to "global_assets/puzzle_bg.png",
+            // Server-wide vault interior backdrop for the bank ("The Vault") panel.
+            // Global only — banks share one look; the bank_vault icon is the emblem.
+            "bank_bg" to "global_assets/bank_bg.png",
             "dialog_indicator" to "global_assets/dialog_indicator.png",
             "aggro_indicator" to "global_assets/aggro_indicator.png",
             "quest_available_indicator" to "global_assets/quest_available_indicator.png",

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -856,7 +856,7 @@ function App() {
       case "crafting": return "Crafting";
       case "housing": return "Housing";
       case "leaderboard": return "Leaderboard";
-      case "bank": return "Bank";
+      case "bank": return "The Vault";
       case "stylist": return "Stylist";
       case "inn": return state.room.title !== "-" ? state.room.title : "Inn";
       case "auction": return "Auction House";
@@ -927,6 +927,8 @@ function App() {
         variant={
           drawerPanel === "puzzle"
             ? "tome"
+            : drawerPanel === "bank"
+            ? "vault"
             : drawerPanel === "features"
             ? "feature"
             : drawerPanel === "inventory"
@@ -953,6 +955,8 @@ function App() {
           drawerPanel === "puzzle"
             ? (state.puzzle?.puzzles.find((p) => p.backgroundImage)?.backgroundImage
                 ?? state.serverAssets["puzzle_bg"])
+            : drawerPanel === "bank"
+            ? state.serverAssets["bank_bg"]
             : drawerPanel === "features"
             ? (featurePanelFeature && featurePanelFeature.type !== "lever"
                 ? (featureArt(featurePanelFeature, state.serverAssets) ?? undefined)
@@ -1233,7 +1237,7 @@ function App() {
         )}
 
         {drawerPanel === "bank" && (
-          <BankPanel bankState={state.bankState} onCommand={sendCommand} />
+          <BankPanel bankState={state.bankState} serverAssets={state.serverAssets} onCommand={sendCommand} />
         )}
 
         {drawerPanel === "stylist" && (

--- a/web-v3/src/components/Drawer.tsx
+++ b/web-v3/src/components/Drawer.tsx
@@ -9,7 +9,7 @@ interface DrawerProps {
   /** Visual skin for the sheet chrome: warm leather (satchel), a dim
    *  dressing-chamber (equipment), a merchant cart (shop), a chalkboard
    *  (trainer), a parchment journal (combat log), or a cork quest board. */
-  variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "desk" | "mail" | "feature" | "tome";
+  variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "desk" | "mail" | "feature" | "tome" | "vault";
   /** Optional background art for a skinned variant (server asset). */
   skinBg?: string;
 }

--- a/web-v3/src/components/panels/BankPanel.tsx
+++ b/web-v3/src/components/panels/BankPanel.tsx
@@ -1,24 +1,42 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { BankState } from "../../types";
 
 interface BankPanelProps {
   bankState: BankState | null;
+  serverAssets: Record<string, string>;
   onCommand: (cmd: string) => void;
 }
 
-export function BankPanel({ bankState, onCommand }: BankPanelProps) {
+export function BankPanel({ bankState, serverAssets, onCommand }: BankPanelProps) {
   const [goldAmount, setGoldAmount] = useState("");
   const [itemKeyword, setItemKeyword] = useState("");
+  const emblem = serverAssets["bank_vault"] ?? null;
+
+  // Coin glint whenever the deposited gold goes up.
+  const gold = bankState?.gold ?? 0;
+  const [seenGold, setSeenGold] = useState(gold);
+  const [glint, setGlint] = useState(false);
+  if (gold !== seenGold) {
+    const increased = gold > seenGold;
+    setSeenGold(gold);
+    if (increased) setGlint(true);
+  }
+  useEffect(() => {
+    if (!glint) return;
+    const timer = setTimeout(() => setGlint(false), 900);
+    return () => clearTimeout(timer);
+  }, [glint]);
 
   if (!bankState) {
     return (
-      <div className="bank-panel">
-        <div className="panel-header">
-          <span className="panel-title">Bank</span>
-        </div>
+      <div className="bank-panel bank-vault">
         <div className="bank-empty-state">
-          <span className="bank-empty-icon">{"\u{1F3E6}"}</span>
-          <p className="empty-note">No bank data available.</p>
+          {emblem ? (
+            <img className="bank-empty-emblem" src={emblem} alt="" />
+          ) : (
+            <span className="bank-empty-icon">{"\u{1F3E6}"}</span>
+          )}
+          <p className="empty-note">The vault is quiet.</p>
           <p className="bank-hint">
             Visit a bank room and use the <code>bank balance</code> command.
           </p>
@@ -32,16 +50,15 @@ export function BankPanel({ bankState, onCommand }: BankPanelProps) {
     : 0;
 
   return (
-    <div className="bank-panel">
-      <div className="panel-header">
-        <span className="panel-title">Bank</span>
-      </div>
-
+    <div className="bank-panel bank-vault">
       <div className="bank-content">
         {/* Gold balance */}
         <div className="bank-gold-section">
-          <div className="bank-gold-label">Gold on Deposit</div>
-          <div className="bank-gold-value">{bankState.gold.toLocaleString()}</div>
+          <div className="bank-gold-heading">
+            {emblem && <img className="bank-emblem" src={emblem} alt="" />}
+            <span className="bank-gold-label">Gold on Deposit</span>
+          </div>
+          <div className={`bank-gold-value${glint ? " is-glint" : ""}`}>{gold.toLocaleString()}</div>
         </div>
 
         {/* Gold deposit/withdraw */}

--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -597,7 +597,15 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
         pushLevelUp,
         pushQuestNotification,
         setMobInfo,
-        setRoomFeatures,
+        setRoomFeatures: (value) => {
+          setRoomFeatures(value);
+          // Auto-close the World Features panel when the room has nothing to show
+          // (e.g. after walking through a door into a featureless room) so it
+          // doesn't linger on the empty "no interactive features" state.
+          if (Array.isArray(value) && value.length === 0) {
+            setActivePopout((prev) => (prev === "features" ? null : prev));
+          }
+        },
         setContainerContents,
         setLoginPrompt,
         setLoginError,

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -17257,6 +17257,103 @@ body {
   overflow-y: auto;
 }
 
+/* ── The Vault — bank panel over the vault-interior skin ─────── */
+.drawer-sheet.drawer-sheet-vault {
+  background-image:
+    var(--skin-bg, none),
+    linear-gradient(180deg, rgb(43 53 79 / 98%), rgb(34 41 64 / 98%));
+  background-size: cover, auto;
+  background-position: center, center;
+  background-repeat: no-repeat, no-repeat;
+}
+
+.drawer-sheet-vault .drawer-title {
+  text-shadow: 0 1px 2px rgb(0 0 0 / 72%), 0 1px 12px rgb(0 0 0 / 55%);
+}
+
+.drawer-sheet-vault .drawer-header {
+  border-bottom: none;
+}
+
+.drawer-sheet-vault .drawer-body {
+  padding: 0;
+}
+
+.bank-panel.bank-vault {
+  padding: clamp(14px, 3vw, 24px);
+}
+
+/* The content floats over the vault art — give each block a dark glass backing
+   so the gold + items stay legible on any interior. */
+.bank-vault .bank-gold-section {
+  background: linear-gradient(135deg, rgb(20 18 28 / 64%), rgb(12 13 22 / 58%));
+  border-color: rgb(212 178 110 / 34%);
+  backdrop-filter: blur(2px);
+}
+
+.bank-vault .bank-gold-heading {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.bank-emblem {
+  width: 30px;
+  height: 30px;
+  object-fit: contain;
+  filter: drop-shadow(0 0 6px rgb(226 198 134 / 45%));
+}
+
+.bank-vault .bank-gold-value {
+  text-shadow: 0 1px 8px rgb(0 0 0 / 55%);
+}
+
+.bank-vault .bank-item-row {
+  background: rgb(12 13 22 / 52%);
+  border-color: rgb(255 255 255 / 10%);
+  backdrop-filter: blur(2px);
+  /* Drawer slide — items glide in (on open, and as each is stored). */
+  animation: bank-drawer-slide 0.34s var(--ease-out-soft) both;
+}
+
+.bank-vault .bank-item-row:hover {
+  background: rgb(22 24 36 / 64%);
+}
+
+.bank-empty-emblem {
+  width: 64px;
+  height: 64px;
+  object-fit: contain;
+  filter: drop-shadow(0 0 10px rgb(226 198 134 / 40%));
+}
+
+/* Coin glint when gold is deposited. */
+.bank-gold-value.is-glint {
+  animation: bank-coin-glint 0.9s ease-out;
+}
+
+@keyframes bank-coin-glint {
+  0% { transform: scale(1); text-shadow: 0 1px 8px rgb(0 0 0 / 55%); }
+  35% {
+    transform: scale(1.12);
+    color: #ffe6a3;
+    text-shadow: 0 0 12px rgb(255 214 120 / 90%), 0 0 24px rgb(255 190 90 / 60%);
+  }
+  100% { transform: scale(1); text-shadow: 0 1px 8px rgb(0 0 0 / 55%); }
+}
+
+@keyframes bank-drawer-slide {
+  from { opacity: 0; transform: translateX(-14px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bank-gold-value.is-glint,
+  .bank-vault .bank-item-row {
+    animation: none;
+  }
+}
+
 /* ===== Inn modal — a brass key on a hook ============================== */
 .inn-backdrop {
   position: fixed;


### PR DESCRIPTION
## Bank — "The Vault"

Bank reskin to the art contract. **Global only** (no per-instance fields — banks share one look), so the server change is just one asset key.

- New global asset **`bank_bg`** (vault interior) drives a new Drawer **`vault`** variant — full-bleed like the inventory/equipment/feature panels.
- Panel re-titled **"The Vault"**; the existing **`bank_vault`** icon is reused as the emblem beside the gold balance.
- Dropped the redundant in-panel header (the Drawer header already shows the title) and gave each content block a dark-glass backing so the gold + items stay legible over the vault art.

### Delight
- **Coin glint** on the balance when a deposit lands (the gold value flares + scales when it goes up).
- **Drawer slide** — items glide into the vault list (on open, and as each one is stored).
- Both respect `prefers-reduced-motion`.

## Also folded in (per your note)
The **World Features panel now auto-closes when the room has no features** — after walking through a door into a featureless room it was lingering on the empty *"This room exposes no interactive features…"* state. `setRoomFeatures([])` now closes the panel if it's the open one (same pattern as the puzzle/shop auto-close).

Verified: `eslint` ✓ · `tsc -b` ✓ · `vite build` ✓ · `compileKotlin` ✓.

> `bank_bg` art is authored separately; until it ships the panel falls back to the default dark sheet (content stays fully legible via the dark-glass backings).