### PR TITLE
fix(web): compact large numbers in the character cabinet

### DIFF
--- a/web-v3/src/components/panels/CharacterPanel.tsx
+++ b/web-v3/src/components/panels/CharacterPanel.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { formatCompact } from "../../utils";
 import type {
   AchievementData,
   CharacterInfo,
@@ -85,6 +86,7 @@ function CharBar({
   value,
   max,
   text,
+  title,
   pct,
 }: {
   kind: "hp" | "mana" | "xp";
@@ -92,9 +94,11 @@ function CharBar({
   value?: number;
   max?: number;
   text?: string;
+  title?: string;
   pct: number;
 }) {
   const clamped = Math.max(0, Math.min(100, pct));
+  const display = text ?? (value != null && max != null ? `${formatCompact(value)} / ${formatCompact(max)}` : "");
   return (
     <div className={`cc-bar cc-bar-${kind}`}>
       <span className="cc-bar-icon" aria-hidden="true" />
@@ -102,7 +106,7 @@ function CharBar({
       <span className="cc-bar-track">
         <span className="cc-bar-fill" style={{ width: `${clamped}%` }} />
       </span>
-      <span className="cc-bar-value">{text ?? (value != null && max != null ? `${value} / ${max}` : "")}</span>
+      <span className="cc-bar-value" title={title ?? (value != null && max != null ? `${value} / ${max}` : undefined)}>{display}</span>
     </div>
   );
 }
@@ -389,8 +393,11 @@ export function CharacterPanel({
           <div className="cc-derived">
             <div className="cc-plaque cc-derived-item">
               <span className="cc-derived-label">Damage</span>
-              <span className="cc-derived-value">
-                {charStats ? `${charStats.baseDamageMin} – ${charStats.baseDamageMax}` : "—"}
+              <span
+                className="cc-derived-value"
+                title={charStats ? `${charStats.baseDamageMin.toLocaleString()} – ${charStats.baseDamageMax.toLocaleString()}` : undefined}
+              >
+                {charStats ? `${formatCompact(charStats.baseDamageMin)} – ${formatCompact(charStats.baseDamageMax)}` : "—"}
               </span>
             </div>
             <div className="cc-plaque cc-derived-item">

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -22821,7 +22821,7 @@ html:has(.game-shell),
 }
 
 .cc-derived-label { font-size: 0.74rem; font-weight: 700; color: var(--cc-ink-dim); text-transform: uppercase; letter-spacing: 0.05em; }
-.cc-derived-value { font-size: 1.02rem; font-weight: 800; color: var(--cc-brass-soft); }
+.cc-derived-value { font-size: 0.98rem; font-weight: 800; color: var(--cc-brass-soft); white-space: nowrap; }
 
 /* ── Stats plaque ──────────────────────────────────────────── */
 .cc-stats { padding: 12px 10px; }


### PR DESCRIPTION
Follow-up to the character cabinet (#1255, merged).

**Bug:** six-figure damage ranges (e.g. `220406 – 298196`) wrapped to two lines and broke the DAMAGE plaque; very high HP/Mana (`1825461 / 1825461`) were long and unformatted too.

**Fix:** format the damage range and the HP/Mana bar values with the shared `formatCompact` helper — `220K – 298K`, `1.8M / 1.8M` — the same abbreviation the vitals HUD already uses, with the full comma-separated numbers available on hover (`title`). The derived value is also pinned to one line so it can't wrap.

Verified: `eslint` ✓ · `tsc -b` ✓ · `vite build` ✓.