### PR TITLE
feat(web): collapse character auto-loot/peek/wimpy onto one line

### DIFF
--- a/web-v3/src/components/panels/CharacterPanel.tsx
+++ b/web-v3/src/components/panels/CharacterPanel.tsx
@@ -294,59 +294,56 @@ export function CharacterPanel({
             </div>
           </div>
 
-          <div className="cc-toggle-row">
-            <span className="cc-toggle-label">Auto Loot</span>
+          <div className="cc-controls">
             <button
               type="button"
-              className={`cc-toggle${autolootEnabled ? " is-on" : ""}`}
+              className={`cc-ctl cc-ctl-toggle${autolootEnabled ? " is-on" : ""}`}
               role="switch"
               aria-checked={autolootEnabled}
-              aria-label="Auto loot"
               disabled={!connected}
+              title="Mob drops go straight into your pack after a kill."
               onClick={() => onCommand(autolootEnabled ? "autoloot off" : "autoloot on")}
             >
-              <span className="cc-toggle-track"><span className="cc-toggle-thumb" /></span>
-              <span className="cc-toggle-state">{autolootEnabled ? "ON" : "OFF"}</span>
+              <span className="cc-ctl-leaf" aria-hidden="true" />
+              <span className="cc-ctl-name">Auto Loot</span>
+              <span className="cc-switch"><span className="cc-switch-thumb" /></span>
             </button>
-          </div>
-          <div className="cc-toggle-row">
-            <span className="cc-toggle-label">Auto Peek</span>
             <button
               type="button"
-              className={`cc-toggle${autopeekEnabled ? " is-on" : ""}`}
+              className={`cc-ctl cc-ctl-toggle${autopeekEnabled ? " is-on" : ""}`}
               role="switch"
               aria-checked={autopeekEnabled}
-              aria-label="Auto peek"
               disabled={!connected}
+              title="Room descriptions name what lies through each open exit."
               onClick={() => onCommand(autopeekEnabled ? "autopeek off" : "autopeek on")}
             >
-              <span className="cc-toggle-track"><span className="cc-toggle-thumb" /></span>
-              <span className="cc-toggle-state">{autopeekEnabled ? "ON" : "OFF"}</span>
+              <span className="cc-ctl-leaf" aria-hidden="true" />
+              <span className="cc-ctl-name">Auto Peek</span>
+              <span className="cc-switch"><span className="cc-switch-thumb" /></span>
             </button>
-          </div>
-          <div className="cc-wimpy">
-            <span className="cc-toggle-label">Wimpy %</span>
-            <input
-              type="range"
-              className="cc-wimpy-slider"
-              min={0}
-              max={100}
-              step={5}
-              value={wimpyPct}
-              disabled={!connected}
-              onChange={(e) => setWimpyDraft(Number(e.target.value))}
-              onPointerUp={(e) => commitWimpy(Number((e.target as HTMLInputElement).value))}
-            />
-            <span className="cc-wimpy-value">{wimpyPct}</span>
-            <button
-              type="button"
-              className="cc-wimpy-step"
-              aria-label="Increase wimpy threshold"
-              disabled={!connected || wimpyPct >= 100}
-              onClick={() => commitWimpy(wimpyPct + 5)}
-            >
-              +
-            </button>
+            <div className="cc-ctl cc-ctl-wimpy" title="Auto-flee combat when HP drops to this %.">
+              <span className="cc-ctl-leaf" aria-hidden="true" />
+              <span className="cc-ctl-name">Wimpy</span>
+              <button
+                type="button"
+                className="cc-step"
+                aria-label="Lower wimpy threshold"
+                disabled={!connected || wimpyPct <= 0}
+                onClick={() => commitWimpy(wimpyPct - 5)}
+              >
+                −
+              </button>
+              <span className="cc-step-val">{wimpyPct}%</span>
+              <button
+                type="button"
+                className="cc-step"
+                aria-label="Raise wimpy threshold"
+                disabled={!connected || wimpyPct >= 100}
+                onClick={() => commitWimpy(wimpyPct + 5)}
+              >
+                +
+              </button>
+            </div>
           </div>
         </section>
 

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -22663,6 +22663,101 @@ html:has(.game-shell),
 .cc-wimpy-step:hover:not(:disabled) { background: rgb(82 62 34 / 85%); }
 .cc-wimpy-step:disabled { opacity: 0.4; cursor: default; }
 
+/* ── Compact single-line controls (auto-loot / peek / wimpy) ─── */
+.cc-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 14px;
+  margin-top: 2px;
+}
+
+.cc-ctl {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.cc-ctl-toggle {
+  border: none;
+  background: none;
+  padding: 4px 2px;
+  cursor: pointer;
+}
+
+.cc-ctl-toggle:disabled { opacity: 0.5; cursor: default; }
+
+.cc-ctl-leaf {
+  width: 13px;
+  height: 13px;
+  flex-shrink: 0;
+  border-radius: 3px 8px 3px 8px;
+  background: var(--cc-leaf);
+  opacity: 0.7;
+}
+
+.cc-ctl-name {
+  font-size: 0.84rem;
+  font-weight: 600;
+  color: var(--cc-ink);
+  white-space: nowrap;
+}
+
+.cc-switch {
+  position: relative;
+  width: 38px;
+  height: 20px;
+  flex-shrink: 0;
+  border-radius: 999px;
+  background: rgb(20 15 9 / 85%);
+  border: 1px solid rgb(201 162 74 / 30%);
+  transition: background 180ms;
+}
+
+.cc-switch-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, #efe1bd, #b08a3c);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 50%);
+  transition: transform 180ms var(--ease-out-soft);
+}
+
+.cc-ctl-toggle.is-on .cc-switch {
+  background: linear-gradient(160deg, rgb(123 191 106 / 72%), rgb(90 150 80 / 72%));
+  border-color: rgb(123 191 106 / 55%);
+}
+
+.cc-ctl-toggle.is-on .cc-switch-thumb { transform: translateX(18px); }
+
+.cc-ctl-wimpy { gap: 5px; margin-left: auto; }
+
+.cc-step {
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  border: 1px solid rgb(201 162 74 / 36%);
+  background: rgb(60 46 26 / 65%);
+  color: var(--cc-brass-soft);
+  font-size: 0.95rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.cc-step:hover:not(:disabled) { background: rgb(82 62 34 / 85%); }
+.cc-step:disabled { opacity: 0.4; cursor: default; }
+
+.cc-step-val {
+  min-width: 36px;
+  text-align: center;
+  font-size: 0.84rem;
+  font-weight: 700;
+  color: var(--cc-ink);
+}
+
 /* ── Readouts ──────────────────────────────────────────────── */
 .cc-readouts {
   display: flex;


### PR DESCRIPTION
Tightens the character cabinet's identity card so it's more likely to fit without scrolling.

Auto Loot, Auto Peek and Wimpy were three full-height rows (plus a slider). They now share **one compact line**:
- The two toggles drop their `ON`/`OFF` text — the switch colour shows state — and use a smaller switch.
- **Wimpy** becomes a compact `−  10%  +` stepper (5% steps) instead of a slider, tucked to the right of the row.
- The row `flex-wrap`s, so on narrow widths it still reflows cleanly.

Each control keeps its hover tooltip explaining what it does. That reclaims two rows of vertical space from the identity card.

Verified: `eslint` ✓ · `tsc -b` ✓ · `vite build` ✓.

> Dropped the wimpy slider for the stepper to fit the line — if you'd rather keep a slider, I can do a short inline one instead, but it crowds the row.