### PR TITLE
feat(web): door panel polish — bigger/aligned door, floating controls, swirling portal

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -3055,6 +3055,9 @@ data class ImagesConfig(
             "door_leaf" to "global_assets/door_leaf.png",
             "door_lock" to "global_assets/door_lock.png",
             "door_bg" to "global_assets/door_bg.png",
+            // Swirling portal shown in the doorway behind the leaf (revealed when
+            // the door opens). Global only; falls back to a CSS vortex.
+            "door_portal" to "global_assets/door_portal.png",
             // Server-wide default backdrop for the puzzle (grimoire/parchment) panel.
             // Used when a puzzle doesn't author its own backgroundImage; falls back
             // further to a CSS tome treatment when this isn't present either.

--- a/web-v3/src/components/WorldFeaturesPopout.tsx
+++ b/web-v3/src/components/WorldFeaturesPopout.tsx
@@ -269,7 +269,7 @@ function DoorPanel({
   // smaller than the leaf box and centred on it, so the (arch-shaped, transparent-
   // edged) leaf fully covers it when closed instead of bleeding past the edges.
   // PORTAL_SHRINK is the single tuning dial.
-  const PORTAL_SHRINK = 0.78;
+  const PORTAL_SHRINK = 0.62;
   const portalW = leafScale * PORTAL_SHRINK;
   const leafCx = leafInset + leafScale / 2;
   const leafCy = leafInset + leafOffsetY + leafScale / 2;

--- a/web-v3/src/components/WorldFeaturesPopout.tsx
+++ b/web-v3/src/components/WorldFeaturesPopout.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from "react";
 import type { ContainerContents, FeaturePopoutFocus, RoomFeature } from "../types";
-import { DirectionIcon } from "./Icons";
 import { featureArt, pickFocusedFeature } from "./worldFeatures";
 
 interface WorldFeaturesPopoutProps {
@@ -246,6 +245,7 @@ function DoorPanel({
   const frameSrc = feature.frameImage ?? serverAssets["door_frame"] ?? null;
   const leafSrc = feature.leafImage ?? serverAssets["door_leaf"] ?? null;
   const lockSrc = serverAssets["door_lock"] ?? null;
+  const portalSrc = serverAssets["door_portal"] ?? null;
   const hinge = feature.hinge === "left" ? "left" : "right";
   const openAngle = feature.openAngle ?? 60;
   // Door opens toward the viewer; swing direction comes from the hinge, not the
@@ -264,6 +264,14 @@ function DoorPanel({
     height: `${leafScale * 100}%`,
     transformOrigin: hinge === "right" ? "right center" : "left center",
     transform: `rotateY(${leafAngle}deg)`,
+  };
+  // The portal sits in the same opening box as the leaf (behind it), so it's
+  // revealed when the leaf swings open.
+  const portalStyle = {
+    left: leafStyle.left,
+    top: leafStyle.top,
+    width: leafStyle.width,
+    height: leafStyle.height,
   };
   const actions = featureActions(feature);
 
@@ -287,12 +295,11 @@ function DoorPanel({
   return (
     <div className="feat-panel feat-door">
       <div className={`feat-door-stage hinge-${hinge}${isOpen ? " is-open" : ""}`}>
-        <div className="feat-door-portal" aria-hidden="true">
-          {dir && (
-            <span className="feat-door-peek">
-              <DirectionIcon direction={dir} className="feat-door-peek-icon" />
-              {titleCase(dir)}
-            </span>
+        <div className="feat-door-portal" style={portalStyle} aria-hidden="true">
+          {portalSrc ? (
+            <img className="feat-door-portal-art" src={portalSrc} alt="" draggable={false} />
+          ) : (
+            <span className="feat-door-portal-css" />
           )}
         </div>
         {frameSrc ? (

--- a/web-v3/src/components/WorldFeaturesPopout.tsx
+++ b/web-v3/src/components/WorldFeaturesPopout.tsx
@@ -265,13 +265,19 @@ function DoorPanel({
     transformOrigin: hinge === "right" ? "right center" : "left center",
     transform: `rotateY(${leafAngle}deg)`,
   };
-  // The portal sits in the same opening box as the leaf (behind it), so it's
-  // revealed when the leaf swings open.
+  // The portal sits behind the leaf, revealed when it swings open. Keep it a bit
+  // smaller than the leaf box and centred on it, so the (arch-shaped, transparent-
+  // edged) leaf fully covers it when closed instead of bleeding past the edges.
+  // PORTAL_SHRINK is the single tuning dial.
+  const PORTAL_SHRINK = 0.78;
+  const portalW = leafScale * PORTAL_SHRINK;
+  const leafCx = leafInset + leafScale / 2;
+  const leafCy = leafInset + leafOffsetY + leafScale / 2;
   const portalStyle = {
-    left: leafStyle.left,
-    top: leafStyle.top,
-    width: leafStyle.width,
-    height: leafStyle.height,
+    left: `${(leafCx - portalW / 2) * 100}%`,
+    top: `${(leafCy - portalW / 2) * 100}%`,
+    width: `${portalW * 100}%`,
+    height: `${portalW * 100}%`,
   };
   const actions = featureActions(feature);
 

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -3669,10 +3669,10 @@ body {
 .feat-door {
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  /* Anchor the door near the top (the info floats absolutely at the bottom). */
+  justify-content: flex-start;
   gap: 10px;
-  /* Symmetric padding — the info floats absolutely now, so no downward bias. */
-  padding: clamp(8px, 1.5vh, 16px) 16px;
+  padding: clamp(6px, 1.2vh, 14px) 16px;
 }
 
 .feat-door-stage {

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -3671,12 +3671,13 @@ body {
   align-items: center;
   justify-content: center;
   gap: 10px;
-  padding: clamp(8px, 1.5vh, 16px) 16px;
+  /* Heavier top padding biases the door downward toward the floor. */
+  padding: clamp(28px, 7vh, 72px) 16px clamp(6px, 1vh, 12px);
 }
 
 .feat-door-stage {
   position: relative;
-  width: min(460px, 64vw);
+  width: min(500px, 67vw);
   aspect-ratio: 3 / 4;
   perspective: 1100px;
 }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -3688,24 +3688,27 @@ body {
 /* The doorway portal — a swirling vortex in the opening box (same box as the
    leaf), revealed when the leaf swings open. Sits behind the frame + leaf, so
    it stays confined to the opening (no black box around the frame). */
+/* A circular portal art spins in place — no clip mask, no scale (which would
+   inflate it past the box and clip on rotation). */
 .feat-door-portal {
   position: absolute;
   z-index: 0;
-  overflow: hidden;
-  /* Arch-domed top so the swirl reads as a doorway rather than a rectangle. */
-  border-radius: 46% 46% 14px 14px / 34% 34% 14px 14px;
 }
 
-.feat-door-portal-art,
+.feat-door-portal-art {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  animation: door-portal-spin 26s linear infinite;
+}
+
+/* CSS fallback — a circular vortex, so rotating it has no corners to clip. */
 .feat-door-portal-css {
   display: block;
   width: 100%;
   height: 100%;
-  object-fit: cover;
-  animation: door-portal-swirl 26s linear infinite;
-}
-
-.feat-door-portal-css {
+  border-radius: 50%;
   background:
     radial-gradient(circle at 50% 50%, rgb(190 226 255 / 42%), transparent 58%),
     conic-gradient(
@@ -3717,11 +3720,11 @@ body {
       rgb(40 86 160 / 78%)
     );
   filter: blur(1px);
+  animation: door-portal-spin 22s linear infinite;
 }
 
-@keyframes door-portal-swirl {
-  from { transform: scale(1.35) rotate(0deg); }
-  to { transform: scale(1.35) rotate(360deg); }
+@keyframes door-portal-spin {
+  to { transform: rotate(360deg); }
 }
 
 /* The swinging leaf — pivots on its hinge edge between 0° and the open angle. */

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -3670,15 +3670,15 @@ body {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 14px;
-  padding: clamp(20px, 4vh, 36px) 16px;
+  gap: 10px;
+  padding: clamp(8px, 1.5vh, 16px) 16px;
 }
 
 .feat-door-stage {
   position: relative;
-  width: min(300px, 56vw);
+  width: min(460px, 64vw);
   aspect-ratio: 3 / 4;
-  perspective: 1000px;
+  perspective: 1100px;
 }
 
 /* Holds the destination peek label, centred in the doorway. Transparent — the

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -3682,7 +3682,7 @@ body {
   perspective: 1100px;
   /* Lift the door art up so its base meets the wall/floor seam of door_bg
      (the two are independent layers). Tune this single value to taste. */
-  transform: translateY(clamp(-72px, -8vh, -40px));
+  transform: translateY(clamp(-40px, -4vh, -22px));
 }
 
 /* Holds the destination peek label, centred in the doorway. Transparent — the

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -3685,37 +3685,42 @@ body {
   transform: translateY(clamp(-40px, -4vh, -22px));
 }
 
-/* Holds the destination peek label, centred in the doorway. Transparent — the
-   frame art paints its own opening, so no recess fill (that read as a black box). */
+/* The doorway portal — a swirling vortex in the opening box (same box as the
+   leaf), revealed when the leaf swings open. Sits behind the frame + leaf, so
+   it stays confined to the opening (no black box around the frame). */
 .feat-door-portal {
   position: absolute;
-  inset: 0;
   z-index: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  overflow: hidden;
+  border-radius: 8px 8px 4px 4px;
 }
 
-.feat-door-peek {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  opacity: 0;
-  color: rgb(206 224 246 / 92%);
-  font-size: 0.86rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-shadow: 0 0 10px rgb(120 160 220 / 70%), 0 1px 3px rgb(0 0 0 / 70%);
-  transition: opacity 300ms var(--ease-out-soft) 250ms;
+.feat-door-portal-art,
+.feat-door-portal-css {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  animation: door-portal-swirl 26s linear infinite;
 }
 
-.feat-door-peek-icon {
-  width: 18px;
-  height: 18px;
+.feat-door-portal-css {
+  background:
+    radial-gradient(circle at 50% 50%, rgb(190 226 255 / 42%), transparent 58%),
+    conic-gradient(
+      from 0deg,
+      rgb(40 86 160 / 78%),
+      rgb(118 80 200 / 78%),
+      rgb(44 132 188 / 78%),
+      rgb(84 60 184 / 78%),
+      rgb(40 86 160 / 78%)
+    );
+  filter: blur(1px);
 }
 
-.feat-door-stage.is-open .feat-door-peek {
-  opacity: 1;
+@keyframes door-portal-swirl {
+  from { transform: scale(1.35) rotate(0deg); }
+  to { transform: scale(1.35) rotate(360deg); }
 }
 
 /* The swinging leaf — pivots on its hinge edge between 0° and the open angle. */
@@ -3917,11 +3922,12 @@ body {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .feat-door-leaf,
-  .feat-door-peek {
+  .feat-door-leaf {
     transition: none;
   }
 
+  .feat-door-portal-art,
+  .feat-door-portal-css,
   .feat-door-seal.is-locked,
   .feat-door-seal.is-shatter,
   .feat-door-keyhole,

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -3846,13 +3846,26 @@ body {
   100% { opacity: 0; filter: blur(3px) brightness(1.3); transform: translate(-50%, -50%) scale(1.55) rotate(9deg); }
 }
 
-/* Info + actions below the door */
+/* Info + actions float over the bottom of the door (rather than stacking below
+   it and pushing the panel into a scroll). A soft scrim keeps them legible. */
 .feat-door-info {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: clamp(10px, 2.5vh, 24px);
+  z-index: 2;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
+  padding-top: 36px;
   text-align: center;
+  pointer-events: none;
+  background: linear-gradient(to top, rgb(8 6 4 / 46%) 0%, rgb(8 6 4 / 22%) 45%, transparent 100%);
+}
+
+.feat-door-info > * {
+  pointer-events: auto;
 }
 
 .feat-door-line {

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -3692,7 +3692,8 @@ body {
   position: absolute;
   z-index: 0;
   overflow: hidden;
-  border-radius: 8px 8px 4px 4px;
+  /* Arch-domed top so the swirl reads as a doorway rather than a rectangle. */
+  border-radius: 46% 46% 14px 14px / 34% 34% 14px 14px;
 }
 
 .feat-door-portal-art,

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -3671,8 +3671,8 @@ body {
   align-items: center;
   justify-content: center;
   gap: 10px;
-  /* Heavier top padding biases the door downward toward the floor. */
-  padding: clamp(28px, 7vh, 72px) 16px clamp(6px, 1vh, 12px);
+  /* Symmetric padding — the info floats absolutely now, so no downward bias. */
+  padding: clamp(8px, 1.5vh, 16px) 16px;
 }
 
 .feat-door-stage {

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -3680,6 +3680,9 @@ body {
   width: min(500px, 67vw);
   aspect-ratio: 3 / 4;
   perspective: 1100px;
+  /* Lift the door art up so its base meets the wall/floor seam of door_bg
+     (the two are independent layers). Tune this single value to taste. */
+  transform: translateY(clamp(-72px, -8vh, -40px));
 }
 
 /* Holds the destination peek label, centred in the doorway. Transparent — the


### PR DESCRIPTION
A pass of door-panel polish (iterated from live feedback):

- **Bigger door** — scaled the frame + leaf up (`min(500px, 67vw)`) so the archway fills the stone `door_bg` wall instead of floating small in the center.
- **Aligned to the wall** — a `translateY` lift so the door's base meets the wall/floor seam of `door_bg` (the art and the wall are independent layers); top-anchored.
- **Floating controls** — the "Leads …" label, key chip, and action buttons now float absolutely over the bottom of the door (with a soft scrim) instead of stacking below it and forcing a scroll.
- **Swirling portal** — replaced the awkward floating direction arrow in the open doorway with a swirling portal that sits in the opening (same box as the leaf, revealed when it swings open). New global asset **`door_portal`**, with a CSS conic-gradient vortex fallback. Direction still appears in the "Leads <dir>" line below.

Verified: `eslint` ✓ · `tsc -b` ✓ · `vite build` ✓ · `compileKotlin` ✓.

> `door_portal` is authored separately; until it ships the CSS vortex renders.