### PR TITLE
fix(web): clear lookTarget on HUD reset (#1145)

### DIFF
--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -704,6 +704,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     setZoneCinematic(null);
     setCombatTarget(null);
     setConsiderResult(null);
+    setLookTarget(null);
     setCharStats(null);
     setQuests([]);
     setQuestsAvailable([]);


### PR DESCRIPTION
Closes #1145.

`resetHud()` in `useGameState.ts` zeroes the transient overlays (combat target, consider result, dialogue, shop, …) but omitted `setLookTarget(null)`. So an examine card from `look <mob>`/`look <item>` could survive **disconnect → reconnect → new login** until manually dismissed.

One-liner: add `setLookTarget(null)` alongside the other overlay resets (next to the `considerResult` reset that #1144 already added).

Verified: `eslint` ✓ · `tsc -b` ✓.