### PR TITLE
feat(engine): inn rooms grant 2x HP + mana regen (#1155)

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -227,6 +227,9 @@ data class AppConfig(
         require(engine.regen.inCombatMultiplier in 0.0..1.0) {
             "ambonMUD.engine.regen.inCombatMultiplier must be in [0.0, 1.0]"
         }
+        require(engine.regen.innMultiplier >= 1.0) {
+            "ambonMUD.engine.regen.innMultiplier must be >= 1.0"
+        }
         engine.regen.mana.baseIntervalMillis.requirePositive("ambonMUD.engine.regen.mana.baseIntervalMillis")
         engine.regen.mana.minIntervalMillis.requirePositive("ambonMUD.engine.regen.mana.minIntervalMillis")
         require(engine.regen.mana.regenPercent > 0.0 && engine.regen.mana.regenPercent <= 1.0) {
@@ -2547,6 +2550,8 @@ data class RegenEngineConfig(
     val minIntervalMillis: Long = 1_000L,
     val regenPercent: Double = 0.05,
     val inCombatMultiplier: Double = 0.5,
+    /** Regen multiplier while resting in a room flagged as an inn (HP + mana). */
+    val innMultiplier: Double = 2.0,
     val mana: ManaRegenConfig = ManaRegenConfig(),
 )
 

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -771,6 +771,8 @@ class GameEngine(
             manaRegenPercent = engineConfig.regen.mana.regenPercent,
             inCombatMultiplier = engineConfig.regen.inCombatMultiplier,
             inCombat = { sid -> combatSystem.isInCombat(sid) },
+            innMultiplier = engineConfig.regen.innMultiplier,
+            inInn = { sid -> players.get(sid)?.roomId?.let { world.rooms[it]?.inn } == true },
             tickIntervalMs = tickMillis,
             cycleTargetMs = engineConfig.regen.cycleTargetMillis,
             minPlayersPerTick = engineConfig.regen.minPlayersPerTick,

--- a/src/main/kotlin/dev/ambon/engine/RegenSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/RegenSystem.kt
@@ -20,6 +20,8 @@ class RegenSystem(
     private val manaRegenPercent: Double = 0.05,
     private val inCombatMultiplier: Double = 0.5,
     private val inCombat: (SessionId) -> Boolean = { false },
+    private val innMultiplier: Double = 2.0,
+    private val inInn: (SessionId) -> Boolean = { false },
     private val tickIntervalMs: Long = 100L,
     private val cycleTargetMs: Long = 2_000L,
     private val minPlayersPerTick: Int = 5,
@@ -64,7 +66,9 @@ class RegenSystem(
 
             val sessionId = player.sessionId
             val equipStats = items.equipmentBonuses(sessionId, classRegistry?.get(player.playerClass)).stats
-            val multiplier = if (inCombat(sessionId)) inCombatMultiplier else 1.0
+            val combatMult = if (inCombat(sessionId)) inCombatMultiplier else 1.0
+            val innMult = if (inInn(sessionId)) innMultiplier else 1.0
+            val multiplier = combatMult * innMult
 
             applyRegen(
                 now = now,

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -898,6 +898,9 @@ ambonmud:
       # Multiplier applied to regen amount while the player is in combat
       # (0.5 = half regen, 0.0 = no regen while fighting).
       inCombatMultiplier: 0.5
+      # Multiplier applied to HP + mana regen while resting in an inn room
+      # (2.0 = double regen). Stacks with inCombatMultiplier.
+      innMultiplier: 2.0
       mana:
         baseIntervalMillis: 4500
         minIntervalMillis: 1000

--- a/src/test/kotlin/dev/ambon/engine/RegenSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/RegenSystemTest.kt
@@ -26,6 +26,8 @@ class RegenSystemTest {
         manaRegenPercent: Double = 0.05,
         inCombatMultiplier: Double = 0.5,
         inCombat: (dev.ambon.domain.ids.SessionId) -> Boolean = { false },
+        innMultiplier: Double = 2.0,
+        inInn: (dev.ambon.domain.ids.SessionId) -> Boolean = { false },
     ): RegenSystem =
         RegenSystem(
             players = players,
@@ -38,6 +40,8 @@ class RegenSystemTest {
             manaRegenPercent = manaRegenPercent,
             inCombatMultiplier = inCombatMultiplier,
             inCombat = inCombat,
+            innMultiplier = innMultiplier,
+            inInn = inInn,
         )
 
     private fun makeRegistry(): PlayerRegistry =
@@ -72,6 +76,34 @@ class RegenSystemTest {
             regen.tick()
 
             assertEquals(player.maxHp - 2, player.hp, "Expected one regen tick (+1 HP)")
+        }
+
+    @Test
+    fun `inn room doubles hp and mana regen`() =
+        runTest {
+            val players = makeRegistry()
+            val clock = MutableClock(0L)
+            val regen = makeRegen(players, clock, inInn = { true })
+
+            val sid = SessionId(1L)
+            players.loginOrFail(sid, "Inny")
+            regen.tick() // record trackers while full
+
+            val player = players.get(sid)!!
+            val baseHp = (player.maxHp * 0.10).toInt().coerceAtLeast(1)
+            val expectedHp = (player.maxHp * 0.10 * 2.0).toInt().coerceAtLeast(1)
+            val expectedMana = (player.maxMana * 0.05 * 2.0).toInt().coerceAtLeast(1)
+            player.hp = player.maxHp - expectedHp - 5
+            player.mana = player.maxMana - expectedMana - 5
+            val hp0 = player.hp
+            val mana0 = player.mana
+
+            clock.advance(5_000L)
+            regen.tick()
+
+            assertEquals(hp0 + expectedHp, player.hp, "Inn HP regen should be the 2x amount")
+            assertEquals(mana0 + expectedMana, player.mana, "Inn mana regen should be the 2x amount")
+            assertTrue(expectedHp > baseHp, "2x inn regen should exceed the base regen amount")
         }
 
     @Test


### PR DESCRIPTION
Refs #1155.

Per the scope call: instead of a new "sanctuary" room type, any room already flagged **`inn: true`** now grants **2× HP and mana regen** to players resting in it.

- New config **`engine.regen.innMultiplier`** (default `2.0`, validated `>= 1.0`), in `AppConfig` + `application.yaml`.
- `RegenSystem` applies it next to the in-combat multiplier: `multiplier = inCombat × inn`. So resting at an inn doubles regen, and an inn cancels the in-combat penalty (0.5 × 2.0 = 1.0) if you somehow fight there.
- The engine resolves "is the player's room an inn?" via an injected predicate (`world.rooms[roomId]?.inn`), mirroring the existing `inCombat` hook — no new per-player state.

Reuses the existing `inn` zone-YAML flag (the one that already powers the Inn panel), so no world-content or schema changes.

Tested: `RegenSystemTest` — *inn room doubles hp and mana regen*. Verified: `compileKotlin` ✓ · `ktlintCheck` ✓ · regen tests ✓.