### PR TITLE
fix(web): keep the character cabinet from scrolling

### DIFF
--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -22461,7 +22461,9 @@ html:has(.game-shell),
   box-shadow: inset 0 0 18px rgb(0 0 0 / 45%);
   overflow-y: auto;
   min-height: 60px;
-  max-height: 188px;
+  /* Exactly three 46px rows (138 + 2*6 gap + 16 padding) so the showcase
+     column doesn't outgrow the rows beside it and scroll the whole drawer. */
+  max-height: 166px;
   scrollbar-width: thin;
   scrollbar-color: rgb(201 162 74 / 65%) transparent;
 }


### PR DESCRIPTION
Follow-up to #1261. On the live server the cabinet drawer scrolled by a hair: the showcase column (preview + thumbnail rack) outgrew the rows beside it, so the drawer body picked up a tiny scrollbar.

Cap the sprite rack at **166px** — exactly three 46px rows (138 + 2×6 gap + 16 padding) — so the showcase column bottom lines up with the stats/readouts beside it and any overflow stays inside the rack's own scroll instead of the whole drawer.

Verified with `bun run build`.