### PR TITLE
fix(web): reflect title selection in the character cabinet dropdown

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -535,6 +535,7 @@ class GmcpEmitter(
                 autolootEnabled = player.autolootEnabled,
                 autopeekEnabled = player.autopeekEnabled,
                 wimpyThresholdPct = player.wimpyThresholdPct,
+                title = player.activeTitle,
                 isDemo = player.playerId == null,
             ),
         )
@@ -2790,6 +2791,8 @@ class GmcpEmitter(
         val autolootEnabled: Boolean,
         val autopeekEnabled: Boolean,
         val wimpyThresholdPct: Int,
+        /** The player's currently-equipped achievement title, or null when none is set. */
+        val title: String?,
         /**
          * True for unclaimed demo characters (no persistent account). Web client
          * surfaces a "Save your progress" prompt when set. Flips to false after

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/DialogueQuestHandler.kt
@@ -371,12 +371,14 @@ class DialogueQuestHandler(
             )
         } else {
             players.setDisplayTitle(sessionId, match.second)
+            players.get(sessionId)?.let { gmcpEmitter?.sendCharName(sessionId, it) }
             outbound.send(OutboundEvent.SendInfo(sessionId, "Title set to: ${match.second}"))
         }
     }
 
     private suspend fun handleTitleClear(sessionId: SessionId) {
         players.setDisplayTitle(sessionId, null)
+        players.get(sessionId)?.let { gmcpEmitter?.sendCharName(sessionId, it) }
         outbound.send(OutboundEvent.SendInfo(sessionId, "Title cleared."))
     }
 }

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -558,6 +558,19 @@ class GmcpEmitterTest {
             assertTrue(data.jsonData.contains("\"class\":\"MAGE\""))
             assertTrue(data.jsonData.contains("\"level\":10"))
             assertTrue(data.jsonData.contains("\"autolootEnabled\":true"))
+            assertTrue(data.jsonData.contains("\"title\":null"))
+        }
+
+    @Test
+    fun `sendCharName emits the active title verbatim including commas`() =
+        runTest {
+            val e = emitter("Char.Name")
+            e.sendCharName(
+                sid,
+                player(name = "Alice").copy(activeTitle = "Ambonien, King of Ambon"),
+            )
+            val data = drainGmcp()[0]
+            assertTrue(data.jsonData.contains("\"title\":\"Ambonien, King of Ambon\""))
         }
 
     // ── Comm.Channel ──

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -1008,7 +1008,7 @@ function App() {
             charStats={state.charStats}
             guildInfo={state.guildInfo}
             groupInfo={state.groupInfo}
-            activeTitle={state.whoPlayers.find((p) => p.name === state.character.name)?.title ?? null}
+            activeTitle={state.character.title}
             spriteList={state.spriteList}
             currencies={state.currencies}
             factions={state.factions}

--- a/web-v3/src/canvas/GameStateBridge.ts
+++ b/web-v3/src/canvas/GameStateBridge.ts
@@ -151,7 +151,7 @@ export const gameStateRef: { current: GameStateSnapshot } = {
     combatTarget: null,
     inCombat: false,
     effects: [],
-    character: { name: "-", gender: "", race: "", className: "", level: null, sprite: null, isStaff: false, autolootEnabled: false, autopeekEnabled: false, wimpyThresholdPct: 10, isDemo: false },
+    character: { name: "-", gender: "", race: "", className: "", level: null, sprite: null, isStaff: false, title: null, autolootEnabled: false, autopeekEnabled: false, wimpyThresholdPct: 10, isDemo: false },
     mobInfo: [],
     groupInfo: { leader: null, members: [] },
     dialogue: null,

--- a/web-v3/src/constants.ts
+++ b/web-v3/src/constants.ts
@@ -95,7 +95,7 @@ export const DEFAULT_STATUS_VAR_LABELS: StatusVarLabels = {
   xp: "XP",
 };
 
-export const EMPTY_CHAR: CharacterInfo = { name: "-", gender: "", race: "", className: "", level: null, sprite: null, isStaff: false, autolootEnabled: false, autopeekEnabled: false, wimpyThresholdPct: 10, isDemo: false };
+export const EMPTY_CHAR: CharacterInfo = { name: "-", gender: "", race: "", className: "", level: null, sprite: null, isStaff: false, title: null, autolootEnabled: false, autopeekEnabled: false, wimpyThresholdPct: 10, isDemo: false };
 export const DEFAULT_SERVER_FEATURES: ServerFeatures = {
   dailyQuests: false,
   weeklyQuests: false,

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -376,6 +376,7 @@ export function applyGmcpPackage(
         level: typeof packet.level === "number" ? packet.level : null,
         sprite: typeof packet.sprite === "string" ? packet.sprite : null,
         isStaff: packet.isStaff === true,
+        title: typeof packet.title === "string" ? packet.title : null,
         autolootEnabled: packet.autolootEnabled === true,
         autopeekEnabled: packet.autopeekEnabled === true,
         wimpyThresholdPct: typeof packet.wimpyThresholdPct === "number" ? packet.wimpyThresholdPct : 10,

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -203,6 +203,8 @@ export interface CharacterInfo {
   level: number | null;
   sprite: string | null;
   isStaff: boolean;
+  /** The player's currently-equipped achievement title, or null when none is set. */
+  title: string | null;
   autolootEnabled: boolean;
   /** When true, room descriptions gain a peek paragraph naming adjacent rooms. */
   autopeekEnabled: boolean;


### PR DESCRIPTION
## Symptom
Picking a title in the character cabinet's **Title** dropdown looked like it did nothing — the dropdown closed and snapped back to **None** — even though the title was visible in the list. Setting the same title with the `title` terminal command worked and showed up in the GUI.

## Root cause
The command was succeeding in *both* cases. The bug was purely in how the panel sourced the dropdown's *current value*:

```tsx
activeTitle={state.whoPlayers.find((p) => p.name === state.character.name)?.title ?? null}
```

`whoPlayers` is only populated by `Server.Who`, which the server pushes **on demand** (in response to a `who`). A title change never refreshes it, so the controlled `<select>` reverted to the stale who-list value (None) immediately after a successful set. The terminal case only *looked* right because a `who` had refreshed the list.

The comma in *"Ambonien, King of Ambon"* was a red herring: the dropdown option and the server's match target both come from the same `rewards.title`, so the strings always matched (verified `Char.Achievements` and `availableTitles` share the source).

## Fix
Push the player's current title to the client and read the select from it — the same pattern gender / autoloot / sprite already follow.

- **Server:** add `title` (the player's `activeTitle`) to the `Char.Name` payload; re-emit `Char.Name` from the `TitleSet` / `TitleClear` handlers so a change propagates immediately.
- **Client:** add `title` to `CharacterInfo`, populate it from `Char.Name`, and source the cabinet's Title `<select>` from `character.title` instead of the who list.

## Tests / verification
- New `GmcpEmitterTest` asserting the title (with a comma) round-trips in the `Char.Name` payload; `title":null` when none set.
- `./gradlew compileKotlin compileTestKotlin ktlintCheck` ✓, `GmcpEmitterTest` ✓
- `bun run lint` ✓, `npx tsc -b` ✓, `bun run build` ✓