### PR TITLE
feat(web): auto-collapse the Help/Social/Mail services stack

### DIFF
--- a/web-v3/src/components/GameShell.tsx
+++ b/web-v3/src/components/GameShell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { PixiCanvas } from "../canvas/PixiCanvas";
 import { CombatLog } from "./CombatLog";
 import { RoomPanel } from "./RoomPanel";
@@ -75,6 +75,43 @@ export function GameShell({
 }: GameShellProps) {
   const loggedIn = connected && hasCharacterProfile;
   const [signZoom, setSignZoom] = useState(false);
+
+  // Services stack (Help / Social / Mail) auto-collapses to a slim handle at
+  // the right edge so it doesn't sit over the minimap. Tapping the handle
+  // reveals the icons; they tuck away again after a few seconds of no use.
+  // (Desktop gets hover-to-peek via CSS, independent of this state.)
+  const [servicesOpen, setServicesOpen] = useState(false);
+  const servicesCollapseTimer = useRef<number | null>(null);
+
+  const scheduleServicesCollapse = useCallback(() => {
+    if (servicesCollapseTimer.current !== null) window.clearTimeout(servicesCollapseTimer.current);
+    servicesCollapseTimer.current = window.setTimeout(() => setServicesOpen(false), 3500);
+  }, []);
+
+  const openServices = useCallback(() => {
+    setServicesOpen(true);
+    scheduleServicesCollapse();
+  }, [scheduleServicesCollapse]);
+
+  const closeServices = useCallback(() => {
+    if (servicesCollapseTimer.current !== null) window.clearTimeout(servicesCollapseTimer.current);
+    setServicesOpen(false);
+  }, []);
+
+  const openServicePanel = useCallback(
+    (panel: PopoutPanel) => {
+      onOpenPanel(panel);
+      closeServices();
+    },
+    [onOpenPanel, closeServices],
+  );
+
+  useEffect(
+    () => () => {
+      if (servicesCollapseTimer.current !== null) window.clearTimeout(servicesCollapseTimer.current);
+    },
+    [],
+  );
 
   // Dismiss the enlarged sign on Escape.
   useEffect(() => {
@@ -181,42 +218,53 @@ export function GameShell({
             />
 
             {/* Services stack — Help / Social / Mail, top-right under the minimap.
-                Tiny round widget buttons; the corner overlaps the minimap's
-                decorative torn margin only. */}
-            <nav className="canvas-hud-stack" aria-label="Services">
+                Auto-collapses to a slim handle so it doesn't crowd the minimap;
+                tap the handle (or hover on desktop) to reveal the widgets. */}
+            <nav className={`canvas-hud-stack${servicesOpen ? " is-open" : ""}`} aria-label="Services">
               <button
                 type="button"
-                className="hud-stack-btn"
-                onClick={() => onOpenPanel("help")}
-                title="Help"
-                aria-label="Help"
+                className="hud-stack-toggle"
+                aria-label={servicesOpen ? "Hide services" : "Show services"}
+                aria-expanded={servicesOpen}
+                onClick={() => (servicesOpen ? closeServices() : openServices())}
               >
-                {serverAssets["help_widget"]
-                  ? <img className="hud-stack-img" src={serverAssets["help_widget"]} alt="" />
-                  : <span className="hud-stack-glyph">?</span>}
+                <span className="hud-stack-toggle-glyph" aria-hidden="true" />
               </button>
-              <button
-                type="button"
-                className="hud-stack-btn"
-                onClick={() => onOpenPanel("chat")}
-                title="Social"
-                aria-label="Social"
-              >
-                {serverAssets["social_widget"]
-                  ? <img className="hud-stack-img" src={serverAssets["social_widget"]} alt="" />
-                  : <span className="hud-stack-glyph">☺</span>}
-              </button>
-              <button
-                type="button"
-                className="hud-stack-btn"
-                onClick={() => onOpenPanel("mail")}
-                title="Mail"
-                aria-label="Mail"
-              >
-                {serverAssets["mail_widget"]
-                  ? <img className="hud-stack-img" src={serverAssets["mail_widget"]} alt="" />
-                  : <span className="hud-stack-glyph">✉</span>}
-              </button>
+              <div className="hud-stack-items" onPointerDown={scheduleServicesCollapse}>
+                <button
+                  type="button"
+                  className="hud-stack-btn"
+                  onClick={() => openServicePanel("help")}
+                  title="Help"
+                  aria-label="Help"
+                >
+                  {serverAssets["help_widget"]
+                    ? <img className="hud-stack-img" src={serverAssets["help_widget"]} alt="" />
+                    : <span className="hud-stack-glyph">?</span>}
+                </button>
+                <button
+                  type="button"
+                  className="hud-stack-btn"
+                  onClick={() => openServicePanel("chat")}
+                  title="Social"
+                  aria-label="Social"
+                >
+                  {serverAssets["social_widget"]
+                    ? <img className="hud-stack-img" src={serverAssets["social_widget"]} alt="" />
+                    : <span className="hud-stack-glyph">☺</span>}
+                </button>
+                <button
+                  type="button"
+                  className="hud-stack-btn"
+                  onClick={() => openServicePanel("mail")}
+                  title="Mail"
+                  aria-label="Mail"
+                >
+                  {serverAssets["mail_widget"]
+                    ? <img className="hud-stack-img" src={serverAssets["mail_widget"]} alt="" />
+                    : <span className="hud-stack-glyph">✉</span>}
+                </button>
+              </div>
             </nav>
 
             {/* Flee — only during combat */}

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -18968,11 +18968,80 @@ html:has(.game-shell),
   z-index: 10;
   display: flex;
   flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+  /* Only the buttons capture touch — the empty column stays transparent to
+     pointers so the minimap underneath remains usable. */
+  pointer-events: none;
+}
+
+/* Slim always-visible handle that toggles the stack open/closed. */
+.hud-stack-toggle {
+  pointer-events: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 1px solid var(--line-soft);
+  border-radius: 50%;
+  background: linear-gradient(160deg, rgb(20 24 40 / 84%), rgb(14 17 28 / 90%));
+  color: var(--text-secondary);
+  cursor: pointer;
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  transition: border-color 150ms var(--ease-out-soft), color 150ms var(--ease-out-soft), transform 150ms var(--ease-out-soft);
+}
+
+.hud-stack-toggle:hover {
+  border-color: rgb(176 193 255 / 50%);
+  color: var(--text-bright);
+}
+
+/* Chevron drawn from borders: points down when collapsed, up when open. */
+.hud-stack-toggle-glyph {
+  width: 7px;
+  height: 7px;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: translateY(-2px) rotate(45deg);
+  transition: transform 200ms var(--ease-out-soft);
+}
+
+.canvas-hud-stack.is-open .hud-stack-toggle-glyph {
+  transform: translateY(1px) rotate(225deg);
+}
+
+/* The revealable widgets. Collapsed: tucked toward the right edge, faded,
+   and non-interactive. Open (via .is-open) or hover (desktop) slides them in. */
+.hud-stack-items {
+  display: flex;
+  flex-direction: column;
   align-items: center;
   gap: 8px;
+  opacity: 0;
+  transform: translateX(14px);
+  pointer-events: none;
+  transition: opacity 200ms var(--ease-out-soft), transform 200ms var(--ease-out-soft);
+}
+
+.canvas-hud-stack.is-open .hud-stack-items {
+  opacity: 1;
+  transform: translateX(0);
+  pointer-events: auto;
+}
+
+@media (hover: hover) {
+  .canvas-hud-stack:hover .hud-stack-items {
+    opacity: 1;
+    transform: translateX(0);
+    pointer-events: auto;
+  }
 }
 
 .hud-stack-btn {
+  pointer-events: auto;
   display: inline-flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
First step toward decluttering the top-right HUD (and prep for splitting the giant social panel into smaller, art-contract-skinnable widgets).

## What changed
The three service widgets (Help / Social / Mail) used to sit permanently in the top-right corner, overlapping the minimap on mobile. They now collapse behind a slim handle:

- **Slim chevron handle** hugs the right edge and is the only thing visible when idle. Tap it → the widgets slide in from the right. Tap again (chevron flips up) → they tuck away.
- **Auto-collapse** after ~3.5s of no interaction. Touching a widget resets the timer; opening a panel collapses the stack immediately.
- **Desktop hover-to-peek** via `@media (hover: hover)`, independent of the tap state — no handle hunting with a mouse.
- The stack container is now `pointer-events: none` with the buttons re-enabling pointer events, so the empty column no longer steals touches from the minimap beneath it.

## Why
- Keeps the minimap clear on mobile (the original ask).
- The stack can now grow longer without permanently eating screen space — which is what makes splitting the oversized social panel into per-feature widgets viable next.

## Verification
- `bun run lint` ✓, `npx tsc -b` ✓, `bun run build` ✓
- Behavior is CSS/JS-only; no server or asset-contract changes. Existing `help_widget` / `social_widget` / `mail_widget` art keys still drive the icons.

Send a screen grab once it's deployed and I'll tune the handle size, collapse delay, or slide direction.