### PR TITLE
feat(web): split chat into a standalone painted Social Board

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -3082,6 +3082,8 @@ data class ImagesConfig(
             "char_btn_prestige" to "global_assets/char_btn_prestige.png",
             // Parchment backdrop for the pop-out describe editor.
             "character_scribe_bg" to "global_assets/character_scribe_bg.png",
+            "chat_bg" to "global_assets/chat_bg.png",
+            "chat_widget" to "global_assets/chat_widget.png",
             "dialog_indicator" to "global_assets/dialog_indicator.png",
             "aggro_indicator" to "global_assets/aggro_indicator.png",
             "quest_available_indicator" to "global_assets/quest_available_indicator.png",

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -10,6 +10,7 @@ import { TradePanel } from "./components/TradePanel";
 import { WorldFeaturesPopout } from "./components/WorldFeaturesPopout";
 import { featureArt, pickFocusedFeature } from "./components/worldFeatures";
 import { ChatPanel } from "./components/panels/ChatPanel";
+import { ChatBoardPanel } from "./components/panels/ChatBoardPanel";
 import { CharacterPanel } from "./components/panels/CharacterPanel";
 import { SpellbookPanel } from "./components/SpellbookPanel";
 import { QuestPanel } from "./components/panels/QuestPanel";
@@ -846,6 +847,7 @@ function App() {
       case "quests": return "Quests";
       case "questOffers": return "Quest Offers";
       case "chat": return "Social";
+      case "chatboard": return "Social Board";
       case "shop": return state.shop?.name ?? "Shop";
       case "puzzle": return "Puzzle";
       case "features": return featurePanelFeature
@@ -927,6 +929,8 @@ function App() {
         variant={
           drawerPanel === "puzzle"
             ? "tome"
+            : drawerPanel === "chatboard"
+            ? "board"
             : drawerPanel === "character"
             ? "cabinet"
             : drawerPanel === "bank"
@@ -957,6 +961,8 @@ function App() {
           drawerPanel === "puzzle"
             ? (state.puzzle?.puzzles.find((p) => p.backgroundImage)?.backgroundImage
                 ?? state.serverAssets["puzzle_bg"])
+            : drawerPanel === "chatboard"
+            ? state.serverAssets["chat_bg"]
             : drawerPanel === "character"
             ? state.serverAssets["character_bg"]
             : drawerPanel === "bank"
@@ -985,6 +991,7 @@ function App() {
                             ? state.serverAssets["mail_bg"]
                             : undefined
         }
+        initialHeight={drawerPanel === "chatboard" ? 0.94 : undefined}
       >
         {drawerPanel === "character" && (
           <CharacterPanel
@@ -1073,14 +1080,28 @@ function App() {
           />
         )}
 
-        {drawerPanel === "chat" && (
-          <ChatPanel
+        {drawerPanel === "chatboard" && (
+          <ChatBoardPanel
             connected={connected}
             canChat={connected && hasCharacterProfile}
             playerName={state.character.name}
             activeChannel={state.activeChatChannel}
             chatByChannel={state.chatByChannel}
             emotePresets={state.emotePresets}
+            tellTarget={state.tellTarget}
+            onTellTargetChange={state.setTellTarget}
+            onChannelChange={state.setActiveChatChannel}
+            onSendMessage={sendChatMessage}
+            onCommand={sendCommand}
+          />
+        )}
+
+        {drawerPanel === "chat" && (
+          <ChatPanel
+            connected={connected}
+            canChat={connected && hasCharacterProfile}
+            playerName={state.character.name}
+            chatByChannel={state.chatByChannel}
             whoPlayers={state.whoPlayers}
             groupInfo={state.groupInfo}
             pendingGroupInvite={state.pendingGroupInvite}
@@ -1090,9 +1111,13 @@ function App() {
             guildHall={state.guildHall}
             friends={state.friends}
             friendNotifications={state.friendNotifications}
-            onChannelChange={state.setActiveChatChannel}
             onRequestWho={() => sendCommand("who")}
             onSendMessage={sendChatMessage}
+            onTellPlayer={(name) => {
+              state.setActiveChatChannel("tell");
+              state.setTellTarget(name);
+              openPanel("chatboard");
+            }}
             onCommand={sendCommand}
           />
         )}

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -961,8 +961,6 @@ function App() {
           drawerPanel === "puzzle"
             ? (state.puzzle?.puzzles.find((p) => p.backgroundImage)?.backgroundImage
                 ?? state.serverAssets["puzzle_bg"])
-            : drawerPanel === "chatboard"
-            ? state.serverAssets["chat_bg"]
             : drawerPanel === "character"
             ? state.serverAssets["character_bg"]
             : drawerPanel === "bank"
@@ -1089,6 +1087,7 @@ function App() {
             chatByChannel={state.chatByChannel}
             emotePresets={state.emotePresets}
             tellTarget={state.tellTarget}
+            backgroundImage={state.serverAssets["chat_bg"] ?? null}
             onTellTargetChange={state.setTellTarget}
             onChannelChange={state.setActiveChatChannel}
             onSendMessage={sendChatMessage}

--- a/web-v3/src/components/Drawer.tsx
+++ b/web-v3/src/components/Drawer.tsx
@@ -9,9 +9,11 @@ interface DrawerProps {
   /** Visual skin for the sheet chrome: warm leather (satchel), a dim
    *  dressing-chamber (equipment), a merchant cart (shop), a chalkboard
    *  (trainer), a parchment journal (combat log), or a cork quest board. */
-  variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "desk" | "mail" | "feature" | "tome" | "vault" | "cabinet";
+  variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "desk" | "mail" | "feature" | "tome" | "vault" | "cabinet" | "board";
   /** Optional background art for a skinned variant (server asset). */
   skinBg?: string;
+  /** Height (as a fraction of the viewport) the drawer snaps to when it opens. */
+  initialHeight?: number;
 }
 
 const SNAP_HALF = 0.6;
@@ -20,8 +22,8 @@ const DISMISS_THRESHOLD = 0.3;
 const DRAG_VELOCITY_DISMISS = 800; // px/s
 const ANIMATION_MS = 300;
 
-export function Drawer({ open, title, onClose, children, variant = "default", skinBg }: DrawerProps) {
-  const [height, setHeight] = useState(SNAP_HALF);
+export function Drawer({ open, title, onClose, children, variant = "default", skinBg, initialHeight = SNAP_HALF }: DrawerProps) {
+  const [height, setHeight] = useState(initialHeight);
   const [dragging, setDragging] = useState(false);
   const [renderPhase, setRenderPhase] = useState<"hidden" | "animating" | "open">(open ? "open" : "hidden");
   const [prevOpen, setPrevOpen] = useState(open);
@@ -32,8 +34,8 @@ export function Drawer({ open, title, onClose, children, variant = "default", sk
   if (open !== prevOpen) {
     setPrevOpen(open);
     if (open) {
-      // Drawer is opening — mount it and snap to half-height
-      setHeight(SNAP_HALF);
+      // Drawer is opening — mount it and snap to its initial height
+      setHeight(initialHeight);
       setRenderPhase("open");
     } else {
       // Drawer is closing — collapse height, animation phase will unmount when done

--- a/web-v3/src/components/GameShell.tsx
+++ b/web-v3/src/components/GameShell.tsx
@@ -245,6 +245,17 @@ export function GameShell({
                 <button
                   type="button"
                   className="hud-stack-btn"
+                  onClick={() => openServicePanel("chatboard")}
+                  title="Chat"
+                  aria-label="Chat"
+                >
+                  {serverAssets["chat_widget"]
+                    ? <img className="hud-stack-img" src={serverAssets["chat_widget"]} alt="" />
+                    : <span className="hud-stack-glyph">&#9998;</span>}
+                </button>
+                <button
+                  type="button"
+                  className="hud-stack-btn"
                   onClick={() => openServicePanel("chat")}
                   title="Social"
                   aria-label="Social"

--- a/web-v3/src/components/panels/ChatBoardPanel.tsx
+++ b/web-v3/src/components/panels/ChatBoardPanel.tsx
@@ -27,11 +27,11 @@ type Rect = { left: number; top: number; width: number; height: number };
  * Tweak these to nudge the lineup against the painted frame.
  */
 const CHANNEL_RECTS: Record<string, Rect> = {
-  say: { left: 18.3, top: 24.8, width: 11.2, height: 9.0 },
-  tell: { left: 30.1, top: 24.8, width: 11.2, height: 9.0 },
-  gossip: { left: 42.0, top: 24.8, width: 11.2, height: 9.0 },
-  shout: { left: 55.0, top: 24.8, width: 11.2, height: 9.0 },
-  ooc: { left: 68.7, top: 24.8, width: 11.2, height: 9.0 },
+  say: { left: 17.7, top: 23.1, width: 11.2, height: 9.0 },
+  tell: { left: 30.1, top: 23.1, width: 11.2, height: 9.0 },
+  gossip: { left: 43.0, top: 23.1, width: 11.2, height: 9.0 },
+  shout: { left: 56.0, top: 23.1, width: 11.2, height: 9.0 },
+  ooc: { left: 69.0, top: 23.1, width: 11.2, height: 9.0 },
 };
 // Measured off social-final.png (1448×1086): chalkboard l15.9 t34.3 w69.3 h44.7;
 // parchment l21.3 t82.0 w46.3 h13.4; send-scroll l~77 w~17.

--- a/web-v3/src/components/panels/ChatBoardPanel.tsx
+++ b/web-v3/src/components/panels/ChatBoardPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { FormEvent } from "react";
+import type { CSSProperties, FormEvent } from "react";
 import { CHAT_CHANNELS } from "../../constants";
 import type { ChatChannel, ChatMessage, EmotePreset } from "../../types";
 
@@ -11,30 +11,56 @@ interface ChatBoardPanelProps {
   chatByChannel: Record<ChatChannel, ChatMessage[]>;
   emotePresets: EmotePreset[];
   tellTarget: string;
+  backgroundImage: string | null;
   onTellTargetChange: (value: string) => void;
   onChannelChange: (channel: ChatChannel) => void;
   onSendMessage: (channel: ChatChannel, message: string, target: string | null) => boolean;
   onCommand: (command: string) => void;
 }
 
-/** Per-channel flavour for the painted plaques: a sub-label and accent colour. */
-const CHANNEL_META: Record<string, { sub: string; accent: string }> = {
-  say: { sub: "Local Room", accent: "var(--chat-accent-say)" },
-  tell: { sub: "Private", accent: "var(--chat-accent-tell)" },
-  gossip: { sub: "Server-Wide", accent: "var(--chat-accent-gossip)" },
-  shout: { sub: "Zone-Wide", accent: "var(--chat-accent-shout)" },
-  ooc: { sub: "Out of Character", accent: "var(--chat-accent-ooc)" },
+type Rect = { left: number; top: number; width: number; height: number };
+
+/**
+ * Hotspot rectangles, expressed as percentages of the painted `chat_bg`
+ * frame (1447×1087, 4:3). The labels/icons/buttons are baked into the art;
+ * these transparent overlays sit on top to make the chrome interactive.
+ * Tweak these to nudge the lineup against the painted frame.
+ */
+const CHANNEL_RECTS: Record<string, Rect> = {
+  say: { left: 17.8, top: 23.0, width: 12.1, height: 7.8 },
+  tell: { left: 31.0, top: 23.0, width: 12.0, height: 7.8 },
+  gossip: { left: 44.1, top: 23.0, width: 12.0, height: 7.8 },
+  shout: { left: 57.2, top: 23.0, width: 12.0, height: 7.8 },
+  ooc: { left: 70.4, top: 23.0, width: 12.0, height: 7.8 },
 };
+const FEED_RECT: Rect = { left: 15.5, top: 33.0, width: 69.1, height: 46.0 };
+const INPUT_RECT: Rect = { left: 17.1, top: 81.7, width: 53.2, height: 11.2 };
+const EMOTE_RECT: Rect = { left: 72.0, top: 80.8, width: 4.6, height: 6.0 };
+const CLEAR_RECT: Rect = { left: 71.5, top: 87.6, width: 6.6, height: 6.0 };
+const SEND_RECT: Rect = { left: 80.0, top: 81.7, width: 13.4, height: 12.0 };
+
+const CHANNEL_ACCENTS: Record<string, string> = {
+  say: "var(--chat-accent-say)",
+  tell: "var(--chat-accent-tell)",
+  gossip: "var(--chat-accent-gossip)",
+  shout: "var(--chat-accent-shout)",
+  ooc: "var(--chat-accent-ooc)",
+};
+
+function rectStyle(r: Rect): CSSProperties {
+  return { left: `${r.left}%`, top: `${r.top}%`, width: `${r.width}%`, height: `${r.height}%` };
+}
 
 function createEmptyDrafts(): Record<ChatChannel, string> {
   return { say: "", tell: "", gossip: "", shout: "", ooc: "", gtell: "", gchat: "" };
 }
 
 /**
- * Standalone, fully-painted "Social Board" — the chat channels split out of the
- * larger Social panel. The board frame comes from the `chat_bg` drawer skin;
- * this component lays the channel rail, the chalkboard feed, and the parchment
- * composer on top, with carved-CSS fallbacks so it works before the art ships.
+ * Standalone "Social Board" — chat split out of the larger Social panel.
+ * The entire frame (banner, channel plaques, side notes, parchment input,
+ * Send/Clear buttons, footer) is painted into the `chat_bg` art; this
+ * component overlays transparent hotspots + the live feed and input text on
+ * top, pixel-mapped to the painted controls.
  */
 export function ChatBoardPanel({
   connected,
@@ -44,6 +70,7 @@ export function ChatBoardPanel({
   chatByChannel,
   emotePresets,
   tellTarget,
+  backgroundImage,
   onTellTargetChange,
   onChannelChange,
   onSendMessage,
@@ -77,39 +104,52 @@ export function ChatBoardPanel({
     setDraftByChannel((prev) => ({ ...prev, [activeChannel]: "" }));
   };
 
-  return (
-    <section className="chatboard" aria-label="Social board">
-      <div className="chatboard-channels" role="tablist" aria-label="Chat channels">
-        {CHAT_CHANNELS.map((channel) => {
-          const meta = CHANNEL_META[channel.id];
-          const isActive = activeChannel === channel.id;
-          return (
-            <button
-              key={channel.id}
-              type="button"
-              role="tab"
-              className={`chatboard-channel${isActive ? " is-active" : ""}`}
-              style={{ ["--chat-accent" as string]: meta?.accent ?? "var(--brass)" }}
-              onClick={() => onChannelChange(channel.id)}
-              aria-selected={isActive}
-            >
-              <span className="chatboard-channel-gem" aria-hidden="true" />
-              <span className="chatboard-channel-label">{channel.label}</span>
-              {meta && <span className="chatboard-channel-sub">{meta.sub}</span>}
-            </button>
-          );
-        })}
-      </div>
+  // When the "tell" channel is active, split the painted input field into a
+  // target box (left third) and a message box (right two-thirds).
+  const targetRect: Rect = { ...INPUT_RECT, width: INPUT_RECT.width * 0.32 };
+  const messageRect: Rect = isTargetedChannel
+    ? {
+      ...INPUT_RECT,
+      left: INPUT_RECT.left + INPUT_RECT.width * 0.35,
+      width: INPUT_RECT.width * 0.65,
+    }
+    : INPUT_RECT;
 
+  const boardStyle: CSSProperties = backgroundImage
+    ? { ["--chat-bg" as string]: `url("${backgroundImage}")` }
+    : {};
+
+  return (
+    <div className="chatboard" style={boardStyle}>
+      {/* ── Channel hotspots (labels painted into the art) ────── */}
+      {CHAT_CHANNELS.map((channel) => {
+        const isActive = activeChannel === channel.id;
+        return (
+          <button
+            key={channel.id}
+            type="button"
+            role="tab"
+            className={`cb-hotspot cb-channel${isActive ? " is-active" : ""}`}
+            style={{ ...rectStyle(CHANNEL_RECTS[channel.id] ?? FEED_RECT), ["--chat-accent" as string]: CHANNEL_ACCENTS[channel.id] ?? "var(--chat-accent-say)" }}
+            onClick={() => onChannelChange(channel.id)}
+            aria-selected={isActive}
+            aria-label={channel.label}
+            title={channel.label}
+          />
+        );
+      })}
+
+      {/* ── Message feed (over the painted chalkboard) ────────── */}
       <div
         ref={feedRef}
-        className="chatboard-feed"
+        className="cb-feed"
+        style={rectStyle(FEED_RECT)}
         role="log"
         aria-live="polite"
         aria-label={`${activeMeta.label} messages`}
       >
         {messages.length === 0 ? (
-          <p className="chatboard-empty">
+          <p className="cb-empty">
             {canChat
               ? `No ${activeMeta.label.toLowerCase()} messages yet.`
               : connected
@@ -141,8 +181,9 @@ export function ChatBoardPanel({
         )}
       </div>
 
+      {/* ── Emote picker (floats over the feed when open) ─────── */}
       {emotePickerOpen && canChat && (
-        <div className="emote-picker">
+        <div className="cb-emote-picker" style={rectStyle({ ...FEED_RECT, top: FEED_RECT.top + FEED_RECT.height - 22, height: 22 })}>
           <div className="emote-presets">
             {emotePresets.map((preset) => (
               <button
@@ -174,27 +215,17 @@ export function ChatBoardPanel({
               onChange={(e) => setCustomEmote(e.target.value)}
               aria-label="Custom emote"
             />
-            <button
-              type="button"
-              className="emote-name-btn"
-              title="Insert your name for freeform pose"
-              aria-label="Insert your character name"
-              onClick={() => setCustomEmote((prev) => prev + playerName + " ")}
-            >
-              @me
-            </button>
             <button type="submit" className="social-action-btn" disabled={!customEmote.trim()}>Emote</button>
           </form>
         </div>
       )}
 
-      <form
-        className={`chatboard-compose${isTargetedChannel ? " is-targeted" : ""}`}
-        onSubmit={submitMessage}
-      >
+      {/* ── Composer (over the painted parchment + buttons) ───── */}
+      <form className="cb-compose" onSubmit={submitMessage}>
         {isTargetedChannel && (
           <input
-            className="chatboard-target"
+            className="cb-input cb-target"
+            style={rectStyle(targetRect)}
             type="text"
             value={tellTarget}
             onChange={(event) => onTellTargetChange(event.target.value)}
@@ -206,7 +237,8 @@ export function ChatBoardPanel({
         )}
         <input
           ref={messageInputRef}
-          className="chatboard-input"
+          className="cb-input"
+          style={rectStyle(messageRect)}
           type="text"
           value={draft}
           onChange={(event) => setDraftByChannel((prev) => ({ ...prev, [activeChannel]: event.target.value }))}
@@ -218,29 +250,32 @@ export function ChatBoardPanel({
         />
         <button
           type="button"
-          className={`chatboard-emote-btn${emotePickerOpen ? " is-active" : ""}`}
+          className={`cb-hotspot cb-emote${emotePickerOpen ? " is-active" : ""}`}
+          style={rectStyle(EMOTE_RECT)}
           title="Emotes"
           aria-label="Toggle emote picker"
           aria-expanded={emotePickerOpen}
           onClick={() => setEmotePickerOpen((v) => !v)}
           disabled={!canChat}
-        >
-          &#9786;
-        </button>
+        />
         <button
           type="button"
-          className="chatboard-clear-btn"
+          className="cb-hotspot cb-clear"
+          style={rectStyle(CLEAR_RECT)}
           title="Clear message"
           aria-label="Clear message"
           onClick={() => setDraftByChannel((prev) => ({ ...prev, [activeChannel]: "" }))}
           disabled={!draft}
-        >
-          Clear
-        </button>
-        <button type="submit" className="chatboard-send-btn" disabled={!canChat}>
-          Send<span className="chatboard-send-btn-line">Message</span>
-        </button>
+        />
+        <button
+          type="submit"
+          className="cb-hotspot cb-send"
+          style={rectStyle(SEND_RECT)}
+          title="Send message"
+          aria-label="Send message"
+          disabled={!canChat}
+        />
       </form>
-    </section>
+    </div>
   );
 }

--- a/web-v3/src/components/panels/ChatBoardPanel.tsx
+++ b/web-v3/src/components/panels/ChatBoardPanel.tsx
@@ -41,6 +41,12 @@ const EMOTE_RECT: Rect = { left: 70.5, top: 80.0, width: 5.2, height: 6.0 };
 const CLEAR_RECT: Rect = { left: 69.8, top: 87.0, width: 6.6, height: 6.8 };
 const SEND_RECT: Rect = { left: 77.0, top: 80.5, width: 16.8, height: 13.5 };
 
+// Global nudge applied to every hotspot — corrects a uniform offset between
+// where the painted frame renders and the hotspot coordinate box. Positive X
+// moves right, negative Y moves up. Tune these two to shift everything at once.
+const OFFSET_X = 2.5;
+const OFFSET_Y = -3.0;
+
 const CHANNEL_ACCENTS: Record<string, string> = {
   say: "var(--chat-accent-say)",
   tell: "var(--chat-accent-tell)",
@@ -50,7 +56,12 @@ const CHANNEL_ACCENTS: Record<string, string> = {
 };
 
 function rectStyle(r: Rect): CSSProperties {
-  return { left: `${r.left}%`, top: `${r.top}%`, width: `${r.width}%`, height: `${r.height}%` };
+  return {
+    left: `${r.left + OFFSET_X}%`,
+    top: `${r.top + OFFSET_Y}%`,
+    width: `${r.width}%`,
+    height: `${r.height}%`,
+  };
 }
 
 function createEmptyDrafts(): Record<ChatChannel, string> {

--- a/web-v3/src/components/panels/ChatBoardPanel.tsx
+++ b/web-v3/src/components/panels/ChatBoardPanel.tsx
@@ -27,18 +27,18 @@ type Rect = { left: number; top: number; width: number; height: number };
  * Tweak these to nudge the lineup against the painted frame.
  */
 const CHANNEL_RECTS: Record<string, Rect> = {
-  say: { left: 17.5, top: 25.5, width: 11.2, height: 7.5 },
-  tell: { left: 30.5, top: 25.5, width: 11.2, height: 7.5 },
-  gossip: { left: 43.5, top: 25.5, width: 11.2, height: 7.5 },
-  shout: { left: 56.5, top: 25.5, width: 11.2, height: 7.5 },
-  ooc: { left: 69.5, top: 25.5, width: 11.2, height: 7.5 },
+  say: { left: 18.3, top: 24.8, width: 11.2, height: 9.0 },
+  tell: { left: 30.1, top: 24.8, width: 11.2, height: 9.0 },
+  gossip: { left: 42.0, top: 24.8, width: 11.2, height: 9.0 },
+  shout: { left: 55.0, top: 24.8, width: 11.2, height: 9.0 },
+  ooc: { left: 68.7, top: 24.8, width: 11.2, height: 9.0 },
 };
 // Measured off social-final.png (1448×1086): chalkboard l15.9 t34.3 w69.3 h44.7;
 // parchment l21.3 t82.0 w46.3 h13.4; send-scroll l~77 w~17.
-const FEED_RECT: Rect = { left: 16.0, top: 34.5, width: 69.0, height: 44.5 };
+const FEED_RECT: Rect = { left: 14.5, top: 34.5, width: 69.0, height: 44.5 };
 const INPUT_RECT: Rect = { left: 20.5, top: 81.8, width: 47.0, height: 13.6 };
-const EMOTE_RECT: Rect = { left: 70.5, top: 80.0, width: 5.2, height: 6.0 };
-const CLEAR_RECT: Rect = { left: 69.8, top: 87.0, width: 6.6, height: 6.8 };
+const EMOTE_RECT: Rect = { left: 69.0, top: 81.5, width: 5.2, height: 6.0 };
+const CLEAR_RECT: Rect = { left: 68.3, top: 88.5, width: 6.6, height: 6.8 };
 const SEND_RECT: Rect = { left: 77.0, top: 80.5, width: 16.8, height: 13.5 };
 
 // Global nudge applied to every hotspot — corrects a uniform offset between

--- a/web-v3/src/components/panels/ChatBoardPanel.tsx
+++ b/web-v3/src/components/panels/ChatBoardPanel.tsx
@@ -1,0 +1,246 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { FormEvent } from "react";
+import { CHAT_CHANNELS } from "../../constants";
+import type { ChatChannel, ChatMessage, EmotePreset } from "../../types";
+
+interface ChatBoardPanelProps {
+  connected: boolean;
+  canChat: boolean;
+  playerName: string;
+  activeChannel: ChatChannel;
+  chatByChannel: Record<ChatChannel, ChatMessage[]>;
+  emotePresets: EmotePreset[];
+  tellTarget: string;
+  onTellTargetChange: (value: string) => void;
+  onChannelChange: (channel: ChatChannel) => void;
+  onSendMessage: (channel: ChatChannel, message: string, target: string | null) => boolean;
+  onCommand: (command: string) => void;
+}
+
+/** Per-channel flavour for the painted plaques: a sub-label and accent colour. */
+const CHANNEL_META: Record<string, { sub: string; accent: string }> = {
+  say: { sub: "Local Room", accent: "var(--chat-accent-say)" },
+  tell: { sub: "Private", accent: "var(--chat-accent-tell)" },
+  gossip: { sub: "Server-Wide", accent: "var(--chat-accent-gossip)" },
+  shout: { sub: "Zone-Wide", accent: "var(--chat-accent-shout)" },
+  ooc: { sub: "Out of Character", accent: "var(--chat-accent-ooc)" },
+};
+
+function createEmptyDrafts(): Record<ChatChannel, string> {
+  return { say: "", tell: "", gossip: "", shout: "", ooc: "", gtell: "", gchat: "" };
+}
+
+/**
+ * Standalone, fully-painted "Social Board" — the chat channels split out of the
+ * larger Social panel. The board frame comes from the `chat_bg` drawer skin;
+ * this component lays the channel rail, the chalkboard feed, and the parchment
+ * composer on top, with carved-CSS fallbacks so it works before the art ships.
+ */
+export function ChatBoardPanel({
+  connected,
+  canChat,
+  playerName,
+  activeChannel,
+  chatByChannel,
+  emotePresets,
+  tellTarget,
+  onTellTargetChange,
+  onChannelChange,
+  onSendMessage,
+  onCommand,
+}: ChatBoardPanelProps) {
+  const feedRef = useRef<HTMLDivElement | null>(null);
+  const messageInputRef = useRef<HTMLInputElement | null>(null);
+  const [draftByChannel, setDraftByChannel] = useState<Record<ChatChannel, string>>(createEmptyDrafts);
+  const [emotePickerOpen, setEmotePickerOpen] = useState(false);
+  const [customEmote, setCustomEmote] = useState("");
+
+  const messages = chatByChannel[activeChannel];
+  const activeMeta = useMemo(
+    () => CHAT_CHANNELS.find((channel) => channel.id === activeChannel) ?? CHAT_CHANNELS[0],
+    [activeChannel],
+  );
+  const draft = draftByChannel[activeChannel];
+  const isTargetedChannel = activeMeta.requiresTarget;
+
+  useEffect(() => {
+    const feed = feedRef.current;
+    if (!feed) return;
+    feed.scrollTop = feed.scrollHeight;
+  }, [activeChannel, messages.length]);
+
+  const submitMessage = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const target = activeMeta.requiresTarget ? tellTarget : null;
+    const sent = onSendMessage(activeChannel, draft, target);
+    if (!sent) return;
+    setDraftByChannel((prev) => ({ ...prev, [activeChannel]: "" }));
+  };
+
+  return (
+    <section className="chatboard" aria-label="Social board">
+      <div className="chatboard-channels" role="tablist" aria-label="Chat channels">
+        {CHAT_CHANNELS.map((channel) => {
+          const meta = CHANNEL_META[channel.id];
+          const isActive = activeChannel === channel.id;
+          return (
+            <button
+              key={channel.id}
+              type="button"
+              role="tab"
+              className={`chatboard-channel${isActive ? " is-active" : ""}`}
+              style={{ ["--chat-accent" as string]: meta?.accent ?? "var(--brass)" }}
+              onClick={() => onChannelChange(channel.id)}
+              aria-selected={isActive}
+            >
+              <span className="chatboard-channel-gem" aria-hidden="true" />
+              <span className="chatboard-channel-label">{channel.label}</span>
+              {meta && <span className="chatboard-channel-sub">{meta.sub}</span>}
+            </button>
+          );
+        })}
+      </div>
+
+      <div
+        ref={feedRef}
+        className="chatboard-feed"
+        role="log"
+        aria-live="polite"
+        aria-label={`${activeMeta.label} messages`}
+      >
+        {messages.length === 0 ? (
+          <p className="chatboard-empty">
+            {canChat
+              ? `No ${activeMeta.label.toLowerCase()} messages yet.`
+              : connected
+                ? "Log in to unlock chat."
+                : "Reconnect to resume chat."}
+          </p>
+        ) : (
+          <ul className="chat-message-list">
+            {messages.map((entry) => {
+              const isSelf = entry.sender.localeCompare(playerName, undefined, { sensitivity: "accent" }) === 0;
+              const time = new Date(entry.receivedAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+              return (
+                <li
+                  key={entry.id}
+                  className={`chat-message-item ${isSelf ? "chat-message-item-self" : ""}${entry.isWhisper ? " chat-message-item-whisper" : ""}`}
+                >
+                  <div className="chat-message-meta">
+                    <span className="chat-message-sender">
+                      {entry.isWhisper && <span className="chat-whisper-tag">whisper</span>}
+                      {isSelf ? "You" : entry.sender}
+                    </span>
+                    <span className="chat-message-time">{time}</span>
+                  </div>
+                  <p className="chat-message-body">{entry.message}</p>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      {emotePickerOpen && canChat && (
+        <div className="emote-picker">
+          <div className="emote-presets">
+            {emotePresets.map((preset) => (
+              <button
+                key={preset.label}
+                type="button"
+                className="emote-preset-btn"
+                title={`${playerName} ${preset.action}`}
+                aria-label={preset.label}
+                onClick={() => { onCommand(`emote ${preset.action}`); }}
+              >
+                <span className="emote-preset-emoji">{preset.emoji}</span>
+                <span className="emote-preset-label">{preset.label}</span>
+              </button>
+            ))}
+          </div>
+          <form className="emote-custom-form" onSubmit={(e) => {
+            e.preventDefault();
+            const msg = customEmote.trim();
+            if (!msg) return;
+            const cmd = msg.toLowerCase().includes(playerName.toLowerCase()) ? "pose" : "emote";
+            onCommand(`${cmd} ${msg}`);
+            setCustomEmote("");
+          }}>
+            <input
+              type="text"
+              className="social-action-input"
+              placeholder={`${playerName} does what…`}
+              value={customEmote}
+              onChange={(e) => setCustomEmote(e.target.value)}
+              aria-label="Custom emote"
+            />
+            <button
+              type="button"
+              className="emote-name-btn"
+              title="Insert your name for freeform pose"
+              aria-label="Insert your character name"
+              onClick={() => setCustomEmote((prev) => prev + playerName + " ")}
+            >
+              @me
+            </button>
+            <button type="submit" className="social-action-btn" disabled={!customEmote.trim()}>Emote</button>
+          </form>
+        </div>
+      )}
+
+      <form
+        className={`chatboard-compose${isTargetedChannel ? " is-targeted" : ""}`}
+        onSubmit={submitMessage}
+      >
+        {isTargetedChannel && (
+          <input
+            className="chatboard-target"
+            type="text"
+            value={tellTarget}
+            onChange={(event) => onTellTargetChange(event.target.value)}
+            placeholder={activeMeta.targetPlaceholder ?? "Target"}
+            aria-label={`${activeMeta.label} target`}
+            autoComplete="off"
+            spellCheck={false}
+          />
+        )}
+        <input
+          ref={messageInputRef}
+          className="chatboard-input"
+          type="text"
+          value={draft}
+          onChange={(event) => setDraftByChannel((prev) => ({ ...prev, [activeChannel]: event.target.value }))}
+          placeholder={canChat ? "Type your message…" : "Chat unavailable"}
+          aria-label={`${activeMeta.label} message`}
+          autoComplete="off"
+          spellCheck={false}
+          disabled={!canChat}
+        />
+        <button
+          type="button"
+          className={`chatboard-emote-btn${emotePickerOpen ? " is-active" : ""}`}
+          title="Emotes"
+          aria-label="Toggle emote picker"
+          aria-expanded={emotePickerOpen}
+          onClick={() => setEmotePickerOpen((v) => !v)}
+          disabled={!canChat}
+        >
+          &#9786;
+        </button>
+        <button
+          type="button"
+          className="chatboard-clear-btn"
+          title="Clear message"
+          aria-label="Clear message"
+          onClick={() => setDraftByChannel((prev) => ({ ...prev, [activeChannel]: "" }))}
+          disabled={!draft}
+        >
+          Clear
+        </button>
+        <button type="submit" className="chatboard-send-btn" disabled={!canChat}>
+          Send<span className="chatboard-send-btn-line">Message</span>
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/web-v3/src/components/panels/ChatBoardPanel.tsx
+++ b/web-v3/src/components/panels/ChatBoardPanel.tsx
@@ -27,18 +27,19 @@ type Rect = { left: number; top: number; width: number; height: number };
  * Tweak these to nudge the lineup against the painted frame.
  */
 const CHANNEL_RECTS: Record<string, Rect> = {
-  say: { left: 18.2, top: 23.0, width: 12.1, height: 7.8 },
-  tell: { left: 31.6, top: 23.0, width: 12.0, height: 7.8 },
-  gossip: { left: 44.7, top: 23.0, width: 12.0, height: 7.8 },
-  shout: { left: 59.5, top: 23.0, width: 12.0, height: 7.8 },
-  ooc: { left: 73.2, top: 23.0, width: 12.0, height: 7.8 },
+  say: { left: 17.5, top: 25.5, width: 11.2, height: 7.5 },
+  tell: { left: 30.5, top: 25.5, width: 11.2, height: 7.5 },
+  gossip: { left: 43.5, top: 25.5, width: 11.2, height: 7.5 },
+  shout: { left: 56.5, top: 25.5, width: 11.2, height: 7.5 },
+  ooc: { left: 69.5, top: 25.5, width: 11.2, height: 7.5 },
 };
-const FEED_RECT: Rect = { left: 15.5, top: 33.0, width: 69.1, height: 46.0 };
-// Parchment interior measured from the base art: l19.7 t84.2 r66.0 b97.1.
-const INPUT_RECT: Rect = { left: 19.3, top: 84.0, width: 46.7, height: 13.0 };
-const EMOTE_RECT: Rect = { left: 72.0, top: 80.2, width: 4.8, height: 6.8 };
-const CLEAR_RECT: Rect = { left: 71.5, top: 87.6, width: 6.6, height: 7.6 };
-const SEND_RECT: Rect = { left: 78.3, top: 81.7, width: 17.0, height: 12.0 };
+// Measured off social-final.png (1448×1086): chalkboard l15.9 t34.3 w69.3 h44.7;
+// parchment l21.3 t82.0 w46.3 h13.4; send-scroll l~77 w~17.
+const FEED_RECT: Rect = { left: 16.0, top: 34.5, width: 69.0, height: 44.5 };
+const INPUT_RECT: Rect = { left: 20.5, top: 81.8, width: 47.0, height: 13.6 };
+const EMOTE_RECT: Rect = { left: 70.5, top: 80.0, width: 5.2, height: 6.0 };
+const CLEAR_RECT: Rect = { left: 69.8, top: 87.0, width: 6.6, height: 6.8 };
+const SEND_RECT: Rect = { left: 77.0, top: 80.5, width: 16.8, height: 13.5 };
 
 const CHANNEL_ACCENTS: Record<string, string> = {
   say: "var(--chat-accent-say)",

--- a/web-v3/src/components/panels/ChatBoardPanel.tsx
+++ b/web-v3/src/components/panels/ChatBoardPanel.tsx
@@ -27,17 +27,18 @@ type Rect = { left: number; top: number; width: number; height: number };
  * Tweak these to nudge the lineup against the painted frame.
  */
 const CHANNEL_RECTS: Record<string, Rect> = {
-  say: { left: 17.8, top: 23.0, width: 12.1, height: 7.8 },
-  tell: { left: 31.0, top: 23.0, width: 12.0, height: 7.8 },
-  gossip: { left: 44.1, top: 23.0, width: 12.0, height: 7.8 },
-  shout: { left: 57.2, top: 23.0, width: 12.0, height: 7.8 },
-  ooc: { left: 70.4, top: 23.0, width: 12.0, height: 7.8 },
+  say: { left: 18.2, top: 23.0, width: 12.1, height: 7.8 },
+  tell: { left: 31.6, top: 23.0, width: 12.0, height: 7.8 },
+  gossip: { left: 44.7, top: 23.0, width: 12.0, height: 7.8 },
+  shout: { left: 59.5, top: 23.0, width: 12.0, height: 7.8 },
+  ooc: { left: 73.2, top: 23.0, width: 12.0, height: 7.8 },
 };
 const FEED_RECT: Rect = { left: 15.5, top: 33.0, width: 69.1, height: 46.0 };
-const INPUT_RECT: Rect = { left: 17.1, top: 81.7, width: 53.2, height: 11.2 };
-const EMOTE_RECT: Rect = { left: 72.0, top: 80.8, width: 4.6, height: 6.0 };
-const CLEAR_RECT: Rect = { left: 71.5, top: 87.6, width: 6.6, height: 6.0 };
-const SEND_RECT: Rect = { left: 80.0, top: 81.7, width: 13.4, height: 12.0 };
+// Parchment interior measured from the base art: l19.7 t84.2 r66.0 b97.1.
+const INPUT_RECT: Rect = { left: 19.3, top: 84.0, width: 46.7, height: 13.0 };
+const EMOTE_RECT: Rect = { left: 72.0, top: 80.2, width: 4.8, height: 6.8 };
+const CLEAR_RECT: Rect = { left: 71.5, top: 87.6, width: 6.6, height: 7.6 };
+const SEND_RECT: Rect = { left: 78.3, top: 81.7, width: 17.0, height: 12.0 };
 
 const CHANNEL_ACCENTS: Record<string, string> = {
   say: "var(--chat-accent-say)",

--- a/web-v3/src/components/panels/ChatPanel.tsx
+++ b/web-v3/src/components/panels/ChatPanel.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { FormEvent } from "react";
-import { CHAT_CHANNELS } from "../../constants";
 import { RefreshIcon, TellIcon } from "../Icons";
-import type { ChatChannel, ChatMessage, EmotePreset, FriendEntry, FriendNotification, GroupInfo, GuildHallInfo, GuildInfo, GuildMemberEntry, PendingGroupInvite, PendingGuildInvite, SocialTab, WhoPlayer } from "../../types";
+import type { ChatChannel, ChatMessage, FriendEntry, FriendNotification, GroupInfo, GuildHallInfo, GuildInfo, GuildMemberEntry, PendingGroupInvite, PendingGuildInvite, SocialTab, WhoPlayer } from "../../types";
 
 type WhoSortField = "name" | "level" | "race" | "class" | "idle";
 type SortDir = "asc" | "desc";
@@ -11,9 +10,7 @@ interface ChatPanelProps {
   connected: boolean;
   canChat: boolean;
   playerName: string;
-  activeChannel: ChatChannel;
   chatByChannel: Record<ChatChannel, ChatMessage[]>;
-  emotePresets: EmotePreset[];
   whoPlayers: WhoPlayer[];
   groupInfo: GroupInfo;
   pendingGroupInvite: PendingGroupInvite | null;
@@ -23,28 +20,10 @@ interface ChatPanelProps {
   guildHall: GuildHallInfo | null;
   friends: FriendEntry[];
   friendNotifications: FriendNotification[];
-  onChannelChange: (channel: ChatChannel) => void;
   onRequestWho: () => void;
   onSendMessage: (channel: ChatChannel, message: string, target: string | null) => boolean;
+  onTellPlayer: (target: string) => void;
   onCommand: (command: string) => void;
-}
-
-function createEmptyDrafts(): Record<ChatChannel, string> {
-  return {
-    say: "",
-    tell: "",
-    gossip: "",
-    shout: "",
-    ooc: "",
-    gtell: "",
-    gchat: "",
-  };
-}
-
-function createEmptyTargets(): Record<"tell", string> {
-  return {
-    tell: "",
-  };
 }
 
 function formatIdleTime(seconds: number): string {
@@ -54,7 +33,6 @@ function formatIdleTime(seconds: number): string {
 }
 
 const SOCIAL_TABS: Array<{ id: SocialTab; label: string }> = [
-  { id: "chat", label: "Chat" },
   { id: "friends", label: "Friends" },
   { id: "guild", label: "Guild" },
   { id: "group", label: "Group" },
@@ -65,9 +43,7 @@ export function ChatPanel({
   connected,
   canChat,
   playerName,
-  activeChannel,
   chatByChannel,
-  emotePresets,
   whoPlayers,
   groupInfo,
   pendingGroupInvite,
@@ -77,20 +53,17 @@ export function ChatPanel({
   guildHall,
   friends,
   friendNotifications,
-  onChannelChange,
   onRequestWho,
   onSendMessage,
+  onTellPlayer,
   onCommand,
 }: ChatPanelProps) {
   const feedRef = useRef<HTMLDivElement | null>(null);
   const guildFeedRef = useRef<HTMLDivElement | null>(null);
   const groupFeedRef = useRef<HTMLDivElement | null>(null);
-  const messageInputRef = useRef<HTMLInputElement | null>(null);
-  const [draftByChannel, setDraftByChannel] = useState<Record<ChatChannel, string>>(createEmptyDrafts);
-  const [targets, setTargets] = useState<Record<"tell", string>>(createEmptyTargets);
   const [guildDraft, setGuildDraft] = useState("");
   const [groupDraft, setGroupDraft] = useState("");
-  const [activeSocialTab, setActiveSocialTab] = useState<SocialTab>("chat");
+  const [activeSocialTab, setActiveSocialTab] = useState<SocialTab>("friends");
   const [whoFilter, setWhoFilter] = useState("");
   const [whoSort, setWhoSort] = useState<WhoSortField>("name");
   const [whoSortDir, setWhoSortDir] = useState<SortDir>("asc");
@@ -105,12 +78,8 @@ export function ChatPanel({
   const [groupInviteTarget, setGroupInviteTarget] = useState("");
   // Friends action state
   const [friendAddTarget, setFriendAddTarget] = useState("");
-  // Emote picker state
-  const [emotePickerOpen, setEmotePickerOpen] = useState(false);
-  const [customEmote, setCustomEmote] = useState("");
   const [friendConfirmRemove, setFriendConfirmRemove] = useState<string | null>(null);
 
-  const messages = chatByChannel[activeChannel];
   const gchatMessages = chatByChannel.gchat;
   const gtellMessages = chatByChannel.gtell;
 
@@ -148,7 +117,7 @@ export function ChatPanel({
     const feed = feedRef.current;
     if (!feed) return;
     feed.scrollTop = feed.scrollHeight;
-  }, [activeSocialTab, activeChannel, messages.length, whoPlayers.length]);
+  }, [activeSocialTab, whoPlayers.length]);
 
   useEffect(() => {
     const feed = guildFeedRef.current;
@@ -162,32 +131,13 @@ export function ChatPanel({
     feed.scrollTop = feed.scrollHeight;
   }, [activeSocialTab, gtellMessages.length]);
 
-  const activeMeta = useMemo(
-    () => CHAT_CHANNELS.find((channel) => channel.id === activeChannel) ?? CHAT_CHANNELS[0],
-    [activeChannel],
-  );
-  const draft = draftByChannel[activeChannel];
-  const isTargetedChannel = activeMeta.requiresTarget;
-  const targetValue = activeChannel === "tell" ? targets.tell : "";
-
-  const submitMessage = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const target = activeMeta.requiresTarget ? targetValue : null;
-    const sent = onSendMessage(activeChannel, draft, target);
-    if (!sent) return;
-    setDraftByChannel((prev) => ({ ...prev, [activeChannel]: "" }));
-  };
-
   const handleSocialTabChange = (tab: SocialTab) => {
     setActiveSocialTab(tab);
     if (tab === "who" && canChat) onRequestWho();
   };
 
   const handleTellFromWho = (target: string) => {
-    setTargets((prev) => ({ ...prev, tell: target }));
-    setActiveSocialTab("chat");
-    onChannelChange("tell");
-    window.requestAnimationFrame(() => messageInputRef.current?.focus());
+    onTellPlayer(target);
   };
 
   const inGroup = groupInfo.members.length > 0;
@@ -251,154 +201,6 @@ export function ChatPanel({
       </div>
 
       <div className="chat-shell">
-        {activeSocialTab === "chat" && (
-          <>
-            <div className="chat-channel-tabs" role="tablist" aria-label="Chat channels">
-              {CHAT_CHANNELS.map((channel) => (
-                <button
-                  key={channel.id}
-                  type="button"
-                  role="tab"
-                  className={`chat-channel-tab ${activeChannel === channel.id ? "chat-channel-tab-active" : ""}`}
-                  onClick={() => onChannelChange(channel.id)}
-                  aria-selected={activeChannel === channel.id}
-                >
-                  {channel.label}
-                </button>
-              ))}
-            </div>
-
-            <div ref={feedRef} className="chat-feed" role="log" aria-live="polite" aria-label={`${activeMeta.label} messages`}>
-              <section key={activeChannel} className="chat-feed-panel chat-feed-panel-flip" aria-label={`${activeMeta.label} subwindow`}>
-                {messages.length === 0 ? (
-                  <p className="empty-note">
-                    {canChat
-                      ? `No ${activeMeta.label.toLowerCase()} messages yet.`
-                      : connected
-                        ? "Log in to unlock chat."
-                        : "Reconnect to resume chat."}
-                  </p>
-                ) : (
-                  <ul className="chat-message-list">
-                    {messages.map((entry) => {
-                      const isSelf = entry.sender.localeCompare(playerName, undefined, { sensitivity: "accent" }) === 0;
-                      const time = new Date(entry.receivedAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-                      return (
-                        <li
-                          key={entry.id}
-                          className={`chat-message-item ${isSelf ? "chat-message-item-self" : ""}${entry.isWhisper ? " chat-message-item-whisper" : ""}`}
-                        >
-                          <div className="chat-message-meta">
-                            <span className="chat-message-sender">
-                              {entry.isWhisper && <span className="chat-whisper-tag">whisper</span>}
-                              {isSelf ? "You" : entry.sender}
-                            </span>
-                            <span className="chat-message-time">{time}</span>
-                          </div>
-                          <p className="chat-message-body">{entry.message}</p>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                )}
-              </section>
-            </div>
-
-            {emotePickerOpen && canChat && (
-              <div className="emote-picker">
-                <div className="emote-presets">
-                  {emotePresets.map((preset) => (
-                    <button
-                      key={preset.label}
-                      type="button"
-                      className="emote-preset-btn"
-                      title={`${playerName} ${preset.action}`}
-                      aria-label={preset.label}
-                      onClick={() => { onCommand(`emote ${preset.action}`); }}
-                    >
-                      <span className="emote-preset-emoji">{preset.emoji}</span>
-                      <span className="emote-preset-label">{preset.label}</span>
-                    </button>
-                  ))}
-                </div>
-                <form className="emote-custom-form" onSubmit={(e) => {
-                  e.preventDefault();
-                  const msg = customEmote.trim();
-                  if (!msg) return;
-                  // If text contains the player's name, send as pose (freeform); otherwise emote (third-person)
-                  const cmd = msg.toLowerCase().includes(playerName.toLowerCase()) ? "pose" : "emote";
-                  onCommand(`${cmd} ${msg}`);
-                  setCustomEmote("");
-                }}>
-                  <input
-                    type="text"
-                    className="social-action-input"
-                    placeholder={`${playerName} does what\u2026`}
-                    value={customEmote}
-                    onChange={(e) => setCustomEmote(e.target.value)}
-                    aria-label="Custom emote"
-                  />
-                  <button
-                    type="button"
-                    className="emote-name-btn"
-                    title="Insert your name for freeform pose"
-                    aria-label="Insert your character name"
-                    onClick={() => setCustomEmote((prev) => prev + playerName + " ")}
-                  >
-                    @me
-                  </button>
-                  <button type="submit" className="social-action-btn" disabled={!customEmote.trim()}>Emote</button>
-                </form>
-              </div>
-            )}
-
-            <form
-              className={`chat-form ${isTargetedChannel ? "chat-form-targeted" : ""}`}
-              onSubmit={submitMessage}
-            >
-              {isTargetedChannel && (
-                <input
-                  className="chat-target-input"
-                  type="text"
-                  value={targetValue}
-                  onChange={(event) => {
-                    const next = event.target.value;
-                    if (activeChannel !== "tell") return;
-                    setTargets((prev) => ({ ...prev, tell: next }));
-                  }}
-                  placeholder={activeMeta.targetPlaceholder ?? "Target"}
-                  aria-label={`${activeMeta.label} target`}
-                  autoComplete="off"
-                  spellCheck={false}
-                />
-              )}
-              <input
-                ref={messageInputRef}
-                className="chat-input"
-                type="text"
-                value={draft}
-                onChange={(event) => setDraftByChannel((prev) => ({ ...prev, [activeChannel]: event.target.value }))}
-                placeholder={canChat ? activeMeta.messagePlaceholder : "Chat unavailable"}
-                aria-label={`${activeMeta.label} message`}
-                autoComplete="off"
-                spellCheck={false}
-                disabled={!canChat}
-              />
-              <button type="submit" className="soft-button" disabled={!canChat}>Send</button>
-              <button
-                type="button"
-                className={`emote-toggle-btn${emotePickerOpen ? " emote-toggle-btn-active" : ""}`}
-                title="Emotes"
-                aria-label="Toggle emote picker"
-                aria-expanded={emotePickerOpen}
-                onClick={() => setEmotePickerOpen((v) => !v)}
-                disabled={!canChat}
-              >
-                &#9786;
-              </button>
-            </form>
-          </>
-        )}
 
         {activeSocialTab === "friends" && (
           <>

--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -255,6 +255,9 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
   const [friendNotifications, setFriendNotifications] = useState<FriendNotification[]>([]);
   const [chatByChannel, setChatByChannel] = useState<Record<ChatChannel, ChatMessage[]>>(createEmptyChatByChannel);
   const [activeChatChannel, setActiveChatChannel] = useState<ChatChannel>("say");
+  // The "tell" target, lifted to app state so the Who/Friends "Tell" buttons can
+  // prefill it when they open the standalone chat board.
+  const [tellTarget, setTellTarget] = useState("");
   const [whoPlayers, setWhoPlayers] = useState<WhoPlayer[]>([]);
   const [tradeState, setTradeState] = useState<TradeState | null>(null);
 
@@ -698,6 +701,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     setFriendNotifications([]);
     setChatByChannel(createEmptyChatByChannel());
     setActiveChatChannel("say");
+    setTellTarget("");
     setDialogue(null);
     setWhoPlayers([]);
     setZoneInstances({ zone: null, currentEngineId: null, instances: [] });
@@ -784,7 +788,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     achievements, charStats, prestigeInfo,
     // Social
     groupInfo, pendingGroupInvite, guildInfo, pendingGuildInvite, guildMembers, guildHall,
-    friends, friendNotifications, chatByChannel, activeChatChannel, setActiveChatChannel,
+    friends, friendNotifications, chatByChannel, activeChatChannel, setActiveChatChannel, tellTarget, setTellTarget,
     whoPlayers, tradeState,
     // Quests
     quests, questsAvailable, questNotifications, setQuestNotifications,

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -23300,36 +23300,58 @@ html:has(.game-shell),
 }
 
 /* ════════════════════════════════════════════════════════════
-   Social Board — standalone painted chat panel (drawerPanel "chatboard")
-   The frame comes from the `chat_bg` skin; the channel rail, chalkboard
-   feed, and parchment composer are laid on top with carved-CSS fallbacks
-   so the panel works before any art ships.
+   Social Board — standalone painted chat (drawerPanel "chatboard")
+   The whole frame — banner, channel plaques, side notes, parchment input,
+   Send/Clear buttons, footer — is painted into the `chat_bg` art. The board
+   is an aspect-locked canvas carrying that image; transparent hotspots and
+   the live feed/input are pixel-mapped on top (see *_RECT in the panel).
    ════════════════════════════════════════════════════════════ */
 .drawer-sheet.drawer-sheet-board {
-  background-image:
-    var(--skin-bg, none),
-    linear-gradient(165deg, rgb(48 34 20 / 98%), rgb(28 20 12 / 98%));
-  background-size: cover, auto;
-  background-position: center, center;
-  background-repeat: no-repeat, no-repeat;
+  background:
+    linear-gradient(165deg, rgb(34 24 14 / 96%), rgb(20 14 8 / 97%));
 }
 
-/* The painted board carries its own banner, so hide the drawer title and
-   shrink the header to just the close button. */
+/* The painted board carries its own banner, so drop the title and the drag
+   handle, and float the close button over the art. */
 .drawer-sheet-board .drawer-title {
   display: none;
 }
 
+.drawer-sheet-board .drawer-handle-zone {
+  display: none;
+}
+
 .drawer-sheet-board .drawer-header {
-  border-bottom: none;
-  padding: 6px 12px 0;
+  position: absolute;
+  top: 4px;
+  left: 6px;
+  z-index: 6;
+  padding: 0;
   min-height: 0;
+  border-bottom: none;
 }
 
 .drawer-sheet-board .drawer-body {
-  padding: clamp(8px, 2vh, 18px) clamp(10px, 3vw, 30px) clamp(12px, 2.5vh, 22px);
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
+/* Desktop: size the sheet to the painted frame's 4:3 ratio so it scales up
+   whole and dominates the viewport. height is pre-clamped against width so
+   the derived width never exceeds 96vw. */
+@media (min-width: 768px) {
+  .drawer-sheet.drawer-sheet-board {
+    width: auto;
+    height: min(94vh, 71vw);
+    max-height: 94vh;
+    aspect-ratio: 1447 / 1087;
+  }
+}
+
+/* The board canvas: the painted frame stretched to a 4:3 box (it is 4:3, so
+   no distortion), with hotspots positioned as percentages of this box. */
 .chatboard {
   --chat-accent-say: #79c46b;
   --chat-accent-tell: #b08be0;
@@ -23337,244 +23359,127 @@ html:has(.game-shell),
   --chat-accent-shout: #e08a46;
   --chat-accent-ooc: #5fb0e0;
   --chat-ink: #f3e7cf;
-  display: flex;
-  flex-direction: column;
-  gap: clamp(8px, 1.6vh, 14px);
-  height: 100%;
-  min-height: 0;
+  position: relative;
+  width: 100%;
+  max-height: 100%;
+  aspect-ratio: 1447 / 1087;
+  margin: auto;
+  background-image: var(--chat-bg, none);
+  background-size: 100% 100%;
+  background-position: center;
+  background-repeat: no-repeat;
 }
 
-/* ── Channel rail ─────────────────────────────────────────── */
-.chatboard-channels {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: clamp(5px, 1vw, 10px);
-}
-
-.chatboard-channel {
-  flex: 1 1 0;
-  min-width: 84px;
-  max-width: 150px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2px;
-  padding: clamp(6px, 1vh, 10px) 8px;
-  border-radius: 12px;
-  border: 1px solid rgb(201 162 74 / 30%);
-  background: linear-gradient(160deg, rgb(48 37 22 / 92%), rgb(30 23 14 / 94%));
-  box-shadow: inset 0 1px 0 rgb(230 205 146 / 12%), 0 2px 6px rgb(0 0 0 / 40%);
-  color: var(--chat-ink);
+/* Shared transparent hotspot — the painted control shows through. */
+.cb-hotspot {
+  position: absolute;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  border-radius: 10px;
   cursor: pointer;
-  transition: transform 150ms var(--ease-out-soft), border-color 150ms var(--ease-out-soft), box-shadow 150ms var(--ease-out-soft);
+  transition: box-shadow 150ms var(--ease-out-soft), background 150ms var(--ease-out-soft);
 }
 
-.chatboard-channel:hover {
-  transform: translateY(-1px);
-  border-color: rgb(230 205 146 / 50%);
+.cb-hotspot:hover:not(:disabled) {
+  background: rgb(255 255 255 / 8%);
 }
 
-.chatboard-channel.is-active {
-  border-color: var(--chat-accent);
-  box-shadow: inset 0 0 0 1px var(--chat-accent), 0 0 12px rgb(201 162 74 / 40%);
+.cb-hotspot:disabled {
+  cursor: default;
 }
 
-.chatboard-channel-gem {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background: radial-gradient(circle at 35% 30%, rgb(255 255 255 / 65%), transparent 60%), var(--chat-accent);
-  box-shadow: 0 0 8px rgb(255 255 255 / 22%);
+.cb-hotspot:focus-visible {
+  outline: 2px solid rgb(230 205 146 / 80%);
+  outline-offset: 1px;
 }
 
-.chatboard-channel-label {
-  font-family: var(--font-display);
-  font-size: clamp(0.82rem, 2.4vw, 0.98rem);
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  color: var(--chat-accent);
+/* Active channel: glow ring in the channel's accent over the painted plaque. */
+.cb-channel.is-active {
+  box-shadow: inset 0 0 0 2px var(--chat-accent), 0 0 14px rgb(201 162 74 / 35%);
+  border-radius: 12px;
 }
 
-.chatboard-channel-sub {
-  font-size: 0.64rem;
-  color: rgb(243 231 207 / 62%);
-  white-space: nowrap;
+.cb-emote.is-active {
+  box-shadow: inset 0 0 0 2px var(--chat-accent-gossip);
 }
 
-/* ── Chalkboard feed ──────────────────────────────────────── */
-.chatboard-feed {
-  flex: 1 1 auto;
-  min-height: 0;
+/* Live message feed over the painted chalkboard. */
+.cb-feed {
+  position: absolute;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  border-radius: 14px;
-  border: 1px solid rgb(201 162 74 / 28%);
-  background: linear-gradient(180deg, rgb(18 16 14 / 88%), rgb(10 9 8 / 90%));
-  box-shadow: inset 0 0 40px rgb(0 0 0 / 70%);
-  padding: clamp(8px, 1.6vh, 14px) clamp(10px, 2vw, 16px);
+  padding: clamp(6px, 1.2vh, 12px) clamp(8px, 1.4vw, 14px);
+  color: var(--chat-ink);
   scrollbar-width: thin;
-  scrollbar-color: rgb(201 162 74 / 55%) transparent;
+  scrollbar-color: rgb(201 162 74 / 50%) transparent;
 }
 
-.chatboard-feed::-webkit-scrollbar {
-  width: 8px;
+.cb-feed::-webkit-scrollbar {
+  width: 7px;
 }
 
-.chatboard-feed::-webkit-scrollbar-thumb {
+.cb-feed::-webkit-scrollbar-thumb {
   border-radius: 999px;
-  background: linear-gradient(180deg, rgb(201 162 74 / 70%), rgb(140 104 52 / 65%));
+  background: linear-gradient(180deg, rgb(201 162 74 / 65%), rgb(140 104 52 / 60%));
 }
 
-.chatboard-feed::-webkit-scrollbar-track {
+.cb-feed::-webkit-scrollbar-track {
   background: transparent;
 }
 
-.chatboard-empty {
+.cb-empty {
   margin: auto;
   text-align: center;
   font-style: italic;
-  color: rgb(243 231 207 / 55%);
-  padding: clamp(20px, 6vh, 60px) 12px;
+  color: rgb(243 231 207 / 50%);
 }
 
-/* ── Composer (parchment) ─────────────────────────────────── */
-.chatboard-compose {
-  display: flex;
-  align-items: stretch;
-  flex-wrap: wrap;
-  gap: clamp(5px, 1vw, 9px);
+/* Composer is a layout-less wrapper; its inputs/buttons are absolutely placed. */
+.cb-compose {
+  display: contents;
 }
 
-.chatboard-target {
-  flex: 0 0 auto;
-  width: clamp(110px, 22%, 180px);
-}
-
-.chatboard-target,
-.chatboard-input {
-  border-radius: 10px;
-  border: 1px solid rgb(201 162 74 / 30%);
-  background: linear-gradient(180deg, rgb(232 215 176 / 95%), rgb(214 193 150 / 95%));
+/* Text inputs over the painted parchment — transparent so the parchment
+   texture shows; dark ink for legibility. */
+.cb-input {
+  position: absolute;
+  border: none;
+  background: transparent;
   color: #2a2113;
-  padding: clamp(8px, 1.4vh, 12px) 12px;
-  font-size: 0.92rem;
+  font-size: clamp(0.78rem, 1.5vw, 1rem);
+  padding: 0 clamp(6px, 1vw, 14px);
+  border-radius: 8px;
 }
 
-.chatboard-input {
-  flex: 1 1 160px;
-  min-width: 0;
-}
-
-.chatboard-target::placeholder,
-.chatboard-input::placeholder {
-  color: rgb(42 33 19 / 55%);
+.cb-input::placeholder {
+  color: rgb(42 33 19 / 50%);
   font-style: italic;
 }
 
-.chatboard-input:focus,
-.chatboard-target:focus {
+.cb-input:focus {
   outline: none;
-  border-color: rgb(201 162 74 / 90%);
-  box-shadow: 0 0 0 2px rgb(201 162 74 / 35%);
+  box-shadow: inset 0 0 0 2px rgb(201 162 74 / 45%);
 }
 
-.chatboard-emote-btn,
-.chatboard-clear-btn {
-  flex: 0 0 auto;
-  border-radius: 10px;
-  border: 1px solid rgb(201 162 74 / 32%);
-  background: linear-gradient(160deg, rgb(60 46 26 / 90%), rgb(40 31 18 / 92%));
-  color: var(--chat-ink);
-  cursor: pointer;
-  padding: 0 clamp(8px, 1.4vw, 12px);
-  font-size: 1rem;
-  transition: border-color 150ms var(--ease-out-soft), transform 150ms var(--ease-out-soft);
+.cb-target {
+  border-right: 1px solid rgb(120 96 52 / 35%);
 }
 
-.chatboard-clear-btn {
-  font-family: var(--font-display);
-  font-size: 0.82rem;
-  letter-spacing: 0.04em;
-}
-
-.chatboard-emote-btn:hover:not(:disabled),
-.chatboard-clear-btn:hover:not(:disabled) {
-  border-color: rgb(230 205 146 / 55%);
-  transform: translateY(-1px);
-}
-
-.chatboard-emote-btn.is-active {
-  border-color: var(--chat-accent-gossip);
-  color: var(--chat-accent-gossip);
-}
-
-.chatboard-emote-btn:disabled,
-.chatboard-clear-btn:disabled {
-  opacity: 0.45;
-  cursor: default;
-}
-
-.chatboard-send-btn {
-  flex: 0 0 auto;
+/* Emote picker floats over the lower feed when toggled. */
+.cb-emote-picker {
+  position: absolute;
+  z-index: 7;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  line-height: 1.05;
-  min-width: clamp(96px, 22%, 150px);
-  padding: clamp(6px, 1vh, 10px) clamp(12px, 2vw, 20px);
-  border-radius: 12px;
-  border: 1px solid rgb(201 162 74 / 45%);
-  background: linear-gradient(165deg, rgb(86 60 120 / 95%), rgb(58 40 86 / 96%));
-  color: #f3e7cf;
-  font-family: var(--font-display);
-  font-size: clamp(0.9rem, 2.4vw, 1.05rem);
-  font-weight: 700;
-  letter-spacing: 0.03em;
-  cursor: pointer;
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 18%), 0 3px 10px rgb(0 0 0 / 45%);
-  transition: transform 150ms var(--ease-out-soft), box-shadow 150ms var(--ease-out-soft);
+  gap: 6px;
+  padding: 8px;
+  overflow-y: auto;
+  border-radius: 10px;
+  border: 1px solid rgb(201 162 74 / 35%);
+  background: linear-gradient(160deg, rgb(40 31 20 / 96%), rgb(26 20 13 / 97%));
+  box-shadow: 0 6px 20px rgb(0 0 0 / 55%);
 }
 
-.chatboard-send-btn-line {
-  font-size: 0.82em;
-}
-
-.chatboard-send-btn:hover:not(:disabled) {
-  transform: translateY(-1px);
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 22%), 0 0 16px rgb(140 110 200 / 50%);
-}
-
-.chatboard-send-btn:disabled {
-  opacity: 0.5;
-  cursor: default;
-}
-
-/* On desktop the drawer is a centered modal that sizes to content (width
-   capped at 720px, height auto). The chat board is meant to dominate the
-   screen, so override both: claim most of the viewport and let the feed
-   stretch. (Mobile already opens tall via the drawer `initialHeight`.) */
-@media (min-width: 768px) {
-  .drawer-sheet.drawer-sheet-board {
-    /* Size to the painted frame's aspect (~4:3) so it scales up whole rather
-       than cropping the banner/composer. Height-led on wide screens, width-
-       clamped on tall ones — either way it dominates the viewport. */
-    width: auto;
-    height: 94vh;
-    max-height: 94vh;
-    max-width: 96vw;
-    aspect-ratio: 4 / 3;
-  }
-
-  .drawer-sheet-board .drawer-body {
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
-  }
-
-  .drawer-sheet-board .chatboard {
-    flex: 1 1 auto;
-  }
-}

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -23551,3 +23551,30 @@ html:has(.game-shell),
   opacity: 0.5;
   cursor: default;
 }
+
+/* On desktop the drawer is a centered modal that sizes to content (width
+   capped at 720px, height auto). The chat board is meant to dominate the
+   screen, so override both: claim most of the viewport and let the feed
+   stretch. (Mobile already opens tall via the drawer `initialHeight`.) */
+@media (min-width: 768px) {
+  .drawer-sheet.drawer-sheet-board {
+    /* Size to the painted frame's aspect (~4:3) so it scales up whole rather
+       than cropping the banner/composer. Height-led on wide screens, width-
+       clamped on tall ones — either way it dominates the viewport. */
+    width: auto;
+    height: 94vh;
+    max-height: 94vh;
+    max-width: 96vw;
+    aspect-ratio: 4 / 3;
+  }
+
+  .drawer-sheet-board .drawer-body {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  .drawer-sheet-board .chatboard {
+    flex: 1 1 auto;
+  }
+}

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -23298,3 +23298,256 @@ html:has(.game-shell),
     transition: none;
   }
 }
+
+/* ════════════════════════════════════════════════════════════
+   Social Board — standalone painted chat panel (drawerPanel "chatboard")
+   The frame comes from the `chat_bg` skin; the channel rail, chalkboard
+   feed, and parchment composer are laid on top with carved-CSS fallbacks
+   so the panel works before any art ships.
+   ════════════════════════════════════════════════════════════ */
+.drawer-sheet.drawer-sheet-board {
+  background-image:
+    var(--skin-bg, none),
+    linear-gradient(165deg, rgb(48 34 20 / 98%), rgb(28 20 12 / 98%));
+  background-size: cover, auto;
+  background-position: center, center;
+  background-repeat: no-repeat, no-repeat;
+}
+
+/* The painted board carries its own banner, so hide the drawer title and
+   shrink the header to just the close button. */
+.drawer-sheet-board .drawer-title {
+  display: none;
+}
+
+.drawer-sheet-board .drawer-header {
+  border-bottom: none;
+  padding: 6px 12px 0;
+  min-height: 0;
+}
+
+.drawer-sheet-board .drawer-body {
+  padding: clamp(8px, 2vh, 18px) clamp(10px, 3vw, 30px) clamp(12px, 2.5vh, 22px);
+}
+
+.chatboard {
+  --chat-accent-say: #79c46b;
+  --chat-accent-tell: #b08be0;
+  --chat-accent-gossip: #e0b24f;
+  --chat-accent-shout: #e08a46;
+  --chat-accent-ooc: #5fb0e0;
+  --chat-ink: #f3e7cf;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(8px, 1.6vh, 14px);
+  height: 100%;
+  min-height: 0;
+}
+
+/* ── Channel rail ─────────────────────────────────────────── */
+.chatboard-channels {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: clamp(5px, 1vw, 10px);
+}
+
+.chatboard-channel {
+  flex: 1 1 0;
+  min-width: 84px;
+  max-width: 150px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: clamp(6px, 1vh, 10px) 8px;
+  border-radius: 12px;
+  border: 1px solid rgb(201 162 74 / 30%);
+  background: linear-gradient(160deg, rgb(48 37 22 / 92%), rgb(30 23 14 / 94%));
+  box-shadow: inset 0 1px 0 rgb(230 205 146 / 12%), 0 2px 6px rgb(0 0 0 / 40%);
+  color: var(--chat-ink);
+  cursor: pointer;
+  transition: transform 150ms var(--ease-out-soft), border-color 150ms var(--ease-out-soft), box-shadow 150ms var(--ease-out-soft);
+}
+
+.chatboard-channel:hover {
+  transform: translateY(-1px);
+  border-color: rgb(230 205 146 / 50%);
+}
+
+.chatboard-channel.is-active {
+  border-color: var(--chat-accent);
+  box-shadow: inset 0 0 0 1px var(--chat-accent), 0 0 12px rgb(201 162 74 / 40%);
+}
+
+.chatboard-channel-gem {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, rgb(255 255 255 / 65%), transparent 60%), var(--chat-accent);
+  box-shadow: 0 0 8px rgb(255 255 255 / 22%);
+}
+
+.chatboard-channel-label {
+  font-family: var(--font-display);
+  font-size: clamp(0.82rem, 2.4vw, 0.98rem);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--chat-accent);
+}
+
+.chatboard-channel-sub {
+  font-size: 0.64rem;
+  color: rgb(243 231 207 / 62%);
+  white-space: nowrap;
+}
+
+/* ── Chalkboard feed ──────────────────────────────────────── */
+.chatboard-feed {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  border-radius: 14px;
+  border: 1px solid rgb(201 162 74 / 28%);
+  background: linear-gradient(180deg, rgb(18 16 14 / 88%), rgb(10 9 8 / 90%));
+  box-shadow: inset 0 0 40px rgb(0 0 0 / 70%);
+  padding: clamp(8px, 1.6vh, 14px) clamp(10px, 2vw, 16px);
+  scrollbar-width: thin;
+  scrollbar-color: rgb(201 162 74 / 55%) transparent;
+}
+
+.chatboard-feed::-webkit-scrollbar {
+  width: 8px;
+}
+
+.chatboard-feed::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgb(201 162 74 / 70%), rgb(140 104 52 / 65%));
+}
+
+.chatboard-feed::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.chatboard-empty {
+  margin: auto;
+  text-align: center;
+  font-style: italic;
+  color: rgb(243 231 207 / 55%);
+  padding: clamp(20px, 6vh, 60px) 12px;
+}
+
+/* ── Composer (parchment) ─────────────────────────────────── */
+.chatboard-compose {
+  display: flex;
+  align-items: stretch;
+  flex-wrap: wrap;
+  gap: clamp(5px, 1vw, 9px);
+}
+
+.chatboard-target {
+  flex: 0 0 auto;
+  width: clamp(110px, 22%, 180px);
+}
+
+.chatboard-target,
+.chatboard-input {
+  border-radius: 10px;
+  border: 1px solid rgb(201 162 74 / 30%);
+  background: linear-gradient(180deg, rgb(232 215 176 / 95%), rgb(214 193 150 / 95%));
+  color: #2a2113;
+  padding: clamp(8px, 1.4vh, 12px) 12px;
+  font-size: 0.92rem;
+}
+
+.chatboard-input {
+  flex: 1 1 160px;
+  min-width: 0;
+}
+
+.chatboard-target::placeholder,
+.chatboard-input::placeholder {
+  color: rgb(42 33 19 / 55%);
+  font-style: italic;
+}
+
+.chatboard-input:focus,
+.chatboard-target:focus {
+  outline: none;
+  border-color: rgb(201 162 74 / 90%);
+  box-shadow: 0 0 0 2px rgb(201 162 74 / 35%);
+}
+
+.chatboard-emote-btn,
+.chatboard-clear-btn {
+  flex: 0 0 auto;
+  border-radius: 10px;
+  border: 1px solid rgb(201 162 74 / 32%);
+  background: linear-gradient(160deg, rgb(60 46 26 / 90%), rgb(40 31 18 / 92%));
+  color: var(--chat-ink);
+  cursor: pointer;
+  padding: 0 clamp(8px, 1.4vw, 12px);
+  font-size: 1rem;
+  transition: border-color 150ms var(--ease-out-soft), transform 150ms var(--ease-out-soft);
+}
+
+.chatboard-clear-btn {
+  font-family: var(--font-display);
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+}
+
+.chatboard-emote-btn:hover:not(:disabled),
+.chatboard-clear-btn:hover:not(:disabled) {
+  border-color: rgb(230 205 146 / 55%);
+  transform: translateY(-1px);
+}
+
+.chatboard-emote-btn.is-active {
+  border-color: var(--chat-accent-gossip);
+  color: var(--chat-accent-gossip);
+}
+
+.chatboard-emote-btn:disabled,
+.chatboard-clear-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.chatboard-send-btn {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  line-height: 1.05;
+  min-width: clamp(96px, 22%, 150px);
+  padding: clamp(6px, 1vh, 10px) clamp(12px, 2vw, 20px);
+  border-radius: 12px;
+  border: 1px solid rgb(201 162 74 / 45%);
+  background: linear-gradient(165deg, rgb(86 60 120 / 95%), rgb(58 40 86 / 96%));
+  color: #f3e7cf;
+  font-family: var(--font-display);
+  font-size: clamp(0.9rem, 2.4vw, 1.05rem);
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 18%), 0 3px 10px rgb(0 0 0 / 45%);
+  transition: transform 150ms var(--ease-out-soft), box-shadow 150ms var(--ease-out-soft);
+}
+
+.chatboard-send-btn-line {
+  font-size: 0.82em;
+}
+
+.chatboard-send-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 22%), 0 0 16px rgb(140 110 200 / 50%);
+}
+
+.chatboard-send-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -1,4 +1,4 @@
-export type PopoutPanel = "map" | "inventory" | "equipment" | "room" | "help" | "character" | "chat" | "shop" | "spellbook" | "quests" | "questOffers" | "mail" | "crafting" | "housing" | "leaderboard" | "trainer" | "bank" | "stylist" | "auction" | "dungeon" | "lottery" | "dice" | "puzzle" | "features" | "combatlog" | "inn" | "terminal" | null;
+export type PopoutPanel = "map" | "inventory" | "equipment" | "room" | "help" | "character" | "chat" | "chatboard" | "shop" | "spellbook" | "quests" | "questOffers" | "mail" | "crafting" | "housing" | "leaderboard" | "trainer" | "bank" | "stylist" | "auction" | "dungeon" | "lottery" | "dice" | "puzzle" | "features" | "combatlog" | "inn" | "terminal" | null;
 export type SystemPanelView = "dungeon" | "duel" | "lottery" | "pet" | "prestige" | "currencies" | "factions";
 export type ChatChannel = "say" | "tell" | "gossip" | "shout" | "ooc" | "gtell" | "gchat";
 export type SocialTab = "chat" | "friends" | "guild" | "group" | "who";


### PR DESCRIPTION
First step of breaking up the giant Social panel: **chat moves out into its own fully-painted board**, opened from a dedicated **Chat** widget in the (now-collapsible) services stack.

## What's here
- **New `ChatBoardPanel`** — just the channels (Say/Tell/Gossip/Shout/Ooc): a rail of carved plaques (accent gem + label + sub-label like "Local Room"/"Private"), a dark *chalkboard* feed, and a parchment composer (message + emote + Clear + Send). All carved-CSS fallbacks so it works before art lands.
- **New `board` drawer skin** driven by `chat_bg`, following the cabinet/vault pattern (cover background + gradient fallback, hidden drawer title since the painted board carries its own banner).
- **Opens big** — near-full height (94vh) via a new `Drawer initialHeight` prop, since players tend to swap between game and chat rather than use both at once.
- **Social panel loses its Chat tab** (now Friends/Guild/Group/Who). Its **Tell** buttons open the board with the target prefilled, via a new app-level `tellTarget` state.

## Art contract (minimal, per request)
| key | drives | fallback |
|---|---|---|
| `chat_bg` | the whole painted board frame (drawer skin) | carved-wood gradient |
| `chat_widget` | the services-stack launcher icon | quill glyph (✎) |

Everything else (channel plaques, chalkboard feed, parchment input, send scroll, emote/clear buttons) is CSS-painted and needs no art.

## Verification
- `bun run lint` ✓, `npx tsc -b` ✓, `bun run build` ✓
- `./gradlew compileKotlin ktlintCheck` ✓

Known next step (your call-out): the DOM control **lineup** vs. the painted frame — the rail/feed/input want to sit in the art's slots. Sizing first, then alignment.