### PR TITLE
feat(web): split Guild into a fae-botanical archive board

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -3087,6 +3087,7 @@ data class ImagesConfig(
             "who_bg" to "global_assets/who_bg.png",
             "who_examine_btn" to "global_assets/who_examine_btn.png",
             "who_tell_btn" to "global_assets/who_tell_btn.png",
+            "guild_bg" to "global_assets/guild_bg.png",
             "dialog_indicator" to "global_assets/dialog_indicator.png",
             "aggro_indicator" to "global_assets/aggro_indicator.png",
             "quest_available_indicator" to "global_assets/quest_available_indicator.png",

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -12,6 +12,7 @@ import { featureArt, pickFocusedFeature } from "./components/worldFeatures";
 import { ChatPanel } from "./components/panels/ChatPanel";
 import { ChatBoardPanel } from "./components/panels/ChatBoardPanel";
 import { WhoBoardPanel } from "./components/panels/WhoBoardPanel";
+import { GuildBoardPanel } from "./components/panels/GuildBoardPanel";
 import { PlayerExaminePanel } from "./components/panels/PlayerExaminePanel";
 import { CharacterPanel } from "./components/panels/CharacterPanel";
 import { SpellbookPanel } from "./components/SpellbookPanel";
@@ -854,6 +855,7 @@ function App() {
       case "chat": return "Social";
       case "chatboard": return "Social Board";
       case "whoboard": return "Who";
+      case "guildboard": return "Guild";
       case "shop": return state.shop?.name ?? "Shop";
       case "puzzle": return "Puzzle";
       case "features": return featurePanelFeature
@@ -939,6 +941,8 @@ function App() {
             ? "board"
             : drawerPanel === "whoboard"
             ? "starframe"
+            : drawerPanel === "guildboard"
+            ? "archive"
             : drawerPanel === "character"
             ? "cabinet"
             : drawerPanel === "bank"
@@ -971,6 +975,8 @@ function App() {
                 ?? state.serverAssets["puzzle_bg"])
             : drawerPanel === "whoboard"
             ? state.serverAssets["who_bg"]
+            : drawerPanel === "guildboard"
+            ? state.serverAssets["guild_bg"]
             : drawerPanel === "character"
             ? state.serverAssets["character_bg"]
             : drawerPanel === "bank"
@@ -999,7 +1005,7 @@ function App() {
                             ? state.serverAssets["mail_bg"]
                             : undefined
         }
-        initialHeight={drawerPanel === "chatboard" || drawerPanel === "whoboard" ? 0.94 : undefined}
+        initialHeight={drawerPanel === "chatboard" || drawerPanel === "whoboard" || drawerPanel === "guildboard" ? 0.94 : undefined}
       >
         {drawerPanel === "character" && (
           <CharacterPanel
@@ -1122,6 +1128,21 @@ function App() {
           />
         )}
 
+        {drawerPanel === "guildboard" && (
+          <GuildBoardPanel
+            connected={connected}
+            canChat={connected && hasCharacterProfile}
+            playerName={state.character.name}
+            guildInfo={state.guildInfo}
+            pendingGuildInvite={state.pendingGuildInvite}
+            guildMembers={state.guildMembers}
+            guildHall={state.guildHall}
+            gchatMessages={state.chatByChannel.gchat}
+            onSendMessage={sendChatMessage}
+            onCommand={sendCommand}
+          />
+        )}
+
         {drawerPanel === "chat" && (
           <ChatPanel
             connected={connected}
@@ -1130,10 +1151,6 @@ function App() {
             chatByChannel={state.chatByChannel}
             groupInfo={state.groupInfo}
             pendingGroupInvite={state.pendingGroupInvite}
-            guildInfo={state.guildInfo}
-            pendingGuildInvite={state.pendingGuildInvite}
-            guildMembers={state.guildMembers}
-            guildHall={state.guildHall}
             friends={state.friends}
             friendNotifications={state.friendNotifications}
             onSendMessage={sendChatMessage}

--- a/web-v3/src/components/Drawer.tsx
+++ b/web-v3/src/components/Drawer.tsx
@@ -9,7 +9,7 @@ interface DrawerProps {
   /** Visual skin for the sheet chrome: warm leather (satchel), a dim
    *  dressing-chamber (equipment), a merchant cart (shop), a chalkboard
    *  (trainer), a parchment journal (combat log), or a cork quest board. */
-  variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "desk" | "mail" | "feature" | "tome" | "vault" | "cabinet" | "board" | "starframe";
+  variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "desk" | "mail" | "feature" | "tome" | "vault" | "cabinet" | "board" | "starframe" | "archive";
   /** Optional background art for a skinned variant (server asset). */
   skinBg?: string;
   /** Height (as a fraction of the viewport) the drawer snaps to when it opens. */

--- a/web-v3/src/components/GameShell.tsx
+++ b/web-v3/src/components/GameShell.tsx
@@ -267,6 +267,17 @@ export function GameShell({
                 <button
                   type="button"
                   className="hud-stack-btn"
+                  onClick={() => openServicePanel("guildboard")}
+                  title="Guild"
+                  aria-label="Guild"
+                >
+                  {serverAssets["guild_widget"]
+                    ? <img className="hud-stack-img" src={serverAssets["guild_widget"]} alt="" />
+                    : <span className="hud-stack-glyph">&#9884;</span>}
+                </button>
+                <button
+                  type="button"
+                  className="hud-stack-btn"
                   onClick={() => openServicePanel("chat")}
                   title="Social"
                   aria-label="Social"

--- a/web-v3/src/components/panels/ChatPanel.tsx
+++ b/web-v3/src/components/panels/ChatPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { FormEvent } from "react";
 import { TellIcon } from "../Icons";
-import type { ChatChannel, ChatMessage, FriendEntry, FriendNotification, GroupInfo, GuildHallInfo, GuildInfo, GuildMemberEntry, PendingGroupInvite, PendingGuildInvite, SocialTab } from "../../types";
+import type { ChatChannel, ChatMessage, FriendEntry, FriendNotification, GroupInfo, PendingGroupInvite, SocialTab } from "../../types";
 
 interface ChatPanelProps {
   connected: boolean;
@@ -10,10 +10,6 @@ interface ChatPanelProps {
   chatByChannel: Record<ChatChannel, ChatMessage[]>;
   groupInfo: GroupInfo;
   pendingGroupInvite: PendingGroupInvite | null;
-  guildInfo: GuildInfo;
-  pendingGuildInvite: PendingGuildInvite | null;
-  guildMembers: GuildMemberEntry[];
-  guildHall: GuildHallInfo | null;
   friends: FriendEntry[];
   friendNotifications: FriendNotification[];
   onSendMessage: (channel: ChatChannel, message: string, target: string | null) => boolean;
@@ -23,7 +19,6 @@ interface ChatPanelProps {
 
 const SOCIAL_TABS: Array<{ id: SocialTab; label: string }> = [
   { id: "friends", label: "Friends" },
-  { id: "guild", label: "Guild" },
   { id: "group", label: "Group" },
 ];
 
@@ -34,10 +29,6 @@ export function ChatPanel({
   chatByChannel,
   groupInfo,
   pendingGroupInvite,
-  guildInfo,
-  pendingGuildInvite,
-  guildMembers,
-  guildHall,
   friends,
   friendNotifications,
   onSendMessage,
@@ -45,25 +36,15 @@ export function ChatPanel({
   onCommand,
 }: ChatPanelProps) {
   const feedRef = useRef<HTMLDivElement | null>(null);
-  const guildFeedRef = useRef<HTMLDivElement | null>(null);
   const groupFeedRef = useRef<HTMLDivElement | null>(null);
-  const [guildDraft, setGuildDraft] = useState("");
   const [groupDraft, setGroupDraft] = useState("");
   const [activeSocialTab, setActiveSocialTab] = useState<SocialTab>("friends");
-  // Guild action state
-  const [guildCreateName, setGuildCreateName] = useState("");
-  const [guildCreateTag, setGuildCreateTag] = useState("");
-  const [guildInviteTarget, setGuildInviteTarget] = useState("");
-  const [guildMotdDraft, setGuildMotdDraft] = useState("");
-  const [guildEditingMotd, setGuildEditingMotd] = useState(false);
-  const [guildConfirmAction, setGuildConfirmAction] = useState<"leave" | "disband" | null>(null);
   // Group action state
   const [groupInviteTarget, setGroupInviteTarget] = useState("");
   // Friends action state
   const [friendAddTarget, setFriendAddTarget] = useState("");
   const [friendConfirmRemove, setFriendConfirmRemove] = useState<string | null>(null);
 
-  const gchatMessages = chatByChannel.gchat;
   const gtellMessages = chatByChannel.gtell;
 
   useEffect(() => {
@@ -71,12 +52,6 @@ export function ChatPanel({
     if (!feed) return;
     feed.scrollTop = feed.scrollHeight;
   }, [activeSocialTab]);
-
-  useEffect(() => {
-    const feed = guildFeedRef.current;
-    if (!feed) return;
-    feed.scrollTop = feed.scrollHeight;
-  }, [activeSocialTab, gchatMessages.length]);
 
   useEffect(() => {
     const feed = groupFeedRef.current;
@@ -93,26 +68,6 @@ export function ChatPanel({
   };
 
   const inGroup = groupInfo.members.length > 0;
-  const inGuild = guildInfo.name !== null;
-
-  const rankLabel = (rank: string) => {
-    switch (rank) {
-      case "LEADER": return "Leader";
-      case "OFFICER": return "Officer";
-      default: return "Member";
-    }
-  };
-
-  const sortedGuildMembers = useMemo(() => {
-    const rankOrder: Record<string, number> = { LEADER: 0, OFFICER: 1, MEMBER: 2 };
-    return [...guildMembers].sort((a, b) => {
-      const onlineDiff = (a.online ? 0 : 1) - (b.online ? 0 : 1);
-      if (onlineDiff !== 0) return onlineDiff;
-      const rankDiff = (rankOrder[a.rank] ?? 2) - (rankOrder[b.rank] ?? 2);
-      if (rankDiff !== 0) return rankDiff;
-      return a.name.localeCompare(b.name);
-    });
-  }, [guildMembers]);
 
   const sortedFriends = useMemo(() => {
     return [...friends].sort((a, b) => {
@@ -239,220 +194,6 @@ export function ChatPanel({
             </div>
             <div aria-hidden="true" />
           </>
-        )}
-
-        {activeSocialTab === "guild" && (
-          !canChat ? (
-            <>
-              <div aria-hidden="true" />
-              <div className="chat-feed" role="region" aria-label="Guild info">
-                <section className="chat-feed-panel" aria-label="Guild subwindow">
-                  <p className="empty-note">
-                    {connected ? "Log in to unlock social features." : "Reconnect to load social data."}
-                  </p>
-                </section>
-              </div>
-              <div aria-hidden="true" />
-            </>
-          ) : !inGuild ? (
-            <>
-              <div aria-hidden="true" />
-              <div className="chat-feed" role="region" aria-label="Guild info">
-                <section className="chat-feed-panel" aria-label="Guild subwindow">
-                  <div className="social-empty-action">
-                    <p className="empty-note">You are not in a guild.</p>
-                    {pendingGuildInvite ? (
-                      <div className="invite-card">
-                        <p className="invite-card-text"><strong>{pendingGuildInvite.inviterName}</strong> invites you to join <strong>{pendingGuildInvite.guildName}</strong> [{pendingGuildInvite.guildTag}].</p>
-                        <div className="invite-card-actions">
-                          <button type="button" className="social-action-btn social-accept-btn" onClick={() => { onCommand("guild accept"); }}>Accept</button>
-                          <button type="button" className="social-action-btn social-decline-btn" onClick={() => onCommand("guild decline")}>Decline</button>
-                        </div>
-                      </div>
-                    ) : (
-                      <button type="button" className="social-action-btn social-accept-btn" onClick={() => onCommand("guild accept")}>Accept Invite</button>
-                    )}
-                    <form className="guild-create-form" onSubmit={(e) => { e.preventDefault(); const n = guildCreateName.trim(); const t = guildCreateTag.trim(); if (n && t) { onCommand(`guild create ${n} ${t}`); setGuildCreateName(""); setGuildCreateTag(""); } }}>
-                      <input type="text" className="social-action-input" placeholder="Guild name" value={guildCreateName} onChange={(e) => setGuildCreateName(e.target.value)} aria-label="Guild name" />
-                      <input type="text" className="social-action-input guild-tag-input" placeholder="Tag" value={guildCreateTag} onChange={(e) => setGuildCreateTag(e.target.value)} aria-label="Guild tag" maxLength={5} />
-                      <button type="submit" className="social-action-btn" disabled={!guildCreateName.trim() || !guildCreateTag.trim()}>Create</button>
-                    </form>
-                  </div>
-                </section>
-              </div>
-              <div aria-hidden="true" />
-            </>
-          ) : (
-            <div className="guild-tab-layout">
-              <div className="guild-tab-info">
-                <div className="guild-compact-header">
-                  <span className="guild-name">{guildInfo.name}</span>
-                  {guildInfo.tag && <span className="guild-tag">[{guildInfo.tag}]</span>}
-                  {guildInfo.rank && <span className="guild-compact-rank">{rankLabel(guildInfo.rank)}</span>}
-                </div>
-                <div className="guild-motd">
-                  <span className="guild-motd-label">MOTD</span>
-                  {guildEditingMotd ? (
-                    <form className="guild-motd-edit" onSubmit={(e) => { e.preventDefault(); onCommand(`guild motd ${guildMotdDraft}`); setGuildEditingMotd(false); }}>
-                      <input type="text" className="social-action-input" value={guildMotdDraft} onChange={(e) => setGuildMotdDraft(e.target.value)} aria-label="Guild MOTD" autoFocus />
-                      <button type="submit" className="social-action-btn">Save</button>
-                      <button type="button" className="social-action-btn social-cancel-btn" onClick={() => setGuildEditingMotd(false)}>Cancel</button>
-                    </form>
-                  ) : (
-                    <div className="guild-motd-display">
-                      <p className="guild-motd-text">{guildInfo.motd || "No message set."}</p>
-                      {(guildInfo.rank === "LEADER" || guildInfo.rank === "OFFICER") && (
-                        <button type="button" className="social-edit-btn" onClick={() => { setGuildMotdDraft(guildInfo.motd ?? ""); setGuildEditingMotd(true); }} title="Edit MOTD">&#9998;</button>
-                      )}
-                    </div>
-                  )}
-                </div>
-                <form className="social-action-bar guild-invite-bar" onSubmit={(e) => { e.preventDefault(); const t = guildInviteTarget.trim(); if (t) { onCommand(`guild invite ${t}`); setGuildInviteTarget(""); } }}>
-                  <input type="text" className="social-action-input" placeholder="Invite player\u2026" value={guildInviteTarget} onChange={(e) => setGuildInviteTarget(e.target.value)} aria-label="Player to invite" disabled={!canChat} />
-                  <button type="submit" className="social-action-btn" disabled={!canChat || !guildInviteTarget.trim()}>Invite</button>
-                </form>
-                <div className="guild-roster-header">
-                  Roster ({guildInfo.memberCount} / {guildInfo.maxSize})
-                </div>
-                <div className="guild-roster-scroll">
-                  {sortedGuildMembers.length === 0 ? (
-                    <p className="empty-note">No roster data yet.</p>
-                  ) : (
-                    <ul className="guild-member-list">
-                      {sortedGuildMembers.map((member) => {
-                        const isMe = member.name.localeCompare(playerName, undefined, { sensitivity: "accent" }) === 0;
-                        const canManage = guildInfo.rank === "LEADER" || guildInfo.rank === "OFFICER";
-                        const isLeader = guildInfo.rank === "LEADER";
-                        const showActions = canManage && !isMe && member.rank !== "LEADER";
-                        return (
-                          <li key={member.name} className={`guild-member-item ${member.online ? "" : "guild-member-offline"}`}>
-                            <span className="guild-member-name">{member.name}</span>
-                            <span className="guild-member-details">
-                              <span className={`guild-member-status ${member.online ? "guild-member-status-online" : "guild-member-status-offline"}`} />
-                              <span className="guild-member-rank">{rankLabel(member.rank)}</span>
-                              {member.level !== null && <span className="guild-member-level">Lv {member.level}</span>}
-                              {showActions && (
-                                <span className="guild-member-actions">
-                                  {isLeader && member.rank === "MEMBER" && (
-                                    <button type="button" className="social-inline-btn" onClick={() => onCommand(`guild promote ${member.name}`)} title="Promote">&#9650;</button>
-                                  )}
-                                  {isLeader && member.rank === "OFFICER" && (
-                                    <button type="button" className="social-inline-btn" onClick={() => onCommand(`guild demote ${member.name}`)} title="Demote">&#9660;</button>
-                                  )}
-                                  <button type="button" className="social-inline-btn social-inline-btn-danger" onClick={() => onCommand(`guild kick ${member.name}`)} title="Kick">&times;</button>
-                                </span>
-                              )}
-                            </span>
-                          </li>
-                        );
-                      })}
-                    </ul>
-                  )}
-                </div>
-                {guildHall && (
-                  <div className="guild-hall-section">
-                    <div className="guild-hall-header">
-                      <span className="guild-hall-label">Guild Hall</span>
-                      <span className="guild-hall-meta">{guildHall.rooms.length} / {guildHall.maxRooms} rooms &middot; {guildHall.membersInHall} inside</span>
-                    </div>
-                    {guildHall.rooms.length > 0 && (
-                      <ul className="guild-hall-room-list">
-                        {guildHall.rooms.map((room) => (
-                          <li key={room.id} className="guild-hall-room-item">
-                            <span className="guild-hall-room-title">{room.title}</span>
-                            <span className="guild-hall-room-template">{room.template}</span>
-                          </li>
-                        ))}
-                      </ul>
-                    )}
-                    <div className="guild-hall-actions">
-                      <button type="button" className="social-action-btn" onClick={() => onCommand("guild hallenter")}>Enter Hall</button>
-                      {(guildInfo.rank === "LEADER" || guildInfo.rank === "OFFICER") && (
-                        <button type="button" className="social-action-btn" onClick={() => onCommand("guild hallexpand")}>Expand</button>
-                      )}
-                    </div>
-                  </div>
-                )}
-                {!guildHall && (guildInfo.rank === "LEADER" || guildInfo.rank === "OFFICER") && (
-                  <div className="guild-hall-section">
-                    <div className="guild-hall-header">
-                      <span className="guild-hall-label">Guild Hall</span>
-                    </div>
-                    <p className="empty-note">No guild hall yet.</p>
-                    <div className="guild-hall-actions">
-                      <button type="button" className="social-action-btn" onClick={() => onCommand("guild hallbuy")}>Purchase Hall</button>
-                    </div>
-                  </div>
-                )}
-                <div className="guild-footer-actions">
-                  {guildConfirmAction === "leave" ? (
-                    <span className="social-confirm-inline">
-                      <span>Leave guild?</span>
-                      <button type="button" className="social-confirm-yes" onClick={() => { onCommand("guild leave"); setGuildConfirmAction(null); }}>Yes</button>
-                      <button type="button" className="social-confirm-no" onClick={() => setGuildConfirmAction(null)}>No</button>
-                    </span>
-                  ) : guildConfirmAction === "disband" ? (
-                    <span className="social-confirm-inline">
-                      <span>Disband guild?</span>
-                      <button type="button" className="social-confirm-yes" onClick={() => { onCommand("guild disband"); setGuildConfirmAction(null); }}>Yes</button>
-                      <button type="button" className="social-confirm-no" onClick={() => setGuildConfirmAction(null)}>No</button>
-                    </span>
-                  ) : (
-                    <>
-                      <button type="button" className="social-action-btn social-danger-btn" onClick={() => setGuildConfirmAction("leave")}>Leave</button>
-                      {guildInfo.rank === "LEADER" && (
-                        <button type="button" className="social-action-btn social-danger-btn" onClick={() => setGuildConfirmAction("disband")}>Disband</button>
-                      )}
-                    </>
-                  )}
-                </div>
-              </div>
-
-              <div ref={guildFeedRef} className="embedded-chat-feed" role="log" aria-live="polite" aria-label="Guild chat messages">
-                {gchatMessages.length === 0 ? (
-                  <p className="empty-note">No guild messages yet.</p>
-                ) : (
-                  <ul className="chat-message-list">
-                    {gchatMessages.map((entry) => {
-                      const isSelf = entry.sender.localeCompare(playerName, undefined, { sensitivity: "accent" }) === 0;
-                      const time = new Date(entry.receivedAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-                      return (
-                        <li key={entry.id} className={`chat-message-item ${isSelf ? "chat-message-item-self" : ""}`}>
-                          <div className="chat-message-meta">
-                            <span className="chat-message-sender">{isSelf ? "You" : entry.sender}</span>
-                            <span className="chat-message-time">{time}</span>
-                          </div>
-                          <p className="chat-message-body">{entry.message}</p>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                )}
-              </div>
-
-              <form
-                className="chat-form"
-                onSubmit={(event: FormEvent<HTMLFormElement>) => {
-                  event.preventDefault();
-                  const sent = onSendMessage("gchat", guildDraft, null);
-                  if (sent) setGuildDraft("");
-                }}
-              >
-                <input
-                  className="chat-input"
-                  type="text"
-                  value={guildDraft}
-                  onChange={(event) => setGuildDraft(event.target.value)}
-                  placeholder="Message your guild"
-                  aria-label="Guild chat message"
-                  autoComplete="off"
-                  spellCheck={false}
-                  disabled={!canChat}
-                />
-                <button type="submit" className="soft-button" disabled={!canChat}>Send</button>
-              </form>
-            </div>
-          )
         )}
 
         {activeSocialTab === "group" && (

--- a/web-v3/src/components/panels/GuildBoardPanel.tsx
+++ b/web-v3/src/components/panels/GuildBoardPanel.tsx
@@ -1,0 +1,300 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { FormEvent } from "react";
+import type { ChatChannel, ChatMessage, GuildHallInfo, GuildInfo, GuildMemberEntry, PendingGuildInvite } from "../../types";
+
+interface GuildBoardPanelProps {
+  connected: boolean;
+  canChat: boolean;
+  playerName: string;
+  guildInfo: GuildInfo;
+  pendingGuildInvite: PendingGuildInvite | null;
+  guildMembers: GuildMemberEntry[];
+  guildHall: GuildHallInfo | null;
+  gchatMessages: ChatMessage[];
+  onSendMessage: (channel: ChatChannel, message: string, target: string | null) => boolean;
+  onCommand: (command: string) => void;
+}
+
+function rankLabel(rank: string): string {
+  switch (rank) {
+    case "LEADER": return "Leader";
+    case "OFFICER": return "Officer";
+    default: return "Member";
+  }
+}
+
+/**
+ * Standalone "Guild" board — the guild archive split out of the Social panel
+ * onto the fae-botanical `guild_bg` parchment frame. Two states: not-in-a-guild
+ * (incoming invite + create form) and in-a-guild (identity, MOTD, roster,
+ * officer controls, and guild chat). Built in plain CSS over the painted frame.
+ */
+export function GuildBoardPanel({
+  connected,
+  canChat,
+  playerName,
+  guildInfo,
+  pendingGuildInvite,
+  guildMembers,
+  guildHall,
+  gchatMessages,
+  onSendMessage,
+  onCommand,
+}: GuildBoardPanelProps) {
+  const feedRef = useRef<HTMLDivElement | null>(null);
+  const [draft, setDraft] = useState("");
+  const [createName, setCreateName] = useState("");
+  const [createTag, setCreateTag] = useState("");
+  const [inviteTarget, setInviteTarget] = useState("");
+  const [motdDraft, setMotdDraft] = useState("");
+  const [editingMotd, setEditingMotd] = useState(false);
+  const [confirmAction, setConfirmAction] = useState<"leave" | "disband" | null>(null);
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const inGuild = guildInfo.name !== null;
+  const isLeader = guildInfo.rank === "LEADER";
+  const canManage = isLeader || guildInfo.rank === "OFFICER";
+
+  const sortedMembers = useMemo(() => {
+    const order: Record<string, number> = { LEADER: 0, OFFICER: 1, MEMBER: 2 };
+    return [...guildMembers].sort((a, b) => {
+      const onlineDiff = (a.online ? 0 : 1) - (b.online ? 0 : 1);
+      if (onlineDiff !== 0) return onlineDiff;
+      const rankDiff = (order[a.rank] ?? 2) - (order[b.rank] ?? 2);
+      if (rankDiff !== 0) return rankDiff;
+      return a.name.localeCompare(b.name);
+    });
+  }, [guildMembers]);
+
+  const selectedMember = sortedMembers.find((m) => m.name === selected) ?? null;
+  const selectedIsMe = selectedMember?.name.localeCompare(playerName, undefined, { sensitivity: "accent" }) === 0;
+
+  useEffect(() => {
+    const feed = feedRef.current;
+    if (feed) feed.scrollTop = feed.scrollHeight;
+  }, [gchatMessages.length, inGuild]);
+
+  if (!canChat) {
+    return (
+      <div className="guildboard guildboard-centered">
+        <p className="gb-empty">{connected ? "Log in to view your guild." : "Reconnect to load guild data."}</p>
+      </div>
+    );
+  }
+
+  // ── State A — not in a guild ──────────────────────────────
+  if (!inGuild) {
+    return (
+      <div className="guildboard guildboard-state-a">
+        <section className="gb-card gb-invites">
+          <h3 className="gb-card-title">Invites</h3>
+          {pendingGuildInvite ? (
+            <div className="gb-invite-row">
+              <div className="gb-invite-info">
+                <span className="gb-invite-guild">{pendingGuildInvite.guildName} <span className="gb-tag">[{pendingGuildInvite.guildTag}]</span></span>
+                <span className="gb-invite-from">from {pendingGuildInvite.inviterName}</span>
+              </div>
+              <div className="gb-invite-actions">
+                <button type="button" className="gb-btn gb-btn-accept" onClick={() => onCommand("guild accept")}>Accept</button>
+                <button type="button" className="gb-btn gb-btn-decline" onClick={() => onCommand("guild decline")}>Decline</button>
+              </div>
+            </div>
+          ) : (
+            <p className="gb-empty">No pending invites.</p>
+          )}
+        </section>
+
+        <section className="gb-card gb-create">
+          <h3 className="gb-card-title">Create Guild</h3>
+          <form
+            className="gb-create-form"
+            onSubmit={(e) => {
+              e.preventDefault();
+              const n = createName.trim();
+              const t = createTag.trim();
+              if (n && t) { onCommand(`guild create ${n} ${t}`); setCreateName(""); setCreateTag(""); }
+            }}
+          >
+            <label className="gb-field">
+              <span className="gb-label">Name <em>(required)</em></span>
+              <input type="text" className="gb-input" placeholder="Enter guild name…" value={createName} onChange={(e) => setCreateName(e.target.value)} aria-label="Guild name" />
+            </label>
+            <label className="gb-field">
+              <span className="gb-label">Tag <em>(required)</em></span>
+              <input type="text" className="gb-input gb-input-tag" placeholder="2–5 chars…" value={createTag} maxLength={5} onChange={(e) => setCreateTag(e.target.value)} aria-label="Guild tag" />
+            </label>
+            <button type="submit" className="gb-btn gb-btn-primary gb-create-btn" disabled={!createName.trim() || !createTag.trim()}>Create Guild</button>
+          </form>
+        </section>
+      </div>
+    );
+  }
+
+  // ── State B — in a guild ──────────────────────────────────
+  return (
+    <div className="guildboard guildboard-state-b">
+      <header className="gb-identity">
+        <div className="gb-crest" aria-hidden="true">
+          <span className="gb-crest-tag">{guildInfo.tag ?? "✦"}</span>
+        </div>
+        <div className="gb-identity-text">
+          <h2 className="gb-guild-name">{guildInfo.name}{guildInfo.tag && <span className="gb-tag"> [{guildInfo.tag}]</span>}</h2>
+          <p className="gb-identity-meta">
+            {guildInfo.rank && <>Rank: {rankLabel(guildInfo.rank)}</>}
+            {guildInfo.rank && " · "}Members: {guildInfo.memberCount} / {guildInfo.maxSize}
+          </p>
+        </div>
+      </header>
+
+      <section className="gb-card gb-motd">
+        <div className="gb-card-titlerow">
+          <h3 className="gb-card-title">MOTD</h3>
+          {canManage && !editingMotd && (
+            <button type="button" className="gb-icon-btn" title="Set MOTD" aria-label="Set MOTD" onClick={() => { setMotdDraft(guildInfo.motd ?? ""); setEditingMotd(true); }}>&#9998;</button>
+          )}
+        </div>
+        {editingMotd ? (
+          <form className="gb-motd-edit" onSubmit={(e) => { e.preventDefault(); onCommand(`guild motd ${motdDraft}`); setEditingMotd(false); }}>
+            <input type="text" className="gb-input" value={motdDraft} onChange={(e) => setMotdDraft(e.target.value)} aria-label="Guild MOTD" autoFocus />
+            <button type="submit" className="gb-btn gb-btn-accept">Save</button>
+            <button type="button" className="gb-btn gb-btn-ghost" onClick={() => setEditingMotd(false)}>Cancel</button>
+          </form>
+        ) : (
+          <p className="gb-motd-text">{guildInfo.motd || "No message set."}</p>
+        )}
+      </section>
+
+      <div className="gb-columns">
+        <section className="gb-card gb-roster">
+          <h3 className="gb-card-title">Roster ({guildInfo.memberCount}/{guildInfo.maxSize})</h3>
+          <div className="gb-roster-scroll">
+            {sortedMembers.length === 0 ? (
+              <p className="gb-empty">No roster data yet.</p>
+            ) : (
+              <ul className="gb-member-list">
+                {sortedMembers.map((m, i) => (
+                  <li key={m.name}>
+                    <button
+                      type="button"
+                      className={`gb-member${selected === m.name ? " is-selected" : ""}${m.online ? "" : " is-offline"}`}
+                      onClick={() => setSelected(selected === m.name ? null : m.name)}
+                      aria-pressed={selected === m.name}
+                    >
+                      <span className="gb-member-num">{i + 1}.</span>
+                      <span className={`gb-member-dot ${m.online ? "is-online" : "is-offline"}`} aria-hidden="true" />
+                      <span className="gb-member-name">{m.name}</span>
+                      {m.level !== null && <span className="gb-member-level">Lv {m.level}</span>}
+                      <span className="gb-member-rank">{rankLabel(m.rank)}</span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </section>
+
+        {canManage ? (
+          <section className="gb-card gb-controls">
+            <h3 className="gb-card-title">Officer Controls</h3>
+            <p className="gb-controls-hint">{selectedMember ? `Managing ${selectedMember.name}` : "Select a member to manage."}</p>
+            <div className="gb-controls-actions">
+              <button
+                type="button"
+                className="gb-btn gb-btn-kick"
+                disabled={!selectedMember || selectedIsMe || selectedMember?.rank === "LEADER"}
+                onClick={() => { if (selectedMember) { onCommand(`guild kick ${selectedMember.name}`); setSelected(null); } }}
+              >Kick</button>
+              <button
+                type="button"
+                className="gb-btn gb-btn-promote"
+                disabled={!isLeader || !selectedMember || selectedMember?.rank !== "MEMBER"}
+                onClick={() => { if (selectedMember) onCommand(`guild promote ${selectedMember.name}`); }}
+              >Promote</button>
+              <button
+                type="button"
+                className="gb-btn gb-btn-demote"
+                disabled={!isLeader || !selectedMember || selectedMember?.rank !== "OFFICER"}
+                onClick={() => { if (selectedMember) onCommand(`guild demote ${selectedMember.name}`); }}
+              >Demote</button>
+              <button
+                type="button"
+                className="gb-btn gb-btn-setmotd"
+                onClick={() => { setMotdDraft(guildInfo.motd ?? ""); setEditingMotd(true); }}
+              >Set MOTD</button>
+            </div>
+            <form className="gb-invite-bar" onSubmit={(e) => { e.preventDefault(); const t = inviteTarget.trim(); if (t) { onCommand(`guild invite ${t}`); setInviteTarget(""); } }}>
+              <input type="text" className="gb-input" placeholder="Invite player…" value={inviteTarget} onChange={(e) => setInviteTarget(e.target.value)} aria-label="Player to invite" />
+              <button type="submit" className="gb-btn gb-btn-ghost" disabled={!inviteTarget.trim()}>Invite</button>
+            </form>
+          </section>
+        ) : (
+          <section className="gb-card gb-controls">
+            <h3 className="gb-card-title">Guild</h3>
+            <p className="gb-controls-hint">Members coordinate here. Officers can manage the roster.</p>
+          </section>
+        )}
+      </div>
+
+      {(guildHall || canManage) && (
+        <section className="gb-card gb-hall">
+          <div className="gb-card-titlerow">
+            <h3 className="gb-card-title">Guild Hall</h3>
+            {guildHall && <span className="gb-hall-meta">{guildHall.rooms.length}/{guildHall.maxRooms} rooms · {guildHall.membersInHall} inside</span>}
+          </div>
+          <div className="gb-hall-actions">
+            {guildHall ? (
+              <>
+                <button type="button" className="gb-btn gb-btn-ghost" onClick={() => onCommand("guild hallenter")}>Enter Hall</button>
+                {canManage && <button type="button" className="gb-btn gb-btn-ghost" onClick={() => onCommand("guild hallexpand")}>Expand</button>}
+              </>
+            ) : (
+              <button type="button" className="gb-btn gb-btn-ghost" onClick={() => onCommand("guild hallbuy")}>Purchase Hall</button>
+            )}
+          </div>
+        </section>
+      )}
+
+      <section className="gb-card gb-chat">
+        <h3 className="gb-card-title">Guild Chat</h3>
+        <div ref={feedRef} className="gb-chat-feed" role="log" aria-live="polite" aria-label="Guild chat messages">
+          {gchatMessages.length === 0 ? (
+            <p className="gb-empty">No guild messages yet.</p>
+          ) : (
+            <ul className="gb-chat-list">
+              {gchatMessages.map((entry) => {
+                const isSelf = entry.sender.localeCompare(playerName, undefined, { sensitivity: "accent" }) === 0;
+                return (
+                  <li key={entry.id} className="gb-chat-msg">
+                    <span className="gb-chat-sender">[{isSelf ? "You" : entry.sender}]</span>
+                    <span className="gb-chat-body">{entry.message}</span>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+        <form
+          className="gb-chat-form"
+          onSubmit={(e: FormEvent<HTMLFormElement>) => { e.preventDefault(); if (onSendMessage("gchat", draft, null)) setDraft(""); }}
+        >
+          <span className="gb-chat-say">Say:</span>
+          <input className="gb-input" type="text" value={draft} onChange={(e) => setDraft(e.target.value)} placeholder="Type your message…" aria-label="Guild chat message" autoComplete="off" spellCheck={false} />
+          <button type="submit" className="gb-btn gb-btn-primary">Send</button>
+        </form>
+      </section>
+
+      <div className="gb-footer">
+        {confirmAction === "leave" ? (
+          <span className="gb-confirm"><span>Leave guild?</span><button type="button" className="gb-btn gb-btn-kick" onClick={() => { onCommand("guild leave"); setConfirmAction(null); }}>Yes</button><button type="button" className="gb-btn gb-btn-ghost" onClick={() => setConfirmAction(null)}>No</button></span>
+        ) : confirmAction === "disband" ? (
+          <span className="gb-confirm"><span>Disband guild?</span><button type="button" className="gb-btn gb-btn-kick" onClick={() => { onCommand("guild disband"); setConfirmAction(null); }}>Yes</button><button type="button" className="gb-btn gb-btn-ghost" onClick={() => setConfirmAction(null)}>No</button></span>
+        ) : (
+          <>
+            <button type="button" className="gb-btn gb-btn-ghost gb-leave" onClick={() => setConfirmAction("leave")}>Leave Guild</button>
+            {isLeader && <button type="button" className="gb-btn gb-btn-kick" onClick={() => setConfirmAction("disband")}>Disband</button>}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -23885,8 +23885,8 @@ html:has(.game-shell),
 
 .guildboard-state-a {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: clamp(8px, 1.6vw, 18px);
+  grid-template-columns: 1fr;
+  gap: clamp(8px, 1.6vh, 16px);
   align-content: start;
 }
 

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -23812,3 +23812,317 @@ html:has(.game-shell),
   color: rgb(168 196 255 / 90%);
   font-size: 0.95rem;
 }
+
+/* ════════════════════════════════════════════════════════════
+   Guild board — standalone guild archive (drawerPanel "guildboard")
+   Fae-botanical guild_bg parchment frame (skin) with all content built in
+   plain CSS over the painted interior: dark ink on parchment cards, botanical
+   accent buttons. Two states — not-in-a-guild (invite + create) and in-guild.
+   ════════════════════════════════════════════════════════════ */
+.drawer-sheet.drawer-sheet-archive {
+  background-image:
+    var(--skin-bg, none),
+    radial-gradient(ellipse at 50% 40%, rgb(34 30 52 / 96%), rgb(14 14 28 / 98%));
+  background-size: cover, auto;
+  background-position: center, center;
+  background-repeat: no-repeat, no-repeat;
+}
+
+.drawer-sheet-archive .drawer-title { display: none; }
+.drawer-sheet-archive .drawer-handle-zone { display: none; }
+
+/* The painted frame has its close glyph in the upper-right — float the real
+   button there. */
+.drawer-sheet-archive .drawer-header {
+  position: absolute;
+  top: 9.5%;
+  right: 6.8%;
+  left: auto;
+  z-index: 6;
+  padding: 0;
+  min-height: 0;
+  border-bottom: none;
+}
+
+.drawer-sheet-archive .drawer-close {
+  background: transparent;
+  border-color: transparent;
+  color: #3a2f25;
+}
+
+.drawer-sheet-archive .drawer-body {
+  padding: 0;
+  position: relative;
+}
+
+@media (min-width: 768px) {
+  .drawer-sheet.drawer-sheet-archive {
+    width: auto;
+    height: min(94vh, 71vw);
+    max-height: 94vh;
+    aspect-ratio: 4 / 3;
+  }
+}
+
+/* Content inset into the parchment interior of the frame. */
+.guildboard {
+  position: absolute;
+  top: 12.5%;
+  left: 6.5%;
+  right: 6.5%;
+  bottom: 6.5%;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(6px, 1.2vh, 12px);
+  overflow-y: auto;
+  color: #3a2f25;
+  font-size: clamp(0.8rem, 1.5vw, 1rem);
+  scrollbar-width: thin;
+  scrollbar-color: rgb(120 100 70 / 55%) transparent;
+}
+
+.guildboard-centered { align-items: center; justify-content: center; }
+
+.guildboard-state-a {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: clamp(8px, 1.6vw, 18px);
+  align-content: start;
+}
+
+/* Parchment cards. */
+.gb-card {
+  background: rgb(248 242 225 / 55%);
+  border: 1px solid rgb(120 100 70 / 30%);
+  border-radius: 10px;
+  padding: clamp(8px, 1.4vh, 14px) clamp(10px, 1.4vw, 16px);
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 30%), 0 2px 8px rgb(40 30 20 / 18%);
+}
+
+.gb-card-title {
+  margin: 0 0 8px;
+  text-align: center;
+  font-family: var(--font-display);
+  font-size: clamp(0.82rem, 1.7vw, 1rem);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #3a5048;
+  border-bottom: 1px solid rgb(90 110 100 / 30%);
+  padding-bottom: 5px;
+}
+
+.gb-card-titlerow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.gb-card-titlerow .gb-card-title { flex: 1; margin-bottom: 6px; }
+
+.gb-empty {
+  margin: 6px 0;
+  font-style: italic;
+  color: rgb(58 47 37 / 65%);
+  text-align: center;
+}
+
+/* Buttons. */
+.gb-btn {
+  border: 1px solid rgb(80 70 50 / 35%);
+  border-radius: 8px;
+  padding: clamp(5px, 0.9vh, 9px) clamp(10px, 1.4vw, 16px);
+  font-family: var(--font-display);
+  font-size: clamp(0.74rem, 1.4vw, 0.9rem);
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  color: #f3ecd8;
+  cursor: pointer;
+  transition: transform 150ms var(--ease-out-soft), filter 150ms var(--ease-out-soft), box-shadow 150ms var(--ease-out-soft);
+}
+
+.gb-btn:hover:not(:disabled) { transform: translateY(-1px); filter: brightness(1.1); box-shadow: 0 2px 8px rgb(40 30 20 / 30%); }
+.gb-btn:disabled { opacity: 0.45; cursor: default; }
+
+.gb-btn-accept,
+.gb-btn-promote,
+.gb-btn-setmotd,
+.gb-btn-primary { background: linear-gradient(165deg, #5a8a7e, #3f6a60); }
+.gb-btn-decline,
+.gb-btn-kick { background: linear-gradient(165deg, #a8615a, #82433d); }
+.gb-btn-demote { background: linear-gradient(165deg, #8a6ca0, #634a78); }
+.gb-btn-ghost {
+  background: rgb(236 226 200 / 70%);
+  color: #4a3c2c;
+  border-color: rgb(120 100 70 / 40%);
+}
+
+/* State A: invites + create. */
+.gb-invite-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 4px;
+}
+
+.gb-invite-info { display: flex; flex-direction: column; min-width: 0; }
+.gb-invite-guild { font-family: var(--font-display); font-weight: 600; font-size: 1.02rem; color: #3a2f25; }
+.gb-tag { color: #7a5f8e; font-weight: 600; }
+.gb-invite-from { font-size: 0.8rem; font-style: italic; color: rgb(58 47 37 / 70%); }
+.gb-invite-actions { display: flex; gap: 6px; flex-shrink: 0; }
+
+.gb-create-form { display: flex; flex-direction: column; gap: 10px; }
+.gb-field { display: flex; flex-direction: column; gap: 4px; }
+.gb-label { font-size: 0.82rem; font-weight: 600; color: #4a3c2c; }
+.gb-label em { font-style: italic; font-weight: 400; color: rgb(74 60 44 / 70%); }
+
+.gb-input {
+  border: 1px solid rgb(120 100 70 / 40%);
+  border-radius: 8px;
+  background: rgb(255 252 244 / 80%);
+  color: #3a2f25;
+  padding: clamp(7px, 1.2vh, 11px) 12px;
+  font-size: 0.9rem;
+  min-width: 0;
+}
+.gb-input::placeholder { color: rgb(90 76 58 / 55%); font-style: italic; }
+.gb-input:focus { outline: none; border-color: #5a8a7e; box-shadow: 0 0 0 2px rgb(90 138 126 / 30%); }
+.gb-input-tag { max-width: 120px; text-transform: uppercase; letter-spacing: 0.1em; }
+.gb-create-btn { margin-top: 4px; align-self: stretch; }
+
+/* State B: identity / MOTD / roster / controls / chat. */
+.guildboard-state-b { padding-right: 2px; }
+
+.gb-identity { display: flex; align-items: center; gap: clamp(10px, 1.6vw, 18px); }
+
+.gb-crest {
+  flex: 0 0 auto;
+  width: clamp(48px, 9vw, 78px);
+  aspect-ratio: 1;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  border: 2px solid rgb(150 130 90 / 55%);
+  background:
+    radial-gradient(circle at 50% 35%, rgb(70 90 140 / 70%), transparent 65%),
+    linear-gradient(160deg, #2a3354, #16203c);
+  box-shadow: inset 0 0 14px rgb(0 0 0 / 50%), 0 0 10px rgb(120 140 200 / 30%);
+}
+
+.gb-crest-tag {
+  font-family: var(--font-display);
+  font-size: clamp(0.8rem, 1.8vw, 1.1rem);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: #cfe0ff;
+}
+
+.gb-guild-name {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(1.1rem, 2.6vw, 1.7rem);
+  font-weight: 700;
+  color: #2f2519;
+}
+
+.gb-identity-meta { margin: 2px 0 0; font-size: 0.9rem; color: rgb(58 47 37 / 80%); }
+
+.gb-motd-text { margin: 0; line-height: 1.4; }
+.gb-motd-edit { display: flex; gap: 6px; }
+.gb-motd-edit .gb-input { flex: 1; }
+.gb-icon-btn {
+  border: 1px solid rgb(120 100 70 / 35%);
+  border-radius: 7px;
+  background: rgb(236 226 200 / 70%);
+  color: #4a3c2c;
+  padding: 3px 9px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+.gb-icon-btn:hover { filter: brightness(1.08); }
+
+.gb-columns {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr;
+  gap: clamp(8px, 1.4vw, 16px);
+  align-items: start;
+}
+
+.gb-roster-scroll {
+  max-height: clamp(140px, 28vh, 280px);
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgb(120 100 70 / 55%) transparent;
+}
+
+.gb-member-list { list-style: none; margin: 0; padding: 0; }
+
+.gb-member {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 8px;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: none;
+  color: #3a2f25;
+  cursor: pointer;
+  text-align: left;
+  transition: background 150ms var(--ease-out-soft), border-color 150ms var(--ease-out-soft);
+}
+
+.gb-member:hover { background: rgb(120 138 126 / 16%); }
+.gb-member.is-selected { background: rgb(90 138 126 / 22%); border-color: rgb(90 138 126 / 60%); }
+.gb-member.is-offline { opacity: 0.55; }
+
+.gb-member-num { color: rgb(58 47 37 / 55%); font-variant-numeric: tabular-nums; min-width: 1.4em; }
+.gb-member-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
+.gb-member-dot.is-online { background: #5a8a5a; box-shadow: 0 0 5px rgb(90 138 90 / 70%); }
+.gb-member-dot.is-offline { background: rgb(120 100 70 / 50%); }
+.gb-member-name { font-weight: 600; flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.gb-member-level { font-size: 0.78rem; color: rgb(58 47 37 / 70%); }
+.gb-member-rank { font-size: 0.8rem; color: #5a4a78; font-weight: 600; min-width: 4em; text-align: right; }
+
+.gb-controls-hint { margin: 0 0 8px; font-size: 0.82rem; font-style: italic; color: rgb(58 47 37 / 70%); text-align: center; }
+.gb-controls-actions { display: grid; gap: 6px; }
+.gb-controls-actions .gb-btn { width: 100%; }
+.gb-invite-bar { display: flex; gap: 6px; margin-top: 10px; }
+.gb-invite-bar .gb-input { flex: 1; }
+
+.gb-hall { display: flex; flex-direction: column; gap: 8px; }
+.gb-hall-meta { font-size: 0.78rem; color: rgb(58 47 37 / 70%); }
+.gb-hall-actions { display: flex; gap: 6px; flex-wrap: wrap; }
+
+/* Guild chat. */
+.gb-chat { display: flex; flex-direction: column; gap: 8px; flex: 1 1 auto; min-height: 0; }
+.gb-chat-feed {
+  flex: 1 1 auto;
+  min-height: clamp(80px, 16vh, 180px);
+  max-height: 28vh;
+  overflow-y: auto;
+  border-radius: 8px;
+  border: 1px solid rgb(120 100 70 / 30%);
+  background: rgb(28 26 22 / 78%);
+  padding: 8px 10px;
+  scrollbar-width: thin;
+  scrollbar-color: rgb(150 130 90 / 55%) transparent;
+}
+
+.gb-chat-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 3px; }
+.gb-chat-msg { line-height: 1.35; color: #e8ddc4; font-size: 0.9rem; }
+.gb-chat-sender { color: #9fc4b8; font-weight: 600; margin-right: 6px; }
+
+.gb-chat-form { display: flex; align-items: center; gap: 6px; }
+.gb-chat-say { font-family: var(--font-display); font-weight: 600; color: #4a3c2c; }
+.gb-chat-form .gb-input { flex: 1; }
+
+.gb-footer { display: flex; justify-content: flex-end; gap: 8px; padding-top: 2px; }
+.gb-confirm { display: flex; align-items: center; gap: 8px; font-size: 0.86rem; color: #4a3c2c; }
+
+@media (max-width: 720px) {
+  .guildboard-state-a,
+  .gb-columns { grid-template-columns: 1fr; }
+}

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -1,4 +1,4 @@
-export type PopoutPanel = "map" | "inventory" | "equipment" | "room" | "help" | "character" | "chat" | "chatboard" | "whoboard" | "shop" | "spellbook" | "quests" | "questOffers" | "mail" | "crafting" | "housing" | "leaderboard" | "trainer" | "bank" | "stylist" | "auction" | "dungeon" | "lottery" | "dice" | "puzzle" | "features" | "combatlog" | "inn" | "terminal" | null;
+export type PopoutPanel = "map" | "inventory" | "equipment" | "room" | "help" | "character" | "chat" | "chatboard" | "whoboard" | "guildboard" | "shop" | "spellbook" | "quests" | "questOffers" | "mail" | "crafting" | "housing" | "leaderboard" | "trainer" | "bank" | "stylist" | "auction" | "dungeon" | "lottery" | "dice" | "puzzle" | "features" | "combatlog" | "inn" | "terminal" | null;
 export type SystemPanelView = "dungeon" | "duel" | "lottery" | "pet" | "prestige" | "currencies" | "factions";
 export type ChatChannel = "say" | "tell" | "gossip" | "shout" | "ooc" | "gtell" | "gchat";
 export type SocialTab = "chat" | "friends" | "guild" | "group" | "who";


### PR DESCRIPTION
Next piece of the Social-panel split: **Guild** moves out onto the painted `guild_bg` parchment frame, opened from a new **Guild** widget in the services stack. As you called it — mostly plain CSS over the frame, **one asset key**.

## What's here (matches the concept's two states)
**Not in a guild** — incoming invite with Accept/Decline + a **Create Guild** form (Name + Tag, both required).

**In a guild** —
- Crest + identity (name `[TAG]`, Rank, Members X/Y)
- **MOTD** with a Set MOTD edit (officer+)
- Scrollable **Roster**
- **Officer Controls** using the concept's *select-a-member* pattern: click a roster member, then **Kick / Promote / Demote** (correctly gated by your rank and theirs), plus **Set MOTD** and **Invite**
- Guild-hall section, **Guild Chat**, and **Leave / Disband**

## Under the hood
- Extracted from the Social panel's old guild tab — **reuses all the existing guild commands** (`guild create/accept/decline/invite/motd/promote/demote/kick/leave/disband/hall*`) and the `gchat` channel. **No server logic changes** — just the asset key.
- Social panel drops its Guild tab (now Friends / Group).

## Art contract
| key | drives | fallback |
|---|---|---|
| `guild_bg` | the parchment frame (drawer skin) | dark gradient |

Dark-ink-on-parchment cards, the celestial crest, and the botanical accent buttons (teal Accept/Promote/Send, red Decline/Kick, purple Demote) are all CSS. The Guild launcher uses a ⚜ glyph.

## Verification
- `bun run lint` ✓, `npx tsc -b` ✓, `bun run build` ✓
- `./gradlew compileKotlin ktlintCheck` ✓

Content is inset into the parchment interior (top 12.5% / sides 6.5% / bottom 6.5%) eyeballed off your frame — send a shot and I'll nudge the inset, and tune the card palette to sit best on the parchment.