### PR TITLE
feat(web): add a Friend action to the Who board

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -3087,6 +3087,7 @@ data class ImagesConfig(
             "who_bg" to "global_assets/who_bg.png",
             "who_examine_btn" to "global_assets/who_examine_btn.png",
             "who_tell_btn" to "global_assets/who_tell_btn.png",
+            "who_friend_btn" to "global_assets/who_friend_btn.png",
             "guild_bg" to "global_assets/guild_bg.png",
             "dialog_indicator" to "global_assets/dialog_indicator.png",
             "aggro_indicator" to "global_assets/aggro_indicator.png",

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -1118,6 +1118,7 @@ function App() {
             playerName={state.character.name}
             whoPlayers={state.whoPlayers}
             serverAssets={state.serverAssets}
+            friendNames={state.friends.map((f) => f.name)}
             onRequestWho={() => sendCommand("who")}
             onExamine={(p) => setExaminePlayer(p)}
             onTellPlayer={(name) => {
@@ -1125,6 +1126,7 @@ function App() {
               state.setTellTarget(name);
               openPanel("chatboard");
             }}
+            onAddFriend={(name) => sendCommand(`friend add ${name}`)}
           />
         )}
 

--- a/web-v3/src/components/panels/WhoBoardPanel.tsx
+++ b/web-v3/src/components/panels/WhoBoardPanel.tsx
@@ -10,9 +10,12 @@ interface WhoBoardPanelProps {
   playerName: string;
   whoPlayers: WhoPlayer[];
   serverAssets: Record<string, string>;
+  /** Names already on the player's friends list — hides the Friend action for them. */
+  friendNames: string[];
   onRequestWho: () => void;
   onExamine: (player: WhoPlayer) => void;
   onTellPlayer: (name: string) => void;
+  onAddFriend: (name: string) => void;
 }
 
 /**
@@ -27,9 +30,11 @@ export function WhoBoardPanel({
   playerName,
   whoPlayers,
   serverAssets,
+  friendNames,
   onRequestWho,
   onExamine,
   onTellPlayer,
+  onAddFriend,
 }: WhoBoardPanelProps) {
   const [filter, setFilter] = useState("");
   const [classFilter, setClassFilter] = useState("");
@@ -82,6 +87,8 @@ export function WhoBoardPanel({
 
   const examineArt = serverAssets["who_examine_btn"];
   const tellArt = serverAssets["who_tell_btn"];
+  const friendArt = serverAssets["who_friend_btn"];
+  const friendSet = useMemo(() => new Set(friendNames.map((n) => n.toLowerCase())), [friendNames]);
 
   return (
     <div className="whoboard">
@@ -138,6 +145,17 @@ export function WhoBoardPanel({
                         onClick={() => onTellPlayer(p.name)}
                       >
                         {tellArt ? <img src={tellArt} alt="" aria-hidden="true" /> : <span className="whoboard-action-glyph" aria-hidden="true">✉</span>}
+                      </button>
+                    )}
+                    {!isSelf && !friendSet.has(p.name.toLowerCase()) && (
+                      <button
+                        type="button"
+                        className="whoboard-action"
+                        title={`Add ${p.name} as a friend`}
+                        aria-label={`Add ${p.name} as a friend`}
+                        onClick={() => onAddFriend(p.name)}
+                      >
+                        {friendArt ? <img src={friendArt} alt="" aria-hidden="true" /> : <span className="whoboard-action-glyph" aria-hidden="true">✚</span>}
                       </button>
                     )}
                   </span>

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -23560,7 +23560,7 @@ html:has(.game-shell),
 .whoboard-head,
 .whoboard-row {
   display: grid;
-  grid-template-columns: clamp(40px, 6%, 70px) 1.7fr 1fr 1fr 0.6fr clamp(78px, 12%, 124px);
+  grid-template-columns: clamp(40px, 6%, 70px) 1.7fr 1fr 1fr 0.6fr clamp(108px, 16%, 172px);
   align-items: center;
   gap: clamp(4px, 1vw, 12px);
   padding: 0 clamp(4px, 1vw, 14px);


### PR DESCRIPTION
Adds a third action button to each Who-board row: **add the player as a friend** (`friend add <name>`).

- Shown only for *other* players who aren't already on your friends list (the board now receives your friend names to gate it).
- Uses a new `who_friend_btn` asset with a ✚ glyph fallback, alongside the existing Examine / Tell icons.
- Actions column widened to fit three icons.

This pairs with the upcoming Friends panel, which will reuse the same Examine + Tell buttons.

Verified: `bun run lint`, `npx tsc -b`, `bun run build`, `./gradlew compileKotlin ktlintCheck` all green.