### PR TITLE
feat(web): split Friends into a celestial roster board

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -3089,6 +3089,7 @@ data class ImagesConfig(
             "who_tell_btn" to "global_assets/who_tell_btn.png",
             "who_friend_btn" to "global_assets/who_friend_btn.png",
             "guild_bg" to "global_assets/guild_bg.png",
+            "friends_bg" to "global_assets/friends_bg.png",
             "dialog_indicator" to "global_assets/dialog_indicator.png",
             "aggro_indicator" to "global_assets/aggro_indicator.png",
             "quest_available_indicator" to "global_assets/quest_available_indicator.png",

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -13,6 +13,7 @@ import { ChatPanel } from "./components/panels/ChatPanel";
 import { ChatBoardPanel } from "./components/panels/ChatBoardPanel";
 import { WhoBoardPanel } from "./components/panels/WhoBoardPanel";
 import { GuildBoardPanel } from "./components/panels/GuildBoardPanel";
+import { FriendsBoardPanel } from "./components/panels/FriendsBoardPanel";
 import { PlayerExaminePanel } from "./components/panels/PlayerExaminePanel";
 import { CharacterPanel } from "./components/panels/CharacterPanel";
 import { SpellbookPanel } from "./components/SpellbookPanel";
@@ -856,6 +857,7 @@ function App() {
       case "chatboard": return "Social Board";
       case "whoboard": return "Who";
       case "guildboard": return "Guild";
+      case "friendsboard": return "Friends";
       case "shop": return state.shop?.name ?? "Shop";
       case "puzzle": return "Puzzle";
       case "features": return featurePanelFeature
@@ -943,6 +945,8 @@ function App() {
             ? "starframe"
             : drawerPanel === "guildboard"
             ? "archive"
+            : drawerPanel === "friendsboard"
+            ? "starframe"
             : drawerPanel === "character"
             ? "cabinet"
             : drawerPanel === "bank"
@@ -977,6 +981,8 @@ function App() {
             ? state.serverAssets["who_bg"]
             : drawerPanel === "guildboard"
             ? state.serverAssets["guild_bg"]
+            : drawerPanel === "friendsboard"
+            ? state.serverAssets["friends_bg"]
             : drawerPanel === "character"
             ? state.serverAssets["character_bg"]
             : drawerPanel === "bank"
@@ -1005,7 +1011,7 @@ function App() {
                             ? state.serverAssets["mail_bg"]
                             : undefined
         }
-        initialHeight={drawerPanel === "chatboard" || drawerPanel === "whoboard" || drawerPanel === "guildboard" ? 0.94 : undefined}
+        initialHeight={drawerPanel === "chatboard" || drawerPanel === "whoboard" || drawerPanel === "guildboard" || drawerPanel === "friendsboard" ? 0.94 : undefined}
       >
         {drawerPanel === "character" && (
           <CharacterPanel
@@ -1145,6 +1151,26 @@ function App() {
           />
         )}
 
+        {drawerPanel === "friendsboard" && (
+          <FriendsBoardPanel
+            connected={connected}
+            canChat={connected && hasCharacterProfile}
+            friends={state.friends}
+            friendNotifications={state.friendNotifications}
+            whoPlayers={state.whoPlayers}
+            serverAssets={state.serverAssets}
+            onRequestWho={() => sendCommand("who")}
+            onExamine={(p) => setExaminePlayer(p)}
+            onTellPlayer={(name) => {
+              state.setActiveChatChannel("tell");
+              state.setTellTarget(name);
+              openPanel("chatboard");
+            }}
+            onAddFriend={(name) => sendCommand(`friend add ${name}`)}
+            onRemoveFriend={(name) => sendCommand(`friend remove ${name}`)}
+          />
+        )}
+
         {drawerPanel === "chat" && (
           <ChatPanel
             connected={connected}
@@ -1153,14 +1179,7 @@ function App() {
             chatByChannel={state.chatByChannel}
             groupInfo={state.groupInfo}
             pendingGroupInvite={state.pendingGroupInvite}
-            friends={state.friends}
-            friendNotifications={state.friendNotifications}
             onSendMessage={sendChatMessage}
-            onTellPlayer={(name) => {
-              state.setActiveChatChannel("tell");
-              state.setTellTarget(name);
-              openPanel("chatboard");
-            }}
             onCommand={sendCommand}
           />
         )}

--- a/web-v3/src/components/GameShell.tsx
+++ b/web-v3/src/components/GameShell.tsx
@@ -267,6 +267,17 @@ export function GameShell({
                 <button
                   type="button"
                   className="hud-stack-btn"
+                  onClick={() => openServicePanel("friendsboard")}
+                  title="Friends"
+                  aria-label="Friends"
+                >
+                  {serverAssets["friends_widget"]
+                    ? <img className="hud-stack-img" src={serverAssets["friends_widget"]} alt="" />
+                    : <span className="hud-stack-glyph">&#9829;</span>}
+                </button>
+                <button
+                  type="button"
+                  className="hud-stack-btn"
                   onClick={() => openServicePanel("guildboard")}
                   title="Guild"
                   aria-label="Guild"

--- a/web-v3/src/components/panels/ChatPanel.tsx
+++ b/web-v3/src/components/panels/ChatPanel.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { FormEvent } from "react";
-import { TellIcon } from "../Icons";
-import type { ChatChannel, ChatMessage, FriendEntry, FriendNotification, GroupInfo, PendingGroupInvite, SocialTab } from "../../types";
+import type { ChatChannel, ChatMessage, GroupInfo, PendingGroupInvite } from "../../types";
 
 interface ChatPanelProps {
   connected: boolean;
@@ -10,17 +9,9 @@ interface ChatPanelProps {
   chatByChannel: Record<ChatChannel, ChatMessage[]>;
   groupInfo: GroupInfo;
   pendingGroupInvite: PendingGroupInvite | null;
-  friends: FriendEntry[];
-  friendNotifications: FriendNotification[];
   onSendMessage: (channel: ChatChannel, message: string, target: string | null) => boolean;
-  onTellPlayer: (target: string) => void;
   onCommand: (command: string) => void;
 }
-
-const SOCIAL_TABS: Array<{ id: SocialTab; label: string }> = [
-  { id: "friends", label: "Friends" },
-  { id: "group", label: "Group" },
-];
 
 export function ChatPanel({
   connected,
@@ -29,174 +20,28 @@ export function ChatPanel({
   chatByChannel,
   groupInfo,
   pendingGroupInvite,
-  friends,
-  friendNotifications,
   onSendMessage,
-  onTellPlayer,
   onCommand,
 }: ChatPanelProps) {
-  const feedRef = useRef<HTMLDivElement | null>(null);
   const groupFeedRef = useRef<HTMLDivElement | null>(null);
   const [groupDraft, setGroupDraft] = useState("");
-  const [activeSocialTab, setActiveSocialTab] = useState<SocialTab>("friends");
-  // Group action state
   const [groupInviteTarget, setGroupInviteTarget] = useState("");
-  // Friends action state
-  const [friendAddTarget, setFriendAddTarget] = useState("");
-  const [friendConfirmRemove, setFriendConfirmRemove] = useState<string | null>(null);
 
   const gtellMessages = chatByChannel.gtell;
-
-  useEffect(() => {
-    const feed = feedRef.current;
-    if (!feed) return;
-    feed.scrollTop = feed.scrollHeight;
-  }, [activeSocialTab]);
 
   useEffect(() => {
     const feed = groupFeedRef.current;
     if (!feed) return;
     feed.scrollTop = feed.scrollHeight;
-  }, [activeSocialTab, gtellMessages.length]);
-
-  const handleSocialTabChange = (tab: SocialTab) => {
-    setActiveSocialTab(tab);
-  };
-
-  const handleTellFromWho = (target: string) => {
-    onTellPlayer(target);
-  };
+  }, [gtellMessages.length]);
 
   const inGroup = groupInfo.members.length > 0;
 
-  const sortedFriends = useMemo(() => {
-    return [...friends].sort((a, b) => {
-      const onlineDiff = (a.online ? 0 : 1) - (b.online ? 0 : 1);
-      if (onlineDiff !== 0) return onlineDiff;
-      return a.name.localeCompare(b.name);
-    });
-  }, [friends]);
-
-  const [friendsNow, setFriendsNow] = useState(() => Date.now());
-  const hasFriendNotifications = friendNotifications.length > 0;
-
-  useEffect(() => {
-    if (!hasFriendNotifications || activeSocialTab !== "friends") return;
-    const interval = window.setInterval(() => setFriendsNow(Date.now()), 5_000);
-    return () => window.clearInterval(interval);
-  }, [hasFriendNotifications, activeSocialTab]);
-
-  const recentNotifications = useMemo(() => {
-    return friendNotifications.filter((n) => friendsNow - n.receivedAt < 30_000);
-  }, [friendNotifications, friendsNow]);
-
   return (
-    <section className="panel panel-chat" aria-label="Social channels">
-      <div className="social-tabs" role="tablist" aria-label="Social sections">
-        {SOCIAL_TABS.map((tab) => (
-          <button
-            key={tab.id}
-            type="button"
-            role="tab"
-            className={`social-tab ${activeSocialTab === tab.id ? "social-tab-active" : ""}`}
-            onClick={() => handleSocialTabChange(tab.id)}
-            aria-selected={activeSocialTab === tab.id}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </div>
-
+    <section className="panel panel-chat" aria-label="Group">
       <div className="chat-shell">
 
-        {activeSocialTab === "friends" && (
-          <>
-            <form className="social-action-bar" onSubmit={(e) => { e.preventDefault(); const t = friendAddTarget.trim(); if (t) { onCommand(`friend add ${t}`); setFriendAddTarget(""); } }}>
-              <input
-                type="text"
-                className="social-action-input"
-                placeholder="Add friend\u2026"
-                value={friendAddTarget}
-                onChange={(e) => setFriendAddTarget(e.target.value)}
-                aria-label="Friend name to add"
-                disabled={!canChat}
-              />
-              <button type="submit" className="social-action-btn" disabled={!canChat || !friendAddTarget.trim()}>Add</button>
-            </form>
-            <div ref={feedRef} className="chat-feed" role="region" aria-label="Friends list">
-              <section className="chat-feed-panel chat-feed-panel-flip" aria-label="Friends subwindow">
-                {!canChat ? (
-                  <p className="empty-note">
-                    {connected ? "Log in to unlock social features." : "Reconnect to load social data."}
-                  </p>
-                ) : sortedFriends.length === 0 && recentNotifications.length === 0 ? (
-                  <p className="empty-note">No friends yet. Add someone above to get started.</p>
-                ) : (
-                  <div className="friends-panel-content">
-                    {recentNotifications.length > 0 && (
-                      <ul className="friend-notifications">
-                        {recentNotifications.map((n) => (
-                          <li key={n.id} className={`friend-notification friend-notification-${n.event}`}>
-                            <span className={`friend-status-dot friend-status-dot-${n.event === "online" ? "online" : "offline"}`} />
-                            <span className="friend-notification-text">
-                              {n.name} {n.event === "online" ? "came online" : "went offline"}
-                            </span>
-                          </li>
-                        ))}
-                      </ul>
-                    )}
-                    {sortedFriends.length > 0 && (
-                      <ul className="friend-list">
-                        {sortedFriends.map((friend) => (
-                          <li key={friend.name} className={`friend-item ${friend.online ? "" : "friend-item-offline"}`}>
-                            <div className="friend-item-left">
-                              <span className={`friend-status-dot friend-status-dot-${friend.online ? "online" : "offline"}`} />
-                              <span className="friend-item-name">{friend.name}</span>
-                            </div>
-                            <div className="friend-item-right">
-                              {friend.online && friend.zone && <span className="friend-item-zone">{friend.zone}</span>}
-                              {friend.level !== null && <span className="friend-item-level">Lv {friend.level}</span>}
-                              {friend.online && (
-                                <button
-                                  type="button"
-                                  className="who-tell-button"
-                                  title={`Tell ${friend.name}`}
-                                  aria-label={`Tell ${friend.name}`}
-                                  onClick={() => handleTellFromWho(friend.name)}
-                                >
-                                  <TellIcon className="who-tell-icon" />
-                                </button>
-                              )}
-                              {friendConfirmRemove === friend.name ? (
-                                <span className="social-confirm-inline">
-                                  <button type="button" className="social-confirm-yes" aria-label="Confirm removal" onClick={() => { onCommand(`friend remove ${friend.name}`); setFriendConfirmRemove(null); }}>Remove?</button>
-                                  <button type="button" className="social-confirm-no" aria-label="Cancel removal" onClick={() => setFriendConfirmRemove(null)}>&times;</button>
-                                </span>
-                              ) : (
-                                <button
-                                  type="button"
-                                  className="social-remove-btn"
-                                  title={`Remove ${friend.name}`}
-                                  aria-label={`Remove ${friend.name}`}
-                                  onClick={() => setFriendConfirmRemove(friend.name)}
-                                >
-                                  &times;
-                                </button>
-                              )}
-                            </div>
-                          </li>
-                        ))}
-                      </ul>
-                    )}
-                  </div>
-                )}
-              </section>
-            </div>
-            <div aria-hidden="true" />
-          </>
-        )}
-
-        {activeSocialTab === "group" && (
+        {(
           !canChat ? (
             <>
               <div aria-hidden="true" />

--- a/web-v3/src/components/panels/FriendsBoardPanel.tsx
+++ b/web-v3/src/components/panels/FriendsBoardPanel.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { FriendEntry, FriendNotification, WhoPlayer } from "../../types";
+
+interface FriendsBoardPanelProps {
+  connected: boolean;
+  canChat: boolean;
+  friends: FriendEntry[];
+  friendNotifications: FriendNotification[];
+  whoPlayers: WhoPlayer[];
+  serverAssets: Record<string, string>;
+  onRequestWho: () => void;
+  onExamine: (player: WhoPlayer) => void;
+  onTellPlayer: (name: string) => void;
+  onAddFriend: (name: string) => void;
+  onRemoveFriend: (name: string) => void;
+}
+
+/**
+ * Standalone "Friends" board — split out of the Social panel onto the celestial
+ * `friends_bg` conservatory frame. Generated DOM (no paint-matching): an
+ * add-a-friend field, then a roster of friends with portrait, name + title,
+ * location, level, and the shared Examine / Tell action buttons plus Remove.
+ *
+ * FriendEntry is sparse (name/online/level/zone), so each row is enriched from
+ * the live Who roster (sprite, title, examine data) — the board refreshes Who
+ * on open so online friends carry full detail.
+ */
+export function FriendsBoardPanel({
+  connected,
+  canChat,
+  friends,
+  friendNotifications,
+  whoPlayers,
+  serverAssets,
+  onRequestWho,
+  onExamine,
+  onTellPlayer,
+  onAddFriend,
+  onRemoveFriend,
+}: FriendsBoardPanelProps) {
+  const [addTarget, setAddTarget] = useState("");
+  const [confirmRemove, setConfirmRemove] = useState<string | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+
+  // Refresh Who on open so online friends pick up sprites/titles/examine data.
+  const requested = useRef(false);
+  useEffect(() => {
+    if (canChat && !requested.current) { requested.current = true; onRequestWho(); }
+  }, [canChat, onRequestWho]);
+
+  const whoByName = useMemo(() => {
+    const m = new Map<string, WhoPlayer>();
+    for (const p of whoPlayers) m.set(p.name.toLowerCase(), p);
+    return m;
+  }, [whoPlayers]);
+
+  const sortedFriends = useMemo(
+    () => [...friends].sort((a, b) => {
+      const onlineDiff = (a.online ? 0 : 1) - (b.online ? 0 : 1);
+      if (onlineDiff !== 0) return onlineDiff;
+      return a.name.localeCompare(b.name);
+    }),
+    [friends],
+  );
+
+  const onlineCount = friends.filter((f) => f.online).length;
+
+  // Expire the transient "came online / went offline" banners after 30s.
+  const hasNotes = friendNotifications.length > 0;
+  useEffect(() => {
+    if (!hasNotes) return;
+    const t = window.setInterval(() => setNow(Date.now()), 5_000);
+    return () => window.clearInterval(t);
+  }, [hasNotes]);
+  const recentNotes = useMemo(
+    () => friendNotifications.filter((n) => now - n.receivedAt < 30_000),
+    [friendNotifications, now],
+  );
+
+  const examineArt = serverAssets["who_examine_btn"];
+  const tellArt = serverAssets["who_tell_btn"];
+
+  const examineFriend = (f: FriendEntry) => {
+    const wp = whoByName.get(f.name.toLowerCase());
+    onExamine(wp ?? {
+      name: f.name,
+      level: f.level ?? 0,
+      race: "",
+      playerClass: "",
+      title: null,
+      guild: null,
+      groupSize: 0,
+      idle: 0,
+      sprite: null,
+      description: null,
+    });
+  };
+
+  return (
+    <div className="friendsboard">
+      <section className="fb-add-card">
+        <h3 className="fb-add-title">Add a Friend</h3>
+        <form
+          className="fb-add-form"
+          onSubmit={(e) => { e.preventDefault(); const t = addTarget.trim(); if (t) { onAddFriend(t); setAddTarget(""); } }}
+        >
+          <input
+            type="text"
+            className="fb-add-input"
+            placeholder="Enter character name…"
+            value={addTarget}
+            onChange={(e) => setAddTarget(e.target.value)}
+            aria-label="Friend name to add"
+            disabled={!canChat}
+          />
+          <button type="submit" className="fb-add-btn" disabled={!canChat || !addTarget.trim()}>Add</button>
+        </form>
+      </section>
+
+      <div className="fb-list-head">
+        <h3 className="fb-list-title">Online Friends</h3>
+        <span className="fb-online-count">{onlineCount} Online <span className="fb-online-dot" aria-hidden="true" /></span>
+      </div>
+
+      <div className="fb-grid" role="table" aria-label="Friends">
+        <div className="fb-head" role="row">
+          <span className="fb-col-portrait" role="columnheader" aria-label="Portrait" />
+          <span className="fb-col-name" role="columnheader">Friend Name</span>
+          <span className="fb-col-loc" role="columnheader">Location</span>
+          <span className="fb-col-level" role="columnheader">Level</span>
+          <span className="fb-col-actions" role="columnheader">Actions</span>
+        </div>
+
+        <div className="fb-body">
+          {!canChat ? (
+            <p className="fb-empty">{connected ? "Log in to see your friends." : "Reconnect to load social data."}</p>
+          ) : sortedFriends.length === 0 && recentNotes.length === 0 ? (
+            <p className="fb-empty">No friends yet. Add someone above to get started.</p>
+          ) : (
+            <>
+              {recentNotes.length > 0 && (
+                <ul className="fb-notes">
+                  {recentNotes.map((n) => (
+                    <li key={n.id} className={`fb-note fb-note-${n.event}`}>
+                      <span className={`fb-dot ${n.event === "online" ? "is-online" : "is-offline"}`} aria-hidden="true" />
+                      {n.name} {n.event === "online" ? "came online" : "went offline"}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {sortedFriends.map((f) => {
+                const wp = whoByName.get(f.name.toLowerCase());
+                return (
+                  <div key={f.name} className={`fb-row${f.online ? "" : " is-offline"}`} role="row">
+                    <span className="fb-col-portrait">
+                      <span className="fb-portrait">
+                        <span className={`fb-dot fb-portrait-dot ${f.online ? "is-online" : "is-offline"}`} aria-hidden="true" />
+                        {wp?.sprite
+                          ? <img className="fb-sprite" src={wp.sprite} alt="" draggable={false} />
+                          : <span className="fb-sprite-empty" aria-hidden="true" />}
+                      </span>
+                    </span>
+                    <span className="fb-col-name">
+                      <span className="fb-name">{f.name}</span>
+                      {wp?.title && <span className="fb-title">{wp.title}</span>}
+                    </span>
+                    <span className="fb-col-loc">{f.online ? (f.zone ?? "—") : "Offline"}</span>
+                    <span className="fb-col-level">{f.level ?? wp?.level ?? "—"}</span>
+                    <span className="fb-col-actions">
+                      <button type="button" className="whoboard-action" title={`Examine ${f.name}`} aria-label={`Examine ${f.name}`} onClick={() => examineFriend(f)}>
+                        {examineArt ? <img src={examineArt} alt="" aria-hidden="true" /> : <span className="whoboard-action-glyph" aria-hidden="true">❦</span>}
+                      </button>
+                      {f.online && (
+                        <button type="button" className="whoboard-action" title={`Send a tell to ${f.name}`} aria-label={`Send a tell to ${f.name}`} onClick={() => onTellPlayer(f.name)}>
+                          {tellArt ? <img src={tellArt} alt="" aria-hidden="true" /> : <span className="whoboard-action-glyph" aria-hidden="true">✉</span>}
+                        </button>
+                      )}
+                      {confirmRemove === f.name ? (
+                        <span className="fb-confirm">
+                          <button type="button" className="fb-confirm-yes" aria-label="Confirm removal" onClick={() => { onRemoveFriend(f.name); setConfirmRemove(null); }}>Remove?</button>
+                          <button type="button" className="fb-confirm-no" aria-label="Cancel" onClick={() => setConfirmRemove(null)}>×</button>
+                        </span>
+                      ) : (
+                        <button type="button" className="whoboard-action fb-remove" title={`Remove ${f.name}`} aria-label={`Remove ${f.name}`} onClick={() => setConfirmRemove(f.name)}>
+                          <span className="whoboard-action-glyph" aria-hidden="true">×</span>
+                        </button>
+                      )}
+                    </span>
+                  </div>
+                );
+              })}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -24126,3 +24126,281 @@ html:has(.game-shell),
   .guildboard-state-a,
   .gb-columns { grid-template-columns: 1fr; }
 }
+
+/* ════════════════════════════════════════════════════════════
+   Friends board — standalone friends roster (drawerPanel "friendsboard")
+   Reuses the celestial "starframe" skin (friends_bg) and the whoboard action
+   buttons. Add-a-friend field, online header, and a roster table with
+   portrait, name + title, location, level, and Examine / Tell / Remove.
+   ════════════════════════════════════════════════════════════ */
+.friendsboard {
+  position: absolute;
+  top: 15.5%;
+  left: 8%;
+  right: 8%;
+  bottom: 8%;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(8px, 1.6vh, 14px);
+  color: #dfe6ff;
+}
+
+.fb-add-card {
+  border: 1px solid rgb(150 180 255 / 30%);
+  border-radius: 12px;
+  background: rgb(16 24 50 / 55%);
+  padding: clamp(8px, 1.4vh, 14px) clamp(10px, 1.6vw, 18px);
+  box-shadow: inset 0 0 18px rgb(0 0 0 / 35%);
+}
+
+.fb-add-title {
+  margin: 0 0 8px;
+  font-family: var(--font-display);
+  font-size: clamp(0.82rem, 1.7vw, 1rem);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgb(196 212 255 / 92%);
+}
+
+.fb-add-form { display: flex; gap: clamp(6px, 1vw, 12px); }
+
+.fb-add-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  border-radius: 999px;
+  border: 1px solid rgb(150 180 255 / 35%);
+  background: rgb(10 16 36 / 75%);
+  color: #eaf0ff;
+  padding: clamp(8px, 1.2vh, 11px) 16px;
+  font-size: 0.92rem;
+}
+.fb-add-input::placeholder { color: rgb(176 196 255 / 55%); font-style: italic; }
+.fb-add-input:focus { outline: none; border-color: rgb(176 200 255 / 75%); box-shadow: 0 0 0 2px rgb(120 150 255 / 30%); }
+
+.fb-add-btn {
+  flex: 0 0 auto;
+  border-radius: 10px;
+  border: 1px solid rgb(150 180 255 / 45%);
+  background: linear-gradient(165deg, rgb(58 92 84 / 95%), rgb(40 66 60 / 96%));
+  color: #eaf6f0;
+  font-family: var(--font-display);
+  font-size: clamp(0.82rem, 1.6vw, 1rem);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  padding: 0 clamp(16px, 2.4vw, 32px);
+  cursor: pointer;
+  transition: transform 150ms var(--ease-out-soft), filter 150ms var(--ease-out-soft);
+}
+.fb-add-btn:hover:not(:disabled) { transform: translateY(-1px); filter: brightness(1.1); }
+.fb-add-btn:disabled { opacity: 0.45; cursor: default; }
+
+.fb-list-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 4px;
+}
+
+.fb-list-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(0.82rem, 1.7vw, 1rem);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgb(196 212 255 / 92%);
+}
+
+.fb-online-count {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: clamp(0.74rem, 1.4vw, 0.9rem);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgb(176 196 255 / 80%);
+}
+.fb-online-dot { width: 8px; height: 8px; border-radius: 50%; background: #79c46b; box-shadow: 0 0 6px rgb(121 196 107 / 80%); }
+
+.fb-grid {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid rgb(150 180 255 / 24%);
+  border-radius: 12px;
+  background: rgb(12 18 40 / 45%);
+  overflow: hidden;
+}
+
+.fb-head,
+.fb-row {
+  display: grid;
+  grid-template-columns: clamp(44px, 8%, 74px) 1.8fr 1.6fr 0.6fr clamp(100px, 16%, 168px);
+  align-items: center;
+  gap: clamp(4px, 1vw, 12px);
+  padding: 0 clamp(8px, 1.4vw, 16px);
+}
+
+.fb-head {
+  padding-top: 10px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid rgb(150 180 255 / 26%);
+  font-family: var(--font-display);
+  font-size: clamp(0.72rem, 1.4vw, 0.88rem);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgb(176 196 255 / 80%);
+}
+
+.fb-col-actions { text-align: center; }
+
+.fb-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgb(150 180 255 / 55%) transparent;
+}
+.fb-body::-webkit-scrollbar { width: 8px; }
+.fb-body::-webkit-scrollbar-thumb { border-radius: 999px; background: linear-gradient(180deg, rgb(150 180 255 / 70%), rgb(90 120 210 / 65%)); }
+.fb-body::-webkit-scrollbar-track { background: transparent; }
+
+.fb-row {
+  min-height: clamp(48px, 10%, 78px);
+  border-bottom: 1px solid rgb(120 150 230 / 12%);
+  transition: background 150ms var(--ease-out-soft);
+}
+.fb-row:hover { background: rgb(120 150 255 / 9%); }
+.fb-row.is-offline { opacity: 0.55; }
+
+.fb-portrait {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: clamp(36px, 92%, 56px);
+  aspect-ratio: 1;
+  border-radius: 50%;
+  border: 1px solid rgb(150 180 255 / 45%);
+  background:
+    radial-gradient(circle at 50% 35%, rgb(70 100 180 / 55%), transparent 65%),
+    linear-gradient(160deg, rgb(24 32 64 / 92%), rgb(12 16 34 / 94%));
+  box-shadow: inset 0 0 10px rgb(0 0 0 / 55%), 0 0 8px rgb(120 150 255 / 25%);
+  overflow: hidden;
+}
+.fb-portrait-dot {
+  position: absolute;
+  left: -2px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  z-index: 1;
+}
+.fb-sprite { max-width: 90%; max-height: 90%; object-fit: contain; filter: drop-shadow(0 2px 4px rgb(0 0 0 / 55%)); }
+.fb-sprite-empty { width: 55%; height: 55%; border-radius: 50%; background: rgb(150 180 255 / 14%); }
+
+.fb-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+.fb-dot.is-online { background: #79c46b; box-shadow: 0 0 6px rgb(121 196 107 / 80%); }
+.fb-dot.is-offline { background: rgb(150 170 210 / 45%); }
+
+.fb-col-name { display: flex; flex-direction: column; min-width: 0; }
+.fb-name {
+  font-family: var(--font-display);
+  font-size: clamp(0.94rem, 2vw, 1.2rem);
+  font-weight: 600;
+  color: #eaf0ff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.fb-title {
+  font-size: clamp(0.68rem, 1.3vw, 0.84rem);
+  font-style: italic;
+  color: rgb(168 196 255 / 85%);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.fb-col-loc {
+  font-size: clamp(0.8rem, 1.5vw, 0.98rem);
+  color: rgb(206 220 255 / 88%);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.fb-col-level {
+  font-family: var(--font-display);
+  font-size: clamp(0.9rem, 1.8vw, 1.1rem);
+  color: #eaf0ff;
+  text-align: center;
+}
+
+.fb-col-actions {
+  display: flex;
+  gap: clamp(4px, 0.8vw, 10px);
+  justify-content: center;
+  align-items: center;
+}
+
+.fb-remove .whoboard-action-glyph { font-size: 1.2rem; line-height: 1; color: rgb(230 160 160 / 90%); }
+
+.fb-confirm { display: inline-flex; align-items: center; gap: 4px; }
+.fb-confirm-yes {
+  border: 1px solid rgb(200 120 120 / 50%);
+  border-radius: 8px;
+  background: rgb(120 50 50 / 70%);
+  color: #ffe0e0;
+  font-size: 0.74rem;
+  padding: 4px 8px;
+  cursor: pointer;
+}
+.fb-confirm-no {
+  border: 1px solid rgb(150 180 255 / 35%);
+  border-radius: 8px;
+  background: rgb(30 40 78 / 80%);
+  color: #cfe0ff;
+  font-size: 0.9rem;
+  padding: 2px 8px;
+  cursor: pointer;
+}
+
+.fb-notes {
+  list-style: none;
+  margin: 6px clamp(8px, 1.4vw, 16px);
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.fb-note {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 10px;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  background: rgb(60 80 140 / 22%);
+  color: rgb(214 224 255 / 90%);
+}
+.fb-note-online { background: rgb(60 110 80 / 24%); }
+.fb-note-offline { background: rgb(80 70 100 / 22%); }
+
+.fb-empty {
+  margin: auto;
+  text-align: center;
+  font-style: italic;
+  color: rgb(196 212 255 / 60%);
+  padding: clamp(20px, 8vh, 70px) 12px;
+}
+
+@media (max-width: 720px) {
+  .fb-head,
+  .fb-row { grid-template-columns: clamp(40px, 12%, 60px) 1.6fr 0.6fr clamp(96px, 26%, 150px); }
+  .fb-col-loc { display: none; }
+}

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -24146,15 +24146,14 @@ html:has(.game-shell),
 }
 
 .fb-add-card {
-  /* Span only the left portion so the painted flowers/book on the right
-     of the frame stay visible. */
+  /* No card chrome — just the label + input + button. Span only the left
+     portion so the painted flowers/book on the right stay visible. */
   align-self: flex-start;
   width: 70%;
-  border: 1px solid rgb(150 180 255 / 30%);
-  border-radius: 12px;
-  background: rgb(16 24 50 / 55%);
-  padding: clamp(8px, 1.4vh, 14px) clamp(10px, 1.6vw, 18px);
-  box-shadow: inset 0 0 18px rgb(0 0 0 / 35%);
+  border: none;
+  background: transparent;
+  padding: clamp(4px, 1vh, 10px) 0 0;
+  box-shadow: none;
 }
 
 .fb-add-title {

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -24146,6 +24146,10 @@ html:has(.game-shell),
 }
 
 .fb-add-card {
+  /* Span only the left portion so the painted flowers/book on the right
+     of the frame stay visible. */
+  align-self: flex-start;
+  width: 70%;
   border: 1px solid rgb(150 180 255 / 30%);
   border-radius: 12px;
   background: rgb(16 24 50 / 55%);

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -24135,10 +24135,10 @@ html:has(.game-shell),
    ════════════════════════════════════════════════════════════ */
 .friendsboard {
   position: absolute;
-  top: 15.5%;
-  left: 8%;
-  right: 8%;
-  bottom: 8%;
+  top: 16%;
+  left: 10.5%;
+  right: 9.5%;
+  bottom: 7%;
   display: flex;
   flex-direction: column;
   gap: clamp(8px, 1.6vh, 14px);

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -1,4 +1,4 @@
-export type PopoutPanel = "map" | "inventory" | "equipment" | "room" | "help" | "character" | "chat" | "chatboard" | "whoboard" | "guildboard" | "shop" | "spellbook" | "quests" | "questOffers" | "mail" | "crafting" | "housing" | "leaderboard" | "trainer" | "bank" | "stylist" | "auction" | "dungeon" | "lottery" | "dice" | "puzzle" | "features" | "combatlog" | "inn" | "terminal" | null;
+export type PopoutPanel = "map" | "inventory" | "equipment" | "room" | "help" | "character" | "chat" | "chatboard" | "whoboard" | "guildboard" | "friendsboard" | "shop" | "spellbook" | "quests" | "questOffers" | "mail" | "crafting" | "housing" | "leaderboard" | "trainer" | "bank" | "stylist" | "auction" | "dungeon" | "lottery" | "dice" | "puzzle" | "features" | "combatlog" | "inn" | "terminal" | null;
 export type SystemPanelView = "dungeon" | "duel" | "lottery" | "pet" | "prestige" | "currencies" | "factions";
 export type ChatChannel = "say" | "tell" | "gossip" | "shout" | "ooc" | "gtell" | "gchat";
 export type SocialTab = "chat" | "friends" | "guild" | "group" | "who";


### PR DESCRIPTION
Next piece of the Social-panel split: **Friends** moves out onto the celestial `friends_bg` conservatory frame (reusing the `starframe` skin), opened from a new **Friends** widget in the services stack.

## What's here
- **`FriendsBoardPanel`** — add-a-friend field, an online count, and a roster table: **portrait**, **name + title**, **location**, **level**, and the shared **Examine / Tell** buttons (from the Who board) plus **Remove** (inline confirm). The transient "came online / went offline" notes still fade after 30s.
- **Enriched rows** — `FriendEntry` is sparse (name/online/level/zone), so each row is merged with the live **Who** roster for sprite, title, and examine data. The board refreshes Who on open so online friends carry full detail; **Examine** reuses the `PlayerExaminePanel` manual card.
- **Reused actions** — Examine + Tell are the same buttons as Who (per your call).
- **Split** — drops the Friends tab from the Social panel. **ChatPanel is now Group-only** — the last piece before the legacy Social panel retires.

## Art contract
| key | drives | fallback |
|---|---|---|
| `friends_bg` | the conservatory frame (drawer skin) | dark starfield gradient |

## Verification
- `bun run lint` ✓, `npx tsc -b` ✓, `bun run build` ✓
- `./gradlew compileKotlin ktlintCheck` ✓