### PR TITLE
feat(web): reskin the Command Reference as the painted Arcanum book

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -3091,6 +3091,7 @@ data class ImagesConfig(
             "guild_bg" to "global_assets/guild_bg.png",
             "friends_bg" to "global_assets/friends_bg.png",
             "group_bg" to "global_assets/group_bg.png",
+            "command_reference_bg" to "global_assets/command_reference_bg.png",
             "dialog_indicator" to "global_assets/dialog_indicator.png",
             "aggro_indicator" to "global_assets/aggro_indicator.png",
             "quest_available_indicator" to "global_assets/quest_available_indicator.png",

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -963,6 +963,8 @@ function App() {
             ? "starframe"
             : drawerPanel === "groupboard"
             ? "stainedglass"
+            : drawerPanel === "help"
+            ? "codex"
             : drawerPanel === "character"
             ? "cabinet"
             : drawerPanel === "bank"
@@ -1001,6 +1003,8 @@ function App() {
             ? state.serverAssets["friends_bg"]
             : drawerPanel === "groupboard"
             ? state.serverAssets["group_bg"]
+            : drawerPanel === "help"
+            ? state.serverAssets["command_reference_bg"]
             : drawerPanel === "character"
             ? state.serverAssets["character_bg"]
             : drawerPanel === "bank"
@@ -1029,7 +1033,7 @@ function App() {
                             ? state.serverAssets["mail_bg"]
                             : undefined
         }
-        initialHeight={drawerPanel === "chatboard" || drawerPanel === "whoboard" || drawerPanel === "guildboard" || drawerPanel === "friendsboard" || drawerPanel === "groupboard" ? 0.94 : undefined}
+        initialHeight={drawerPanel === "chatboard" || drawerPanel === "whoboard" || drawerPanel === "guildboard" || drawerPanel === "friendsboard" || drawerPanel === "groupboard" || drawerPanel === "help" ? 0.94 : undefined}
       >
         {drawerPanel === "character" && (
           <CharacterPanel

--- a/web-v3/src/components/Drawer.tsx
+++ b/web-v3/src/components/Drawer.tsx
@@ -9,7 +9,7 @@ interface DrawerProps {
   /** Visual skin for the sheet chrome: warm leather (satchel), a dim
    *  dressing-chamber (equipment), a merchant cart (shop), a chalkboard
    *  (trainer), a parchment journal (combat log), or a cork quest board. */
-  variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "desk" | "mail" | "feature" | "tome" | "vault" | "cabinet" | "board" | "starframe" | "archive" | "stainedglass";
+  variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "desk" | "mail" | "feature" | "tome" | "vault" | "cabinet" | "board" | "starframe" | "archive" | "stainedglass" | "codex";
   /** Optional background art for a skinned variant (server asset). */
   skinBg?: string;
   /** Height (as a fraction of the viewport) the drawer snaps to when it opens. */

--- a/web-v3/src/components/HelpContent.tsx
+++ b/web-v3/src/components/HelpContent.tsx
@@ -2,25 +2,28 @@ import { useMemo, useState } from "react";
 import type { CommandEntry } from "../types";
 
 interface HelpCommand {
+  name: string;
   syntax: string;
   description: string;
 }
 
 interface HelpCategory {
+  key: string;
   name: string;
+  glyph: string;
   commands: HelpCommand[];
 }
 
 const CATEGORY_LABELS: Record<string, string> = {
   navigation: "Navigation",
   communication: "Communication",
-  items: "Inventory & Equipment",
+  items: "Inventory",
   world: "World Interaction",
   combat: "Combat",
   progression: "Character",
   social: "NPCs & Social",
-  shops: "NPCs & Shops",
-  quests: "Quests & Achievements",
+  shops: "Shops",
+  quests: "Quests",
   groups: "Groups",
   guilds: "Guild",
   crafting: "Crafting",
@@ -28,44 +31,49 @@ const CATEGORY_LABELS: Record<string, string> = {
   admin: "Staff",
 };
 
+// Glyph fallbacks per category (a painted icon set can replace these later).
+const CATEGORY_GLYPHS: Record<string, string> = {
+  navigation: "✦",
+  communication: "❝",
+  items: "▤",
+  world: "❦",
+  combat: "⚔",
+  progression: "❂",
+  social: "❧",
+  shops: "⚖",
+  quests: "★",
+  groups: "⚇",
+  guilds: "⚜",
+  crafting: "⚒",
+  utility: "⚙",
+  admin: "✪",
+};
+
 const CATEGORY_ORDER: string[] = [
-  "navigation",
-  "communication",
-  "items",
-  "world",
-  "combat",
-  "progression",
-  "social",
-  "shops",
-  "quests",
-  "groups",
-  "guilds",
-  "crafting",
-  "utility",
-  "admin",
+  "navigation", "communication", "items", "world", "combat", "progression",
+  "social", "shops", "quests", "groups", "guilds", "crafting", "utility", "admin",
 ];
 
-function buildFromServerCommands(commands: CommandEntry[], isStaff: boolean): HelpCategory[] {
+function buildCategories(commands: CommandEntry[], isStaff: boolean): HelpCategory[] {
   const grouped = new Map<string, HelpCommand[]>();
   for (const cmd of commands) {
     if (cmd.staff && !isStaff) continue;
-    const key = cmd.category;
-    if (!grouped.has(key)) grouped.set(key, []);
-    grouped.get(key)!.push({ syntax: cmd.usage, description: cmd.description });
+    if (!grouped.has(cmd.category)) grouped.set(cmd.category, []);
+    grouped.get(cmd.category)!.push({ name: cmd.name, syntax: cmd.usage, description: cmd.description });
   }
-
-  const categories: HelpCategory[] = [];
+  const ordered: HelpCategory[] = [];
+  const seen = new Set<string>();
   for (const key of CATEGORY_ORDER) {
     const cmds = grouped.get(key);
     if (!cmds) continue;
-    categories.push({ name: CATEGORY_LABELS[key] ?? key, commands: cmds });
-    grouped.delete(key);
+    ordered.push({ key, name: CATEGORY_LABELS[key] ?? key, glyph: CATEGORY_GLYPHS[key] ?? "✦", commands: cmds });
+    seen.add(key);
   }
-  // Append any categories not in CATEGORY_ORDER
   for (const [key, cmds] of grouped) {
-    categories.push({ name: CATEGORY_LABELS[key] ?? key, commands: cmds });
+    if (seen.has(key)) continue;
+    ordered.push({ key, name: CATEGORY_LABELS[key] ?? key, glyph: CATEGORY_GLYPHS[key] ?? "✦", commands: cmds });
   }
-  return categories;
+  return ordered;
 }
 
 interface HelpContentProps {
@@ -73,75 +81,98 @@ interface HelpContentProps {
   serverCommands: CommandEntry[];
 }
 
+/**
+ * Command Reference — the painted open-book "Arcanum". Categories down the
+ * left page, a searchable command table (command / usage / description) across
+ * the two parchment pages. The frame comes from the `command_reference_bg`
+ * skin; content is inset into the painted pages.
+ */
 export function HelpContent({ isStaff, serverCommands }: HelpContentProps) {
   const [search, setSearch] = useState("");
+  const [activeCategory, setActiveCategory] = useState<string | null>(null);
 
-  const filteredCategories = useMemo(() => {
-    if (serverCommands.length === 0) return [];
-    const categories = buildFromServerCommands(serverCommands, isStaff);
+  const categories = useMemo(() => buildCategories(serverCommands, isStaff), [serverCommands, isStaff]);
 
-    const query = search.trim().toLowerCase();
-    if (query.length === 0) return categories;
+  const query = search.trim().toLowerCase();
+  const current = activeCategory ?? categories[0]?.key ?? null;
 
-    return categories
-      .map((cat) => ({
-        ...cat,
-        commands: cat.commands.filter(
-          (cmd) =>
-            cmd.syntax.toLowerCase().includes(query) ||
-            cmd.description.toLowerCase().includes(query),
-        ),
-      }))
-      .filter((cat) => cat.commands.length > 0);
-  }, [search, isStaff, serverCommands]);
+  // Search spans every category; otherwise show the selected category's commands.
+  const rows = useMemo(() => {
+    if (query.length > 0) {
+      return categories.flatMap((cat) =>
+        cat.commands
+          .filter((c) => c.name.toLowerCase().includes(query) || c.syntax.toLowerCase().includes(query) || c.description.toLowerCase().includes(query))
+          .map((c) => ({ ...c, glyph: cat.glyph })),
+      );
+    }
+    const cat = categories.find((c) => c.key === current);
+    return cat ? cat.commands.map((c) => ({ ...c, glyph: cat.glyph })) : [];
+  }, [query, categories, current]);
 
   if (serverCommands.length === 0) {
     return (
-      <div className="help-content">
-        <p className="empty-note">Loading commands&hellip;</p>
+      <div className="command-reference command-reference-loading">
+        <p className="cr-empty">Inscribing the Arcanum…</p>
       </div>
     );
   }
 
   return (
-    <div className="help-content">
-      <div className="help-search-wrap">
-        <input
-          type="text"
-          className="help-search-input"
-          placeholder="Search commands..."
-          aria-label="Search help commands"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          autoFocus
-        />
+    <div className="command-reference">
+      {/* ── Categories (left page) ───────────────────────────── */}
+      <nav className="cr-categories" aria-label="Command categories">
+        {categories.map((cat) => (
+          <button
+            key={cat.key}
+            type="button"
+            className={`cr-cat${current === cat.key && query.length === 0 ? " is-active" : ""}`}
+            onClick={() => { setActiveCategory(cat.key); setSearch(""); }}
+            aria-pressed={current === cat.key && query.length === 0}
+          >
+            <span className="cr-cat-glyph" aria-hidden="true">{cat.glyph}</span>
+            <span className="cr-cat-name">{cat.name}</span>
+          </button>
+        ))}
+      </nav>
+
+      {/* ── Search + command table (center pages) ────────────── */}
+      <div className="cr-main">
+        <div className="cr-search-wrap">
+          <span className="cr-search-icon" aria-hidden="true">⚲</span>
+          <input
+            type="text"
+            className="cr-search"
+            placeholder="Search commands…"
+            aria-label="Search commands"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            autoFocus
+          />
+        </div>
+
+        <div className="cr-table-head" aria-hidden="true">
+          <span className="cr-col-cmd">Command</span>
+          <span className="cr-col-usage">Usage</span>
+          <span className="cr-col-desc">Description</span>
+        </div>
+
+        <div className="cr-rows" role="list">
+          {rows.length === 0 ? (
+            <p className="cr-empty">No commands match your search.</p>
+          ) : (
+            rows.map((r) => (
+              <div key={`${r.name}-${r.syntax}`} className="cr-row" role="listitem">
+                <span className="cr-col-cmd">
+                  <span className="cr-row-glyph" aria-hidden="true">{r.glyph}</span>
+                  <span className="cr-cmd-name">{r.name}</span>
+                </span>
+                <span className="cr-col-usage">{r.syntax}</span>
+                <span className="cr-col-desc">{r.description}</span>
+              </div>
+            ))
+          )}
+        </div>
       </div>
-
-      {search.trim().length > 0 && (
-        <div className="sr-only" aria-live="polite" aria-atomic="true">
-          {filteredCategories.reduce((n, cat) => n + cat.commands.length, 0)} commands found
-        </div>
-      )}
-
-      {filteredCategories.length === 0 ? (
-        <p className="empty-note">No commands match your search.</p>
-      ) : (
-        <div className="help-category-list">
-          {filteredCategories.map((cat) => (
-            <section key={cat.name} className="help-category">
-              <h3 className="help-category-title">{cat.name}</h3>
-              <dl className="help-command-list">
-                {cat.commands.map((cmd) => (
-                  <div key={cmd.syntax} className="help-command-entry">
-                    <dt className="help-command-syntax">{cmd.syntax}</dt>
-                    <dd className="help-command-desc">{cmd.description}</dd>
-                  </div>
-                ))}
-              </dl>
-            </section>
-          ))}
-        </div>
-      )}
     </div>
   );
 }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -24810,11 +24810,13 @@ html:has(.game-shell),
   left: 30%;
   right: 28.5%;
   top: 18.5%;
-  bottom: 19%;
+  bottom: 21.5%;
   display: flex;
   flex-direction: column;
   gap: clamp(6px, 1.2vh, 12px);
-  color: #3a2c18;
+  color: #2e2110;
+  /* Subtle light "engraving" lifts the ink off the busy parchment texture. */
+  text-shadow: 0 1px 1px rgb(255 248 228 / 65%);
 }
 
 .cr-search-wrap {
@@ -24879,7 +24881,7 @@ html:has(.game-shell),
   font-family: var(--font-display);
   font-weight: 700;
   font-size: clamp(0.84rem, 1.5vw, 1.04rem);
-  color: #2f2410;
+  color: #241a08;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -24887,12 +24889,13 @@ html:has(.game-shell),
 .cr-col-usage {
   font-family: "JetBrains Mono", "Cascadia Mono", monospace;
   font-size: clamp(0.68rem, 1.2vw, 0.84rem);
-  color: #5a4426;
+  color: #463418;
+  font-weight: 600;
   word-break: break-word;
 }
 .cr-col-desc {
   font-size: clamp(0.72rem, 1.3vw, 0.9rem);
-  color: #3a2c18;
+  color: #2a1f0e;
   line-height: 1.35;
 }
 

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -24715,3 +24715,191 @@ html:has(.game-shell),
 .gp-chat-form .gp-input { flex: 1; }
 
 .gp-footer { display: flex; justify-content: center; margin-top: clamp(6px, 1.4vh, 12px); }
+
+/* ════════════════════════════════════════════════════════════
+   Command Reference — the painted open-book Arcanum (drawerPanel "help")
+   `command_reference_bg` skin: a dark Categories panel on the left page and a
+   searchable command table (command / usage / description) across the two
+   parchment pages. Content is inset into the painted regions.
+   ════════════════════════════════════════════════════════════ */
+.drawer-sheet.drawer-sheet-codex {
+  background-image:
+    var(--skin-bg, none),
+    radial-gradient(ellipse at 50% 35%, rgb(20 26 56 / 96%), rgb(8 10 28 / 98%));
+  background-size: cover, auto;
+  background-position: center, center;
+  background-repeat: no-repeat, no-repeat;
+}
+
+.drawer-sheet-codex .drawer-title { display: none; }
+.drawer-sheet-codex .drawer-handle-zone { display: none; }
+
+.drawer-sheet-codex .drawer-header {
+  position: absolute;
+  top: 2.2%;
+  right: 2.4%;
+  left: auto;
+  z-index: 6;
+  padding: 0;
+  min-height: 0;
+  border-bottom: none;
+}
+
+.drawer-sheet-codex .drawer-body {
+  padding: 0;
+  position: relative;
+}
+
+@media (min-width: 768px) {
+  .drawer-sheet.drawer-sheet-codex {
+    width: auto;
+    height: min(94vh, 71vw);
+    max-height: 94vh;
+    aspect-ratio: 1456 / 1093;
+  }
+}
+
+.command-reference { position: absolute; inset: 0; }
+.command-reference-loading { display: grid; place-items: center; }
+
+/* ── Categories (left page, dark panel) ───────────────────── */
+.cr-categories {
+  position: absolute;
+  left: 14%;
+  top: 25%;
+  width: 12.5%;
+  bottom: 24%;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2px, 0.6vh, 6px);
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgb(210 180 110 / 50%) transparent;
+}
+
+.cr-cat {
+  display: flex;
+  align-items: center;
+  gap: clamp(5px, 0.6vw, 9px);
+  padding: clamp(4px, 0.9vh, 8px) clamp(5px, 0.7vw, 10px);
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: none;
+  color: #d9c089;
+  cursor: pointer;
+  font-family: var(--font-display);
+  font-size: clamp(0.68rem, 1.2vw, 0.9rem);
+  text-align: left;
+  transition: background 150ms var(--ease-out-soft), border-color 150ms var(--ease-out-soft), color 150ms var(--ease-out-soft);
+}
+
+.cr-cat:hover { background: rgb(210 180 110 / 12%); color: #f0d89a; }
+.cr-cat.is-active {
+  border-color: rgb(210 180 110 / 60%);
+  background: rgb(210 180 110 / 16%);
+  box-shadow: 0 0 12px rgb(210 180 110 / 28%), inset 0 0 8px rgb(210 180 110 / 12%);
+  color: #f4dca0;
+}
+
+.cr-cat-glyph { flex-shrink: 0; color: #e6c878; font-size: 1.1em; }
+.cr-cat-name { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+/* ── Search + table (center parchment pages) ──────────────── */
+.cr-main {
+  position: absolute;
+  left: 30%;
+  right: 28.5%;
+  top: 18.5%;
+  bottom: 19%;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(6px, 1.2vh, 12px);
+  color: #3a2c18;
+}
+
+.cr-search-wrap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid rgb(120 96 52 / 45%);
+  border-radius: 999px;
+  background: rgb(255 250 235 / 35%);
+  padding: clamp(5px, 1vh, 9px) 14px;
+}
+.cr-search-icon { color: rgb(120 96 52 / 80%); font-size: 1rem; }
+.cr-search {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: none;
+  color: #3a2c18;
+  font-size: 0.92rem;
+}
+.cr-search:focus { outline: none; }
+.cr-search::placeholder { color: rgb(90 72 44 / 60%); font-style: italic; }
+
+.cr-table-head,
+.cr-row {
+  display: grid;
+  grid-template-columns: 1.1fr 1.3fr 2.4fr;
+  gap: clamp(6px, 1.1vw, 18px);
+  align-items: baseline;
+}
+
+.cr-table-head {
+  font-family: var(--font-display);
+  font-size: clamp(0.62rem, 1.1vw, 0.78rem);
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgb(90 66 38 / 80%);
+  padding-bottom: 4px;
+  border-bottom: 1px solid rgb(120 96 52 / 38%);
+}
+
+.cr-rows {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgb(150 120 70 / 55%) transparent;
+}
+.cr-rows::-webkit-scrollbar { width: 7px; }
+.cr-rows::-webkit-scrollbar-thumb { border-radius: 999px; background: rgb(150 120 70 / 55%); }
+.cr-rows::-webkit-scrollbar-track { background: transparent; }
+
+.cr-row {
+  padding: clamp(5px, 1vh, 9px) 0;
+  border-bottom: 1px solid rgb(120 96 52 / 18%);
+}
+
+.cr-col-cmd { display: flex; align-items: center; gap: 7px; min-width: 0; }
+.cr-row-glyph { flex-shrink: 0; color: #8a6a3a; font-size: 1.05em; }
+.cr-cmd-name {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(0.84rem, 1.5vw, 1.04rem);
+  color: #2f2410;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cr-col-usage {
+  font-family: "JetBrains Mono", "Cascadia Mono", monospace;
+  font-size: clamp(0.68rem, 1.2vw, 0.84rem);
+  color: #5a4426;
+  word-break: break-word;
+}
+.cr-col-desc {
+  font-size: clamp(0.72rem, 1.3vw, 0.9rem);
+  color: #3a2c18;
+  line-height: 1.35;
+}
+
+.cr-empty {
+  margin: auto;
+  text-align: center;
+  font-style: italic;
+  color: rgb(90 72 44 / 70%);
+  padding: clamp(16px, 5vh, 40px) 12px;
+}


### PR DESCRIPTION
Reskins the Command Reference (the `help` panel) into the painted open-book **Arcanum** from your concept.

## Layout
- **Categories** down the left page (dark panel) — click to filter; gold-on-dark with an active glow on the selected one.
- **Searchable command table** across the two parchment pages: **Command · Usage · Description**, with a category glyph per row. Search spans every category; clearing it returns to the selected category.
- Built on the server's command metadata (no new data) — same source the old list used.

## Skin
- New **`codex`** drawer variant (4:3, opens near-full height). Title hidden (the book paints its own "Command Reference" banner), close floated to the top-right corner.
- Content inset into the painted regions (categories panel left ~14%, table centered across the pages).

## Art contract
| key | drives | fallback |
|---|---|---|
| `command_reference_bg` | the open-book frame (drawer skin) | dark starfield gradient |

Category icons are glyph fallbacks (✦ ⚔ ⚜ …) — paint a set and I'll wire `cr_cat_*` keys to upgrade them.

## Verification
- `bun run lint` ✓, `npx tsc -b` ✓, `bun run build` ✓
- `./gradlew compileKotlin ktlintCheck` ✓

Insets (categories panel + table) are eyeballed off your blank frame — send a shot and I'll seat the columns/rail cleanly onto the painted pages.