### PR TITLE
feat(web): reskin the Stylist as the painted race-change parlour

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -3092,6 +3092,7 @@ data class ImagesConfig(
             "friends_bg" to "global_assets/friends_bg.png",
             "group_bg" to "global_assets/group_bg.png",
             "command_reference_bg" to "global_assets/command_reference_bg.png",
+            "stylist_bg" to "global_assets/stylist_bg.png",
             "dialog_indicator" to "global_assets/dialog_indicator.png",
             "aggro_indicator" to "global_assets/aggro_indicator.png",
             "quest_available_indicator" to "global_assets/quest_available_indicator.png",

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -965,6 +965,8 @@ function App() {
             ? "stainedglass"
             : drawerPanel === "help"
             ? "codex"
+            : drawerPanel === "stylist"
+            ? "boudoir"
             : drawerPanel === "character"
             ? "cabinet"
             : drawerPanel === "bank"
@@ -1005,6 +1007,8 @@ function App() {
             ? state.serverAssets["group_bg"]
             : drawerPanel === "help"
             ? state.serverAssets["command_reference_bg"]
+            : drawerPanel === "stylist"
+            ? state.serverAssets["stylist_bg"]
             : drawerPanel === "character"
             ? state.serverAssets["character_bg"]
             : drawerPanel === "bank"
@@ -1033,7 +1037,7 @@ function App() {
                             ? state.serverAssets["mail_bg"]
                             : undefined
         }
-        initialHeight={drawerPanel === "chatboard" || drawerPanel === "whoboard" || drawerPanel === "guildboard" || drawerPanel === "friendsboard" || drawerPanel === "groupboard" || drawerPanel === "help" ? 0.94 : undefined}
+        initialHeight={drawerPanel === "chatboard" || drawerPanel === "whoboard" || drawerPanel === "guildboard" || drawerPanel === "friendsboard" || drawerPanel === "groupboard" || drawerPanel === "help" || drawerPanel === "stylist" ? 0.94 : undefined}
       >
         {drawerPanel === "character" && (
           <CharacterPanel
@@ -1355,7 +1359,7 @@ function App() {
         )}
 
         {drawerPanel === "stylist" && (
-          <StylistPanel stylistState={state.stylistState} onCommand={sendCommand} />
+          <StylistPanel stylistState={state.stylistState} serverAssets={state.serverAssets} onCommand={sendCommand} />
         )}
 
         {drawerPanel === "auction" && (

--- a/web-v3/src/components/Drawer.tsx
+++ b/web-v3/src/components/Drawer.tsx
@@ -9,7 +9,7 @@ interface DrawerProps {
   /** Visual skin for the sheet chrome: warm leather (satchel), a dim
    *  dressing-chamber (equipment), a merchant cart (shop), a chalkboard
    *  (trainer), a parchment journal (combat log), or a cork quest board. */
-  variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "desk" | "mail" | "feature" | "tome" | "vault" | "cabinet" | "board" | "starframe" | "archive" | "stainedglass" | "codex";
+  variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "desk" | "mail" | "feature" | "tome" | "vault" | "cabinet" | "board" | "starframe" | "archive" | "stainedglass" | "codex" | "boudoir";
   /** Optional background art for a skinned variant (server asset). */
   skinBg?: string;
   /** Height (as a fraction of the viewport) the drawer snaps to when it opens. */

--- a/web-v3/src/components/panels/StylistPanel.tsx
+++ b/web-v3/src/components/panels/StylistPanel.tsx
@@ -1,107 +1,106 @@
+import { useState } from "react";
 import type { StylistRace, StylistState } from "../../types";
 
 interface StylistPanelProps {
   stylistState: StylistState | null;
+  serverAssets: Record<string, string>;
   onCommand: (cmd: string) => void;
 }
 
-function formatMod(key: string, value: number): string {
-  return value >= 0 ? `${key} +${value}` : `${key} ${value}`;
+/** Tint a stat mod by its kind to echo the concept's colour coding. */
+function modClass(key: string): string {
+  const k = key.toUpperCase();
+  if (k.includes("HP") || k.includes("CRIT")) return "sty-mod-red";
+  if (k.includes("MANA")) return "sty-mod-blue";
+  if (k.includes("DEX") || k.includes("EVADE") || k.includes("STEALTH") || k.includes("NATURE")) return "sty-mod-green";
+  return "sty-mod-gold";
 }
 
-export function StylistPanel({ stylistState, onCommand }: StylistPanelProps) {
+/**
+ * Stylist — race change parlour, reskinned onto the painted `stylist_bg`
+ * frame. Six selectable race cards in the central grid; the painted "Change
+ * Race" button (an invisible hotspot) commits the selected race. Cost, current
+ * race, and gold are inset into their painted slots.
+ */
+export function StylistPanel({ stylistState, serverAssets, onCommand }: StylistPanelProps) {
+  const [selected, setSelected] = useState<string | null>(null);
+
   if (!stylistState) {
     return (
-      <div className="stylist-panel">
-        <div className="panel-header">
-          <span className="panel-title">Stylist</span>
-        </div>
-        <div className="stylist-empty-state">
-          <span className="stylist-empty-icon">{"\u{2728}"}</span>
-          <p className="empty-note">The mirror is dim.</p>
-          <p className="stylist-hint">
-            Visit a stylist room and use the <code>stylist</code> command.
-          </p>
-        </div>
+      <div className="stylist-board stylist-board-empty">
+        <p className="sty-empty">The mirror is dim. Visit a stylist and use the <code>stylist</code> command.</p>
       </div>
     );
   }
 
-  const affordable = stylistState.playerGold >= stylistState.feeGold;
+  const { feeGold, playerGold, currentRace, races } = stylistState;
+  const affordable = playerGold >= feeGold;
+  const isCurrentId = (id: string) => id.toUpperCase() === currentRace.toUpperCase();
+  const current = races.find((r) => isCurrentId(r.id));
+  const selectedRace = races.find((r) => r.id === selected) ?? null;
+  const canChange = !!selectedRace && !isCurrentId(selectedRace.id) && affordable;
 
   return (
-    <div className="stylist-panel">
-      <div className="stylist-wallet">
-        <span className="stylist-gold-icon" aria-hidden="true" />
-        <span className="stylist-gold-amount">{stylistState.playerGold.toLocaleString()}</span>
-        <span className="stylist-gold-label">gold</span>
-        <span className="stylist-fee-tag">
-          {stylistState.feeGold.toLocaleString()}g per change
-        </span>
+    <div className="stylist-board">
+      <div className="sty-cost">Race Change Price: <strong>{feeGold.toLocaleString()} Gold</strong></div>
+
+      <div className="sty-grid">
+        {races.map((race: StylistRace) => {
+          const isCurrent = isCurrentId(race.id);
+          const mods = Object.entries(race.statMods).filter(([, v]) => v !== 0).sort(([a], [b]) => a.localeCompare(b));
+          return (
+            <button
+              key={race.id}
+              type="button"
+              className={`sty-card${selected === race.id ? " is-selected" : ""}${isCurrent ? " is-current" : ""}`}
+              onClick={() => setSelected(race.id)}
+              aria-pressed={selected === race.id}
+            >
+              {race.image && <img className="sty-card-portrait" src={race.image} alt="" loading="lazy" />}
+              <div className="sty-card-text">
+                <span className="sty-card-name">{race.displayName}{isCurrent && <span className="sty-card-tag">current</span>}</span>
+                {race.description && <span className="sty-card-desc">{race.description}</span>}
+                {mods.length > 0 && (
+                  <span className="sty-card-mods">
+                    {mods.map(([k, v]) => (
+                      <span key={k} className={`sty-mod ${modClass(k)}`}>{v >= 0 ? `+${v}` : v} {k}</span>
+                    ))}
+                  </span>
+                )}
+              </div>
+            </button>
+          );
+        })}
       </div>
 
-      {stylistState.races.length === 0 ? (
-        <p className="empty-note">No races available.</p>
-      ) : (
-        <div className="stylist-race-list">
-          {stylistState.races.map((race: StylistRace) => {
-            const isCurrent = race.id.toUpperCase() === stylistState.currentRace.toUpperCase();
-            const mods = Object.entries(race.statMods).filter(([, v]) => v !== 0);
-            return (
-              <div
-                key={race.id}
-                className={`stylist-race-card${isCurrent ? " stylist-race-card-current" : ""}${!affordable && !isCurrent ? " stylist-race-card-unaffordable" : ""}`}
-              >
-                <div className="stylist-race-card-top">
-                  <div className="stylist-race-card-info">
-                    {race.image && (
-                      <img
-                        src={race.image}
-                        alt=""
-                        className="stylist-race-thumb"
-                        loading="lazy"
-                      />
-                    )}
-                    <div className="stylist-race-card-text">
-                      <span className="stylist-race-name">
-                        {race.displayName}
-                        {isCurrent && <span className="stylist-badge-current">current</span>}
-                      </span>
-                      {race.description && (
-                        <span className="stylist-race-desc">{race.description}</span>
-                      )}
-                      {mods.length > 0 && (
-                        <span className="stylist-race-mods">
-                          {mods.sort(([a], [b]) => a.localeCompare(b)).map(([k, v]) => (
-                            <span key={k} className={`stylist-mod-chip${v >= 0 ? " stylist-mod-pos" : " stylist-mod-neg"}`}>
-                              {formatMod(k, v)}
-                            </span>
-                          ))}
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                  <div className="stylist-race-card-action">
-                    {!isCurrent && (
-                      <span className={`stylist-race-price${affordable ? "" : " stylist-race-price-cant"}`}>
-                        {stylistState.feeGold.toLocaleString()}g
-                      </span>
-                    )}
-                    <button
-                      type="button"
-                      className="soft-button stylist-change-btn"
-                      disabled={isCurrent || !affordable}
-                      onClick={() => onCommand(`changerace ${race.id}`)}
-                    >
-                      {isCurrent ? "Current" : "Change"}
-                    </button>
-                  </div>
-                </div>
-              </div>
-            );
-          })}
+      {/* Invisible hotspot over the painted CHANGE RACE button. */}
+      <button
+        type="button"
+        className="sty-change-hit"
+        disabled={!canChange}
+        aria-label={selectedRace ? `Change race to ${selectedRace.displayName}` : "Select a race to change"}
+        title={
+          !selectedRace ? "Select a race first"
+            : isCurrentId(selectedRace.id) ? "That's already your race"
+              : !affordable ? "Not enough gold"
+                : `Change to ${selectedRace.displayName}`
+        }
+        onClick={() => { if (canChange && selectedRace) onCommand(`changerace ${selectedRace.id}`); }}
+      />
+
+      {/* Current race, inset into the painted "Your Current Race" card. */}
+      <div className="sty-current">
+        {current?.image && <img className="sty-current-portrait" src={current.image} alt="" />}
+        <div className="sty-current-text">
+          <span className="sty-current-name">{current?.displayName ?? currentRace}</span>
+          <span className="sty-current-bonuses">Bonuses Active</span>
         </div>
-      )}
+      </div>
+
+      <div className="sty-gold">
+        <span className="sty-gold-icon" aria-hidden="true">{serverAssets["coin_icon"] ? <img src={serverAssets["coin_icon"]} alt="" /> : "◉"}</span>
+        Your Gold: <strong>{playerGold.toLocaleString()}</strong>
+      </div>
     </div>
   );
 }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -24962,7 +24962,7 @@ html:has(.game-shell),
 /* Price banner slot under the title. */
 .sty-cost {
   position: absolute;
-  top: 20.2%;
+  top: 19.5%;
   left: 33%;
   width: 34%;
   text-align: center;
@@ -25055,8 +25055,8 @@ html:has(.game-shell),
 /* Invisible hotspot over the painted CHANGE RACE button. */
 .sty-change-hit {
   position: absolute;
-  left: 37%;
-  top: 79.5%;
+  left: 38.5%;
+  top: 78%;
   width: 26%;
   height: 9.5%;
   border: none;
@@ -25073,7 +25073,7 @@ html:has(.game-shell),
 .sty-current {
   position: absolute;
   left: 67.5%;
-  top: 82.3%;
+  top: 80.8%;
   width: 21%;
   height: 9%;
   display: flex;

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -24906,3 +24906,200 @@ html:has(.game-shell),
   color: rgb(90 72 44 / 70%);
   padding: clamp(16px, 5vh, 40px) 12px;
 }
+
+/* ════════════════════════════════════════════════════════════
+   Stylist — race-change parlour (drawerPanel "stylist")
+   Painted `stylist_bg` frame (skin). Content inset into the painted slots:
+   the price banner, a 3x2 grid of selectable race cards, the current-race
+   card, gold, and an invisible hotspot over the painted CHANGE RACE button.
+   ════════════════════════════════════════════════════════════ */
+.drawer-sheet.drawer-sheet-boudoir {
+  background-image:
+    var(--skin-bg, none),
+    radial-gradient(ellipse at 50% 30%, rgb(40 24 56 / 96%), rgb(16 10 26 / 98%));
+  background-size: cover, auto;
+  background-position: center, center;
+  background-repeat: no-repeat, no-repeat;
+}
+
+.drawer-sheet-boudoir .drawer-title { display: none; }
+.drawer-sheet-boudoir .drawer-handle-zone { display: none; }
+
+.drawer-sheet-boudoir .drawer-header {
+  position: absolute;
+  top: 3.5%;
+  right: 3%;
+  left: auto;
+  z-index: 6;
+  padding: 0;
+  min-height: 0;
+  border-bottom: none;
+}
+.drawer-sheet-boudoir .drawer-close {
+  background: transparent;
+  border-color: transparent;
+  color: #e0c074;
+}
+
+.drawer-sheet-boudoir .drawer-body {
+  padding: 0;
+  position: relative;
+}
+
+@media (min-width: 768px) {
+  .drawer-sheet.drawer-sheet-boudoir {
+    width: auto;
+    height: min(94vh, 71vw);
+    max-height: 94vh;
+    aspect-ratio: 1456 / 1093;
+  }
+}
+
+.stylist-board { position: absolute; inset: 0; }
+.stylist-board-empty { display: grid; place-items: center; }
+.sty-empty { color: #d9c089; text-align: center; max-width: 60%; }
+
+/* Price banner slot under the title. */
+.sty-cost {
+  position: absolute;
+  top: 18.6%;
+  left: 33%;
+  width: 34%;
+  text-align: center;
+  font-family: var(--font-display);
+  font-size: clamp(0.78rem, 1.6vw, 1.08rem);
+  letter-spacing: 0.05em;
+  color: #e6c878;
+}
+.sty-cost strong { color: #f4dc9a; }
+
+/* 3x2 race-card grid. */
+.sty-grid {
+  position: absolute;
+  left: 11%;
+  right: 11%;
+  top: 25%;
+  bottom: 28%;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(2, 1fr);
+  gap: clamp(8px, 1.3vw, 18px);
+}
+
+.sty-card {
+  display: flex;
+  gap: clamp(6px, 0.8vw, 12px);
+  padding: clamp(6px, 1vh, 12px);
+  border: 1px solid rgb(200 170 90 / 35%);
+  border-radius: 12px;
+  background: linear-gradient(160deg, rgb(30 20 44 / 72%), rgb(18 12 28 / 78%));
+  color: #e8e0f0;
+  cursor: pointer;
+  text-align: left;
+  overflow: hidden;
+  transition: border-color 150ms var(--ease-out-soft), box-shadow 150ms var(--ease-out-soft), transform 150ms var(--ease-out-soft);
+}
+.sty-card:hover { transform: translateY(-2px); border-color: rgb(230 200 115 / 60%); }
+.sty-card.is-selected {
+  border-color: #e6c878;
+  box-shadow: 0 0 16px rgb(200 170 90 / 45%), inset 0 0 10px rgb(200 170 90 / 12%);
+}
+.sty-card.is-current { border-color: rgb(120 200 140 / 55%); }
+
+.sty-card-portrait {
+  width: clamp(40px, 26%, 86px);
+  aspect-ratio: 3 / 4;
+  object-fit: cover;
+  border-radius: 8px;
+  flex-shrink: 0;
+  border: 1px solid rgb(200 170 90 / 30%);
+}
+.sty-card-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.sty-card-name {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-display);
+  font-size: clamp(0.82rem, 1.5vw, 1.12rem);
+  font-weight: 700;
+  color: #f0d89a;
+}
+.sty-card-tag {
+  font-size: 0.58rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #8fd6a0;
+  border: 1px solid rgb(120 200 140 / 50%);
+  border-radius: 999px;
+  padding: 0 6px;
+}
+.sty-card-desc {
+  font-size: clamp(0.62rem, 1.05vw, 0.78rem);
+  font-style: italic;
+  color: rgb(220 210 235 / 78%);
+  line-height: 1.22;
+}
+.sty-card-mods { display: flex; flex-direction: column; gap: 0; margin-top: 2px; }
+.sty-mod { font-size: clamp(0.6rem, 1.05vw, 0.78rem); font-weight: 600; line-height: 1.3; }
+.sty-mod-gold { color: #e6c878; }
+.sty-mod-red { color: #e08a8a; }
+.sty-mod-blue { color: #7fb6e6; }
+.sty-mod-green { color: #8fd6a0; }
+
+/* Invisible hotspot over the painted CHANGE RACE button. */
+.sty-change-hit {
+  position: absolute;
+  left: 39%;
+  top: 79.5%;
+  width: 22%;
+  height: 9.5%;
+  border: none;
+  background: transparent;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: box-shadow 150ms var(--ease-out-soft);
+}
+.sty-change-hit:disabled { cursor: default; }
+.sty-change-hit:hover:not(:disabled) { box-shadow: 0 0 18px rgb(230 200 115 / 45%); }
+.sty-change-hit:focus-visible { outline: 2px solid rgb(230 200 115 / 80%); outline-offset: 2px; }
+
+/* Current race, inset into the painted "Your Current Race" card. */
+.sty-current {
+  position: absolute;
+  left: 67.5%;
+  top: 84%;
+  width: 21%;
+  height: 9%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.sty-current-portrait {
+  width: clamp(28px, 28%, 46px);
+  aspect-ratio: 1;
+  object-fit: cover;
+  border-radius: 50%;
+  border: 1px solid rgb(200 170 90 / 50%);
+  flex-shrink: 0;
+}
+.sty-current-text { display: flex; flex-direction: column; min-width: 0; }
+.sty-current-name { font-family: var(--font-display); font-size: clamp(0.84rem, 1.5vw, 1.08rem); font-weight: 700; color: #f0e0f8; }
+.sty-current-bonuses { font-size: 0.72rem; color: #8fd6a0; }
+
+/* Gold at the bottom. */
+.sty-gold {
+  position: absolute;
+  left: 50%;
+  right: 11%;
+  bottom: 2.4%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  font-family: var(--font-display);
+  font-size: clamp(0.76rem, 1.4vw, 1rem);
+  color: #d9c089;
+}
+.sty-gold strong { color: #f4dc9a; }
+.sty-gold-icon { color: #e6c878; display: inline-flex; }
+.sty-gold-icon img { width: 1.1em; height: 1.1em; object-fit: contain; }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -24962,7 +24962,7 @@ html:has(.game-shell),
 /* Price banner slot under the title. */
 .sty-cost {
   position: absolute;
-  top: 18.6%;
+  top: 20.2%;
   left: 33%;
   width: 34%;
   text-align: center;
@@ -24978,8 +24978,8 @@ html:has(.game-shell),
   position: absolute;
   left: 11%;
   right: 11%;
-  top: 25%;
-  bottom: 28%;
+  top: 24%;
+  bottom: 26%;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   grid-template-rows: repeat(2, 1fr);
@@ -25034,10 +25034,16 @@ html:has(.game-shell),
   padding: 0 6px;
 }
 .sty-card-desc {
-  font-size: clamp(0.62rem, 1.05vw, 0.78rem);
+  font-size: clamp(0.6rem, 1vw, 0.76rem);
   font-style: italic;
   color: rgb(220 210 235 / 78%);
-  line-height: 1.22;
+  line-height: 1.2;
+  /* Clamp long lore to 2 lines so the stat mods always fit on the card. */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 .sty-card-mods { display: flex; flex-direction: column; gap: 0; margin-top: 2px; }
 .sty-mod { font-size: clamp(0.6rem, 1.05vw, 0.78rem); font-weight: 600; line-height: 1.3; }
@@ -25049,9 +25055,9 @@ html:has(.game-shell),
 /* Invisible hotspot over the painted CHANGE RACE button. */
 .sty-change-hit {
   position: absolute;
-  left: 39%;
+  left: 37%;
   top: 79.5%;
-  width: 22%;
+  width: 26%;
   height: 9.5%;
   border: none;
   background: transparent;
@@ -25067,7 +25073,7 @@ html:has(.game-shell),
 .sty-current {
   position: absolute;
   left: 67.5%;
-  top: 84%;
+  top: 82.3%;
   width: 21%;
   height: 9%;
   display: flex;
@@ -25091,7 +25097,7 @@ html:has(.game-shell),
   position: absolute;
   left: 50%;
   right: 11%;
-  bottom: 2.4%;
+  bottom: 1.3%;
   display: flex;
   align-items: center;
   justify-content: flex-end;


### PR DESCRIPTION
Reskins the Stylist onto the painted `stylist_bg` frame from your concept.

## What's painted in
- **Price banner** — `Race Change Price: N Gold` in the slot under the title.
- **Race cards** — a 3×2 grid of selectable cards (portrait, description, colour-coded stat mods: HP/crit red, mana blue, dex/evade/stealth/nature green, else gold). The current race is tagged.
- **Current race** — inset into the painted *Your Current Race* card (portrait + name + Bonuses Active).
- **Gold** — `Your Gold: N` at the bottom.

## Flow change (matches the concept)
Instead of a Change button per card, you **select a race card** and the painted **CHANGE RACE** button commits it. Per your note, that button is an **invisible hotspot over the art** — no DOM button drawn. It's enabled only for a non-current, affordable selection and sends `changerace <id>` (with a tooltip explaining why it's disabled otherwise).

## Skin
- New **`boudoir`** drawer variant (4:3, opens near-full height); title hidden (the art paints its own banner), close floated to the painted X.

## Art contract
| key | drives | fallback |
|---|---|---|
| `stylist_bg` | the parlour frame (drawer skin) | dark purple gradient |

(Race portraits come from the existing `stylistState.races[].image` data.)

## Verification
- `bun run lint` ✓, `npx tsc -b` ✓, `bun run build` ✓, `./gradlew compileKotlin ktlintCheck` ✓

Region insets (cost, grid, current-race, gold, the hotspot) are eyeballed off your blank frame — send a shot and I'll seat each onto its painted slot.