### PR TITLE
feat(web): reskin Housing as the painted Housing Broker

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -3093,6 +3093,7 @@ data class ImagesConfig(
             "group_bg" to "global_assets/group_bg.png",
             "command_reference_bg" to "global_assets/command_reference_bg.png",
             "stylist_bg" to "global_assets/stylist_bg.png",
+            "housing_bg" to "global_assets/housing_bg.png",
             "dialog_indicator" to "global_assets/dialog_indicator.png",
             "aggro_indicator" to "global_assets/aggro_indicator.png",
             "quest_available_indicator" to "global_assets/quest_available_indicator.png",

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -967,6 +967,8 @@ function App() {
             ? "codex"
             : drawerPanel === "stylist"
             ? "boudoir"
+            : drawerPanel === "housing"
+            ? "estate"
             : drawerPanel === "character"
             ? "cabinet"
             : drawerPanel === "bank"
@@ -1009,6 +1011,8 @@ function App() {
             ? state.serverAssets["command_reference_bg"]
             : drawerPanel === "stylist"
             ? state.serverAssets["stylist_bg"]
+            : drawerPanel === "housing"
+            ? state.serverAssets["housing_bg"]
             : drawerPanel === "character"
             ? state.serverAssets["character_bg"]
             : drawerPanel === "bank"
@@ -1037,7 +1041,7 @@ function App() {
                             ? state.serverAssets["mail_bg"]
                             : undefined
         }
-        initialHeight={drawerPanel === "chatboard" || drawerPanel === "whoboard" || drawerPanel === "guildboard" || drawerPanel === "friendsboard" || drawerPanel === "groupboard" || drawerPanel === "help" || drawerPanel === "stylist" ? 0.94 : undefined}
+        initialHeight={drawerPanel === "chatboard" || drawerPanel === "whoboard" || drawerPanel === "guildboard" || drawerPanel === "friendsboard" || drawerPanel === "groupboard" || drawerPanel === "help" || drawerPanel === "stylist" || drawerPanel === "housing" ? 0.94 : undefined}
       >
         {drawerPanel === "character" && (
           <CharacterPanel
@@ -1350,6 +1354,7 @@ function App() {
             templates={state.housingTemplates}
             room={state.room}
             uiFeedbackFeed={state.uiFeedbackFeed}
+            gold={state.vitals.gold}
             onSendCommand={sendCommand}
           />
         )}

--- a/web-v3/src/components/Drawer.tsx
+++ b/web-v3/src/components/Drawer.tsx
@@ -9,7 +9,7 @@ interface DrawerProps {
   /** Visual skin for the sheet chrome: warm leather (satchel), a dim
    *  dressing-chamber (equipment), a merchant cart (shop), a chalkboard
    *  (trainer), a parchment journal (combat log), or a cork quest board. */
-  variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "desk" | "mail" | "feature" | "tome" | "vault" | "cabinet" | "board" | "starframe" | "archive" | "stainedglass" | "codex" | "boudoir";
+  variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "desk" | "mail" | "feature" | "tome" | "vault" | "cabinet" | "board" | "starframe" | "archive" | "stainedglass" | "codex" | "boudoir" | "estate";
   /** Optional background art for a skinned variant (server asset). */
   skinBg?: string;
   /** Height (as a fraction of the viewport) the drawer snaps to when it opens. */

--- a/web-v3/src/components/panels/HousingPanel.tsx
+++ b/web-v3/src/components/panels/HousingPanel.tsx
@@ -8,34 +8,22 @@ interface HousingPanelProps {
   templates: HousingTemplate[];
   room: RoomState;
   uiFeedbackFeed: UiFeedbackEntry[];
+  gold: number;
   onSendCommand: (cmd: string) => void;
 }
 
-function TemplateList({ templates }: { templates: HousingTemplate[] }) {
-  if (templates.length === 0) return null;
-  return (
-    <div className="housing-templates-section">
-      <p className="housing-section-label">Available Templates</p>
-      <ul className="housing-room-list">
-        {templates.map((t) => (
-          <li key={t.id} className="housing-room-item">
-            <div className="housing-room-header">
-              <span className="housing-room-title">{t.title}</span>
-              <span className="housing-template-cost">{t.cost > 0 ? `${t.cost} gold` : "Free"}</span>
-            </div>
-            <p className="housing-room-desc">{t.description}</p>
-            <div className="housing-template-meta">
-              <span className="housing-room-template">{t.id}</span>
-              {t.owned && <span className="housing-template-badge">Owned</span>}
-              {t.isEntry && <span className="housing-template-badge housing-template-badge-entry">Entry</span>}
-            </div>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
+const DIRECTIONS: Array<{ key: string; label: string }> = [
+  { key: "n", label: "N" }, { key: "s", label: "S" }, { key: "e", label: "E" },
+  { key: "w", label: "W" }, { key: "u", label: "Up" }, { key: "d", label: "Down" },
+];
 
+/**
+ * Housing Broker — reskinned onto the painted `housing_bg` frame. Your owned
+ * rooms inset into the left "Your Estate" card, the room templates into the
+ * central "Browse Room Templates" card, and a single Buy bar at the bottom.
+ * The entry buys via `house buy`; rooms need a direction, so selecting a room
+ * and buying reveals a compact direction picker (`house expand <id> <dir>`).
+ */
 export function HousingPanel({
   connected,
   hasCharacterProfile,
@@ -43,182 +31,125 @@ export function HousingPanel({
   templates,
   room,
   uiFeedbackFeed,
+  gold,
   onSendCommand,
 }: HousingPanelProps) {
-  const [editField, setEditField] = useState<"title" | "desc" | null>(null);
-  const [editValue, setEditValue] = useState("");
+  const [selected, setSelected] = useState<string | null>(null);
+  const [choosingDir, setChoosingDir] = useState(false);
 
   const activeFeedback = useMemo(
     () => [...uiFeedbackFeed].reverse().find((e) => e.scope === "housing") ?? null,
     [uiFeedbackFeed],
   );
 
-  if (!connected) return <p className="empty-note">Connect to view housing.</p>;
-  if (!hasCharacterProfile) return <p className="empty-note">Log in to view housing.</p>;
+  if (!connected) return <div className="housing-broker housing-broker-empty"><p className="hb-empty">Connect to view housing.</p></div>;
+  if (!hasCharacterProfile) return <div className="housing-broker housing-broker-empty"><p className="hb-empty">Log in to view housing.</p></div>;
 
-  const inOwnHouse = room.housing === true && room.housingOwner === housing?.ownerName;
-  const inAnyHouse = room.housing === true;
+  const rooms = housing?.rooms ?? [];
+  const hasHouse = housing?.hasHouse ?? false;
+  const selectedTemplate = templates.find((t) => t.id === selected) ?? null;
+  const isEntryBuy = !!selectedTemplate && (selectedTemplate.isEntry || !hasHouse);
+  const affordable = !!selectedTemplate && gold >= selectedTemplate.cost;
+  const canBuy = !!selectedTemplate && !selectedTemplate.owned && affordable;
 
-  if (!housing?.hasHouse) {
-    return (
-      <div className="housing-panel">
-        {inAnyHouse && (
-          <div className="housing-visiting-banner">
-            Visiting {room.housingOwner ?? "someone"}&apos;s house
-          </div>
-        )}
-        <div className="housing-empty-state">
-          <span className="housing-empty-icon">{"\u{1F3E0}"}</span>
-          <p className="empty-note">You don't own a house yet.</p>
-          {room.housingBroker && housing?.available !== false ? (
-            <div className="housing-actions">
-              <button type="button" className="housing-action-btn" onClick={() => onSendCommand("house buy")}>
-                Purchase a House
-              </button>
-              <button type="button" className="housing-action-btn" onClick={() => onSendCommand("house list")}>
-                Browse Templates
-              </button>
-            </div>
-          ) : housing?.available === false ? (
-            <p className="housing-hint">Housing is not available on this server.</p>
-          ) : (
-            <p className="housing-hint">Visit a housing broker to purchase one.</p>
-          )}
-          {activeFeedback && (
-            <p className={`systems-local-message systems-local-message-${activeFeedback.type}`}>
-              {activeFeedback.message}
-            </p>
-          )}
-        </div>
-        <TemplateList templates={templates} />
-      </div>
-    );
-  }
+  const buyLabel = !selectedTemplate
+    ? "Select a Room"
+    : selectedTemplate.owned
+      ? "Already Owned"
+      : selectedTemplate.isEntry
+        ? "Purchase Entry"
+        : "Buy Selected Room";
 
-  const startEdit = (field: "title" | "desc") => {
-    setEditField(field);
-    setEditValue("");
-  };
-
-  const submitEdit = () => {
-    if (!editField || !editValue.trim()) return;
-    if (editField === "title") {
-      onSendCommand(`house describe title ${editValue.trim()}`);
+  const onBuy = () => {
+    if (!selectedTemplate || !canBuy) return;
+    if (isEntryBuy) {
+      onSendCommand("house buy");
     } else {
-      onSendCommand(`house describe desc ${editValue.trim()}`);
+      setChoosingDir(true);
     }
-    setEditField(null);
-    setEditValue("");
   };
 
-  const cancelEdit = () => {
-    setEditField(null);
-    setEditValue("");
+  const expand = (dir: string) => {
+    if (selectedTemplate) onSendCommand(`house expand ${selectedTemplate.id} ${dir}`);
+    setChoosingDir(false);
   };
 
   return (
-    <div className="housing-panel">
-      <div className="housing-owner-header">
-        <span className="housing-owner-name">{housing.ownerName}&apos;s House</span>
-        <span className="housing-room-count">{housing.rooms.length} room{housing.rooms.length !== 1 ? "s" : ""}</span>
+    <div className="housing-broker">
+      {/* ── Your Estate (left card) ──────────────────────────── */}
+      <div className="hb-estate">
+        {rooms.length === 0 ? (
+          <p className="hb-empty">No rooms yet. Secure a Carriage House to begin your legacy.</p>
+        ) : (
+          <ul className="hb-owned-list">
+            {rooms.map((r, i) => (
+              <li key={`${r.templateId}-${i}`} className="hb-owned">
+                <span className="hb-owned-name">{r.title}</span>
+                <span className="hb-owned-type">{r.templateId}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+        <div className="hb-owned-total">Total Owned Rooms: {rooms.length}</div>
       </div>
-      {activeFeedback && (
-        <p className={`systems-local-message systems-local-message-${activeFeedback.type}`}>
-          {activeFeedback.message}
-        </p>
-      )}
 
-      {inOwnHouse && (
-        <div className="housing-actions">
-          <button type="button" className="housing-action-btn" onClick={() => onSendCommand("house guests")}>
-            Guests
-          </button>
-          <button type="button" className="housing-action-btn" onClick={() => onSendCommand("house list")}>
-            Templates
-          </button>
-        </div>
-      )}
+      {/* ── Browse Room Templates (center card) ──────────────── */}
+      <div className="hb-templates">
+        {templates.length === 0 ? (
+          <p className="hb-empty">No templates available here.</p>
+        ) : (
+          <ul className="hb-template-list">
+            {templates.map((t) => (
+              <li key={t.id}>
+                <button
+                  type="button"
+                  className={`hb-template${selected === t.id ? " is-selected" : ""}${t.owned ? " is-owned" : ""}`}
+                  onClick={() => { setSelected(t.id); setChoosingDir(false); }}
+                  aria-pressed={selected === t.id}
+                >
+                  <span className="hb-template-main">
+                    <span className="hb-template-name">
+                      {t.title}
+                      {t.owned && <span className="hb-tag">Owned</span>}
+                      {t.isEntry && <span className="hb-tag hb-tag-entry">Entry</span>}
+                    </span>
+                    {t.description && <span className="hb-template-desc">{t.description}</span>}
+                  </span>
+                  <span className="hb-template-cost">
+                    <span className="hb-coin" aria-hidden="true">◉</span>
+                    {t.cost > 0 ? t.cost.toLocaleString() : "Free"}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
 
-      {!inOwnHouse && (
-        <div className="housing-actions">
-          <button type="button" className="housing-action-btn" onClick={() => onSendCommand("recall")}>
-            Recall Home
-          </button>
-          {room.housingBroker && (
-            <button type="button" className="housing-action-btn" onClick={() => onSendCommand("house list")}>
-              Browse Templates
-            </button>
-          )}
-        </div>
-      )}
-
-      {inAnyHouse && !inOwnHouse && (
-        <div className="housing-visiting-banner">
-          Visiting {room.housingOwner ?? "someone"}&apos;s house
-        </div>
-      )}
-
-      <ul className="housing-room-list">
-        {housing.rooms.map((r, i) => (
-          <li key={`${r.templateId}-${i}`} className="housing-room-item">
-            <div className="housing-room-header">
-              <span className="housing-room-title">{r.title}</span>
-              <span className="housing-room-template">{r.templateId}</span>
-            </div>
-            <p className="housing-room-desc">{r.description}</p>
-          </li>
-        ))}
-      </ul>
-
-      <TemplateList templates={templates} />
-
-      {inOwnHouse && (
-        <div className="housing-customize-section">
-          <p className="housing-section-label">Customize This Room</p>
-          {editField === null ? (
-            <div className="housing-edit-buttons">
-              <button type="button" className="housing-action-btn" onClick={() => startEdit("title")}>
-                Edit Title
-              </button>
-              <button type="button" className="housing-action-btn" onClick={() => startEdit("desc")}>
-                Edit Description
-              </button>
-            </div>
-          ) : (
-            <div className="housing-edit-form">
-              <label className="housing-edit-label">
-                {editField === "title" ? "New Title" : "New Description"}
-              </label>
-              {editField === "title" ? (
-                <input
-                  type="text"
-                  className="housing-edit-input"
-                  maxLength={60}
-                  value={editValue}
-                  onChange={(e) => setEditValue(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === "Enter") submitEdit(); if (e.key === "Escape") cancelEdit(); }}
-                  autoFocus
-                  placeholder="Enter new title..."
-                />
-              ) : (
-                <textarea
-                  className="housing-edit-textarea"
-                  maxLength={500}
-                  rows={3}
-                  value={editValue}
-                  onChange={(e) => setEditValue(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === "Escape") cancelEdit(); }}
-                  autoFocus
-                  placeholder="Enter new description..."
-                />
-              )}
-              <div className="housing-edit-actions">
-                <button type="button" className="housing-action-btn housing-save-btn" onClick={submitEdit}>Save</button>
-                <button type="button" className="housing-action-btn" onClick={cancelEdit}>Cancel</button>
-              </div>
-            </div>
-          )}
-        </div>
+      {/* ── Buy bar (bottom) ─────────────────────────────────── */}
+      <div className="hb-buybar">
+        {activeFeedback && (
+          <span className={`hb-feedback hb-feedback-${activeFeedback.type}`}>{activeFeedback.message}</span>
+        )}
+        {choosingDir ? (
+          <div className="hb-dir-picker">
+            <span className="hb-dir-label">Attach where?</span>
+            {DIRECTIONS.map((d) => (
+              <button key={d.key} type="button" className="hb-dir-btn" onClick={() => expand(d.key)}>{d.label}</button>
+            ))}
+            <button type="button" className="hb-dir-cancel" onClick={() => setChoosingDir(false)}>✕</button>
+          </div>
+        ) : (
+          <button type="button" className="hb-buy-btn" disabled={!canBuy} onClick={onBuy}>{buyLabel}</button>
+        )}
+        <span className="hb-funds">
+          <span className="hb-coin" aria-hidden="true">◉</span>
+          Funds: <strong>{gold.toLocaleString()}</strong>
+        </span>
+      </div>
+      {/* room state is read above; reference kept so visiting context stays available */}
+      {room.housing === true && room.housingOwner && room.housingOwner !== housing?.ownerName && (
+        <div className="hb-visiting">Visiting {room.housingOwner}&apos;s estate</div>
       )}
     </div>
   );

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -25109,3 +25109,247 @@ html:has(.game-shell),
 .sty-gold strong { color: #f4dc9a; }
 .sty-gold-icon { color: #e6c878; display: inline-flex; }
 .sty-gold-icon img { width: 1.1em; height: 1.1em; object-fit: contain; }
+
+/* ════════════════════════════════════════════════════════════
+   Housing Broker — estate shop (drawerPanel "housing")
+   Painted `housing_bg` frame (skin). Owned rooms inset into the left "Your
+   Estate" card, templates into the central "Browse Room Templates" card, and
+   a single Buy bar at the bottom.
+   ════════════════════════════════════════════════════════════ */
+.drawer-sheet.drawer-sheet-estate {
+  background-image:
+    var(--skin-bg, none),
+    radial-gradient(ellipse at 50% 35%, rgb(28 36 30 / 96%), rgb(14 18 14 / 98%));
+  background-size: cover, auto;
+  background-position: center, center;
+  background-repeat: no-repeat, no-repeat;
+}
+
+.drawer-sheet-estate .drawer-title { display: none; }
+.drawer-sheet-estate .drawer-handle-zone { display: none; }
+
+.drawer-sheet-estate .drawer-header {
+  position: absolute;
+  top: 1.5%;
+  right: 1.5%;
+  left: auto;
+  z-index: 6;
+  padding: 0;
+  min-height: 0;
+  border-bottom: none;
+}
+
+.drawer-sheet-estate .drawer-body {
+  padding: 0;
+  position: relative;
+}
+
+@media (min-width: 768px) {
+  .drawer-sheet.drawer-sheet-estate {
+    width: auto;
+    height: min(94vh, 71vw);
+    max-height: 94vh;
+    aspect-ratio: 1456 / 1093;
+  }
+}
+
+.housing-broker { position: absolute; inset: 0; }
+.housing-broker-empty { display: grid; place-items: center; }
+.hb-empty { color: #5a4a2e; text-align: center; font-style: italic; padding: 10px; }
+
+/* ── Your Estate (left card) ──────────────────────────────── */
+.hb-estate {
+  position: absolute;
+  left: 12.8%;
+  top: 29%;
+  width: 13.8%;
+  bottom: 24%;
+  display: flex;
+  flex-direction: column;
+  color: #3a2c18;
+}
+
+.hb-owned-list {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  scrollbar-width: thin;
+  scrollbar-color: rgb(120 96 52 / 50%) transparent;
+}
+
+.hb-owned {
+  display: flex;
+  flex-direction: column;
+  padding: clamp(4px, 0.8vh, 7px) 4px;
+  border-bottom: 1px solid rgb(120 96 52 / 20%);
+}
+.hb-owned-name { font-family: var(--font-display); font-weight: 600; font-size: clamp(0.74rem, 1.3vw, 0.94rem); color: #2f2410; }
+.hb-owned-type { font-size: 0.66rem; color: rgb(90 72 44 / 70%); }
+
+.hb-owned-total {
+  flex-shrink: 0;
+  padding-top: 6px;
+  margin-top: 4px;
+  border-top: 1px solid rgb(120 96 52 / 35%);
+  text-align: center;
+  font-family: var(--font-display);
+  font-size: clamp(0.7rem, 1.2vw, 0.84rem);
+  color: #5a4426;
+}
+
+/* ── Browse Room Templates (center card) ──────────────────── */
+.hb-templates {
+  position: absolute;
+  left: 31.5%;
+  right: 11.5%;
+  top: 31.5%;
+  bottom: 19%;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgb(150 120 70 / 55%) transparent;
+}
+.hb-templates::-webkit-scrollbar { width: 8px; }
+.hb-templates::-webkit-scrollbar-thumb { border-radius: 999px; background: rgb(150 120 70 / 55%); }
+.hb-templates::-webkit-scrollbar-track { background: transparent; }
+
+.hb-template-list { list-style: none; margin: 0; padding: 2px; display: flex; flex-direction: column; gap: clamp(4px, 0.8vh, 8px); }
+
+.hb-template {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: clamp(6px, 1vh, 11px) clamp(8px, 1.2vw, 14px);
+  border: 1px solid rgb(120 96 52 / 28%);
+  border-radius: 10px;
+  background: rgb(250 244 228 / 32%);
+  color: #3a2c18;
+  cursor: pointer;
+  text-align: left;
+  transition: background 150ms var(--ease-out-soft), border-color 150ms var(--ease-out-soft), box-shadow 150ms var(--ease-out-soft);
+}
+.hb-template:hover { background: rgb(180 150 90 / 20%); border-color: rgb(150 120 70 / 50%); }
+.hb-template.is-selected {
+  border-color: #9a7a3a;
+  box-shadow: 0 0 10px rgb(150 120 70 / 35%);
+  background: rgb(200 170 100 / 24%);
+}
+.hb-template.is-owned { opacity: 0.68; }
+
+.hb-template-main { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.hb-template-name {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(0.84rem, 1.5vw, 1.08rem);
+  color: #2a1f0e;
+}
+.hb-template-desc { font-size: clamp(0.64rem, 1.1vw, 0.82rem); color: rgb(74 60 40 / 88%); line-height: 1.25; }
+.hb-tag {
+  font-size: 0.54rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0 6px;
+  border-radius: 999px;
+  border: 1px solid rgb(120 96 52 / 50%);
+  color: #6a5026;
+}
+.hb-tag-entry { border-color: rgb(90 130 80 / 60%); color: #4a7a3a; }
+
+.hb-template-cost {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(0.78rem, 1.4vw, 1rem);
+  color: #8a6a2a;
+}
+.hb-coin { color: #c8a24a; }
+
+/* ── Buy bar (bottom dark band) ───────────────────────────── */
+.hb-buybar {
+  position: absolute;
+  left: 17%;
+  right: 17%;
+  top: 85.5%;
+  bottom: 5%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(8px, 2vw, 24px);
+}
+
+.hb-buy-btn {
+  padding: clamp(7px, 1.3vh, 13px) clamp(20px, 4vw, 50px);
+  border: 1px solid rgb(200 170 90 / 50%);
+  border-radius: 10px;
+  background: linear-gradient(165deg, #4a3a78, #2e2454);
+  color: #f0e0c0;
+  font-family: var(--font-display);
+  font-size: clamp(0.88rem, 1.7vw, 1.18rem);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: filter 150ms var(--ease-out-soft), transform 150ms var(--ease-out-soft);
+}
+.hb-buy-btn:hover:not(:disabled) { filter: brightness(1.12); transform: translateY(-1px); }
+.hb-buy-btn:disabled { opacity: 0.45; cursor: default; }
+
+.hb-funds {
+  position: absolute;
+  right: 0;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--font-display);
+  font-size: clamp(0.76rem, 1.4vw, 1rem);
+  color: #d9c089;
+}
+.hb-funds strong { color: #f4dc9a; }
+
+.hb-feedback { position: absolute; left: 0; max-width: 32%; font-size: 0.78rem; line-height: 1.2; }
+.hb-feedback-error { color: #e08a8a; }
+.hb-feedback-success { color: #8fd6a0; }
+.hb-feedback-info { color: #cfe0ff; }
+
+.hb-dir-picker { display: flex; align-items: center; gap: 6px; }
+.hb-dir-label { color: #d9c089; font-family: var(--font-display); font-size: clamp(0.74rem, 1.3vw, 0.92rem); }
+.hb-dir-btn {
+  padding: clamp(5px, 0.9vh, 9px) clamp(9px, 1.2vw, 15px);
+  border: 1px solid rgb(200 170 90 / 40%);
+  border-radius: 8px;
+  background: rgb(60 46 90 / 75%);
+  color: #f0e0c0;
+  font-family: var(--font-display);
+  font-weight: 600;
+  cursor: pointer;
+  transition: filter 150ms var(--ease-out-soft);
+}
+.hb-dir-btn:hover { filter: brightness(1.18); }
+.hb-dir-cancel {
+  border: 1px solid rgb(200 120 120 / 40%);
+  border-radius: 8px;
+  background: rgb(90 40 44 / 70%);
+  color: #ffd6d6;
+  padding: 4px 10px;
+  cursor: pointer;
+}
+
+.hb-visiting {
+  position: absolute;
+  top: 24%;
+  left: 31.5%;
+  right: 11.5%;
+  text-align: center;
+  font-size: 0.8rem;
+  font-style: italic;
+  color: #c8b48a;
+}


### PR DESCRIPTION
Reskins the housing panel onto the painted **Housing Broker** frame.

## Layout
- **Your Estate** (left card) — your owned rooms + a *Total Owned Rooms* count.
- **Browse Room Templates** (centre card) — selectable template rows (name, description, cost, Owned/Entry tags).
- **Buy bar** (bottom) — a single adaptive Buy button + your Funds, per your note that the concept's multi-button bottom is collapsed to one "Buy Selected" control.

## Buy flow
- The button label/state adapts: **Purchase Entry** (no house) / **Buy Selected Room** / Already Owned / Select a Room — gated by ownership + affordability.
- The **entry** buys via `house buy`. **Rooms** need a direction (the server's `house expand <template> <direction>`), so buying a room reveals a **compact direction picker** (N/S/E/W/Up/Down) — which actually makes room-buying work in the GUI (it was terminal-only before).
- UI feedback (success/error) surfaces in the buy bar.

## Skin
- New **`estate`** drawer variant (4:3, opens near-full height); title hidden (painted banner), close floated to the top-right.

## Art contract
| key | drives | fallback |
|---|---|---|
| `housing_bg` | the broker frame (drawer skin) | dark green gradient |

(The concept's Tier badges / room thumbnails / requirements aren't in the current housing data, so they're omitted; easy to add if you extend the template payload later.)

## Verification
- `bun run lint` ✓, `npx tsc -b` ✓, `bun run build` ✓, `./gradlew compileKotlin ktlintCheck` ✓

Region insets (estate card, templates card, buy bar) are eyeballed off your blank frame — send a shot and I'll seat them onto the painted slots.