### PR TITLE
feat(web): reskin the Lottery onto the painted fortune hall

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -3094,6 +3094,7 @@ data class ImagesConfig(
             "command_reference_bg" to "global_assets/command_reference_bg.png",
             "stylist_bg" to "global_assets/stylist_bg.png",
             "housing_bg" to "global_assets/housing_bg.png",
+            "lottery_bg" to "global_assets/lottery_bg.png",
             "dialog_indicator" to "global_assets/dialog_indicator.png",
             "aggro_indicator" to "global_assets/aggro_indicator.png",
             "quest_available_indicator" to "global_assets/quest_available_indicator.png",

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -969,6 +969,8 @@ function App() {
             ? "boudoir"
             : drawerPanel === "housing"
             ? "estate"
+            : drawerPanel === "lottery"
+            ? "fortune"
             : drawerPanel === "character"
             ? "cabinet"
             : drawerPanel === "bank"
@@ -1013,6 +1015,8 @@ function App() {
             ? state.serverAssets["stylist_bg"]
             : drawerPanel === "housing"
             ? state.serverAssets["housing_bg"]
+            : drawerPanel === "lottery"
+            ? state.serverAssets["lottery_bg"]
             : drawerPanel === "character"
             ? state.serverAssets["character_bg"]
             : drawerPanel === "bank"
@@ -1041,7 +1045,7 @@ function App() {
                             ? state.serverAssets["mail_bg"]
                             : undefined
         }
-        initialHeight={drawerPanel === "chatboard" || drawerPanel === "whoboard" || drawerPanel === "guildboard" || drawerPanel === "friendsboard" || drawerPanel === "groupboard" || drawerPanel === "help" || drawerPanel === "stylist" || drawerPanel === "housing" ? 0.94 : undefined}
+        initialHeight={drawerPanel === "chatboard" || drawerPanel === "whoboard" || drawerPanel === "guildboard" || drawerPanel === "friendsboard" || drawerPanel === "groupboard" || drawerPanel === "help" || drawerPanel === "stylist" || drawerPanel === "housing" || drawerPanel === "lottery" ? 0.94 : undefined}
       >
         {drawerPanel === "character" && (
           <CharacterPanel

--- a/web-v3/src/components/Drawer.tsx
+++ b/web-v3/src/components/Drawer.tsx
@@ -9,7 +9,7 @@ interface DrawerProps {
   /** Visual skin for the sheet chrome: warm leather (satchel), a dim
    *  dressing-chamber (equipment), a merchant cart (shop), a chalkboard
    *  (trainer), a parchment journal (combat log), or a cork quest board. */
-  variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "desk" | "mail" | "feature" | "tome" | "vault" | "cabinet" | "board" | "starframe" | "archive" | "stainedglass" | "codex" | "boudoir" | "estate";
+  variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "desk" | "mail" | "feature" | "tome" | "vault" | "cabinet" | "board" | "starframe" | "archive" | "stainedglass" | "codex" | "boudoir" | "estate" | "fortune";
   /** Optional background art for a skinned variant (server asset). */
   skinBg?: string;
   /** Height (as a fraction of the viewport) the drawer snaps to when it opens. */

--- a/web-v3/src/components/panels/LotteryPanel.tsx
+++ b/web-v3/src/components/panels/LotteryPanel.tsx
@@ -7,21 +7,24 @@ interface LotteryPanelProps {
   onCommand: (command: string) => void;
 }
 
-function formatCountdown(ms: number): string {
-  if (ms <= 0) return "Drawing soon";
-  const totalSeconds = Math.floor(ms / 1000);
-  const hours = Math.floor(totalSeconds / 3600);
-  const minutes = Math.floor((totalSeconds % 3600) / 60);
-  const seconds = totalSeconds % 60;
-  if (hours > 0) return `${hours}h ${minutes}m`;
-  if (minutes > 0) return `${minutes}m ${seconds}s`;
-  return `${seconds}s`;
+function pad(n: number): string { return n.toString().padStart(2, "0"); }
+
+function formatHMS(ms: number): string {
+  if (ms <= 0) return "00:00:00";
+  const t = Math.floor(ms / 1000);
+  return `${pad(Math.floor(t / 3600))}:${pad(Math.floor((t % 3600) / 60))}:${pad(t % 60)}`;
 }
 
+/**
+ * Lottery — reskinned onto the painted `lottery_bg` frame. The labels (Current
+ * Jackpot, Time Remaining, Owned Tickets, etc.) are painted; this overlays the
+ * live values into their slots, plus the quantity selector, purchase summary,
+ * and Buy Tickets button in the bottom panel.
+ */
 export function LotteryPanel({ lotteryInfo, uiFeedbackFeed, onCommand }: LotteryPanelProps) {
-  const [ticketDraft, setTicketDraft] = useState("1");
-  // nextDrawingMs is an absolute epoch timestamp; tick so the pill counts down.
   const [now, setNow] = useState(() => Date.now());
+  const [qty, setQty] = useState(1);
+
   useEffect(() => {
     const timer = window.setInterval(() => setNow(Date.now()), 1000);
     return () => window.clearInterval(timer);
@@ -32,80 +35,54 @@ export function LotteryPanel({ lotteryInfo, uiFeedbackFeed, onCommand }: Lottery
     [uiFeedbackFeed],
   );
 
+  if (!lotteryInfo) {
+    return (
+      <div className="lottery-board lottery-board-empty">
+        <p className="lot-empty">Fortune is quiet. Lottery information is not available right now.</p>
+      </div>
+    );
+  }
+
+  const { jackpot, totalTickets, playerTickets, nextDrawingMs, ticketCost, maxTicketsPerPlayer } = lotteryInfo;
+  const cap = Math.min(10, maxTicketsPerPlayer || 10);
+  const clamp = (n: number) => Math.max(1, Math.min(cap, n));
+  const total = qty * ticketCost;
+
   return (
-    <div className="lottery-panel">
-      <div className="panel-header">
-        <span className="panel-title">Lottery</span>
+    <div className="lottery-board">
+      <div className="lot-jackpot">
+        <span className="lot-jackpot-value">{jackpot.toLocaleString()}</span>
+        <span className="lot-jackpot-unit">Gold Pieces</span>
       </div>
 
-      {activeFeedback && (
-        <p className={`systems-local-message systems-local-message-${activeFeedback.type}`}>
-          {activeFeedback.message}
-        </p>
-      )}
+      <div className="lot-countdown">{formatHMS(nextDrawingMs - now)}</div>
+      <div className="lot-owned">{playerTickets}</div>
+      <div className="lot-total">{totalTickets.toLocaleString()}</div>
+      <div className="lot-cost">{ticketCost.toLocaleString()}</div>
+      <div className="lot-limit">{maxTicketsPerPlayer}<span className="lot-limit-unit">Tickets Max</span></div>
 
-      {lotteryInfo ? (
-        <article className="systems-card">
-          <div className="systems-card-header">
-            <div>
-              <p className="systems-card-label">Current Drawing</p>
-              <h4>{lotteryInfo.jackpot.toLocaleString()} gold jackpot</h4>
-            </div>
-            <span className="systems-pill">{formatCountdown(lotteryInfo.nextDrawingMs - now)}</span>
-          </div>
-          <dl className="systems-stat-grid">
-            <div><dt>Your Tickets</dt><dd>{lotteryInfo.playerTickets}</dd></div>
-            <div><dt>Total Tickets</dt><dd>{lotteryInfo.totalTickets}</dd></div>
-            <div><dt>Ticket Cost</dt><dd>{lotteryInfo.ticketCost} gold</dd></div>
-            <div><dt>Per-Player Limit</dt><dd>{lotteryInfo.maxTicketsPerPlayer}</dd></div>
-          </dl>
-          <div className="systems-choice-list systems-choice-list-compact">
-            {[1, 3, 5].map((count) => (
-              <button
-                key={count}
-                type="button"
-                className="systems-choice-card"
-                onClick={() => onCommand(`lottery buy ${count}`)}
-              >
-                <span className="systems-choice-title">{count} ticket{count === 1 ? "" : "s"}</span>
-                <span className="systems-choice-copy">{(count * lotteryInfo.ticketCost).toLocaleString()} gold</span>
-              </button>
-            ))}
-          </div>
-          <div className="systems-action-row">
-            <input
-              type="number"
-              min={1}
-              max={lotteryInfo.maxTicketsPerPlayer}
-              step={1}
-              inputMode="numeric"
-              className="systems-number-input"
-              value={ticketDraft}
-              onChange={(event) => setTicketDraft(event.target.value)}
-            />
-            <button
-              type="button"
-              className="systems-primary-btn"
-              onClick={() => {
-                const count = Number(ticketDraft);
-                if (!Number.isSafeInteger(count) || count < 1) return;
-                onCommand(`lottery buy ${count}`);
-              }}
-            >
-              Buy Custom Quantity
-            </button>
-            <button
-              type="button"
-              className="systems-secondary-btn"
-              onClick={() => onCommand("lottery")}
-            >
-              Refresh Info
-            </button>
-          </div>
-        </article>
-      ) : (
-        <p className="empty-note">Lottery information is not available right now.</p>
-      )}
+      <div className="lot-buy">
+        <div className="lot-buy-sub">Select Quantity (1–{cap})</div>
+        <div className="lot-qty" role="group" aria-label="Ticket quantity">
+          <button type="button" className="lot-qty-step" onClick={() => setQty((q) => clamp(q - 10))} aria-label="Minus ten">−10</button>
+          <button type="button" className="lot-qty-step" onClick={() => setQty((q) => clamp(q - 1))} aria-label="Minus one">−</button>
+          {Array.from({ length: cap }, (_, i) => i + 1).map((n) => (
+            <button key={n} type="button" className={`lot-qty-num${qty === n ? " is-active" : ""}`} onClick={() => setQty(n)}>{n}</button>
+          ))}
+          <button type="button" className="lot-qty-step" onClick={() => setQty((q) => clamp(q + 1))} aria-label="Plus one">+</button>
+          <button type="button" className="lot-qty-step" onClick={() => setQty((q) => clamp(q + 10))} aria-label="Plus ten">+10</button>
+        </div>
+
+        <p className="lot-summary">
+          You will purchase <strong>{qty}</strong> ticket{qty === 1 ? "" : "s"} for <strong>{total.toLocaleString()}</strong> gold pieces.
+        </p>
+
+        {activeFeedback && (
+          <p className={`lot-feedback lot-feedback-${activeFeedback.type}`}>{activeFeedback.message}</p>
+        )}
+
+        <button type="button" className="lot-buy-btn" onClick={() => onCommand(`lottery buy ${qty}`)}>Buy Tickets</button>
+      </div>
     </div>
   );
 }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -25428,7 +25428,7 @@ html:has(.game-shell),
 .lot-countdown {
   position: absolute;
   left: 31%;
-  top: 55.5%;
+  top: 50%;
   width: 20%;
   text-align: center;
   font-size: clamp(1.1rem, 2.6vw, 1.9rem);
@@ -25440,7 +25440,7 @@ html:has(.game-shell),
 .lot-owned {
   position: absolute;
   left: 63%;
-  top: 54.5%;
+  top: 50.5%;
   width: 14%;
   text-align: center;
   font-size: clamp(1.1rem, 2.6vw, 1.9rem);
@@ -25451,7 +25451,7 @@ html:has(.game-shell),
 .lot-total {
   position: absolute;
   left: 27%;
-  top: 66.5%;
+  top: 64.5%;
   width: 11%;
   text-align: center;
   font-size: clamp(1rem, 2.2vw, 1.6rem);
@@ -25462,7 +25462,7 @@ html:has(.game-shell),
 .lot-cost {
   position: absolute;
   left: 44%;
-  top: 65.5%;
+  top: 63.5%;
   width: 10%;
   text-align: center;
   font-size: clamp(1rem, 2.2vw, 1.6rem);
@@ -25473,7 +25473,7 @@ html:has(.game-shell),
 .lot-limit {
   position: absolute;
   left: 63%;
-  top: 65%;
+  top: 63%;
   width: 12%;
   display: flex;
   flex-direction: column;

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -25428,7 +25428,7 @@ html:has(.game-shell),
 .lot-countdown {
   position: absolute;
   left: 31%;
-  top: 50%;
+  top: 52%;
   width: 20%;
   text-align: center;
   font-size: clamp(1.1rem, 2.6vw, 1.9rem);
@@ -25472,7 +25472,7 @@ html:has(.game-shell),
 
 .lot-limit {
   position: absolute;
-  left: 63%;
+  left: 65.5%;
   top: 63%;
   width: 12%;
   display: flex;

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -25353,3 +25353,215 @@ html:has(.game-shell),
   font-style: italic;
   color: #c8b48a;
 }
+
+/* ════════════════════════════════════════════════════════════
+   Lottery — fortune hall (drawerPanel "lottery")
+   Painted `lottery_bg` frame (skin). The labels are painted; this overlays the
+   live values into their slots, plus the quantity selector + Buy button.
+   ════════════════════════════════════════════════════════════ */
+.drawer-sheet.drawer-sheet-fortune {
+  background-image:
+    var(--skin-bg, none),
+    radial-gradient(ellipse at 50% 30%, rgb(24 22 56 / 96%), rgb(10 10 28 / 98%));
+  background-size: cover, auto;
+  background-position: center, center;
+  background-repeat: no-repeat, no-repeat;
+}
+
+.drawer-sheet-fortune .drawer-title { display: none; }
+.drawer-sheet-fortune .drawer-handle-zone { display: none; }
+
+.drawer-sheet-fortune .drawer-header {
+  position: absolute;
+  top: 1.5%;
+  right: 1.5%;
+  left: auto;
+  z-index: 6;
+  padding: 0;
+  min-height: 0;
+  border-bottom: none;
+}
+
+.drawer-sheet-fortune .drawer-body {
+  padding: 0;
+  position: relative;
+}
+
+@media (min-width: 768px) {
+  .drawer-sheet.drawer-sheet-fortune {
+    width: auto;
+    height: min(94vh, 71vw);
+    max-height: 94vh;
+    aspect-ratio: 1456 / 1093;
+  }
+}
+
+.lottery-board { position: absolute; inset: 0; font-family: var(--font-display); }
+.lottery-board-empty { display: grid; place-items: center; }
+.lot-empty { color: #c8b48a; text-align: center; font-style: italic; }
+
+/* Each value sits in its painted slot. */
+.lot-jackpot {
+  position: absolute;
+  left: 41%;
+  top: 33.5%;
+  width: 36%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.lot-jackpot-value {
+  font-size: clamp(1.6rem, 4.6vw, 3.4rem);
+  font-weight: 700;
+  color: #f3d271;
+  text-shadow: 0 0 14px rgb(240 200 90 / 45%), 0 2px 3px rgb(0 0 0 / 60%);
+  line-height: 1;
+}
+.lot-jackpot-unit {
+  font-size: clamp(0.6rem, 1.2vw, 0.82rem);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgb(240 210 130 / 70%);
+  margin-top: 4px;
+}
+
+.lot-countdown {
+  position: absolute;
+  left: 31%;
+  top: 55.5%;
+  width: 20%;
+  text-align: center;
+  font-size: clamp(1.1rem, 2.6vw, 1.9rem);
+  font-weight: 700;
+  color: #74d4e6;
+  text-shadow: 0 0 12px rgb(116 212 230 / 45%);
+}
+
+.lot-owned {
+  position: absolute;
+  left: 63%;
+  top: 54.5%;
+  width: 14%;
+  text-align: center;
+  font-size: clamp(1.1rem, 2.6vw, 1.9rem);
+  font-weight: 700;
+  color: #9fc0ff;
+}
+
+.lot-total {
+  position: absolute;
+  left: 27%;
+  top: 66.5%;
+  width: 11%;
+  text-align: center;
+  font-size: clamp(1rem, 2.2vw, 1.6rem);
+  font-weight: 700;
+  color: #8fd6a0;
+}
+
+.lot-cost {
+  position: absolute;
+  left: 44%;
+  top: 65.5%;
+  width: 10%;
+  text-align: center;
+  font-size: clamp(1rem, 2.2vw, 1.6rem);
+  font-weight: 700;
+  color: #f3d271;
+}
+
+.lot-limit {
+  position: absolute;
+  left: 63%;
+  top: 65%;
+  width: 12%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: clamp(1rem, 2.2vw, 1.6rem);
+  font-weight: 700;
+  color: #c89ae0;
+}
+.lot-limit-unit {
+  font-size: clamp(0.52rem, 1vw, 0.68rem);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgb(200 154 224 / 70%);
+}
+
+/* Buy section (bottom panel). */
+.lot-buy {
+  position: absolute;
+  left: 22%;
+  right: 22%;
+  top: 79%;
+  bottom: 3%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(4px, 0.9vh, 9px);
+}
+
+.lot-buy-sub {
+  font-size: clamp(0.62rem, 1.2vw, 0.84rem);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgb(214 200 240 / 75%);
+}
+
+.lot-qty {
+  display: flex;
+  gap: clamp(3px, 0.5vw, 7px);
+  flex-wrap: nowrap;
+}
+.lot-qty-step,
+.lot-qty-num {
+  min-width: clamp(22px, 3vw, 38px);
+  padding: clamp(4px, 0.8vh, 8px) clamp(3px, 0.5vw, 8px);
+  border: 1px solid rgb(200 170 90 / 45%);
+  border-radius: 7px;
+  background: rgb(28 26 60 / 70%);
+  color: #e8dcc0;
+  font-family: var(--font-display);
+  font-size: clamp(0.7rem, 1.3vw, 0.92rem);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 150ms var(--ease-out-soft), border-color 150ms var(--ease-out-soft), box-shadow 150ms var(--ease-out-soft);
+}
+.lot-qty-step:hover,
+.lot-qty-num:hover { background: rgb(48 44 96 / 80%); border-color: rgb(230 200 115 / 60%); }
+.lot-qty-num.is-active {
+  border-color: #74d4e6;
+  color: #bfeefa;
+  box-shadow: 0 0 12px rgb(116 212 230 / 45%), inset 0 0 8px rgb(116 212 230 / 18%);
+}
+
+.lot-summary {
+  margin: 0;
+  font-size: clamp(0.68rem, 1.3vw, 0.92rem);
+  color: rgb(224 214 244 / 90%);
+}
+.lot-summary strong { color: #f3d271; }
+
+.lot-feedback { margin: 0; font-size: 0.78rem; }
+.lot-feedback-error { color: #e08a8a; }
+.lot-feedback-success { color: #8fd6a0; }
+.lot-feedback-info { color: #9fc0ff; }
+
+.lot-buy-btn {
+  margin-top: 2px;
+  padding: clamp(7px, 1.3vh, 13px) clamp(28px, 6vw, 80px);
+  border: 1px solid rgb(200 170 90 / 55%);
+  border-radius: 10px;
+  background: linear-gradient(165deg, #6a3f9e, #3e2470);
+  color: #f4e6c8;
+  font-family: var(--font-display);
+  font-size: clamp(0.92rem, 1.9vw, 1.35rem);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 14%), 0 3px 12px rgb(0 0 0 / 45%);
+  transition: filter 150ms var(--ease-out-soft), transform 150ms var(--ease-out-soft);
+}
+.lot-buy-btn:hover { filter: brightness(1.14); transform: translateY(-1px); }


### PR DESCRIPTION
Reskins the Lottery onto the painted `lottery_bg` frame — a background with the overlay generated, as you described.

## What's overlaid
The painted labels (Current Jackpot, Time Remaining, Owned Tickets, Total Tickets Sold, Ticket Cost, Per-Player Ticket Limit) get their **live values** dropped into their slots:
- Jackpot (gold), **HH:MM:SS** countdown (cyan, ticking), owned tickets, total sold (green), ticket cost (gold), per-player limit (+ "Tickets Max").

The bottom **Buy Tickets** panel is fully generated:
- A quantity selector — **−10 / − / 1…10 / + / +10** with the active number highlighted.
- A live purchase summary ("You will purchase N tickets for X gold pieces").
- The **Buy Tickets** button → `lottery buy <n>`. UI feedback surfaces above it.

## Skin
- New **`fortune`** drawer variant (4:3, opens near-full height); title hidden (painted banner), close floated top-right.

## Art contract
| key | drives | fallback |
|---|---|---|
| `lottery_bg` | the fortune-hall frame (drawer skin) | dark indigo gradient |

## Verification
- `bun run lint` ✓, `npx tsc -b` ✓, `bun run build` ✓, `./gradlew compileKotlin ktlintCheck` ✓

Every value slot is positioned absolutely off your blank frame — this one has a lot of scattered slots, so expect a nudge pass; send a shot and I'll seat each value onto its painted label.