### PR TITLE
feat(dice): Aineroira's Dice — new six-die game with the Luneqrae coin

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -567,7 +567,12 @@ data class AppConfig(
             "ambonMUD.engine.gambling.diceMaxBet must be >= diceMinBet"
         }
         require(engine.gambling.diceWinMultiplier > 0.0) { "ambonMUD.engine.gambling.diceWinMultiplier must be > 0" }
-        require(engine.gambling.diceWinChance in 0.0..1.0) { "ambonMUD.engine.gambling.diceWinChance must be in 0.0..1.0" }
+        require(engine.gambling.diceWinTarget in 6..52) { "ambonMUD.engine.gambling.diceWinTarget must be in 6..52" }
+        require(engine.gambling.coinMaxThreshold in 1..6) { "ambonMUD.engine.gambling.coinMaxThreshold must be in 1..6" }
+        require(engine.gambling.coinWinMultiplier > 0.0) { "ambonMUD.engine.gambling.coinWinMultiplier must be > 0" }
+        require(engine.gambling.coinJackpotMultiplier > 0.0) {
+            "ambonMUD.engine.gambling.coinJackpotMultiplier must be > 0"
+        }
         require(engine.gambling.cooldownMs >= 0) { "ambonMUD.engine.gambling.cooldownMs must be >= 0" }
     }
 
@@ -902,9 +907,21 @@ data class GamblingConfig(
     val enabled: Boolean = true,
     val diceMinBet: Long = 10L,
     val diceMaxBet: Long = 10_000L,
+    /**
+     * Aineroira's Dice. Six dice — the goddess's children — are rolled in
+     * descending size: the large pair (Ophirae/Mycorae, d20), the medium pair
+     * (Pyrae/Aetherae, d16), the small pair (Lustriae/Aureliae, d8). Their sum
+     * decides the base wager; the Luneqrae coin decides the miracle.
+     */
     val diceWinMultiplier: Double = 2.0,
-    /** Probability of winning a dice roll (0.0–1.0). */
-    val diceWinChance: Double = 0.45,
+    /** A summed roll at or below this target wins the base payout (mean roll ≈ 47). */
+    val diceWinTarget: Int = 45,
+    /** This many dice (or more) landing on their max face summons the Luneqrae coin flip. */
+    val coinMaxThreshold: Int = 3,
+    /** Payout multiplier when the Luneqrae coin flip wins (and the sum busted). */
+    val coinWinMultiplier: Double = 10.0,
+    /** Payout multiplier when the coin flip wins AND the sum was at or below the target. */
+    val coinJackpotMultiplier: Double = 12.0,
     /** Cooldown between gamble attempts in milliseconds. */
     val cooldownMs: Long = 5_000L,
 )
@@ -3095,6 +3112,24 @@ data class ImagesConfig(
             "stylist_bg" to "global_assets/stylist_bg.png",
             "housing_bg" to "global_assets/housing_bg.png",
             "lottery_bg" to "global_assets/lottery_bg.png",
+            "dice_bg" to "global_assets/dice_bg.png",
+            // Aineroira's Dice — the six children, each with a themed die sprite
+            // and an illustrated max face, plus the Luneqrae coin's two sides.
+            // All optional; each die falls back to a themed CSS render.
+            "dice_ophirae" to "global_assets/dice_ophirae.png",
+            "dice_ophirae_max" to "global_assets/dice_ophirae_max.png",
+            "dice_mycorae" to "global_assets/dice_mycorae.png",
+            "dice_mycorae_max" to "global_assets/dice_mycorae_max.png",
+            "dice_pyrae" to "global_assets/dice_pyrae.png",
+            "dice_pyrae_max" to "global_assets/dice_pyrae_max.png",
+            "dice_aetherae" to "global_assets/dice_aetherae.png",
+            "dice_aetherae_max" to "global_assets/dice_aetherae_max.png",
+            "dice_lustriae" to "global_assets/dice_lustriae.png",
+            "dice_lustriae_max" to "global_assets/dice_lustriae_max.png",
+            "dice_aureliae" to "global_assets/dice_aureliae.png",
+            "dice_aureliae_max" to "global_assets/dice_aureliae_max.png",
+            "coin_luneqrae_moon" to "global_assets/coin_luneqrae_moon.png",
+            "coin_luneqrae_wind" to "global_assets/coin_luneqrae_wind.png",
             "dialog_indicator" to "global_assets/dialog_indicator.png",
             "aggro_indicator" to "global_assets/aggro_indicator.png",
             "quest_available_indicator" to "global_assets/quest_available_indicator.png",

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -1489,7 +1489,10 @@ class GmcpEmitter(
         val diceMinBet: Long,
         val diceMaxBet: Long,
         val diceWinMultiplier: Double,
-        val diceWinThreshold: Int,
+        val diceWinTarget: Int,
+        val coinMaxThreshold: Int,
+        val coinWinMultiplier: Double,
+        val coinJackpotMultiplier: Double,
         val diceCooldownMs: Long,
     )
 
@@ -1510,18 +1513,36 @@ class GmcpEmitter(
                 diceMinBet = info.diceMinBet,
                 diceMaxBet = info.diceMaxBet,
                 diceWinMultiplier = info.diceWinMultiplier,
-                diceWinThreshold = info.diceWinThreshold,
+                diceWinTarget = info.diceWinTarget,
+                coinMaxThreshold = info.coinMaxThreshold,
+                coinWinMultiplier = info.coinWinMultiplier,
+                coinJackpotMultiplier = info.coinJackpotMultiplier,
                 diceCooldownMs = info.diceCooldownMs,
             ),
         )
     }
 
+    /** One die within a resolved roll, in tumble order. */
+    data class GambleDiePayload(
+        val kind: String,
+        val sides: Int,
+        val value: Int,
+        val isMax: Boolean,
+    )
+
     data class GambleResultPayload(
+        /** "win" (base), "lose", "coin" (Luneqrae rescue), or "jackpot" (coin + base). */
         val outcome: String,
         val bet: Long,
         val payout: Long,
-        val roll: Int,
-        val needed: Int,
+        val multiplier: Double,
+        /** The six children in roll order, big → small. */
+        val dice: List<GambleDiePayload>,
+        val sum: Int,
+        val target: Int,
+        val maxCount: Int,
+        val coinFired: Boolean,
+        val coinWon: Boolean,
         val cooldownMs: Long,
     )
 

--- a/src/main/kotlin/dev/ambon/engine/LotterySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/LotterySystem.kt
@@ -350,10 +350,7 @@ class LotterySystem(
         // win or bust, fate decides. A winning flip rescues a bust into a 10×, or
         // gilds an already-winning sum into a 12×. A losing flip leaves the base
         // result untouched.
-        // TEMP(dice-verify): force the Luneqrae coin to fire on EVERY roll so the
-        // flip animation, coin art, and 10×/12× payouts can be verified visually.
-        // REVERT before merge — restore: maxCount >= gamblingConfig.coinMaxThreshold
-        val coinFired = true
+        val coinFired = maxCount >= gamblingConfig.coinMaxThreshold
         val coinWon = coinFired && random.nextInt(2) == 0
 
         val multiplier: Double =

--- a/src/main/kotlin/dev/ambon/engine/LotterySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/LotterySystem.kt
@@ -26,9 +26,48 @@ data class LotteryInfo(
     val diceMinBet: Long,
     val diceMaxBet: Long,
     val diceWinMultiplier: Double,
-    /** Roll this value or less on a d100 to win. */
-    val diceWinThreshold: Int,
+    /** Aineroira's Dice: a summed roll at or below this target wins the base payout. */
+    val diceWinTarget: Int,
+    /** This many dice (or more) on their max face summon the Luneqrae coin flip. */
+    val coinMaxThreshold: Int,
+    /** Payout multiplier when the coin flip wins after a busted sum. */
+    val coinWinMultiplier: Double,
+    /** Payout multiplier when the coin flip wins and the sum stayed at or below target. */
+    val coinJackpotMultiplier: Double,
     val diceCooldownMs: Long,
+)
+
+/**
+ * The six children of Aineroira, rolled in descending size. Each pair shares a
+ * die size; the order here is the order they tumble onto the table.
+ */
+enum class DieKind(
+    val sides: Int,
+) {
+    /** Large pair — whalebone eastern dragon. */
+    OPHIRAE(20),
+
+    /** Large pair — moss-green fungal bloom. */
+    MYCORAE(20),
+
+    /** Medium pair — ember-red phoenix. */
+    PYRAE(16),
+
+    /** Medium pair — obsidian shadow-glass cloak (born of her shadow, not her children). */
+    AETHERAE(16),
+
+    /** Small pair — carved-wood forest faerie. */
+    LUSTRIAE(8),
+
+    /** Small pair — carved-coral jellyfish. */
+    AURELIAE(8),
+}
+
+/** One settled die: which child, what it showed, and whether it crowned its max face. */
+data class DieRoll(
+    val kind: DieKind,
+    val value: Int,
+    val isMax: Boolean,
 )
 
 /** Result of a lottery ticket purchase attempt. */
@@ -64,18 +103,30 @@ data class LotteryDrawingResult(
 
 /** Result of a gamble attempt. */
 sealed interface GambleResult {
-    data class Win(
+    /**
+     * A full resolution of Aineroira's Dice: the six dice in roll order, their
+     * sum against the target, and the optional Luneqrae coin flip.
+     *
+     * @param payout total gold returned (0 on a clean loss); net = payout - bet.
+     * @param multiplier the multiplier applied (0, base, coin, or jackpot).
+     */
+    data class Resolved(
         val bet: Long,
         val payout: Long,
-        val roll: Int,
-        val needed: Int,
-    ) : GambleResult
+        val multiplier: Double,
+        val dice: List<DieRoll>,
+        val sum: Int,
+        val target: Int,
+        val maxCount: Int,
+        val coinFired: Boolean,
+        val coinWon: Boolean,
+    ) : GambleResult {
+        /** Whether the player came out ahead (any payout). */
+        val won: Boolean get() = payout > 0L
 
-    data class Lose(
-        val bet: Long,
-        val roll: Int,
-        val needed: Int,
-    ) : GambleResult
+        /** Whether the summed roll itself landed at or below the target. */
+        val baseWin: Boolean get() = sum <= target
+    }
 
     data class InsufficientGold(
         val have: Long,
@@ -130,8 +181,8 @@ class LotterySystem(
     /** Session id -> last gamble timestamp. */
     private val lastGambleTime = mutableMapOf<SessionId, Long>()
 
-    /** Roll this value or less on a d100 to win. */
-    private val diceWinThreshold = (gamblingConfig.diceWinChance * 100).toInt()
+    /** The six children, in the order they tumble onto the table (big → small). */
+    private val rollOrder = DieKind.entries
 
     /** Cooldown between dice rolls; exposed for GMCP gamble payloads. */
     val diceCooldownMs: Long get() = gamblingConfig.cooldownMs
@@ -150,7 +201,10 @@ class LotterySystem(
             diceMinBet = gamblingConfig.diceMinBet,
             diceMaxBet = gamblingConfig.diceMaxBet,
             diceWinMultiplier = gamblingConfig.diceWinMultiplier,
-            diceWinThreshold = diceWinThreshold,
+            diceWinTarget = gamblingConfig.diceWinTarget,
+            coinMaxThreshold = gamblingConfig.coinMaxThreshold,
+            coinWinMultiplier = gamblingConfig.coinWinMultiplier,
+            coinJackpotMultiplier = gamblingConfig.coinJackpotMultiplier,
             diceCooldownMs = gamblingConfig.cooldownMs,
         )
     }
@@ -281,16 +335,44 @@ class LotterySystem(
 
         lastGambleTime[sessionId] = now
 
-        // Roll 1-100; win threshold based on configured chance
-        val needed = diceWinThreshold
-        val roll = random.nextInt(100) + 1
-
-        return if (roll <= needed) {
-            val payout = (amount * gamblingConfig.diceWinMultiplier).toLong()
-            GambleResult.Win(bet = amount, payout = payout, roll = roll, needed = needed)
-        } else {
-            GambleResult.Lose(bet = amount, roll = roll, needed = needed)
+        // Roll the six children in order, big → small. Each die crowns its max
+        // face if it shows its highest pip.
+        val dice = rollOrder.map { kind ->
+            val value = random.nextInt(kind.sides) + 1
+            DieRoll(kind = kind, value = value, isMax = value == kind.sides)
         }
+        val sum = dice.sumOf { it.value }
+        val target = gamblingConfig.diceWinTarget
+        val baseWin = sum <= target
+        val maxCount = dice.count { it.isMax }
+
+        // The Luneqrae coin flips whenever enough children crown their max face —
+        // win or bust, fate decides. A winning flip rescues a bust into a 10×, or
+        // gilds an already-winning sum into a 12×. A losing flip leaves the base
+        // result untouched.
+        val coinFired = maxCount >= gamblingConfig.coinMaxThreshold
+        val coinWon = coinFired && random.nextInt(2) == 0
+
+        val multiplier: Double =
+            when {
+                coinFired && coinWon && baseWin -> gamblingConfig.coinJackpotMultiplier
+                coinFired && coinWon -> gamblingConfig.coinWinMultiplier
+                baseWin -> gamblingConfig.diceWinMultiplier
+                else -> 0.0
+            }
+        val payout = (amount * multiplier).toLong()
+
+        return GambleResult.Resolved(
+            bet = amount,
+            payout = payout,
+            multiplier = multiplier,
+            dice = dice,
+            sum = sum,
+            target = target,
+            maxCount = maxCount,
+            coinFired = coinFired,
+            coinWon = coinWon,
+        )
     }
 
     /** Clears gamble cooldown for a disconnected player. */

--- a/src/main/kotlin/dev/ambon/engine/LotterySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/LotterySystem.kt
@@ -350,7 +350,10 @@ class LotterySystem(
         // win or bust, fate decides. A winning flip rescues a bust into a 10×, or
         // gilds an already-winning sum into a 12×. A losing flip leaves the base
         // result untouched.
-        val coinFired = maxCount >= gamblingConfig.coinMaxThreshold
+        // TEMP(dice-verify): force the Luneqrae coin to fire on EVERY roll so the
+        // flip animation, coin art, and 10×/12× payouts can be verified visually.
+        // REVERT before merge — restore: maxCount >= gamblingConfig.coinMaxThreshold
+        val coinFired = true
         val coinWon = coinFired && random.nextInt(2) == 0
 
         val multiplier: Double =

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/LotteryHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/LotteryHandler.kt
@@ -1,10 +1,12 @@
 package dev.ambon.engine.commands.handlers
 
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.engine.DieKind
 import dev.ambon.engine.GambleResult
 import dev.ambon.engine.GmcpEmitter
 import dev.ambon.engine.LotteryBuyResult
 import dev.ambon.engine.LotterySystem
+import dev.ambon.engine.PlayerState
 import dev.ambon.engine.commands.Command
 import dev.ambon.engine.commands.CommandHandler
 import dev.ambon.engine.commands.CommandRouter
@@ -191,58 +193,7 @@ class LotteryHandler(
             )
 
             when (result) {
-                is GambleResult.Win -> {
-                    ctx.metrics.onGameEvent("tavern", "gamble")
-                    ctx.metrics.onGameEvent("tavern", "gamble_win")
-                    me.gold = me.gold - result.bet + result.payout
-                    outbound.send(
-                        OutboundEvent.SendInfo(
-                            sessionId,
-                            "You roll the dice... ${result.roll} (need ${result.needed} or less). You WIN!",
-                        ),
-                    )
-                    outbound.send(
-                        OutboundEvent.SendInfo(
-                            sessionId,
-                            "You collect ${result.payout} gold! (Net gain: ${result.payout - result.bet} gold)",
-                        ),
-                    )
-                    markVitalsDirty(sessionId)
-                    emitGambleGmcp(sessionId, system, "win", result.bet, result.payout, result.roll, result.needed)
-                    broadcastToRoomExcept(
-                        me.roomId,
-                        sessionId,
-                        "${me.name} rolls the dice and wins ${result.payout} gold!",
-                        players,
-                        outbound,
-                    )
-                }
-
-                is GambleResult.Lose -> {
-                    ctx.metrics.onGameEvent("tavern", "gamble")
-                    me.gold -= result.bet
-                    outbound.send(
-                        OutboundEvent.SendInfo(
-                            sessionId,
-                            "You roll the dice... ${result.roll} (need ${result.needed} or less). You lose.",
-                        ),
-                    )
-                    outbound.send(
-                        OutboundEvent.SendInfo(
-                            sessionId,
-                            "You lose ${result.bet} gold.",
-                        ),
-                    )
-                    markVitalsDirty(sessionId)
-                    emitGambleGmcp(sessionId, system, "lose", result.bet, 0L, result.roll, result.needed)
-                    broadcastToRoomExcept(
-                        me.roomId,
-                        sessionId,
-                        "${me.name} rolls the dice and loses.",
-                        players,
-                        outbound,
-                    )
-                }
+                is GambleResult.Resolved -> handleGambleResolved(sessionId, me, system, result)
 
                 is GambleResult.InsufficientGold -> {
                     sendErrorWithFeedback(
@@ -328,23 +279,109 @@ class LotteryHandler(
         gmcpEmitter?.sendLotteryInfo(sessionId, info)
     }
 
+    private suspend fun handleGambleResolved(
+        sessionId: SessionId,
+        me: PlayerState,
+        system: LotterySystem,
+        result: GambleResult.Resolved,
+    ) {
+        ctx.metrics.onGameEvent("tavern", "gamble")
+        if (result.won) ctx.metrics.onGameEvent("tavern", "gamble_win")
+        if (result.coinFired) ctx.metrics.onGameEvent("tavern", "gamble_coin")
+
+        me.gold = me.gold - result.bet + result.payout
+
+        val rollLine = result.dice.joinToString(", ") { "${dieName(it.kind)} ${it.value}" }
+        outbound.send(OutboundEvent.SendInfo(sessionId, "The children tumble across the velvet: $rollLine."))
+        outbound.send(OutboundEvent.SendInfo(sessionId, "Total ${result.sum} (target ${result.target} or less)."))
+
+        val net = result.payout - result.bet
+        val outcome = outcomeOf(result)
+        when (outcome) {
+            "jackpot" -> outbound.send(
+                OutboundEvent.SendInfo(
+                    sessionId,
+                    "The Luneqrae coin spins skyward and lands true — and your sum held! " +
+                        "You collect ${result.payout} gold! (Net +$net)",
+                ),
+            )
+
+            "coin" -> outbound.send(
+                OutboundEvent.SendInfo(
+                    sessionId,
+                    "Your sum overran, but the Luneqrae coin flips in your favour! " +
+                        "You collect ${result.payout} gold! (Net +$net)",
+                ),
+            )
+
+            "win" -> outbound.send(
+                OutboundEvent.SendInfo(
+                    sessionId,
+                    "Fate smiles — you WIN! You collect ${result.payout} gold! (Net +$net)",
+                ),
+            )
+
+            else -> {
+                val coinNote = if (result.coinFired) " The Luneqrae coin falls dark." else ""
+                outbound.send(
+                    OutboundEvent.SendInfo(
+                        sessionId,
+                        "The sum overruns the target.$coinNote You lose ${result.bet} gold.",
+                    ),
+                )
+            }
+        }
+
+        markVitalsDirty(sessionId)
+        emitGambleGmcp(sessionId, system, outcome, result)
+
+        val broadcast = when (outcome) {
+            "jackpot", "coin" ->
+                "${me.name} rolls Aineroira's Dice and the Luneqrae coin blesses them with ${result.payout} gold!"
+
+            "win" -> "${me.name} rolls Aineroira's Dice and wins ${result.payout} gold!"
+            else -> "${me.name} rolls Aineroira's Dice and busts."
+        }
+        broadcastToRoomExcept(me.roomId, sessionId, broadcast, players, outbound)
+    }
+
+    private fun dieName(kind: DieKind): String =
+        kind.name.lowercase().replaceFirstChar { it.uppercase() }
+
+    private fun outcomeOf(result: GambleResult.Resolved): String =
+        when {
+            result.coinFired && result.coinWon && result.baseWin -> "jackpot"
+            result.coinFired && result.coinWon -> "coin"
+            result.baseWin -> "win"
+            else -> "lose"
+        }
+
     private suspend fun emitGambleGmcp(
         sessionId: SessionId,
         system: LotterySystem,
         outcome: String,
-        bet: Long,
-        payout: Long,
-        roll: Int,
-        needed: Int,
+        result: GambleResult.Resolved,
     ) {
         gmcpEmitter?.sendGambleResult(
             sessionId,
             GmcpEmitter.GambleResultPayload(
                 outcome = outcome,
-                bet = bet,
-                payout = payout,
-                roll = roll,
-                needed = needed,
+                bet = result.bet,
+                payout = result.payout,
+                multiplier = result.multiplier,
+                dice = result.dice.map {
+                    GmcpEmitter.GambleDiePayload(
+                        kind = it.kind.name.lowercase(),
+                        sides = it.kind.sides,
+                        value = it.value,
+                        isMax = it.isMax,
+                    )
+                },
+                sum = result.sum,
+                target = result.target,
+                maxCount = result.maxCount,
+                coinFired = result.coinFired,
+                coinWon = result.coinWon,
                 cooldownMs = system.diceCooldownMs,
             ),
         )

--- a/src/test/kotlin/dev/ambon/engine/LotterySystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/LotterySystemTest.kt
@@ -35,7 +35,10 @@ class LotterySystemTest {
         diceMinBet = 10L,
         diceMaxBet = 1000L,
         diceWinMultiplier = 2.0,
-        diceWinChance = 0.45,
+        diceWinTarget = 45,
+        coinMaxThreshold = 3,
+        coinWinMultiplier = 10.0,
+        coinJackpotMultiplier = 12.0,
         cooldownMs = 5_000L,
     )
 
@@ -218,50 +221,111 @@ class LotterySystemTest {
         }
     }
 
+    /**
+     * A [Random] that hands back a scripted sequence of `nextInt` results,
+     * letting each dice roll (and the coin flip) be pinned exactly. Values are
+     * reduced modulo `until` so the same script works across die sizes.
+     */
+    private class ScriptedRandom(
+        private val values: IntArray,
+    ) : Random() {
+        private var index = 0
+
+        override fun nextBits(bitCount: Int): Int = 0
+
+        override fun nextInt(until: Int): Int {
+            val v = values[index % values.size]
+            index++
+            return ((v % until) + until) % until
+        }
+    }
+
+    private fun systemWith(random: Random): LotterySystem =
+        LotterySystem(
+            lotteryConfig = lotteryConfig,
+            gamblingConfig = gamblingConfig,
+            clock = clock,
+            random = random,
+        )
+
     @Nested
     inner class DiceGambling {
-        @Test
-        fun `winning gamble returns Win with correct payout`() {
-            // Use random that always wins (roll 1 out of 100, needs <= 45)
-            val alwaysWinRandom = object : Random() {
-                override fun nextBits(bitCount: Int): Int = 0
+        // Roll order: Ophirae(d20), Mycorae(d20), Pyrae(d16), Aetherae(d16),
+        // Lustriae(d8), Aureliae(d8). A nextInt return of N yields a face of N+1.
 
-                override fun nextInt(until: Int): Int = 0 // roll = 0+1 = 1, which is <= 45
-            }
-            val winSystem = LotterySystem(
-                lotteryConfig = lotteryConfig,
-                gamblingConfig = gamblingConfig,
-                clock = clock,
-                random = alwaysWinRandom,
-            )
-            val result = winSystem.gamble(sid1, 100L, 1000L, inTavern = true)
-            assertTrue(result is GambleResult.Win)
-            val win = result as GambleResult.Win
-            assertEquals(100L, win.bet)
-            assertEquals(200L, win.payout) // 2x multiplier
-            assertEquals(1, win.roll)
-            assertEquals(45, win.needed)
+        @Test
+        fun `low sum with no coin wins the base multiplier`() {
+            // All dice show 1 → sum 6, no max faces, no coin.
+            val result = systemWith(ScriptedRandom(intArrayOf(0))).gamble(sid1, 100L, 1000L, inTavern = true)
+            assertTrue(result is GambleResult.Resolved)
+            val r = result as GambleResult.Resolved
+            assertEquals(6, r.sum)
+            assertEquals(6, r.dice.size)
+            assertTrue(r.baseWin)
+            assertTrue(!r.coinFired)
+            assertEquals(2.0, r.multiplier)
+            assertEquals(200L, r.payout)
+            assertTrue(r.won)
         }
 
         @Test
-        fun `losing gamble returns Lose`() {
-            // Use random that always loses (roll 99 out of 100, needs <= 45)
-            val alwaysLoseRandom = object : Random() {
-                override fun nextBits(bitCount: Int): Int = 0
+        fun `high sum with no coin loses`() {
+            // 15,15,12,12,2,2 → sum 58, no die at its max face.
+            val result = systemWith(ScriptedRandom(intArrayOf(14, 14, 11, 11, 1, 1)))
+                .gamble(sid1, 100L, 1000L, inTavern = true)
+            assertTrue(result is GambleResult.Resolved)
+            val r = result as GambleResult.Resolved
+            assertEquals(58, r.sum)
+            assertEquals(0, r.maxCount)
+            assertTrue(!r.coinFired)
+            assertEquals(0.0, r.multiplier)
+            assertEquals(0L, r.payout)
+            assertTrue(!r.won)
+        }
 
-                override fun nextInt(until: Int): Int = until - 1 // roll = 99+1 = 100, which is > 45
-            }
-            val loseSystem = LotterySystem(
-                lotteryConfig = lotteryConfig,
-                gamblingConfig = gamblingConfig,
-                clock = clock,
-                random = alwaysLoseRandom,
-            )
-            val result = loseSystem.gamble(sid1, 100L, 1000L, inTavern = true)
-            assertTrue(result is GambleResult.Lose)
-            val lose = result as GambleResult.Lose
-            assertEquals(100L, lose.bet)
-            assertEquals(100, lose.roll)
+        @Test
+        fun `three max faces on a bust fire a winning coin for the coin multiplier`() {
+            // 20,20,16 (three maxes), 10,4,4 → sum 74 (bust); coin flip wins (0).
+            val result = systemWith(ScriptedRandom(intArrayOf(19, 19, 15, 9, 3, 3, 0)))
+                .gamble(sid1, 100L, 1000L, inTavern = true)
+            assertTrue(result is GambleResult.Resolved)
+            val r = result as GambleResult.Resolved
+            assertEquals(3, r.maxCount)
+            assertTrue(r.coinFired)
+            assertTrue(r.coinWon)
+            assertTrue(!r.baseWin)
+            assertEquals(10.0, r.multiplier)
+            assertEquals(1000L, r.payout)
+        }
+
+        @Test
+        fun `coin win on a held sum pays the jackpot multiplier`() {
+            // 1,1,16,1,8,8 → sum 35 (held), three maxes (Pyrae/Lustriae/Aureliae); coin wins (0).
+            val result = systemWith(ScriptedRandom(intArrayOf(0, 0, 15, 0, 7, 7, 0)))
+                .gamble(sid1, 100L, 1000L, inTavern = true)
+            assertTrue(result is GambleResult.Resolved)
+            val r = result as GambleResult.Resolved
+            assertEquals(35, r.sum)
+            assertEquals(3, r.maxCount)
+            assertTrue(r.coinFired)
+            assertTrue(r.coinWon)
+            assertTrue(r.baseWin)
+            assertEquals(12.0, r.multiplier)
+            assertEquals(1200L, r.payout)
+        }
+
+        @Test
+        fun `coin fires but a losing flip keeps the base bust`() {
+            // 20,20,16,10,4,4 → sum 74 (bust), three maxes; coin flip loses (1).
+            val result = systemWith(ScriptedRandom(intArrayOf(19, 19, 15, 9, 3, 3, 1)))
+                .gamble(sid1, 100L, 1000L, inTavern = true)
+            assertTrue(result is GambleResult.Resolved)
+            val r = result as GambleResult.Resolved
+            assertTrue(r.coinFired)
+            assertTrue(!r.coinWon)
+            assertEquals(0.0, r.multiplier)
+            assertEquals(0L, r.payout)
+            assertTrue(!r.won)
         }
 
         @Test
@@ -305,7 +369,7 @@ class LotterySystemTest {
             system.gamble(sid1, 10L, 1000L, inTavern = true)
             clock.advance(5_000L)
             val result = system.gamble(sid1, 10L, 1000L, inTavern = true)
-            assertTrue(result is GambleResult.Win || result is GambleResult.Lose)
+            assertTrue(result is GambleResult.Resolved)
         }
 
         @Test
@@ -324,7 +388,7 @@ class LotterySystemTest {
             system.gamble(sid1, 10L, 1000L, inTavern = true)
             system.onDisconnect(sid1)
             val result = system.gamble(sid1, 10L, 1000L, inTavern = true)
-            assertTrue(result is GambleResult.Win || result is GambleResult.Lose)
+            assertTrue(result is GambleResult.Resolved)
         }
     }
 

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -971,6 +971,8 @@ function App() {
             ? "estate"
             : drawerPanel === "lottery"
             ? "fortune"
+            : drawerPanel === "dice"
+            ? "dicetable"
             : drawerPanel === "character"
             ? "cabinet"
             : drawerPanel === "bank"
@@ -1017,6 +1019,8 @@ function App() {
             ? state.serverAssets["housing_bg"]
             : drawerPanel === "lottery"
             ? state.serverAssets["lottery_bg"]
+            : drawerPanel === "dice"
+            ? state.serverAssets["dice_bg"]
             : drawerPanel === "character"
             ? state.serverAssets["character_bg"]
             : drawerPanel === "bank"
@@ -1045,7 +1049,7 @@ function App() {
                             ? state.serverAssets["mail_bg"]
                             : undefined
         }
-        initialHeight={drawerPanel === "chatboard" || drawerPanel === "whoboard" || drawerPanel === "guildboard" || drawerPanel === "friendsboard" || drawerPanel === "groupboard" || drawerPanel === "help" || drawerPanel === "stylist" || drawerPanel === "housing" || drawerPanel === "lottery" ? 0.94 : undefined}
+        initialHeight={drawerPanel === "chatboard" || drawerPanel === "whoboard" || drawerPanel === "guildboard" || drawerPanel === "friendsboard" || drawerPanel === "groupboard" || drawerPanel === "help" || drawerPanel === "stylist" || drawerPanel === "housing" || drawerPanel === "lottery" || drawerPanel === "dice" ? 0.94 : undefined}
       >
         {drawerPanel === "character" && (
           <CharacterPanel
@@ -1405,6 +1409,7 @@ function App() {
             lotteryInfo={state.lotteryInfo}
             uiFeedbackFeed={state.uiFeedbackFeed}
             gold={state.vitals.gold}
+            assets={state.serverAssets}
             onCommand={sendCommand}
           />
         )}

--- a/web-v3/src/components/Drawer.tsx
+++ b/web-v3/src/components/Drawer.tsx
@@ -9,7 +9,7 @@ interface DrawerProps {
   /** Visual skin for the sheet chrome: warm leather (satchel), a dim
    *  dressing-chamber (equipment), a merchant cart (shop), a chalkboard
    *  (trainer), a parchment journal (combat log), or a cork quest board. */
-  variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "desk" | "mail" | "feature" | "tome" | "vault" | "cabinet" | "board" | "starframe" | "archive" | "stainedglass" | "codex" | "boudoir" | "estate" | "fortune";
+  variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "desk" | "mail" | "feature" | "tome" | "vault" | "cabinet" | "board" | "starframe" | "archive" | "stainedglass" | "codex" | "boudoir" | "estate" | "fortune" | "dicetable";
   /** Optional background art for a skinned variant (server asset). */
   skinBg?: string;
   /** Height (as a fraction of the viewport) the drawer snaps to when it opens. */

--- a/web-v3/src/components/panels/DicePanel.tsx
+++ b/web-v3/src/components/panels/DicePanel.tsx
@@ -13,14 +13,17 @@ interface DicePanelProps {
 
 /**
  * Per-die cadence. Each child wobbles in the velvet — its face shuffling
- * through random numbers — then LANDS on its real value and holds a beat before
- * dropping into the green felt. Six dice ≈ 5.6s of building suspense.
+ * through random numbers — then LANDS on its real value and holds, drops into
+ * the green felt, and the velvet sits empty for a beat so the player can take
+ * in the new running total before the next child rolls. Six dice ≈ 14s.
  */
-const WOBBLE_MS = 600; // shuffling/wobbling before it lands
-const LAND_HOLD_MS = 340; // landed value held in the velvet before it drops
-const PER_DIE_MS = WOBBLE_MS + LAND_HOLD_MS;
-const WOBBLE_TICK_MS = 70; // how fast the shuffling face cycles
-const COIN_FLIP_MS = 1100;
+const WOBBLE_MS = 1200; // shuffling/wobbling before it lands
+const LAND_HOLD_MS = 700; // landed value held in the velvet before it drops
+const GAP_MS = 500; // empty-velvet pause to register the new total
+const DROP_AT_MS = WOBBLE_MS + LAND_HOLD_MS; // when the die falls to the tray
+const PER_DIE_MS = DROP_AT_MS + GAP_MS; // full slot, next die starts after this
+const WOBBLE_TICK_MS = 90; // how fast the shuffling face cycles
+const COIN_FLIP_MS = 2000;
 
 type Phase = "idle" | "rolling" | "done";
 type CoinState = "none" | "flipping" | "won" | "lost";
@@ -164,8 +167,9 @@ export function DicePanel({ diceResult, lotteryInfo, uiFeedbackFeed, gold, asset
       });
       // Land on the real value (and reveal the crowned max face if any).
       at(base + WOBBLE_MS, () => setActiveLanded(true));
-      // Drop into the green tray; the running total ticks up.
-      at(base + PER_DIE_MS, () => {
+      // Drop into the green tray; the running total ticks up. The velvet then
+      // sits empty for GAP_MS before the next child appears.
+      at(base + DROP_AT_MS, () => {
         setActiveDie(null);
         setSettled((prev) => [...prev, die]);
         setRunningTotal((prev) => prev + die.value);
@@ -174,11 +178,11 @@ export function DicePanel({ diceResult, lotteryInfo, uiFeedbackFeed, gold, asset
 
     const afterDice = diceResult.dice.length * PER_DIE_MS;
     if (diceResult.coinFired) {
-      at(afterDice + 150, () => setCoinState("flipping"));
-      at(afterDice + 150 + COIN_FLIP_MS, () => setCoinState(diceResult.coinWon ? "won" : "lost"));
-      at(afterDice + 150 + COIN_FLIP_MS + 550, () => finish(diceResult));
+      at(afterDice + 400, () => setCoinState("flipping"));
+      at(afterDice + 400 + COIN_FLIP_MS, () => setCoinState(diceResult.coinWon ? "won" : "lost"));
+      at(afterDice + 400 + COIN_FLIP_MS + 900, () => finish(diceResult));
     } else {
-      at(afterDice + 250, () => finish(diceResult));
+      at(afterDice + 500, () => finish(diceResult));
     }
 
     return () => timers.forEach((t) => window.clearTimeout(t));

--- a/web-v3/src/components/panels/DicePanel.tsx
+++ b/web-v3/src/components/panels/DicePanel.tsx
@@ -11,10 +11,16 @@ interface DicePanelProps {
   onCommand: (command: string) => void;
 }
 
-/** Per-die tumble cadence; the active die spins in the velvet, then drops to the green. */
-const PER_DIE_MS = 520;
-const TUMBLE_MS = 360;
-const COIN_FLIP_MS = 900;
+/**
+ * Per-die cadence. Each child wobbles in the velvet — its face shuffling
+ * through random numbers — then LANDS on its real value and holds a beat before
+ * dropping into the green felt. Six dice ≈ 5.6s of building suspense.
+ */
+const WOBBLE_MS = 600; // shuffling/wobbling before it lands
+const LAND_HOLD_MS = 340; // landed value held in the velvet before it drops
+const PER_DIE_MS = WOBBLE_MS + LAND_HOLD_MS;
+const WOBBLE_TICK_MS = 70; // how fast the shuffling face cycles
+const COIN_FLIP_MS = 1100;
 
 type Phase = "idle" | "rolling" | "done";
 type CoinState = "none" | "flipping" | "won" | "lost";
@@ -44,17 +50,25 @@ function Die({
   die,
   extraClass,
   assets,
+  displayValue,
+  suppressMax,
 }: {
   die: DiceRoll;
   extraClass: string;
   assets: Record<string, string>;
+  /** Override the shown number (the shuffling face while wobbling). */
+  displayValue?: number;
+  /** Hold back the crowned max face/glow until the die has landed. */
+  suppressMax?: boolean;
 }) {
+  const showMax = die.isMax && !suppressMax;
   const sprite = assets[`dice_${die.kind}`];
   const maxArt = assets[`dice_${die.kind}_max`];
-  const faceArt = die.isMax ? (maxArt ?? sprite) : sprite;
+  const faceArt = showMax ? (maxArt ?? sprite) : sprite;
+  const value = displayValue ?? die.value;
   const className =
     `dice-die dice-die-${die.kind} ${sizeClass(die.sides)} ${extraClass}` +
-    (die.isMax ? " dice-die-max" : "") +
+    (showMax ? " dice-die-max" : "") +
     (faceArt ? " dice-die-art" : "");
   return (
     <div
@@ -62,7 +76,7 @@ function Die({
       title={`${childName(die.kind)} (d${die.sides}): ${die.value}${die.isMax ? " — max!" : ""}`}
       style={faceArt ? { backgroundImage: `url("${faceArt}")` } : undefined}
     >
-      <span className="dice-die-value">{die.value}</span>
+      <span className="dice-die-value">{value}</span>
       <span className="dice-die-tag">d{die.sides}</span>
     </div>
   );
@@ -87,6 +101,8 @@ export function DicePanel({ diceResult, lotteryInfo, uiFeedbackFeed, gold, asset
   const [phase, setPhase] = useState<Phase>("idle");
   const [animatedSeq, setAnimatedSeq] = useState(0);
   const [activeDie, setActiveDie] = useState<DiceRoll | null>(null);
+  const [activeLanded, setActiveLanded] = useState(false);
+  const [wobbleValue, setWobbleValue] = useState(1);
   const [settled, setSettled] = useState<DiceRoll[]>([]);
   const [runningTotal, setRunningTotal] = useState(0);
   const [coinState, setCoinState] = useState<CoinState>("none");
@@ -105,6 +121,7 @@ export function DicePanel({ diceResult, lotteryInfo, uiFeedbackFeed, gold, asset
     setAnimatedSeq(diceResult.seq);
     setPhase("rolling");
     setActiveDie(null);
+    setActiveLanded(false);
     setSettled([]);
     setRunningTotal(0);
     setCoinState("none");
@@ -138,8 +155,17 @@ export function DicePanel({ diceResult, lotteryInfo, uiFeedbackFeed, gold, asset
     }
 
     diceResult.dice.forEach((die, i) => {
-      at(i * PER_DIE_MS, () => setActiveDie(die));
-      at(i * PER_DIE_MS + TUMBLE_MS, () => {
+      const base = i * PER_DIE_MS;
+      // Appear and start wobbling (face shuffles via the interval below).
+      at(base, () => {
+        setActiveDie(die);
+        setActiveLanded(false);
+        setWobbleValue(1 + Math.floor(Math.random() * die.sides));
+      });
+      // Land on the real value (and reveal the crowned max face if any).
+      at(base + WOBBLE_MS, () => setActiveLanded(true));
+      // Drop into the green tray; the running total ticks up.
+      at(base + PER_DIE_MS, () => {
         setActiveDie(null);
         setSettled((prev) => [...prev, die]);
         setRunningTotal((prev) => prev + die.value);
@@ -157,6 +183,18 @@ export function DicePanel({ diceResult, lotteryInfo, uiFeedbackFeed, gold, asset
 
     return () => timers.forEach((t) => window.clearTimeout(t));
   }, [phase, diceResult]);
+
+  // While a die wobbles, cycle its shown face through random numbers so it
+  // looks like it's tumbling to a stop. Stops the moment it lands.
+  useEffect(() => {
+    if (!activeDie || activeLanded) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    const sides = activeDie.sides;
+    const id = window.setInterval(() => {
+      setWobbleValue(1 + Math.floor(Math.random() * sides));
+    }, WOBBLE_TICK_MS);
+    return () => window.clearInterval(id);
+  }, [activeDie, activeLanded]);
 
   // Tick the post-roll cooldown down so the Roll button re-enables itself.
   useEffect(() => {
@@ -227,7 +265,15 @@ export function DicePanel({ diceResult, lotteryInfo, uiFeedbackFeed, gold, asset
 
       {/* Velvet roll stage */}
       <div className="dice-velvet" aria-live="polite">
-        {activeDie && <Die die={activeDie} extraClass="dice-die-tumbling" assets={assets} />}
+        {activeDie && (
+          <Die
+            die={activeDie}
+            extraClass={activeLanded ? "dice-die-landing" : "dice-die-wobbling"}
+            assets={assets}
+            displayValue={activeLanded ? undefined : wobbleValue}
+            suppressMax={!activeLanded}
+          />
+        )}
         {coinState !== "none" && (() => {
           // Moon side = the Luneqrae's blessing (win); dark-wind side = the loss.
           const coinArt = coinState === "lost" ? assets["coin_luneqrae_wind"] : assets["coin_luneqrae_moon"];

--- a/web-v3/src/components/panels/DicePanel.tsx
+++ b/web-v3/src/components/panels/DicePanel.tsx
@@ -1,33 +1,97 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { DiceGambleResult, LotteryInfo, UiFeedbackEntry } from "../../types";
+import type { DiceGambleResult, DiceRoll, LotteryInfo, UiFeedbackEntry } from "../../types";
 
 interface DicePanelProps {
   diceResult: DiceGambleResult | null;
   lotteryInfo: LotteryInfo | null;
   uiFeedbackFeed: UiFeedbackEntry[];
   gold: number;
+  /** Resolved global-asset URLs (dice sprites, max faces, coin sides). */
+  assets: Record<string, string>;
   onCommand: (command: string) => void;
 }
 
-/** How long the die tumbles before settling on the real roll. */
-const ROLL_DURATION_MS = 1100;
-/** Number-shuffle cadence while tumbling. */
-const ROLL_TICK_MS = 70;
+/** Per-die tumble cadence; the active die spins in the velvet, then drops to the green. */
+const PER_DIE_MS = 520;
+const TUMBLE_MS = 360;
+const COIN_FLIP_MS = 900;
 
-type DiePhase = "idle" | "rolling" | "won" | "lost";
+type Phase = "idle" | "rolling" | "done";
+type CoinState = "none" | "flipping" | "won" | "lost";
 
-export function DicePanel({ diceResult, lotteryInfo, uiFeedbackFeed, gold, onCommand }: DicePanelProps) {
+/** Display name for one of Aineroira's children. */
+function childName(kind: string): string {
+  return kind ? kind.charAt(0).toUpperCase() + kind.slice(1) : "";
+}
+
+/** Large d20, medium d16, small d8 — a CSS hint that mirrors the roll order. */
+function sizeClass(sides: number): string {
+  if (sides >= 20) return "dice-die-lg";
+  if (sides >= 16) return "dice-die-md";
+  return "dice-die-sm";
+}
+
+function formatGold(n: number): string {
+  return Math.round(n).toLocaleString();
+}
+
+/**
+ * Renders one die: the Arcanum sprite (and illustrated max face on a crowned
+ * roll) when the art has shipped, otherwise a themed CSS render. The value and
+ * d-size tag overlay either way.
+ */
+function Die({
+  die,
+  extraClass,
+  assets,
+}: {
+  die: DiceRoll;
+  extraClass: string;
+  assets: Record<string, string>;
+}) {
+  const sprite = assets[`dice_${die.kind}`];
+  const maxArt = assets[`dice_${die.kind}_max`];
+  const faceArt = die.isMax ? (maxArt ?? sprite) : sprite;
+  const className =
+    `dice-die dice-die-${die.kind} ${sizeClass(die.sides)} ${extraClass}` +
+    (die.isMax ? " dice-die-max" : "") +
+    (faceArt ? " dice-die-art" : "");
+  return (
+    <div
+      className={className}
+      title={`${childName(die.kind)} (d${die.sides}): ${die.value}${die.isMax ? " — max!" : ""}`}
+      style={faceArt ? { backgroundImage: `url("${faceArt}")` } : undefined}
+    >
+      <span className="dice-die-value">{die.value}</span>
+      <span className="dice-die-tag">d{die.sides}</span>
+    </div>
+  );
+}
+
+/**
+ * Aineroira's Dice — reskinned onto the painted `dice_bg` frame. The six
+ * children tumble big → small in the purple velvet, settling one by one into
+ * the green felt as the running total climbs; the Luneqrae coin flips last when
+ * three or more crown their max face. Values, the bet controls, and the result
+ * banner overlay their painted slots.
+ */
+export function DicePanel({ diceResult, lotteryInfo, uiFeedbackFeed, gold, assets, onCommand }: DicePanelProps) {
   const minBet = lotteryInfo?.diceMinBet ?? 10;
   const maxBet = lotteryInfo?.diceMaxBet ?? 1000;
-  const multiplier = lotteryInfo?.diceWinMultiplier ?? 2;
-  const threshold = lotteryInfo?.diceWinThreshold ?? 45;
+  const winMult = lotteryInfo?.diceWinMultiplier ?? 2;
+  const target = lotteryInfo?.diceWinTarget ?? 45;
+  const coinMult = lotteryInfo?.coinWinMultiplier ?? 10;
+  const jackpotMult = lotteryInfo?.coinJackpotMultiplier ?? 12;
 
   const [betDraft, setBetDraft] = useState(`${minBet}`);
-  const [phase, setPhase] = useState<DiePhase>("idle");
-  const [displayRoll, setDisplayRoll] = useState<number | null>(null);
-  const [settled, setSettled] = useState<DiceGambleResult | null>(null);
-  const [cooldownLeft, setCooldownLeft] = useState(0);
+  const [phase, setPhase] = useState<Phase>("idle");
   const [animatedSeq, setAnimatedSeq] = useState(0);
+  const [activeDie, setActiveDie] = useState<DiceRoll | null>(null);
+  const [settled, setSettled] = useState<DiceRoll[]>([]);
+  const [runningTotal, setRunningTotal] = useState(0);
+  const [coinState, setCoinState] = useState<CoinState>("none");
+  const [finalResult, setFinalResult] = useState<DiceGambleResult | null>(null);
+  const [cooldownLeft, setCooldownLeft] = useState(0);
   const cooldownUntilRef = useRef(0);
 
   const activeFeedback = useMemo(
@@ -35,37 +99,63 @@ export function DicePanel({ diceResult, lotteryInfo, uiFeedbackFeed, gold, onCom
     [uiFeedbackFeed],
   );
 
-  // A fresh result arrived: kick the die into its tumble (state adjusted
-  // during render, per the React "you might not need an effect" pattern).
+  // A fresh result arrived: reset and kick off the tumble (state set during
+  // render, per the React "you might not need an effect" pattern).
   if (diceResult && diceResult.seq !== animatedSeq) {
     setAnimatedSeq(diceResult.seq);
     setPhase("rolling");
-    setSettled(null);
+    setActiveDie(null);
+    setSettled([]);
+    setRunningTotal(0);
+    setCoinState("none");
+    setFinalResult(null);
   }
 
-  // While tumbling, shuffle the shown number, then settle on the real roll.
+  // Drive the sequenced reveal: each die tumbles in the velvet, then drops into
+  // the green tray as the total grows; the coin flips last if it fired.
   useEffect(() => {
     if (phase !== "rolling" || !diceResult) return;
-
-    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-    const settle = () => {
-      setDisplayRoll(diceResult.roll);
-      setSettled(diceResult);
-      setPhase(diceResult.outcome === "win" ? "won" : "lost");
-      cooldownUntilRef.current = Date.now() + diceResult.cooldownMs;
-      setCooldownLeft(diceResult.cooldownMs);
+    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const timers: number[] = [];
+    const at = (delay: number, fn: () => void) => {
+      timers.push(window.setTimeout(fn, delay));
+    };
+    const finish = (r: DiceGambleResult) => {
+      setPhase("done");
+      setFinalResult(r);
+      cooldownUntilRef.current = Date.now() + r.cooldownMs;
+      setCooldownLeft(r.cooldownMs);
     };
 
-    const shuffle = reducedMotion
-      ? null
-      : window.setInterval(() => {
-          setDisplayRoll(1 + Math.floor(Math.random() * 100));
-        }, ROLL_TICK_MS);
-    const stop = window.setTimeout(settle, reducedMotion ? 0 : ROLL_DURATION_MS);
-    return () => {
-      if (shuffle !== null) window.clearInterval(shuffle);
-      window.clearTimeout(stop);
-    };
+    if (reduced) {
+      at(0, () => {
+        setSettled(diceResult.dice);
+        setRunningTotal(diceResult.sum);
+        setCoinState(diceResult.coinFired ? (diceResult.coinWon ? "won" : "lost") : "none");
+        finish(diceResult);
+      });
+      return () => timers.forEach((t) => window.clearTimeout(t));
+    }
+
+    diceResult.dice.forEach((die, i) => {
+      at(i * PER_DIE_MS, () => setActiveDie(die));
+      at(i * PER_DIE_MS + TUMBLE_MS, () => {
+        setActiveDie(null);
+        setSettled((prev) => [...prev, die]);
+        setRunningTotal((prev) => prev + die.value);
+      });
+    });
+
+    const afterDice = diceResult.dice.length * PER_DIE_MS;
+    if (diceResult.coinFired) {
+      at(afterDice + 150, () => setCoinState("flipping"));
+      at(afterDice + 150 + COIN_FLIP_MS, () => setCoinState(diceResult.coinWon ? "won" : "lost"));
+      at(afterDice + 150 + COIN_FLIP_MS + 550, () => finish(diceResult));
+    } else {
+      at(afterDice + 250, () => finish(diceResult));
+    }
+
+    return () => timers.forEach((t) => window.clearTimeout(t));
   }, [phase, diceResult]);
 
   // Tick the post-roll cooldown down so the Roll button re-enables itself.
@@ -79,115 +169,136 @@ export function DicePanel({ diceResult, lotteryInfo, uiFeedbackFeed, gold, onCom
 
   const rolling = phase === "rolling";
   const coolingDown = cooldownLeft > 0;
+  const bet = Math.min(maxBet, Math.max(minBet, Math.floor(Number(betDraft) || minBet)));
 
-  const placeBet = (amount: number) => {
-    if (rolling) return;
-    const bet = Math.min(maxBet, Math.max(minBet, Math.floor(amount)));
-    setBetDraft(`${bet}`);
-    onCommand(`gamble ${bet}`);
-  };
+  const clampBet = (n: number) => Math.max(minBet, Math.min(maxBet, Math.floor(n)));
+  const nudge = (delta: number) => setBetDraft(`${clampBet(bet + delta)}`);
 
   const quickBets = useMemo(() => {
-    const steps = [minBet, minBet * 5, minBet * 10, maxBet];
-    return [...new Set(steps.filter((b) => b >= minBet && b <= maxBet))];
+    const candidates = [minBet, 50, 100, 250, 500, 1000, 5000, maxBet];
+    return [...new Set(candidates.filter((b) => b >= minBet && b <= maxBet))].slice(0, 6);
   }, [minBet, maxBet]);
 
+  const roll = () => {
+    if (rolling || coolingDown) return;
+    const b = clampBet(bet);
+    setBetDraft(`${b}`);
+    onCommand(`gamble ${b}`);
+  };
+
+  const totalOver = runningTotal > target;
+  const showTotal = rolling || phase === "done";
+
+  // Outcome banner copy for the green felt band.
+  const banner = (() => {
+    if (rolling) return { cls: "rolling", text: "The children tumble across the velvet…" };
+    if (phase === "done" && finalResult) {
+      const net = finalResult.payout - finalResult.bet;
+      switch (finalResult.outcome) {
+        case "jackpot":
+          return { cls: "jackpot", text: `LUNEQRAE'S BLESSING — ${jackpotMult}× — you win ${formatGold(finalResult.payout)} gold! (+${formatGold(net)})` };
+        case "coin":
+          return { cls: "coin", text: `The coin rescues you — ${coinMult}× — ${formatGold(finalResult.payout)} gold! (+${formatGold(net)})` };
+        case "win":
+          return { cls: "win", text: `You WIN — ${formatGold(finalResult.payout)} gold! (+${formatGold(net)})` };
+        default:
+          return { cls: "lose", text: `Busted at ${finalResult.sum}. The house keeps your ${formatGold(finalResult.bet)} gold.` };
+      }
+    }
+    return { cls: "idle", text: `Sum ${target} or less wins ${winMult}× your bet.` };
+  })();
+
   return (
-    <div className="dice-panel">
-      <div className="panel-header">
-        <span className="panel-title">Dice Table</span>
+    <div className="dice-board">
+      {/* Your Gold */}
+      <div className="dice-gold">{formatGold(gold)}</div>
+
+      {/* How to Play */}
+      <div className="dice-howto">
+        <p>Six dice — the children of Aineroira — roll big to small.</p>
+        <p>Sum <strong>{target}</strong> or less and win <strong>{winMult}×</strong> your bet.</p>
+        <p>Land <strong>3+</strong> max faces and the Luneqrae coin flips: <strong>{coinMult}×</strong> on a bust, <strong>{jackpotMult}×</strong> if your sum also held.</p>
       </div>
 
-      {activeFeedback && (
-        <p className={`systems-local-message systems-local-message-${activeFeedback.type}`}>
-          {activeFeedback.message}
-        </p>
+      {/* Stat slots */}
+      <div className="dice-stat dice-stat-target">{target}<span className="dice-stat-sub">or less</span></div>
+      <div className="dice-stat dice-stat-payout">{formatGold(bet * winMult)}</div>
+      <div className="dice-stat dice-stat-bet">{formatGold(bet)}</div>
+
+      {/* Velvet roll stage */}
+      <div className="dice-velvet" aria-live="polite">
+        {activeDie && <Die die={activeDie} extraClass="dice-die-tumbling" assets={assets} />}
+        {coinState !== "none" && (() => {
+          // Moon side = the Luneqrae's blessing (win); dark-wind side = the loss.
+          const coinArt = coinState === "lost" ? assets["coin_luneqrae_wind"] : assets["coin_luneqrae_moon"];
+          return (
+            <div
+              className={`dice-coin dice-coin-${coinState}${coinArt ? " dice-coin-art" : ""}`}
+              style={coinArt ? { backgroundImage: `url("${coinArt}")` } : undefined}
+            >
+              {!coinArt && (
+                <span className="dice-coin-face">{coinState === "lost" ? "✦" : "☾"}</span>
+              )}
+            </div>
+          );
+        })()}
+        {!activeDie && coinState === "none" && !rolling && phase !== "done" && (
+          <p className="dice-velvet-hint">Place your bet and roll the dice.</p>
+        )}
+      </div>
+      {showTotal && (
+        <div className={`dice-total${totalOver ? " dice-total-over" : ""}`}>{runningTotal}</div>
       )}
 
-      <article className="systems-card">
-        <div className="systems-card-header">
-          <div>
-            <p className="systems-card-label">High-Stakes d100</p>
-            <h4>Roll {threshold} or less to win {multiplier}× your bet</h4>
-          </div>
-          <span className="systems-pill">{gold.toLocaleString()} gold</span>
+      {/* Place your bet (parchment) */}
+      <div className="dice-bet">
+        <div className="dice-bet-title">Place Your Bet</div>
+        <input
+          type="number"
+          min={minBet}
+          max={maxBet}
+          step={1}
+          inputMode="numeric"
+          className="dice-bet-input"
+          value={betDraft}
+          onChange={(e) => setBetDraft(e.target.value)}
+          aria-label="Bet amount"
+        />
+        <div className="dice-bet-steppers">
+          <button type="button" onClick={() => nudge(-10)} aria-label="Minus ten">−10</button>
+          <button type="button" onClick={() => nudge(-1)} aria-label="Minus one">−1</button>
+          <button type="button" onClick={() => nudge(1)} aria-label="Plus one">+1</button>
+          <button type="button" onClick={() => nudge(10)} aria-label="Plus ten">+10</button>
         </div>
-
-        <div className="dice-stage">
-          <div className={`dice-die dice-die-${phase}`} aria-hidden="true">
-            {displayRoll !== null ? (
-              <span className="dice-die-number">{displayRoll}</span>
-            ) : (
-              <span className="dice-die-mystery">?</span>
-            )}
-            <span className="dice-die-pip dice-die-pip-tl" />
-            <span className="dice-die-pip dice-die-pip-tr" />
-            <span className="dice-die-pip dice-die-pip-bl" />
-            <span className="dice-die-pip dice-die-pip-br" />
-          </div>
-          <p className="dice-outcome" aria-live="polite">
-            {rolling && "The die clatters across the table…"}
-            {(phase === "won" || phase === "lost") && settled && (
-              <span className="sr-only">Rolled {settled.roll}, needed {settled.needed} or less. </span>
-            )}
-            {phase === "won" && settled && (
-              <span className="dice-outcome-win">
-                You win {settled.payout.toLocaleString()} gold! (net +{(settled.payout - settled.bet).toLocaleString()})
-              </span>
-            )}
-            {phase === "lost" && settled && (
-              <span className="dice-outcome-lose">
-                Lost {settled.bet.toLocaleString()} gold. The house grins.
-              </span>
-            )}
-            {phase === "idle" && `Place a bet between ${minBet.toLocaleString()} and ${maxBet.toLocaleString()} gold.`}
-          </p>
-        </div>
-
-        <div className="systems-choice-list systems-choice-list-compact">
+        <div className="dice-bet-quick">
           {quickBets.map((amount) => (
             <button
               key={amount}
               type="button"
-              className="systems-choice-card"
-              disabled={rolling || coolingDown}
-              onClick={() => placeBet(amount)}
+              className={`dice-bet-chip${bet === amount ? " is-active" : ""}`}
+              onClick={() => setBetDraft(`${amount}`)}
             >
-              <span className="systems-choice-title">{amount.toLocaleString()} gold</span>
-              <span className="systems-choice-copy">wins {Math.floor(amount * multiplier).toLocaleString()}</span>
+              {amount >= 1000 ? `${amount / 1000}K` : amount}
             </button>
           ))}
         </div>
+        <button type="button" className="dice-roll-btn" disabled={rolling || coolingDown} onClick={roll}>
+          {rolling ? "Rolling…" : coolingDown ? `Wait ${Math.ceil(cooldownLeft / 1000)}s` : "ROLL"}
+        </button>
+        {activeFeedback && (
+          <p className={`dice-feedback dice-feedback-${activeFeedback.type}`}>{activeFeedback.message}</p>
+        )}
+      </div>
 
-        <div className="systems-action-row">
-          <input
-            type="number"
-            min={minBet}
-            max={maxBet}
-            step={1}
-            inputMode="numeric"
-            className="systems-number-input"
-            value={betDraft}
-            onChange={(event) => setBetDraft(event.target.value)}
-          />
-          <button
-            type="button"
-            className="systems-primary-btn"
-            disabled={rolling || coolingDown}
-            onClick={() => {
-              const bet = Number(betDraft);
-              if (!Number.isSafeInteger(bet) || bet < 1) return;
-              placeBet(bet);
-            }}
-          >
-            {rolling
-              ? "Rolling…"
-              : coolingDown
-                ? `Catch your breath (${Math.ceil(cooldownLeft / 1000)}s)`
-                : "Roll the Dice"}
-          </button>
+      {/* Green felt — settled dice + result banner */}
+      <div className="dice-felt">
+        <div className="dice-tray">
+          {settled.map((die, i) => (
+            <Die key={`${die.kind}-${i}`} die={die} extraClass="dice-die-settled" assets={assets} />
+          ))}
         </div>
-      </article>
+        <p className={`dice-banner dice-banner-${banner.cls}`}>{banner.text}</p>
+      </div>
     </div>
   );
 }

--- a/web-v3/src/components/panels/DicePanel.tsx
+++ b/web-v3/src/components/panels/DicePanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import type { CSSProperties } from "react";
 import type { DiceGambleResult, DiceRoll, LotteryInfo, UiFeedbackEntry } from "../../types";
 
 interface DicePanelProps {
@@ -42,6 +43,19 @@ function sizeClass(sides: number): string {
 
 function formatGold(n: number): string {
   return Math.round(n).toLocaleString();
+}
+
+/** Stable pseudo-random in [0,1) so firework bursts vary but never re-shuffle on re-render. */
+function jitter(i: number, salt: number): number {
+  const x = Math.sin((i + 1) * 12.9898 + salt * 78.233) * 43758.5453;
+  return x - Math.floor(x);
+}
+
+/** Headline for the win toast, by payout tier. */
+function celebrateTitle(tier: string): string {
+  if (tier === "jackpot") return "LUNEQRAE'S BLESSING!";
+  if (tier === "coin") return "MOONLIT FORTUNE!";
+  return "YOU WIN!";
 }
 
 /**
@@ -110,6 +124,7 @@ export function DicePanel({ diceResult, lotteryInfo, uiFeedbackFeed, gold, asset
   const [runningTotal, setRunningTotal] = useState(0);
   const [coinState, setCoinState] = useState<CoinState>("none");
   const [finalResult, setFinalResult] = useState<DiceGambleResult | null>(null);
+  const [celebrate, setCelebrate] = useState<{ seq: number; tier: string; payout: number } | null>(null);
   const [cooldownLeft, setCooldownLeft] = useState(0);
   const cooldownUntilRef = useRef(0);
 
@@ -129,6 +144,7 @@ export function DicePanel({ diceResult, lotteryInfo, uiFeedbackFeed, gold, asset
     setRunningTotal(0);
     setCoinState("none");
     setFinalResult(null);
+    setCelebrate(null);
   }
 
   // Drive the sequenced reveal: each die tumbles in the velvet, then drops into
@@ -145,6 +161,7 @@ export function DicePanel({ diceResult, lotteryInfo, uiFeedbackFeed, gold, asset
       setFinalResult(r);
       cooldownUntilRef.current = Date.now() + r.cooldownMs;
       setCooldownLeft(r.cooldownMs);
+      if (r.payout > 0) setCelebrate({ seq: r.seq, tier: r.outcome, payout: r.payout });
     };
 
     if (reduced) {
@@ -199,6 +216,36 @@ export function DicePanel({ diceResult, lotteryInfo, uiFeedbackFeed, gold, asset
     }, WOBBLE_TICK_MS);
     return () => window.clearInterval(id);
   }, [activeDie, activeLanded]);
+
+  // Clear the win celebration once its burst has played out.
+  useEffect(() => {
+    if (!celebrate) return;
+    const t = window.setTimeout(() => setCelebrate(null), 2800);
+    return () => window.clearTimeout(t);
+  }, [celebrate]);
+
+  // Firework spark vectors — deterministic per win so they don't reshuffle on
+  // re-render; richer bursts for the coin/jackpot tiers.
+  const sparks = useMemo<CSSProperties[]>(() => {
+    if (!celebrate) return [];
+    const n = celebrate.tier === "jackpot" ? 30 : celebrate.tier === "coin" ? 24 : 16;
+    const palette =
+      celebrate.tier === "jackpot"
+        ? [48, 0, 130, 280, 200, 340]
+        : celebrate.tier === "coin"
+          ? [205, 230, 280, 48]
+          : [120, 90, 48, 160];
+    return Array.from({ length: n }, (_, i) => {
+      const angle = ((i / n) * 360 + jitter(i, 1) * 44) * (Math.PI / 180);
+      const dist = 56 + jitter(i, 2) * 130;
+      return {
+        ["--tx" as string]: `${Math.cos(angle) * dist}px`,
+        ["--ty" as string]: `${Math.sin(angle) * dist}px`,
+        ["--hue" as string]: `${palette[i % palette.length]}`,
+        animationDelay: `${jitter(i, 3) * 0.5}s`,
+      } as CSSProperties;
+    });
+  }, [celebrate]);
 
   // Tick the post-roll cooldown down so the Roll button re-enables itself.
   useEffect(() => {
@@ -349,6 +396,21 @@ export function DicePanel({ diceResult, lotteryInfo, uiFeedbackFeed, gold, asset
         </div>
         <p className={`dice-banner dice-banner-${banner.cls}`}>{banner.text}</p>
       </div>
+
+      {/* Win celebration — a brief fireworks burst + toast. */}
+      {celebrate && (
+        <div className={`dice-celebrate dice-celebrate-${celebrate.tier}`} key={celebrate.seq} aria-hidden="true">
+          <div className="dice-fireworks">
+            {sparks.map((s, i) => (
+              <span key={i} className="dice-spark" style={s} />
+            ))}
+          </div>
+          <div className="dice-celebrate-toast">
+            <span className="dice-celebrate-title">{celebrateTitle(celebrate.tier)}</span>
+            <span className="dice-celebrate-amount">{formatGold(celebrate.payout)} gold</span>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -96,6 +96,7 @@ import type {
   GlobalQuestLeaderboardEntry,
   LotteryInfo,
   DiceGambleResult,
+  DiceRoll,
   GuildHallInfo,
   GuildHallRoom,
   DuelState,
@@ -2348,7 +2349,10 @@ export function applyGmcpPackage(
         diceMinBet: safeNumber(packet.diceMinBet, 10),
         diceMaxBet: safeNumber(packet.diceMaxBet, 1000),
         diceWinMultiplier: safeNumber(packet.diceWinMultiplier, 2),
-        diceWinThreshold: safeNumber(packet.diceWinThreshold, 45),
+        diceWinTarget: safeNumber(packet.diceWinTarget, 45),
+        coinMaxThreshold: safeNumber(packet.coinMaxThreshold, 3),
+        coinWinMultiplier: safeNumber(packet.coinWinMultiplier, 10),
+        coinJackpotMultiplier: safeNumber(packet.coinJackpotMultiplier, 12),
         diceCooldownMs: safeNumber(packet.diceCooldownMs, 5000),
       });
       break;
@@ -2356,12 +2360,34 @@ export function applyGmcpPackage(
 
     case "Lottery.Gamble": {
       const packet = data as Partial<Record<string, unknown>>;
+      const outcome =
+        packet.outcome === "win" ||
+        packet.outcome === "coin" ||
+        packet.outcome === "jackpot"
+          ? packet.outcome
+          : "lose";
+      const dice: DiceRoll[] = Array.isArray(packet.dice)
+        ? (packet.dice as unknown[]).map((d) => {
+            const entry = d as Partial<Record<string, unknown>>;
+            return {
+              kind: typeof entry.kind === "string" ? entry.kind : "",
+              sides: safeNumber(entry.sides, 6),
+              value: safeNumber(entry.value, 1),
+              isMax: entry.isMax === true,
+            };
+          })
+        : [];
       ctx.setDiceResult((prev) => ({
-        outcome: packet.outcome === "win" ? "win" : "lose",
+        outcome,
         bet: safeNumber(packet.bet, 0),
         payout: safeNumber(packet.payout, 0),
-        roll: safeNumber(packet.roll, 0),
-        needed: safeNumber(packet.needed, 45),
+        multiplier: safeNumber(packet.multiplier, 0),
+        dice,
+        sum: safeNumber(packet.sum, 0),
+        target: safeNumber(packet.target, 45),
+        maxCount: safeNumber(packet.maxCount, 0),
+        coinFired: packet.coinFired === true,
+        coinWon: packet.coinWon === true,
         cooldownMs: safeNumber(packet.cooldownMs, 5000),
         seq: (prev?.seq ?? 0) + 1,
       }));

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -25717,11 +25717,16 @@ html:has(.game-shell),
   padding: 0;
 }
 .dice-bet-title {
-  font-size: clamp(0.5rem, 1vw, 0.72rem);
-  letter-spacing: 0.14em;
+  font-size: clamp(0.64rem, 1.25vw, 0.92rem);
+  letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: #6a3c1a;
-  font-weight: 700;
+  color: #4a2710;
+  font-weight: 800;
+  text-shadow: 0 1px 0 rgb(255 246 224 / 55%);
+  padding-bottom: clamp(2px, 0.5vh, 5px);
+  border-bottom: 1px solid rgb(120 84 44 / 38%);
+  width: 100%;
+  text-align: center;
 }
 .dice-bet-input {
   width: 100%;
@@ -25744,13 +25749,13 @@ html:has(.game-shell),
 }
 .dice-bet-steppers button {
   padding: clamp(3px, 0.7vh, 7px) 0;
-  border: 1px solid rgb(120 84 44 / 45%);
+  border: 1px solid rgb(120 84 44 / 55%);
   border-radius: 6px;
-  background: rgb(74 48 24 / 28%);
-  color: #4a2f17;
+  background: rgb(74 48 24 / 34%);
+  color: #34200d;
   font-family: var(--font-display);
-  font-size: clamp(0.52rem, 1.05vw, 0.74rem);
-  font-weight: 700;
+  font-size: clamp(0.56rem, 1.1vw, 0.8rem);
+  font-weight: 800;
   cursor: pointer;
   transition: background 140ms var(--ease-out-soft), border-color 140ms var(--ease-out-soft);
 }
@@ -25763,13 +25768,13 @@ html:has(.game-shell),
 }
 .dice-bet-chip {
   padding: clamp(3px, 0.6vh, 6px) 0;
-  border: 1px solid rgb(120 84 44 / 40%);
+  border: 1px solid rgb(120 84 44 / 50%);
   border-radius: 6px;
-  background: rgb(247 238 214 / 35%);
-  color: #4a2f17;
+  background: rgb(247 238 214 / 48%);
+  color: #34200d;
   font-family: var(--font-display);
-  font-size: clamp(0.5rem, 1vw, 0.72rem);
-  font-weight: 700;
+  font-size: clamp(0.54rem, 1.05vw, 0.76rem);
+  font-weight: 800;
   cursor: pointer;
   transition: background 140ms var(--ease-out-soft), border-color 140ms var(--ease-out-soft), box-shadow 140ms var(--ease-out-soft);
 }
@@ -25990,3 +25995,98 @@ html:has(.game-shell),
   border-color: rgb(185 188 224 / 70%);
 }
 .dice-coin-art.dice-coin-won { border-color: #f7d96a; }
+
+/* ---- win celebration: brief fireworks burst + toast ---- */
+.dice-celebrate {
+  position: absolute;
+  inset: 0;
+  z-index: 8;
+  pointer-events: none;
+  display: grid;
+  place-items: center;
+}
+.dice-fireworks {
+  position: absolute;
+  left: 50%;
+  top: 44%;
+  width: 0;
+  height: 0;
+}
+.dice-spark {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: clamp(6px, 0.9vw, 11px);
+  height: clamp(6px, 0.9vw, 11px);
+  border-radius: 50%;
+  background: hsl(var(--hue, 48) 92% 62%);
+  box-shadow: 0 0 10px hsl(var(--hue, 48) 95% 66%), 0 0 18px hsl(var(--hue, 48) 90% 60% / 60%);
+  opacity: 0;
+  animation: dice-spark-burst 1.5s ease-out forwards;
+}
+@keyframes dice-spark-burst {
+  0% { transform: translate(0, 0) scale(0.4); opacity: 0; }
+  12% { opacity: 1; }
+  65% { opacity: 1; }
+  100% { transform: translate(var(--tx, 0), var(--ty, 0)) scale(0.85); opacity: 0; }
+}
+
+.dice-celebrate-toast {
+  position: relative;
+  margin-top: -6%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(2px, 0.6vh, 6px);
+  padding: clamp(8px, 1.5vh, 17px) clamp(20px, 3.4vw, 46px);
+  border-radius: 14px;
+  background: linear-gradient(165deg, rgb(42 32 72 / 92%), rgb(18 14 38 / 95%));
+  border: 2px solid rgb(247 217 106 / 70%);
+  box-shadow: 0 0 32px rgb(247 217 106 / 45%), 0 10px 26px rgb(0 0 0 / 55%);
+  animation: dice-toast-pop 2.7s var(--ease-out-soft) forwards;
+}
+.dice-celebrate-title {
+  font-family: var(--font-display);
+  font-size: clamp(1.1rem, 2.9vw, 2.2rem);
+  font-weight: 800;
+  letter-spacing: 0.03em;
+  line-height: 1;
+  color: #f7e08a;
+  text-shadow: 0 0 16px rgb(247 224 138 / 70%), 0 2px 4px rgb(0 0 0 / 50%);
+}
+.dice-celebrate-amount {
+  font-family: var(--font-display);
+  font-size: clamp(0.82rem, 1.8vw, 1.3rem);
+  font-weight: 700;
+  color: #ffeebb;
+  text-shadow: 0 1px 3px rgb(0 0 0 / 50%);
+}
+
+/* Coin tier — moonlit blue/silver. */
+.dice-celebrate-coin .dice-celebrate-toast { border-color: rgb(150 200 240 / 75%); box-shadow: 0 0 32px rgb(140 200 240 / 50%), 0 10px 26px rgb(0 0 0 / 55%); }
+.dice-celebrate-coin .dice-celebrate-title { color: #cfe9fb; text-shadow: 0 0 16px rgb(150 200 240 / 75%), 0 2px 4px rgb(0 0 0 / 50%); }
+.dice-celebrate-coin .dice-celebrate-amount { color: #e6f3ff; }
+
+/* Plain win — verdant green/gold. */
+.dice-celebrate-win .dice-celebrate-toast { border-color: rgb(160 220 150 / 70%); box-shadow: 0 0 28px rgb(143 214 160 / 45%), 0 10px 26px rgb(0 0 0 / 55%); }
+.dice-celebrate-win .dice-celebrate-title { color: #c6f3cf; text-shadow: 0 0 14px rgb(143 214 160 / 65%), 0 2px 4px rgb(0 0 0 / 50%); }
+.dice-celebrate-win .dice-celebrate-amount { color: #e6ffe9; }
+
+@keyframes dice-toast-pop {
+  0% { transform: scale(0.4) translateY(12px); opacity: 0; }
+  10% { transform: scale(1.14); opacity: 1; }
+  18% { transform: scale(1); }
+  80% { transform: scale(1); opacity: 1; }
+  100% { transform: scale(1.05); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dice-spark { display: none; }
+  .dice-celebrate-toast { animation: dice-toast-fade 2.7s ease-out forwards; }
+}
+@keyframes dice-toast-fade {
+  0% { opacity: 0; }
+  10% { opacity: 1; }
+  80% { opacity: 1; }
+  100% { opacity: 0; }
+}

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -25613,11 +25613,11 @@ html:has(.game-shell),
 /* Your Gold — sits beneath the painted label, top-left. */
 .dice-gold {
   position: absolute;
-  left: 6.5%;
-  top: 16.2%;
-  width: 21%;
+  left: 8%;
+  top: 16.5%;
+  width: 20%;
   text-align: center;
-  font-size: clamp(1rem, 2.3vw, 1.6rem);
+  font-size: clamp(0.72rem, 1.45vw, 1.15rem);
   font-weight: 700;
   color: #f3d271;
   text-shadow: 0 0 12px rgb(240 200 90 / 40%), 0 2px 3px rgb(0 0 0 / 60%);
@@ -25645,7 +25645,7 @@ html:has(.game-shell),
 /* The three painted stat slots: WIN TARGET / PAYOUT / CURRENT BET. */
 .dice-stat {
   position: absolute;
-  top: 30.5%;
+  top: 29%;
   text-align: center;
   font-size: clamp(1rem, 2.3vw, 1.7rem);
   font-weight: 700;
@@ -25655,8 +25655,8 @@ html:has(.game-shell),
   align-items: center;
 }
 .dice-stat-target { left: 30.5%; width: 13.5%; color: #8fd6a0; }
-.dice-stat-payout { left: 46%; width: 13%; color: #f3d271; }
-.dice-stat-bet { left: 60.5%; width: 14.5%; color: #9fc0ff; }
+.dice-stat-payout { left: 45%; width: 13%; color: #f3d271; }
+.dice-stat-bet { left: 59.5%; width: 14.5%; color: #9fc0ff; }
 .dice-stat-sub {
   font-size: clamp(0.46rem, 0.9vw, 0.62rem);
   letter-spacing: 0.14em;
@@ -25700,43 +25700,46 @@ html:has(.game-shell),
   text-shadow: 0 0 14px rgb(232 154 134 / 45%), 0 2px 3px rgb(0 0 0 / 60%);
 }
 
-/* Place Your Bet — parchment column on the right. */
+/* Place Your Bet — parchment column on the right. The hanging-dice charms
+   overlap the parchment's top-right, so the controls sit in its clear lower
+   half and stay inside the paper edge (≈78.5%–91%). */
 .dice-bet {
   position: absolute;
-  left: 77.2%;
-  top: 26%;
-  width: 18.6%;
-  bottom: 33%;
+  left: 78.4%;
+  top: 31%;
+  width: 12.8%;
+  bottom: 35%;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: flex-start;
-  gap: clamp(4px, 1vh, 9px);
-  padding: 1% 1.5%;
+  justify-content: center;
+  gap: clamp(5px, 1.2vh, 11px);
+  padding: 0;
 }
 .dice-bet-title {
-  font-size: clamp(0.56rem, 1.1vw, 0.78rem);
-  letter-spacing: 0.12em;
+  font-size: clamp(0.5rem, 1vw, 0.72rem);
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: #5a3a1f;
+  color: #6a3c1a;
   font-weight: 700;
 }
 .dice-bet-input {
   width: 100%;
   padding: clamp(3px, 0.7vh, 7px);
-  border: 1px solid rgb(120 84 44 / 55%);
+  border: 1px solid rgb(120 84 44 / 60%);
   border-radius: 7px;
-  background: rgb(247 238 214 / 75%);
+  background: rgb(243 231 203 / 90%);
+  box-shadow: inset 0 1px 3px rgb(90 60 30 / 25%);
   color: #3a2814;
   font-family: var(--font-display);
-  font-size: clamp(0.86rem, 1.7vw, 1.2rem);
+  font-size: clamp(0.78rem, 1.5vw, 1.08rem);
   font-weight: 700;
   text-align: center;
 }
 .dice-bet-steppers {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: clamp(2px, 0.4vw, 5px);
+  gap: clamp(2px, 0.35vw, 4px);
   width: 100%;
 }
 .dice-bet-steppers button {
@@ -25746,7 +25749,7 @@ html:has(.game-shell),
   background: rgb(74 48 24 / 28%);
   color: #4a2f17;
   font-family: var(--font-display);
-  font-size: clamp(0.6rem, 1.2vw, 0.84rem);
+  font-size: clamp(0.52rem, 1.05vw, 0.74rem);
   font-weight: 700;
   cursor: pointer;
   transition: background 140ms var(--ease-out-soft), border-color 140ms var(--ease-out-soft);
@@ -25755,7 +25758,7 @@ html:has(.game-shell),
 .dice-bet-quick {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: clamp(2px, 0.4vw, 5px);
+  gap: clamp(2px, 0.35vw, 4px);
   width: 100%;
 }
 .dice-bet-chip {
@@ -25765,7 +25768,7 @@ html:has(.game-shell),
   background: rgb(247 238 214 / 35%);
   color: #4a2f17;
   font-family: var(--font-display);
-  font-size: clamp(0.56rem, 1.1vw, 0.8rem);
+  font-size: clamp(0.5rem, 1vw, 0.72rem);
   font-weight: 700;
   cursor: pointer;
   transition: background 140ms var(--ease-out-soft), border-color 140ms var(--ease-out-soft), box-shadow 140ms var(--ease-out-soft);
@@ -25785,7 +25788,7 @@ html:has(.game-shell),
   background: linear-gradient(165deg, #6a3f9e, #3e2470);
   color: #f4e6c8;
   font-family: var(--font-display);
-  font-size: clamp(0.9rem, 1.9vw, 1.3rem);
+  font-size: clamp(0.82rem, 1.65vw, 1.18rem);
   font-weight: 700;
   letter-spacing: 0.08em;
   cursor: pointer;

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -25565,3 +25565,415 @@ html:has(.game-shell),
   transition: filter 150ms var(--ease-out-soft), transform 150ms var(--ease-out-soft);
 }
 .lot-buy-btn:hover { filter: brightness(1.14); transform: translateY(-1px); }
+
+/* ============================================================
+   Aineroira's Dice — painted `dice_bg` frame (1280×960, 4:3).
+   The six children tumble in the purple velvet and settle into
+   the green felt; values + bet controls overlay painted slots.
+   ============================================================ */
+.drawer-sheet.drawer-sheet-dicetable {
+  background-image:
+    var(--skin-bg, none),
+    radial-gradient(ellipse at 50% 30%, rgb(22 20 50 / 96%), rgb(9 9 24 / 98%));
+  background-size: cover, auto;
+  background-position: center, center;
+  background-repeat: no-repeat, no-repeat;
+}
+
+.drawer-sheet-dicetable .drawer-title { display: none; }
+.drawer-sheet-dicetable .drawer-handle-zone { display: none; }
+
+.drawer-sheet-dicetable .drawer-header {
+  position: absolute;
+  top: 1.5%;
+  right: 1.5%;
+  left: auto;
+  z-index: 6;
+  padding: 0;
+  min-height: 0;
+  border-bottom: none;
+}
+
+.drawer-sheet-dicetable .drawer-body {
+  padding: 0;
+  position: relative;
+}
+
+@media (min-width: 768px) {
+  .drawer-sheet.drawer-sheet-dicetable {
+    width: auto;
+    height: min(94vh, 71vw);
+    max-height: 94vh;
+    aspect-ratio: 4 / 3;
+  }
+}
+
+.dice-board { position: absolute; inset: 0; font-family: var(--font-display); }
+
+/* Your Gold — sits beneath the painted label, top-left. */
+.dice-gold {
+  position: absolute;
+  left: 6.5%;
+  top: 16.2%;
+  width: 21%;
+  text-align: center;
+  font-size: clamp(1rem, 2.3vw, 1.6rem);
+  font-weight: 700;
+  color: #f3d271;
+  text-shadow: 0 0 12px rgb(240 200 90 / 40%), 0 2px 3px rgb(0 0 0 / 60%);
+}
+
+/* How to Play — wooden plaque on the left. */
+.dice-howto {
+  position: absolute;
+  left: 6.5%;
+  top: 34%;
+  width: 20%;
+  bottom: 30%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: clamp(5px, 1.4vh, 12px);
+  padding: 0 2%;
+  color: rgb(224 210 178 / 88%);
+  font-size: clamp(0.6rem, 1.18vw, 0.86rem);
+  line-height: 1.32;
+}
+.dice-howto p { margin: 0; }
+.dice-howto strong { color: #f3d271; }
+
+/* The three painted stat slots: WIN TARGET / PAYOUT / CURRENT BET. */
+.dice-stat {
+  position: absolute;
+  top: 30.5%;
+  text-align: center;
+  font-size: clamp(1rem, 2.3vw, 1.7rem);
+  font-weight: 700;
+  line-height: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.dice-stat-target { left: 30.5%; width: 13.5%; color: #8fd6a0; }
+.dice-stat-payout { left: 46%; width: 13%; color: #f3d271; }
+.dice-stat-bet { left: 60.5%; width: 14.5%; color: #9fc0ff; }
+.dice-stat-sub {
+  font-size: clamp(0.46rem, 0.9vw, 0.62rem);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgb(160 200 170 / 70%);
+  margin-top: 3px;
+}
+
+/* Purple velvet roll stage — the active die tumbles here. */
+.dice-velvet {
+  position: absolute;
+  left: 31%;
+  top: 38.5%;
+  width: 42%;
+  height: 13.5%;
+  display: grid;
+  place-items: center;
+}
+.dice-velvet-hint {
+  margin: 0;
+  font-style: italic;
+  color: rgb(214 200 240 / 62%);
+  font-size: clamp(0.66rem, 1.3vw, 0.92rem);
+}
+
+/* Running total, just above the painted TOTAL plaque. */
+.dice-total {
+  position: absolute;
+  left: 40%;
+  top: 49.5%;
+  width: 22%;
+  text-align: center;
+  font-size: clamp(1.4rem, 3.4vw, 2.6rem);
+  font-weight: 700;
+  color: #8fd6a0;
+  text-shadow: 0 0 14px rgb(143 214 160 / 45%), 0 2px 3px rgb(0 0 0 / 60%);
+  line-height: 1;
+}
+.dice-total-over {
+  color: #e89a86;
+  text-shadow: 0 0 14px rgb(232 154 134 / 45%), 0 2px 3px rgb(0 0 0 / 60%);
+}
+
+/* Place Your Bet — parchment column on the right. */
+.dice-bet {
+  position: absolute;
+  left: 77.2%;
+  top: 26%;
+  width: 18.6%;
+  bottom: 33%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: clamp(4px, 1vh, 9px);
+  padding: 1% 1.5%;
+}
+.dice-bet-title {
+  font-size: clamp(0.56rem, 1.1vw, 0.78rem);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #5a3a1f;
+  font-weight: 700;
+}
+.dice-bet-input {
+  width: 100%;
+  padding: clamp(3px, 0.7vh, 7px);
+  border: 1px solid rgb(120 84 44 / 55%);
+  border-radius: 7px;
+  background: rgb(247 238 214 / 75%);
+  color: #3a2814;
+  font-family: var(--font-display);
+  font-size: clamp(0.86rem, 1.7vw, 1.2rem);
+  font-weight: 700;
+  text-align: center;
+}
+.dice-bet-steppers {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: clamp(2px, 0.4vw, 5px);
+  width: 100%;
+}
+.dice-bet-steppers button {
+  padding: clamp(3px, 0.7vh, 7px) 0;
+  border: 1px solid rgb(120 84 44 / 45%);
+  border-radius: 6px;
+  background: rgb(74 48 24 / 28%);
+  color: #4a2f17;
+  font-family: var(--font-display);
+  font-size: clamp(0.6rem, 1.2vw, 0.84rem);
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 140ms var(--ease-out-soft), border-color 140ms var(--ease-out-soft);
+}
+.dice-bet-steppers button:hover { background: rgb(120 84 44 / 30%); border-color: rgb(150 104 54 / 65%); }
+.dice-bet-quick {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: clamp(2px, 0.4vw, 5px);
+  width: 100%;
+}
+.dice-bet-chip {
+  padding: clamp(3px, 0.6vh, 6px) 0;
+  border: 1px solid rgb(120 84 44 / 40%);
+  border-radius: 6px;
+  background: rgb(247 238 214 / 35%);
+  color: #4a2f17;
+  font-family: var(--font-display);
+  font-size: clamp(0.56rem, 1.1vw, 0.8rem);
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 140ms var(--ease-out-soft), border-color 140ms var(--ease-out-soft), box-shadow 140ms var(--ease-out-soft);
+}
+.dice-bet-chip:hover { background: rgb(247 238 214 / 60%); }
+.dice-bet-chip.is-active {
+  border-color: #7e4ba0;
+  background: rgb(126 75 160 / 22%);
+  box-shadow: 0 0 10px rgb(126 75 160 / 35%), inset 0 0 6px rgb(126 75 160 / 18%);
+}
+.dice-roll-btn {
+  margin-top: clamp(2px, 0.6vh, 6px);
+  width: 100%;
+  padding: clamp(6px, 1.2vh, 12px) 0;
+  border: 1px solid rgb(200 170 90 / 55%);
+  border-radius: 9px;
+  background: linear-gradient(165deg, #6a3f9e, #3e2470);
+  color: #f4e6c8;
+  font-family: var(--font-display);
+  font-size: clamp(0.9rem, 1.9vw, 1.3rem);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  transition: transform 140ms var(--ease-out-soft), box-shadow 140ms var(--ease-out-soft), filter 140ms var(--ease-out-soft);
+}
+.dice-roll-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 0 16px rgb(140 90 200 / 45%);
+  filter: brightness(1.08);
+}
+.dice-roll-btn:disabled { opacity: 0.55; cursor: default; }
+.dice-feedback { margin: 0; font-size: clamp(0.54rem, 1.05vw, 0.76rem); text-align: center; }
+.dice-feedback-error { color: #b0381f; }
+.dice-feedback-success { color: #2f6b3a; }
+.dice-feedback-info { color: #2f4f8f; }
+
+/* Green felt band — settled dice tray + result banner. */
+.dice-felt {
+  position: absolute;
+  left: 10%;
+  top: 76.5%;
+  width: 62%;
+  height: 15.5%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(3px, 0.9vh, 8px);
+  padding: 0 2%;
+}
+.dice-tray {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(4px, 0.8vw, 10px);
+  min-height: clamp(28px, 5vh, 46px);
+  flex-wrap: nowrap;
+}
+.dice-banner {
+  margin: 0;
+  text-align: center;
+  font-size: clamp(0.66rem, 1.45vw, 1.05rem);
+  font-weight: 700;
+  line-height: 1.15;
+}
+.dice-banner-idle { color: rgb(214 234 210 / 78%); font-weight: 600; }
+.dice-banner-rolling { color: rgb(214 234 210 / 88%); font-style: italic; font-weight: 600; }
+.dice-banner-win { color: #b6f0c2; text-shadow: 0 0 12px rgb(143 214 160 / 45%); }
+.dice-banner-coin { color: #bfe6fa; text-shadow: 0 0 12px rgb(116 200 230 / 50%); }
+.dice-banner-jackpot {
+  color: #f7e08a;
+  text-shadow: 0 0 14px rgb(240 200 90 / 60%);
+  animation: dice-banner-pulse 1.4s ease-in-out infinite;
+}
+.dice-banner-lose { color: #e8a896; }
+
+@keyframes dice-banner-pulse {
+  0%, 100% { filter: brightness(1); }
+  50% { filter: brightness(1.28); }
+}
+
+/* ---- the dice themselves ---- */
+.dice-die {
+  position: relative;
+  display: grid;
+  place-items: center;
+  border-radius: 22%;
+  border: 1.5px solid rgb(0 0 0 / 25%);
+  box-shadow: 0 3px 8px rgb(0 0 0 / 45%), inset 0 1px 2px rgb(255 255 255 / 25%);
+  font-weight: 800;
+}
+.dice-die-lg { width: clamp(38px, 5vw, 60px); height: clamp(38px, 5vw, 60px); }
+.dice-die-md { width: clamp(32px, 4.2vw, 50px); height: clamp(32px, 4.2vw, 50px); }
+.dice-die-sm { width: clamp(26px, 3.4vw, 42px); height: clamp(26px, 3.4vw, 42px); }
+.dice-die-value {
+  font-size: clamp(0.9rem, 2vw, 1.5rem);
+  line-height: 1;
+  text-shadow: 0 1px 2px rgb(0 0 0 / 40%);
+}
+.dice-die-tag {
+  position: absolute;
+  right: 8%;
+  bottom: 6%;
+  font-size: clamp(0.34rem, 0.7vw, 0.5rem);
+  letter-spacing: 0.04em;
+  opacity: 0.7;
+  font-weight: 700;
+}
+
+/* Per-child identities. */
+.dice-die-ophirae { background: linear-gradient(155deg, #efe7d6, #cdbfa0); color: #3a3326; border-color: #b8a884; }
+.dice-die-mycorae { background: linear-gradient(155deg, #6a9a5b, #36502f); color: #eaf3df; border-color: #9fc08a; }
+.dice-die-pyrae { background: linear-gradient(155deg, #e0702f, #7e2412); color: #ffe9d2; border-color: #f0a060; }
+.dice-die-aetherae { background: linear-gradient(155deg, #34304e, #0e0c1c); color: #cfc8e8; border-color: #6b5fa0; }
+.dice-die-lustriae { background: linear-gradient(155deg, #a5733f, #5e3c1d); color: #f3e3c8; border-color: #c79a5e; }
+.dice-die-aureliae { background: linear-gradient(155deg, #ec8fa4, #b24d6e); color: #ffe6ee; border-color: #f2a8bd; }
+
+/* Max-face crown glow. */
+.dice-die-max {
+  border-color: #f7d96a;
+  box-shadow: 0 0 14px rgb(247 217 106 / 70%), 0 3px 8px rgb(0 0 0 / 45%), inset 0 0 8px rgb(247 217 106 / 30%);
+}
+.dice-die-max::before {
+  content: "♛";
+  position: absolute;
+  top: -34%;
+  font-size: clamp(0.6rem, 1.3vw, 0.95rem);
+  color: #f7d96a;
+  text-shadow: 0 0 8px rgb(247 217 106 / 70%);
+}
+
+.dice-die-tumbling { animation: dice-tumble 360ms var(--ease-out-soft); }
+.dice-die-settled { animation: dice-drop 320ms var(--ease-out-soft); }
+
+@keyframes dice-tumble {
+  0% { transform: scale(0.5) rotate(-180deg); opacity: 0; }
+  55% { transform: scale(1.18) rotate(22deg); opacity: 1; }
+  100% { transform: scale(1) rotate(0deg); opacity: 1; }
+}
+@keyframes dice-drop {
+  0% { transform: translateY(-46px) scale(1.1); opacity: 0; }
+  100% { transform: translateY(0) scale(1); opacity: 1; }
+}
+
+/* Luneqrae coin. */
+.dice-coin {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: clamp(40px, 5.4vw, 64px);
+  height: clamp(40px, 5.4vw, 64px);
+  border-radius: 50%;
+  background: radial-gradient(circle at 38% 32%, #dfe3f5, #8b8fc0 55%, #3a3a66);
+  border: 2px solid #b9bce0;
+  box-shadow: 0 0 18px rgb(150 160 230 / 55%), inset 0 0 10px rgb(255 255 255 / 30%);
+  color: #2a2a4e;
+}
+.dice-coin-face { font-size: clamp(1.1rem, 2.6vw, 2rem); line-height: 1; }
+.dice-coin-flipping { animation: dice-coin-flip 900ms linear; }
+.dice-coin-won {
+  background: radial-gradient(circle at 38% 32%, #fff3c4, #f0c25a 55%, #9a6a1e);
+  border-color: #f7d96a;
+  box-shadow: 0 0 22px rgb(240 200 90 / 70%), inset 0 0 10px rgb(255 255 255 / 35%);
+  color: #5a3c10;
+}
+.dice-coin-lost { filter: grayscale(0.5) brightness(0.8); }
+
+@keyframes dice-coin-flip {
+  0% { transform: rotateY(0deg) scale(0.7); }
+  100% { transform: rotateY(1980deg) scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dice-die-tumbling,
+  .dice-die-settled,
+  .dice-coin-flipping,
+  .dice-banner-jackpot { animation: none; }
+}
+
+/* Art-backed dice/coin — the shipped sprite carries its own look; the value
+   drops to a small legible badge so the painted face stays readable. */
+.dice-die-art {
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  border-color: transparent;
+  box-shadow: 0 3px 8px rgb(0 0 0 / 45%);
+}
+.dice-die-art .dice-die-value {
+  position: absolute;
+  left: 7%;
+  bottom: 5%;
+  padding: 0 4px;
+  border-radius: 6px;
+  background: rgb(8 6 18 / 62%);
+  color: #f5edd6;
+  font-size: clamp(0.56rem, 1.2vw, 0.9rem);
+  text-shadow: none;
+}
+.dice-die-art.dice-die-max {
+  box-shadow: 0 0 16px rgb(247 217 106 / 75%), 0 3px 8px rgb(0 0 0 / 45%);
+}
+.dice-die-art .dice-die-tag { display: none; }
+
+.dice-coin-art {
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  border-color: rgb(185 188 224 / 70%);
+}
+.dice-coin-art.dice-coin-won { border-color: #f7d96a; }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -25897,13 +25897,22 @@ html:has(.game-shell),
   text-shadow: 0 0 8px rgb(247 217 106 / 70%);
 }
 
-.dice-die-tumbling { animation: dice-tumble 360ms var(--ease-out-soft); }
+.dice-die-wobbling { animation: dice-wobble 0.42s ease-in-out infinite; }
+.dice-die-landing { animation: dice-land 0.4s var(--ease-out-soft); }
 .dice-die-settled { animation: dice-drop 320ms var(--ease-out-soft); }
 
-@keyframes dice-tumble {
-  0% { transform: scale(0.5) rotate(-180deg); opacity: 0; }
-  55% { transform: scale(1.18) rotate(22deg); opacity: 1; }
-  100% { transform: scale(1) rotate(0deg); opacity: 1; }
+@keyframes dice-wobble {
+  0% { transform: rotate(-8deg) scale(0.97); }
+  25% { transform: rotate(6deg) scale(1.05); }
+  50% { transform: rotate(-4deg) scale(1); }
+  75% { transform: rotate(8deg) scale(1.05); }
+  100% { transform: rotate(-8deg) scale(0.97); }
+}
+@keyframes dice-land {
+  0% { transform: scale(1.32) rotate(-6deg); }
+  40% { transform: scale(0.88) rotate(4deg); }
+  70% { transform: scale(1.09) rotate(-1deg); }
+  100% { transform: scale(1) rotate(0deg); }
 }
 @keyframes dice-drop {
   0% { transform: translateY(-46px) scale(1.1); opacity: 0; }
@@ -25924,7 +25933,7 @@ html:has(.game-shell),
   color: #2a2a4e;
 }
 .dice-coin-face { font-size: clamp(1.1rem, 2.6vw, 2rem); line-height: 1; }
-.dice-coin-flipping { animation: dice-coin-flip 900ms linear; }
+.dice-coin-flipping { animation: dice-coin-flip 1100ms linear; }
 .dice-coin-won {
   background: radial-gradient(circle at 38% 32%, #fff3c4, #f0c25a 55%, #9a6a1e);
   border-color: #f7d96a;
@@ -25939,7 +25948,8 @@ html:has(.game-shell),
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .dice-die-tumbling,
+  .dice-die-wobbling,
+  .dice-die-landing,
   .dice-die-settled,
   .dice-coin-flipping,
   .dice-banner-jackpot { animation: none; }

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -1202,19 +1202,43 @@ export interface LotteryInfo {
   maxTicketsPerPlayer: number;
   diceMinBet: number;
   diceMaxBet: number;
+  /** Base payout multiplier when the summed roll lands at or below the target. */
   diceWinMultiplier: number;
-  /** Roll this value or less on a d100 to win. */
-  diceWinThreshold: number;
+  /** Aineroira's Dice: a summed roll at or below this wins the base payout. */
+  diceWinTarget: number;
+  /** This many dice (or more) on their max face summon the Luneqrae coin flip. */
+  coinMaxThreshold: number;
+  /** Payout multiplier when the coin flip wins after a busted sum. */
+  coinWinMultiplier: number;
+  /** Payout multiplier when the coin flip wins and the sum stayed at or below target. */
+  coinJackpotMultiplier: number;
   diceCooldownMs: number;
 }
 
-/** One resolved tavern dice roll, from the Lottery.Gamble GMCP package. */
+/** One settled die within a resolved roll, in tumble order (big → small). */
+export interface DiceRoll {
+  /** Which child: ophirae/mycorae/pyrae/aetherae/lustriae/aureliae. */
+  kind: string;
+  sides: number;
+  value: number;
+  /** Whether the die crowned its highest face. */
+  isMax: boolean;
+}
+
+/** One resolved game of Aineroira's Dice, from the Lottery.Gamble GMCP package. */
 export interface DiceGambleResult {
-  outcome: "win" | "lose";
+  /** "win" (base), "lose", "coin" (Luneqrae rescue), or "jackpot" (coin + held sum). */
+  outcome: "win" | "lose" | "coin" | "jackpot";
   bet: number;
   payout: number;
-  roll: number;
-  needed: number;
+  multiplier: number;
+  /** The six children in roll order, big → small. */
+  dice: DiceRoll[];
+  sum: number;
+  target: number;
+  maxCount: number;
+  coinFired: boolean;
+  coinWon: boolean;
   cooldownMs: number;
   /** Client-side monotonic id so the panel can animate each new roll. */
   seq: number;


### PR DESCRIPTION
## Aineroira's Dice

Replaces the single d100 roll-under gamble with a themed game of six dice — the children of the goddess Aineroira — rolled big → small:

| Pair | Children | Die |
|------|----------|-----|
| Large | Ophirae + Mycorae | d20 |
| Medium | Pyrae + Aetherae | d16 |
| Small | Lustriae + Aureliae | d8 |

**Rules**
- Sum **≤ 45** → wins the base **2×** payout (mean roll ≈ 47, so ~5–6% house edge).
- **3+ dice on their max face** summon the **Luneqrae coin** flip (50%): a winning flip pays **10×** on a bust, or **12×** if the sum also held. A losing flip leaves the base result untouched. The coin always fires when its condition is met — fate decides.

## Server
- New `GamblingConfig` fields: `diceWinTarget` (45), `coinMaxThreshold` (3), `coinWinMultiplier` (10), `coinJackpotMultiplier` (12). `diceWinChance` removed.
- `DieKind` model (six children, fixed roll order) + `GambleResult.Resolved` carrying the six dice, the sum vs. target, and the coin flip.
- Richer `Lottery.Gamble` GMCP payload: per-die values + identities, `isMax`, coin fired/won, payout tier — drives the sequenced client animation.

## Client
- Rebuilt `DicePanel` onto the painted **`dice_bg`** skin (new `dicetable` Drawer variant). Dice tumble in the purple velvet and settle into the green felt as the running **TOTAL** climbs; the Luneqrae coin flips last. Bet controls (input, ±10/±1, quick chips, **ROLL**) live on the right parchment.
- Registers `dice_bg` plus **14 Arcanum art keys** — 6 die sprites, 6 illustrated max faces, 2 coin sides. Every die falls back to a **themed CSS render** until the art ships, so the panel works today.

## Notes
- `application.yaml` is intentionally **not** touched (it carries unrelated WIP). Hoplite is non-strict, so the old `diceWinChance` key is ignored and the new fields take their schema defaults — local dev and the R2 overlay both load cleanly.
- Validation: `LotterySystemTest` (new scripted-RNG coverage of base/coin/jackpot/bust), `ktlintCheck`, config tests, and `bun run lint && bun run build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)