### PR TITLE
feat(dice): telnet suspense + rules, and fix the goddess's name

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -908,7 +908,7 @@ data class GamblingConfig(
     val diceMinBet: Long = 10L,
     val diceMaxBet: Long = 10_000L,
     /**
-     * Aineroira's Dice. Six dice — the goddess's children — are rolled in
+     * Aineroia's Dice. Six dice — the goddess's children — are rolled in
      * descending size: the large pair (Ophirae/Mycorae, d20), the medium pair
      * (Pyrae/Aetherae, d16), the small pair (Lustriae/Aureliae, d8). Their sum
      * decides the base wager; the Luneqrae coin decides the miracle.
@@ -3113,7 +3113,7 @@ data class ImagesConfig(
             "housing_bg" to "global_assets/housing_bg.png",
             "lottery_bg" to "global_assets/lottery_bg.png",
             "dice_bg" to "global_assets/dice_bg.png",
-            // Aineroira's Dice — the six children, each with a themed die sprite
+            // Aineroia's Dice — the six children, each with a themed die sprite
             // and an illustrated max face, plus the Luneqrae coin's two sides.
             // All optional; each die falls back to a themed CSS render.
             "dice_ophirae" to "global_assets/dice_ophirae.png",

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -1486,6 +1486,7 @@ class GameEngine(
                 ctx = ctx,
                 lotterySystem = lotterySystem,
                 markVitalsDirty = ::markVitalsDirty,
+                getEngineScope = { engineScope },
             ),
             ReputationHandler(
                 ctx = ctx,

--- a/src/main/kotlin/dev/ambon/engine/LotterySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/LotterySystem.kt
@@ -26,7 +26,7 @@ data class LotteryInfo(
     val diceMinBet: Long,
     val diceMaxBet: Long,
     val diceWinMultiplier: Double,
-    /** Aineroira's Dice: a summed roll at or below this target wins the base payout. */
+    /** Aineroia's Dice: a summed roll at or below this target wins the base payout. */
     val diceWinTarget: Int,
     /** This many dice (or more) on their max face summon the Luneqrae coin flip. */
     val coinMaxThreshold: Int,
@@ -38,7 +38,7 @@ data class LotteryInfo(
 )
 
 /**
- * The six children of Aineroira, rolled in descending size. Each pair shares a
+ * The six children of Aineroia, rolled in descending size. Each pair shares a
  * die size; the order here is the order they tumble onto the table.
  */
 enum class DieKind(
@@ -104,7 +104,7 @@ data class LotteryDrawingResult(
 /** Result of a gamble attempt. */
 sealed interface GambleResult {
     /**
-     * A full resolution of Aineroira's Dice: the six dice in roll order, their
+     * A full resolution of Aineroia's Dice: the six dice in roll order, their
      * sum against the target, and the optional Luneqrae coin flip.
      *
      * @param payout total gold returned (0 on a clean loss); net = payout - bet.

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -222,6 +222,9 @@ sealed interface Command {
         val amount: Long,
     ) : Command
 
+    /** Bare `gamble`/`dice` with no amount — print the rules of Aineroia's Dice. */
+    data object DiceRules : Command
+
     // ---- Bank commands ----
 
     sealed interface Bank : Command {
@@ -1089,7 +1092,8 @@ object CommandParser {
         matchPrefix(line, listOf("gamble", "dice")) { rest ->
             val trimmed = rest.trim()
             if (trimmed.isEmpty()) {
-                Command.Invalid(line, "gamble <amount>")
+                // No amount — show the rules of Aineroia's Dice rather than an error.
+                Command.DiceRules
             } else {
                 val amount = trimmed.toLongOrNull()
                 if (amount == null || amount < 1) {

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/LotteryHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/LotteryHandler.kt
@@ -1,5 +1,6 @@
 package dev.ambon.engine.commands.handlers
 
+import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.engine.DieKind
 import dev.ambon.engine.GambleResult
@@ -12,11 +13,16 @@ import dev.ambon.engine.commands.CommandHandler
 import dev.ambon.engine.commands.CommandRouter
 import dev.ambon.engine.commands.on
 import dev.ambon.engine.events.OutboundEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 class LotteryHandler(
     private val ctx: EngineContext,
     private val lotterySystem: LotterySystem? = null,
     private val markVitalsDirty: (SessionId) -> Unit = {},
+    /** Engine scope for pacing the dice reveal off-tick; null skips the suspense. */
+    private val getEngineScope: (() -> CoroutineScope)? = null,
 ) : CommandHandler {
     private val players = ctx.players
     private val outbound = ctx.outbound
@@ -26,6 +32,7 @@ class LotteryHandler(
         router.on<Command.LotteryInfo> { sid, _ -> handleLotteryInfo(sid) }
         router.on<Command.LotteryBuy> { sid, cmd -> handleLotteryBuy(sid, cmd) }
         router.on<Command.Gamble> { sid, cmd -> handleGamble(sid, cmd) }
+        router.on<Command.DiceRules> { sid, _ -> handleDiceRules(sid) }
     }
 
     private suspend fun handleLotteryInfo(sessionId: SessionId) {
@@ -289,60 +296,138 @@ class LotteryHandler(
         if (result.won) ctx.metrics.onGameEvent("tavern", "gamble_win")
         if (result.coinFired) ctx.metrics.onGameEvent("tavern", "gamble_coin")
 
+        // Settle gold and the web animation immediately; the GMCP payload drives
+        // the client's own sequenced reveal. The text feed is paced separately so
+        // the telnet crowd feels the dice climb too.
         me.gold = me.gold - result.bet + result.payout
+        markVitalsDirty(sessionId)
 
-        val rollLine = result.dice.joinToString(", ") { "${dieName(it.kind)} ${it.value}" }
-        outbound.send(OutboundEvent.SendInfo(sessionId, "The children tumble across the velvet: $rollLine."))
-        outbound.send(OutboundEvent.SendInfo(sessionId, "Total ${result.sum} (target ${result.target} or less)."))
+        val outcome = outcomeOf(result)
+        emitGambleGmcp(sessionId, system, outcome, result)
 
         val net = result.payout - result.bet
-        val outcome = outcomeOf(result)
-        when (outcome) {
-            "jackpot" -> outbound.send(
-                OutboundEvent.SendInfo(
-                    sessionId,
-                    "The Luneqrae coin spins skyward and lands true — and your sum held! " +
-                        "You collect ${result.payout} gold! (Net +$net)",
-                ),
-            )
+        val name = me.name
+        val roomId = me.roomId
+        val scope = getEngineScope?.invoke()
+        if (scope != null) {
+            scope.launch { revealDice(sessionId, result, outcome, net, name, roomId, paced = true) }
+        } else {
+            revealDice(sessionId, result, outcome, net, name, roomId, paced = false)
+        }
+    }
 
-            "coin" -> outbound.send(
-                OutboundEvent.SendInfo(
-                    sessionId,
-                    "Your sum overran, but the Luneqrae coin flips in your favour! " +
-                        "You collect ${result.payout} gold! (Net +$net)",
-                ),
-            )
-
-            "win" -> outbound.send(
-                OutboundEvent.SendInfo(
-                    sessionId,
-                    "Fate smiles — you WIN! You collect ${result.payout} gold! (Net +$net)",
-                ),
-            )
-
-            else -> {
-                val coinNote = if (result.coinFired) " The Luneqrae coin falls dark." else ""
-                outbound.send(
-                    OutboundEvent.SendInfo(
-                        sessionId,
-                        "The sum overruns the target.$coinNote You lose ${result.bet} gold.",
-                    ),
-                )
-            }
+    /**
+     * Streams the roll to the text feed one child at a time, the running total
+     * climbing with each, then the Luneqrae coin and the verdict. When [paced]
+     * the lines are spaced a beat apart for suspense (run off-tick on the engine
+     * scope); otherwise they flush instantly (no scope, e.g. tests).
+     */
+    private suspend fun revealDice(
+        sessionId: SessionId,
+        result: GambleResult.Resolved,
+        outcome: String,
+        net: Long,
+        name: String,
+        roomId: RoomId,
+        paced: Boolean,
+    ) {
+        suspend fun beat() {
+            if (paced) delay(REVEAL_BEAT_MS)
         }
 
-        markVitalsDirty(sessionId)
-        emitGambleGmcp(sessionId, system, outcome, result)
+        outbound.send(OutboundEvent.SendInfo(sessionId, "You cast Aineroia's six children across the velvet..."))
+
+        var running = 0
+        for (die in result.dice) {
+            beat()
+            running += die.value
+            val crown = if (die.isMax) " — its crown blazes!" else ""
+            outbound.send(
+                OutboundEvent.SendInfo(
+                    sessionId,
+                    "  ${dieName(die.kind)} (d${die.kind.sides}) settles on ${die.value}$crown   (total: $running)",
+                ),
+            )
+        }
+
+        beat()
+        outbound.send(
+            OutboundEvent.SendInfo(
+                sessionId,
+                "  The dice lie still. Total ${result.sum} — you needed ${result.target} or less.",
+            ),
+        )
+
+        if (result.coinFired) {
+            beat()
+            outbound.send(
+                OutboundEvent.SendInfo(
+                    sessionId,
+                    "  ${result.maxCount} children wear their crowns — the Luneqrae coin leaps skyward...",
+                ),
+            )
+        }
+
+        beat()
+        val outcomeLine = when (outcome) {
+            "jackpot" ->
+                "The Luneqrae coin lands true — and your sum held! You collect ${result.payout} gold! (Net +$net)"
+
+            "coin" ->
+                "Your sum overran, but the Luneqrae coin lands in your favour! " +
+                    "You collect ${result.payout} gold! (Net +$net)"
+
+            "win" -> "Fate smiles — you WIN! You collect ${result.payout} gold! (Net +$net)"
+            else -> {
+                val coinNote = if (result.coinFired) " The coin falls dark." else ""
+                "The sum overruns the target.$coinNote You lose ${result.bet} gold."
+            }
+        }
+        outbound.send(OutboundEvent.SendInfo(sessionId, outcomeLine))
 
         val broadcast = when (outcome) {
             "jackpot", "coin" ->
-                "${me.name} rolls Aineroira's Dice and the Luneqrae coin blesses them with ${result.payout} gold!"
+                "$name rolls Aineroia's Dice and the Luneqrae coin blesses them with ${result.payout} gold!"
 
-            "win" -> "${me.name} rolls Aineroira's Dice and wins ${result.payout} gold!"
-            else -> "${me.name} rolls Aineroira's Dice and busts."
+            "win" -> "$name rolls Aineroia's Dice and wins ${result.payout} gold!"
+            else -> "$name rolls Aineroia's Dice and busts."
         }
-        broadcastToRoomExcept(me.roomId, sessionId, broadcast, players, outbound)
+        broadcastToRoomExcept(roomId, sessionId, broadcast, players, outbound)
+    }
+
+    private suspend fun handleDiceRules(sessionId: SessionId) {
+        val system =
+            lotterySystem
+                ?: return sendErrorWithFeedback(
+                    sessionId,
+                    outbound,
+                    gmcpEmitter,
+                    "Gambling is not available on this server.",
+                    "lottery",
+                    code = "UNAVAILABLE",
+                )
+
+        players.withPlayer(sessionId) { me ->
+            val info = system.getInfo(me.name)
+            val lines = listOf(
+                "[ Aineroia's Dice ]",
+                "  Six dice — the children of the goddess Aineroia — are cast big to small:",
+                "    Ophirae & Mycorae (d20), Pyrae & Aetherae (d16), Lustriae & Aureliae (d8).",
+                "  Roll a total of ${info.diceWinTarget} or less to win ${formatMult(info.diceWinMultiplier)} your bet.",
+                "  If ${info.coinMaxThreshold}+ dice land on their highest face, the Luneqrae coin flips:",
+                "    a win pays ${formatMult(info.coinWinMultiplier)} on a bust, " +
+                    "or ${formatMult(info.coinJackpotMultiplier)} if your total also held.",
+                "  Bets: ${info.diceMinBet}–${info.diceMaxBet} gold. Play with 'dice <amount>' in a tavern.",
+            )
+            for (line in lines) {
+                outbound.send(OutboundEvent.SendInfo(sessionId, line))
+            }
+        }
+    }
+
+    private fun formatMult(value: Double): String {
+        val whole = value.toLong()
+        return if (value == whole.toDouble()) "$whole×" else "$value×"
     }
 
     private fun dieName(kind: DieKind): String =
@@ -385,5 +470,11 @@ class LotteryHandler(
                 cooldownMs = system.diceCooldownMs,
             ),
         )
+    }
+
+    private companion object {
+        /** Beat between revealed dice/lines in the paced text feed. Six dice +
+         *  coin + verdict stays under the default 5s gamble cooldown. */
+        const val REVEAL_BEAT_MS = 480L
     }
 }

--- a/src/test/kotlin/dev/ambon/engine/WebClientParityTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/WebClientParityTest.kt
@@ -126,6 +126,7 @@ class WebClientParityTest {
         "LotteryInfo" to "lottery",
         "LotteryBuy" to "lottery",
         "Gamble" to "gamble",
+        "DiceRules" to "gamble",
         // Quests
         "QuestLog" to "quest_log",
         "QuestInfo" to "quest_info",

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
@@ -928,8 +928,13 @@ class CommandParserTest {
     }
 
     @Test
-    fun `gamble rejects missing or invalid amount`() {
-        assertTrue(CommandParser.parse("gamble") is Command.Invalid)
+    fun `bare gamble or dice shows the rules`() {
+        assertEquals(Command.DiceRules, CommandParser.parse("gamble"))
+        assertEquals(Command.DiceRules, CommandParser.parse("dice"))
+    }
+
+    @Test
+    fun `gamble rejects invalid amount`() {
         assertTrue(CommandParser.parse("gamble abc") is Command.Invalid)
         assertTrue(CommandParser.parse("gamble 0") is Command.Invalid)
         assertTrue(CommandParser.parse("gamble -5") is Command.Invalid)

--- a/web-v3/src/components/panels/DicePanel.tsx
+++ b/web-v3/src/components/panels/DicePanel.tsx
@@ -29,7 +29,7 @@ const COIN_FLIP_MS = 2000;
 type Phase = "idle" | "rolling" | "done";
 type CoinState = "none" | "flipping" | "won" | "lost";
 
-/** Display name for one of Aineroira's children. */
+/** Display name for one of Aineroia's children. */
 function childName(kind: string): string {
   return kind ? kind.charAt(0).toUpperCase() + kind.slice(1) : "";
 }
@@ -100,7 +100,7 @@ function Die({
 }
 
 /**
- * Aineroira's Dice — reskinned onto the painted `dice_bg` frame. The six
+ * Aineroia's Dice — reskinned onto the painted `dice_bg` frame. The six
  * children tumble big → small in the purple velvet, settling one by one into
  * the green felt as the running total climbs; the Luneqrae coin flips last when
  * three or more crown their max face. Values, the bet controls, and the result
@@ -304,7 +304,7 @@ export function DicePanel({ diceResult, lotteryInfo, uiFeedbackFeed, gold, asset
 
       {/* How to Play */}
       <div className="dice-howto">
-        <p>Six dice — the children of Aineroira — roll big to small.</p>
+        <p>Six dice — the children of Aineroia — roll big to small.</p>
         <p>Sum <strong>{target}</strong> or less and win <strong>{winMult}×</strong> your bet.</p>
         <p>Land <strong>3+</strong> max faces and the Luneqrae coin flips: <strong>{coinMult}×</strong> on a bust, <strong>{jackpotMult}×</strong> if your sum also held.</p>
       </div>

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -25567,7 +25567,7 @@ html:has(.game-shell),
 .lot-buy-btn:hover { filter: brightness(1.14); transform: translateY(-1px); }
 
 /* ============================================================
-   Aineroira's Dice — painted `dice_bg` frame (1280×960, 4:3).
+   Aineroia's Dice — painted `dice_bg` frame (1280×960, 4:3).
    The six children tumble in the purple velvet and settle into
    the green felt; values + bet controls overlay painted slots.
    ============================================================ */

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -1204,7 +1204,7 @@ export interface LotteryInfo {
   diceMaxBet: number;
   /** Base payout multiplier when the summed roll lands at or below the target. */
   diceWinMultiplier: number;
-  /** Aineroira's Dice: a summed roll at or below this wins the base payout. */
+  /** Aineroia's Dice: a summed roll at or below this wins the base payout. */
   diceWinTarget: number;
   /** This many dice (or more) on their max face summon the Luneqrae coin flip. */
   coinMaxThreshold: number;
@@ -1225,7 +1225,7 @@ export interface DiceRoll {
   isMax: boolean;
 }
 
-/** One resolved game of Aineroira's Dice, from the Lottery.Gamble GMCP package. */
+/** One resolved game of Aineroia's Dice, from the Lottery.Gamble GMCP package. */
 export interface DiceGambleResult {
   /** "win" (base), "lose", "coin" (Luneqrae rescue), or "jackpot" (coin + held sum). */
   outcome: "win" | "lose" | "coin" | "jackpot";


### PR DESCRIPTION
Follow-up to #1277. Three dice-game refinements.

## 1. Fix the goddess's name — Aineroira → Aineroia
The lore (and the `aineroia_cottage` zone, 573 canonical uses) spells it **Aineroia**. "Aineroira" was my typo. Corrected across the Kotlin and web sources (comments, player-facing text, broadcasts).

## 2. Rules on bare `gamble` / `dice`
Typing `gamble` or `dice` with no amount now prints the rules instead of a usage error (new `Command.DiceRules`):
```
[ Aineroia's Dice ]
  Six dice — the children of the goddess Aineroia — are cast big to small:
    Ophirae & Mycorae (d20), Pyrae & Aetherae (d16), Lustriae & Aureliae (d8).
  Roll a total of 45 or less to win 2× your bet.
  If 3+ dice land on their highest face, the Luneqrae coin flips:
    a win pays 10× on a bust, or 12× if your total also held.
  Bets: 10–10000 gold. Play with 'dice <amount>' in a tavern.
```
Numbers are pulled live from config, so they track any tuning.

## 3. Paced telnet reveal
The text feed now streams the roll so telnet players feel the climb too — each child settles a beat apart (~480ms) with the running total, then the coin and the verdict:
```
You cast Aineroia's six children across the velvet...
  Ophirae (d20) settles on 14   (total: 14)
  Mycorae (d20) settles on 8   (total: 22)
  ...
  The dice lie still. Total 44 — you needed 45 or less.
Fate smiles — you WIN! You collect 20 gold! (Net +10)
```
- Runs **off-tick** on the engine scope (same pattern as `ClaimHandler`); gold and the web GMCP animation still settle immediately, so the panel animation is unaffected.
- The full reveal stays under the default 5s gamble cooldown, so sequences can't overlap.
- No scope (tests) → lines flush instantly.

## Testing
`ktlintCheck test` (full suite), web `lint` + `build` all green. Parser test now asserts bare `gamble`/`dice` → `DiceRules`; `WebClientParityTest` maps the new command. `LotteryHandler` isn't wired into `buildTestRouter` (no existing router harness for it), so the reveal/rules text is covered by parser/parity and verified live on telnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)