### PR TITLE
feat(mail): attach gold and an item to a letter, claimed by the recipient

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/mail/MailMessage.kt
+++ b/src/main/kotlin/dev/ambon/domain/mail/MailMessage.kt
@@ -1,9 +1,21 @@
 package dev.ambon.domain.mail
 
+import dev.ambon.domain.items.ItemInstance
+
 data class MailMessage(
     val id: String,
     val fromName: String,
     val body: String,
     val sentAtEpochMs: Long,
     val read: Boolean = false,
-)
+    /** Gold attached to the letter, granted to the recipient on claim. */
+    val gold: Long = 0L,
+    /** A single item attached to the letter, granted to the recipient on claim. */
+    val item: ItemInstance? = null,
+    /** Whether the recipient has already claimed the gold/item. */
+    val claimed: Boolean = false,
+) {
+    /** Whether this letter carries gold or an item the recipient has not yet claimed. */
+    val hasUnclaimedAttachments: Boolean
+        get() = !claimed && (gold > 0L || item != null)
+}

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -1537,7 +1537,7 @@ class GameEngine(
             ),
         ).forEach { it.register(router) }
 
-        mailHandler = MailHandler(ctx = ctx, clock = clock)
+        mailHandler = MailHandler(ctx = ctx, clock = clock, markVitalsDirty = ::markVitalsDirty)
         mailHandler.register(router)
 
         autoQuestHandler = AutoQuestHandler(

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -1849,6 +1849,10 @@ class GmcpEmitter(
                     date = msg.sentAtEpochMs,
                     read = msg.read,
                     preview = msg.body.lineSequence().firstOrNull()?.take(80) ?: "",
+                    gold = msg.gold,
+                    itemName = msg.item?.item?.displayName,
+                    itemImage = msg.item?.item?.image,
+                    claimed = msg.claimed,
                 )
             },
             supportCheck = "Mail",
@@ -1870,6 +1874,10 @@ class GmcpEmitter(
                 body = msg.body,
                 date = msg.sentAtEpochMs,
                 read = msg.read,
+                gold = msg.gold,
+                itemName = msg.item?.item?.displayName,
+                itemImage = msg.item?.item?.image,
+                claimed = msg.claimed,
             ),
             supportCheck = "Mail",
         )
@@ -3230,6 +3238,10 @@ class GmcpEmitter(
         val date: Long,
         val read: Boolean,
         val preview: String,
+        val gold: Long,
+        val itemName: String?,
+        val itemImage: String?,
+        val claimed: Boolean,
     )
 
     private data class MailMessagePayload(
@@ -3239,6 +3251,10 @@ class GmcpEmitter(
         val body: String,
         val date: Long,
         val read: Boolean,
+        val gold: Long,
+        val itemName: String?,
+        val itemImage: String?,
+        val claimed: Boolean,
     )
 
     private data class MailNotificationPayload(

--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -151,6 +151,10 @@ data class PlayerState(
     data class MailComposeState(
         val recipientName: String,
         val lines: MutableList<String> = mutableListOf(),
+        /** Gold to attach to the letter, consumed from the sender when sent. */
+        val attachGold: Long = 0L,
+        /** Inventory keyword of an item to attach, resolved/removed when sent. */
+        val attachItemKeyword: String? = null,
     )
 
     companion object {

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -745,9 +745,19 @@ sealed interface Command {
             val index: Int,
         ) : Mail
 
-        /** `mail send <player>` — begin composing a message to [recipientName]. */
+        /**
+         * `mail send <player> [gold <n>] [item <name>]` — begin composing a
+         * message, optionally attaching gold and/or a single carried item.
+         */
         data class Send(
             val recipientName: String,
+            val gold: Long = 0L,
+            val itemKeyword: String? = null,
+        ) : Mail
+
+        /** `mail claim <n>` — claim the gold/item attached to a received message. */
+        data class Claim(
+            val index: Int,
         ) : Mail
 
         /** `mail abort` — cancel an in-progress compose. */
@@ -1589,12 +1599,18 @@ object CommandParser {
                         ?: return@matchPrefix Command.Invalid(line, "mail delete <number>")
                     Command.Mail.Delete(n)
                 }
-                "send" -> {
-                    val name = parts.getOrNull(1)?.trim() ?: ""
-                    if (name.isEmpty()) Command.Invalid(line, "mail send <player>") else Command.Mail.Send(name)
+                "claim" -> {
+                    val n = parts.getOrNull(1)?.trim()?.toIntOrNull()
+                        ?: return@matchPrefix Command.Invalid(line, "mail claim <number>")
+                    Command.Mail.Claim(n)
                 }
+                "send" -> parseMailSend(line, parts.getOrNull(1)?.trim() ?: "")
                 "abort" -> Command.Mail.Abort
-                else -> Command.Invalid(line, "mail list | mail read <n> | mail delete <n> | mail send <player>")
+                else -> Command.Invalid(
+                    line,
+                    "mail list | mail read <n> | mail delete <n> | mail claim <n> | " +
+                        "mail send <player> [gold <n>] [item <name>]",
+                )
             }
         }?.let { return it }
 
@@ -1922,5 +1938,39 @@ object CommandParser {
             lower == "withdraw" -> Command.Invalid("bank withdraw", "bank withdraw <amount> | bank withdraw <item>")
             else -> Command.Invalid("bank", "bank [balance] | bank deposit ... | bank withdraw ...")
         }
+    }
+
+    /**
+     * Parses `mail send` arguments: `<recipient> [gold <n>] [item <name...>]`.
+     * The recipient is the first token; `gold <n>` and `item <name>` are optional
+     * and may appear in either order, but `item` slurps the remainder so it must
+     * come last.
+     */
+    private fun parseMailSend(line: String, args: String): Command {
+        val usage = "mail send <player> [gold <n>] [item <name>]"
+        if (args.isEmpty()) return Command.Invalid(line, usage)
+        val tokens = args.split(Regex("\\s+"))
+        val recipient = tokens[0]
+        var gold = 0L
+        var itemKeyword: String? = null
+        var i = 1
+        while (i < tokens.size) {
+            when (tokens[i].lowercase()) {
+                "gold" -> {
+                    val amount = tokens.getOrNull(i + 1)?.toLongOrNull()
+                    if (amount == null || amount <= 0L) return Command.Invalid(line, usage)
+                    gold = amount
+                    i += 2
+                }
+                "item" -> {
+                    val keyword = tokens.drop(i + 1).joinToString(" ").trim()
+                    if (keyword.isEmpty()) return Command.Invalid(line, usage)
+                    itemKeyword = keyword
+                    i = tokens.size
+                }
+                else -> return Command.Invalid(line, usage)
+            }
+        }
+        return Command.Mail.Send(recipientName = recipient, gold = gold, itemKeyword = itemKeyword)
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/MailHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/MailHandler.kt
@@ -1,6 +1,7 @@
 package dev.ambon.engine.commands.handlers
 
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.mail.MailMessage
 import dev.ambon.engine.PlayerState
 import dev.ambon.engine.commands.Command
@@ -15,17 +16,20 @@ import java.util.UUID
 class MailHandler(
     ctx: EngineContext,
     private val clock: Clock = Clock.systemUTC(),
+    private val markVitalsDirty: (SessionId) -> Unit = {},
 ) : CommandHandler {
     private val players = ctx.players
     private val outbound = ctx.outbound
     private val gmcpEmitter = ctx.gmcpEmitter
     private val metrics = ctx.metrics
+    private val items = ctx.items
 
     override fun register(router: CommandRouter) {
         router.on<Command.Mail.List> { sid, _ -> handleList(sid) }
         router.on<Command.Mail.Read> { sid, cmd -> handleRead(sid, cmd) }
         router.on<Command.Mail.Delete> { sid, cmd -> handleDelete(sid, cmd) }
         router.on<Command.Mail.Send> { sid, cmd -> handleSend(sid, cmd) }
+        router.on<Command.Mail.Claim> { sid, cmd -> handleClaim(sid, cmd) }
         router.on<Command.Mail.Abort> { sid, _ -> handleAbort(sid) }
     }
 
@@ -55,10 +59,13 @@ class MailHandler(
             outbound.send(OutboundEvent.SendInfo(sessionId, "-- Inbox (${me.inbox.size} message(s)) --"))
             me.inbox.forEachIndexed { index, msg ->
                 val marker = if (!msg.read) "[NEW] " else "      "
+                val gift = if (msg.hasUnclaimedAttachments) "[GIFT] " else ""
                 val date = java.time.Instant.ofEpochMilli(msg.sentAtEpochMs)
                     .atZone(ZoneOffset.UTC)
                     .toLocalDate()
-                outbound.send(OutboundEvent.SendInfo(sessionId, "${index + 1}. $marker From: ${msg.fromName}  ($date)"))
+                outbound.send(
+                    OutboundEvent.SendInfo(sessionId, "${index + 1}. $marker${gift}From: ${msg.fromName}  ($date)"),
+                )
             }
             outbound.send(OutboundEvent.SendInfo(sessionId, "Type 'mail read <n>' to read a message."))
         }
@@ -82,6 +89,17 @@ class MailHandler(
             outbound.send(OutboundEvent.SendInfo(sessionId, msg.body))
             outbound.send(OutboundEvent.SendInfo(sessionId, "-- End of message --"))
 
+            if (msg.gold > 0L || msg.item != null) {
+                val parts = buildList {
+                    if (msg.gold > 0L) add("${msg.gold} gold")
+                    msg.item?.let { add(it.item.displayName) }
+                }
+                val state = if (msg.claimed) "(claimed)" else "(unclaimed — 'mail claim ${cmd.index}')"
+                outbound.send(
+                    OutboundEvent.SendInfo(sessionId, "Attached: ${parts.joinToString(" and ")} $state"),
+                )
+            }
+
             if (!msg.read) {
                 me.inbox[cmd.index - 1] = msg.copy(read = true)
                 players.persistPlayer(sessionId)
@@ -98,6 +116,15 @@ class MailHandler(
         players.withPlayer(sessionId) { me ->
             if (cmd.index < 1 || cmd.index > me.inbox.size) {
                 outbound.send(OutboundEvent.SendError(sessionId, "No message at index ${cmd.index}."))
+                return@withPlayer
+            }
+            if (me.inbox[cmd.index - 1].hasUnclaimedAttachments) {
+                outbound.send(
+                    OutboundEvent.SendError(
+                        sessionId,
+                        "Claim the gift on message ${cmd.index} before deleting it (mail claim ${cmd.index}).",
+                    ),
+                )
                 return@withPlayer
             }
             me.inbox.removeAt(cmd.index - 1)
@@ -122,8 +149,37 @@ class MailHandler(
                 )
                 return@withPlayer
             }
-            me.mailCompose = PlayerState.MailComposeState(recipientName = cmd.recipientName)
+            // Up-front attachment checks for fast feedback; re-validated on send.
+            if (cmd.gold > 0L && me.gold < cmd.gold) {
+                outbound.send(
+                    OutboundEvent.SendError(sessionId, "You only have ${me.gold} gold to attach."),
+                )
+                return@withPlayer
+            }
+            if (cmd.itemKeyword != null && items.peekOwnedItem(sessionId, cmd.itemKeyword) == null) {
+                outbound.send(
+                    OutboundEvent.SendError(sessionId, "You aren't carrying '${cmd.itemKeyword}'."),
+                )
+                return@withPlayer
+            }
+            me.mailCompose = PlayerState.MailComposeState(
+                recipientName = cmd.recipientName,
+                attachGold = cmd.gold,
+                attachItemKeyword = cmd.itemKeyword,
+            )
             outbound.send(OutboundEvent.SendInfo(sessionId, "Composing mail to ${cmd.recipientName}."))
+            if (cmd.gold > 0L || cmd.itemKeyword != null) {
+                val parts = buildList {
+                    if (cmd.gold > 0L) add("${cmd.gold} gold")
+                    cmd.itemKeyword?.let { add("item '$it'") }
+                }
+                outbound.send(
+                    OutboundEvent.SendInfo(
+                        sessionId,
+                        "Attaching ${parts.joinToString(" and ")} (consumed when you send).",
+                    ),
+                )
+            }
             outbound.send(
                 OutboundEvent.SendInfo(sessionId, "Enter your message line by line. Type '.' alone to send, or 'mail abort' to cancel."),
             )
@@ -155,24 +211,70 @@ class MailHandler(
             return
         }
 
+        // Validate, then consume the attachments. The item is removed first so it
+        // can be handed back cleanly if anything downstream fails.
+        if (compose.attachGold > 0L && sender.gold < compose.attachGold) {
+            outbound.send(
+                OutboundEvent.SendError(sessionId, "You no longer have ${compose.attachGold} gold. Mail not sent."),
+            )
+            outbound.send(OutboundEvent.SendPrompt(sessionId))
+            return
+        }
+        var attachedItem: ItemInstance? = null
+        if (compose.attachItemKeyword != null) {
+            val removed = items.removeFromInventory(sessionId, compose.attachItemKeyword)
+            if (removed == null) {
+                outbound.send(
+                    OutboundEvent.SendError(
+                        sessionId,
+                        "You aren't carrying '${compose.attachItemKeyword}' anymore. Mail not sent.",
+                    ),
+                )
+                outbound.send(OutboundEvent.SendPrompt(sessionId))
+                return
+            }
+            if (removed.item.questItem) {
+                items.addToInventory(sessionId, removed)
+                outbound.send(
+                    OutboundEvent.SendError(
+                        sessionId,
+                        "You can't mail ${removed.item.displayName} — it's a quest item. Mail not sent.",
+                    ),
+                )
+                outbound.send(OutboundEvent.SendPrompt(sessionId))
+                return
+            }
+            attachedItem = removed
+        }
+        if (compose.attachGold > 0L) {
+            sender.gold -= compose.attachGold
+            markVitalsDirty(sessionId)
+        }
+        attachedItem?.let { gmcpEmitter?.sendCharItemsRemove(sessionId, it) }
+
         val message = MailMessage(
             id = UUID.randomUUID().toString(),
             fromName = sender.name,
             body = compose.lines.joinToString("\n"),
             sentAtEpochMs = clock.millis(),
+            gold = compose.attachGold,
+            item = attachedItem,
         )
+        val attachNote = attachmentSummary(message.gold, message.item)?.let { " (with $it)" } ?: ""
 
         val recipientOnline = players.getByName(compose.recipientName)
         if (recipientOnline != null) {
             recipientOnline.inbox.add(message)
             players.persistPlayer(recipientOnline.sessionId)
+            if (message.gold > 0L || message.item != null) players.persistPlayer(sessionId)
             metrics.onGameEvent("mail", "sent")
-            outbound.send(OutboundEvent.SendInfo(sessionId, "Mail delivered to ${recipientOnline.name}."))
+            outbound.send(OutboundEvent.SendInfo(sessionId, "Mail delivered to ${recipientOnline.name}$attachNote."))
             if (recipientOnline.sessionId != sessionId) {
+                val gift = if (message.hasUnclaimedAttachments) " (with a gift!)" else ""
                 outbound.send(
                     OutboundEvent.SendInfo(
                         recipientOnline.sessionId,
-                        "You have new mail from ${sender.name}. Type 'mail' to read it.",
+                        "You have new mail from ${sender.name}$gift. Type 'mail' to read it.",
                     ),
                 )
                 val unread = recipientOnline.inbox.count { !it.read }
@@ -182,6 +284,7 @@ class MailHandler(
         } else {
             val delivered = players.deliverMailOffline(compose.recipientName, message)
             if (!delivered) {
+                refundAttachments(sessionId, sender, message.gold, attachedItem)
                 outbound.send(
                     OutboundEvent.SendError(
                         sessionId,
@@ -191,9 +294,70 @@ class MailHandler(
                 outbound.send(OutboundEvent.SendPrompt(sessionId))
                 return
             }
+            if (message.gold > 0L || message.item != null) players.persistPlayer(sessionId)
             metrics.onGameEvent("mail", "sent")
-            outbound.send(OutboundEvent.SendInfo(sessionId, "Mail delivered to ${compose.recipientName}."))
+            outbound.send(OutboundEvent.SendInfo(sessionId, "Mail delivered to ${compose.recipientName}$attachNote."))
         }
         outbound.send(OutboundEvent.SendPrompt(sessionId))
+    }
+
+    private suspend fun handleClaim(
+        sessionId: SessionId,
+        cmd: Command.Mail.Claim,
+    ) {
+        players.withPlayer(sessionId) { me ->
+            val msg = me.inbox.getOrNull(cmd.index - 1)
+            if (msg == null) {
+                outbound.send(OutboundEvent.SendError(sessionId, "No message at index ${cmd.index}."))
+                return@withPlayer
+            }
+            if (!msg.hasUnclaimedAttachments) {
+                outbound.send(OutboundEvent.SendError(sessionId, "There is nothing to claim on message ${cmd.index}."))
+                return@withPlayer
+            }
+
+            if (msg.gold > 0L) {
+                me.gold += msg.gold
+                markVitalsDirty(sessionId)
+            }
+            msg.item?.let { instance ->
+                items.addToInventory(sessionId, instance)
+                gmcpEmitter?.sendCharItemsAdd(sessionId, instance)
+            }
+            me.inbox[cmd.index - 1] = msg.copy(claimed = true)
+            players.persistPlayer(sessionId)
+            metrics.onGameEvent("mail", "claimed")
+
+            val summary = attachmentSummary(msg.gold, msg.item) ?: "your gift"
+            outbound.send(OutboundEvent.SendInfo(sessionId, "You claim $summary from ${msg.fromName}'s letter."))
+            gmcpEmitter?.sendMailList(sessionId, me.inbox)
+            gmcpEmitter?.sendMailMessage(sessionId, cmd.index, me.inbox[cmd.index - 1])
+        }
+    }
+
+    /** Hands consumed attachments back to the sender (used when delivery fails). */
+    private suspend fun refundAttachments(
+        sessionId: SessionId,
+        sender: PlayerState,
+        gold: Long,
+        item: ItemInstance?,
+    ) {
+        if (gold > 0L) {
+            sender.gold += gold
+            markVitalsDirty(sessionId)
+        }
+        if (item != null) {
+            items.addToInventory(sessionId, item)
+            gmcpEmitter?.sendCharItemsAdd(sessionId, item)
+        }
+    }
+
+    /** "100 gold and a Rusty Sword", or null when there is nothing attached. */
+    private fun attachmentSummary(gold: Long, item: ItemInstance?): String? {
+        val parts = buildList {
+            if (gold > 0L) add("$gold gold")
+            item?.let { add(it.item.displayName) }
+        }
+        return if (parts.isEmpty()) null else parts.joinToString(" and ")
     }
 }

--- a/src/test/kotlin/dev/ambon/engine/WebClientParityTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/WebClientParityTest.kt
@@ -243,6 +243,7 @@ class WebClientParityTest {
         "Mail.Read" to "mail",
         "Mail.Delete" to "mail",
         "Mail.Send" to "mail",
+        "Mail.Claim" to "mail",
         "Mail.Abort" to "mail",
         "House.Status" to "house",
         "House.ListTemplates" to "house_list",

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
@@ -941,6 +941,39 @@ class CommandParserTest {
     }
 
     @Test
+    fun `mail send parses recipient with no attachments`() {
+        assertEquals(Command.Mail.Send("Bob"), CommandParser.parse("mail send Bob"))
+    }
+
+    @Test
+    fun `mail send parses gold and item attachments`() {
+        assertEquals(
+            Command.Mail.Send("Bob", gold = 100L, itemKeyword = null),
+            CommandParser.parse("mail send Bob gold 100"),
+        )
+        assertEquals(
+            Command.Mail.Send("Bob", gold = 0L, itemKeyword = "rusty sword"),
+            CommandParser.parse("mail send Bob item rusty sword"),
+        )
+        assertEquals(
+            Command.Mail.Send("Bob", gold = 50L, itemKeyword = "shield"),
+            CommandParser.parse("mail send Bob gold 50 item shield"),
+        )
+    }
+
+    @Test
+    fun `mail send rejects invalid gold`() {
+        assertTrue(CommandParser.parse("mail send Bob gold abc") is Command.Invalid)
+        assertTrue(CommandParser.parse("mail send Bob gold 0") is Command.Invalid)
+    }
+
+    @Test
+    fun `mail claim parses index`() {
+        assertEquals(Command.Mail.Claim(2), CommandParser.parse("mail claim 2"))
+        assertTrue(CommandParser.parse("mail claim") is Command.Invalid)
+    }
+
+    @Test
     fun `petition parses keyword`() {
         assertEquals(Command.Petition("peanut"), CommandParser.parse("petition peanut"))
         assertEquals(Command.Petition("noecker"), CommandParser.parse("petition Noecker"))

--- a/src/test/kotlin/dev/ambon/engine/commands/MailHandlerTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/MailHandlerTest.kt
@@ -1,7 +1,13 @@
 package dev.ambon.engine.commands
 
+import dev.ambon.domain.ids.ItemId
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.items.Item
+import dev.ambon.domain.items.ItemInstance
+import dev.ambon.domain.items.ItemSlot
 import dev.ambon.domain.mail.MailMessage
+import dev.ambon.engine.commands.handlers.EngineContext
+import dev.ambon.engine.commands.handlers.MailHandler
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.persistence.InMemoryPlayerRepository
 import dev.ambon.test.CommandRouterHarness
@@ -375,5 +381,139 @@ class MailHandlerTest {
 
             val errors = h.drain().filterIsInstance<OutboundEvent.SendError>()
             assertTrue(errors.isNotEmpty(), "Expected error when starting compose while already composing")
+        }
+
+    // -------------------------------------------------------------------------
+    // Attachments — gold + item
+    // -------------------------------------------------------------------------
+
+    /** A standalone handler over the harness's state, for driving compose lines. */
+    private fun composeHandler(h: CommandRouterHarness): MailHandler =
+        MailHandler(
+            ctx = EngineContext(
+                players = h.players,
+                mobs = h.mobs,
+                world = h.world,
+                items = h.items,
+                outbound = h.outbound,
+                combat = h.combat,
+                gmcpEmitter = null,
+                worldState = null,
+            ),
+        )
+
+    private fun sword() = ItemInstance(
+        id = ItemId("sword_1"),
+        item = Item(keyword = "sword", displayName = "a copper sword", slot = ItemSlot.WEAPON, damage = 4),
+    )
+
+    @Test
+    fun `mail send with gold and item consumes from sender and attaches to recipient`() =
+        runTest {
+            val h = harness()
+            val alice = SessionId(1)
+            val bob = SessionId(2)
+            h.loginPlayer(alice, "Alice")
+            h.loginPlayer(bob, "Bob")
+            h.players.get(alice)!!.gold = 1000L
+            h.items.addToInventory(alice, sword())
+            h.drain()
+
+            h.router.handle(alice, Command.Mail.Send("Bob", gold = 100L, itemKeyword = "sword"))
+            h.drain()
+            composeHandler(h).run {
+                handleComposeLine(alice, "A gift for you")
+                handleComposeLine(alice, ".")
+            }
+
+            assertEquals(900L, h.players.get(alice)!!.gold, "sender's gold should be consumed")
+            assertTrue(h.items.inventory(alice).isEmpty(), "sender's item should be consumed")
+            val msg = h.players.get(bob)!!.inbox[0]
+            assertEquals(100L, msg.gold)
+            assertNotNull(msg.item)
+            assertFalse(msg.claimed, "attachment should start unclaimed")
+        }
+
+    @Test
+    fun `claim grants gold and item to recipient and marks claimed`() =
+        runTest {
+            val h = harness()
+            val alice = SessionId(1)
+            val bob = SessionId(2)
+            h.loginPlayer(alice, "Alice")
+            h.loginPlayer(bob, "Bob")
+            h.players.get(alice)!!.gold = 1000L
+            h.items.addToInventory(alice, sword())
+            h.drain()
+            h.router.handle(alice, Command.Mail.Send("Bob", gold = 100L, itemKeyword = "sword"))
+            h.drain()
+            composeHandler(h).run {
+                handleComposeLine(alice, "Gift")
+                handleComposeLine(alice, ".")
+            }
+            val bobGoldBefore = h.players.get(bob)!!.gold
+            h.drain()
+
+            h.router.handle(bob, Command.Mail.Claim(1))
+
+            assertEquals(bobGoldBefore + 100L, h.players.get(bob)!!.gold, "recipient should gain the gold")
+            assertEquals(1, h.items.inventory(bob).size, "recipient should gain the item")
+            assertTrue(h.players.get(bob)!!.inbox[0].claimed, "message should be marked claimed")
+
+            // A second claim finds nothing.
+            h.drain()
+            h.router.handle(bob, Command.Mail.Claim(1))
+            val errors = h.drain().filterIsInstance<OutboundEvent.SendError>()
+            assertTrue(errors.any { it.text.contains("nothing to claim", ignoreCase = true) }, "got=$errors")
+        }
+
+    @Test
+    fun `cannot delete a message with an unclaimed gift but can after claiming`() =
+        runTest {
+            val h = harness()
+            val alice = SessionId(1)
+            val bob = SessionId(2)
+            h.loginPlayer(alice, "Alice")
+            h.loginPlayer(bob, "Bob")
+            h.players.get(alice)!!.gold = 1000L
+            h.drain()
+            h.router.handle(alice, Command.Mail.Send("Bob", gold = 50L))
+            h.drain()
+            composeHandler(h).run {
+                handleComposeLine(alice, "Coins")
+                handleComposeLine(alice, ".")
+            }
+            h.drain()
+
+            // Delete is refused while the gift is unclaimed.
+            h.router.handle(bob, Command.Mail.Delete(1))
+            assertEquals(1, h.players.get(bob)!!.inbox.size, "message should survive a blocked delete")
+            val errors = h.drain().filterIsInstance<OutboundEvent.SendError>()
+            assertTrue(errors.any { it.text.contains("claim", ignoreCase = true) }, "got=$errors")
+
+            // After claiming, delete works.
+            h.router.handle(bob, Command.Mail.Claim(1))
+            h.drain()
+            h.router.handle(bob, Command.Mail.Delete(1))
+            assertEquals(0, h.players.get(bob)!!.inbox.size, "message should be deletable after claim")
+        }
+
+    @Test
+    fun `attaching more gold than held is rejected before composing`() =
+        runTest {
+            val h = harness()
+            val alice = SessionId(1)
+            val bob = SessionId(2)
+            h.loginPlayer(alice, "Alice")
+            h.loginPlayer(bob, "Bob")
+            h.players.get(alice)!!.gold = 30L
+            h.drain()
+
+            h.router.handle(alice, Command.Mail.Send("Bob", gold = 100L))
+
+            val errors = h.drain().filterIsInstance<OutboundEvent.SendError>()
+            assertTrue(errors.any { it.text.contains("only have", ignoreCase = true) }, "got=$errors")
+            assertEquals(null, h.players.get(alice)!!.mailCompose, "compose should not start")
+            assertEquals(30L, h.players.get(alice)!!.gold, "gold should be untouched")
         }
 }

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -1298,13 +1298,19 @@ function App() {
             hasCharacterProfile={hasCharacterProfile}
             inbox={state.mailInbox}
             openMessage={state.mailMessage}
+            inventory={state.inventory}
+            gold={state.vitals.gold}
             onReadMessage={(index) => sendCommand(`mail read ${index}`)}
             onDeleteMessage={(index) => sendCommand(`mail delete ${index}`)}
-            onCompose={(recipient, body) => {
-              sendCommand(`mail send ${recipient}`);
+            onCompose={(recipient, body, goldAmount, itemKeyword) => {
+              let cmd = `mail send ${recipient}`;
+              if (goldAmount > 0) cmd += ` gold ${goldAmount}`;
+              if (itemKeyword) cmd += ` item ${itemKeyword}`;
+              sendCommand(cmd);
               for (const line of body.split("\n")) sendCommand(line);
               sendCommand(".");
             }}
+            onClaim={(index) => sendCommand(`mail claim ${index}`)}
             onClearMessage={() => state.setMailMessage(null)}
             onCommand={sendCommand}
           />

--- a/web-v3/src/components/panels/MailPanel.tsx
+++ b/web-v3/src/components/panels/MailPanel.tsx
@@ -1,16 +1,25 @@
 import { useEffect, useRef, useState } from "react";
-import type { MailEntry, MailMessage } from "../../types";
+import type { ItemSummary, MailEntry, MailMessage } from "../../types";
 
 interface MailPanelProps {
   connected: boolean;
   hasCharacterProfile: boolean;
   inbox: MailEntry[] | null;
   openMessage: MailMessage | null;
+  /** The player's carried items, for the attach-item picker. */
+  inventory: ItemSummary[];
+  /** The player's gold, to cap the attach-gold field. */
+  gold: number;
   onReadMessage: (index: number) => void;
   onDeleteMessage: (index: number) => void;
-  onCompose: (recipient: string, body: string) => void;
+  onCompose: (recipient: string, body: string, gold: number, itemKeyword: string | null) => void;
+  onClaim: (index: number) => void;
   onClearMessage: () => void;
   onCommand: (cmd: string) => void;
+}
+
+function hasUnclaimed(m: { gold: number; itemName: string | null; claimed: boolean }): boolean {
+  return !m.claimed && (m.gold > 0 || m.itemName !== null);
 }
 
 function formatDate(epochMs: number): string {
@@ -24,14 +33,19 @@ export function MailPanel({
   hasCharacterProfile,
   inbox,
   openMessage,
+  inventory,
+  gold,
   onReadMessage,
   onDeleteMessage,
   onCompose,
+  onClaim,
   onClearMessage,
   onCommand,
 }: MailPanelProps) {
   const [composeTarget, setComposeTarget] = useState("");
   const [composeBody, setComposeBody] = useState("");
+  const [composeGold, setComposeGold] = useState("");
+  const [composeItem, setComposeItem] = useState("");
   const [showCompose, setShowCompose] = useState(false);
   const [confirmDeleteIndex, setConfirmDeleteIndex] = useState<number | null>(null);
   const autoLoaded = useRef(false);
@@ -76,6 +90,26 @@ export function MailPanel({
             <span className="mail-message-date">{formatDate(openMessage.date)}</span>
           </div>
           <pre className="mail-message-body">{openMessage.body}</pre>
+          {(openMessage.gold > 0 || openMessage.itemName) && (
+            <div className="mail-attachments">
+              <span className="mail-attach-label">Attached</span>
+              <div className="mail-attach-items">
+                {openMessage.gold > 0 && (
+                  <span className="mail-attach-chip mail-attach-gold">{openMessage.gold.toLocaleString()} gold</span>
+                )}
+                {openMessage.itemName && (
+                  <span className="mail-attach-chip mail-attach-item">{openMessage.itemName}</span>
+                )}
+              </div>
+              {openMessage.claimed ? (
+                <span className="mail-attach-claimed">{"✓"} Claimed</span>
+              ) : (
+                <button className="mail-claim-button" onClick={() => onClaim(openMessage.index)}>
+                  Claim
+                </button>
+              )}
+            </div>
+          )}
         </div>
       </div>
     );
@@ -83,25 +117,28 @@ export function MailPanel({
 
   // Compose form
   if (showCompose) {
-    const canSend = composeTarget.trim().length > 0 && composeBody.trim().length > 0;
+    const goldValue = Math.max(0, Math.min(gold, Math.floor(Number(composeGold) || 0)));
+    const canSend = composeTarget.trim().length > 0 && composeBody.trim().length > 0 && goldValue <= gold;
+
+    const resetCompose = () => {
+      setShowCompose(false);
+      setComposeTarget("");
+      setComposeBody("");
+      setComposeGold("");
+      setComposeItem("");
+    };
 
     const handleSend = () => {
       if (!canSend) return;
-      onCompose(composeTarget.trim(), composeBody);
-      setComposeTarget("");
-      setComposeBody("");
-      setShowCompose(false);
+      onCompose(composeTarget.trim(), composeBody, goldValue, composeItem || null);
+      resetCompose();
     };
 
     return (
       <div className="mail-panel" aria-label="Mail">
         <div className="mail-compose">
           <div className="mail-message-header">
-            <button
-              className="mail-back-button"
-              aria-label="Back to inbox"
-              onClick={() => { setShowCompose(false); setComposeTarget(""); setComposeBody(""); }}
-            >
+            <button className="mail-back-button" aria-label="Back to inbox" onClick={resetCompose}>
               &larr; Back
             </button>
             <span className="mail-message-title">New Message</span>
@@ -126,18 +163,43 @@ export function MailPanel({
               value={composeBody}
               onChange={(e) => setComposeBody(e.target.value)}
             />
+            <div className="mail-compose-attach">
+              <div className="mail-compose-attach-field">
+                <label className="mail-compose-label" htmlFor="mail-compose-gold">Attach gold</label>
+                <input
+                  id="mail-compose-gold"
+                  type="number"
+                  min={0}
+                  max={gold}
+                  step={1}
+                  inputMode="numeric"
+                  className="mail-compose-input"
+                  placeholder="0"
+                  value={composeGold}
+                  onChange={(e) => setComposeGold(e.target.value)}
+                />
+                <span className="mail-compose-hint">You have {gold.toLocaleString()} gold</span>
+              </div>
+              <div className="mail-compose-attach-field">
+                <label className="mail-compose-label" htmlFor="mail-compose-item">Attach item</label>
+                <select
+                  id="mail-compose-item"
+                  className="mail-compose-input"
+                  value={composeItem}
+                  onChange={(e) => setComposeItem(e.target.value)}
+                >
+                  <option value="">None</option>
+                  {inventory.map((it) => (
+                    <option key={it.id} value={it.keyword}>{it.name}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
             <div className="mail-compose-actions">
-              <button
-                className="mail-compose-send"
-                disabled={!canSend}
-                onClick={handleSend}
-              >
+              <button className="mail-compose-send" disabled={!canSend} onClick={handleSend}>
                 Send
               </button>
-              <button
-                className="mail-compose-abort"
-                onClick={() => { setShowCompose(false); setComposeTarget(""); setComposeBody(""); }}
-              >
+              <button className="mail-compose-abort" onClick={resetCompose}>
                 Cancel
               </button>
             </div>
@@ -171,6 +233,9 @@ export function MailPanel({
                 <span className="mail-inbox-marker" aria-hidden="true">{entry.read ? "" : "\u2022"}</span>
                 <span className="mail-inbox-from">{entry.from}</span>
                 <span className="mail-inbox-preview">{entry.preview}</span>
+                {hasUnclaimed(entry) && (
+                  <span className="mail-inbox-gift" title="Has an unclaimed gift" aria-label="Has an unclaimed gift">{"\u{1F381}"}</span>
+                )}
                 <span className="mail-inbox-date">{formatDate(entry.date)}</span>
               </button>
               {confirmDeleteIndex === entry.index ? (

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -2167,6 +2167,10 @@ export function applyGmcpPackage(
             date: safeNumber(e.date, 0),
             read: e.read === true,
             preview: typeof e.preview === "string" ? e.preview : "",
+            gold: safeNumber(e.gold, 0),
+            itemName: typeof e.itemName === "string" ? e.itemName : null,
+            itemImage: typeof e.itemImage === "string" ? e.itemImage : null,
+            claimed: e.claimed === true,
           })),
       );
       break;
@@ -2181,6 +2185,10 @@ export function applyGmcpPackage(
         body: typeof packet.body === "string" ? packet.body : "",
         date: safeNumber(packet.date, 0),
         read: packet.read === true,
+        gold: safeNumber(packet.gold, 0),
+        itemName: typeof packet.itemName === "string" ? packet.itemName : null,
+        itemImage: typeof packet.itemImage === "string" ? packet.itemImage : null,
+        claimed: packet.claimed === true,
       });
       break;
     }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -6104,6 +6104,104 @@ body {
   border-color: var(--text-secondary);
 }
 
+/* Compose attachments — gold + item, side by side. */
+.mail-compose-attach {
+  display: flex;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.mail-compose-attach-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  flex: 1 1 140px;
+}
+
+.mail-compose-hint {
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+}
+
+/* Read-view attachment strip + claim. */
+.mail-attachments {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--line-faint);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+}
+
+.mail-attach-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+}
+
+.mail-attach-items {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  flex: 1;
+}
+
+.mail-attach-chip {
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.mail-attach-gold {
+  background: color-mix(in srgb, var(--color-gold-bright) 22%, transparent);
+  color: var(--color-gold-bright);
+}
+
+.mail-attach-item {
+  background: color-mix(in srgb, var(--color-primary-lavender) 20%, transparent);
+  color: var(--text-primary);
+}
+
+.mail-attach-claimed {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.mail-claim-button {
+  padding: var(--space-1) var(--space-4);
+  min-height: 36px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: var(--color-gold-bright);
+  color: var(--bg-deep);
+  font-family: var(--font-body);
+  font-size: 0.8rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: filter 150ms var(--ease-out-soft), transform 150ms var(--ease-out-soft);
+}
+
+.mail-claim-button:hover {
+  filter: brightness(1.1);
+  transform: translateY(-1px);
+}
+
+.mail-claim-button:active {
+  transform: scale(0.97);
+}
+
+.mail-inbox-gift {
+  font-size: 0.9rem;
+  line-height: 1;
+}
+
 /* ── Quest panel ── */
 
 .quest-panel {

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -744,7 +744,19 @@ export interface ContainerContents {
   items: Array<{ name: string; keyword: string }>;
 }
 
-export interface MailEntry {
+/** Gold/item attachment fields shared by mail list entries and opened messages. */
+export interface MailAttachment {
+  /** Attached gold (0 when none). */
+  gold: number;
+  /** Attached item's display name, or null when none. */
+  itemName: string | null;
+  /** Attached item's image hash for the icon, or null. */
+  itemImage: string | null;
+  /** Whether the recipient has already claimed the gold/item. */
+  claimed: boolean;
+}
+
+export interface MailEntry extends MailAttachment {
   index: number;
   id: string;
   from: string;
@@ -753,7 +765,7 @@ export interface MailEntry {
   preview: string;
 }
 
-export interface MailMessage {
+export interface MailMessage extends MailAttachment {
   index: number;
   id: string;
   from: string;


### PR DESCRIPTION
Expands the mail system so players can send **gold and/or a single item** along with a letter. You picked **explicit Claim** (reusable for the future lottery/auction-via-mail delivery, safe against inventory limits) and **block delete until claimed** (nothing is ever destroyed).

## How it works
**Sending** — `mail send <player> [gold <n>] [item <name>]`, or via the web compose form's new gold field + item picker. The gold/item are validated up front and consumed from the sender when the letter is sent. Quest items can't be mailed. If delivery fails (unknown recipient), the attachments are fully refunded.

**Receiving** — the inbox flags letters carrying a gift; reading shows the attachment chips; **`mail claim <n>`** (or the web Claim button) credits the gold and drops the item into the recipient's inventory, then marks the letter claimed. A letter with an unclaimed gift can't be deleted until it's claimed.

## Changes
**Backend**
- `MailMessage` + `gold`/`item`/`claimed` (with `hasUnclaimedAttachments`); `MailComposeState` carries the pending attachment.
- `CommandParser`: `mail send … gold/item` + new `Command.Mail.Claim`.
- `MailHandler`: consume-on-send (validate → apply → refund-on-failure), `handleClaim`, delete guard, attachment lines in list/read.
- `GmcpEmitter`: Mail.List / Mail.Message carry `gold`/`itemName`/`itemImage`/`claimed`.
- Gold changes flag vitals dirty so the HUD updates.

**Web**
- `MailPanel` compose gains attach-gold + item-picker; read view shows attachment chips + Claim/Claimed; inbox shows a 🎁 on unclaimed gifts.
- Types + GMCP parse extended; `App.tsx` builds the attachment command and wires Claim.

## Testing
Full backend suite, `ktlintCheck`, web `lint` + `build` all green. New coverage: parser (attachment parse, claim), handler (consume+attach, claim grants & marks claimed, delete blocked until claimed, over-budget gold rejected up front), and the parity mapping.

## Foundation for later
The claim model + attachment fields are the primitive for **delivering lottery and auction winnings through the mail** (a system-generated letter with gold/item the player claims) — a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)