### PR TITLE
feat(web): reskin the Auction House onto the painted moonlit frame

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -3130,6 +3130,7 @@ data class ImagesConfig(
             "dice_aureliae_max" to "global_assets/dice_aureliae_max.png",
             "coin_luneqrae_moon" to "global_assets/coin_luneqrae_moon.png",
             "coin_luneqrae_wind" to "global_assets/coin_luneqrae_wind.png",
+            "auction_bg" to "global_assets/auction_bg.png",
             "dialog_indicator" to "global_assets/dialog_indicator.png",
             "aggro_indicator" to "global_assets/aggro_indicator.png",
             "quest_available_indicator" to "global_assets/quest_available_indicator.png",

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -973,6 +973,8 @@ function App() {
             ? "fortune"
             : drawerPanel === "dice"
             ? "dicetable"
+            : drawerPanel === "auction"
+            ? "auctionhouse"
             : drawerPanel === "character"
             ? "cabinet"
             : drawerPanel === "bank"
@@ -1021,6 +1023,8 @@ function App() {
             ? state.serverAssets["lottery_bg"]
             : drawerPanel === "dice"
             ? state.serverAssets["dice_bg"]
+            : drawerPanel === "auction"
+            ? state.serverAssets["auction_bg"]
             : drawerPanel === "character"
             ? state.serverAssets["character_bg"]
             : drawerPanel === "bank"
@@ -1049,7 +1053,7 @@ function App() {
                             ? state.serverAssets["mail_bg"]
                             : undefined
         }
-        initialHeight={drawerPanel === "chatboard" || drawerPanel === "whoboard" || drawerPanel === "guildboard" || drawerPanel === "friendsboard" || drawerPanel === "groupboard" || drawerPanel === "help" || drawerPanel === "stylist" || drawerPanel === "housing" || drawerPanel === "lottery" || drawerPanel === "dice" ? 0.94 : undefined}
+        initialHeight={drawerPanel === "chatboard" || drawerPanel === "whoboard" || drawerPanel === "guildboard" || drawerPanel === "friendsboard" || drawerPanel === "groupboard" || drawerPanel === "help" || drawerPanel === "stylist" || drawerPanel === "housing" || drawerPanel === "lottery" || drawerPanel === "dice" || drawerPanel === "auction" ? 0.94 : undefined}
       >
         {drawerPanel === "character" && (
           <CharacterPanel

--- a/web-v3/src/components/Drawer.tsx
+++ b/web-v3/src/components/Drawer.tsx
@@ -9,7 +9,7 @@ interface DrawerProps {
   /** Visual skin for the sheet chrome: warm leather (satchel), a dim
    *  dressing-chamber (equipment), a merchant cart (shop), a chalkboard
    *  (trainer), a parchment journal (combat log), or a cork quest board. */
-  variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "desk" | "mail" | "feature" | "tome" | "vault" | "cabinet" | "board" | "starframe" | "archive" | "stainedglass" | "codex" | "boudoir" | "estate" | "fortune" | "dicetable";
+  variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "desk" | "mail" | "feature" | "tome" | "vault" | "cabinet" | "board" | "starframe" | "archive" | "stainedglass" | "codex" | "boudoir" | "estate" | "fortune" | "dicetable" | "auctionhouse";
   /** Optional background art for a skinned variant (server asset). */
   skinBg?: string;
   /** Height (as a fraction of the viewport) the drawer snaps to when it opens. */

--- a/web-v3/src/components/panels/AuctionPanel.tsx
+++ b/web-v3/src/components/panels/AuctionPanel.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { AuctionListing, ItemSummary, UiFeedbackEntry } from "../../types";
-
-type AuctionView = "browse" | "sell" | "mine";
+import { resolveItemImage } from "../../imageDefaults";
 
 interface Props {
   listings: AuctionListing[];
@@ -13,17 +12,24 @@ interface Props {
   onCommand: (cmd: string) => void;
 }
 
+function gold(n: number): string {
+  return n.toLocaleString();
+}
+
+/**
+ * Auction House — reskinned onto the painted `auction_bg` frame. A single
+ * unified board: live listings to buy on the left, your inventory + the
+ * selected item's details + the set-price/list control on the upper right, and
+ * your active listings along the bottom right. Fixed price, buy now, instant
+ * delivery — no bidding.
+ */
 export function AuctionPanel({ listings, inventory, playerName, isDemo, feedbackFeed, onCommand }: Props) {
-  const [view, setView] = useState<AuctionView>("browse");
   const [filter, setFilter] = useState("");
   const [selectedItemId, setSelectedItemId] = useState<string>("");
   const [priceDraft, setPriceDraft] = useState("");
   const [localMessage, setLocalMessage] = useState<string | null>(null);
 
-  // Fetch the current listings when the panel opens. The panel is only mounted
-  // while open (see App.tsx), so an effect guarded by a ref fires exactly once
-  // per open — otherwise the panel would show stale/empty data until the user
-  // hit Refresh. Mirrors the shop panel's load-on-open behaviour.
+  // Fetch listings once per open (panel only mounts while open).
   const fetched = useRef(false);
   useEffect(() => {
     if (!fetched.current) {
@@ -32,17 +38,19 @@ export function AuctionPanel({ listings, inventory, playerName, isDemo, feedback
     }
   }, [onCommand]);
 
+  const isMine = (seller: string) =>
+    seller.localeCompare(playerName, undefined, { sensitivity: "accent" }) === 0;
+
   const filtered = useMemo(() => {
     const lowered = filter.trim().toLowerCase();
     if (!lowered) return listings;
-    return listings.filter((listing) =>
-      listing.itemName.toLowerCase().includes(lowered) ||
-      listing.seller.toLowerCase().includes(lowered),
+    return listings.filter(
+      (l) => l.itemName.toLowerCase().includes(lowered) || l.seller.toLowerCase().includes(lowered),
     );
   }, [filter, listings]);
 
   const mine = useMemo(
-    () => listings.filter((listing) => listing.seller.localeCompare(playerName, undefined, { sensitivity: "accent" }) === 0),
+    () => listings.filter((l) => l.seller.localeCompare(playerName, undefined, { sensitivity: "accent" }) === 0),
     [listings, playerName],
   );
 
@@ -50,265 +58,205 @@ export function AuctionPanel({ listings, inventory, playerName, isDemo, feedback
     () => [...inventory].sort((a, b) => a.name.localeCompare(b.name)),
     [inventory],
   );
+  const selectedItem = sortedInventory.find((it) => it.id === selectedItemId) ?? null;
 
-  const selectedItem = sortedInventory.find((item) => item.id === selectedItemId) ?? null;
   const activeFeedback = useMemo(
-    () => [...feedbackFeed].reverse().find((entry) => entry.scope === "auction") ?? null,
+    () => [...feedbackFeed].reverse().find((e) => e.scope === "auction") ?? null,
     [feedbackFeed],
   );
+  const message = activeFeedback?.message ?? localMessage;
+  const messageKind = activeFeedback?.type ?? "info";
 
-  const createListing = () => {
+  const listSelected = () => {
     if (isDemo) {
-      setLocalMessage("Demo characters can't post auction listings. Claim your character first.");
+      setLocalMessage("Demo characters can't post listings. Claim your character first.");
       return;
     }
     if (!selectedItem) {
-      setLocalMessage("Choose an inventory item to list.");
+      setLocalMessage("Pick an inventory item to list.");
       return;
     }
-
-    if (!/^\d+$/.test(priceDraft.trim())) {
-      setLocalMessage("Enter a whole-number gold price.");
-      return;
-    }
-
     const price = Number(priceDraft);
-    if (!Number.isSafeInteger(price) || price <= 0) {
-      setLocalMessage("Listing price must be greater than zero.");
+    if (!/^\d+$/.test(priceDraft.trim()) || !Number.isSafeInteger(price) || price <= 0) {
+      setLocalMessage("Enter a whole-number gold price above zero.");
       return;
     }
-
     onCommand(`auction sell ${selectedItem.keyword} ${price}`);
-    setLocalMessage(`Listing ${selectedItem.name} for ${price.toLocaleString()} gold.`);
+    setLocalMessage(`Listing ${selectedItem.name} for ${gold(price)} gold.`);
     setPriceDraft("");
     setSelectedItemId("");
-    setView("mine");
   };
 
+  const selectedImage = selectedItem ? resolveItemImage(selectedItem) : null;
+
   return (
-    <div className="auction-panel">
-      <div className="panel-header">
-        <span className="panel-title">Auction House</span>
-      </div>
+    <div className="ah-board">
+      {message && <p className={`ah-toast ah-toast-${messageKind}`}>{message}</p>}
 
-      <div className="auction-view-tabs" role="tablist" aria-label="Auction views">
-        {[
-          { id: "browse", label: "Browse" },
-          { id: "sell", label: "Create Listing" },
-          { id: "mine", label: "My Listings" },
-        ].map((tab) => (
+      {/* ───────── Browse (left) ───────── */}
+      <div className="ah-browse">
+        <div className="ah-browse-head">
+          <input
+            type="text"
+            className="ah-search"
+            placeholder="Search items or sellers…"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+          />
           <button
-            key={tab.id}
             type="button"
-            role="tab"
-            aria-selected={view === tab.id}
-            className={`auction-view-tab ${view === tab.id ? "auction-view-tab-active" : ""}`}
-            onClick={() => setView(tab.id as AuctionView)}
+            className="ah-refresh"
+            onClick={() => {
+              onCommand(filter.trim().length > 0 ? `auction ${filter.trim()}` : "auction list");
+            }}
           >
-            {tab.label}
+            Refresh
           </button>
-        ))}
-      </div>
-
-      <div className="auction-toolbar">
-        <input
-          type="text"
-          className="auction-filter-input"
-          placeholder={view === "browse" ? "Filter listings by item or seller..." : "Search current listings..."}
-          value={filter}
-          onChange={(e) => setFilter(e.target.value)}
-        />
-        <button
-          type="button"
-          className="auction-refresh-btn"
-          onClick={() => {
-            onCommand(filter.trim().length > 0 ? `auction ${filter.trim()}` : "auction list");
-            setLocalMessage("Refreshing auction listings.");
-          }}
-        >
-          Refresh
-        </button>
-      </div>
-
-      {isDemo && (
-        <p className="auction-local-message auction-local-message-error">
-          Demo characters can browse the auction house but can&rsquo;t buy or sell.
-          Use &ldquo;Save Progress&rdquo; in the top bar to claim your character first.
-        </p>
-      )}
-      {localMessage && <p className="auction-local-message">{localMessage}</p>}
-      {activeFeedback && (
-        <p className={`auction-local-message auction-local-message-${activeFeedback.type}`}>
-          {activeFeedback.message}
-        </p>
-      )}
-
-      {view === "browse" && (
-        filtered.length === 0 ? (
-          <div className="auction-empty">
-            <p>No auction listings match your filter.</p>
-            <p>Try refreshing or create a listing from your inventory.</p>
-          </div>
-        ) : (
-          <div className="auction-content">
-            <table className="auction-table">
-              <thead>
-                <tr className="auction-header-row">
-                  <th className="auction-col-item">Item</th>
-                  <th className="auction-col-price">Price</th>
-                  <th className="auction-col-seller">Seller</th>
-                  <th className="auction-col-action" />
-                </tr>
-              </thead>
-              <tbody>
-                {filtered.map((listing) => {
-                  const mineListing = listing.seller.localeCompare(playerName, undefined, { sensitivity: "accent" }) === 0;
-                  return (
-                    <tr key={listing.id} className={`auction-row${mineListing ? " auction-row-owned" : ""}`}>
-                      <td className="auction-cell-item">
-                        <div className="auction-item-main">
-                          <span>{listing.itemName}</span>
-                          {mineListing && <span className="auction-owned-badge">Yours</span>}
-                        </div>
-                      </td>
-                      <td className="auction-cell-price">
-                        <span className="auction-gold-coin" />
-                        {listing.price.toLocaleString()}
-                      </td>
-                      <td className="auction-cell-seller">{mineListing ? "You" : listing.seller}</td>
-                      <td className="auction-cell-action">
-                        {mineListing ? (
-                          <button
-                            type="button"
-                            className="auction-buy-btn auction-buy-btn-secondary"
-                            onClick={() => {
-                              onCommand(`auction cancel ${listing.id}`);
-                              setLocalMessage(`Cancelling listing #${listing.id}.`);
-                            }}
-                          >
-                            Cancel
-                          </button>
-                        ) : (
-                          <button
-                            type="button"
-                            className="auction-buy-btn"
-                            disabled={isDemo}
-                            title={isDemo ? "Claim your character to buy from the auction house." : undefined}
-                            onClick={() => {
-                              onCommand(`auction buy ${listing.id}`);
-                              setLocalMessage(`Purchasing ${listing.itemName}.`);
-                            }}
-                          >
-                            Buy
-                          </button>
-                        )}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        )
-      )}
-
-      {view === "sell" && (
-        <div className="auction-create">
-          <section className="auction-create-card">
-            <h3 className="auction-create-title">Create a Listing</h3>
-
-            {sortedInventory.length === 0 ? (
-              <div className="auction-empty">
-                <p>You do not have any inventory items available to list right now.</p>
-              </div>
-            ) : (
-              <>
-                <div className="auction-create-field">
-                  <span className="auction-create-label">Inventory Item</span>
-                  <div className="auction-create-grid">
-                    {sortedInventory.map((item) => (
-                      <button
-                        key={item.id}
-                        type="button"
-                        className={`auction-item-picker ${selectedItemId === item.id ? "auction-item-picker-active" : ""}`}
-                        onClick={() => setSelectedItemId(item.id)}
-                      >
-                        <span className="auction-item-picker-name">{item.name}</span>
-                        <span className="auction-item-picker-meta">
-                          {item.slot ? `${item.slot} item` : "Inventory item"}
-                        </span>
-                      </button>
-                    ))}
-                  </div>
-                </div>
-
-                <label className="auction-create-field" htmlFor="auction-price-input">
-                  <span className="auction-create-label">Sale Price</span>
-                  <div className="auction-price-row">
-                    <input
-                      id="auction-price-input"
-                      type="number"
-                      min={1}
-                      step={1}
-                      inputMode="numeric"
-                      className="auction-price-input"
-                      placeholder="Enter price in gold"
-                      value={priceDraft}
-                      onChange={(event) => setPriceDraft(event.target.value)}
-                    />
+        </div>
+        <div className="ah-browse-cols">
+          <span className="ah-col-item">Item</span>
+          <span className="ah-col-price">Price</span>
+          <span className="ah-col-seller">Seller</span>
+          <span className="ah-col-buy" />
+        </div>
+        <div className="ah-browse-list">
+          {filtered.length === 0 ? (
+            <p className="ah-empty">No listings match. Try refreshing or list something of your own.</p>
+          ) : (
+            filtered.map((l) => (
+              <div key={l.id} className={`ah-row${isMine(l.seller) ? " ah-row-mine" : ""}`}>
+                <span className="ah-col-item">{l.itemName}</span>
+                <span className="ah-col-price"><span className="ah-coin" />{gold(l.price)}</span>
+                <span className="ah-col-seller">{isMine(l.seller) ? "You" : l.seller}</span>
+                <span className="ah-col-buy">
+                  {isMine(l.seller) ? (
                     <button
                       type="button"
-                      className="auction-create-submit"
-                      disabled={isDemo}
-                      title={isDemo ? "Claim your character to post auction listings." : undefined}
-                      onClick={createListing}
+                      className="ah-btn ah-btn-cancel"
+                      onClick={() => { onCommand(`auction cancel ${l.id}`); setLocalMessage(`Cancelling #${l.id}.`); }}
                     >
-                      Post Listing
+                      Cancel
                     </button>
-                  </div>
-                </label>
-
-                {selectedItem && (
-                  <div className="auction-create-summary">
-                    <span className="auction-create-summary-label">Ready to list</span>
-                    <strong>{selectedItem.name}</strong>
-                  </div>
-                )}
-              </>
-            )}
-          </section>
+                  ) : (
+                    <button
+                      type="button"
+                      className="ah-btn ah-btn-buy"
+                      disabled={isDemo}
+                      title={isDemo ? "Claim your character to buy." : undefined}
+                      onClick={() => { onCommand(`auction buy ${l.id}`); setLocalMessage(`Buying ${l.itemName}.`); }}
+                    >
+                      Buy Now
+                    </button>
+                  )}
+                </span>
+              </div>
+            ))
+          )}
         </div>
-      )}
+      </div>
 
-      {view === "mine" && (
-        mine.length === 0 ? (
-          <div className="auction-empty">
-            <p>You do not have any active listings.</p>
-            <p>Open the create-listing view to post something from your inventory.</p>
+      {/* ───────── Your inventory (mid) ───────── */}
+      <div className="ah-inventory">
+        <div className="ah-inv-list">
+          {sortedInventory.length === 0 ? (
+            <p className="ah-empty">No items to list.</p>
+          ) : (
+            sortedInventory.map((it) => {
+              const img = resolveItemImage(it);
+              return (
+                <button
+                  key={it.id}
+                  type="button"
+                  className={`ah-inv-row${selectedItemId === it.id ? " ah-inv-row-active" : ""}`}
+                  onClick={() => setSelectedItemId(it.id)}
+                >
+                  <span className="ah-inv-icon">{img && <img src={img} alt="" />}</span>
+                  <span className="ah-inv-name">{it.name}</span>
+                </button>
+              );
+            })
+          )}
+        </div>
+      </div>
+
+      {/* ───────── Selected item (right) ───────── */}
+      <div className="ah-selected">
+        {selectedItem ? (
+          <div className="ah-detail">
+            <div className="ah-detail-icon">{selectedImage && <img src={selectedImage} alt="" />}</div>
+            <div className="ah-detail-body">
+              <h3 className="ah-detail-name">{selectedItem.name}</h3>
+              <p className="ah-detail-sub">{selectedItem.itemType ?? selectedItem.slot ?? "Item"}</p>
+              <dl className="ah-detail-stats">
+                {selectedItem.damage ? (
+                  <div><dt>Weapon Damage</dt><dd>{selectedItem.damage}</dd></div>
+                ) : null}
+                {selectedItem.armor ? (
+                  <div><dt>Armor</dt><dd>+{selectedItem.armor}</dd></div>
+                ) : null}
+                {Object.entries(selectedItem.stats ?? {}).map(([k, v]) => (
+                  <div key={k}><dt>{k}</dt><dd>{v > 0 ? `+${v}` : v}</dd></div>
+                ))}
+              </dl>
+              {selectedItem.enchantments && selectedItem.enchantments.length > 0 && (
+                <p className="ah-detail-ench">{selectedItem.enchantments.join(", ")}</p>
+              )}
+            </div>
           </div>
         ) : (
-          <div className="auction-my-listings">
-            {mine.map((listing) => (
-              <article key={listing.id} className="auction-owned-card">
-                <div className="auction-owned-copy">
-                  <p className="auction-owned-item">{listing.itemName}</p>
-                  <p className="auction-owned-price">{listing.price.toLocaleString()} gold</p>
-                </div>
+          <p className="ah-empty ah-detail-empty">Select an item from your inventory to list it.</p>
+        )}
+      </div>
+
+      {/* ───────── List action (below selected) ───────── */}
+      <div className="ah-list-action">
+        <label className="ah-price-label" htmlFor="ah-price">Set Price</label>
+        <div className="ah-price-row">
+          <input
+            id="ah-price"
+            type="number"
+            min={1}
+            step={1}
+            inputMode="numeric"
+            className="ah-price-input"
+            placeholder="Gold"
+            value={priceDraft}
+            onChange={(e) => setPriceDraft(e.target.value)}
+          />
+          <button
+            type="button"
+            className="ah-list-btn"
+            disabled={isDemo || !selectedItem}
+            title={isDemo ? "Claim your character to list items." : undefined}
+            onClick={listSelected}
+          >
+            List Instantly
+          </button>
+        </div>
+      </div>
+
+      {/* ───────── My listings (bottom-right) ───────── */}
+      <div className="ah-mine">
+        <div className="ah-mine-list">
+          {mine.length === 0 ? (
+            <p className="ah-empty">You have no active listings.</p>
+          ) : (
+            mine.map((l) => (
+              <div key={l.id} className="ah-mine-row">
+                <span className="ah-mine-name">{l.itemName}</span>
+                <span className="ah-mine-price"><span className="ah-coin" />{gold(l.price)}</span>
                 <button
                   type="button"
-                  className="auction-buy-btn auction-buy-btn-secondary"
-                  onClick={() => {
-                    onCommand(`auction cancel ${listing.id}`);
-                    setLocalMessage(`Cancelling listing #${listing.id}.`);
-                  }}
+                  className="ah-btn ah-btn-cancel"
+                  onClick={() => { onCommand(`auction cancel ${l.id}`); setLocalMessage(`Cancelling #${l.id}.`); }}
                 >
-                  Cancel Listing
+                  Cancel
                 </button>
-              </article>
-            ))}
-          </div>
-        )
-      )}
+              </div>
+            ))
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -16910,467 +16910,6 @@ body {
   padding: 3px 0;
 }
 
-/* ── Auction Panel ────────────────────────────────────────────── */
-
-.auction-panel {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  overflow: hidden;
-  gap: var(--space-3);
-}
-
-.auction-view-tabs {
-  display: flex;
-  gap: var(--space-2);
-  padding: 0 var(--space-3);
-}
-
-.auction-view-tab {
-  padding: 7px 12px;
-  border: 1px solid var(--line-faint);
-  border-radius: 999px;
-  background: rgb(255 255 255 / 5%);
-  color: var(--text-secondary);
-  font-size: 0.78rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s, border-color 0.15s;
-}
-
-.auction-view-tab:hover {
-  background: rgb(255 255 255 / 8%);
-  color: var(--text-primary);
-}
-
-.auction-view-tab-active {
-  border-color: var(--primary-dim);
-  background: var(--primary-glass);
-  color: var(--text-primary);
-}
-
-.auction-toolbar {
-  display: flex;
-  gap: var(--space-2);
-  padding: 0 var(--space-3);
-}
-
-.auction-filter-input {
-  flex: 1;
-  padding: 9px 12px;
-  border: 1px solid var(--line-faint);
-  border-radius: 10px;
-  background: rgb(255 255 255 / 5%);
-  color: var(--text-primary);
-  font-size: 0.82rem;
-}
-
-.auction-filter-input:focus,
-.auction-price-input:focus {
-  outline: none;
-  border-color: var(--color-primary-lavender);
-  box-shadow: 0 0 0 1px rgb(190 176 255 / 24%);
-}
-
-.auction-filter-input::placeholder {
-  color: var(--text-muted);
-}
-
-.auction-refresh-btn {
-  padding: 8px 14px;
-  border: 1px solid var(--line-faint);
-  border-radius: 10px;
-  background: rgb(255 255 255 / 5%);
-  color: var(--text-secondary);
-  font-size: 0.8rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s, border-color 0.15s;
-}
-
-.auction-refresh-btn:hover {
-  background: var(--primary-glass);
-  color: var(--text-primary);
-  border-color: var(--primary-dim);
-}
-
-.auction-local-message {
-  margin: 0;
-  padding: 0 var(--space-3);
-  color: var(--text-secondary);
-  font-size: 0.78rem;
-}
-
-.auction-local-message-success {
-  color: #b8f5d0;
-}
-
-.auction-local-message-error {
-  color: #ffb4b4;
-}
-
-.auction-empty {
-  padding: var(--space-4);
-  color: var(--text-muted);
-  font-size: 0.85rem;
-  text-align: center;
-}
-
-.auction-empty p {
-  margin: 0 0 var(--space-2);
-}
-
-.auction-content {
-  flex: 1;
-  overflow-y: auto;
-  padding: 0 var(--space-3) var(--space-3);
-}
-
-.auction-table {
-  width: 100%;
-  border-collapse: collapse;
-  border-radius: 16px;
-  overflow: hidden;
-  background: rgb(0 0 0 / 12%);
-  border: 1px solid rgb(255 255 255 / 5%);
-}
-
-.auction-header-row {
-  border-bottom: 1px solid var(--line-faint);
-}
-
-.auction-header-row th {
-  font-size: 0.72rem;
-  font-weight: 600;
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding: var(--space-2) var(--space-1);
-  text-align: left;
-}
-
-.auction-col-price,
-.auction-cell-price {
-  text-align: right;
-}
-
-.auction-col-action,
-.auction-cell-action {
-  text-align: center;
-  width: 3.5rem;
-}
-
-.auction-row {
-  transition: background 0.1s;
-}
-
-.auction-row:hover {
-  background: rgb(255 255 255 / 3%);
-}
-
-.auction-row-owned {
-  background: rgb(190 176 255 / 8%);
-}
-
-.auction-cell-item {
-  color: var(--text-primary);
-  font-size: 0.85rem;
-  padding: 10px var(--space-1);
-}
-
-.auction-cell-price {
-  color: var(--accent-gold);
-  font-size: 0.82rem;
-  font-variant-numeric: tabular-nums;
-  padding: 10px var(--space-1);
-  white-space: nowrap;
-}
-
-.auction-gold-coin {
-  display: inline-block;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: var(--accent-gold);
-  margin-right: 4px;
-  vertical-align: middle;
-}
-
-.auction-cell-seller {
-  color: var(--text-secondary);
-  font-size: 0.82rem;
-  padding: 10px var(--space-1);
-}
-
-.auction-item-main {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
-.auction-owned-badge {
-  display: inline-flex;
-  align-items: center;
-  padding: 2px 8px;
-  border-radius: 999px;
-  background: rgb(190 176 255 / 18%);
-  color: var(--text-primary);
-  font-size: 0.7rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.auction-buy-btn {
-  padding: 6px 12px;
-  border: 1px solid var(--line-faint);
-  border-radius: 10px;
-  background: rgb(255 255 255 / 5%);
-  color: var(--text-secondary);
-  font-size: 0.76rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s, border-color 0.15s, transform 0.15s;
-}
-
-.auction-buy-btn:hover:not(:disabled) {
-  background: var(--primary-glass);
-  color: var(--text-primary);
-  border-color: var(--primary-dim);
-  transform: translateY(-1px);
-}
-
-.auction-buy-btn:disabled,
-.auction-create-submit:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-}
-
-.auction-buy-btn-secondary {
-  border-color: rgb(255 255 255 / 9%);
-  background: rgb(255 255 255 / 7%);
-}
-
-.auction-create,
-.auction-my-listings {
-  flex: 1;
-  overflow-y: auto;
-  padding: 0 var(--space-3) var(--space-3);
-}
-
-.auction-create-card {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-4);
-  padding: var(--space-4);
-  border-radius: 18px;
-  border: 1px solid rgb(255 255 255 / 6%);
-  background: linear-gradient(160deg, rgb(0 0 0 / 14%), rgb(255 255 255 / 4%));
-}
-
-.auction-create-title {
-  margin: 0;
-  color: var(--text-heading);
-  font-size: 1rem;
-}
-
-
-.auction-create-field {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.auction-create-label {
-  color: var(--text-secondary);
-  font-size: 0.76rem;
-  font-weight: 700;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-
-.auction-create-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 10px;
-}
-
-.auction-item-picker {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  align-items: flex-start;
-  padding: 12px;
-  border-radius: 12px;
-  border: 1px solid rgb(255 255 255 / 7%);
-  background: rgb(0 0 0 / 18%);
-  color: var(--text-primary);
-  cursor: pointer;
-  text-align: left;
-  transition: transform 0.15s, border-color 0.15s, background 0.15s;
-}
-
-.auction-item-picker:hover {
-  transform: translateY(-1px);
-  border-color: var(--color-primary-lavender);
-  background: rgb(190 176 255 / 10%);
-}
-
-.auction-item-picker-active {
-  border-color: var(--color-primary-lavender);
-  background: rgb(190 176 255 / 14%);
-  box-shadow: inset 0 0 0 1px rgb(190 176 255 / 14%);
-}
-
-.auction-item-picker-name {
-  font-size: 0.84rem;
-  font-weight: 600;
-}
-
-.auction-item-picker-meta {
-  color: var(--text-tertiary);
-  font-size: 0.74rem;
-}
-
-.auction-price-row {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-}
-
-.auction-price-input {
-  flex: 1 1 220px;
-  min-width: 0;
-  padding: 10px 12px;
-  border-radius: 10px;
-  border: 1px solid var(--line-faint);
-  background: rgb(255 255 255 / 5%);
-  color: var(--text-primary);
-  font: inherit;
-}
-
-.auction-create-submit {
-  padding: 10px 16px;
-  border: 1px solid var(--primary-dim);
-  border-radius: 10px;
-  background: var(--primary-glass);
-  color: var(--text-primary);
-  font-size: 0.82rem;
-  font-weight: 700;
-  cursor: pointer;
-  transition: transform 0.15s, border-color 0.15s, background 0.15s;
-}
-
-.auction-create-submit:hover:not(:disabled) {
-  transform: translateY(-1px);
-  border-color: var(--color-primary-lavender);
-  background: rgb(190 176 255 / 18%);
-}
-
-.auction-create-summary {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 12px 14px;
-  border-radius: 12px;
-  background: rgb(255 255 255 / 5%);
-  color: var(--text-primary);
-}
-
-.auction-create-summary-label {
-  color: var(--text-tertiary);
-  font-size: 0.76rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.auction-my-listings {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.auction-owned-card {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 14px 16px;
-  border-radius: 14px;
-  border: 1px solid rgb(255 255 255 / 6%);
-  background: rgb(0 0 0 / 16%);
-}
-
-.auction-owned-copy {
-  min-width: 0;
-}
-
-.auction-owned-item,
-.auction-owned-price {
-  margin: 0;
-}
-
-.auction-owned-item {
-  color: var(--text-primary);
-  font-size: 0.88rem;
-  font-weight: 600;
-}
-
-.auction-owned-price {
-  margin-top: 4px;
-  color: var(--accent-gold);
-  font-size: 0.8rem;
-}
-
-@media (width <= 760px) {
-  .auction-toolbar,
-  .auction-view-tabs,
-  .auction-content,
-  .auction-create,
-  .auction-my-listings,
-  .auction-local-message {
-    padding-left: var(--space-2);
-    padding-right: var(--space-2);
-  }
-
-  .auction-toolbar {
-    flex-direction: column;
-  }
-
-  .auction-table,
-  .auction-header-row,
-  .auction-header-row th,
-  .auction-row,
-  .auction-cell-item,
-  .auction-cell-price,
-  .auction-cell-seller,
-  .auction-cell-action {
-    display: block;
-    width: 100%;
-    text-align: left;
-  }
-
-  .auction-row {
-    padding: 10px 0;
-    border-bottom: 1px solid rgb(255 255 255 / 6%);
-  }
-
-  .auction-header-row {
-    display: none;
-  }
-
-  .auction-cell-action {
-    margin-top: 8px;
-  }
-
-  .auction-owned-card {
-    flex-direction: column;
-    align-items: stretch;
-  }
-}
-
 /* ── Bank Panel ── */
 
 .bank-panel {
@@ -26188,3 +25727,373 @@ html:has(.game-shell),
   80% { opacity: 1; }
   100% { opacity: 0; }
 }
+
+/* ============================================================
+   Auction House — painted `auction_bg` frame. A unified board:
+   browse listings (left), your inventory + selected item +
+   set-price (upper right), and your listings (bottom right).
+   ============================================================ */
+.drawer-sheet.drawer-sheet-auctionhouse {
+  background-image:
+    var(--skin-bg, none),
+    radial-gradient(ellipse at 50% 22%, #141a3e 0%, #080b20 70%);
+  background-size: cover, auto;
+  background-position: center, center;
+  background-repeat: no-repeat, no-repeat;
+}
+
+.drawer-sheet-auctionhouse .drawer-title { display: none; }
+.drawer-sheet-auctionhouse .drawer-handle-zone { display: none; }
+
+.drawer-sheet-auctionhouse .drawer-header {
+  position: absolute;
+  top: 1.4%;
+  right: 1.4%;
+  left: auto;
+  z-index: 6;
+  padding: 0;
+  min-height: 0;
+  border-bottom: none;
+}
+
+.drawer-sheet-auctionhouse .drawer-body {
+  padding: 0;
+  position: relative;
+}
+
+@media (min-width: 768px) {
+  .drawer-sheet.drawer-sheet-auctionhouse {
+    width: auto;
+    height: min(94vh, 71vw);
+    max-height: 94vh;
+    aspect-ratio: 4 / 3;
+  }
+}
+
+.ah-board {
+  position: absolute;
+  inset: 0;
+  font-family: var(--font-display);
+  color: #ccd6f4;
+}
+
+/* Floating feedback toast near the top. */
+.ah-toast {
+  position: absolute;
+  left: 50%;
+  top: 21.5%;
+  transform: translateX(-50%);
+  margin: 0;
+  padding: 4px 16px;
+  border-radius: 8px;
+  background: rgb(10 14 36 / 88%);
+  border: 1px solid rgb(120 150 230 / 45%);
+  font-size: clamp(0.6rem, 1.15vw, 0.84rem);
+  z-index: 5;
+  white-space: nowrap;
+}
+.ah-toast-error { color: #f0a0a0; border-color: rgb(220 120 120 / 50%); }
+.ah-toast-success { color: #a6e6c0; border-color: rgb(120 220 160 / 50%); }
+.ah-toast-info { color: #bcd0ff; }
+
+/* Shared coin glyph. */
+.ah-coin {
+  display: inline-block;
+  width: 0.72em;
+  height: 0.72em;
+  margin-right: 0.3em;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, #ffe9a0, #e0b84e 60%, #9a7a26);
+  box-shadow: 0 0 5px rgb(230 200 90 / 50%);
+  vertical-align: -0.04em;
+}
+
+/* Shared scrollable lists. */
+.ah-browse-list,
+.ah-inv-list,
+.ah-mine-list {
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgb(120 150 230 / 45%) transparent;
+}
+.ah-browse-list::-webkit-scrollbar,
+.ah-inv-list::-webkit-scrollbar,
+.ah-mine-list::-webkit-scrollbar { width: 7px; }
+.ah-browse-list::-webkit-scrollbar-thumb,
+.ah-inv-list::-webkit-scrollbar-thumb,
+.ah-mine-list::-webkit-scrollbar-thumb {
+  background: rgb(120 150 230 / 40%);
+  border-radius: 4px;
+}
+
+.ah-empty {
+  margin: 0;
+  padding: 10% 8% 0;
+  text-align: center;
+  font-style: italic;
+  color: rgb(180 196 240 / 60%);
+  font-size: clamp(0.62rem, 1.2vw, 0.86rem);
+}
+
+/* ───────── Browse (left) ───────── */
+.ah-browse {
+  position: absolute;
+  left: 3.5%;
+  top: 24%;
+  width: 39.5%;
+  height: 64%;
+  display: flex;
+  flex-direction: column;
+  padding: 1.4% 1.6%;
+  gap: clamp(4px, 0.8vh, 9px);
+}
+.ah-browse-head {
+  display: flex;
+  gap: clamp(4px, 0.6vw, 8px);
+}
+.ah-search {
+  flex: 1;
+  min-width: 0;
+  padding: clamp(4px, 0.7vh, 8px) clamp(6px, 0.8vw, 11px);
+  border: 1px solid rgb(120 150 230 / 35%);
+  border-radius: 8px;
+  background: rgb(10 16 40 / 70%);
+  color: #dce6ff;
+  font-family: var(--font-display);
+  font-size: clamp(0.66rem, 1.2vw, 0.9rem);
+}
+.ah-search::placeholder { color: rgb(170 188 235 / 50%); }
+.ah-refresh {
+  padding: 0 clamp(8px, 1.2vw, 16px);
+  border: 1px solid rgb(120 150 230 / 40%);
+  border-radius: 8px;
+  background: rgb(40 54 110 / 60%);
+  color: #cfdcff;
+  font-family: var(--font-display);
+  font-size: clamp(0.62rem, 1.1vw, 0.82rem);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 140ms var(--ease-out-soft), border-color 140ms var(--ease-out-soft);
+}
+.ah-refresh:hover { background: rgb(58 76 150 / 70%); border-color: rgb(150 180 250 / 55%); }
+
+.ah-browse-cols,
+.ah-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto auto;
+  align-items: center;
+  gap: clamp(4px, 0.7vw, 10px);
+}
+.ah-browse-cols {
+  padding: 0 1% clamp(2px, 0.5vh, 5px);
+  border-bottom: 1px solid rgb(120 150 230 / 25%);
+  font-size: clamp(0.5rem, 0.95vw, 0.66rem);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgb(160 180 235 / 70%);
+}
+.ah-browse-list { flex: 1; display: flex; flex-direction: column; }
+.ah-row {
+  padding: clamp(4px, 0.8vh, 9px) 1%;
+  border-bottom: 1px solid rgb(120 150 230 / 12%);
+  font-size: clamp(0.62rem, 1.15vw, 0.88rem);
+}
+.ah-row-mine { background: rgb(90 110 210 / 10%); }
+.ah-col-item { color: #a9c6ff; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ah-col-price { color: #ecd58a; font-weight: 700; white-space: nowrap; }
+.ah-col-seller { color: rgb(196 208 245 / 85%); white-space: nowrap; }
+.ah-col-buy { justify-self: end; }
+
+/* Buttons. */
+.ah-btn {
+  padding: clamp(3px, 0.6vh, 7px) clamp(8px, 1vw, 15px);
+  border-radius: 7px;
+  border: 1px solid transparent;
+  font-family: var(--font-display);
+  font-size: clamp(0.58rem, 1.05vw, 0.8rem);
+  font-weight: 700;
+  cursor: pointer;
+  transition: filter 140ms var(--ease-out-soft), transform 140ms var(--ease-out-soft);
+}
+.ah-btn:disabled { opacity: 0.45; cursor: default; }
+.ah-btn-buy {
+  background: linear-gradient(165deg, #5a4fb0, #3a2e80);
+  border-color: rgb(150 170 250 / 50%);
+  color: #eef0ff;
+}
+.ah-btn-buy:not(:disabled):hover { filter: brightness(1.12); transform: translateY(-1px); }
+.ah-btn-cancel {
+  background: rgb(70 28 38 / 70%);
+  border-color: rgb(210 110 120 / 45%);
+  color: #f2c4c8;
+}
+.ah-btn-cancel:hover { filter: brightness(1.15); }
+
+/* ───────── Your inventory (mid) ───────── */
+.ah-inventory {
+  position: absolute;
+  left: 44.5%;
+  top: 30%;
+  width: 17.5%;
+  height: 31.5%;
+  padding: 0.6% 0.6% 0.6% 1%;
+}
+.ah-inv-list { height: 100%; display: flex; flex-direction: column; gap: 2px; }
+.ah-inv-row {
+  display: flex;
+  align-items: center;
+  gap: clamp(4px, 0.5vw, 8px);
+  padding: clamp(3px, 0.6vh, 7px) clamp(4px, 0.6vw, 9px);
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: transparent;
+  color: #cfdcff;
+  font-family: var(--font-display);
+  font-size: clamp(0.6rem, 1.1vw, 0.84rem);
+  text-align: left;
+  cursor: pointer;
+  transition: background 130ms var(--ease-out-soft), border-color 130ms var(--ease-out-soft);
+}
+.ah-inv-row:hover { background: rgb(70 90 180 / 18%); }
+.ah-inv-row-active {
+  background: rgb(80 104 210 / 26%);
+  border-color: rgb(150 180 255 / 55%);
+  box-shadow: 0 0 10px rgb(120 150 240 / 35%);
+}
+.ah-inv-icon {
+  width: clamp(18px, 2.2vw, 28px);
+  height: clamp(18px, 2.2vw, 28px);
+  flex-shrink: 0;
+  border-radius: 5px;
+  background: rgb(20 28 60 / 60%);
+  overflow: hidden;
+}
+.ah-inv-icon img { width: 100%; height: 100%; object-fit: cover; }
+.ah-inv-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* ───────── Selected item (right) ───────── */
+.ah-selected {
+  position: absolute;
+  left: 63%;
+  top: 30%;
+  width: 33.8%;
+  height: 24%;
+  padding: 0.8% 1.4%;
+  overflow-y: auto;
+}
+.ah-detail { display: flex; gap: clamp(8px, 1.2vw, 18px); height: 100%; }
+.ah-detail-icon {
+  width: clamp(54px, 8vw, 104px);
+  height: clamp(54px, 8vw, 104px);
+  flex-shrink: 0;
+  border-radius: 10px;
+  border: 1px solid rgb(120 150 230 / 40%);
+  background: rgb(16 22 50 / 70%);
+  overflow: hidden;
+}
+.ah-detail-icon img { width: 100%; height: 100%; object-fit: cover; }
+.ah-detail-body { flex: 1; min-width: 0; }
+.ah-detail-name {
+  margin: 0;
+  font-size: clamp(0.86rem, 1.7vw, 1.3rem);
+  font-weight: 700;
+  color: #a9c6ff;
+  line-height: 1.1;
+}
+.ah-detail-sub {
+  margin: 2px 0 clamp(4px, 0.8vh, 9px);
+  font-size: clamp(0.58rem, 1.1vw, 0.82rem);
+  color: rgb(190 160 230 / 90%);
+  text-transform: capitalize;
+}
+.ah-detail-stats { margin: 0; display: flex; flex-direction: column; gap: 2px; }
+.ah-detail-stats div {
+  display: flex;
+  justify-content: space-between;
+  gap: 1em;
+  font-size: clamp(0.56rem, 1.05vw, 0.8rem);
+}
+.ah-detail-stats dt { margin: 0; color: rgb(190 204 244 / 78%); }
+.ah-detail-stats dd { margin: 0; color: #dce6ff; font-weight: 600; }
+.ah-detail-ench {
+  margin: clamp(4px, 0.8vh, 8px) 0 0;
+  font-size: clamp(0.54rem, 1vw, 0.76rem);
+  font-style: italic;
+  color: #8fd0e6;
+}
+.ah-detail-empty { padding-top: 14%; }
+
+/* ───────── List action (below selected) ───────── */
+.ah-list-action {
+  position: absolute;
+  left: 63%;
+  top: 56%;
+  width: 33.8%;
+  height: 6.5%;
+  display: flex;
+  align-items: center;
+  gap: clamp(6px, 1vw, 14px);
+  padding: 0 1.4%;
+}
+.ah-price-label {
+  font-size: clamp(0.52rem, 1vw, 0.72rem);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgb(170 188 235 / 80%);
+  white-space: nowrap;
+}
+.ah-price-row { display: flex; gap: clamp(5px, 0.8vw, 11px); flex: 1; }
+.ah-price-input {
+  width: clamp(70px, 9vw, 130px);
+  padding: clamp(4px, 0.7vh, 8px) clamp(6px, 0.7vw, 10px);
+  border: 1px solid rgb(120 150 230 / 40%);
+  border-radius: 8px;
+  background: rgb(10 16 40 / 75%);
+  color: #ecd58a;
+  font-family: var(--font-display);
+  font-size: clamp(0.7rem, 1.3vw, 1rem);
+  font-weight: 700;
+  text-align: center;
+}
+.ah-list-btn {
+  flex: 1;
+  padding: clamp(5px, 0.9vh, 11px) clamp(8px, 1.4vw, 22px);
+  border: 1px solid rgb(170 150 250 / 55%);
+  border-radius: 9px;
+  background: linear-gradient(165deg, #6e51b4, #3f2a86);
+  color: #f1ecff;
+  font-family: var(--font-display);
+  font-size: clamp(0.7rem, 1.4vw, 1.05rem);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: filter 140ms var(--ease-out-soft), transform 140ms var(--ease-out-soft), box-shadow 140ms var(--ease-out-soft);
+}
+.ah-list-btn:not(:disabled):hover {
+  filter: brightness(1.12);
+  transform: translateY(-1px);
+  box-shadow: 0 0 16px rgb(150 110 230 / 45%);
+}
+.ah-list-btn:disabled { opacity: 0.45; cursor: default; }
+
+/* ───────── My listings (bottom-right) ───────── */
+.ah-mine {
+  position: absolute;
+  left: 44.5%;
+  top: 68%;
+  width: 52.3%;
+  height: 20%;
+  padding: 0.8% 1.4%;
+}
+.ah-mine-list { height: 100%; display: flex; flex-direction: column; gap: 2px; }
+.ah-mine-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: clamp(6px, 1vw, 16px);
+  padding: clamp(4px, 0.7vh, 8px) 1%;
+  border-bottom: 1px solid rgb(120 150 230 / 12%);
+  font-size: clamp(0.62rem, 1.15vw, 0.88rem);
+}
+.ah-mine-name { color: #a9c6ff; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ah-mine-price { color: #ecd58a; font-weight: 700; white-space: nowrap; }


### PR DESCRIPTION
Redoes the Auction House panel onto the painted **`auction_bg`** frame (new `auctionhouse` Drawer variant), following your inspiration + blank. Retires the old tabbed layout for a **single unified board**:

- **Browse (left)** — search + refresh, rows of item / price / seller / **Buy Now** (your own listings show **Cancel**).
- **Your Inventory (mid)** — click an item to populate…
- **Selected Item (right)** — icon, type, weapon-damage/armor/stat lines, enchantments…
- **Set Price + List Instantly** (below selected).
- **My Listings (bottom-right)** — your active listings with **Cancel**.

Fixed price, buy now, instant delivery — no bidding (matches the existing backend).

## Notes
- **No backend changes** beyond registering the `auction_bg` global asset — same `auction list/buy/sell/cancel` commands and `Auction.List` GMCP.
- All content is pixel-mapped over the painted frame with a **CSS fallback** so it works before the art ships.
- Removed the now-dead `.auction-*` styles (the old tabbed panel's CSS).
- `AuctionListing` only carries item/price/seller, so the browse rows show those (no per-listing category/expiry like the full concept — that'd need richer listing data).

## Heads-up for review
`auction_bg` isn't in the asset overlay yet, so I **mapped the region positions by eye** from the blank (browse / inventory / selected / list-action / my-listings). Once you publish the art and screenshot it on the demo server, I'll nudge the `%` positions the same way we did Lottery / Dice.

Verified: web `lint` + `build`, backend `compileKotlin` + `ktlintCheck` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)