### PR TITLE
feat(web): reskin Staff Control + move staff pills to the canvas

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -3134,6 +3134,7 @@ data class ImagesConfig(
             "auction_bg" to "global_assets/auction_bg.png",
             "crafting_bg" to "global_assets/crafting_bg.png",
             "professions_bg" to "global_assets/professions_bg.png",
+            "admin_bg" to "global_assets/admin_bg.png",
             "dialog_indicator" to "global_assets/dialog_indicator.png",
             "aggro_indicator" to "global_assets/aggro_indicator.png",
             "quest_available_indicator" to "global_assets/quest_available_indicator.png",

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -946,6 +946,31 @@ function App() {
         onCommand={sendCommand}
         onOpenPanel={(panel) => openPanel(panel)}
         audio={audio}
+        canvasOverlay={
+          state.character.isStaff ? (
+            <div className="staff-fab">
+              <button
+                type="button"
+                className="staff-fab-btn"
+                onClick={() => setShowAdminPanel(true)}
+                title="Open staff admin panel"
+                aria-label="Open staff admin panel"
+              >
+                Staff
+              </button>
+              <button
+                type="button"
+                className={`staff-fab-btn staff-fab-invis${staffInvisible ? " staff-fab-invis-active" : ""}`}
+                onClick={() => { sendCommand("invis"); setStaffInvisible((v) => !v); }}
+                title={staffInvisible ? "You are invisible — click to reappear" : "Become invisible"}
+                aria-label="Toggle staff invisibility"
+                aria-pressed={staffInvisible}
+              >
+                {staffInvisible ? "👁‍🗨" : "👁"}
+              </button>
+            </div>
+          ) : null
+        }
       />
 
       <Drawer
@@ -1884,49 +1909,24 @@ function App() {
         </div>
       )}
 
-      {/* Staff-only floating controls + admin panel */}
-      {state.character.isStaff && (
-        <>
-          <div className="staff-fab">
-            <button
-              type="button"
-              className="staff-fab-btn"
-              onClick={() => setShowAdminPanel(true)}
-              title="Open staff admin panel"
-              aria-label="Open staff admin panel"
-            >
-              Staff
-            </button>
-            <button
-              type="button"
-              className={`staff-fab-btn staff-fab-invis${staffInvisible ? " staff-fab-invis-active" : ""}`}
-              onClick={() => { sendCommand("invis"); setStaffInvisible((v) => !v); }}
-              title={staffInvisible ? "You are invisible — click to reappear" : "Become invisible"}
-              aria-label="Toggle staff invisibility"
-              aria-pressed={staffInvisible}
-            >
-              {staffInvisible ? "\uD83D\uDC41\u200D\uD83D\uDDE8" : "\uD83D\uDC41"}
-            </button>
-          </div>
-
-          {showAdminPanel && (
-            <AdminPanel
-              onCommand={(command) => {
-                sendCommand(command);
-                if (command === "invis") setStaffInvisible((value) => !value);
-              }}
-              onClose={() => setShowAdminPanel(false)}
-              worldInfo={state.staffWorldInfo}
-              mobTemplates={state.staffMobTemplates}
-              whoPlayers={state.whoPlayers}
-              roomMobs={state.mobs}
-              currentPlayerName={state.character.name}
-              possessing={state.possessing}
-              invisible={staffInvisible}
-              feedbackFeed={state.uiFeedbackFeed}
-            />
-          )}
-        </>
+      {/* Staff admin panel (the STAFF pill lives on the canvas, in GameShell). */}
+      {state.character.isStaff && showAdminPanel && (
+        <AdminPanel
+          onCommand={(command) => {
+            sendCommand(command);
+            if (command === "invis") setStaffInvisible((value) => !value);
+          }}
+          onClose={() => setShowAdminPanel(false)}
+          backgroundImage={state.serverAssets["admin_bg"] ?? null}
+          worldInfo={state.staffWorldInfo}
+          mobTemplates={state.staffMobTemplates}
+          whoPlayers={state.whoPlayers}
+          roomMobs={state.mobs}
+          currentPlayerName={state.character.name}
+          possessing={state.possessing}
+          invisible={staffInvisible}
+          feedbackFeed={state.uiFeedbackFeed}
+        />
       )}
 
       {/* Toast */}

--- a/web-v3/src/components/GameShell.tsx
+++ b/web-v3/src/components/GameShell.tsx
@@ -35,6 +35,8 @@ interface GameShellProps {
   onOpenPanel: (panel: PopoutPanel) => void;
   audio: AudioEngine;
   children?: ReactNode;
+  /** Overlay rendered inside the canvas layer (e.g. staff pills near Recall). */
+  canvasOverlay?: ReactNode;
 }
 
 /** Font-size multiplier so longer room names shrink to fit the sign plaque. */
@@ -72,6 +74,7 @@ export function GameShell({
   onOpenPanel,
   audio,
   children,
+  canvasOverlay,
 }: GameShellProps) {
   const loggedIn = connected && hasCharacterProfile;
   const [signZoom, setSignZoom] = useState(false);
@@ -128,6 +131,7 @@ export function GameShell({
       {/* Canvas fills the shell; all HUD elements are overlays on top of it */}
       <div className="game-canvas-layer">
         <PixiCanvas />
+        {canvasOverlay}
 
         {loggedIn && (
           <>

--- a/web-v3/src/components/panels/AdminPanel.tsx
+++ b/web-v3/src/components/panels/AdminPanel.tsx
@@ -14,6 +14,8 @@ import type { AdminAction } from "./AdminPanel.logic";
 interface AdminPanelProps {
   onCommand: (command: string) => void;
   onClose: () => void;
+  /** Painted `admin_bg` frame URL; null falls back to the plain dialog skin. */
+  backgroundImage: string | null;
   worldInfo: StaffWorldZone[];
   mobTemplates: StaffMobZone[];
   whoPlayers: WhoPlayer[];
@@ -348,6 +350,7 @@ function TargetBrowser({
 export function AdminPanel({
   onCommand,
   onClose,
+  backgroundImage,
   worldInfo,
   mobTemplates,
   whoPlayers,
@@ -471,18 +474,25 @@ export function AdminPanel({
   return (
     <div className="popout-backdrop" onClick={onClose}>
       <section
-        className="popout-dialog admin-dialog"
+        className={`popout-dialog admin-dialog${backgroundImage ? " admin-dialog-skinned" : ""}`}
+        style={backgroundImage ? { ["--admin-bg" as string]: `url("${backgroundImage}")` } : undefined}
         role="dialog"
         aria-modal="true"
         aria-label="Staff Administration"
         onClick={(event) => event.stopPropagation()}
       >
-        <header className="popout-header">
-          <h2>Admin Console</h2>
-          <button type="button" className="soft-button popout-close" onClick={onClose}>
-            Close
+        {backgroundImage ? (
+          <button type="button" className="admin-skin-close" onClick={onClose} aria-label="Close">
+            ✕
           </button>
-        </header>
+        ) : (
+          <header className="popout-header">
+            <h2>Admin Console</h2>
+            <button type="button" className="soft-button popout-close" onClick={onClose}>
+              Close
+            </button>
+          </header>
+        )}
 
         <div className="popout-content admin-content">
           <div className="admin-status-strip">

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -25949,3 +25949,165 @@ html:has(.game-shell),
   transition: background 140ms var(--ease-out-soft), border-color 140ms var(--ease-out-soft);
 }
 .spellbook-craft-btn:hover { background: rgb(82 54 28 / 70%); border-color: rgb(230 150 60 / 60%); }
+
+/* ============================================================
+   Staff Control — admin console reskinned onto the painted
+   `admin_bg` frame. The title is painted; live content (target
+   strip, action sections, form) overlays the inner panel.
+   ============================================================ */
+.admin-dialog.admin-dialog-skinned {
+  position: relative;
+  width: min(95vw, 132vh);
+  max-width: 95vw;
+  max-height: 94vh;
+  aspect-ratio: 1456 / 1024;
+  padding: 0;
+  background:
+    var(--admin-bg, none) center / 100% 100% no-repeat;
+  border: none;
+  border-radius: 18px;
+  box-shadow: 0 24px 60px rgb(4 6 18 / 70%);
+  overflow: hidden;
+}
+
+.admin-dialog-skinned .admin-skin-close {
+  position: absolute;
+  top: 2.2%;
+  right: 2.4%;
+  z-index: 6;
+  width: clamp(28px, 3vw, 40px);
+  height: clamp(28px, 3vw, 40px);
+  border-radius: 50%;
+  border: 1px solid rgb(190 150 90 / 55%);
+  background: rgb(40 24 50 / 75%);
+  color: #e8c878;
+  font-size: clamp(0.8rem, 1.6vw, 1.1rem);
+  cursor: pointer;
+  transition: filter 140ms var(--ease-out-soft);
+}
+.admin-dialog-skinned .admin-skin-close:hover { filter: brightness(1.2); }
+
+/* Live content sits in the painted inner panel (below the title strip). */
+.admin-dialog-skinned .admin-content {
+  position: absolute;
+  inset: 16% 3.5% 6% 3.5%;
+  overflow-y: auto;
+  padding: 0 1% 1%;
+  scrollbar-width: thin;
+  scrollbar-color: rgb(150 170 230 / 45%) transparent;
+  color: #d6def4;
+}
+.admin-dialog-skinned .admin-content::-webkit-scrollbar { width: 8px; }
+.admin-dialog-skinned .admin-content::-webkit-scrollbar-thumb { background: rgb(150 170 230 / 40%); border-radius: 4px; }
+
+/* Target/status strip — moonlit cards. */
+.admin-dialog-skinned .admin-status-strip {
+  display: flex;
+  gap: clamp(6px, 1vw, 14px);
+  margin-bottom: clamp(6px, 1.2vh, 14px);
+}
+.admin-dialog-skinned .admin-status-card {
+  flex: 1;
+  padding: clamp(5px, 1vh, 11px) clamp(8px, 1.2vw, 16px);
+  border: 1px solid rgb(150 170 230 / 35%);
+  border-radius: 10px;
+  background: rgb(16 22 52 / 65%);
+}
+.admin-dialog-skinned .admin-status-label {
+  font-size: clamp(0.52rem, 1vw, 0.72rem);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgb(180 196 240 / 75%);
+}
+.admin-dialog-skinned .admin-status-card strong { color: #e8c878; }
+
+/* Section grid → 3 moonlit columns (Movement / Intervention / World Ops / Presence). */
+.admin-dialog-skinned .admin-section-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(clamp(160px, 22%, 280px), 1fr));
+  gap: clamp(8px, 1.2vw, 18px);
+}
+.admin-dialog-skinned .admin-action-section {
+  border: 1px solid rgb(150 170 230 / 30%);
+  border-radius: 12px;
+  background: rgb(14 20 46 / 55%);
+  padding: clamp(6px, 1vh, 12px);
+}
+.admin-dialog-skinned .admin-section-title {
+  margin: 0 0 clamp(4px, 0.8vh, 9px);
+  text-align: center;
+  font-family: var(--font-display);
+  font-size: clamp(0.7rem, 1.4vw, 1.05rem);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #c9b06a;
+}
+.admin-dialog-skinned .admin-action-grid {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(4px, 0.7vh, 8px);
+}
+.admin-dialog-skinned .admin-action-tile {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: clamp(5px, 0.9vh, 10px) clamp(7px, 1vw, 13px);
+  border: 1px solid rgb(150 170 230 / 30%);
+  border-radius: 9px;
+  background: linear-gradient(160deg, rgb(34 28 66 / 75%), rgb(18 16 40 / 80%));
+  color: #dce4fa;
+  font-family: var(--font-display);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 140ms var(--ease-out-soft), box-shadow 140ms var(--ease-out-soft);
+}
+.admin-dialog-skinned .admin-action-tile:hover { border-color: rgb(180 160 240 / 55%); }
+.admin-dialog-skinned .admin-action-tile-active {
+  border-color: rgb(200 175 90 / 75%);
+  box-shadow: 0 0 12px rgb(200 175 90 / 35%), inset 0 0 8px rgb(200 175 90 / 12%);
+}
+.admin-dialog-skinned .admin-action-tile-danger { border-color: rgb(210 120 130 / 40%); }
+.admin-dialog-skinned .admin-action-tile-utility { border-color: rgb(150 200 230 / 40%); }
+.admin-dialog-skinned .admin-action-label {
+  font-size: clamp(0.66rem, 1.2vw, 0.92rem);
+  font-weight: 700;
+  color: #f0e6c8;
+}
+.admin-dialog-skinned .admin-action-desc {
+  font-size: clamp(0.52rem, 0.95vw, 0.72rem);
+  color: rgb(190 200 235 / 70%);
+  line-height: 1.2;
+}
+
+/* The dynamic form below the grid. */
+.admin-dialog-skinned .admin-form {
+  margin-top: clamp(8px, 1.4vh, 16px);
+  border: 1px solid rgb(150 170 230 / 35%);
+  border-radius: 12px;
+  background: rgb(14 20 46 / 65%);
+  padding: clamp(8px, 1.4vh, 16px);
+}
+.admin-dialog-skinned .admin-form-title { color: #e8c878; }
+.admin-dialog-skinned .admin-input {
+  background: rgb(10 16 40 / 75%);
+  border-color: rgb(150 170 230 / 40%);
+  color: #e4ecff;
+}
+.admin-dialog-skinned .admin-submit {
+  background: linear-gradient(165deg, #5a4fb0, #3a2e80);
+  border-color: rgb(180 160 240 / 50%);
+  color: #f1ecff;
+}
+
+/* ── Staff pills — moved onto the canvas bottom-left, along the Recall row. ── */
+.staff-fab {
+  position: absolute;
+  top: auto;
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 14px);
+  left: calc(env(safe-area-inset-left, 0px) + 96px);
+  z-index: 12;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}


### PR DESCRIPTION
Reskins the staff admin console onto the painted `admin_bg` frame and relocates the STAFF + invis pills.

## Staff Control reskin
- The admin dialog now paints the **`admin_bg`** frame behind it (skinned variant). The painted "STAFF CONTROL" title shows through, a floated ✕ replaces the header, and the **status strip / action sections (Movement, Intervention, World Ops, Presence) / dynamic form** are restyled to the moonlit stained-glass theme over the inner panel.
- Falls back to the plain dialog when the art isn't present. **No backend/logic changes** — same staff commands, target browsers, and confirmation flows.

## Staff pills moved
- The **STAFF + invis (👁) pills** move off the old top-left floating FAB to the **canvas bottom-left, along the Recall row** (per your note that Recall sits there). GameShell gains a `canvasOverlay` slot that renders inside the canvas layer, and the pills anchor there as a horizontal row.

## Notes / heads-up for review
- **Target-player card:** per your call, this uses the data the client already has (name/level/race/class via the Who list) — full vitals/IP/login would be a backend GMCP follow-up.
- **Reskin scope:** I kept the existing tile→form interaction and skinned it onto the frame rather than rebuilding the concept's all-inline 3-column layout (that's a much larger rewrite). The content flows/scrolls over the painted inner panel.
- **Positions mapped by eye** (admin_bg not in my overlay copy yet) — the content insets and the **pills' offset from the Pixi-drawn Recall button** will likely need a nudge once you see it on the demo. The Recall button is canvas-drawn (Pixi), so the DOM pills use a fixed offset; if you want them perfectly inline I can render them as canvas buttons instead.

Verified: web `lint` + `build`, backend `compileKotlin` + `ktlintCheck` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)