### PR TITLE
fix(web): panel alignment polish + Staff Control redesign

### DIFF
--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -452,6 +452,8 @@ function App() {
     canvasCallbacks.openDice = () => openPanel("dice");
     canvasCallbacks.openHousing = () => openPanel("housing");
     canvasCallbacks.openInn = () => setShowInn(true);
+    canvasCallbacks.openAdminPanel = () => setShowAdminPanel(true);
+    canvasCallbacks.toggleInvis = () => { sendCommand("invis"); setStaffInvisible((v) => !v); };
     canvasCallbacks.openMail = () => openPanel("mail");
     canvasCallbacks.openMap = () => openPanel("map");
     canvasCallbacks.openRoom = () => openPanel("room");
@@ -509,6 +511,8 @@ function App() {
       canvasCallbacks.openLottery = null;
       canvasCallbacks.openHousing = null;
       canvasCallbacks.openInn = null;
+      canvasCallbacks.openAdminPanel = null;
+      canvasCallbacks.toggleInvis = null;
       canvasCallbacks.openMail = null;
       canvasCallbacks.openMap = null;
       canvasCallbacks.openRoom = null;
@@ -946,31 +950,6 @@ function App() {
         onCommand={sendCommand}
         onOpenPanel={(panel) => openPanel(panel)}
         audio={audio}
-        canvasOverlay={
-          state.character.isStaff ? (
-            <div className="staff-fab">
-              <button
-                type="button"
-                className="staff-fab-btn"
-                onClick={() => setShowAdminPanel(true)}
-                title="Open staff admin panel"
-                aria-label="Open staff admin panel"
-              >
-                Staff
-              </button>
-              <button
-                type="button"
-                className={`staff-fab-btn staff-fab-invis${staffInvisible ? " staff-fab-invis-active" : ""}`}
-                onClick={() => { sendCommand("invis"); setStaffInvisible((v) => !v); }}
-                title={staffInvisible ? "You are invisible — click to reappear" : "Become invisible"}
-                aria-label="Toggle staff invisibility"
-                aria-pressed={staffInvisible}
-              >
-                {staffInvisible ? "👁‍🗨" : "👁"}
-              </button>
-            </div>
-          ) : null
-        }
       />
 
       <Drawer

--- a/web-v3/src/canvas/GameStateBridge.ts
+++ b/web-v3/src/canvas/GameStateBridge.ts
@@ -101,8 +101,14 @@ export const canvasCallbacks: {
   openPlayerCard: ((player: RoomPlayer) => void) | null;
   /** Open the parchment item card for a clicked room item. */
   openItemManual: ((entry: ItemEntry) => void) | null;
+  /** Staff: open the admin console (the canvas STAFF button). */
+  openAdminPanel: (() => void) | null;
+  /** Staff: toggle invisibility (the canvas eye button). */
+  toggleInvis: (() => void) | null;
 } = {
   sendCommand: null,
+  openAdminPanel: null,
+  toggleInvis: null,
   prefillCommand: null,
   openPlayerCard: null,
   openShop: null,

--- a/web-v3/src/canvas/scenes/WorldScene.ts
+++ b/web-v3/src/canvas/scenes/WorldScene.ts
@@ -167,6 +167,13 @@ export class WorldScene {
   private recallBtn: Container;
   private lastLoggedIn = false;
 
+  // Staff buttons (visible when the logged-in player is staff) — drawn next to
+  // Recall so they always line up with it regardless of canvas size.
+  private staffBtn: Container;
+  private invisBtn: Container;
+  private invisActive = false;
+  private lastStaff = false;
+
   // Depart button (visible at the death sanctum when there's a place to return to)
   private departBtn: Container;
   private lastCanDepart = false;
@@ -841,6 +848,18 @@ export class WorldScene {
     });
     this.departBtn.visible = false;
 
+    // Staff buttons — STAFF opens the admin console; the eye toggles invisibility.
+    this.staffBtn = this.buildActionButton("STAFF", 0xe6c878, 0x4a3a12, () => {
+      canvasCallbacks.openAdminPanel?.();
+    });
+    this.staffBtn.visible = false;
+    this.invisBtn = this.buildActionButton("\u{1F441}", 0xe6c878, 0x3a2e50, () => {
+      this.invisActive = !this.invisActive;
+      this.invisBtn.alpha = this.invisActive ? 0.6 : 1;
+      canvasCallbacks.toggleInvis?.();
+    });
+    this.invisBtn.visible = false;
+
     this.container.addChildAt(this.skyRenderer.graphics, 0);
     this.container.addChild(this.ambientMotes.graphics);
     this.container.addChild(this.roleGraphics);
@@ -869,6 +888,8 @@ export class WorldScene {
     this.container.addChild(this.signBadge!);
     this.container.addChild(this.recallBtn);
     this.container.addChild(this.departBtn);
+    this.container.addChild(this.staffBtn);
+    this.container.addChild(this.invisBtn);
     // Weather lives in the overlay so it stays visible during room-transition
     // fades (container.alpha → 0) and reliably renders above room art/sky.
     this.overlayContainer.addChild(this.weatherParticles.graphics);
@@ -1196,6 +1217,14 @@ export class WorldScene {
       this.recallBtn.visible = showRecall;
     }
 
+    // Staff buttons — visible whenever a staff player is logged in.
+    const showStaff = loggedIn && state.character.isStaff;
+    if (showStaff !== this.lastStaff) {
+      this.lastStaff = showStaff;
+      this.staffBtn.visible = showStaff;
+      this.invisBtn.visible = showStaff;
+    }
+
     // Hide the minimap until logged in — otherwise its parchment flashes on the
     // pre-login screen (the minimap is drawn in-scene, not a gated DOM overlay).
     this.minimap.container.visible = loggedIn;
@@ -1272,6 +1301,8 @@ export class WorldScene {
     if (this.signBadge) this.signBadge.visible = this.signVisible && !stripMode;
     this.recallBtn.visible = this.recallBtn.visible && !stripMode;
     this.departBtn.visible = this.departBtn.visible && !stripMode;
+    this.staffBtn.visible = this.staffBtn.visible && !stripMode;
+    this.invisBtn.visible = this.invisBtn.visible && !stripMode;
 
     // Dynamic entity sizing
     const scale = Math.min(w / REF_WIDTH, h / REF_HEIGHT);
@@ -1676,6 +1707,17 @@ export class WorldScene {
       // Offset to the right of Recall (button width 80 + 8px gap), or take Recall's slot if hidden
       this.departBtn.x = this.recallBtn.visible ? 16 + 40 + 88 : 16 + 40;
       this.departBtn.y = h - 24;
+    }
+
+    // Staff + invis buttons — line up after Recall/Depart on the same row.
+    if (this.staffBtn.visible) {
+      let slot = 0;
+      if (this.recallBtn.visible) slot++;
+      if (this.departBtn.visible) slot++;
+      this.staffBtn.x = 16 + 40 + slot * 88;
+      this.staffBtn.y = h - 24;
+      this.invisBtn.x = this.staffBtn.x + 88;
+      this.invisBtn.y = h - 24;
     }
 
     // Video button: bottom-center

--- a/web-v3/src/components/panels/AdminPanel.tsx
+++ b/web-v3/src/components/panels/AdminPanel.tsx
@@ -516,6 +516,7 @@ export function AdminPanel({
             </p>
           )}
 
+          <div className="admin-workspace">
           <div className="admin-section-grid">
             {ADMIN_ACTION_SECTIONS.map((section) => {
               const sectionActions = ADMIN_ACTIONS.filter((entry) => entry.section === section.id);
@@ -541,7 +542,8 @@ export function AdminPanel({
             })}
           </div>
 
-          {activeAction && activeDefinition && (
+          <div className="admin-form-pane">
+          {activeAction && activeDefinition ? (
             <form className="admin-form" onSubmit={submit}>
               <h3 className="admin-form-title">{activeDefinition.label}</h3>
 
@@ -1169,7 +1171,11 @@ export function AdminPanel({
                 </button>
               </div>
             </form>
+          ) : (
+            <p className="admin-form-hint">Select an action from the left to configure and run it.</p>
           )}
+          </div>
+          </div>
         </div>
       </section>
     </div>

--- a/web-v3/src/components/panels/AuctionPanel.tsx
+++ b/web-v3/src/components/panels/AuctionPanel.tsx
@@ -210,7 +210,6 @@ export function AuctionPanel({ listings, inventory, playerName, isDemo, feedback
 
       {/* ───────── List action (below selected) ───────── */}
       <div className="ah-list-action">
-        <label className="ah-price-label" htmlFor="ah-price">Set Price</label>
         <div className="ah-price-row">
           <input
             id="ah-price"

--- a/web-v3/src/components/panels/CharacterPanel.tsx
+++ b/web-v3/src/components/panels/CharacterPanel.tsx
@@ -435,6 +435,14 @@ export function CharacterPanel({
         </button>
         <button
           type="button"
+          className={`cc-plaque-btn${profBtn ? " has-art" : ""}`}
+          style={profBtn ? { ["--cc-plaque" as string]: `url("${profBtn}")` } : undefined}
+          onClick={onOpenProfessions}
+        >
+          <span className="cc-plaque-label">Professions</span>
+        </button>
+        <button
+          type="button"
           className={`cc-gem-btn cc-gem-green${achBtn ? " has-art" : ""}`}
           style={achBtn ? { ["--cc-btn" as string]: `url("${achBtn}")` } : undefined}
           onClick={() => setShowAchievements(true)}
@@ -442,14 +450,6 @@ export function CharacterPanel({
           <span className="cc-gem-label">Achievements</span>
         </button>
       </div>
-      <button
-        type="button"
-        className={`cc-plaque-btn${profBtn ? " has-art" : ""}`}
-        style={profBtn ? { ["--cc-plaque" as string]: `url("${profBtn}")` } : undefined}
-        onClick={onOpenProfessions}
-      >
-        <span className="cc-plaque-label">Professions</span>
-      </button>
 
       {/* ── Describe pop-out ──────────────────────────────── */}
       {showScribe && (

--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -533,11 +533,26 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     const item = result.itemName ? ` ${result.itemName}${result.quantity && result.quantity > 1 ? ` x${result.quantity}` : ""}` : "";
     const xp = result.xpAwarded > 0 ? ` (+${result.xpAwarded} ${result.skill} XP)` : "";
     const levelUp = result.leveledUp ? ` \u2014 Level up! ${result.skill} \u2192 Lv ${result.newLevel}` : "";
+    const text = `${verb}${item}${xp}${levelUp}`;
     pushCombatLogMessage({
       id: ++combatLogIdCounter,
-      text: `${verb}${item}${xp}${levelUp}`,
+      text,
       style: result.leveledUp ? "xp" : "heal",
       receivedAt: Date.now(),
+    });
+    // Also surface it as crafting-scoped feedback so the Crafting panel confirms
+    // in-place that the item was actually made (appended directly to avoid a
+    // duplicate combat-log line from pushUiFeedback).
+    setUiFeedbackFeed((prev) => {
+      const entry: UiFeedbackEntry = {
+        type: "success",
+        message: text,
+        scope: "crafting",
+        id: `ui-feedback-${Date.now()}-${++systemActivityIdCounter}`,
+        receivedAt: Date.now(),
+      };
+      const next = [...prev, entry];
+      return next.length > MAX_UI_FEEDBACK_FEED ? next.slice(-MAX_UI_FEEDBACK_FEED) : next;
     });
   }, [pushCombatLogMessage]);
 

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -25348,9 +25348,9 @@ html:has(.game-shell),
 /* ───────── Your inventory (mid) ───────── */
 .ah-inventory {
   position: absolute;
-  left: 44.5%;
+  left: 45.8%;
   top: 30%;
-  width: 17.5%;
+  width: 16.8%;
   height: 31.5%;
   padding: 0.6% 0.6% 0.6% 1%;
 }
@@ -25390,11 +25390,11 @@ html:has(.game-shell),
 /* ───────── Selected item (right) ───────── */
 .ah-selected {
   position: absolute;
-  left: 63%;
+  left: 64.5%;
   top: 30%;
-  width: 33.8%;
+  width: 32%;
   height: 24%;
-  padding: 0.8% 1.4%;
+  padding: 0.8% 2%;
   overflow-y: auto;
 }
 .ah-detail { display: flex; gap: clamp(8px, 1.2vw, 18px); height: 100%; }
@@ -25442,21 +25442,14 @@ html:has(.game-shell),
 /* ───────── List action (below selected) ───────── */
 .ah-list-action {
   position: absolute;
-  left: 63%;
+  left: 64.5%;
   top: 56%;
-  width: 33.8%;
+  width: 32%;
   height: 6.5%;
   display: flex;
   align-items: center;
   gap: clamp(6px, 1vw, 14px);
-  padding: 0 1.4%;
-}
-.ah-price-label {
-  font-size: clamp(0.52rem, 1vw, 0.72rem);
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: rgb(170 188 235 / 80%);
-  white-space: nowrap;
+  padding: 0 2%;
 }
 .ah-price-row { display: flex; gap: clamp(5px, 0.8vw, 11px); flex: 1; }
 .ah-price-input {
@@ -25581,9 +25574,9 @@ html:has(.game-shell),
 .cr-recipes {
   position: absolute;
   left: 12.5%;
-  top: 18%;
+  top: 21%;
   width: 28%;
-  height: 70%;
+  height: 66%;
   display: flex;
   flex-direction: column;
   gap: clamp(4px, 0.9vh, 10px);
@@ -25673,9 +25666,9 @@ html:has(.game-shell),
 .cr-detail {
   position: absolute;
   left: 44.5%;
-  top: 19%;
+  top: 21%;
   width: 47%;
-  height: 56%;
+  height: 54%;
   display: flex;
   flex-direction: column;
   gap: clamp(6px, 1.4vh, 16px);
@@ -25758,10 +25751,10 @@ html:has(.game-shell),
 /* Hotspot over the painted CRAFT button. */
 .cr-craft-hotspot {
   position: absolute;
-  left: 49%;
-  top: 78%;
-  width: 30%;
-  height: 9%;
+  left: 51%;
+  top: 73.5%;
+  width: 31%;
+  height: 9.5%;
   border: none;
   border-radius: 12px;
   background: transparent;
@@ -25769,8 +25762,9 @@ html:has(.game-shell),
   transition: box-shadow 150ms var(--ease-out-soft), background 150ms var(--ease-out-soft);
 }
 .cr-craft-hotspot:hover { box-shadow: 0 0 22px rgb(240 150 50 / 55%); background: rgb(240 150 50 / 10%); }
-.cr-craft-disabled { cursor: not-allowed; background: rgb(10 8 6 / 45%); }
-.cr-craft-disabled:hover { box-shadow: none; }
+/* Missing level/ingredients — clearly dim the painted CRAFT button. */
+.cr-craft-disabled { cursor: not-allowed; background: rgb(8 5 3 / 62%); }
+.cr-craft-disabled:hover { box-shadow: none; background: rgb(8 5 3 / 62%); }
 
 /* ============================================================
    Professions — painted `professions_bg` book. One row per
@@ -25812,7 +25806,7 @@ html:has(.game-shell),
   position: absolute;
   left: 14%;
   top: 20%;
-  width: 77%;
+  width: 73%;
   height: 71%;
   display: flex;
   flex-direction: column;
@@ -25908,11 +25902,10 @@ html:has(.game-shell),
 
 /* ── Character popout: Professions plaque button ── */
 .cc-plaque-btn {
+  flex: 1.7;
   display: grid;
   place-items: center;
-  width: 100%;
-  min-height: clamp(40px, 7vh, 62px);
-  margin-top: var(--space-2, 8px);
+  min-height: 56px;
   border: none;
   border-radius: 12px;
   background: linear-gradient(165deg, #6a4a22, #3e2a12);

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -25983,11 +25983,12 @@ html:has(.game-shell),
 /* Live content sits in the painted inner panel (below the title strip). */
 .admin-dialog-skinned .admin-content {
   position: absolute;
-  inset: 16% 3.5% 6% 3.5%;
-  overflow-y: auto;
-  padding: 0 1% 1%;
-  scrollbar-width: thin;
-  scrollbar-color: rgb(150 170 230 / 45%) transparent;
+  inset: 17% 4% 11% 4%;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(5px, 1vh, 12px);
+  overflow: hidden;
+  padding: 0 1%;
   color: #d6def4;
 }
 .admin-dialog-skinned .admin-content::-webkit-scrollbar { width: 8px; }
@@ -26014,11 +26015,45 @@ html:has(.game-shell),
 }
 .admin-dialog-skinned .admin-status-card strong { color: #e8c878; }
 
-/* Section grid → 3 moonlit columns (Movement / Intervention / World Ops / Presence). */
-.admin-dialog-skinned .admin-section-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(clamp(160px, 22%, 280px), 1fr));
+/* Workspace — action menu (left) + the selected action's form (right). Each
+   pane scrolls within the painted content panel so nothing spills past it. */
+.admin-dialog-skinned .admin-workspace {
+  flex: 1;
+  min-height: 0;
+  display: flex;
   gap: clamp(8px, 1.2vw, 18px);
+}
+.admin-dialog-skinned .admin-form-pane {
+  flex: 1;
+  min-width: 0;
+  overflow-y: auto;
+  border-left: 1px solid rgb(150 170 230 / 22%);
+  padding-left: clamp(8px, 1.2vw, 16px);
+  scrollbar-width: thin;
+  scrollbar-color: rgb(150 170 230 / 45%) transparent;
+}
+.admin-dialog-skinned .admin-form-hint {
+  margin: 20% auto 0;
+  max-width: 80%;
+  text-align: center;
+  font-style: italic;
+  color: rgb(190 200 235 / 60%);
+  font-size: clamp(0.66rem, 1.2vw, 0.92rem);
+}
+.admin-dialog-skinned .admin-form { margin-top: 0; border: none; background: none; padding: 0; }
+
+/* Section grid → 4 moonlit columns (Movement / Intervention / World Ops / Presence). */
+.admin-dialog-skinned .admin-section-grid {
+  flex: 1.6;
+  min-width: 0;
+  overflow-y: auto;
+  align-content: start;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(6px, 0.9vw, 14px);
+  padding-right: 4px;
+  scrollbar-width: thin;
+  scrollbar-color: rgb(150 170 230 / 45%) transparent;
 }
 .admin-dialog-skinned .admin-action-section {
   border: 1px solid rgb(150 170 230 / 30%);
@@ -26097,10 +26132,21 @@ html:has(.game-shell),
 .staff-fab {
   position: absolute;
   top: auto;
-  bottom: calc(env(safe-area-inset-bottom, 0px) + 14px);
-  left: calc(env(safe-area-inset-left, 0px) + 96px);
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 16px);
+  left: calc(env(safe-area-inset-left, 0px) + 104px);
   z-index: 12;
   flex-direction: row;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
+}
+/* Match the Recall button's height/baseline so the three read as one row. */
+.staff-fab .staff-fab-btn {
+  display: flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 0 14px;
+}
+.staff-fab .staff-fab-invis {
+  padding: 0 11px;
+  font-size: 1rem;
 }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -26042,53 +26042,64 @@ html:has(.game-shell),
 }
 .admin-dialog-skinned .admin-form { margin-top: 0; border: none; background: none; padding: 0; }
 
-/* Section grid → 4 moonlit columns (Movement / Intervention / World Ops / Presence). */
+/* Action menu — a compact single-column nav grouped by section (master), with
+   all four groups visible/scrollable; the form (detail) sits in the wider pane. */
 .admin-dialog-skinned .admin-section-grid {
-  flex: 1.6;
+  flex: 0 0 32%;
   min-width: 0;
   overflow-y: auto;
-  align-content: start;
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: clamp(6px, 0.9vw, 14px);
-  padding-right: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(8px, 1.3vh, 16px);
+  padding-right: 5px;
   scrollbar-width: thin;
   scrollbar-color: rgb(150 170 230 / 45%) transparent;
 }
+.admin-dialog-skinned .admin-section-grid::-webkit-scrollbar { width: 7px; }
+.admin-dialog-skinned .admin-section-grid::-webkit-scrollbar-thumb { background: rgb(150 170 230 / 40%); border-radius: 4px; }
 .admin-dialog-skinned .admin-action-section {
-  border: 1px solid rgb(150 170 230 / 30%);
-  border-radius: 12px;
-  background: rgb(14 20 46 / 55%);
-  padding: clamp(6px, 1vh, 12px);
+  border: none;
+  padding: 0;
+  background: none;
 }
 .admin-dialog-skinned .admin-section-title {
-  margin: 0 0 clamp(4px, 0.8vh, 9px);
-  text-align: center;
+  margin: 0 0 clamp(3px, 0.6vh, 7px);
+  padding-left: 2px;
+  text-align: left;
   font-family: var(--font-display);
-  font-size: clamp(0.7rem, 1.4vw, 1.05rem);
+  font-size: clamp(0.58rem, 1.1vw, 0.82rem);
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   color: #c9b06a;
 }
 .admin-dialog-skinned .admin-action-grid {
   display: flex;
   flex-direction: column;
-  gap: clamp(4px, 0.7vh, 8px);
+  gap: clamp(2px, 0.4vh, 5px);
 }
 .admin-dialog-skinned .admin-action-tile {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
-  padding: clamp(5px, 0.9vh, 10px) clamp(7px, 1vw, 13px);
-  border: 1px solid rgb(150 170 230 / 30%);
-  border-radius: 9px;
-  background: linear-gradient(160deg, rgb(34 28 66 / 75%), rgb(18 16 40 / 80%));
+  align-items: baseline;
+  gap: 0.5em;
+  padding: clamp(4px, 0.7vh, 8px) clamp(7px, 1vw, 12px);
+  border: 1px solid rgb(150 170 230 / 22%);
+  border-radius: 8px;
+  background: rgb(22 28 58 / 60%);
   color: #dce4fa;
   font-family: var(--font-display);
   text-align: left;
   cursor: pointer;
-  transition: border-color 140ms var(--ease-out-soft), box-shadow 140ms var(--ease-out-soft);
+  transition: border-color 140ms var(--ease-out-soft), background 140ms var(--ease-out-soft), box-shadow 140ms var(--ease-out-soft);
+}
+.admin-dialog-skinned .admin-action-tile:hover { background: rgb(40 50 96 / 70%); }
+.admin-dialog-skinned .admin-action-tile .admin-action-label { flex: 0 0 auto; font-size: clamp(0.66rem, 1.2vw, 0.9rem); }
+.admin-dialog-skinned .admin-action-tile .admin-action-desc {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: clamp(0.5rem, 0.92vw, 0.68rem);
 }
 .admin-dialog-skinned .admin-action-tile:hover { border-color: rgb(180 160 240 / 55%); }
 .admin-dialog-skinned .admin-action-tile-active {


### PR DESCRIPTION
Follow-up polish on the recently-merged panels, from screenshot review.

## Character popout
- **Professions button** now sits **between** Prestige and Achievements (inline, sized to the plaque art) instead of squished below the row.

## Professions book
- Trimmed the row width so entries stay **inside the painted border**.

## Crafting
- Recipe list + filters nudged **down**; the **CRAFT hotspot** moved **up and right** onto the painted button.
- The CRAFT button now **dims clearly** when you lack the level or ingredients.
- Crafting a recipe now emits **crafting-scoped feedback**, so the panel confirms in-place that the item was actually made (previously the result only went to the combat log).

## Auction House
- Shifted the **Selected Item** and **inventory** columns right; dropped the redundant **"Set Price"** label so the list controls line up.

## Staff Control + pills
- **STAFF + invis pills** now match the Recall button's height/baseline and read as one clean row alongside Recall.
- **Staff Control redesigned** into a contained **2-pane workspace**: the action menu (Movement / Intervention / World Ops / Presence) scrolls on the left, the selected action's form on the right — both clipped to the painted panel so the columns no longer **spill into the footer**. An empty form pane shows a hint until an action is selected.

Verified: web `lint` + `build` green (no backend changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)