### PR TITLE
fix(bounty): cap kill count to placement count for unique mobs

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/AutoQuestSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/AutoQuestSystem.kt
@@ -66,6 +66,10 @@ class AutoQuestSystem(
             ?: return Result.failure(AutoQuestError("Player not found."))
 
         val playerZone = player.roomId.zone
+        // How many placements each template has in the world. Used to cap the
+        // requested kill count so we never ask players to kill a unique mob
+        // (a single placement) more times than it can ever appear. See #1097.
+        val spawnCounts = world.mobSpawns.groupingBy { it.templateId }.eachCount()
         val candidates = world.mobSpawns
             .asSequence()
             .filter { idZone(it.id.value) == playerZone }
@@ -79,7 +83,9 @@ class AutoQuestSystem(
         }
 
         val mob = candidates[random.nextInt(candidates.size)]
+        val spawnCount = spawnCounts[mob.id] ?: 1
         val killCount = random.nextInt(config.killCountMin, config.killCountMax + 1)
+            .coerceAtMost(spawnCount.coerceAtLeast(1))
         val rewardGold = config.rewardGoldBase + config.rewardGoldPerLevel * player.level
         val rewardXp = config.rewardXpBase + config.rewardXpPerLevel * player.level
 

--- a/src/test/kotlin/dev/ambon/engine/AutoQuestSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/AutoQuestSystemTest.kt
@@ -39,11 +39,16 @@ class AutoQuestSystemTest {
         xpReward = 30L,
     )
 
-    private val testMobSpawn = MobSpawn(
-        id = MobId(mobTemplateId),
-        templateId = MobId(mobTemplateId),
-        roomId = testRoomId,
-    )
+    // A common mob with several placements, so kill-count capping (#1097) does
+    // not constrain quests built from it.
+    private val testMobSpawns = (0 until 8).map { i ->
+        MobSpawn(
+            id = MobId("$mobTemplateId#$i"),
+            templateId = MobId(mobTemplateId),
+            roomId = testRoomId,
+            instanceIndex = i,
+        )
+    }
 
     private val defaultConfig = AutoQuestsConfig(
         enabled = true,
@@ -66,7 +71,7 @@ class AutoQuestSystemTest {
             rooms = mapOf(testRoomId to Room(testRoomId, "Town Square", "A busy square.", emptyMap())),
             startRoom = testRoomId,
             mobTemplates = mapOf(testMobTemplate.id to testMobTemplate),
-            mobSpawns = listOf(testMobSpawn),
+            mobSpawns = testMobSpawns,
         )
         val system = AutoQuestSystem(
             config = config,
@@ -345,6 +350,72 @@ class AutoQuestSystemTest {
         val result = system.requestQuest(sid)
         assertTrue(result.isFailure)
         assertTrue(result.exceptionOrNull()?.message?.contains("No suitable targets") == true)
+    }
+
+    @Test
+    fun `killsRequired is capped to spawn count for unique mobs`() = runTest {
+        // A unique mob has a single placement, so a bounty must never ask for
+        // more than 1 kill regardless of the configured kill-count range. See #1097.
+        val c = SystemTestComponents(roomId = testRoomId, clockInitialMs = 1_000L)
+        val uniqueId = MobId("$testZone:el_steckley")
+        val uniqueTemplate = MobTemplateDef(
+            id = uniqueId,
+            name = "El Steckley",
+            maxHp = 200,
+            damage = DamageRange(5, 10),
+            xpReward = 500L,
+        )
+        val uniqueSpawn = MobSpawn(uniqueId, uniqueId, testRoomId)
+        val world = World(
+            rooms = mapOf(testRoomId to Room(testRoomId, "Town Square", "A busy square.", emptyMap())),
+            startRoom = testRoomId,
+            mobTemplates = mapOf(uniqueId to uniqueTemplate),
+            mobSpawns = listOf(uniqueSpawn),
+        )
+        val system = AutoQuestSystem(
+            config = defaultConfig.copy(killCountMin = 8, killCountMax = 8),
+            world = world,
+            players = c.players,
+            clock = c.clock,
+            random = Random(42),
+        )
+        c.players.loginOrFail(sid, "Hero")
+
+        val result = system.requestQuest(sid)
+        assertTrue(result.isSuccess)
+        assertEquals(1, result.getOrThrow().killsRequired)
+    }
+
+    @Test
+    fun `killsRequired is capped to spawn count for limited mobs`() = runTest {
+        // A mob with two placements should never demand more than two kills.
+        val c = SystemTestComponents(roomId = testRoomId, clockInitialMs = 1_000L)
+        val secondRoomId = RoomId("$testZone:alley")
+        val twoSpawns = listOf(
+            MobSpawn(MobId(mobTemplateId), MobId(mobTemplateId), testRoomId, instanceIndex = 0),
+            MobSpawn(MobId(mobTemplateId), MobId(mobTemplateId), secondRoomId, instanceIndex = 1),
+        )
+        val world = World(
+            rooms = mapOf(
+                testRoomId to Room(testRoomId, "Town Square", "A busy square.", emptyMap()),
+                secondRoomId to Room(secondRoomId, "Alley", "A dark alley.", emptyMap()),
+            ),
+            startRoom = testRoomId,
+            mobTemplates = mapOf(testMobTemplate.id to testMobTemplate),
+            mobSpawns = twoSpawns,
+        )
+        val system = AutoQuestSystem(
+            config = defaultConfig.copy(killCountMin = 8, killCountMax = 8),
+            world = world,
+            players = c.players,
+            clock = c.clock,
+            random = Random(42),
+        )
+        c.players.loginOrFail(sid, "Hero")
+
+        val result = system.requestQuest(sid)
+        assertTrue(result.isSuccess)
+        assertEquals(2, result.getOrThrow().killsRequired)
     }
 
     @Test


### PR DESCRIPTION
## Summary
Fixes #1097 — the bounty generator could ask players to kill a unique mob (a mob with a single world placement, e.g. *El Steckley*) up to `killCountMax` times, making the bounty effectively uncompletable.

## Change
`AutoQuestSystem.requestQuest` now counts each template's placements in `world.mobSpawns` and caps `killsRequired` at that count. A unique mob (one placement) therefore asks for exactly 1 kill, while common mobs are unaffected.

## Tests
- Added `killsRequired is capped to spawn count for unique mobs` (1 placement → 1 kill, even with killCountMin/Max = 8).
- Added `killsRequired is capped to spawn count for limited mobs` (2 placements → 2 kills).
- Updated the shared test fixture to give the goblin multiple placements, reflecting that common mobs aren't unique.

`./gradlew ktlintCheck test --tests "*AutoQuestSystemTest"` passes.