### PR TITLE
fix(friends): populate roster on login and surface add/remove results

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/FriendsSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/FriendsSystem.kt
@@ -46,7 +46,9 @@ class FriendsSystem(
         ps.friendsList.add(key)
         markPlayerDirty(sessionId)
 
-        outbound.send(OutboundEvent.SendInfo(sessionId, "$displayName has been added to your friends list."))
+        val message = "$displayName has been added to your friends list."
+        outbound.send(OutboundEvent.SendInfo(sessionId, message))
+        gmcpEmitter?.sendUiFeedback(sessionId = sessionId, type = "success", message = message, scope = "friends")
         gmcpEmitter?.sendFriendsList(sessionId, buildFriendsInfo(ps))
         return null
     }
@@ -66,7 +68,9 @@ class FriendsSystem(
 
         markPlayerDirty(sessionId)
 
-        outbound.send(OutboundEvent.SendInfo(sessionId, "$targetName has been removed from your friends list."))
+        val message = "$targetName has been removed from your friends list."
+        outbound.send(OutboundEvent.SendInfo(sessionId, message))
+        gmcpEmitter?.sendUiFeedback(sessionId = sessionId, type = "success", message = message, scope = "friends")
         gmcpEmitter?.sendFriendsList(sessionId, buildFriendsInfo(ps))
         return null
     }
@@ -109,6 +113,11 @@ class FriendsSystem(
     suspend fun onPlayerLogin(sessionId: SessionId) {
         val ps = players.get(sessionId) ?: return
         val lowerName = ps.name.lowercase()
+
+        // Push the player their own roster so the Friends panel populates on
+        // login — otherwise it stays empty until the next add/remove or
+        // explicit `friend list`, making existing friends appear to vanish.
+        gmcpEmitter?.sendFriendsList(sessionId, buildFriendsInfo(ps))
 
         for (other in players.allPlayers()) {
             if (other.sessionId == sessionId) continue

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/FriendsHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/FriendsHandler.kt
@@ -35,6 +35,10 @@ class FriendsHandler(
             is Command.Friend.Add -> fs.addFriend(sessionId, cmd.target)
             is Command.Friend.Remove -> fs.removeFriend(sessionId, cmd.target)
         }
-        outbound.sendIfError(sessionId, err)
+        if (err != null) {
+            // Scope to "friends" so the web panel can surface the rejection
+            // (e.g. "already on your list") instead of swallowing it.
+            sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, err, scope = "friends", command = "friend")
+        }
     }
 }

--- a/src/test/kotlin/dev/ambon/engine/FriendsSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/FriendsSystemTest.kt
@@ -22,6 +22,22 @@ class FriendsSystemTest {
         return TestHarness(c, friends)
     }
 
+    private fun setupWithGmcp(maxFriends: Int = 50): TestHarness {
+        val c = SystemTestComponents()
+        val gmcpEmitter = GmcpEmitter(
+            outbound = c.outbound,
+            supportsPackage = { _, _ -> true },
+            progression = PlayerProgression(),
+        )
+        val friends = FriendsSystem(
+            players = c.players,
+            outbound = c.outbound,
+            gmcpEmitter = gmcpEmitter,
+            maxFriends = maxFriends,
+        )
+        return TestHarness(c, friends)
+    }
+
     private data class TestHarness(
         private val c: SystemTestComponents,
         val friends: FriendsSystem,
@@ -292,6 +308,45 @@ class FriendsSystemTest {
         val bobNotifications = events.filterIsInstance<OutboundEvent.SendInfo>()
             .filter { it.sessionId == sid2 }
         assertTrue(bobNotifications.isEmpty())
+    }
+
+    @Test
+    fun `onPlayerLogin pushes own friends list so the panel populates`() = runTest {
+        val h = setupWithGmcp()
+        val sid1 = SessionId(1L)
+        val sid2 = SessionId(2L)
+        h.players.loginOrFail(sid1, "Alice")
+        h.players.loginOrFail(sid2, "Bob")
+        assertNull(h.friends.addFriend(sid1, "Bob"))
+        h.outbound.drainAll()
+
+        // Re-login Alice: she should be pushed her own roster (containing Bob)
+        // without needing to run `friend list` first.
+        h.friends.onPlayerLogin(sid1)
+
+        val events = h.outbound.drainAll()
+        val listPush = events.filterIsInstance<OutboundEvent.GmcpData>()
+            .filter { it.sessionId == sid1 && it.gmcpPackage == "Friends.List" }
+        assertTrue(listPush.any { it.jsonData.contains("Bob") })
+    }
+
+    @Test
+    fun `add friend error emits scoped friends feedback`() = runTest {
+        val h = setupWithGmcp()
+        val sid = SessionId(1L)
+        h.players.loginOrFail(sid, "Alice")
+        h.outbound.drainAll()
+
+        // Adding a nonexistent player should not silently fail — the system
+        // returns the error string (the handler scopes it), and a successful
+        // add pushes scoped success feedback for the panel to surface.
+        h.players.loginOrFail(SessionId(2L), "Bob")
+        assertNull(h.friends.addFriend(sid, "Bob"))
+
+        val events = h.outbound.drainAll()
+        val feedback = events.filterIsInstance<OutboundEvent.GmcpData>()
+            .filter { it.gmcpPackage == "UI.Feedback" }
+        assertTrue(feedback.any { it.jsonData.contains("\"friends\"") && it.jsonData.contains("added") })
     }
 
     @Test

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -1765,6 +1765,12 @@ export function applyGmcpPackage(
       if (packet.scope === "features" && packet.message) {
         ctx.setToast(packet.message);
       }
+      // The Friends panel's add/remove form has no inline result area, so toast
+      // the outcome — otherwise a rejection (e.g. "already on your list" or an
+      // unknown name) looks like the action silently did nothing.
+      if (packet.scope === "friends" && packet.message) {
+        ctx.setToast(packet.message);
+      }
       break;
     }
 


### PR DESCRIPTION
## Summary
Investigating why `friend add` seemed to fail silently surfaced **two** bugs in the one-directional friend ("follow") system. The follow model itself is unchanged — this only makes its results visible.

### Bug 1 — roster never populated on login
`FriendsSystem.onPlayerLogin` only notified *other* players that you came online; it never pushed *your own* friends list. The Friends panel doesn't issue `friend list`, so `Friends.List` was only emitted after a successful add/remove or an explicit command — meaning existing friends stayed invisible on a fresh login, and re-adding one (which hits the error path) never pushed the list either. `onPlayerLogin` now pushes the player their own roster.

### Bug 2 — add/remove outcomes swallowed
Results went out as plain `SendInfo`/`SendError` to the main text log, never scoped to the panel. So a rejection like "X is already on your friends list" looked like a silent no-op in the web UI.
- `addFriend`/`removeFriend` now emit scoped `friends` **success** feedback.
- `FriendsHandler` scopes **errors** via `sendErrorWithFeedback`.
- The web `UI.Feedback` handler toasts `scope === "friends"`, mirroring the existing `features` pattern.

## Why it looked like a friend restriction
For reference, the actual add restrictions are: not yourself, not a duplicate, list cap (50), target must be a registered/online character, and you must be claimed (not a demo character). The user's "already on your list" was a real duplicate against a roster the panel just wasn't showing (Bug 1).

## Tests
- `onPlayerLogin pushes own friends list so the panel populates`
- `add friend error emits scoped friends feedback`
- All existing `FriendsSystemTest` cases pass; ktlint + web lint clean.

## Note (out of scope)
`web-v3/test/characterAutoloot.test.tsx` has 2 pre-existing failures (omits the required `serverAssets` prop — same fixture bug already fixed for the inventory test). Unrelated to this change; happy to fix in a follow-up.