### PR TITLE
test(web): repair stale characterAutoloot test

### DIFF
--- a/web-v3/test/characterAutoloot.test.tsx
+++ b/web-v3/test/characterAutoloot.test.tsx
@@ -32,6 +32,7 @@ const baseProps = {
     gold: 55,
   },
   statusVarLabels: DEFAULT_STATUS_VAR_LABELS,
+  serverAssets: {},
   xpValue: 20,
   xpMax: 100,
   xpText: "20 / 100",
@@ -62,10 +63,11 @@ describe("character auto-loot UI", () => {
   test("renders the auto-loot control in the off state", () => {
     const html = renderToStaticMarkup(<CharacterPanel {...baseProps} />);
 
-    expect(html).toContain("Auto-Loot");
-    expect(html).toContain("Drops stay in the room until you pick them up.");
-    expect(html).toContain('aria-pressed="false"');
-    expect(html).toContain(">Off<");
+    expect(html).toContain("Auto Loot");
+    expect(html).toContain("Mob drops go straight into your pack after a kill.");
+    // Off state: the switch is unchecked and carries no "is-on" modifier.
+    expect(html).toContain('aria-checked="false"');
+    expect(html).not.toContain("cc-ctl-toggle is-on");
   });
 
   test("renders the auto-loot control in the on state", () => {
@@ -76,9 +78,11 @@ describe("character auto-loot UI", () => {
       />,
     );
 
-    expect(html).toContain("Mob drops go straight into your pack after a kill.");
-    expect(html).toContain('aria-pressed="true"');
-    expect(html).toContain(">On<");
+    // Only auto-loot is enabled here, so the checked switch + "is-on" modifier
+    // uniquely identify the auto-loot control.
+    expect(html).toContain("Auto Loot");
+    expect(html).toContain('aria-checked="true"');
+    expect(html).toContain("cc-ctl-toggle is-on");
   });
 });
 


### PR DESCRIPTION
## Summary
Fixes 2 pre-existing failures in `web-v3/test/characterAutoloot.test.tsx` (surfaced while working on the Friends panel PR #1285).

Two stale issues:
1. **Missing required prop** — `baseProps` omitted `serverAssets`, so `CharacterPanel` crashed on `serverAssets[key]` during render. Added `serverAssets: {}` (same fixture-omission class as the earlier inventoryPanel fix).
2. **Stale markup assertions** — the auto-loot control was reskinned from an `aria-pressed` button with `>On<`/`>Off<` text and an off-state subtitle into a `role="switch"` toggle. Assertions now target the current markup: `aria-checked` + the `is-on` class modifier.

## Tests
`bun test` → 23 pass, 0 fail (was 21 pass / 2 fail). `bun run lint` clean.

No production code touched — test-only.