### PR TITLE
fix(web): seat Staff Control content in the painted frame boxes

### DIFF
--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -1905,6 +1905,7 @@ function App() {
           possessing={state.possessing}
           invisible={staffInvisible}
           feedbackFeed={state.uiFeedbackFeed}
+          serverAssets={state.serverAssets}
         />
       )}
 

--- a/web-v3/src/components/panels/AdminPanel.tsx
+++ b/web-v3/src/components/panels/AdminPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { FormEvent } from "react";
 import type { RoomMob, StaffMobZone, StaffWorldZone, UiFeedbackEntry, WhoPlayer } from "../../types";
 import {
@@ -9,7 +9,7 @@ import {
   getAdminActionDefinition,
   requiresAdminConfirmation,
 } from "./AdminPanel.logic";
-import type { AdminAction } from "./AdminPanel.logic";
+import type { AdminAction, AdminActionSection } from "./AdminPanel.logic";
 
 interface AdminPanelProps {
   onCommand: (command: string) => void;
@@ -439,6 +439,18 @@ export function AdminPanel({
     return adminFeedback[0];
   }, [adminFeedback, activeAction]);
 
+  // Auto-dismiss the feedback banner a few seconds after each new message so it
+  // doesn't stick across the panel (e.g. the "You are now visible" green bar).
+  // Track the dismissed id rather than a boolean so a fresh message reappears.
+  const [dismissedFeedbackId, setDismissedFeedbackId] = useState<string | null>(null);
+  const activeFeedbackId = activeFeedback?.id;
+  useEffect(() => {
+    if (!activeFeedbackId) return;
+    const timer = setTimeout(() => setDismissedFeedbackId(activeFeedbackId), 4000);
+    return () => clearTimeout(timer);
+  }, [activeFeedbackId]);
+  const feedbackVisible = activeFeedback != null && activeFeedback.id !== dismissedFeedbackId;
+
   const activeDefinition = activeAction ? getAdminActionDefinition(activeAction) : null;
   const pendingCommand = activeAction ? buildAdminCommand(activeAction, inputA, inputB) : null;
   const pendingConfirmKey =
@@ -472,6 +484,43 @@ export function AdminPanel({
     event.preventDefault();
     if (!activeAction || !pendingCommand) return;
     executeAction(activeAction, pendingCommand);
+  };
+
+  const closeForm = () => {
+    setActiveAction(null);
+    resetForm();
+  };
+
+  // One category block: a centered title over its grid of plaque buttons.
+  const renderSection = (section: AdminActionSection) => {
+    const sectionActions = ADMIN_ACTIONS.filter((entry) => entry.section === section.id)
+      .filter((entry) => {
+        // Possession is binary — show only the relevant verb (Possess when free,
+        // Return when in a mob). Also evens out the grid.
+        if (entry.id === "possess") return possessing == null;
+        if (entry.id === "return") return possessing != null;
+        return true;
+      });
+    if (sectionActions.length === 0) return null;
+    return (
+      <section key={section.id} className="admin-action-section">
+        <h3 className="admin-section-title">{section.title}</h3>
+        <div className="admin-action-grid">
+          {sectionActions.map((action) => (
+            <button
+              key={action.id}
+              type="button"
+              className={`admin-action-tile ${activeAction === action.id ? "admin-action-tile-active" : ""} admin-action-tile-${action.tone}`}
+              onClick={() => selectAction(action.id)}
+              aria-pressed={activeAction === action.id}
+            >
+              <span className="admin-action-label">{action.label}</span>
+              <span className="admin-action-desc">{action.description}</span>
+            </button>
+          ))}
+        </div>
+      </section>
+    );
   };
 
   // Painted-frame CSS variables. The command tiles fall back to a gilded-glass
@@ -532,47 +581,28 @@ export function AdminPanel({
           </div>
 
           <div className="admin-main-pane">
-          {activeFeedback && (
+          {activeFeedback && feedbackVisible && (
             <p className={`admin-feedback-banner admin-feedback-banner-${activeFeedback.type}`}>
               {activeFeedback.message}
             </p>
           )}
 
-          <div className="admin-workspace">
-          <div className="admin-section-grid">
-            {ADMIN_ACTION_SECTIONS.map((section) => {
-              const sectionActions = ADMIN_ACTIONS.filter((entry) => entry.section === section.id)
-                .filter((entry) => {
-                  // Possession is binary — show only the relevant verb (Possess
-                  // when free, Return when in a mob). Also evens out the grid.
-                  if (entry.id === "possess") return possessing == null;
-                  if (entry.id === "return") return possessing != null;
-                  return true;
-                });
-              return (
-                <section key={section.id} className="admin-action-section">
-                  <h3 className="admin-section-title">{section.title}</h3>
-                  <div className="admin-action-grid">
-                    {sectionActions.map((action) => (
-                      <button
-                        key={action.id}
-                        type="button"
-                        className={`admin-action-tile ${activeAction === action.id ? "admin-action-tile-active" : ""} admin-action-tile-${action.tone}`}
-                        onClick={() => selectAction(action.id)}
-                        aria-pressed={activeAction === action.id}
-                      >
-                        <span className="admin-action-label">{action.label}</span>
-                        <span className="admin-action-desc">{action.description}</span>
-                      </button>
-                    ))}
-                  </div>
-                </section>
-              );
-            })}
+          <div className="admin-board">
+            <div className="admin-board-col">
+              {ADMIN_ACTION_SECTIONS.filter((section) => section.id === "mobility" || section.id === "presence").map(renderSection)}
+            </div>
+            <div className="admin-board-col">
+              {ADMIN_ACTION_SECTIONS.filter((section) => section.id === "intervention" || section.id === "world").map(renderSection)}
+            </div>
+          </div>
           </div>
 
-          <div className="admin-form-pane">
-          {activeAction && activeDefinition ? (
+          {activeAction && activeDefinition && (
+            <div className="admin-modal-backdrop" onClick={closeForm}>
+              <div className="admin-modal" onClick={(event) => event.stopPropagation()}>
+                <button type="button" className="admin-modal-close" onClick={closeForm} aria-label="Close">
+                  ✕
+                </button>
             <form className="admin-form" onSubmit={submit}>
               <h3 className="admin-form-title">{activeDefinition.label}</h3>
 
@@ -1200,12 +1230,9 @@ export function AdminPanel({
                 </button>
               </div>
             </form>
-          ) : (
-            <p className="admin-form-hint">Select an action from the left to configure and run it.</p>
+              </div>
+            </div>
           )}
-          </div>
-          </div>
-          </div>
         </div>
       </section>
     </div>

--- a/web-v3/src/components/panels/AdminPanel.tsx
+++ b/web-v3/src/components/panels/AdminPanel.tsx
@@ -2,14 +2,13 @@ import { useEffect, useMemo, useState } from "react";
 import type { FormEvent } from "react";
 import type { RoomMob, StaffMobZone, StaffWorldZone, UiFeedbackEntry, WhoPlayer } from "../../types";
 import {
-  ADMIN_ACTION_SECTIONS,
   ADMIN_ACTIONS,
   ADMIN_RELOAD_SCOPES,
   buildAdminCommand,
   getAdminActionDefinition,
   requiresAdminConfirmation,
 } from "./AdminPanel.logic";
-import type { AdminAction, AdminActionSection } from "./AdminPanel.logic";
+import type { AdminAction } from "./AdminPanel.logic";
 
 interface AdminPanelProps {
   onCommand: (command: string) => void;
@@ -491,38 +490,6 @@ export function AdminPanel({
     resetForm();
   };
 
-  // One category block: a centered title over its grid of plaque buttons.
-  const renderSection = (section: AdminActionSection) => {
-    const sectionActions = ADMIN_ACTIONS.filter((entry) => entry.section === section.id)
-      .filter((entry) => {
-        // Possession is binary — show only the relevant verb (Possess when free,
-        // Return when in a mob). Also evens out the grid.
-        if (entry.id === "possess") return possessing == null;
-        if (entry.id === "return") return possessing != null;
-        return true;
-      });
-    if (sectionActions.length === 0) return null;
-    return (
-      <section key={section.id} className="admin-action-section">
-        <h3 className="admin-section-title">{section.title}</h3>
-        <div className="admin-action-grid">
-          {sectionActions.map((action) => (
-            <button
-              key={action.id}
-              type="button"
-              className={`admin-action-tile ${activeAction === action.id ? "admin-action-tile-active" : ""} admin-action-tile-${action.tone}`}
-              onClick={() => selectAction(action.id)}
-              aria-pressed={activeAction === action.id}
-            >
-              <span className="admin-action-label">{action.label}</span>
-              <span className="admin-action-desc">{action.description}</span>
-            </button>
-          ))}
-        </div>
-      </section>
-    );
-  };
-
   // Painted-frame CSS variables. The command tiles fall back to a gilded-glass
   // gradient (see styles.css) and pick up a real stained-glass asset if the
   // server advertises `staff_action_btn` / `staff_action_btn_active`.
@@ -588,12 +555,24 @@ export function AdminPanel({
           )}
 
           <div className="admin-board">
-            <div className="admin-board-col">
-              {ADMIN_ACTION_SECTIONS.filter((section) => section.id === "mobility" || section.id === "presence" || section.id === "world").map(renderSection)}
-            </div>
-            <div className="admin-board-col">
-              {ADMIN_ACTION_SECTIONS.filter((section) => section.id === "intervention").map(renderSection)}
-            </div>
+            {ADMIN_ACTIONS.filter((action) => {
+              // Possession is binary — show only the relevant verb (Possess when
+              // free, Return when in a mob).
+              if (action.id === "possess") return possessing == null;
+              if (action.id === "return") return possessing != null;
+              return true;
+            }).map((action) => (
+              <button
+                key={action.id}
+                type="button"
+                className={`admin-action-tile ${activeAction === action.id ? "admin-action-tile-active" : ""} admin-action-tile-${action.tone}`}
+                onClick={() => selectAction(action.id)}
+                aria-pressed={activeAction === action.id}
+              >
+                <span className="admin-action-label">{action.label}</span>
+                <span className="admin-action-desc">{action.description}</span>
+              </button>
+            ))}
           </div>
           </div>
 

--- a/web-v3/src/components/panels/AdminPanel.tsx
+++ b/web-v3/src/components/panels/AdminPanel.tsx
@@ -481,6 +481,10 @@ export function AdminPanel({
   if (backgroundImage) skinVars["--admin-bg"] = `url("${backgroundImage}")`;
   if (serverAssets.staff_action_btn) {
     skinVars["--admin-action-btn"] = `url("${serverAssets.staff_action_btn}")`;
+    // The asset carries its own gold frame, so suppress the CSS edge/rounding
+    // that the gradient fallback uses (avoids a double border and clipped corners).
+    skinVars["--admin-action-edge"] = "transparent";
+    skinVars["--admin-action-radius"] = "0px";
   }
   if (serverAssets.staff_action_btn_active) {
     skinVars["--admin-action-btn-active"] = `url("${serverAssets.staff_action_btn_active}")`;

--- a/web-v3/src/components/panels/AdminPanel.tsx
+++ b/web-v3/src/components/panels/AdminPanel.tsx
@@ -24,6 +24,8 @@ interface AdminPanelProps {
   possessing: string | null;
   invisible: boolean;
   feedbackFeed: UiFeedbackEntry[];
+  /** Global painted assets; used here for the optional stained-glass command button. */
+  serverAssets?: Record<string, string>;
 }
 
 function TeleportBrowser({
@@ -359,6 +361,7 @@ export function AdminPanel({
   possessing,
   invisible,
   feedbackFeed,
+  serverAssets = {},
 }: AdminPanelProps) {
   const [activeAction, setActiveAction] = useState<AdminAction | null>(null);
   const [inputA, setInputA] = useState("");
@@ -471,11 +474,23 @@ export function AdminPanel({
     executeAction(activeAction, pendingCommand);
   };
 
+  // Painted-frame CSS variables. The command tiles fall back to a gilded-glass
+  // gradient (see styles.css) and pick up a real stained-glass asset if the
+  // server advertises `staff_action_btn` / `staff_action_btn_active`.
+  const skinVars: Record<string, string> = {};
+  if (backgroundImage) skinVars["--admin-bg"] = `url("${backgroundImage}")`;
+  if (serverAssets.staff_action_btn) {
+    skinVars["--admin-action-btn"] = `url("${serverAssets.staff_action_btn}")`;
+  }
+  if (serverAssets.staff_action_btn_active) {
+    skinVars["--admin-action-btn-active"] = `url("${serverAssets.staff_action_btn_active}")`;
+  }
+
   return (
     <div className="popout-backdrop" onClick={onClose}>
       <section
         className={`popout-dialog admin-dialog${backgroundImage ? " admin-dialog-skinned" : ""}`}
-        style={backgroundImage ? { ["--admin-bg" as string]: `url("${backgroundImage}")` } : undefined}
+        style={Object.keys(skinVars).length > 0 ? skinVars : undefined}
         role="dialog"
         aria-modal="true"
         aria-label="Staff Administration"

--- a/web-v3/src/components/panels/AdminPanel.tsx
+++ b/web-v3/src/components/panels/AdminPanel.tsx
@@ -541,7 +541,14 @@ export function AdminPanel({
           <div className="admin-workspace">
           <div className="admin-section-grid">
             {ADMIN_ACTION_SECTIONS.map((section) => {
-              const sectionActions = ADMIN_ACTIONS.filter((entry) => entry.section === section.id);
+              const sectionActions = ADMIN_ACTIONS.filter((entry) => entry.section === section.id)
+                .filter((entry) => {
+                  // Possession is binary — show only the relevant verb (Possess
+                  // when free, Return when in a mob). Also evens out the grid.
+                  if (entry.id === "possess") return possessing == null;
+                  if (entry.id === "return") return possessing != null;
+                  return true;
+                });
               return (
                 <section key={section.id} className="admin-action-section">
                   <h3 className="admin-section-title">{section.title}</h3>

--- a/web-v3/src/components/panels/AdminPanel.tsx
+++ b/web-v3/src/components/panels/AdminPanel.tsx
@@ -481,10 +481,12 @@ export function AdminPanel({
   if (backgroundImage) skinVars["--admin-bg"] = `url("${backgroundImage}")`;
   if (serverAssets.staff_action_btn) {
     skinVars["--admin-action-btn"] = `url("${serverAssets.staff_action_btn}")`;
-    // The asset carries its own gold frame, so suppress the CSS edge/rounding
-    // that the gradient fallback uses (avoids a double border and clipped corners).
+    // The asset carries its own gold frame on transparent margins, so suppress
+    // the CSS edge, rounding, and box-shadow the gradient fallback uses — they'd
+    // otherwise show as a rectangle behind the plaque's transparent corners.
     skinVars["--admin-action-edge"] = "transparent";
     skinVars["--admin-action-radius"] = "0px";
+    skinVars["--admin-action-shadow"] = "none";
   }
   if (serverAssets.staff_action_btn_active) {
     skinVars["--admin-action-btn-active"] = `url("${serverAssets.staff_action_btn_active}")`;

--- a/web-v3/src/components/panels/AdminPanel.tsx
+++ b/web-v3/src/components/panels/AdminPanel.tsx
@@ -589,10 +589,10 @@ export function AdminPanel({
 
           <div className="admin-board">
             <div className="admin-board-col">
-              {ADMIN_ACTION_SECTIONS.filter((section) => section.id === "mobility" || section.id === "presence").map(renderSection)}
+              {ADMIN_ACTION_SECTIONS.filter((section) => section.id === "mobility" || section.id === "presence" || section.id === "world").map(renderSection)}
             </div>
             <div className="admin-board-col">
-              {ADMIN_ACTION_SECTIONS.filter((section) => section.id === "intervention" || section.id === "world").map(renderSection)}
+              {ADMIN_ACTION_SECTIONS.filter((section) => section.id === "intervention").map(renderSection)}
             </div>
           </div>
           </div>

--- a/web-v3/src/components/panels/AdminPanel.tsx
+++ b/web-v3/src/components/panels/AdminPanel.tsx
@@ -510,6 +510,7 @@ export function AdminPanel({
             </div>
           </div>
 
+          <div className="admin-main-pane">
           {activeFeedback && (
             <p className={`admin-feedback-banner admin-feedback-banner-${activeFeedback.type}`}>
               {activeFeedback.message}
@@ -1174,6 +1175,7 @@ export function AdminPanel({
           ) : (
             <p className="admin-form-hint">Select an action from the left to configure and run it.</p>
           )}
+          </div>
           </div>
           </div>
         </div>

--- a/web-v3/src/components/panels/AuctionPanel.tsx
+++ b/web-v3/src/components/panels/AuctionPanel.tsx
@@ -64,8 +64,25 @@ export function AuctionPanel({ listings, inventory, playerName, isDemo, feedback
     () => [...feedbackFeed].reverse().find((e) => e.scope === "auction") ?? null,
     [feedbackFeed],
   );
-  const message = activeFeedback?.message ?? localMessage;
-  const messageKind = activeFeedback?.type ?? "info";
+
+  // Auto-dismiss both server feedback and local notices after a few seconds so
+  // the toast doesn't stick across the panel.
+  const [dismissedFeedbackId, setDismissedFeedbackId] = useState<string | null>(null);
+  const activeFeedbackId = activeFeedback?.id;
+  useEffect(() => {
+    if (!activeFeedbackId) return;
+    const timer = setTimeout(() => setDismissedFeedbackId(activeFeedbackId), 4000);
+    return () => clearTimeout(timer);
+  }, [activeFeedbackId]);
+  useEffect(() => {
+    if (!localMessage) return;
+    const timer = setTimeout(() => setLocalMessage(null), 4000);
+    return () => clearTimeout(timer);
+  }, [localMessage]);
+
+  const liveFeedback = activeFeedback != null && activeFeedback.id !== dismissedFeedbackId ? activeFeedback : null;
+  const message = liveFeedback?.message ?? localMessage;
+  const messageKind = liveFeedback?.type ?? "info";
 
   const listSelected = () => {
     if (isDemo) {

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -26056,11 +26056,12 @@ html:has(.game-shell),
   flex: 1;
   min-height: 0;
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  align-items: start;
-  gap: clamp(8px, 1.2vw, 20px);
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  align-content: center;
+  justify-items: center;
+  gap: clamp(6px, 1.4vh, 16px) clamp(8px, 1.2vw, 20px);
   overflow-y: auto;
-  padding-right: 4px;
+  padding: clamp(4px, 1vh, 12px) 4px;
   scrollbar-width: thin;
   scrollbar-color: rgb(150 170 230 / 45%) transparent;
 }
@@ -26152,6 +26153,8 @@ html:has(.game-shell),
   /* Match the plaque art's 3:2 shape so it fills without distortion; text sits in
      the hollow center via percentage padding (clears the ornate frame). */
   aspect-ratio: 3 / 2;
+  width: 100%;
+  max-width: clamp(112px, 13vw, 150px);
   min-width: 0;
   padding: 13% 18%;
   border: 1px solid var(--admin-action-edge, rgb(190 168 96 / 30%));

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -26058,7 +26058,7 @@ html:has(.game-shell),
   display: grid;
   grid-template-columns: 1fr 1fr;
   align-items: start;
-  gap: clamp(10px, 1.8vw, 30px);
+  gap: clamp(8px, 1.2vw, 20px);
   overflow-y: auto;
   padding-right: 4px;
   scrollbar-width: thin;
@@ -26069,7 +26069,7 @@ html:has(.game-shell),
 .admin-dialog-skinned .admin-board-col {
   display: flex;
   flex-direction: column;
-  gap: clamp(8px, 1.6vh, 22px);
+  gap: clamp(5px, 1vh, 13px);
   min-width: 0;
 }
 .admin-dialog-skinned .admin-form { margin-top: 0; border: none; background: none; padding: 0; }
@@ -26121,11 +26121,11 @@ html:has(.game-shell),
   background: none;
 }
 .admin-dialog-skinned .admin-section-title {
-  margin: 0 0 clamp(1px, 0.4vh, 5px);
+  margin: 0 0 clamp(1px, 0.35vh, 4px);
   padding-left: 0;
   text-align: center;
   font-family: var(--font-display);
-  font-size: clamp(0.95rem, 1.9vw, 1.35rem);
+  font-size: clamp(0.72rem, 1.4vw, 1.02rem);
   font-weight: 800;
   letter-spacing: 0.16em;
   text-transform: uppercase;
@@ -26134,8 +26134,10 @@ html:has(.game-shell),
 }
 .admin-dialog-skinned .admin-action-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: clamp(4px, 0.7vw, 9px);
+  /* Auto-fill keeps every plaque the same small size (~3 per board column),
+     so the whole panel reads as a dense ~5-6 across, ~4 down button board. */
+  grid-template-columns: repeat(auto-fill, minmax(min(148px, 100%), 1fr));
+  gap: clamp(4px, 0.6vw, 9px);
 }
 /* Gilded-glass command buttons. Falls back to a jewel-toned gradient with a
    gold edge and glass sheen; swaps to a real stained-glass asset when the
@@ -26175,9 +26177,10 @@ html:has(.game-shell),
 }
 .admin-dialog-skinned .admin-action-tile .admin-action-label {
   flex: 0 0 auto;
-  font-size: clamp(0.74rem, 1.35vw, 1rem);
+  font-size: clamp(0.58rem, 1vw, 0.82rem);
   font-weight: 700;
   text-align: center;
+  line-height: 1.05;
 }
 /* Just the command title on each plaque — the description is dropped. */
 .admin-dialog-skinned .admin-action-tile .admin-action-desc {

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -12286,6 +12286,13 @@ body {
   gap: var(--space-4);
 }
 
+.admin-main-pane {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  min-height: 0;
+}
+
 .admin-section-title,
 .admin-form-title {
   margin: 0;
@@ -25980,32 +25987,50 @@ html:has(.game-shell),
 }
 .admin-dialog-skinned .admin-skin-close:hover { filter: brightness(1.2); }
 
-/* Live content sits in the painted inner panel (below the title strip). */
+/* The painted frame defines three inset boxes. We anchor live content into each
+   with absolute insets measured against the `admin_bg` art (stretched to fill,
+   so image-percentages map straight to the dialog):
+     · top band  (x 16.4–77%, y 18.8–36.8%) — the three status boxes
+     · main box  (x 3–97%,   y 39–88.5%)    — command list (left) + form (right)
+   The left winged emblem and right compass rose flank the top band, so the
+   status strip must NOT run full width. */
 .admin-dialog-skinned .admin-content {
   position: absolute;
-  inset: 17% 4% 11% 4%;
-  display: flex;
-  flex-direction: column;
-  gap: clamp(5px, 1vh, 12px);
+  inset: 0;
+  display: block;
   overflow: hidden;
-  padding: 0 1%;
+  padding: 0;
   color: #d6def4;
 }
-.admin-dialog-skinned .admin-content::-webkit-scrollbar { width: 8px; }
-.admin-dialog-skinned .admin-content::-webkit-scrollbar-thumb { background: rgb(150 170 230 / 40%); border-radius: 4px; }
 
-/* Target/status strip — moonlit cards. */
+/* Status strip — three moonlit cards seated in the painted top boxes. */
 .admin-dialog-skinned .admin-status-strip {
+  position: absolute;
+  inset: 18.8% 23% 63.2% 16.4%;
   display: flex;
-  gap: clamp(6px, 1vw, 14px);
-  margin-bottom: clamp(6px, 1.2vh, 14px);
+  gap: clamp(6px, 0.8vw, 14px);
+  margin: 0;
 }
 .admin-dialog-skinned .admin-status-card {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 2px;
   padding: clamp(5px, 1vh, 11px) clamp(8px, 1.2vw, 16px);
   border: 1px solid rgb(150 170 230 / 35%);
   border-radius: 10px;
   background: rgb(16 22 52 / 65%);
+}
+
+/* Main pane — feedback banner + the command workspace, seated in the big box. */
+.admin-dialog-skinned .admin-main-pane {
+  position: absolute;
+  inset: 39% 3% 11.5% 3%;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(4px, 0.8vh, 10px);
+  min-height: 0;
 }
 .admin-dialog-skinned .admin-status-label {
   font-size: clamp(0.52rem, 1vw, 0.72rem);

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -25935,7 +25935,7 @@ html:has(.game-shell),
   color: #f4e2c0;
   text-shadow: 0 1px 3px rgb(0 0 0 / 60%);
 }
-.cc-plaque-btn.has-art .cc-plaque-label { color: #3a2410; text-shadow: 0 1px 0 rgb(255 230 180 / 50%); }
+.cc-plaque-btn.has-art .cc-plaque-label { color: #fdf3d8; text-shadow: 0 1px 3px rgb(0 0 0 / 70%); }
 
 /* ── Spellbook: open-crafting button ── */
 .spellbook-craft-btn {
@@ -26064,9 +26064,9 @@ html:has(.game-shell),
   justify-items: center;
   /* Tight — the plaque art has transparent margins, so near-zero gap still reads
      as breathing room; on small screens the cells may touch, which is fine. */
-  gap: clamp(0px, 0.5vh, 8px) clamp(0px, 0.6vw, 11px);
+  gap: clamp(0px, 0.35vh, 5px) clamp(0px, 0.6vw, 11px);
   overflow-y: auto;
-  padding: clamp(2px, 0.5vh, 7px) 2px;
+  padding: clamp(1px, 0.3vh, 4px) 2px;
   scrollbar-width: thin;
   scrollbar-color: rgb(150 170 230 / 45%) transparent;
 }
@@ -26159,7 +26159,7 @@ html:has(.game-shell),
      the hollow center via percentage padding (clears the ornate frame). */
   aspect-ratio: 3 / 2;
   width: 100%;
-  max-width: clamp(112px, 13vw, 150px);
+  max-width: clamp(108px, 12vw, 138px);
   min-width: 0;
   padding: 13% 18%;
   border: 1px solid var(--admin-action-edge, rgb(190 168 96 / 30%));

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -26011,16 +26011,18 @@ html:has(.game-shell),
   gap: clamp(6px, 0.8vw, 14px);
   margin: 0;
 }
+/* No chrome — the painted frame already draws the three boxes, so the label and
+   value just float in the empty painted space. */
 .admin-dialog-skinned .admin-status-card {
   flex: 1;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: 2px;
-  padding: clamp(5px, 1vh, 11px) clamp(8px, 1.2vw, 16px);
-  border: 1px solid rgb(150 170 230 / 35%);
-  border-radius: 10px;
-  background: rgb(16 22 52 / 65%);
+  gap: clamp(2px, 0.5vh, 5px);
+  padding: clamp(5px, 1vh, 11px) clamp(10px, 1.4vw, 22px);
+  border: none;
+  background: none;
+  border-radius: 0;
 }
 
 /* Main pane — feedback banner + the command workspace, seated in the big box. */
@@ -26033,12 +26035,19 @@ html:has(.game-shell),
   min-height: 0;
 }
 .admin-dialog-skinned .admin-status-label {
-  font-size: clamp(0.52rem, 1vw, 0.72rem);
-  letter-spacing: 0.1em;
+  font-size: clamp(0.5rem, 0.95vw, 0.7rem);
+  letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: rgb(180 196 240 / 75%);
+  color: rgb(176 192 236 / 65%);
 }
-.admin-dialog-skinned .admin-status-card strong { color: #e8c878; }
+.admin-dialog-skinned .admin-status-card strong {
+  color: #e8c878;
+  font-family: var(--font-display);
+  font-size: clamp(0.95rem, 1.8vw, 1.4rem);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-shadow: 0 1px 8px rgb(180 140 60 / 30%);
+}
 
 /* Workspace — action menu (left) + the selected action's form (right). Each
    pane scrolls within the painted content panel so nothing spills past it. */
@@ -26103,21 +26112,35 @@ html:has(.game-shell),
   flex-direction: column;
   gap: clamp(2px, 0.4vh, 5px);
 }
+/* Gilded-glass command buttons. Falls back to a jewel-toned gradient with a
+   gold edge and glass sheen; swaps to a real stained-glass asset when the
+   server advertises `staff_action_btn` (and `_active`). */
 .admin-dialog-skinned .admin-action-tile {
+  position: relative;
   display: flex;
   align-items: baseline;
   gap: 0.5em;
-  padding: clamp(4px, 0.7vh, 8px) clamp(7px, 1vw, 12px);
-  border: 1px solid rgb(150 170 230 / 22%);
-  border-radius: 8px;
-  background: rgb(22 28 58 / 60%);
+  padding: clamp(5px, 0.85vh, 10px) clamp(9px, 1.1vw, 14px);
+  border: 1px solid rgb(190 168 96 / 30%);
+  border-radius: 9px;
+  background-image: var(--admin-action-btn,
+    linear-gradient(180deg, rgb(255 255 255 / 7%), rgb(255 255 255 / 0%) 42%),
+    linear-gradient(135deg, rgb(66 46 124 / 78%) 0%, rgb(34 32 92 / 78%) 52%, rgb(24 50 104 / 78%) 100%));
+  background-size: cover;
+  background-position: center;
   color: #dce4fa;
   font-family: var(--font-display);
   text-align: left;
   cursor: pointer;
-  transition: border-color 140ms var(--ease-out-soft), background 140ms var(--ease-out-soft), box-shadow 140ms var(--ease-out-soft);
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 7%), 0 2px 9px rgb(4 6 20 / 38%);
+  transition: border-color 140ms var(--ease-out-soft), box-shadow 140ms var(--ease-out-soft), filter 140ms var(--ease-out-soft), transform 140ms var(--ease-out-soft);
 }
-.admin-dialog-skinned .admin-action-tile:hover { background: rgb(40 50 96 / 70%); }
+.admin-dialog-skinned .admin-action-tile:hover {
+  border-color: rgb(224 196 110 / 60%);
+  filter: brightness(1.12) saturate(1.05);
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 10%), 0 4px 14px rgb(4 6 20 / 45%);
+  transform: translateY(-1px);
+}
 .admin-dialog-skinned .admin-action-tile .admin-action-label { flex: 0 0 auto; font-size: clamp(0.66rem, 1.2vw, 0.9rem); }
 .admin-dialog-skinned .admin-action-tile .admin-action-desc {
   flex: 1;
@@ -26126,10 +26149,12 @@ html:has(.game-shell),
   white-space: nowrap;
   font-size: clamp(0.5rem, 0.92vw, 0.68rem);
 }
-.admin-dialog-skinned .admin-action-tile:hover { border-color: rgb(180 160 240 / 55%); }
 .admin-dialog-skinned .admin-action-tile-active {
-  border-color: rgb(200 175 90 / 75%);
-  box-shadow: 0 0 12px rgb(200 175 90 / 35%), inset 0 0 8px rgb(200 175 90 / 12%);
+  border-color: rgb(224 192 100 / 80%);
+  background-image: var(--admin-action-btn-active, var(--admin-action-btn,
+    linear-gradient(180deg, rgb(255 255 255 / 12%), rgb(255 255 255 / 0%) 42%),
+    linear-gradient(135deg, rgb(120 92 184 / 86%) 0%, rgb(74 62 156 / 86%) 52%, rgb(48 84 158 / 86%) 100%)));
+  box-shadow: 0 0 16px rgb(214 182 96 / 42%), inset 0 0 12px rgb(214 182 96 / 16%);
 }
 .admin-dialog-skinned .admin-action-tile-danger { border-color: rgb(210 120 130 / 40%); }
 .admin-dialog-skinned .admin-action-tile-utility { border-color: rgb(150 200 230 / 40%); }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -26049,55 +26049,79 @@ html:has(.game-shell),
   text-shadow: 0 1px 8px rgb(180 140 60 / 30%);
 }
 
-/* Workspace — action menu (left) + the selected action's form (right). Each
-   pane scrolls within the painted content panel so nothing spills past it. */
-.admin-dialog-skinned .admin-workspace {
+/* Board — the whole blue box is a panel of command plaques in two columns
+   (Movement + Presence left, Intervention + World Ops right). The selected
+   action opens as a modal on top, not an inline pane. */
+.admin-dialog-skinned .admin-board {
   flex: 1;
   min-height: 0;
-  display: flex;
-  gap: clamp(8px, 1.2vw, 18px);
-}
-.admin-dialog-skinned .admin-form-pane {
-  flex: 1;
-  min-width: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  align-items: start;
+  gap: clamp(10px, 1.8vw, 30px);
   overflow-y: auto;
-  border-left: 1px solid rgb(150 170 230 / 22%);
-  padding-left: clamp(8px, 1.2vw, 16px);
+  padding-right: 4px;
   scrollbar-width: thin;
   scrollbar-color: rgb(150 170 230 / 45%) transparent;
 }
-.admin-dialog-skinned .admin-form-hint {
-  margin: 20% auto 0;
-  max-width: 80%;
-  text-align: center;
-  font-style: italic;
-  color: rgb(190 200 235 / 60%);
-  font-size: clamp(0.66rem, 1.2vw, 0.92rem);
+.admin-dialog-skinned .admin-board::-webkit-scrollbar { width: 7px; }
+.admin-dialog-skinned .admin-board::-webkit-scrollbar-thumb { background: rgb(150 170 230 / 40%); border-radius: 4px; }
+.admin-dialog-skinned .admin-board-col {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(8px, 1.6vh, 22px);
+  min-width: 0;
 }
 .admin-dialog-skinned .admin-form { margin-top: 0; border: none; background: none; padding: 0; }
 
-/* Action menu — a compact single-column nav grouped by section (master), with
-   all four groups visible/scrollable; the form (detail) sits in the wider pane. */
-.admin-dialog-skinned .admin-section-grid {
-  flex: 0 0 32%;
-  min-width: 0;
+/* Action modal — the selected command's form, floated over the board. */
+.admin-dialog-skinned .admin-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 8;
+  display: grid;
+  place-items: center;
+  padding: 4%;
+  background: rgb(6 9 22 / 58%);
+  backdrop-filter: blur(3px);
+  animation: backdropFadeIn 180ms var(--ease-out-soft);
+}
+.admin-dialog-skinned .admin-modal {
+  position: relative;
+  width: min(72%, 520px);
+  max-height: 88%;
   overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  gap: clamp(8px, 1.3vh, 16px);
-  padding-right: 5px;
+  padding: clamp(18px, 2.2vw, 32px) clamp(16px, 2.2vw, 32px);
+  border: 1px solid rgb(200 176 96 / 45%);
+  border-radius: 14px;
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 6%), rgb(255 255 255 / 0%) 30%),
+    linear-gradient(160deg, rgb(26 30 70 / 96%), rgb(14 18 44 / 97%));
+  box-shadow: 0 24px 60px rgb(3 5 16 / 70%), inset 0 1px 0 rgb(255 255 255 / 8%);
   scrollbar-width: thin;
   scrollbar-color: rgb(150 170 230 / 45%) transparent;
 }
-.admin-dialog-skinned .admin-section-grid::-webkit-scrollbar { width: 7px; }
-.admin-dialog-skinned .admin-section-grid::-webkit-scrollbar-thumb { background: rgb(150 170 230 / 40%); border-radius: 4px; }
+.admin-dialog-skinned .admin-modal-close {
+  position: absolute;
+  top: clamp(6px, 1vw, 12px);
+  right: clamp(8px, 1.1vw, 14px);
+  width: clamp(24px, 2.4vw, 32px);
+  height: clamp(24px, 2.4vw, 32px);
+  border-radius: 50%;
+  border: 1px solid rgb(190 150 90 / 45%);
+  background: rgb(40 24 50 / 70%);
+  color: #e8c878;
+  cursor: pointer;
+  transition: filter 140ms var(--ease-out-soft);
+}
+.admin-dialog-skinned .admin-modal-close:hover { filter: brightness(1.2); }
 .admin-dialog-skinned .admin-action-section {
   border: none;
   padding: 0;
   background: none;
 }
 .admin-dialog-skinned .admin-section-title {
-  margin: 0 0 clamp(5px, 0.9vh, 11px);
+  margin: 0 0 clamp(1px, 0.4vh, 5px);
   padding-left: 0;
   text-align: center;
   font-family: var(--font-display);

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -26169,8 +26169,8 @@ html:has(.game-shell),
   box-shadow: var(--admin-action-shadow, 0 0 16px rgb(214 182 96 / 42%), inset 0 0 12px rgb(214 182 96 / 16%));
   filter: drop-shadow(0 0 9px rgb(214 182 96 / 70%));
 }
-.admin-dialog-skinned .admin-action-tile-danger { border-color: rgb(210 120 130 / 40%); }
-.admin-dialog-skinned .admin-action-tile-utility { border-color: rgb(150 200 230 / 40%); }
+.admin-dialog-skinned .admin-action-tile-danger { border-color: var(--admin-action-edge, rgb(210 120 130 / 40%)); }
+.admin-dialog-skinned .admin-action-tile-utility { border-color: var(--admin-action-edge, rgb(150 200 230 / 40%)); }
 .admin-dialog-skinned .admin-action-label {
   font-size: clamp(0.66rem, 1.2vw, 0.92rem);
   font-weight: 700;

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -26118,39 +26118,49 @@ html:has(.game-shell),
 .admin-dialog-skinned .admin-action-tile {
   position: relative;
   display: flex;
-  align-items: baseline;
-  gap: 0.5em;
-  padding: clamp(5px, 0.85vh, 10px) clamp(9px, 1.1vw, 14px);
-  border: 1px solid rgb(190 168 96 / 30%);
-  border-radius: 9px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(1px, 0.3vh, 3px);
+  padding: clamp(6px, 1vh, 12px) clamp(9px, 1.1vw, 14px);
+  border: 1px solid var(--admin-action-edge, rgb(190 168 96 / 30%));
+  border-radius: var(--admin-action-radius, 9px);
+  /* Stretch to fill so the asset's full frame shows (cover cropped the top/bottom). */
   background-image: var(--admin-action-btn,
     linear-gradient(180deg, rgb(255 255 255 / 7%), rgb(255 255 255 / 0%) 42%),
     linear-gradient(135deg, rgb(66 46 124 / 78%) 0%, rgb(34 32 92 / 78%) 52%, rgb(24 50 104 / 78%) 100%));
-  background-size: cover;
+  background-size: 100% 100%;
   background-position: center;
   color: #dce4fa;
   font-family: var(--font-display);
-  text-align: left;
+  text-align: center;
   cursor: pointer;
   box-shadow: inset 0 1px 0 rgb(255 255 255 / 7%), 0 2px 9px rgb(4 6 20 / 38%);
   transition: border-color 140ms var(--ease-out-soft), box-shadow 140ms var(--ease-out-soft), filter 140ms var(--ease-out-soft), transform 140ms var(--ease-out-soft);
 }
 .admin-dialog-skinned .admin-action-tile:hover {
-  border-color: rgb(224 196 110 / 60%);
+  border-color: var(--admin-action-edge, rgb(224 196 110 / 60%));
   filter: brightness(1.12) saturate(1.05);
   box-shadow: inset 0 1px 0 rgb(255 255 255 / 10%), 0 4px 14px rgb(4 6 20 / 45%);
   transform: translateY(-1px);
 }
-.admin-dialog-skinned .admin-action-tile .admin-action-label { flex: 0 0 auto; font-size: clamp(0.66rem, 1.2vw, 0.9rem); }
+.admin-dialog-skinned .admin-action-tile .admin-action-label {
+  flex: 0 0 auto;
+  font-size: clamp(0.74rem, 1.35vw, 1rem);
+  font-weight: 700;
+  text-align: center;
+}
 .admin-dialog-skinned .admin-action-tile .admin-action-desc {
-  flex: 1;
+  flex: 0 0 auto;
+  max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  text-align: center;
   font-size: clamp(0.5rem, 0.92vw, 0.68rem);
 }
 .admin-dialog-skinned .admin-action-tile-active {
-  border-color: rgb(224 192 100 / 80%);
+  border-color: var(--admin-action-edge, rgb(224 192 100 / 80%));
   background-image: var(--admin-action-btn-active, var(--admin-action-btn,
     linear-gradient(180deg, rgb(255 255 255 / 12%), rgb(255 255 255 / 0%) 42%),
     linear-gradient(135deg, rgb(120 92 184 / 86%) 0%, rgb(74 62 156 / 86%) 52%, rgb(48 84 158 / 86%) 100%)));

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -26097,15 +26097,16 @@ html:has(.game-shell),
   background: none;
 }
 .admin-dialog-skinned .admin-section-title {
-  margin: 0 0 clamp(3px, 0.6vh, 7px);
-  padding-left: 2px;
-  text-align: left;
+  margin: 0 0 clamp(5px, 0.9vh, 11px);
+  padding-left: 0;
+  text-align: center;
   font-family: var(--font-display);
-  font-size: clamp(0.58rem, 1.1vw, 0.82rem);
-  font-weight: 700;
-  letter-spacing: 0.12em;
+  font-size: clamp(0.95rem, 1.9vw, 1.35rem);
+  font-weight: 800;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: #c9b06a;
+  color: #d8bd72;
+  text-shadow: 0 1px 10px rgb(180 140 60 / 35%);
 }
 .admin-dialog-skinned .admin-action-grid {
   display: grid;

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -26108,9 +26108,9 @@ html:has(.game-shell),
   color: #c9b06a;
 }
 .admin-dialog-skinned .admin-action-grid {
-  display: flex;
-  flex-direction: column;
-  gap: clamp(2px, 0.4vh, 5px);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: clamp(4px, 0.7vw, 9px);
 }
 /* Gilded-glass command buttons. Falls back to a jewel-toned gradient with a
    gold edge and glass sheen; swaps to a real stained-glass asset when the
@@ -26122,10 +26122,14 @@ html:has(.game-shell),
   align-items: center;
   justify-content: center;
   gap: clamp(1px, 0.3vh, 3px);
-  padding: clamp(6px, 1vh, 12px) clamp(9px, 1.1vw, 14px);
+  /* Match the plaque art's 3:2 shape so it fills without distortion; text sits in
+     the hollow center via percentage padding (clears the ornate frame). */
+  aspect-ratio: 3 / 2;
+  min-width: 0;
+  padding: 13% 18%;
   border: 1px solid var(--admin-action-edge, rgb(190 168 96 / 30%));
   border-radius: var(--admin-action-radius, 9px);
-  /* Stretch to fill so the asset's full frame shows (cover cropped the top/bottom). */
+  /* Fills the (now matching-ratio) box edge-to-edge with no stretch. */
   background-image: var(--admin-action-btn,
     linear-gradient(180deg, rgb(255 255 255 / 7%), rgb(255 255 255 / 0%) 42%),
     linear-gradient(135deg, rgb(66 46 124 / 78%) 0%, rgb(34 32 92 / 78%) 52%, rgb(24 50 104 / 78%) 100%));
@@ -26153,11 +26157,13 @@ html:has(.game-shell),
 .admin-dialog-skinned .admin-action-tile .admin-action-desc {
   flex: 0 0 auto;
   max-width: 100%;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   text-align: center;
-  font-size: clamp(0.5rem, 0.92vw, 0.68rem);
+  line-height: 1.15;
+  font-size: clamp(0.48rem, 0.88vw, 0.64rem);
 }
 .admin-dialog-skinned .admin-action-tile-active {
   border-color: var(--admin-action-edge, rgb(224 192 100 / 80%));

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -25920,7 +25920,10 @@ html:has(.game-shell),
   transition: filter 150ms var(--ease-out-soft), transform 150ms var(--ease-out-soft);
 }
 .cc-plaque-btn.has-art {
-  background: var(--cc-plaque) center / 100% 100% no-repeat;
+  min-height: 82px;
+  /* Keep the banner's aspect (contain) — 100% 100% stretched it across the
+     wider middle slot. Matches the gem buttons' has-art treatment. */
+  background: var(--cc-plaque) center / contain no-repeat;
 }
 .cc-plaque-btn:hover { filter: brightness(1.1); transform: translateY(-1px); }
 .cc-plaque-btn:active { transform: scale(0.98); }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -26059,9 +26059,11 @@ html:has(.game-shell),
   grid-template-columns: repeat(5, minmax(0, 1fr));
   align-content: center;
   justify-items: center;
-  gap: clamp(6px, 1.4vh, 16px) clamp(8px, 1.2vw, 20px);
+  /* Tight — the plaque art has transparent margins, so near-zero gap still reads
+     as breathing room; on small screens the cells may touch, which is fine. */
+  gap: clamp(0px, 0.5vh, 8px) clamp(0px, 0.6vw, 11px);
   overflow-y: auto;
-  padding: clamp(4px, 1vh, 12px) 4px;
+  padding: clamp(2px, 0.5vh, 7px) 2px;
   scrollbar-width: thin;
   scrollbar-color: rgb(150 170 230 / 45%) transparent;
 }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -26139,13 +26139,13 @@ html:has(.game-shell),
   font-family: var(--font-display);
   text-align: center;
   cursor: pointer;
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 7%), 0 2px 9px rgb(4 6 20 / 38%);
+  box-shadow: var(--admin-action-shadow, inset 0 1px 0 rgb(255 255 255 / 7%), 0 2px 9px rgb(4 6 20 / 38%));
   transition: border-color 140ms var(--ease-out-soft), box-shadow 140ms var(--ease-out-soft), filter 140ms var(--ease-out-soft), transform 140ms var(--ease-out-soft);
 }
 .admin-dialog-skinned .admin-action-tile:hover {
   border-color: var(--admin-action-edge, rgb(224 196 110 / 60%));
   filter: brightness(1.12) saturate(1.05);
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 10%), 0 4px 14px rgb(4 6 20 / 45%);
+  box-shadow: var(--admin-action-shadow, inset 0 1px 0 rgb(255 255 255 / 10%), 0 4px 14px rgb(4 6 20 / 45%));
   transform: translateY(-1px);
 }
 .admin-dialog-skinned .admin-action-tile .admin-action-label {
@@ -26154,23 +26154,20 @@ html:has(.game-shell),
   font-weight: 700;
   text-align: center;
 }
+/* Just the command title on each plaque — the description is dropped. */
 .admin-dialog-skinned .admin-action-tile .admin-action-desc {
-  flex: 0 0 auto;
-  max-width: 100%;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-  text-align: center;
-  line-height: 1.15;
-  font-size: clamp(0.48rem, 0.88vw, 0.64rem);
+  display: none;
 }
 .admin-dialog-skinned .admin-action-tile-active {
   border-color: var(--admin-action-edge, rgb(224 192 100 / 80%));
   background-image: var(--admin-action-btn-active, var(--admin-action-btn,
     linear-gradient(180deg, rgb(255 255 255 / 12%), rgb(255 255 255 / 0%) 42%),
     linear-gradient(135deg, rgb(120 92 184 / 86%) 0%, rgb(74 62 156 / 86%) 52%, rgb(48 84 158 / 86%) 100%)));
-  box-shadow: 0 0 16px rgb(214 182 96 / 42%), inset 0 0 12px rgb(214 182 96 / 16%);
+  /* With the plaque asset the shadow var is none, so the active state glows via a
+     drop-shadow that follows the plaque silhouette instead of a rectangle; the
+     gradient fallback keeps the boxed glow. */
+  box-shadow: var(--admin-action-shadow, 0 0 16px rgb(214 182 96 / 42%), inset 0 0 12px rgb(214 182 96 / 16%));
+  filter: drop-shadow(0 0 9px rgb(214 182 96 / 70%));
 }
 .admin-dialog-skinned .admin-action-tile-danger { border-color: rgb(210 120 130 / 40%); }
 .admin-dialog-skinned .admin-action-tile-utility { border-color: rgb(150 200 230 / 40%); }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -25935,7 +25935,7 @@ html:has(.game-shell),
   color: #f4e2c0;
   text-shadow: 0 1px 3px rgb(0 0 0 / 60%);
 }
-.cc-plaque-btn.has-art .cc-plaque-label { color: #fdf3d8; text-shadow: 0 1px 3px rgb(0 0 0 / 70%); }
+.cc-plaque-btn.has-art .cc-plaque-label { color: #fff6e2; text-shadow: 0 1px 2px rgb(0 0 0 / 85%), 0 0 6px rgb(0 0 0 / 55%); }
 
 /* ── Spellbook: open-crafting button ── */
 .spellbook-craft-btn {


### PR DESCRIPTION
## Summary
The reskinned Staff Control panel laid its content into a single inset region with the status strip and workspace stacked by normal flex flow. Against the painted `admin_bg` frame that meant:
- the three status cards ran **full width**, overlapping the left winged emblem and the right compass rose;
- the command list + form **rode up above** the painted main box (the "Goto" row spilled into the top boxes).

## Fix
Anchor each content group to its painted box with absolute insets measured from the art (the frame is drawn with `center / 100% 100%`, so image-percentages map straight to dialog percentages):

| Group | Painted box | Inset (T R B L) |
|-------|-------------|-----------------|
| `.admin-status-strip` | top band (between emblem & compass) | `18.8% 23% 63.2% 16.4%` |
| `.admin-main-pane` | main work box | `39% 3% 11.5% 3%` |

The command list (left) + form (right) keep their existing two-column `.admin-workspace` split inside the main box.

Structural change: the feedback banner + workspace are wrapped in a new `.admin-main-pane`. Base CSS gives it the same `flex-column` it replaced, so the **non-skinned** dialog is unchanged; the skinned rule positions it absolutely. Status cards now vertically center their content to fill the taller painted boxes.

## How the coordinates were derived
Fetched the live `admin_bg.png` and pixel-scanned it to find the dark box interiors vs. the gold frame:
- top boxes: x ≈ 16.1–76.9%, y ≈ 18.5–37%
- main box: x ≈ 2.2–97.8%, y ≈ 38.6–89%

## Verification
`bun run lint` clean, `bun run build` succeeds, `bun test` 23/0. Headless screenshot wasn't available in this environment, so the percentages are measured-not-eyeballed — they may want a ±1–2% nudge once seen in the live client.