### PR TITLE
docs: documentation audit — add ART_CONTRACT, refresh stale specs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ This file is the entry point for AI coding agents (Claude Code, etc.) working in
 - **[`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md)** — Docker, CDK, env-var reference, CI/CD, EC2 demo, R2 lore overlay.
 - **[`docs/GMCP_PROTOCOL.md`](docs/GMCP_PROTOCOL.md)** — GMCP wire format and per-package payload reference (covers the stable subset; see the doc's coverage notice for the complete emitted-package inventory).
 - **[`docs/WORLD_YAML_SPEC.md`](docs/WORLD_YAML_SPEC.md)** — zone YAML contract.
+- **[`docs/ART_CONTRACT.md`](docs/ART_CONTRACT.md)** — painted UI art: asset registry, `Server.Assets` GMCP delivery, and the panel-reskin pattern.
+- **[`docs/VOICE_OVER_CONTRACT.md`](docs/VOICE_OVER_CONTRACT.md)** — NPC dialogue voice-over pipeline (R2 paths, hash spec, `voiceUrl`).
 - **[`docs/STYLE_GUIDE.md`](docs/STYLE_GUIDE.md)** + **[`.impeccable.md`](.impeccable.md)** — design system.
 
 If you're starting a code change, the relevant change playbook is in `DEVELOPER_GUIDE.md § 13 Common Tasks`. Don't reinvent the steps; read them.
@@ -71,7 +73,7 @@ Full test patterns and utilities: `DEVELOPER_GUIDE.md § 12 Testing`.
 
 - Keep gameplay/state in `engine`; keep protocol/I/O in `transport`. Wire bus/Redis only in `MudServer.kt`.
 - Gameplay features follow the pattern `*System.kt` (logic) + `*Handler.kt` (commands) + config in `application.yaml` or world YAML + `*SystemTest`.
-- `CommandRouter.kt` is thin dispatch (~110 lines); the work happens in the 36 handler files under `src/main/kotlin/dev/ambon/engine/commands/handlers/`.
+- `CommandRouter.kt` is thin dispatch (~110 lines); the work happens in the 37 handler files under `src/main/kotlin/dev/ambon/engine/commands/handlers/`.
 - The single biggest files are `GmcpEmitter.kt`, `GameEngine.kt`, `AppConfig.kt`, `AdminHttpServer.kt`, and `WorldLoader.kt`. Check helper systems and handlers before assuming behavior lives in a top-level file.
 - Generated protobuf/gRPC sources live under `build/generated/`; ktlint is suppressed there via a child `.editorconfig`.
 - Do not commit anything under `data/players/` — runtime state, gitignored.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,14 +64,14 @@ Bus implementations: `Local*` (single-process), `Redis*` (multi-process), `Grpc*
 | Entry/wiring | `Main.kt`, `MudServer.kt` (composition root), `GatewayServer.kt` |
 | Config | `AppConfig.kt` (schema + `validated()`), `application.yaml` |
 | Engine | `GameEngine.kt` (tick loop), `PlayerState.kt`, `PlayerRegistry.kt` |
-| Commands | `CommandParser.kt` (~200 variants, sealed hierarchy), `CommandRouter.kt` (~110-line dispatch), `handlers/` subpackage (36 handler files + `EngineContext.kt` + `HandlerHelpers.kt`) |
+| Commands | `CommandParser.kt` (~200 variants, sealed hierarchy), `CommandRouter.kt` (~110-line dispatch), `handlers/` subpackage (37 handler files + `EngineContext.kt` + `HandlerHelpers.kt`) |
 | Events | `InboundEvent.kt`, `OutboundEvent.kt` |
 | Persistence | `PlayerRecord.kt` (DTO), `PlayerRepository.kt` (interface), `PlayersTable.kt`, `GuildRepository.kt` |
 | Transport | `KtorWebSocketTransport.kt`, `NetworkSession.kt`, `OutboundRouter.kt`, `TelnetLineDecoder.kt` |
 | GMCP | `GmcpEmitter.kt` (server→client), `web-v3/src/gmcp/applyGmcpPackage.ts` (client) |
 | World | `WorldLoader.kt`, zone YAMLs in `src/main/resources/world/` |
 | Web client | `web-v3/` (React + PixiJS), built to `src/main/resources/web-v3/` |
-| Migrations | `src/main/resources/db/migration/` (V1–V38) |
+| Migrations | `src/main/resources/db/migration/` (V1–V42) |
 | Proto | `src/main/proto/ambonmud/v1/` |
 
 ### Test Utilities
@@ -115,6 +115,9 @@ Update `AppConfig.kt` and `application.yaml` together; keep `validated()` strict
 ### World content only
 Edit YAML in `src/main/resources/world/`. See `docs/WORLD_YAML_SPEC.md`.
 
+### Panel reskin (painted art)
+See `docs/ART_CONTRACT.md` (the canonical spec; Staff Control / `AdminPanel.tsx` is the reference implementation). Register a `<panel>_bg` key in `ImagesConfig.DEFAULT_GLOBAL_ASSETS` (`AppConfig.kt`) → URL arrives at the client via the `Server.Assets` GMCP map → component injects it as a CSS variable and toggles a `-skinned` class that locks `aspect-ratio` to the art's pixel size and seats content with percentage insets. The unskinned CSS fallback must keep working (null/404 art). NPC dialogue audio has an analogous contract: `docs/VOICE_OVER_CONTRACT.md`.
+
 ## Kotlin Style (ktlint)
 
 ktlint 1.5.0, `kotlin.code.style=official`. Overrides in `.editorconfig`.
@@ -148,11 +151,12 @@ ktlint 1.5.0, `kotlin.code.style=official`. Overrides in `.editorconfig`.
 
 - Never hardcode colors — use CSS variables. Dark-first. WCAG AA minimum.
 - `web-v3/src/canvas/` for PixiJS rendering. Built assets are gitignored.
+- Painted panel frames / window reskins follow `docs/ART_CONTRACT.md`.
 - Validate: `bun run lint` + `./gradlew demo`.
 
 ## Known Quirks
 
-- **Largest files:** `GmcpEmitter.kt` (~3490 lines), `GameEngine.kt` (~2820 lines), `AppConfig.kt` (~2660 lines), `WorldLoader.kt` (~1875 lines), `AdminHttpServer.kt` (~1475 lines). `CommandRouter.kt` is thin dispatch (~110 lines); all gameplay lives in the 36 handler files under `handlers/` plus the `EngineContext`/`HandlerHelpers` support files.
+- **Largest files:** `GmcpEmitter.kt` (~3960 lines), `GameEngine.kt` (~3000 lines), `AppConfig.kt` (~3240 lines), `WorldLoader.kt` (~1950 lines), `AdminHttpServer.kt` (~1475 lines). `CommandRouter.kt` is thin dispatch (~110 lines); all gameplay lives in the 37 handler files under `handlers/` plus the `EngineContext`/`HandlerHelpers` support files.
 - **Generated sources:** Protobuf under `build/generated/`, ktlint-suppressed via child `.editorconfig`.
 - **Staff access:** Set `isStaff: true` in player YAML or `is_staff` in Postgres — no in-game command.
 - **Metrics:** Uses `io.micrometer.prometheusmetrics` (not deprecated `io.micrometer.prometheus`).

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ See [`docs/ROADMAP.md`](docs/ROADMAP.md) for the full feature inventory and [`do
 | Build | Gradle wrapper, ktlint, JaCoCo, Shadow (fat JAR) |
 | Server | Ktor 3 (WebSocket), blocking socket transport (telnet), Netty |
 | Config | Hoplite (YAML + env var overrides) |
-| Persistence | YAML files (default), PostgreSQL via Exposed + Flyway (V1–V38), optional Redis L2 cache |
+| Persistence | YAML files (default), PostgreSQL via Exposed + Flyway (V1–V42), optional Redis L2 cache |
 | Bus / RPC | Lettuce (Redis), gRPC 1.80 + Protobuf for ENGINE↔GATEWAY |
 | Metrics | Micrometer → Prometheus |
 | Web client | React 19, Vite, TypeScript, PixiJS 8, xterm.js (popout) — built with Bun |
@@ -79,7 +79,7 @@ src/main/kotlin/dev/ambon/
   Main.kt, MudServer.kt, GatewayServer.kt   # bootstrap
   config/                                   # AppConfig.kt schema + validated()
   engine/                                   # tick loop, systems, commands
-    commands/handlers/                      # 36 handler files + EngineContext/HandlerHelpers support
+    commands/handlers/                      # 37 handler files + EngineContext/HandlerHelpers support
     abilities/ status/ crafting/ dialogue/ ...
   transport/                                # telnet + Ktor WebSocket
   bus/                                      # Local/Redis/gRPC bus implementations
@@ -131,8 +131,10 @@ PostgreSQL tests use H2 in PostgreSQL-compatibility mode — no Docker required.
 - [docs/GMCP_PROTOCOL.md](docs/GMCP_PROTOCOL.md) — full GMCP reference for client developers
 - [docs/WORLD_YAML_SPEC.md](docs/WORLD_YAML_SPEC.md) — zone file format
 
-**Web client**
+**Web client & media**
 - [docs/WEB_CLIENT.md](docs/WEB_CLIENT.md) — React + PixiJS architecture and visual progression
+- [docs/ART_CONTRACT.md](docs/ART_CONTRACT.md) — painted UI art pipeline and the panel-reskin pattern
+- [docs/VOICE_OVER_CONTRACT.md](docs/VOICE_OVER_CONTRACT.md) — NPC dialogue voice-over pipeline
 - [docs/STYLE_GUIDE.md](docs/STYLE_GUIDE.md) — Surreal Gentle Magic design system
 - [`.impeccable.md`](.impeccable.md) — brand personality and design principles
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -163,7 +163,7 @@ The persistence chain is: `WriteCoalescingPlayerRepository` → `RedisCachingPla
 Each 100 ms tick runs, in order:
 
 1. **Drain inbound** — up to `maxInboundEventsPerTick` from `InboundBus`
-2. **Dispatch commands** — `CommandRouter` → handler modules (36 handler files)
+2. **Dispatch commands** — `CommandRouter` → handler modules (37 handler files)
 3. **MobSystem.tick()** — NPC wandering and behavior trees
 4. **CombatSystem.tick()** — active fight resolution
 5. **RegenSystem.tick()** — HP / mana regen
@@ -210,7 +210,7 @@ Every write layer is transparent to the caller. Guild persistence mirrors this p
 
 ### Commands: Sealed Hierarchy + Thin Router
 
-`CommandParser.parse()` is a pure function that returns one of ~200 sealed `Command` variants. `CommandRouter` is thin dispatch (~110 lines) that routes each variant to one of 36 handler files. This separates parsing from execution and makes both independently testable.
+`CommandParser.parse()` is a pure function that returns one of ~200 sealed `Command` variants. `CommandRouter` is thin dispatch (~110 lines) that routes each variant to one of 37 handler files. This separates parsing from execution and makes both independently testable.
 
 ### Config-Driven Game Content
 
@@ -226,7 +226,11 @@ All time-dependent logic uses an injected `Clock`, enabling `MutableClock` in te
 
 ### GMCP as the Client Protocol
 
-All structured data between server and client flows through GMCP packages (~50 families). Telnet clients negotiate GMCP opt-in; WebSocket clients auto-subscribe. This means the web client never scrapes text output — it reacts to typed JSON payloads. See [GMCP_PROTOCOL.md](./GMCP_PROTOCOL.md) for the full reference.
+All structured data between server and client flows through GMCP packages (~50 families, ~100 emitted packages). Telnet clients negotiate GMCP opt-in; WebSocket clients auto-subscribe. This means the web client never scrapes text output — it reacts to typed JSON payloads. See [GMCP_PROTOCOL.md](./GMCP_PROTOCOL.md) for the full reference.
+
+### Server-Resolved Media URLs
+
+All media the web client displays — painted panel art, sprites, voice-over clips, videos — is referenced by **fully-resolved URLs that the engine computes and sends over GMCP** (`Server.Assets`, `image` fields, `voiceUrl`). The client never concatenates paths, and every asset degrades to a CSS-only or text-only fallback when absent. The asset contracts live in [ART_CONTRACT.md](./ART_CONTRACT.md) (painted art / panel reskins) and [VOICE_OVER_CONTRACT.md](./VOICE_OVER_CONTRACT.md) (NPC dialogue audio).
 
 ### Zone-Based Sharding
 

--- a/docs/ART_CONTRACT.md
+++ b/docs/ART_CONTRACT.md
@@ -1,0 +1,197 @@
+# Painted Art & Panel Reskin Contract
+
+Shared spec for the web client's painted UI art — the panel frames, control overlays, canvas
+widgets, and default sprites that turn plain glass-morphism dialogs into illustrated windows.
+It is the visual analogue of [`VOICE_OVER_CONTRACT.md`](./VOICE_OVER_CONTRACT.md) and spans the
+same two repos:
+
+- **Arcanum** (content tooling) — generates the painted art, publishes content-hashed files to
+  R2, and maintains the `images.globalAssets` map in the lore config overlay.
+- **AmbonMUD** (this repo) — registers the logical asset keys, resolves them to URLs, and sends
+  the resolved map to the web client over GMCP. The client seats live content into the painted
+  frames with CSS and degrades gracefully when art is absent.
+
+Painted art is a **web-client-only** feature, like canvas rendering and voice-overs. Telnet
+clients are unaffected.
+
+## Division of labor
+
+| Side | Responsibility |
+|---|---|
+| Arcanum | Paint/generate each asset at its target pixel dimensions, upload to R2 under a **content-hashed filename**, and map `logicalKey → <hash>.<ext>` in the published `application-local.yaml` under `ambonmud.images.globalAssets`. Owns regeneration, cost, and licensing. |
+| AmbonMUD engine | Own the logical key registry (`ImagesConfig.DEFAULT_GLOBAL_ASSETS`, `AppConfig.kt`). Resolve every key to a **fully-resolved URL** and emit the map once per session as the `Server.Assets` GMCP package (`GmcpEmitter.sendServerAssets`). No image I/O in the engine. |
+| Web client | Read `state.serverAssets`, inject URLs as CSS custom properties, apply the `-skinned` class variant, seat content into the painted boxes with percentage insets, and fall back to pure-CSS styling when an asset is missing. The client **never concatenates paths**. |
+
+## Asset registry & naming conventions
+
+The single source of truth for logical keys is `ImagesConfig.DEFAULT_GLOBAL_ASSETS` in
+`src/main/kotlin/dev/ambon/config/AppConfig.kt` (~line 3045). Keys are stable identifiers;
+the *values* (paths/filenames) are what deployments override.
+
+| Family | Convention | Examples |
+|---|---|---|
+| Panel frames | `<panel>_bg` | `admin_bg`, `chat_bg`, `who_bg`, `guild_bg`, `friends_bg`, `group_bg`, `auction_bg`, `crafting_bg`, `professions_bg`, `housing_bg`, `stylist_bg`, `lottery_bg`, `dice_bg`, `bank_bg`, `puzzle_bg`, `command_reference_bg`, `character_bg`, `character_scribe_bg` |
+| Control overlays | `<panel>_<control>_btn` / `<scope>_<control>` | `staff_action_btn`, `staff_action_btn_active`, `who_examine_btn`, `who_tell_btn`, `who_friend_btn`, `char_btn_achievements`, `char_btn_prestige`, `char_btn_professions` |
+| Multi-piece sets | `<panel>_<piece>` | Character "Woodland Fae Cabinet": `character_niche` (full art), `character_frame` / `character_plaque` / `character_charm` (**9-slice** carved frames) |
+| World-feature art | `feature_*`, `door_*`, `lever_*`, `container_bg`, `sign_bg` | `door_frame` + `door_leaf` + `door_lock` + `door_portal` (static frame, swinging leaf, warded-seal lock, doorway vortex), `lever_plate` + `lever_handle` |
+| Canvas widgets & indicators | `<thing>_widget`, `<thing>_indicator`, `<thing>_kiosk` | `dice_table_widget`, `lottery_board_widget`, `shop_kiosk`, `aggro_indicator`, `quest_available_indicator` |
+| Game-piece art | themed per system | Aineroia's Dice: `dice_<child>` + `dice_<child>_max`, `coin_luneqrae_moon` / `coin_luneqrae_wind` |
+| Terrain / mob defaults | `default_bg_<terrain>`, `default_mob_<category>` | `default_bg_forest`, `default_mob_undead` |
+
+When adding a new key, keep it `snake_case`, scoped by panel/system, and add it to
+`DEFAULT_GLOBAL_ASSETS` with a bundled-path value (see resolution below) plus a comment stating
+its fallback behavior — the existing entries model this.
+
+## URL resolution
+
+`GmcpEmitter` resolves every registry value at construction (`GmcpEmitter.kt`, `resolvedAssets`):
+
+- Values starting with `defaults/` or `global_assets/` are **bundled** assets — they always
+  resolve against local `/images/` (served from classpath `src/main/resources/world/images/`
+  via the Ktor static route in `KtorWebSocketTransport.kt`). This keeps a fresh checkout
+  working with zero CDN setup.
+- Any other value (in practice: an Arcanum content-hashed filename) resolves against
+  `ambonmud.images.baseUrl` — the CDN base, e.g. `https://assets.ambon.dev/`.
+
+```yaml
+ambonmud:
+  images:
+    baseUrl: "/images/"        # production overlay: https://<r2-host>/
+    globalAssets:              # production overlay remaps keys to hashed filenames
+      admin_bg: 3f9a1c…e2.png  # → https://<r2-host>/3f9a1c…e2.png
+```
+
+### Cache-busting
+
+There is no query-string versioning. Arcanum publishes each image under a **content-hashed
+filename** and updates the overlay's `globalAssets` map to point at the new hash — changing the
+art yields a new URL, so stale images are never served and old files become GC-able. This is the
+image-side equivalent of the voice contract's `<sha8>` path segment. Bundled fallback art (under
+`global_assets/`/`defaults/` in the repo) is versioned by git instead.
+
+## GMCP delivery — `Server.Assets`
+
+On session init the engine emits the complete resolved map (`GmcpEmitter.sendServerAssets`):
+
+```json
+{ "gmcp": "Server.Assets", "data": { "admin_bg": "https://…/3f9a1c…e2.png", "shop_kiosk": "/images/global_assets/shop_kiosk.png", … } }
+```
+
+The client stores it verbatim as `state.serverAssets` (`applyGmcpPackage.ts`, `Server.Assets`
+case) and components receive either the whole map or a pre-plucked URL prop. Keys for which no
+file exists yet simply 404 → the client's CSS fallback renders instead; absent keys mean the
+unskinned variant renders. Either way nothing breaks — same silent-degradation philosophy as
+`voiceUrl: null`.
+
+## The panel reskin pattern
+
+This is the canonical way a window is "reskinned" onto a painted frame. **Staff Control is the
+reference implementation** (PRs #1282, #1283, #1287): `AdminPanel.tsx` + the
+`.admin-dialog-skinned` block in `web-v3/src/styles.css` (~line 25955). Mechanism in one
+sentence: *the painted PNG is stretched full-bleed behind the dialog, the dialog's aspect ratio
+is locked to the art's pixel dimensions, and live content is absolutely positioned into the
+boxes the artist painted, using percentage insets measured off the artwork.*
+
+There is no 9-slice and no PixiJS involved in panel frames (9-slice appears only in the carved
+multi-piece sets noted above). It is plain CSS + React.
+
+### Checklist for reskinning a panel
+
+1. **Commission the frame** at fixed pixel dimensions with the content regions painted as
+   visually empty boxes. Established sizes: full-screen boards `1456×1093`, Staff Control
+   `1456×1024`, Monster Manual `1280×853`, Dice table `1280×960` — match an existing size
+   when the layout is similar.
+2. **Register the key** in `DEFAULT_GLOBAL_ASSETS` (`<panel>_bg` → `global_assets/<panel>_bg.png`)
+   with a comment describing the fallback.
+3. **Thread the prop**: the component takes `backgroundImage: string | null` (and optionally
+   `serverAssets: Record<string, string>` for control overlays); the composition root passes
+   `state.serverAssets["<panel>_bg"] ?? null`.
+4. **Inject CSS variables** (see `AdminPanel.tsx` ~493–509):
+
+   ```tsx
+   const skinVars: Record<string, string> = {};
+   if (backgroundImage) skinVars["--admin-bg"] = `url("${backgroundImage}")`;
+   if (serverAssets.staff_action_btn) {
+     skinVars["--admin-action-btn"] = `url("${serverAssets.staff_action_btn}")`;
+     skinVars["--admin-action-edge"] = "transparent";   // suppress the CSS fallback chrome
+     skinVars["--admin-action-radius"] = "0px";
+     skinVars["--admin-action-shadow"] = "none";
+   }
+   ```
+
+5. **Toggle the skinned class** off prop presence — the unskinned dialog must keep working:
+
+   ```tsx
+   className={`popout-dialog admin-dialog${backgroundImage ? " admin-dialog-skinned" : ""}`}
+   style={Object.keys(skinVars).length > 0 ? skinVars : undefined}
+   ```
+
+6. **Write the skinned CSS** — aspect-ratio lock + full-bleed art + zero padding:
+
+   ```css
+   .admin-dialog.admin-dialog-skinned {
+     position: relative;
+     width: min(95vw, 132vh);          /* cap by both axes so the frame never crops */
+     aspect-ratio: 1456 / 1024;        /* the art's exact pixel dimensions */
+     padding: 0;                       /* content insets handle all spacing */
+     background: var(--admin-bg, none) center / 100% 100% no-repeat;
+     border: none;
+     overflow: hidden;
+   }
+   ```
+
+7. **Seat content into the painted boxes** with absolute percentage insets (top/right/bottom/left):
+
+   ```css
+   .admin-dialog-skinned .admin-status-strip { position: absolute; inset: 18.8% 23% 63.2% 16.4%; }
+   .admin-dialog-skinned .admin-main-pane    { position: absolute; inset: 39% 3% 11.5% 3%; }
+   ```
+
+   **Measuring convention:** because the art is stretched `100% / 100%`, image-space percentages
+   map directly onto the dialog. Open the PNG, measure each painted box's pixel bounds, divide
+   by the art dimensions: `inset-top = boxTop/artHeight`, `inset-right = (artWidth−boxRight)/artWidth`,
+   etc. Document the measured regions in a CSS comment next to the rules (see the
+   `admin_bg` comment block in `styles.css`) so the next person doesn't re-derive them.
+8. **Replace painted-over chrome** — hide the standard header/title/close when skinned and float
+   replacements at art-defined positions (e.g. `.admin-skin-close` at `top: 2.2%; right: 2.4%`).
+9. **Verify the fallback** — render with `backgroundImage={null}`: the unskinned dialog must be
+   fully usable. Also verify a present-but-404 URL (the local default until art is uploaded)
+   doesn't break layout.
+10. **Ship the art** — Arcanum uploads the hashed file to R2 and adds the key to the overlay's
+    `globalAssets`. Until then the panel renders its CSS fallback everywhere except environments
+    that bundle the PNG.
+
+### Fallback hierarchy
+
+Every layer is optional and degrades one step at a time — this ordering is load-bearing:
+
+1. **Entity-authored art** (e.g. a feature's own `backgroundImage`, a zone's room image) — most specific.
+2. **Global asset** from `Server.Assets` (this contract).
+3. **CSS-only treatment** — gradients, borders, vector shapes (e.g. the CSS door/lever, the
+   gilded-glass button gradient behind `staff_action_btn`).
+
+When a painted overlay replaces CSS chrome, the component must explicitly neutralize the
+fallback styling via variables (`…-edge: transparent`, `…-radius: 0`, `…-shadow: none` — step 4
+above), otherwise both render at once.
+
+## Testing checklist
+
+- Component renders correctly with the asset URL **null** (unskinned variant).
+- Component renders correctly with the asset URL **404ing** (CSS fallback, layout intact).
+- Skinned layout holds at desktop, tablet, and `95vw`-constrained small windows (the
+  `min(95vw, …vh)` cap keeps the aspect ratio; insets are percentage-based so they scale).
+- No hardcoded asset paths in the client — everything flows from `Server.Assets`.
+- New keys added to `DEFAULT_GLOBAL_ASSETS` appear in `Server.Assets` (it emits the whole map).
+
+## Summary
+
+| Concern | Decision |
+|---|---|
+| Key registry | `ImagesConfig.DEFAULT_GLOBAL_ASSETS` in `AppConfig.kt`; `snake_case`, `<panel>_bg` for frames |
+| URL resolution | `defaults/` & `global_assets/` paths → local `/images/`; anything else → `images.baseUrl` (CDN) |
+| Delivery | Full resolved map as `Server.Assets` GMCP at session init; client never builds paths |
+| Cache-busting | Arcanum content-hashed filenames remapped via the lore overlay (no query strings) |
+| Reskin mechanism | Full-bleed CSS background + `aspect-ratio` lock + absolute percentage insets; `-skinned` class variant |
+| Reference implementation | Staff Control: `AdminPanel.tsx` + `.admin-dialog-skinned` in `styles.css` |
+| Fallbacks | entity art → global asset → CSS-only; null key → unskinned dialog |
+| Transport scope | Web client only; telnet unaffected |

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -2,7 +2,7 @@
 
 Welcome. This document takes you from a clean checkout to making meaningful changes. If you only read one file besides this one, read [`ARCHITECTURE.md`](./ARCHITECTURE.md).
 
-**What is AmbonMUD?** A Kotlin MUD server with a 100 ms tick engine, telnet + WebSocket transports, YAML world content, config-driven abilities and status effects, class-based progression with skill-point training, 36 command handler subsystems, and three deployment modes (`STANDALONE` / `ENGINE` / `GATEWAY`) that scale from a single process to a Redis-sharded Fargate split.
+**What is AmbonMUD?** A Kotlin MUD server with a 100 ms tick engine, telnet + WebSocket transports, YAML world content, config-driven abilities and status effects, class-based progression with skill-point training, 37 command handler subsystems, and three deployment modes (`STANDALONE` / `ENGINE` / `GATEWAY`) that scale from a single process to a Redis-sharded Fargate split.
 
 ---
 
@@ -99,7 +99,7 @@ src/main/kotlin/dev/ambon/
 │   ├── commands/
 │   │   ├── CommandParser.kt     # sealed Command hierarchy (~200 variants)
 │   │   ├── CommandRouter.kt     # thin dispatch
-│   │   └── handlers/            # 36 handler files + EngineContext + HandlerHelpers
+│   │   └── handlers/            # 37 handler files + EngineContext + HandlerHelpers
 │   ├── abilities/               # AbilitySystem, ability registry loader
 │   ├── status/                  # StatusEffectSystem
 │   ├── crafting/                # CraftingSystem, recipes, gathering, quality
@@ -108,7 +108,7 @@ src/main/kotlin/dev/ambon/
 │   ├── housing/, dungeon/, auction/, trade/, duel/, faction/, pet/, prestige/, lottery/, puzzle/, weather/, worldtime/, worldevent/, leaderboard/, stylist/, bank/, currency/, quest/
 │   ├── scheduler/               # Scheduler.kt — delayed/recurring callbacks
 │   ├── PlayerRegistry.kt        # session ↔ player, login FSM
-│   ├── GmcpEmitter.kt           # GMCP package emissions (~3500 lines)
+│   ├── GmcpEmitter.kt           # GMCP package emissions (~4000 lines)
 │   └── ...
 ├── transport/                   # Network I/O
 │   ├── BlockingSocketTransport.kt     # Telnet server (virtual threads)
@@ -142,7 +142,7 @@ src/main/kotlin/dev/ambon/
 
 src/main/resources/
 ├── application.yaml             # Runtime config (~2000 lines)
-├── db/migration/                # Flyway migrations V1–V38
+├── db/migration/                # Flyway migrations V1–V42
 ├── world/                       # Academy tutorial zone + achievements.yaml + sprites.yaml
 │   ├── academy.yaml
 │   ├── achievements.yaml
@@ -212,11 +212,11 @@ Inbound handling:
 
 **File:** `engine/commands/CommandRouter.kt` — thin dispatch (~110 lines). Every variant routes to one of the handlers under `engine/commands/handlers/`. Each handler implements the `CommandHandler` interface and receives an `EngineContext` carrying the required subsystem references.
 
-### Handler catalog (36 handlers + 2 support files)
+### Handler catalog (37 handlers + 2 support files)
 
 | Handler | Commands |
 |---------|----------|
-| `NavigationHandler` | `n/s/e/w/u/d`, `look`, `exits`, `recall` |
+| `NavigationHandler` | `n/s/e/w/u/d`, `look`, `exits`, `recall`, `rest` (inn rooms set the recall point and grant 2× regen) |
 | `CombatHandler` | `kill`, `flee`, `cast` |
 | `CommunicationHandler` | `say`, `tell`, `whisper`, `gossip`, `shout`, `ooc`, `pose`, `emote` |
 | `ItemHandler` | `inventory`, `equipment`, `get`, `drop`, `wear`, `remove`, `use`, `give`, `put`, `examine` |
@@ -229,7 +229,8 @@ Inbound handling:
 | `CraftingHandler` | `gather`, `craft`, `recipes`, `craftskills`, `specialize` |
 | `EnchantHandler` | `enchant`, `enchantments` |
 | `FriendsHandler` | `friend list`/`add`/`remove` |
-| `MailHandler` | `mail list`/`read`/`send`/`delete`, compose mode |
+| `MailHandler` | `mail list`/`read`/`send`/`delete`/`claim`, compose mode; letters can carry gold + one item attachment |
+| `ClaimHandler` | `claim` — convert a guest session into a permanent account (BCrypt + DB write dispatched off the tick loop) |
 | `SpriteHandler` | `sprite list`/`set`/`default` |
 | `TrainerHandler` | `train list`/`learn`/`unlock` (multi-classing) |
 | `PetHandler` | `pet`, `pet dismiss`, `pet name` |
@@ -239,7 +240,7 @@ Inbound handling:
 | `TradeHandler` | `trade <player>`, `trade offer`/`accept`/`cancel` |
 | `DuelHandler` | `duel`, `duel accept`/`decline` |
 | `PrestigeHandler` | `prestige`, `prestige info` |
-| `LotteryHandler` | `lottery`, `lottery buy` |
+| `LotteryHandler` | `lottery`, `lottery buy`, `gamble`/`dice` (Aineroia's Dice — tavern rooms only) |
 | `ReputationHandler` | `reputation` |
 | `LeaderboardHandler` | `leaderboard`, `halloffame` |
 | `DungeonHandler` | `dungeon enter`/`leave` |
@@ -312,6 +313,7 @@ This is a working index, not an exhaustive spec. Each subsystem follows the patt
 | **GuildSystem** | `engine/GuildSystem.kt` | Permission-based ranks (data-driven), MOTD, roster, `gchat` |
 | **GuildHallSystem** | `engine/GuildHallSystem.kt` | Guild hall rooms (Flyway V33) |
 | **FriendsSystem** | `engine/FriendsSystem.kt` | Friend list, online/offline notifications |
+| **MailSystem** | `commands/handlers/MailHandler.kt` | Offline mail with optional gold + item attachments; recipients `mail claim` rewards |
 | **CraftingSystem** | `engine/crafting/CraftingSystem.kt` | Gathering, recipes, quality tiers (Normal → Masterwork), recipe discovery, specialization |
 | **EnchantingSystem** | `engine/crafting/EnchantingSystem.kt` | `enchant` command, enchanting station, stat/damage bonuses |
 | **HousingSystem** | `engine/housing/HousingSystem.kt` | Personal rooms, furniture, vaults, access control |
@@ -324,7 +326,7 @@ This is a working index, not an exhaustive spec. Each subsystem follows the patt
 | **BankSystem** | `engine/bank/BankSystem.kt` | Bank rooms (`bank: true` flag); gold + item vault |
 | **CurrencySystem** | `engine/CurrencySystem.kt` | Secondary currencies defined in `engine.currencies.definitions`; quest rewards can include currency grants |
 | **PrestigeSystem** | `engine/prestige/PrestigeSystem.kt` | Ranks, perks, XP cost (Flyway V28) |
-| **LotterySystem** | `engine/lottery/LotterySystem.kt` | Tickets, drawings, jackpot, atomic-write JSON persistence |
+| **LotterySystem** | `engine/lottery/LotterySystem.kt` | Tickets, drawings, jackpot, atomic-write JSON persistence; includes Aineroia's Dice (six themed dice + the Luneqrae coin, tavern rooms) |
 | **LeaderboardSystem** | `engine/leaderboard/LeaderboardSystem.kt` | 7 categories, top-N, hall of fame |
 | **WeatherSystem** | `engine/weather/WeatherSystem.kt` | Per-zone weather transitions, config-driven types, `World.Weather` GMCP |
 | **WorldTimeSystem** | `engine/worldtime/WorldTimeSystem.kt` | 24-hour clock, four periods (NIGHT/DAWN/DAY/DUSK), `World.Time` GMCP |
@@ -343,7 +345,7 @@ This is a working index, not an exhaustive spec. Each subsystem follows the patt
 
 **YAML (default):** One file per player under `data/players/`, atomic writes. Zero dependencies — this is what `./gradlew run` uses and what the EC2 demo ships with.
 
-**PostgreSQL:** Schema managed by Flyway migrations (`src/main/resources/db/migration/`, **V1 through V38**). Connection defaults match `docker-compose.yml` (`localhost:5432/ambonmud`, user `ambon`). Switching backends is one flag: `-Pconfig.ambonmud.persistence.backend=POSTGRES`.
+**PostgreSQL:** Schema managed by Flyway migrations (`src/main/resources/db/migration/`, **V1 through V42**). Connection defaults match `docker-compose.yml` (`localhost:5432/ambonmud`, user `ambon`). Switching backends is one flag: `-Pconfig.ambonmud.persistence.backend=POSTGRES`.
 
 ### The stack
 
@@ -619,8 +621,18 @@ Reference it from an ability via `effect.type: APPLY_STATUS` + `effect.statusEff
 
 1. Emit the package from `engine/GmcpEmitter.kt`.
 2. Handle it on the client at `web-v3/src/gmcp/applyGmcpPackage.ts`.
-3. **If it's a new package family**, register the prefix in `KtorWebSocketTransport.kt` (around line 208, `Core.Supports.Set`). Without this, GMCP is silently dropped. Prefix matching: `"Quest 1"` covers `Quest.List`, `Quest.Update`, etc.
+3. **If it's a new package family**, register the prefix in `KtorWebSocketTransport.kt` (around line 265, `Core.Supports.Set`). Without this, GMCP is silently dropped. Prefix matching: `"Quest 1"` covers `Quest.List`, `Quest.Update`, etc.
 4. Telnet clients negotiate via standard `WILL`/`DO`; the WebSocket client auto-opts-in to the full package set.
+
+### Reskin a web panel with painted art
+
+The full contract — asset naming, registry, `Server.Assets` GMCP delivery, the skinned-class CSS
+pattern, inset measuring, and fallbacks — lives in [`ART_CONTRACT.md`](./ART_CONTRACT.md). In
+brief: register a `<panel>_bg` key in `ImagesConfig.DEFAULT_GLOBAL_ASSETS` (`AppConfig.kt`),
+thread `backgroundImage: string | null` into the component, toggle a `-skinned` CSS variant that
+locks `aspect-ratio` to the art's pixel dimensions and seats content with percentage insets, and
+keep the unskinned fallback working. Staff Control (`AdminPanel.tsx`) is the reference
+implementation.
 
 ### Add a new bus / gRPC event variant
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 What's built. This is a living inventory of shipped systems, not a forward-looking roadmap.
 
-## Current State (May 2026)
+## Current State (June 2026)
 
 AmbonMUD has a **mature infrastructure** and **complete gameplay foundation**:
 
@@ -37,7 +37,10 @@ AmbonMUD has a **mature infrastructure** and **complete gameplay foundation**:
 ✅ Quest system (objectives, rewards, tracking)
 ✅ Achievement system + titles
 ✅ Guilds with ranks, guild chat, roster management
-✅ Friends list + offline mail
+✅ Friends list + offline mail (letters can attach gold and an item; recipients `mail claim`)
+✅ Aineroia's Dice — six-die tavern gambling game with the Luneqrae coin
+✅ Inn rooms — `rest` sets the recall point and grants 2× HP/mana regen
+✅ Guest sessions upgradeable to permanent accounts via `claim`
 ✅ Crafting & gathering with specialization, recipe discovery, quality tiers, rare yields
 ✅ Player housing (personal rooms, furniture, vaults, access control)
 ✅ Procedural dungeons (template-driven, instanced, 4 difficulty tiers, boss encounters)
@@ -47,6 +50,8 @@ AmbonMUD has a **mature infrastructure** and **complete gameplay foundation**:
 ✅ Leaderboard system and hall of fame
 ✅ Web-based admin dashboard
 ✅ Remember-me auth tokens for persistent login
+✅ Painted-art panel reskins (Staff Control, Crafting, Auction, Lottery, Housing, Stylist, Dice, social boards) with server-resolved assets via `Server.Assets` GMCP — see `docs/ART_CONTRACT.md`
+✅ NPC dialogue voice-overs (ElevenLabs clips over GMCP) — see `docs/VOICE_OVER_CONTRACT.md`
 
 ---
 
@@ -57,4 +62,4 @@ publishing, and format-preserving YAML round-trip editing
 
 ---
 
-**Last updated:** May 11, 2026
+**Last updated:** June 9, 2026

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1,7 +1,7 @@
 # AmbonMUD Design System: Surreal Gentle Magic
 
 **Version:** surreal_softmagic_v1
-**Last Updated:** March 25, 2026
+**Last Updated:** June 9, 2026
 **Scope:** Unified aesthetic for UI components, world rendering, and interactive experiences
 **Implementation:** Dark-mode theme implemented in `web-v3/src/styles.css` (design tokens + component styles). PixiJS canvas scenes (world, battle, particles) are live. Light mode is planned.
 **Design Context:** See [`.impeccable.md`](../.impeccable.md) for brand personality, user audiences, and high-level design principles.
@@ -542,9 +542,17 @@ web-v3/
 - [x] Spell targeting system (auto-target, targeting mode, Escape cancel)
 - [x] Login modal with race/class selection
 
+### Painted Panel Frames ✅
+- [x] Subsystem windows reskinned onto painted art frames (Staff Control, Crafting, Auction, Lottery, Housing, Stylist, Dice, Bank, Character cabinet, social boards)
+- [x] Server-resolved asset delivery via `Server.Assets` GMCP; CSS-only fallback when art is absent
+
+The asset pipeline, naming conventions, and the reskin pattern (aspect-ratio lock + percentage
+insets) are specified in [`ART_CONTRACT.md`](./ART_CONTRACT.md). Painted frames *extend* this
+design system — content seated inside a frame still uses the tokens, typography, and motion
+rules in this guide, and the CSS fallback variant must remain on-system.
+
 ### Outstanding
 - [ ] Light mode theme (preserve magical warmth — don't just invert)
-- [ ] Admin console redesign using design tokens
 - [ ] Visual regression test templates
 - [ ] Style variants (e.g., `surreal_softmagic_night_v1`)
 
@@ -637,4 +645,4 @@ When creating new variants, document the differences from v1 and update this sec
 
 ---
 
-**Last Updated:** April 2026
+**Last Updated:** June 2026

--- a/docs/WEB_CLIENT.md
+++ b/docs/WEB_CLIENT.md
@@ -35,10 +35,15 @@ Full redesign: dark glassmorphism panels, banner artwork, tabbed Play/Character/
 
 ![v3 web client](screenshots/v3-web-client.jpg)
 
-### v4 — PixiJS Canvas (Current)
+### v4 — PixiJS Canvas
 PixiJS canvas replaces the xterm terminal as the primary game view. Terminal moved to popout (available on command input focus). JRPG-style world and battle scenes with sprite-based rendering. Side panels preserved.
 
 ![v4 web client](screenshots/webclient-v4.jpeg)
+
+### v5 — Painted Panels (Current)
+Subsystem windows reskinned onto full-bleed painted art frames (Staff Control, Crafting, Auction House, Lottery, Housing, Stylist, Dice, and more), with the social panels split into standalone illustrated "boards" (Social Board, Who, Guild, Friends, Group). Server-resolved art URLs arrive via the `Server.Assets` GMCP package; every panel degrades to CSS-only styling when art is absent. See [`ART_CONTRACT.md`](./ART_CONTRACT.md) for the asset pipeline and reskin pattern.
+
+![v5 web client](screenshots/webclient-v5.png)
 
 ---
 
@@ -109,6 +114,25 @@ For push events (combat events, gain popups), `CanvasEventBus.ts` provides a rin
 5. Outbound GMCP is serialized as JSON envelope: `{"gmcp":"<Package>","data":<json>}`
 6. Frontend routes by package in `applyGmcpPackage.ts`
 
+### Painted Panels & Boards (v5)
+
+Most subsystem windows are now **skinned onto painted art frames** rather than styled as plain
+glass dialogs. The pattern (full spec in [`ART_CONTRACT.md`](./ART_CONTRACT.md)):
+
+- The engine sends a map of logical asset keys → fully-resolved URLs in the `Server.Assets`
+  GMCP package; the client stores it as `state.serverAssets`.
+- A panel component takes `backgroundImage: string | null`, injects it as a CSS custom property,
+  and toggles a `-skinned` class variant. The skinned CSS locks `aspect-ratio` to the art's
+  pixel dimensions, stretches the PNG full-bleed, and absolutely positions content into the
+  painted boxes with percentage insets.
+- When the asset is null or missing, the panel renders its original CSS-only variant — no art
+  pipeline is required for local development.
+
+The former monolithic Chat/Social sidebar content was split into standalone illustrated
+**boards**: Social Board (`ChatBoardPanel`), Who (`WhoBoardPanel`), Guild (`GuildBoardPanel`),
+Friends (`FriendsBoardPanel`), and Group (`GroupBoardPanel`), each seated in its own painted
+frame. Staff Control (`AdminPanel`) is the reference implementation of the reskin pattern.
+
 ---
 
 ## File Structure
@@ -132,9 +156,18 @@ web-v3/src/
 │       ├── DialogueOverlay.ts       # NPC dialogue on canvas
 │       └── EntityPopout.ts          # Click-to-interact on sprites
 ├── App.tsx                          # Composition root, state management
-├── gmcp/applyGmcpPackage.ts        # GMCP package → state updates
+├── gmcp/applyGmcpPackage.ts        # GMCP package → state updates (~100 packages)
 ├── components/
-│   ├── panels/                      # PlayPanel, WorldPanel, ChatPanel, CharacterPanel
+│   ├── panels/                      # 31 panel components:
+│   │   #  Core HUD:    PlayPanel, CombatPanel, CombatLogPanel, CharacterPanel,
+│   │   #               InventoryPanel, EquipmentPanel, QuestPanel, QuestOfferPanel
+│   │   #  Boards:      ChatBoardPanel (Social), WhoBoardPanel, GuildBoardPanel,
+│   │   #               FriendsBoardPanel, GroupBoardPanel
+│   │   #  Subsystems:  AuctionPanel, BankPanel, CraftingPanel, ProfessionsPanel,
+│   │   #               DungeonPanel, HousingPanel, InnPanel, LotteryPanel, DicePanel,
+│   │   #               MailPanel, StylistPanel, LeaderboardPanel, SystemsPanel
+│   │   #  Reference:   MonsterManualPanel, ItemManualPanel, PlayerExaminePanel
+│   │   #  Staff:       AdminPanel (+ AdminPanel.logic.ts) — painted-frame reference impl
 │   ├── PopoutLayer.tsx              # Overlay panels (map, equipment, terminal, spellbook)
 │   ├── SpellbookPanel.tsx           # Ability grid with target type filtering
 │   └── ...


### PR DESCRIPTION
## Summary

Full documentation audit against the current codebase (per `/doc-audit`). The docs were already well-consolidated, so this PR is about **accuracy** and one **major gap**: the painted-art / window-reskin pipeline had no written contract.

### New
- **`docs/ART_CONTRACT.md`** — the painted UI art & panel-reskin contract, modeled on `VOICE_OVER_CONTRACT.md`:
  - Logical key registry (`ImagesConfig.DEFAULT_GLOBAL_ASSETS`) and naming conventions (`<panel>_bg`, control overlays, multi-piece sets, widgets, defaults)
  - URL resolution rules (bundled `global_assets/` / `defaults/` resolve to local `/images/`; overlay-remapped hashed filenames resolve to the CDN) and `Server.Assets` GMCP delivery
  - Cache-busting via Arcanum content-hashed filenames in the lore overlay
  - The canonical reskin pattern (aspect-ratio lock, full-bleed background, percentage-inset seating, measuring convention) with Staff Control (#1282 / #1283 / #1287) as the reference implementation
  - Fallback hierarchy (entity art → global asset → CSS-only) and a testing checklist

### Updated
- **WEB_CLIENT.md** — v5 "Painted Panels" generation, real 31-panel inventory, board-split pattern, painted-frame architecture section
- **DEVELOPER_GUIDE.md** — 37 handlers (+ `ClaimHandler`), Flyway V42, mail gold/item attachments, Aineroia's Dice, inn rest/recall, new "Reskin a web panel" common task, corrected `Core.Supports.Set` line ref (208 → 265)
- **ROADMAP.md** — features shipped since May 11
- **ARCHITECTURE.md** — counts + new "Server-Resolved Media URLs" design decision
- **STYLE_GUIDE.md** — painted-frames section; admin redesign removed from Outstanding
- **CLAUDE.md / AGENTS.md / README.md** — corrected handler counts, migration range, big-file sizes; art + voice contracts added to doc maps; reskin playbook in CLAUDE.md

### Verified against code (not just subagent reports)
Handler count (37), migrations (V42), `ImagesConfig` registry, `GmcpEmitter.resolvedAssets` bundled-vs-CDN logic, `Server.Assets` emission, `.admin-dialog-skinned` CSS, and the live overlay's hashed `globalAssets` map on assets.ambon.dev.

Docs-only change — no code touched.
