### PR TITLE
feat(web): full-screen terminal overlay with session-long ANSI log

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -3135,6 +3135,10 @@ data class ImagesConfig(
             "crafting_bg" to "global_assets/crafting_bg.png",
             "professions_bg" to "global_assets/professions_bg.png",
             "admin_bg" to "global_assets/admin_bg.png",
+            // Pressed-flower parchment layered behind the full-screen terminal
+            // overlay (under a dark legibility scrim) once the player commits to
+            // typing. Falls back to the flat translucent CSS panel when absent.
+            "terminal_parchment_bg" to "global_assets/terminal_parchment_bg.png",
             "dialog_indicator" to "global_assets/dialog_indicator.png",
             "aggro_indicator" to "global_assets/aggro_indicator.png",
             "quest_available_indicator" to "global_assets/quest_available_indicator.png",

--- a/web-v3/bun.lock
+++ b/web-v3/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "web-v3",
       "dependencies": {
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/xterm": "^6.0.0",
         "pixi.js": "^8.16.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -251,6 +253,10 @@
     "@webgpu/types": ["@webgpu/types@0.1.69", "", {}, "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.11", "", {}, "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw=="],
+
+    "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
+
+    "@xterm/xterm": ["@xterm/xterm@6.0.0", "", {}, "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 

--- a/web-v3/package.json
+++ b/web-v3/package.json
@@ -11,6 +11,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "pixi.js": "^8.16.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -266,6 +266,7 @@ function App() {
     write: writeTerminal,
     echoCommand,
     writeSystem,
+    hasSelection: terminalHasSelection,
   } = useTerminal({ hiddenHostRef: terminalHiddenRef, overlayHostRef: terminalOverlayRef });
 
   // Wire up the WebSocket
@@ -2174,6 +2175,9 @@ function App() {
         open={terminalOpen}
         opaque={terminalOpaque}
         hostRef={terminalOverlayRef}
+        hasSelection={terminalHasSelection}
+        parchmentBg={state.serverAssets["terminal_parchment_bg"] ?? null}
+        quillUrl={state.serverAssets["desk_quill"] ?? null}
         inputValue={inputValue}
         onInputChange={(value) => {
           setInputValue(value);

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -37,7 +37,7 @@ import { DicePanel } from "./components/panels/DicePanel";
 import { AdminPanel } from "./components/panels/AdminPanel";
 import { CombatLogPanel } from "./components/panels/CombatLogPanel";
 import { HelpContent } from "./components/HelpContent";
-import { CommandInput } from "./components/CommandInput";
+import { TerminalOverlay } from "./components/TerminalOverlay";
 import { Atlas } from "./components/Atlas";
 import { DemoBanner } from "./components/DemoBanner";
 import { LevelUpBanner } from "./components/LevelUpBanner";
@@ -49,6 +49,7 @@ import { CharacterPicker } from "./components/CharacterPicker";
 import { CommandPalette } from "./components/CommandPalette";
 import { useGameState } from "./hooks/useGameState";
 import { useMudSocket } from "./hooks/useMudSocket";
+import { useTerminal } from "./hooks/useTerminal";
 import { useAudioEngine } from "./hooks/useAudioEngine";
 import { useCommandHistory } from "./hooks/useCommandHistory";
 import { useMiniMap } from "./hooks/useMiniMap";
@@ -212,6 +213,11 @@ function App() {
     setInputValue(text);
   };
 
+  // Terminal host elements — refs stay in App (attached to JSX below) so the
+  // useTerminal return value carries no refs (react-hooks/refs rule).
+  const terminalHiddenRef = useRef<HTMLDivElement | null>(null);
+  const terminalOverlayRef = useRef<HTMLDivElement | null>(null);
+
   // Minimap canvas + drawing helpers (owns its own ref, kept out of useGameState)
   const {
     mapCanvasRef,
@@ -249,13 +255,23 @@ function App() {
     resetComposerCompletion,
   } = useCommandHistory(state.serverCommands);
 
+  // Session-long telnet-style log; the GUI stays primary and the overlay
+  // summons this accumulated stream on demand.
+  const {
+    open: terminalOpen,
+    opaque: terminalOpaque,
+    setOpaque: setTerminalOpaque,
+    openTerminal,
+    closeTerminal,
+    write: writeTerminal,
+    echoCommand,
+    writeSystem,
+  } = useTerminal({ hiddenHostRef: terminalHiddenRef, overlayHostRef: terminalOverlayRef });
+
   // Wire up the WebSocket
   const { connected, liveMessage, connect, disconnect, reconnect, sendLine, sendGmcp } = useMudSocket({
     onOpen: () => {},
-    onTextMessage: () => {
-      // Terminal removed — server text other than GMCP is silently ignored.
-      // The login modal handles the auth flow via Login.* GMCP packages.
-    },
+    onTextMessage: writeTerminal,
     onGmcpMessage: state.handleGmcp,
     onClose: () => {
       if (intentionalDisconnectRef.current) {
@@ -264,10 +280,12 @@ function App() {
       }
       if (resumeTokenRef.current) {
         state.setReconnecting(true);
+        writeSystem("Connection lost — reconnecting...");
         window.setTimeout(() => reconnect(), 500);
       } else {
         state.resetHud();
         audio.stopAll();
+        writeSystem("Connection closed.");
       }
     },
     onError: () => {},
@@ -315,7 +333,14 @@ function App() {
     const command = raw.trim();
     if (command.length === 0) return;
     if (!sendLine(command)) return;
-    pushHistory(command);
+    // `claim [newname] <password>` carries the user's password — mask it in
+    // the terminal echo (like a telnet server suppressing echo at a password
+    // prompt) and keep it out of the persisted command history.
+    const carriesSecret = /^claim\s/i.test(command);
+    // Local echo into the background log, like a telnet client — GUI-driven
+    // commands show up there too, so the log reads as a faithful session.
+    echoCommand(carriesSecret ? "claim ********" : command);
+    if (!carriesSecret) pushHistory(command);
     resetComposerTraversal();
   };
 
@@ -897,7 +922,6 @@ function App() {
       case "dice": return "Dice Table";
       case "combatlog": return "Battle Journal";
       case "help": return "Command Reference";
-      case "terminal": return "Terminal";
       case "room": return state.room.title !== "-" ? state.room.title : "Room Details";
       case "map": return "World Map";
       default: return "";
@@ -949,6 +973,7 @@ function App() {
         activePopout={state.activePopout}
         onCommand={sendCommand}
         onOpenPanel={(panel) => openPanel(panel)}
+        onOpenTerminal={openTerminal}
         audio={audio}
       />
 
@@ -1005,11 +1030,9 @@ function App() {
                       ? "questboard"
                       : drawerPanel === "spellbook"
                         ? "grimoire"
-                        : drawerPanel === "terminal"
-                          ? "desk"
-                          : drawerPanel === "mail"
-                            ? "mail"
-                            : "default"
+                        : drawerPanel === "mail"
+                          ? "mail"
+                          : "default"
         }
         skinBg={
           drawerPanel === "puzzle"
@@ -1061,11 +1084,9 @@ function App() {
                       ? state.serverAssets["quest_board_bg"]
                       : drawerPanel === "spellbook"
                         ? state.serverAssets["spellbook_bg"]
-                        : drawerPanel === "terminal"
-                          ? state.serverAssets["terminal_bg"]
-                          : drawerPanel === "mail"
-                            ? state.serverAssets["mail_bg"]
-                            : undefined
+                        : drawerPanel === "mail"
+                          ? state.serverAssets["mail_bg"]
+                          : undefined
         }
         initialHeight={drawerPanel === "chatboard" || drawerPanel === "whoboard" || drawerPanel === "guildboard" || drawerPanel === "friendsboard" || drawerPanel === "groupboard" || drawerPanel === "help" || drawerPanel === "stylist" || drawerPanel === "housing" || drawerPanel === "lottery" || drawerPanel === "dice" || drawerPanel === "auction" || drawerPanel === "crafting" || drawerPanel === "professions" ? 0.94 : undefined}
       >
@@ -1459,30 +1480,6 @@ function App() {
             serverCommands={state.serverCommands}
             isStaff={state.character.isStaff}
           />
-        )}
-
-        {drawerPanel === "terminal" && (
-          <div className="terminal-overlay-body terminal-desk">
-            <div className="terminal-desk-slip">
-              <span className="terminal-desk-quill" aria-hidden="true">
-                {state.serverAssets["desk_quill"]
-                  ? <img src={state.serverAssets["desk_quill"]} alt="" className="terminal-desk-quill-img" />
-                  : "✒"}
-              </span>
-              <p className="terminal-overlay-note">
-                Pen a command and dispatch it to the world.
-              </p>
-              <CommandInput
-                inputValue={inputValue}
-                onInputChange={(value) => {
-                  setInputValue(value);
-                  resetComposerCompletion();
-                }}
-                onInputKeyDown={handleInputKeyDown}
-                onCommand={sendCommand}
-              />
-            </div>
-          </div>
         )}
 
         {drawerPanel === "map" && (
@@ -2170,6 +2167,27 @@ function App() {
           </div>
         </div>
       )}
+
+      {/* Full-screen terminal — the session-long server log, summoned from the
+          dock input (desktop) or the services stack (small screens). */}
+      <TerminalOverlay
+        open={terminalOpen}
+        opaque={terminalOpaque}
+        hostRef={terminalOverlayRef}
+        inputValue={inputValue}
+        onInputChange={(value) => {
+          setInputValue(value);
+          resetComposerCompletion();
+          if (value.length > 0) setTerminalOpaque(true);
+        }}
+        onInputKeyDown={handleInputKeyDown}
+        onCommand={sendCommand}
+        onClose={closeTerminal}
+      />
+
+      {/* Hidden terminal container — keeps xterm alive (and accumulating
+          server text) off-screen while the GUI is in charge. */}
+      <div ref={terminalHiddenRef} className="terminal-hidden" aria-hidden="true" />
 
       <p className="sr-only" aria-live="polite">{liveMessage}</p>
     </>

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -267,7 +267,14 @@ function App() {
     echoCommand,
     writeSystem,
     hasSelection: terminalHasSelection,
+    setInkTheme,
   } = useTerminal({ hiddenHostRef: terminalHiddenRef, overlayHostRef: terminalOverlayRef });
+
+  // Parchment scroll art → dark ink palette; absent art → light-on-dark.
+  const terminalParchmentBg = state.serverAssets["terminal_parchment_bg"] ?? null;
+  useEffect(() => {
+    setInkTheme(terminalParchmentBg !== null);
+  }, [terminalParchmentBg, setInkTheme]);
 
   // Wire up the WebSocket
   const { connected, liveMessage, connect, disconnect, reconnect, sendLine, sendGmcp } = useMudSocket({
@@ -2176,7 +2183,7 @@ function App() {
         opaque={terminalOpaque}
         hostRef={terminalOverlayRef}
         hasSelection={terminalHasSelection}
-        parchmentBg={state.serverAssets["terminal_parchment_bg"] ?? null}
+        parchmentBg={terminalParchmentBg}
         quillUrl={state.serverAssets["desk_quill"] ?? null}
         inputValue={inputValue}
         onInputChange={(value) => {

--- a/web-v3/src/components/CommandInput.tsx
+++ b/web-v3/src/components/CommandInput.tsx
@@ -8,13 +8,24 @@ interface CommandInputProps {
   onCommand: (cmd: string) => void;
   /** Lets the parent focus the input (e.g. when the terminal overlay opens). */
   inputRef?: RefObject<HTMLInputElement | null>;
+  placeholder?: string;
+  /** Painted art for the send button (e.g. the quill); falls back to the SVG. */
+  sendIconUrl?: string | null;
 }
 
 /**
  * Slim command input overlaid on the bottom of the canvas. Replaces the input
  * that lived in the now-removed bottom action bar.
  */
-export function CommandInput({ inputValue, onInputChange, onInputKeyDown, onCommand, inputRef: externalRef }: CommandInputProps) {
+export function CommandInput({
+  inputValue,
+  onInputChange,
+  onInputKeyDown,
+  onCommand,
+  inputRef: externalRef,
+  placeholder = "Type a command...",
+  sendIconUrl = null,
+}: CommandInputProps) {
   const internalRef = useRef<HTMLInputElement | null>(null);
   const inputRef = externalRef ?? internalRef;
 
@@ -32,15 +43,23 @@ export function CommandInput({ inputValue, onInputChange, onInputKeyDown, onComm
         ref={inputRef}
         type="text"
         className="canvas-command-input"
-        placeholder="Type a command..."
+        placeholder={placeholder}
         value={inputValue}
         onChange={(e) => onInputChange(e.target.value)}
         onKeyDown={onInputKeyDown}
       />
-      <button type="submit" className="canvas-command-send" aria-label="Send">
-        <svg viewBox="0 0 24 24" className="canvas-command-send-icon" fill="currentColor">
-          <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" />
-        </svg>
+      <button
+        type="submit"
+        className={`canvas-command-send${sendIconUrl ? " canvas-command-send-skinned" : ""}`}
+        aria-label="Send"
+      >
+        {sendIconUrl ? (
+          <img src={sendIconUrl} alt="" className="canvas-command-send-img" />
+        ) : (
+          <svg viewBox="0 0 24 24" className="canvas-command-send-icon" fill="currentColor">
+            <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" />
+          </svg>
+        )}
       </button>
     </form>
   );

--- a/web-v3/src/components/CommandInput.tsx
+++ b/web-v3/src/components/CommandInput.tsx
@@ -1,19 +1,22 @@
 import { useRef } from "react";
-import type { FormEvent, KeyboardEvent } from "react";
+import type { FormEvent, KeyboardEvent, RefObject } from "react";
 
 interface CommandInputProps {
   inputValue: string;
   onInputChange: (value: string) => void;
   onInputKeyDown?: (event: KeyboardEvent<HTMLInputElement>) => void;
   onCommand: (cmd: string) => void;
+  /** Lets the parent focus the input (e.g. when the terminal overlay opens). */
+  inputRef?: RefObject<HTMLInputElement | null>;
 }
 
 /**
  * Slim command input overlaid on the bottom of the canvas. Replaces the input
  * that lived in the now-removed bottom action bar.
  */
-export function CommandInput({ inputValue, onInputChange, onInputKeyDown, onCommand }: CommandInputProps) {
-  const inputRef = useRef<HTMLInputElement | null>(null);
+export function CommandInput({ inputValue, onInputChange, onInputKeyDown, onCommand, inputRef: externalRef }: CommandInputProps) {
+  const internalRef = useRef<HTMLInputElement | null>(null);
+  const inputRef = externalRef ?? internalRef;
 
   const submit = (e: FormEvent) => {
     e.preventDefault();

--- a/web-v3/src/components/Drawer.tsx
+++ b/web-v3/src/components/Drawer.tsx
@@ -9,7 +9,7 @@ interface DrawerProps {
   /** Visual skin for the sheet chrome: warm leather (satchel), a dim
    *  dressing-chamber (equipment), a merchant cart (shop), a chalkboard
    *  (trainer), a parchment journal (combat log), or a cork quest board. */
-  variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "desk" | "mail" | "feature" | "tome" | "vault" | "cabinet" | "board" | "starframe" | "archive" | "stainedglass" | "codex" | "boudoir" | "estate" | "fortune" | "dicetable" | "auctionhouse" | "forge" | "professions";
+  variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "mail" | "feature" | "tome" | "vault" | "cabinet" | "board" | "starframe" | "archive" | "stainedglass" | "codex" | "boudoir" | "estate" | "fortune" | "dicetable" | "auctionhouse" | "forge" | "professions";
   /** Optional background art for a skinned variant (server asset). */
   skinBg?: string;
   /** Height (as a fraction of the viewport) the drawer snaps to when it opens. */

--- a/web-v3/src/components/GameShell.tsx
+++ b/web-v3/src/components/GameShell.tsx
@@ -384,13 +384,15 @@ export function GameShell({
           {/* Desktop only — focusing this summons the terminal overlay, which
               carries the session-long server log. CSS hides it on small
               screens, where the services stack hosts the terminal instead.
-              Styled as a parchment slip with the quill resting on it. */}
-          <div className="terminal-dock">
-            <span className="terminal-dock-glyph" aria-hidden="true">
-              {serverAssets["desk_quill"]
-                ? <img src={serverAssets["desk_quill"]} alt="" className="terminal-dock-quill-img" />
-                : "✒"}
-            </span>
+              Styled as a parchment slip with the quill resting on its right
+              edge — the same parchment art and quill placement as the
+              terminal it summons. */}
+          <div
+            className={`terminal-dock${serverAssets["terminal_parchment_bg"] ? " terminal-dock-skinned" : ""}`}
+            style={serverAssets["terminal_parchment_bg"]
+              ? { ["--terminal-parchment" as string]: `url("${serverAssets["terminal_parchment_bg"]}")` }
+              : undefined}
+          >
             <input
               type="text"
               className="terminal-dock-input"
@@ -401,6 +403,11 @@ export function GameShell({
               onFocus={onOpenTerminal}
               onChange={() => undefined}
             />
+            <span className="terminal-dock-glyph" aria-hidden="true">
+              {serverAssets["desk_quill"]
+                ? <img src={serverAssets["desk_quill"]} alt="" className="terminal-dock-quill-img" />
+                : "✒"}
+            </span>
           </div>
         </div>
       )}

--- a/web-v3/src/components/GameShell.tsx
+++ b/web-v3/src/components/GameShell.tsx
@@ -383,15 +383,20 @@ export function GameShell({
 
           {/* Desktop only — focusing this summons the terminal overlay, which
               carries the session-long server log. CSS hides it on small
-              screens, where the services stack hosts the terminal instead. */}
+              screens, where the services stack hosts the terminal instead.
+              Styled as a parchment slip with the quill resting on it. */}
           <div className="terminal-dock">
-            <span className="terminal-dock-glyph" aria-hidden="true">&gt;_</span>
+            <span className="terminal-dock-glyph" aria-hidden="true">
+              {serverAssets["desk_quill"]
+                ? <img src={serverAssets["desk_quill"]} alt="" className="terminal-dock-quill-img" />
+                : "✒"}
+            </span>
             <input
               type="text"
               className="terminal-dock-input"
               value=""
               readOnly
-              placeholder="Type a command…"
+              placeholder="Inscribe a command…"
               aria-label="Open terminal"
               onFocus={onOpenTerminal}
               onChange={() => undefined}

--- a/web-v3/src/components/GameShell.tsx
+++ b/web-v3/src/components/GameShell.tsx
@@ -33,6 +33,7 @@ interface GameShellProps {
   activePopout: PopoutPanel;
   onCommand: (cmd: string) => void;
   onOpenPanel: (panel: PopoutPanel) => void;
+  onOpenTerminal: () => void;
   audio: AudioEngine;
   children?: ReactNode;
   /** Overlay rendered inside the canvas layer (e.g. staff pills near Recall). */
@@ -72,6 +73,7 @@ export function GameShell({
   activePopout,
   onCommand,
   onOpenPanel,
+  onOpenTerminal,
   audio,
   children,
   canvasOverlay,
@@ -312,6 +314,19 @@ export function GameShell({
                     ? <img className="hud-stack-img" src={serverAssets["mail_widget"]} alt="" />
                     : <span className="hud-stack-glyph">✉</span>}
                 </button>
+                {/* Small screens only — desktop reaches the terminal via the
+                    dock input under the kiosk row instead. */}
+                <button
+                  type="button"
+                  className="hud-stack-btn hud-stack-btn-terminal"
+                  onClick={() => { onOpenTerminal(); closeServices(); }}
+                  title="Terminal"
+                  aria-label="Terminal"
+                >
+                  {serverAssets["terminal_widget"]
+                    ? <img className="hud-stack-img" src={serverAssets["terminal_widget"]} alt="" />
+                    : <span className="hud-stack-glyph">&gt;_</span>}
+                </button>
               </div>
             </nav>
 
@@ -364,6 +379,23 @@ export function GameShell({
                 onOpenPanel={onOpenPanel}
               />
             )}
+          </div>
+
+          {/* Desktop only — focusing this summons the terminal overlay, which
+              carries the session-long server log. CSS hides it on small
+              screens, where the services stack hosts the terminal instead. */}
+          <div className="terminal-dock">
+            <span className="terminal-dock-glyph" aria-hidden="true">&gt;_</span>
+            <input
+              type="text"
+              className="terminal-dock-input"
+              value=""
+              readOnly
+              placeholder="Type a command…"
+              aria-label="Open terminal"
+              onFocus={onOpenTerminal}
+              onChange={() => undefined}
+            />
           </div>
         </div>
       )}

--- a/web-v3/src/components/KioskBar.tsx
+++ b/web-v3/src/components/KioskBar.tsx
@@ -1,12 +1,12 @@
 import type { ReactNode } from "react";
 import type { PopoutPanel } from "../types";
 import {
+  CharacterAvatarIcon,
   EquipmentIcon,
   WearingIcon,
   SpellbookIcon,
   QuestsTabIcon,
   AttackIcon,
-  TerminalIcon,
 } from "./Icons";
 
 interface KioskDef {
@@ -18,12 +18,12 @@ interface KioskDef {
 }
 
 const KIOSKS: KioskDef[] = [
+  { panel: "character", label: "Character", assetKey: "character_widget", fallback: <CharacterAvatarIcon className="kiosk-icon-svg" /> },
   { panel: "inventory", label: "Inventory", assetKey: "inventory_widget", fallback: <EquipmentIcon className="kiosk-icon-svg" /> },
   { panel: "equipment", label: "Equipment", assetKey: "equipment_widget", fallback: <WearingIcon className="kiosk-icon-svg" /> },
   { panel: "spellbook", label: "Spellbook", assetKey: "spellbook_widget", fallback: <SpellbookIcon className="kiosk-icon-svg" /> },
   { panel: "quests", label: "Quests", assetKey: "quests_widget", fallback: <QuestsTabIcon className="kiosk-icon-svg" /> },
   { panel: "combatlog", label: "Combat Log", assetKey: "combat_log_widget", fallback: <AttackIcon className="kiosk-icon-svg" /> },
-  { panel: "terminal", label: "Terminal", assetKey: "terminal_widget", fallback: <TerminalIcon className="kiosk-icon-svg" /> },
 ];
 
 interface KioskBarProps {

--- a/web-v3/src/components/TerminalOverlay.tsx
+++ b/web-v3/src/components/TerminalOverlay.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import type { FocusEvent, KeyboardEvent, RefObject } from "react";
+import type { FocusEvent, KeyboardEvent, PointerEvent as ReactPointerEvent, RefObject } from "react";
 import { CommandInput } from "./CommandInput";
 
 interface TerminalOverlayProps {
@@ -7,12 +7,23 @@ interface TerminalOverlayProps {
   opaque: boolean;
   /** Host the live xterm element reparents into while the overlay is open. */
   hostRef: RefObject<HTMLDivElement | null>;
+  /** Whether the xterm has an active text selection (its own model, not window.getSelection). */
+  hasSelection: () => boolean;
+  /** Pressed-flower parchment art layered behind the opaque log (ART_CONTRACT). */
+  parchmentBg?: string | null;
+  /** Quill art for the send button; falls back to the SVG. */
+  quillUrl?: string | null;
   inputValue: string;
   onInputChange: (value: string) => void;
   onInputKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
   onCommand: (cmd: string) => void;
   onClose: () => void;
 }
+
+/** Pointer travel beyond this is a drag (text selection / scroll), not a click. */
+const CLICK_SLOP_PX = 8;
+/** Holds longer than this are long-presses (touch selection), not clicks. */
+const CLICK_MAX_MS = 500;
 
 /**
  * Full-screen terminal over the GUI. Summoned by focusing the dock input
@@ -24,6 +35,9 @@ export function TerminalOverlay({
   open,
   opaque,
   hostRef,
+  hasSelection,
+  parchmentBg = null,
+  quillUrl = null,
   inputValue,
   onInputChange,
   onInputKeyDown,
@@ -31,6 +45,7 @@ export function TerminalOverlay({
   onClose,
 }: TerminalOverlayProps) {
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const pointerDownRef = useRef<{ x: number; y: number; at: number; closeEligible: boolean } | null>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -50,14 +65,50 @@ export function TerminalOverlay({
     if (next && !event.currentTarget.contains(next)) onClose();
   };
 
+  // A plain click anywhere in the log dismisses the overlay; click-drag
+  // (selecting text to copy), long-press, and clicks on the input row /
+  // close button / scrollbar do not.
+  const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const target = event.target as HTMLElement;
+    const onChrome = !!target.closest(".canvas-command, .terminal-screen-close");
+    // Clicks on the xterm viewport's native scrollbar land outside clientWidth.
+    const viewport = target.closest(".xterm-viewport") as HTMLElement | null;
+    const onScrollbar = !!viewport
+      && event.clientX >= viewport.getBoundingClientRect().left + viewport.clientWidth;
+    pointerDownRef.current = {
+      x: event.clientX,
+      y: event.clientY,
+      at: performance.now(),
+      closeEligible: !onChrome && !onScrollbar,
+    };
+  };
+
+  const handlePointerUp = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const down = pointerDownRef.current;
+    pointerDownRef.current = null;
+    if (!open || !down || !down.closeEligible) return;
+    if (Math.hypot(event.clientX - down.x, event.clientY - down.y) > CLICK_SLOP_PX) return;
+    if (performance.now() - down.at > CLICK_MAX_MS) return;
+    if (hasSelection()) return;
+    onClose();
+  };
+
+  // Parchment art arrives via Server.Assets; the unskinned flat panel is the
+  // CSS fallback when the key is absent (ART_CONTRACT fallback hierarchy).
+  const skinVars: Record<string, string> = {};
+  if (parchmentBg) skinVars["--terminal-parchment"] = `url("${parchmentBg}")`;
+
   return (
     <div
-      className={`terminal-screen${open ? " terminal-screen-open" : ""}${opaque ? " terminal-screen-opaque" : ""}`}
+      className={`terminal-screen${open ? " terminal-screen-open" : ""}${opaque ? " terminal-screen-opaque" : ""}${parchmentBg ? " terminal-screen-skinned" : ""}`}
       role="dialog"
       aria-modal={open}
       aria-label="Terminal"
       aria-hidden={!open}
+      style={Object.keys(skinVars).length > 0 ? skinVars : undefined}
       onBlur={handleFocusOut}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
     >
       <div className="terminal-screen-bar">
         <span className="terminal-screen-title">Terminal</span>
@@ -78,6 +129,8 @@ export function TerminalOverlay({
         onInputChange={onInputChange}
         onInputKeyDown={onInputKeyDown}
         onCommand={onCommand}
+        placeholder="Inscribe a command..."
+        sendIconUrl={quillUrl}
       />
     </div>
   );

--- a/web-v3/src/components/TerminalOverlay.tsx
+++ b/web-v3/src/components/TerminalOverlay.tsx
@@ -110,28 +110,32 @@ export function TerminalOverlay({
       onPointerDown={handlePointerDown}
       onPointerUp={handlePointerUp}
     >
-      <div className="terminal-screen-bar">
-        <span className="terminal-screen-title">Terminal</span>
-        <button
-          type="button"
-          className="terminal-screen-close"
-          onClick={onClose}
-          aria-label="Close terminal"
-          tabIndex={open ? 0 : -1}
-        >
-          ×
-        </button>
+      {/* The scroll — a narrow column matching the dock input that unrolls
+          upward. With parchment art it IS the parchment; otherwise dark glass. */}
+      <div className="terminal-scroll">
+        <div className="terminal-screen-bar">
+          <span className="terminal-screen-title">Terminal</span>
+          <button
+            type="button"
+            className="terminal-screen-close"
+            onClick={onClose}
+            aria-label="Close terminal"
+            tabIndex={open ? 0 : -1}
+          >
+            ×
+          </button>
+        </div>
+        <div ref={hostRef} className="terminal-screen-host" />
+        <CommandInput
+          inputRef={inputRef}
+          inputValue={inputValue}
+          onInputChange={onInputChange}
+          onInputKeyDown={onInputKeyDown}
+          onCommand={onCommand}
+          placeholder="Inscribe a command..."
+          sendIconUrl={quillUrl}
+        />
       </div>
-      <div ref={hostRef} className="terminal-screen-host" />
-      <CommandInput
-        inputRef={inputRef}
-        inputValue={inputValue}
-        onInputChange={onInputChange}
-        onInputKeyDown={onInputKeyDown}
-        onCommand={onCommand}
-        placeholder="Inscribe a command..."
-        sendIconUrl={quillUrl}
-      />
     </div>
   );
 }

--- a/web-v3/src/components/TerminalOverlay.tsx
+++ b/web-v3/src/components/TerminalOverlay.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useRef } from "react";
+import type { FocusEvent, KeyboardEvent, RefObject } from "react";
+import { CommandInput } from "./CommandInput";
+
+interface TerminalOverlayProps {
+  open: boolean;
+  opaque: boolean;
+  /** Host the live xterm element reparents into while the overlay is open. */
+  hostRef: RefObject<HTMLDivElement | null>;
+  inputValue: string;
+  onInputChange: (value: string) => void;
+  onInputKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
+  onCommand: (cmd: string) => void;
+  onClose: () => void;
+}
+
+/**
+ * Full-screen terminal over the GUI. Summoned by focusing the dock input
+ * (desktop) or the services-stack button (small screens); the session-long
+ * xterm log slides in with its scrollback intact. Translucent until the
+ * player types, then opaque. Esc or the close button returns to the GUI.
+ */
+export function TerminalOverlay({
+  open,
+  opaque,
+  hostRef,
+  inputValue,
+  onInputChange,
+  onInputKeyDown,
+  onCommand,
+  onClose,
+}: TerminalOverlayProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    window.requestAnimationFrame(() => inputRef.current?.focus());
+    const onKey = (event: globalThis.KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  // If focus escapes the overlay entirely (e.g. tabbing out), dismiss it —
+  // the "click away and you're back in the GUI" affordance.
+  const handleFocusOut = (event: FocusEvent<HTMLDivElement>) => {
+    if (!open) return;
+    const next = event.relatedTarget as Node | null;
+    if (next && !event.currentTarget.contains(next)) onClose();
+  };
+
+  return (
+    <div
+      className={`terminal-screen${open ? " terminal-screen-open" : ""}${opaque ? " terminal-screen-opaque" : ""}`}
+      role="dialog"
+      aria-modal={open}
+      aria-label="Terminal"
+      aria-hidden={!open}
+      onBlur={handleFocusOut}
+    >
+      <div className="terminal-screen-bar">
+        <span className="terminal-screen-title">Terminal</span>
+        <button
+          type="button"
+          className="terminal-screen-close"
+          onClick={onClose}
+          aria-label="Close terminal"
+          tabIndex={open ? 0 : -1}
+        >
+          ×
+        </button>
+      </div>
+      <div ref={hostRef} className="terminal-screen-host" />
+      <CommandInput
+        inputRef={inputRef}
+        inputValue={inputValue}
+        onInputChange={onInputChange}
+        onInputKeyDown={onInputKeyDown}
+        onCommand={onCommand}
+      />
+    </div>
+  );
+}

--- a/web-v3/src/hooks/useTerminal.ts
+++ b/web-v3/src/hooks/useTerminal.ts
@@ -136,6 +136,9 @@ export function useTerminal({ hiddenHostRef, overlayHostRef }: TerminalHosts) {
     terminalRef.current?.write(`\r\n\x1b[2m${message}\x1b[0m\r\n`);
   }, []);
 
+  /** xterm tracks its own selection (not window.getSelection). */
+  const hasSelection = useCallback(() => terminalRef.current?.hasSelection() ?? false, []);
+
   const openTerminal = useCallback(() => setOpen(true), []);
 
   const closeTerminal = useCallback(() => {
@@ -152,5 +155,6 @@ export function useTerminal({ hiddenHostRef, overlayHostRef }: TerminalHosts) {
     write,
     echoCommand,
     writeSystem,
+    hasSelection,
   };
 }

--- a/web-v3/src/hooks/useTerminal.ts
+++ b/web-v3/src/hooks/useTerminal.ts
@@ -11,6 +11,41 @@ interface TerminalHosts {
   overlayHostRef: RefObject<HTMLDivElement | null>;
 }
 
+// Both themes keep the cell background transparent (allowTransparency) so the
+// scroll's CSS background — dark glass or the parchment art — shows through.
+const DARK_THEME = {
+  background: "rgba(0, 0, 0, 0)",
+  foreground: "#d8dcef",
+  cursor: "#b9aed8",
+  selectionBackground: "rgba(185, 174, 216, 0.34)",
+};
+
+/** Ink-on-parchment: dark foreground + the 16 ANSI colors remapped to inks
+ *  that stay legible on light paper (server text assumes a dark terminal). */
+const INK_THEME = {
+  background: "rgba(0, 0, 0, 0)",
+  foreground: "#2e2212",
+  cursor: "#2e2212",
+  cursorAccent: "#f3ead2",
+  selectionBackground: "rgba(106, 74, 36, 0.3)",
+  black: "#2e2212",
+  red: "#8c2f28",
+  green: "#3f6d2e",
+  yellow: "#8a6414",
+  blue: "#2f4d8a",
+  magenta: "#7a3a78",
+  cyan: "#1f6b6b",
+  white: "#5a4a30",
+  brightBlack: "#6a5a40",
+  brightRed: "#a83a30",
+  brightGreen: "#4d8438",
+  brightYellow: "#a07818",
+  brightBlue: "#3a5fa8",
+  brightMagenta: "#94508f",
+  brightCyan: "#287f7f",
+  brightWhite: "#2e2212",
+};
+
 /**
  * Owns a single xterm.js instance that lives for the whole session and
  * accumulates every non-GMCP byte the server sends — the same ANSI stream a
@@ -58,12 +93,8 @@ export function useTerminal({ hiddenHostRef, overlayHostRef }: TerminalHosts) {
       rows: 30,
       scrollback: 5000,
       convertEol: false,
-      theme: {
-        background: "#2f3446",
-        foreground: "#d8dcef",
-        cursor: "#b9aed8",
-        selectionBackground: "rgba(185, 174, 216, 0.34)",
-      },
+      allowTransparency: true,
+      theme: DARK_THEME,
     });
 
     const fitAddon = new FitAddon();
@@ -139,6 +170,12 @@ export function useTerminal({ hiddenHostRef, overlayHostRef }: TerminalHosts) {
   /** xterm tracks its own selection (not window.getSelection). */
   const hasSelection = useCallback(() => terminalRef.current?.hasSelection() ?? false, []);
 
+  /** Dark ink on parchment when the scroll art is present; light-on-dark otherwise. */
+  const setInkTheme = useCallback((enabled: boolean) => {
+    const term = terminalRef.current;
+    if (term) term.options.theme = enabled ? INK_THEME : DARK_THEME;
+  }, []);
+
   const openTerminal = useCallback(() => setOpen(true), []);
 
   const closeTerminal = useCallback(() => {
@@ -156,5 +193,6 @@ export function useTerminal({ hiddenHostRef, overlayHostRef }: TerminalHosts) {
     echoCommand,
     writeSystem,
     hasSelection,
+    setInkTheme,
   };
 }

--- a/web-v3/src/hooks/useTerminal.ts
+++ b/web-v3/src/hooks/useTerminal.ts
@@ -1,0 +1,156 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
+import { FitAddon } from "@xterm/addon-fit";
+import { Terminal } from "@xterm/xterm";
+import "@xterm/xterm/css/xterm.css";
+
+interface TerminalHosts {
+  /** Off-screen stash the xterm element lives in while the GUI is in charge. */
+  hiddenHostRef: RefObject<HTMLDivElement | null>;
+  /** Overlay host the element reparents into while the overlay is open. */
+  overlayHostRef: RefObject<HTMLDivElement | null>;
+}
+
+/**
+ * Owns a single xterm.js instance that lives for the whole session and
+ * accumulates every non-GMCP byte the server sends — the same ANSI stream a
+ * telnet user sees. While the GUI is in charge the terminal sits in a hidden
+ * off-screen host (`.terminal-hidden`) so the log keeps growing silently;
+ * opening the overlay reparents the existing element, scrollback intact.
+ *
+ * The host refs stay in App (and are attached to JSX there) so this hook's
+ * return value carries no refs — the react-hooks/refs lint rule forbids
+ * accessing hook-returned ref carriers during render.
+ */
+export function useTerminal({ hiddenHostRef, overlayHostRef }: TerminalHosts) {
+  const terminalRef = useRef<Terminal | null>(null);
+  const fitAddonRef = useRef<FitAddon | null>(null);
+  const [open, setOpen] = useState(false);
+  // Translucent when first summoned (game stays visible behind the log);
+  // turns opaque once the user starts typing and commits to terminal mode.
+  const [opaque, setOpaque] = useState(false);
+
+  const fit = useCallback(() => {
+    const term = terminalRef.current;
+    const fitAddon = fitAddonRef.current;
+    // Fit to whichever container the terminal is currently in
+    const host = overlayHostRef.current ?? hiddenHostRef.current;
+    if (!term || !fitAddon || !host) return;
+    if (host.clientWidth <= 0 || host.clientHeight <= 0) return;
+
+    const width = host.clientWidth;
+    const nextFontSize = width < 560 ? 12 : width < 760 ? 13 : 14;
+    if (term.options.fontSize !== nextFontSize) {
+      term.options.fontSize = nextFontSize;
+    }
+
+    fitAddon.fit();
+  }, [hiddenHostRef, overlayHostRef]);
+
+  useEffect(() => {
+    if (!hiddenHostRef.current) return;
+
+    const term = new Terminal({
+      cursorBlink: false,
+      disableStdin: true,
+      fontFamily: '"JetBrains Mono", "Cascadia Mono", monospace',
+      fontSize: 14,
+      rows: 30,
+      scrollback: 5000,
+      convertEol: false,
+      theme: {
+        background: "#2f3446",
+        foreground: "#d8dcef",
+        cursor: "#b9aed8",
+        selectionBackground: "rgba(185, 174, 216, 0.34)",
+      },
+    });
+
+    const fitAddon = new FitAddon();
+    term.loadAddon(fitAddon);
+    term.open(hiddenHostRef.current);
+
+    terminalRef.current = term;
+    fitAddonRef.current = fitAddon;
+
+    return () => {
+      term.dispose();
+      fitAddonRef.current = null;
+      terminalRef.current = null;
+    };
+  }, [hiddenHostRef]);
+
+  // Refit on window resize and once fonts settle (mono metrics change cols).
+  useEffect(() => {
+    const onResize = () => fit();
+    window.addEventListener("resize", onResize);
+    const fontSet = document.fonts;
+    let cancelled = false;
+    const refit = () => {
+      if (!cancelled) fit();
+    };
+    fontSet?.ready.then(refit).catch(() => undefined);
+    fontSet?.addEventListener("loadingdone", refit);
+    return () => {
+      cancelled = true;
+      window.removeEventListener("resize", onResize);
+      fontSet?.removeEventListener("loadingdone", refit);
+    };
+  }, [fit]);
+
+  // Reparent the live terminal element into the overlay when open, back to
+  // the hidden host when closed — the instance (and its scrollback) survives.
+  useEffect(() => {
+    const term = terminalRef.current;
+    const termEl = term?.element;
+    if (!term || !termEl) return;
+
+    if (open && overlayHostRef.current) {
+      overlayHostRef.current.appendChild(termEl);
+      window.requestAnimationFrame(() => {
+        fit();
+        term.scrollToBottom();
+      });
+      const delayedFit = window.setTimeout(() => {
+        fit();
+        term.scrollToBottom();
+      }, 80);
+      return () => window.clearTimeout(delayedFit);
+    } else if (hiddenHostRef.current && termEl.parentElement !== hiddenHostRef.current) {
+      hiddenHostRef.current.appendChild(termEl);
+    }
+  }, [open, fit, hiddenHostRef, overlayHostRef]);
+
+  /** Raw server output — ANSI escapes pass straight through to xterm. */
+  const write = useCallback((text: string) => {
+    terminalRef.current?.write(text);
+  }, []);
+
+  /** Local echo of a command the player sent, like a telnet client shows. */
+  const echoCommand = useCallback((command: string) => {
+    terminalRef.current?.write(`${command}\r\n`);
+  }, []);
+
+  /** Dim client-side status line (connection lost, reconnecting, ...). */
+  const writeSystem = useCallback((message: string) => {
+    terminalRef.current?.write(`\r\n\x1b[2m${message}\x1b[0m\r\n`);
+  }, []);
+
+  const openTerminal = useCallback(() => setOpen(true), []);
+
+  const closeTerminal = useCallback(() => {
+    setOpen(false);
+    setOpaque(false);
+  }, []);
+
+  return {
+    open,
+    opaque,
+    setOpaque,
+    openTerminal,
+    closeTerminal,
+    write,
+    echoCommand,
+    writeSystem,
+  };
+}

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -26313,6 +26313,16 @@ html:has(.game-shell),
   font-style: italic;
 }
 
+/* With the parchment art authored, the dock slip is cut from the same
+   sheet as the terminal scroll it summons (ART_CONTRACT: the procedural
+   gradient slip is the fallback). */
+.terminal-dock-skinned {
+  background-color: #efe5c8;
+  background-image: var(--terminal-parchment, none);
+  background-size: cover;
+  background-position: center;
+}
+
 /* Pressed-flower parchment scroll: the art IS the terminal window (xterm
    cells are transparent and the ANSI palette swaps to dark inks via
    useTerminal's INK_THEME). Absent art (no key / 404) keeps the dark

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -106,6 +106,8 @@
   --z-popout: 100;
   /* Mobile drawer sheet and its backdrop. */
   --z-drawer: 120;
+  /* Full-screen terminal overlay — above drawers, below inspect/auth. */
+  --z-terminal: 160;
   /* Examine / inspect modals — above drawers but below broadcast/auth. */
   --z-inspect: 1000;
   /* Critical system overlays: broadcasts, login, command palette. */
@@ -17950,20 +17952,6 @@ html:has(.game-shell),
   border-radius: var(--radius-md);
 }
 
-/* ── Terminal overlay (placeholder) ───────────────────── */
-.terminal-overlay-body {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-  padding: var(--space-2) 0;
-}
-
-.terminal-overlay-note {
-  margin: 0;
-  color: var(--text-tertiary);
-  font-size: 0.92rem;
-}
-
 .canvas-command-input {
   flex: 1;
   min-width: 0;
@@ -19938,115 +19926,6 @@ html:has(.game-shell),
   }
 }
 
-/* Writing-desk drawer (terminal): a dark wood desk; you pen commands on a
-   parchment slip with a quill at hand. */
-.drawer-sheet.drawer-sheet-desk {
-  background-image:
-    var(--skin-bg, none),
-    repeating-linear-gradient(92deg, rgb(0 0 0 / 0%) 0 46px, rgb(20 12 4 / 16%) 46px 48px),
-    linear-gradient(168deg, #5a3f22, #402c16 62%, #311f0e);
-  background-size: cover, auto, auto;
-  background-position: center;
-  border: 8px solid #2e1f10;
-  border-top: 8px solid #2e1f10;
-  box-shadow: 0 -16px 48px rgb(8 10 18 / 60%), inset 0 0 28px rgb(20 12 4 / 45%);
-}
-
-@media (min-width: 768px) {
-  .drawer-sheet.drawer-sheet-desk {
-    border: 8px solid #2e1f10;
-    box-shadow: 0 24px 60px rgb(8 10 18 / 62%), 0 8px 24px rgb(8 10 18 / 42%), inset 0 0 28px rgb(20 12 4 / 45%);
-  }
-}
-
-.drawer-sheet-desk .drawer-header { border-bottom: 1px solid rgb(240 225 190 / 18%); }
-.drawer-sheet-desk .drawer-title { color: #f4e6c6; text-shadow: 0 1px 3px rgb(16 8 2 / 70%); }
-.drawer-sheet-desk .drawer-close { border-color: rgb(240 225 190 / 38%); background: rgb(24 14 6 / 50%); color: #f0e3c4; }
-.drawer-sheet-desk .drawer-close:hover { background: rgb(48 30 14 / 70%); color: #fff; }
-.drawer-sheet-desk .drawer-handle { background: rgb(240 225 190 / 38%); }
-
-/* The desk surface centers a parchment slip. */
-.terminal-desk {
-  align-items: center;
-  justify-content: center;
-  padding: 24px 8px;
-}
-
-.terminal-desk-slip {
-  position: relative;
-  width: min(560px, 100%);
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  padding: 26px 26px 22px;
-  border-radius: 4px;
-  background: linear-gradient(160deg, #f3ead2, #e6d8b4);
-  border: 1px solid rgb(106 74 36 / 40%);
-  box-shadow: 0 10px 26px rgb(8 6 2 / 50%), inset 0 1px 0 rgb(255 252 244 / 55%);
-  /* A faint baseline ruling so it reads as writing paper. */
-  background-image:
-    linear-gradient(160deg, #f3ead2, #e6d8b4),
-    repeating-linear-gradient(0deg, transparent 0 31px, rgb(106 74 36 / 12%) 31px 32px);
-  transform: rotate(-0.6deg);
-}
-
-.terminal-desk .terminal-overlay-note {
-  margin: 0;
-  color: #5a4226;
-  font-style: italic;
-  font-size: 0.96rem;
-}
-
-/* The command line reads as an ink line on the slip. */
-.terminal-desk .canvas-command {
-  background: rgb(255 252 244 / 35%);
-  border: none;
-  border-bottom: 2px solid rgb(106 74 36 / 50%);
-  border-radius: 4px 4px 0 0;
-  padding: 6px 8px 8px 4px;
-}
-
-.terminal-desk .canvas-command-input {
-  color: #2e2212;
-  font-family: var(--font-display);
-  font-size: 1.05rem;
-}
-
-.terminal-desk .canvas-command-input::placeholder { color: rgb(106 74 36 / 55%); }
-
-.terminal-desk .canvas-command-send {
-  width: 34px;
-  height: 30px;
-  border-radius: 8px;
-  background: linear-gradient(180deg, #6a4e28, #4c3617);
-  border: 1px solid #c8a24a;
-  color: #f6e8c2;
-}
-
-.terminal-desk .canvas-command-send:hover { filter: brightness(1.08); }
-
-/* The quill, resting over the slip's corner. */
-.terminal-desk-quill {
-  position: absolute;
-  top: -22px;
-  right: 8px;
-  font-size: 3.4rem;
-  line-height: 1;
-  color: #3a2c1a;
-  transform: rotate(28deg);
-  text-shadow: 0 2px 4px rgb(8 6 2 / 45%);
-  pointer-events: none;
-}
-
-.terminal-desk-quill-img {
-  display: block;
-  width: 96px;
-  height: auto;
-  /* Cancel the container tilt so a supplied quill asset shows as drawn. */
-  transform: rotate(-28deg);
-  filter: drop-shadow(0 3px 6px rgb(8 6 2 / 50%));
-}
-
 /* Letters drawer (mail): warm parchment correspondence with wax-seal accents. */
 .drawer-sheet.drawer-sheet-mail {
   background-image:
@@ -20145,11 +20024,11 @@ html:has(.game-shell),
 }
 .drawer-sheet-mail .mail-compose-abort:hover { color: #2e2212; border-color: #8a6a2e; }
 
-/* Hide legacy desktop chrome that no longer renders */
+/* Hide legacy desktop chrome that no longer renders. (.terminal-hidden is
+   live again — it stashes the always-running xterm log off-screen.) */
 .app-shell,
 .top-banner,
 .dashboard,
-.terminal-hidden,
 .terminal-card,
 .panel-play,
 .terminal-overlay,
@@ -26259,4 +26138,143 @@ html:has(.game-shell),
 .staff-fab .staff-fab-invis {
   padding: 0 11px;
   font-size: 1rem;
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Terminal screen — full-viewport overlay carrying the session-long
+ * xterm log (everything a telnet user would see). Summoned by the
+ * desktop dock input or the services-stack button on small screens;
+ * translucent over the game until the player types, then opaque.
+ * ───────────────────────────────────────────────────────────── */
+.terminal-screen {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-terminal);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding:
+    calc(8px + env(safe-area-inset-top, 0px))
+    calc(12px + env(safe-area-inset-right, 0px))
+    calc(10px + env(safe-area-inset-bottom, 0px))
+    calc(12px + env(safe-area-inset-left, 0px));
+  background: rgb(18 22 34 / 55%);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s var(--ease-in-out-smooth), background-color 0.2s var(--ease-in-out-smooth);
+}
+
+.terminal-screen-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.terminal-screen-opaque {
+  background: rgb(18 22 34 / 93%);
+}
+
+.terminal-screen-bar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.terminal-screen-title {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.terminal-screen-close {
+  width: 30px;
+  height: 30px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--line-soft);
+  background: rgb(18 22 34 / 65%);
+  color: var(--text-secondary);
+  font-size: 1.15rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.terminal-screen-close:hover {
+  color: var(--text-primary);
+  background: rgb(34 41 64 / 80%);
+}
+
+.terminal-screen-host {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.terminal-screen-host .xterm,
+.terminal-screen-host .xterm-screen,
+.terminal-screen-host .xterm-viewport {
+  height: 100% !important;
+}
+
+.terminal-screen-host .xterm-viewport {
+  background: transparent !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .terminal-screen {
+    transition: none;
+  }
+}
+
+/* Terminal dock — desktop-only command line under the kiosk row; focusing
+   it summons the terminal screen. Hidden on small screens, where the
+   services stack hosts the terminal button instead. */
+.terminal-dock {
+  display: none;
+}
+
+@media (min-width: 960px) {
+  .terminal-dock {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: min(560px, 92%);
+    margin: 0 auto calc(10px + env(safe-area-inset-bottom, 0px));
+    padding: 7px 12px;
+    background: var(--surface-input);
+    border: 1px solid var(--line-soft);
+    border-radius: var(--radius-md);
+  }
+
+  .terminal-dock:focus-within {
+    border-color: var(--color-accent-violet);
+    box-shadow: var(--shadow-glow);
+  }
+
+  .hud-stack-btn-terminal {
+    display: none;
+  }
+}
+
+.terminal-dock-glyph {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--text-tertiary);
+}
+
+.terminal-dock-input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 0.92rem;
+  outline: none;
+  cursor: text;
+}
+
+.terminal-dock-input::placeholder {
+  color: var(--text-placeholder);
 }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -26227,9 +26227,10 @@ html:has(.game-shell),
   }
 }
 
-/* Terminal dock — desktop-only command line under the kiosk row; focusing
+/* Terminal dock — desktop-only parchment slip under the kiosk row; focusing
    it summons the terminal screen. Hidden on small screens, where the
-   services stack hosts the terminal button instead. */
+   services stack hosts the terminal button instead. Palette matches the
+   parchment family used by the skinned drawers (mail, puzzle). */
 .terminal-dock {
   display: none;
 }
@@ -26238,18 +26239,22 @@ html:has(.game-shell),
   .terminal-dock {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 10px;
     width: min(560px, 92%);
     margin: 0 auto calc(10px + env(safe-area-inset-bottom, 0px));
-    padding: 7px 12px;
-    background: var(--surface-input);
-    border: 1px solid var(--line-soft);
-    border-radius: var(--radius-md);
+    padding: 6px 14px 7px;
+    border-radius: 4px;
+    border: 1px solid rgb(106 74 36 / 40%);
+    background-image:
+      linear-gradient(160deg, #f3ead2, #e6d8b4),
+      repeating-linear-gradient(0deg, transparent 0 26px, rgb(106 74 36 / 12%) 26px 27px);
+    box-shadow: 0 4px 12px rgb(8 6 2 / 35%), inset 0 1px 0 rgb(255 252 244 / 55%);
+    transform: rotate(-0.4deg);
   }
 
   .terminal-dock:focus-within {
-    border-color: var(--color-accent-violet);
-    box-shadow: var(--shadow-glow);
+    border-color: #c8a24a;
+    box-shadow: 0 4px 14px rgb(8 6 2 / 45%), 0 0 14px rgb(200 162 74 / 35%);
   }
 
   .hud-stack-btn-terminal {
@@ -26258,23 +26263,72 @@ html:has(.game-shell),
 }
 
 .terminal-dock-glyph {
-  font-family: var(--font-mono);
-  font-size: 0.85rem;
-  color: var(--text-tertiary);
+  font-size: 1.1rem;
+  line-height: 1;
+  color: #3a2c1a;
+}
+
+.terminal-dock-quill-img {
+  display: block;
+  width: 30px;
+  height: auto;
+  transform: rotate(8deg);
+  filter: drop-shadow(0 2px 3px rgb(8 6 2 / 40%));
 }
 
 .terminal-dock-input {
   flex: 1;
   min-width: 0;
   border: none;
+  border-bottom: 2px solid rgb(106 74 36 / 45%);
   background: transparent;
-  color: var(--text-primary);
-  font-family: var(--font-mono);
-  font-size: 0.92rem;
+  color: #2e2212;
+  font-family: var(--font-display);
+  font-size: 1.05rem;
   outline: none;
   cursor: text;
 }
 
 .terminal-dock-input::placeholder {
-  color: var(--text-placeholder);
+  color: rgb(106 74 36 / 60%);
+  font-style: italic;
+}
+
+/* Pressed-flower parchment behind the committed (opaque) terminal — the
+   scrim gradient sits on top of the art for log legibility. Absent art
+   (no key / 404) leaves the flat fallback panel untouched. */
+.terminal-screen-skinned.terminal-screen-opaque {
+  background-color: rgb(16 18 30);
+  background-image:
+    linear-gradient(rgb(16 18 30 / 74%), rgb(16 18 30 / 82%)),
+    var(--terminal-parchment, none);
+  background-size: auto, cover;
+  background-position: center;
+}
+
+/* Quill send button inside the terminal — the painted art replaces the
+   gradient chrome entirely (ART_CONTRACT: neutralize fallback styling). */
+.canvas-command-send-skinned {
+  background: none;
+  border-radius: 0;
+}
+
+.canvas-command-send-img {
+  display: block;
+  width: 30px;
+  height: 30px;
+  object-fit: contain;
+  transform: rotate(8deg);
+  filter: drop-shadow(0 2px 3px rgb(8 6 2 / 45%));
+  transition: transform 0.15s var(--ease-out-soft);
+}
+
+.canvas-command-send-skinned:hover .canvas-command-send-img {
+  transform: rotate(-4deg) scale(1.08);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .canvas-command-send-img {
+    transition: none;
+  }
 }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -26152,25 +26152,43 @@ html:has(.game-shell),
   z-index: var(--z-terminal);
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  align-items: center;
   padding:
     calc(8px + env(safe-area-inset-top, 0px))
     calc(12px + env(safe-area-inset-right, 0px))
     calc(10px + env(safe-area-inset-bottom, 0px))
     calc(12px + env(safe-area-inset-left, 0px));
-  background: rgb(18 22 34 / 55%);
-  opacity: 0;
+  background: rgb(8 10 18 / 0%);
   pointer-events: none;
-  transition: opacity 0.2s var(--ease-in-out-smooth), background-color 0.2s var(--ease-in-out-smooth);
+  transition: background-color 0.25s var(--ease-in-out-smooth);
 }
 
 .terminal-screen-open {
-  opacity: 1;
   pointer-events: auto;
+  background: rgb(8 10 18 / 38%);
 }
 
-.terminal-screen-opaque {
-  background: rgb(18 22 34 / 93%);
+/* The scroll itself — a column matching the dock input's width that unrolls
+   upward: the reveal window's top edge rises from the bottom (clip-path),
+   like paper coming off a roll. */
+.terminal-scroll {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: min(560px, 92vw);
+  height: 100%;
+  min-height: 0;
+  padding: 10px 14px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--line-soft);
+  background: linear-gradient(180deg, rgb(26 30 46 / 97%), rgb(18 22 34 / 97%));
+  box-shadow: 0 18px 48px rgb(8 10 18 / 55%);
+  clip-path: inset(100% 0 0 0);
+  transition: clip-path 0.32s var(--ease-out-soft);
+}
+
+.terminal-screen-open .terminal-scroll {
+  clip-path: inset(0 0 0 0);
 }
 
 .terminal-screen-bar {
@@ -26222,7 +26240,8 @@ html:has(.game-shell),
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .terminal-screen {
+  .terminal-screen,
+  .terminal-scroll {
     transition: none;
   }
 }
@@ -26294,16 +26313,48 @@ html:has(.game-shell),
   font-style: italic;
 }
 
-/* Pressed-flower parchment behind the committed (opaque) terminal — the
-   scrim gradient sits on top of the art for log legibility. Absent art
-   (no key / 404) leaves the flat fallback panel untouched. */
-.terminal-screen-skinned.terminal-screen-opaque {
-  background-color: rgb(16 18 30);
-  background-image:
-    linear-gradient(rgb(16 18 30 / 74%), rgb(16 18 30 / 82%)),
-    var(--terminal-parchment, none);
-  background-size: auto, cover;
+/* Pressed-flower parchment scroll: the art IS the terminal window (xterm
+   cells are transparent and the ANSI palette swaps to dark inks via
+   useTerminal's INK_THEME). Absent art (no key / 404) keeps the dark
+   glass scroll with the light-on-dark theme. */
+.terminal-screen-skinned .terminal-scroll {
+  border: 1px solid rgb(106 74 36 / 45%);
+  background-color: #efe5c8;
+  background-image: var(--terminal-parchment, none);
+  background-size: cover;
   background-position: center;
+  box-shadow: 0 18px 48px rgb(8 6 2 / 55%), inset 0 1px 0 rgb(255 252 244 / 45%);
+}
+
+.terminal-screen-skinned .terminal-screen-title {
+  color: #5a4226;
+}
+
+.terminal-screen-skinned .terminal-screen-close {
+  border-color: rgb(106 74 36 / 45%);
+  background: rgb(243 234 210 / 55%);
+  color: #5a4226;
+}
+
+.terminal-screen-skinned .terminal-screen-close:hover {
+  background: rgb(255 252 244 / 75%);
+  color: #2e2212;
+}
+
+/* The command line reads as an ink rule on the parchment. */
+.terminal-screen-skinned .canvas-command {
+  background: rgb(255 252 244 / 35%);
+  border: none;
+  border-bottom: 2px solid rgb(106 74 36 / 50%);
+  border-radius: 4px 4px 0 0;
+}
+
+.terminal-screen-skinned .canvas-command-input {
+  color: #2e2212;
+}
+
+.terminal-screen-skinned .canvas-command-input::placeholder {
+  color: rgb(106 74 36 / 55%);
 }
 
 /* Quill send button inside the terminal — the painted art replaces the

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -1,4 +1,4 @@
-export type PopoutPanel = "map" | "inventory" | "equipment" | "room" | "help" | "character" | "chatboard" | "whoboard" | "guildboard" | "friendsboard" | "groupboard" | "shop" | "spellbook" | "quests" | "questOffers" | "mail" | "crafting" | "professions" | "housing" | "leaderboard" | "trainer" | "bank" | "stylist" | "auction" | "dungeon" | "lottery" | "dice" | "puzzle" | "features" | "combatlog" | "inn" | "terminal" | null;
+export type PopoutPanel = "map" | "inventory" | "equipment" | "room" | "help" | "character" | "chatboard" | "whoboard" | "guildboard" | "friendsboard" | "groupboard" | "shop" | "spellbook" | "quests" | "questOffers" | "mail" | "crafting" | "professions" | "housing" | "leaderboard" | "trainer" | "bank" | "stylist" | "auction" | "dungeon" | "lottery" | "dice" | "puzzle" | "features" | "combatlog" | "inn" | null;
 export type SystemPanelView = "dungeon" | "duel" | "lottery" | "pet" | "prestige" | "currencies" | "factions";
 export type ChatChannel = "say" | "tell" | "gossip" | "shout" | "ooc" | "gtell" | "gchat";
 export type SocialTab = "chat" | "friends" | "guild" | "group" | "who";

--- a/web-v3/test/terminalOverlay.test.tsx
+++ b/web-v3/test/terminalOverlay.test.tsx
@@ -18,6 +18,7 @@ describe("terminal overlay", () => {
   const baseProps = {
     opaque: false,
     hostRef: { current: null },
+    hasSelection: () => false,
     inputValue: "",
     onInputChange: () => {},
     onInputKeyDown: () => {},
@@ -31,6 +32,25 @@ describe("terminal overlay", () => {
     expect(html).not.toContain("terminal-screen-open");
     expect(html).toContain('aria-hidden="true"');
     expect(html).toContain("terminal-screen-host");
+  });
+
+  test("applies the parchment skin and quill only when the art is present", () => {
+    const unskinned = renderToStaticMarkup(<TerminalOverlay {...baseProps} open={true} />);
+    expect(unskinned).not.toContain("terminal-screen-skinned");
+    expect(unskinned).not.toContain("canvas-command-send-skinned");
+
+    const skinned = renderToStaticMarkup(
+      <TerminalOverlay
+        {...baseProps}
+        open={true}
+        parchmentBg="https://art.example/parchment.png"
+        quillUrl="https://art.example/quill.png"
+      />,
+    );
+    expect(skinned).toContain("terminal-screen-skinned");
+    expect(skinned).toContain("--terminal-parchment");
+    expect(skinned).toContain("canvas-command-send-skinned");
+    expect(skinned).toContain("Inscribe a command");
   });
 
   test("opens translucent first, then opaque once the player types", () => {

--- a/web-v3/test/terminalOverlay.test.tsx
+++ b/web-v3/test/terminalOverlay.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { KioskBar } from "../src/components/KioskBar";
+import { TerminalOverlay } from "../src/components/TerminalOverlay";
+
+describe("kiosk bar", () => {
+  test("no longer offers a terminal kiosk — the overlay owns that entry point", () => {
+    const html = renderToStaticMarkup(
+      <KioskBar serverAssets={{}} activePopout={null} onOpenPanel={() => {}} />,
+    );
+    expect(html).toContain("Character");
+    expect(html).toContain("Combat Log");
+    expect(html).not.toContain("Terminal");
+  });
+});
+
+describe("terminal overlay", () => {
+  const baseProps = {
+    opaque: false,
+    hostRef: { current: null },
+    inputValue: "",
+    onInputChange: () => {},
+    onInputKeyDown: () => {},
+    onCommand: () => {},
+    onClose: () => {},
+  };
+
+  test("stays mounted but hidden when closed, so the log host survives", () => {
+    const html = renderToStaticMarkup(<TerminalOverlay {...baseProps} open={false} />);
+    expect(html).toContain("terminal-screen");
+    expect(html).not.toContain("terminal-screen-open");
+    expect(html).toContain('aria-hidden="true"');
+    expect(html).toContain("terminal-screen-host");
+  });
+
+  test("opens translucent first, then opaque once the player types", () => {
+    const open = renderToStaticMarkup(<TerminalOverlay {...baseProps} open={true} />);
+    expect(open).toContain("terminal-screen-open");
+    expect(open).not.toContain("terminal-screen-opaque");
+
+    const opaque = renderToStaticMarkup(
+      <TerminalOverlay {...baseProps} open={true} opaque={true} />,
+    );
+    expect(opaque).toContain("terminal-screen-opaque");
+  });
+});


### PR DESCRIPTION
## Summary

Gives web players a real terminal experience without leaving the GUI. A session-long xterm.js instance silently accumulates everything a telnet user would see (full ANSI color, login-screen ASCII art, room text, live world messages, plus local echo of every command sent — including GUI-driven ones). Summoning the overlay slides that log over the whole screen with scrollback intact; dismissing it drops you straight back into the GUI.

This resurrects the terminal architecture removed in the mobile-first redesign (4e430147), reshaped as a hook + overlay around the current full-canvas shell.

## Entry points

- **Desktop (>=960px):** a `>_ Type a command...` input row under the Inventory/Equipment/Spellbook kiosk dock. Focusing it opens the overlay and focus flows into the real input. Stays visible during combat.
- **Small screens:** a Terminal button in the top-right services stack (uses the existing `terminal_widget` art).
- The Terminal kiosk button and its writing-desk drawer are removed; the freed kiosk slot now seats the **Character** panel (`CharacterAvatarIcon` / `character_widget` art).

## Behavior

- Overlay opens translucent over the game, turns opaque once you type; Esc / close button / focus-leave dismisses it. The xterm element reparents between an off-screen stash and the overlay host, so the buffer (5k-line scrollback) survives open/close.
- Connection loss/reconnect surface as dim system lines in the log.
- `claim <password>` is echoed masked (`claim ********`) and excluded from persisted command history — closes a pre-existing history leak too. Login-modal passwords never touch the log (they bypass `sendCommand` via `sendLine`).

## Testing

- `bun run lint`, `bun test` (26 pass, incl. new `terminalOverlay.test.tsx`), `bun run build` all green; no Kotlin changes.
- Verified live against a local server with a demo character at 1280x800 and 375x812: background log accumulation, ANSI rendering, command round-trip with echo, translucent->opaque transition, Esc re-stash, dock/HUD-button visibility swap at the breakpoint, and the mobile services-stack flow.