### PR TITLE
a11y(web): WCAG 2.1 AA pass over the web client (no layout changes)

### DIFF
--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -1887,7 +1887,7 @@ function App() {
           <img
             className="image-preview-img"
             src={imagePreviewUrl}
-            alt=""
+            alt="Enlarged portrait"
             onClick={(e) => e.stopPropagation()}
           />
         </div>
@@ -1954,7 +1954,9 @@ function App() {
                 <span className="look-target-slot">{formatItemSlot(state.lookTarget.slot)}</span>
               )}
             </div>
-            {state.lookTarget.image && <img src={state.lookTarget.image} alt="" className="look-target-image" />}
+            {state.lookTarget.image && (
+              <img src={state.lookTarget.image} alt={`Illustration of ${state.lookTarget.name}`} className="look-target-image" />
+            )}
             {state.lookTarget.description && (
               <p className="look-target-desc">{state.lookTarget.description}</p>
             )}

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -176,6 +176,11 @@ function App() {
   // zone-cinematic autoplay, and the map's replay button all route through it)
   const [videoUrl, setVideoUrl] = useState<string | null>(null);
   const [videoClosing, setVideoClosing] = useState(false);
+  // Close-button refs for the canvas modals — focused on open so the opener
+  // can be restored on dismiss (see the modal focus effects below).
+  const videoCloseRef = useRef<HTMLButtonElement | null>(null);
+  const mobDetailCloseRef = useRef<HTMLButtonElement | null>(null);
+  const imagePreviewCloseRef = useRef<HTMLButtonElement | null>(null);
 
   // Expanded mob detail card — opened from canvas Look button
   const [mobDetail, setMobDetail] = useState<{ name: string; description: string; image: string | null } | null>(null);
@@ -706,6 +711,54 @@ function App() {
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
   }, [state.considerResult]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Canvas modals (mob detail / image preview / video): move focus to the
+  // close button while open, restore it to the opener on dismiss, and close
+  // on Escape regardless of where focus currently sits (WCAG 2.4.3 / 2.1.2).
+  useEffect(() => {
+    if (!mobDetail) return;
+    const opener = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    mobDetailCloseRef.current?.focus();
+    const handler = (e: globalThis.KeyboardEvent) => {
+      if (e.key === "Escape") setMobDetail(null);
+    };
+    window.addEventListener("keydown", handler);
+    return () => {
+      window.removeEventListener("keydown", handler);
+      opener?.focus();
+    };
+  }, [mobDetail]);
+
+  useEffect(() => {
+    if (!imagePreviewUrl) return;
+    const opener = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    imagePreviewCloseRef.current?.focus();
+    const handler = (e: globalThis.KeyboardEvent) => {
+      if (e.key === "Escape") setImagePreviewUrl(null);
+    };
+    window.addEventListener("keydown", handler);
+    return () => {
+      window.removeEventListener("keydown", handler);
+      opener?.focus();
+    };
+  }, [imagePreviewUrl]);
+
+  useEffect(() => {
+    if (!videoUrl) return;
+    const opener = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    videoCloseRef.current?.focus();
+    const handler = (e: globalThis.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setVideoClosing(true);
+        setTimeout(() => { setVideoUrl(null); setVideoClosing(false); }, 600);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => {
+      window.removeEventListener("keydown", handler);
+      opener?.focus();
+    };
+  }, [videoUrl]);
 
   // Close NPC dialogue / quest offers on Escape — but only when the
   // conversation has reached a state with no further choices (mirrors the
@@ -1761,7 +1814,7 @@ function App() {
       )}
 
       {state.reconnecting && (
-        <div className="reconnect-banner" role="status" aria-live="polite">
+        <div className="reconnect-banner" role="status" aria-live="polite" aria-busy="true">
           <span className="reconnect-spinner" aria-hidden="true" />
           Reconnecting...
         </div>
@@ -1789,21 +1842,15 @@ function App() {
             setVideoClosing(true);
             setTimeout(() => { setVideoUrl(null); setVideoClosing(false); }, 600);
           }}
-          onKeyDown={(e) => {
-            if (e.key === "Escape") {
-              setVideoClosing(true);
-              setTimeout(() => { setVideoUrl(null); setVideoClosing(false); }, 600);
-            }
-          }}
           onAnimationEnd={(e) => {
             if (e.animationName === "videoFadeOut") { setVideoUrl(null); setVideoClosing(false); }
           }}
         >
           <div className="video-modal" onClick={(e) => e.stopPropagation()}>
             <button
+              ref={videoCloseRef}
               className="video-modal-close"
               aria-label="Close video"
-              autoFocus
               onClick={() => {
                 setVideoClosing(true);
                 setTimeout(() => { setVideoUrl(null); setVideoClosing(false); }, 600);
@@ -1831,15 +1878,12 @@ function App() {
           aria-modal="true"
           aria-label={`${mobDetail.name} details`}
           onClick={() => setMobDetail(null)}
-          onKeyDown={(e) => {
-            if (e.key === "Escape") setMobDetail(null);
-          }}
         >
           <div className="entity-detail-card" onClick={(e) => e.stopPropagation()}>
             <button
+              ref={mobDetailCloseRef}
               className="entity-detail-close"
               aria-label="Close"
-              autoFocus
               onClick={() => setMobDetail(null)}
             >
               {"✕"}
@@ -1872,14 +1916,11 @@ function App() {
           aria-modal="true"
           aria-label="Image preview"
           onClick={() => setImagePreviewUrl(null)}
-          onKeyDown={(e) => {
-            if (e.key === "Escape") setImagePreviewUrl(null);
-          }}
         >
           <button
+            ref={imagePreviewCloseRef}
             className="image-preview-close"
             aria-label="Close image"
-            autoFocus
             onClick={() => setImagePreviewUrl(null)}
           >
             {"✕"}

--- a/web-v3/src/canvas/LoginModal.tsx
+++ b/web-v3/src/canvas/LoginModal.tsx
@@ -231,7 +231,10 @@ function RaceCardGrid({ races, error, onSelect }: RaceCardGridProps) {
 
   return (
     <div className="login-step char-picker">
-      <p className="login-step-label">Choose your race</p>
+      <p className="login-step-label">
+        Choose your race
+        <span className="sr-only"> — select a card to preview it, then activate the Choose button to confirm.</span>
+      </p>
       {error && <p className="login-error" role="alert">{error}</p>}
 
       <div className="char-card-grid">
@@ -307,7 +310,10 @@ function ClassCardGrid({ classes, error, onSelect }: ClassCardGridProps) {
 
   return (
     <div className="login-step char-picker">
-      <p className="login-step-label">Choose your class</p>
+      <p className="login-step-label">
+        Choose your class
+        <span className="sr-only"> — select a card to preview it, then activate the Choose button to confirm.</span>
+      </p>
       {error && <p className="login-error" role="alert">{error}</p>}
 
       <div className="char-card-grid">

--- a/web-v3/src/canvas/LoginModal.tsx
+++ b/web-v3/src/canvas/LoginModal.tsx
@@ -39,6 +39,14 @@ export function LoginModal({ loginPrompt, loginError, onSubmit }: LoginModalProp
 
   const isWide = loginPrompt.state === "raceSelection" || loginPrompt.state === "classSelection";
 
+  const stepDialogLabel: Record<string, string> = {
+    password: "Sign in",
+    confirmCreate: "Create a new character?",
+    newPassword: "Choose a password",
+    raceSelection: "Choose your race",
+    classSelection: "Choose your class",
+  };
+
   if (loginPrompt.state === "name") {
     return (
       <div className="login-scene-root" role="dialog" aria-modal="true" aria-label="Welcome to AmbonMUD">
@@ -115,7 +123,7 @@ export function LoginModal({ loginPrompt, loginError, onSubmit }: LoginModalProp
         className={`login-modal${isWide ? " login-modal--wide" : ""}`}
         role="dialog"
         aria-modal="true"
-        aria-label="Login"
+        aria-label={stepDialogLabel[loginPrompt.state] ?? "Login"}
       >
         <h2 className="login-modal-title">AmbonMUD</h2>
 
@@ -124,7 +132,7 @@ export function LoginModal({ loginPrompt, loginError, onSubmit }: LoginModalProp
             <p className="login-step-label">
               Welcome back, <strong>{loginPrompt.name}</strong>
             </p>
-            {errorForState && <p className="login-error">{errorForState}</p>}
+            {errorForState && <p className="login-error" id="login-error" role="alert">{errorForState}</p>}
             <form onSubmit={handleSubmit} className="login-form">
               <input
                 ref={inputRef}
@@ -133,6 +141,9 @@ export function LoginModal({ loginPrompt, loginError, onSubmit }: LoginModalProp
                 value={inputValue}
                 onChange={(e) => setInputValue(e.target.value)}
                 placeholder="Password"
+                aria-label="Password"
+                aria-invalid={errorForState ? true : undefined}
+                aria-describedby={errorForState ? "login-error" : undefined}
                 autoComplete="off"
                 autoFocus
               />
@@ -147,7 +158,7 @@ export function LoginModal({ loginPrompt, loginError, onSubmit }: LoginModalProp
               No character named <strong>{loginPrompt.name}</strong> was found.
             </p>
             <p className="login-step-sub">Create a new character?</p>
-            {errorForState && <p className="login-error">{errorForState}</p>}
+            {errorForState && <p className="login-error" role="alert">{errorForState}</p>}
             <div className="login-choice-row">
               <button type="button" className="login-button" onClick={() => handleChoice("yes")}>
                 Yes, create
@@ -164,7 +175,7 @@ export function LoginModal({ loginPrompt, loginError, onSubmit }: LoginModalProp
             <p className="login-step-label">
               Choose a password for <strong>{loginPrompt.name}</strong>
             </p>
-            {errorForState && <p className="login-error">{errorForState}</p>}
+            {errorForState && <p className="login-error" id="login-error" role="alert">{errorForState}</p>}
             <form onSubmit={handleSubmit} className="login-form">
               <input
                 ref={inputRef}
@@ -173,7 +184,10 @@ export function LoginModal({ loginPrompt, loginError, onSubmit }: LoginModalProp
                 value={inputValue}
                 onChange={(e) => setInputValue(e.target.value)}
                 placeholder="New password"
-                autoComplete="off"
+                aria-label="New password"
+                aria-invalid={errorForState ? true : undefined}
+                aria-describedby={errorForState ? "login-error" : undefined}
+                autoComplete="new-password"
                 autoFocus
               />
               <button type="submit" className="login-button">Set Password</button>
@@ -218,7 +232,7 @@ function RaceCardGrid({ races, error, onSelect }: RaceCardGridProps) {
   return (
     <div className="login-step char-picker">
       <p className="login-step-label">Choose your race</p>
-      {error && <p className="login-error">{error}</p>}
+      {error && <p className="login-error" role="alert">{error}</p>}
 
       <div className="char-card-grid">
         {races.map((r, i) => (
@@ -229,9 +243,10 @@ function RaceCardGrid({ races, error, onSelect }: RaceCardGridProps) {
             onClick={() => setSelected(i)}
             onDoubleClick={() => onSelect(i)}
             aria-label={r.name}
+            aria-pressed={i === selected}
           >
             {r.image ? (
-              <img src={r.image} alt={r.name} className="char-card-img" draggable={false} />
+              <img src={r.image} alt="" aria-hidden="true" className="char-card-img" draggable={false} />
             ) : (
               <div className="char-card-placeholder" />
             )}
@@ -293,7 +308,7 @@ function ClassCardGrid({ classes, error, onSelect }: ClassCardGridProps) {
   return (
     <div className="login-step char-picker">
       <p className="login-step-label">Choose your class</p>
-      {error && <p className="login-error">{error}</p>}
+      {error && <p className="login-error" role="alert">{error}</p>}
 
       <div className="char-card-grid">
         {classes.map((c, i) => (
@@ -304,9 +319,10 @@ function ClassCardGrid({ classes, error, onSelect }: ClassCardGridProps) {
             onClick={() => setSelected(i)}
             onDoubleClick={() => onSelect(i)}
             aria-label={c.name}
+            aria-pressed={i === selected}
           >
             {c.image ? (
-              <img src={c.image} alt={c.name} className="char-card-img" draggable={false} />
+              <img src={c.image} alt="" aria-hidden="true" className="char-card-img" draggable={false} />
             ) : (
               <div className="char-card-placeholder" />
             )}

--- a/web-v3/src/canvas/PixiCanvas.tsx
+++ b/web-v3/src/canvas/PixiCanvas.tsx
@@ -29,7 +29,11 @@ export function PixiCanvas() {
         return;
       }
 
-      container.appendChild(app.canvas as HTMLCanvasElement);
+      const canvasEl = app.canvas as HTMLCanvasElement;
+      // The host div carries role="img" + label; the raw canvas adds nothing
+      // for assistive tech and should not be probed separately.
+      canvasEl.setAttribute("aria-hidden", "true");
+      container.appendChild(canvasEl);
       const scene = new SceneManager(app);
       sceneRef.current = scene;
 

--- a/web-v3/src/components/Atlas.tsx
+++ b/web-v3/src/components/Atlas.tsx
@@ -77,6 +77,11 @@ export function Atlas({ areas, currentZone }: AtlasProps) {
     return sort.dir === "asc" ? " ▲" : " ▼";
   }
 
+  function ariaSort(key: SortState["key"]): "ascending" | "descending" | undefined {
+    if (sort.key !== key) return undefined;
+    return sort.dir === "asc" ? "ascending" : "descending";
+  }
+
   if (areas.length === 0) {
     return (
       <div className="atlas-empty">
@@ -130,7 +135,7 @@ export function Atlas({ areas, currentZone }: AtlasProps) {
           />
           <span>Unlisted ranges</span>
         </label>
-        <span className="atlas-count" aria-live="polite">
+        <span className="atlas-count" role="status" aria-live="polite">
           {sorted.length} of {areas.length}
         </span>
       </div>
@@ -139,14 +144,14 @@ export function Atlas({ areas, currentZone }: AtlasProps) {
         <table className="atlas-table">
           <thead>
             <tr>
-              <th scope="col">
+              <th scope="col" aria-sort={ariaSort("zone")}>
                 <button type="button" className="atlas-sort" onClick={() => toggleSort("zone")}>
-                  Area{sortIndicator("zone")}
+                  Area<span aria-hidden="true">{sortIndicator("zone")}</span>
                 </button>
               </th>
-              <th scope="col" className="atlas-col-level">
+              <th scope="col" className="atlas-col-level" aria-sort={ariaSort("level")}>
                 <button type="button" className="atlas-sort" onClick={() => toggleSort("level")}>
-                  Level{sortIndicator("level")}
+                  Level<span aria-hidden="true">{sortIndicator("level")}</span>
                 </button>
               </th>
             </tr>

--- a/web-v3/src/components/AudioControls.tsx
+++ b/web-v3/src/components/AudioControls.tsx
@@ -143,6 +143,7 @@ export function AudioControls({ audio, skinned = false }: AudioControlsProps) {
         onClick={toggleAudio}
         title={audio.enabled ? "Mute audio" : "Enable audio"}
         aria-label={audio.enabled ? "Mute audio" : "Enable audio"}
+        aria-pressed={audio.enabled}
       >
         {audio.enabled
           ? <VolumeOnIcon className="audio-toggle-icon" />
@@ -156,7 +157,7 @@ export function AudioControls({ audio, skinned = false }: AudioControlsProps) {
           className="soft-button audio-expand-btn"
           onClick={toggleExpanded}
           title="Volume settings"
-          aria-label="Toggle volume sliders"
+          aria-label={expanded ? "Hide volume sliders" : "Show volume sliders"}
           aria-expanded={expanded}
         >
           ▾

--- a/web-v3/src/components/CanvasVitalsHud.tsx
+++ b/web-v3/src/components/CanvasVitalsHud.tsx
@@ -44,15 +44,34 @@ export function CanvasVitalsHud({ vitals, inventory, serverAssets, onCommand, au
       <div className="canvas-vitals-skin">
         <img className="vskin-art" src={barBg} alt="" aria-hidden="true" />
         <div className="vskin-overlay">
-          <div className="vskin-slot vskin-slot-hp" title={`HP: ${vitals.hp}/${vitals.maxHp}`}>
+          <div
+            className="vskin-slot vskin-slot-hp"
+            title={`HP: ${vitals.hp}/${vitals.maxHp}`}
+            role="progressbar"
+            aria-label="Health"
+            aria-valuenow={vitals.hp}
+            aria-valuemin={0}
+            aria-valuemax={vitals.maxHp}
+          >
             <span className="vskin-drain" style={{ left: `${hpPct}%` }} />
           </div>
-          <div className="vskin-slot vskin-slot-mp" title={`MP: ${vitals.mana}/${vitals.maxMana}`}>
+          <div
+            className="vskin-slot vskin-slot-mp"
+            title={`MP: ${vitals.mana}/${vitals.maxMana}`}
+            role="progressbar"
+            aria-label="Mana"
+            aria-valuenow={vitals.mana}
+            aria-valuemin={0}
+            aria-valuemax={vitals.maxMana}
+          >
             <span className="vskin-drain" style={{ left: `${mpPct}%` }} />
           </div>
           <span className="vskin-num vskin-num-hp" title={`HP: ${vitals.hp}/${vitals.maxHp}`}>{formatCompact(vitals.hp)}/{formatCompact(vitals.maxHp)}</span>
           <span className="vskin-num vskin-num-mp" title={`MP: ${vitals.mana}/${vitals.maxMana}`}>{formatCompact(vitals.mana)}/{formatCompact(vitals.maxMana)}</span>
-          <span className="vskin-num vskin-num-gold" title={`Gold: ${vitals.gold.toLocaleString()}`}>{formatCompact(vitals.gold)}</span>
+          <span className="vskin-num vskin-num-gold" title={`Gold: ${vitals.gold.toLocaleString()}`}>
+            <span aria-hidden="true">{formatCompact(vitals.gold)}</span>
+            <span className="sr-only">{`Gold: ${vitals.gold.toLocaleString()}`}</span>
+          </span>
           <button
             type="button"
             className="vskin-hotspot vskin-heal"
@@ -93,7 +112,15 @@ export function CanvasVitalsHud({ vitals, inventory, serverAssets, onCommand, au
           <circle cx="0" cy="0" r="2.3" fill="#f0cf72" />
         </g>
       </svg>
-      <div className="vbar-vital" title={`HP: ${vitals.hp}/${vitals.maxHp}`}>
+      <div
+        className="vbar-vital"
+        title={`HP: ${vitals.hp}/${vitals.maxHp}`}
+        role="progressbar"
+        aria-label="Health"
+        aria-valuenow={vitals.hp}
+        aria-valuemin={0}
+        aria-valuemax={vitals.maxHp}
+      >
         <span className="vbar-vital-label">HP</span>
         <div className="vbar-vital-track">
           <span className="vbar-vital-fill vbar-vital-hp" style={{ width: `${percent(vitals.hp, vitals.maxHp)}%` }} />
@@ -111,7 +138,15 @@ export function CanvasVitalsHud({ vitals, inventory, serverAssets, onCommand, au
         <span className="vbar-quick-potion-icon" aria-hidden="true">+</span>
         <span className="vbar-quick-potion-label">Heal</span>
       </button>
-      <div className="vbar-vital" title={`MP: ${vitals.mana}/${vitals.maxMana}`}>
+      <div
+        className="vbar-vital"
+        title={`MP: ${vitals.mana}/${vitals.maxMana}`}
+        role="progressbar"
+        aria-label="Mana"
+        aria-valuenow={vitals.mana}
+        aria-valuemin={0}
+        aria-valuemax={vitals.maxMana}
+      >
         <span className="vbar-vital-label">MP</span>
         <div className="vbar-vital-track">
           <span className="vbar-vital-fill vbar-vital-mp" style={{ width: `${percent(vitals.mana, vitals.maxMana)}%` }} />
@@ -130,8 +165,11 @@ export function CanvasVitalsHud({ vitals, inventory, serverAssets, onCommand, au
         <span className="vbar-quick-potion-label">Mana</span>
       </button>
       <div className="vbar-gold" title={`Gold: ${vitals.gold.toLocaleString()}`}>
-        <span className="vbar-gold-coin" />
-        <span className="vbar-gold-text">{formatCompact(vitals.gold)}</span>
+        <span className="vbar-gold-coin" aria-hidden="true" />
+        <span className="vbar-gold-text">
+          <span aria-hidden="true">{formatCompact(vitals.gold)}</span>
+          <span className="sr-only">{`Gold: ${vitals.gold.toLocaleString()}`}</span>
+        </span>
       </div>
       <AudioControls audio={audio} />
     </div>

--- a/web-v3/src/components/CharacterPicker.tsx
+++ b/web-v3/src/components/CharacterPicker.tsx
@@ -10,7 +10,7 @@ interface CharacterPickerProps {
 export function CharacterPicker({ characters, onSelect, onRemoveCharacter, onNewCharacter }: CharacterPickerProps) {
   const [confirmRemove, setConfirmRemove] = useState<string | null>(null);
 
-  const handleRemove = useCallback((name: string, e: React.MouseEvent | React.PointerEvent) => {
+  const handleRemove = useCallback((name: string, e: React.MouseEvent | React.PointerEvent | React.KeyboardEvent) => {
     e.stopPropagation();
     e.preventDefault();
     if (confirmRemove === name) {
@@ -42,6 +42,9 @@ export function CharacterPicker({ characters, onSelect, onRemoveCharacter, onNew
                 type="button"
                 className={`character-picker-remove${confirmRemove === name ? " character-picker-remove--confirm" : ""}`}
                 onPointerDown={(e) => handleRemove(name, e)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") handleRemove(name, e);
+                }}
                 onBlur={() => setConfirmRemove(null)}
                 title={confirmRemove === name ? "Click again to forget" : `Forget ${name}`}
                 aria-label={confirmRemove === name ? `Confirm forget ${name}` : `Forget ${name}`}

--- a/web-v3/src/components/CommandInput.tsx
+++ b/web-v3/src/components/CommandInput.tsx
@@ -44,6 +44,10 @@ export function CommandInput({
         type="text"
         className="canvas-command-input"
         placeholder={placeholder}
+        aria-label="Game command"
+        autoComplete="off"
+        autoCapitalize="off"
+        spellCheck={false}
         value={inputValue}
         onChange={(e) => onInputChange(e.target.value)}
         onKeyDown={onInputKeyDown}
@@ -54,9 +58,9 @@ export function CommandInput({
         aria-label="Send"
       >
         {sendIconUrl ? (
-          <img src={sendIconUrl} alt="" className="canvas-command-send-img" />
+          <img src={sendIconUrl} alt="" aria-hidden="true" className="canvas-command-send-img" />
         ) : (
-          <svg viewBox="0 0 24 24" className="canvas-command-send-icon" fill="currentColor">
+          <svg viewBox="0 0 24 24" className="canvas-command-send-icon" fill="currentColor" aria-hidden="true">
             <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" />
           </svg>
         )}

--- a/web-v3/src/components/CommandPalette.tsx
+++ b/web-v3/src/components/CommandPalette.tsx
@@ -183,6 +183,12 @@ export function CommandPalette({
               onChange={(e) => setQuery(e.target.value)}
               autoComplete="off"
               spellCheck={false}
+              aria-label="Search commands"
+              role="combobox"
+              aria-expanded={flatItems.length > 0}
+              aria-controls="cmd-palette-listbox"
+              aria-autocomplete="list"
+              aria-activedescendant={flatItems.length > 0 ? `cmd-palette-item-${selectedIndex}` : undefined}
             />
             <kbd className="cmd-palette-kbd">Esc</kbd>
           </div>
@@ -192,19 +198,23 @@ export function CommandPalette({
           {query.trim().length > 0 ? `${flatItems.length} commands found` : ""}
         </div>
 
-        <div className="cmd-palette-list" ref={listRef}>
+        <div className="cmd-palette-list" ref={listRef} id="cmd-palette-listbox" role="listbox" aria-label="Commands">
           {flatItems.length === 0 && (
             <div className="cmd-palette-empty">No commands match your search.</div>
           )}
           {grouped.map(([category, items]) => (
-            <div key={category} className="cmd-palette-group">
-              <div className="cmd-palette-group-label">{categoryLabel(category)}</div>
+            <div key={category} className="cmd-palette-group" role="group" aria-label={categoryLabel(category)}>
+              <div className="cmd-palette-group-label" aria-hidden="true">{categoryLabel(category)}</div>
               {items.map((cmd) => {
                 const idx = flatIndex++;
                 return (
                   <button
                     key={cmd.name}
                     type="button"
+                    id={`cmd-palette-item-${idx}`}
+                    role="option"
+                    aria-selected={idx === selectedIndex}
+                    tabIndex={-1}
                     className={`cmd-palette-item${idx === selectedIndex ? " cmd-palette-item-selected" : ""}${cmd.staff ? " cmd-palette-item-staff" : ""}`}
                     data-palette-index={idx}
                     onClick={() => handleSelect(cmd)}

--- a/web-v3/src/components/Drawer.tsx
+++ b/web-v3/src/components/Drawer.tsx
@@ -137,6 +137,16 @@ export function Drawer({ open, title, onClose, children, variant = "default", sk
     return () => window.removeEventListener("keydown", handler);
   }, [open, onClose]);
 
+  // Move focus into the sheet on open so Tab continues inside the dialog
+  // rather than looping the controls underneath, and hand it back to the
+  // opener (e.g. the kiosk button) when the drawer closes (WCAG 2.4.3).
+  useEffect(() => {
+    if (!open) return;
+    const opener = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    sheetRef.current?.focus();
+    return () => opener?.focus();
+  }, [open]);
+
   if (renderPhase === "hidden") return null;
 
   const transition = dragging ? "none" : `height ${ANIMATION_MS}ms var(--ease-out-soft)`;
@@ -154,6 +164,7 @@ export function Drawer({ open, title, onClose, children, variant = "default", sk
         role="dialog"
         aria-modal="true"
         aria-label={title}
+        tabIndex={-1}
         style={{
           ["--drawer-height" as string]: `${height * 100}vh`,
           ["--drawer-transition" as string]: transition,

--- a/web-v3/src/components/Drawer.tsx
+++ b/web-v3/src/components/Drawer.tsx
@@ -169,7 +169,7 @@ export function Drawer({ open, title, onClose, children, variant = "default", sk
         >
           <div className="drawer-handle" aria-hidden="true" />
         </div>
-        <div className="drawer-header">
+        <header className="drawer-header">
           <h2 className="drawer-title">{title}</h2>
           <button
             type="button"
@@ -179,7 +179,7 @@ export function Drawer({ open, title, onClose, children, variant = "default", sk
           >
             &#x2715;
           </button>
-        </div>
+        </header>
         <div className="drawer-body">
           {children}
         </div>

--- a/web-v3/src/components/GameShell.tsx
+++ b/web-v3/src/components/GameShell.tsx
@@ -80,6 +80,8 @@ export function GameShell({
 }: GameShellProps) {
   const loggedIn = connected && hasCharacterProfile;
   const [signZoom, setSignZoom] = useState(false);
+  const signButtonRef = useRef<HTMLButtonElement | null>(null);
+  const signZoomRef = useRef<HTMLDivElement | null>(null);
 
   // Services stack (Help / Social / Mail) auto-collapses to a slim handle at
   // the right edge so it doesn't sit over the minimap. Tapping the handle
@@ -128,6 +130,15 @@ export function GameShell({
     return () => window.removeEventListener("keydown", onKey);
   }, [signZoom]);
 
+  // Move focus into the sign-zoom dialog while it is open, and hand it back
+  // to the sign button on dismiss so keyboard users don't lose their place.
+  useEffect(() => {
+    if (!signZoom) return;
+    signZoomRef.current?.focus();
+    const opener = signButtonRef.current;
+    return () => opener?.focus();
+  }, [signZoom]);
+
   return (
     <main className="game-shell">
       {/* Canvas fills the shell; all HUD elements are overlays on top of it */}
@@ -151,6 +162,7 @@ export function GameShell({
                 just crop it and center the title in the blank plaque. */}
             {room.title !== "-" && serverAssets["room_sign_bg"] && (
               <button
+                ref={signButtonRef}
                 type="button"
                 className="canvas-room-sign canvas-room-sign-skinned"
                 onClick={() => setSignZoom(true)}
@@ -206,7 +218,14 @@ export function GameShell({
               <div className="game-target-hud">
                 <span className="game-target-name">{combatTarget.targetName}</span>
                 {combatTarget.targetMaxHp != null && combatTarget.targetHp != null && (
-                  <div className="game-target-hp-track">
+                  <div
+                    className="game-target-hp-track"
+                    role="progressbar"
+                    aria-label={`${combatTarget.targetName} health`}
+                    aria-valuenow={combatTarget.targetHp}
+                    aria-valuemin={0}
+                    aria-valuemax={combatTarget.targetMaxHp}
+                  >
                     <span
                       className="game-target-hp-fill"
                       style={{ width: `${Math.max(0, Math.min(100, (combatTarget.targetHp / combatTarget.targetMaxHp) * 100))}%` }}
@@ -245,7 +264,7 @@ export function GameShell({
                   aria-label="Help"
                 >
                   {serverAssets["help_widget"]
-                    ? <img className="hud-stack-img" src={serverAssets["help_widget"]} alt="" />
+                    ? <img aria-hidden="true" className="hud-stack-img" src={serverAssets["help_widget"]} alt="" />
                     : <span className="hud-stack-glyph">?</span>}
                 </button>
                 <button
@@ -256,7 +275,7 @@ export function GameShell({
                   aria-label="Chat"
                 >
                   {serverAssets["chat_widget"]
-                    ? <img className="hud-stack-img" src={serverAssets["chat_widget"]} alt="" />
+                    ? <img aria-hidden="true" className="hud-stack-img" src={serverAssets["chat_widget"]} alt="" />
                     : <span className="hud-stack-glyph">&#9998;</span>}
                 </button>
                 <button
@@ -267,7 +286,7 @@ export function GameShell({
                   aria-label="Who's online"
                 >
                   {serverAssets["who_widget"]
-                    ? <img className="hud-stack-img" src={serverAssets["who_widget"]} alt="" />
+                    ? <img aria-hidden="true" className="hud-stack-img" src={serverAssets["who_widget"]} alt="" />
                     : <span className="hud-stack-glyph">&#9776;</span>}
                 </button>
                 <button
@@ -278,7 +297,7 @@ export function GameShell({
                   aria-label="Friends"
                 >
                   {serverAssets["friends_widget"]
-                    ? <img className="hud-stack-img" src={serverAssets["friends_widget"]} alt="" />
+                    ? <img aria-hidden="true" className="hud-stack-img" src={serverAssets["friends_widget"]} alt="" />
                     : <span className="hud-stack-glyph">&#9829;</span>}
                 </button>
                 <button
@@ -289,7 +308,7 @@ export function GameShell({
                   aria-label="Guild"
                 >
                   {serverAssets["guild_widget"]
-                    ? <img className="hud-stack-img" src={serverAssets["guild_widget"]} alt="" />
+                    ? <img aria-hidden="true" className="hud-stack-img" src={serverAssets["guild_widget"]} alt="" />
                     : <span className="hud-stack-glyph">&#9884;</span>}
                 </button>
                 <button
@@ -300,7 +319,7 @@ export function GameShell({
                   aria-label="Group"
                 >
                   {serverAssets["group_widget"]
-                    ? <img className="hud-stack-img" src={serverAssets["group_widget"]} alt="" />
+                    ? <img aria-hidden="true" className="hud-stack-img" src={serverAssets["group_widget"]} alt="" />
                     : <span className="hud-stack-glyph">&#10022;</span>}
                 </button>
                 <button
@@ -311,7 +330,7 @@ export function GameShell({
                   aria-label="Mail"
                 >
                   {serverAssets["mail_widget"]
-                    ? <img className="hud-stack-img" src={serverAssets["mail_widget"]} alt="" />
+                    ? <img aria-hidden="true" className="hud-stack-img" src={serverAssets["mail_widget"]} alt="" />
                     : <span className="hud-stack-glyph">✉</span>}
                 </button>
                 {/* Small screens only — desktop reaches the terminal via the
@@ -324,7 +343,7 @@ export function GameShell({
                   aria-label="Terminal"
                 >
                   {serverAssets["terminal_widget"]
-                    ? <img className="hud-stack-img" src={serverAssets["terminal_widget"]} alt="" />
+                    ? <img aria-hidden="true" className="hud-stack-img" src={serverAssets["terminal_widget"]} alt="" />
                     : <span className="hud-stack-glyph">&gt;_</span>}
                 </button>
               </div>
@@ -415,10 +434,12 @@ export function GameShell({
       {/* Enlarged, static view of the room sign — click anywhere / Esc to close. */}
       {signZoom && room.title !== "-" && serverAssets["room_sign_bg"] && (
         <div
+          ref={signZoomRef}
           className="sign-zoom-backdrop"
           role="dialog"
           aria-modal="true"
           aria-label={`Room: ${room.title}`}
+          tabIndex={-1}
           onClick={() => setSignZoom(false)}
         >
           <div className="sign-zoom">

--- a/web-v3/src/components/HelpContent.tsx
+++ b/web-v3/src/components/HelpContent.tsx
@@ -150,6 +150,10 @@ export function HelpContent({ isStaff, serverCommands }: HelpContentProps) {
           />
         </div>
 
+        <div className="sr-only" aria-live="polite" aria-atomic="true">
+          {query.length > 0 ? `${rows.length} commands found` : ""}
+        </div>
+
         <div className="cr-table-head" aria-hidden="true">
           <span className="cr-col-cmd">Command</span>
           <span className="cr-col-usage">Usage</span>

--- a/web-v3/src/components/KioskBar.tsx
+++ b/web-v3/src/components/KioskBar.tsx
@@ -50,9 +50,10 @@ export function KioskBar({ serverAssets, activePopout, onOpenPanel }: KioskBarPr
             onClick={() => onOpenPanel(def.panel)}
             title={def.label}
             aria-label={def.label}
+            aria-pressed={activePopout === def.panel}
           >
             <span className="kiosk-icon">
-              {art ? <img src={art} alt="" className="kiosk-img" /> : def.fallback}
+              {art ? <img src={art} alt="" aria-hidden="true" className="kiosk-img" /> : def.fallback}
             </span>
             <span className="kiosk-label">{def.label}</span>
           </button>

--- a/web-v3/src/components/RoomExitsCompass.tsx
+++ b/web-v3/src/components/RoomExitsCompass.tsx
@@ -30,7 +30,7 @@ export function RoomExitsCompass({ exits, serverAssets, onCommand }: RoomExitsCo
   const padStyle = bg ? { ["--compass-bg" as string]: `url("${bg}")` } : undefined;
 
   return (
-    <div className="room-compass" aria-label="Exits">
+    <div className="room-compass" role="navigation" aria-label="Room exits">
       <div className="room-compass-pad" style={padStyle}>
         {DIRECTIONS.map(({ dir, cls, label, asset }) => {
           const active = present.has(dir);
@@ -45,7 +45,7 @@ export function RoomExitsCompass({ exits, serverAssets, onCommand }: RoomExitsCo
               aria-label={active ? `Go ${dir}` : `No ${dir} exit`}
               onClick={active ? go(dir) : undefined}
             >
-              {art ? <img src={art} alt={label} className="compass-btn-img" /> : label}
+              {art ? <img src={art} alt="" aria-hidden="true" className="compass-btn-img" /> : label}
             </button>
           );
         })}

--- a/web-v3/src/components/ShopPopout.tsx
+++ b/web-v3/src/components/ShopPopout.tsx
@@ -37,8 +37,9 @@ function StatChip({
   delta: number | null;
 }) {
   const deltaClass = delta === null ? "" : delta > 0 ? " shop-stat-delta-up" : delta < 0 ? " shop-stat-delta-down" : " shop-stat-delta-same";
+  const title = `${label}: ${value}${delta !== null ? ` (${formatDelta(delta)} vs equipped)` : ""}`;
   return (
-    <span className="shop-stat-chip" title={`${label}: ${value}${delta !== null ? ` (${formatDelta(delta)} vs equipped)` : ""}`}>
+    <span className="shop-stat-chip" title={title} aria-label={title}>
       <span className="shop-stat-chip-label">{label}</span>
       <span className="shop-stat-chip-value">{value}</span>
       {delta !== null && (

--- a/web-v3/src/components/SkillBar.tsx
+++ b/web-v3/src/components/SkillBar.tsx
@@ -48,6 +48,7 @@ interface SkillSlotProps {
 
 function SkillSlot({ skill, index, onCast, onDragStart, onDragOver, onDragLeave, onDrop, onClear }: SkillSlotProps) {
   const { onCooldown, fraction } = useSkillCooldown(skill);
+  const cooldownSeconds = Math.ceil((fraction * skill.cooldownMs) / 1000);
 
   return (
     <button
@@ -62,7 +63,7 @@ function SkillSlot({ skill, index, onCast, onDragStart, onDragOver, onDragLeave,
       onDragOver={onDragOver}
       onDragLeave={onDragLeave}
       onDrop={(e) => onDrop(e, index)}
-      aria-label={`${skill.name} — key ${index + 1}`}
+      aria-label={`${skill.name}, ${skill.manaCost} mana, key ${index + 1}${onCooldown ? `, on cooldown, ${cooldownSeconds} seconds remaining` : ""}`}
     >
       {skill.image
         ? <img src={skill.image} alt="" className="vbar-skill-img" draggable={false} />
@@ -76,6 +77,7 @@ function SkillSlot({ skill, index, onCast, onDragStart, onDragOver, onDragLeave,
 
 function PetSkillSlot({ skill, index, onCast }: { skill: SkillSummary; index: number; onCast: (id: string, cd: number) => void }) {
   const { onCooldown, fraction } = useSkillCooldown(skill);
+  const cooldownSeconds = Math.ceil((fraction * skill.cooldownMs) / 1000);
 
   return (
     <button
@@ -84,7 +86,7 @@ function PetSkillSlot({ skill, index, onCast }: { skill: SkillSummary; index: nu
       disabled={onCooldown}
       title={`${skill.name} (pet) — Shift+${index + 1}`}
       onClick={() => onCast(skill.id, skill.cooldownMs)}
-      aria-label={`${skill.name} pet skill — Shift+${index + 1}`}
+      aria-label={`${skill.name} pet skill, Shift+${index + 1}${onCooldown ? `, on cooldown, ${cooldownSeconds} seconds remaining` : ""}`}
     >
       {skill.image
         ? <img src={skill.image} alt="" className="vbar-skill-img" draggable={false} />

--- a/web-v3/src/components/SkillBar.tsx
+++ b/web-v3/src/components/SkillBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { DragEvent } from "react";
 import type { SkillSummary } from "../types";
 import { SkillCastIcon } from "./Icons";
@@ -35,6 +35,30 @@ function useSkillCooldown(skill: SkillSummary): { onCooldown: boolean; fraction:
   return { onCooldown, fraction };
 }
 
+/**
+ * Announces "ready" to screen readers when a skill leaves cooldown, so
+ * keyboard players get the same cue the visual sweep provides. Returns true
+ * for a short window after the cooldown ends.
+ */
+function useReadyAnnouncement(onCooldown: boolean): boolean {
+  const wasOnCooldown = useRef(onCooldown);
+  const [justReady, setJustReady] = useState(false);
+
+  useEffect(() => {
+    const was = wasOnCooldown.current;
+    wasOnCooldown.current = onCooldown;
+    if (!was || onCooldown) return;
+    const showTimer = window.setTimeout(() => setJustReady(true), 0);
+    const hideTimer = window.setTimeout(() => setJustReady(false), 2000);
+    return () => {
+      window.clearTimeout(showTimer);
+      window.clearTimeout(hideTimer);
+    };
+  }, [onCooldown]);
+
+  return justReady;
+}
+
 interface SkillSlotProps {
   skill: SkillSummary;
   index: number;
@@ -49,8 +73,10 @@ interface SkillSlotProps {
 function SkillSlot({ skill, index, onCast, onDragStart, onDragOver, onDragLeave, onDrop, onClear }: SkillSlotProps) {
   const { onCooldown, fraction } = useSkillCooldown(skill);
   const cooldownSeconds = Math.ceil((fraction * skill.cooldownMs) / 1000);
+  const justReady = useReadyAnnouncement(onCooldown);
 
   return (
+    <>
     <button
       type="button"
       className={`vbar-skill ${skillCategory(skill)}${onCooldown ? " vbar-skill-cd" : ""}`}
@@ -72,14 +98,20 @@ function SkillSlot({ skill, index, onCast, onDragStart, onDragOver, onDragLeave,
       {onCooldown && <span className="vbar-skill-sweep" style={{ height: `${fraction * 100}%` }} />}
       <span className="vbar-skill-key">{index + 1}</span>
     </button>
+    <span className="sr-only" role="status" aria-live="polite">
+      {justReady ? `${skill.name} ready` : ""}
+    </span>
+    </>
   );
 }
 
 function PetSkillSlot({ skill, index, onCast }: { skill: SkillSummary; index: number; onCast: (id: string, cd: number) => void }) {
   const { onCooldown, fraction } = useSkillCooldown(skill);
   const cooldownSeconds = Math.ceil((fraction * skill.cooldownMs) / 1000);
+  const justReady = useReadyAnnouncement(onCooldown);
 
   return (
+    <>
     <button
       type="button"
       className={`vbar-skill vbar-pet-skill${onCooldown ? " vbar-skill-cd" : ""}`}
@@ -95,6 +127,10 @@ function PetSkillSlot({ skill, index, onCast }: { skill: SkillSummary; index: nu
       {onCooldown && <span className="vbar-skill-sweep" style={{ height: `${fraction * 100}%` }} />}
       <span className="vbar-skill-key">{`⇧${index + 1}`}</span>
     </button>
+    <span className="sr-only" role="status" aria-live="polite">
+      {justReady ? `${skill.name} ready` : ""}
+    </span>
+    </>
   );
 }
 

--- a/web-v3/src/components/SpellbookPanel.tsx
+++ b/web-v3/src/components/SpellbookPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import type { SkillSummary } from "../types";
 
 type Category = "ALL" | "DAMAGE" | "HEAL" | "BUFF" | "DEBUFF" | "UTILITY";
@@ -71,6 +71,7 @@ function SkillCard({
   onAssignSlot: (slotIndex: number, skillId: string) => void;
 }) {
   const [showSlotPicker, setShowSlotPicker] = useState(false);
+  const assignBtnRef = useRef<HTMLButtonElement | null>(null);
 
   const isPet = skill.source === "pet";
   return (
@@ -83,7 +84,7 @@ function SkillCard({
       >
         <div className="spellbook-card-icon">
           {skill.image ? (
-            <img src={skill.image} alt="" className="spellbook-card-image" />
+            <img src={skill.image} alt="" aria-hidden="true" className="spellbook-card-image" />
           ) : (
             <div className="spellbook-card-placeholder" />
           )}
@@ -111,9 +112,14 @@ function SkillCard({
         </div>
       </button>
       <button
+        ref={assignBtnRef}
         type="button"
         className={`spellbook-assign-btn${showSlotPicker ? " spellbook-assign-btn-active" : ""}`}
         title={slotNumber !== null ? `Quickbar slot ${slotNumber}` : "Assign to quickbar"}
+        aria-label={slotNumber !== null
+          ? `${skill.name} — assigned to quickbar slot ${slotNumber}, change slot`
+          : `Assign ${skill.name} to a quickbar slot`}
+        aria-expanded={showSlotPicker}
         onClick={() => setShowSlotPicker(!showSlotPicker)}
       >
         {slotNumber !== null ? slotNumber : "+"}
@@ -121,16 +127,22 @@ function SkillCard({
       {showSlotPicker && (
         <div
           className="spellbook-slot-picker"
-          role="menu"
+          role="group"
           aria-label="Assign to quickbar slot"
-          onKeyDown={(e) => { if (e.key === "Escape") { e.stopPropagation(); setShowSlotPicker(false); } }}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              e.stopPropagation();
+              setShowSlotPicker(false);
+              assignBtnRef.current?.focus();
+            }
+          }}
         >
           {Array.from({ length: SLOT_COUNT }, (_, i) => (
             <button
               key={i}
               type="button"
-              role="menuitem"
               className="spellbook-slot-pick"
+              aria-label={`Slot ${i + 1}`}
               autoFocus={i === 0}
               onClick={() => {
                 onAssignSlot(i, skill.id);
@@ -241,14 +253,13 @@ export function SpellbookPanel({
         </span>
       </div>
       {availableCategories.length > 2 && (
-        <div className="spellbook-tabs" role="tablist" aria-label="Filter by ability type">
+        <div className="spellbook-tabs" role="group" aria-label="Filter by ability type">
           {availableCategories.map((cat) => (
             <button
               key={cat.key}
               type="button"
-              role="tab"
               className={`spellbook-tab${activeCategory === cat.key ? " spellbook-tab-active" : ""}`}
-              aria-selected={activeCategory === cat.key}
+              aria-pressed={activeCategory === cat.key}
               onClick={() => setActiveCategory(cat.key)}
             >
               {cat.label}
@@ -257,12 +268,11 @@ export function SpellbookPanel({
         </div>
       )}
       {availableClasses.length > 1 && (
-        <div className="spellbook-class-pills" role="tablist" aria-label="Filter by source class">
+        <div className="spellbook-class-pills" role="group" aria-label="Filter by source class">
           <button
             type="button"
-            role="tab"
             className={`spellbook-class-pill${activeClass === "ALL" ? " spellbook-class-pill-active" : ""}`}
-            aria-selected={activeClass === "ALL"}
+            aria-pressed={activeClass === "ALL"}
             onClick={() => setActiveClass("ALL")}
           >
             All classes
@@ -271,9 +281,8 @@ export function SpellbookPanel({
             <button
               key={cls}
               type="button"
-              role="tab"
               className={`spellbook-class-pill${activeClass === cls ? " spellbook-class-pill-active" : ""}`}
-              aria-selected={activeClass === cls}
+              aria-pressed={activeClass === cls}
               onClick={() => setActiveClass(cls)}
             >
               {prettyClass(cls)}

--- a/web-v3/src/components/TerminalOverlay.tsx
+++ b/web-v3/src/components/TerminalOverlay.tsx
@@ -102,9 +102,10 @@ export function TerminalOverlay({
     <div
       className={`terminal-screen${open ? " terminal-screen-open" : ""}${opaque ? " terminal-screen-opaque" : ""}${parchmentBg ? " terminal-screen-skinned" : ""}`}
       role="dialog"
-      aria-modal={open}
+      aria-modal="true"
       aria-label="Terminal"
       aria-hidden={!open}
+      inert={!open}
       style={Object.keys(skinVars).length > 0 ? skinVars : undefined}
       onBlur={handleFocusOut}
       onPointerDown={handlePointerDown}

--- a/web-v3/src/components/TradePanel.tsx
+++ b/web-v3/src/components/TradePanel.tsx
@@ -73,7 +73,7 @@ export function TradePanel({ trade, inventory, playerGold, onCommand }: TradePan
         <div className="trade-column trade-column-manage">
           <div className="trade-column-topline">
             <h4 className="trade-column-label">Your Offer</h4>
-            <span className={`trade-status ${trade.myAccepted ? "trade-accepted" : ""}`}>
+            <span className={`trade-status ${trade.myAccepted ? "trade-accepted" : ""}`} role="status" aria-live="polite">
               {statusCopy(trade.myAccepted, trade.myItems.length, trade.myGold)}
             </span>
           </div>
@@ -173,7 +173,7 @@ export function TradePanel({ trade, inventory, playerGold, onCommand }: TradePan
         <div className="trade-column">
           <div className="trade-column-topline">
             <h4 className="trade-column-label">{trade.partner}&apos;s Offer</h4>
-            <span className={`trade-status ${trade.theirAccepted ? "trade-accepted" : ""}`}>
+            <span className={`trade-status ${trade.theirAccepted ? "trade-accepted" : ""}`} role="status" aria-live="polite">
               {statusCopy(trade.theirAccepted, trade.theirItems.length, trade.theirGold)}
             </span>
           </div>
@@ -198,7 +198,7 @@ export function TradePanel({ trade, inventory, playerGold, onCommand }: TradePan
           ) : (
             <p className="trade-reset-note">Offer updates appear live for both players.</p>
           )}
-          {localMessage && <p className="trade-local-message">{localMessage}</p>}
+          {localMessage && <p className="trade-local-message" role="status" aria-live="polite">{localMessage}</p>}
         </div>
         <div className="trade-action-buttons">
           <button

--- a/web-v3/src/components/WorldAtmosphereHud.tsx
+++ b/web-v3/src/components/WorldAtmosphereHud.tsx
@@ -57,7 +57,7 @@ export function WorldAtmosphereHud({ worldTime, worldWeather, worldEvents }: Pro
   if (!hasTime && !hasWeather && !hasEvents) return null;
 
   return (
-    <div className="atmosphere-hud" aria-label="World atmosphere">
+    <div className="atmosphere-hud" role="group" aria-label="World atmosphere">
       {hasTime && (
         <span className="atmosphere-hud-chip" title={`${periodLabel(worldTime.period)} — ${String(worldTime.hour).padStart(2, "0")}:${String(worldTime.minute).padStart(2, "0")}`}>
           <span className="atmosphere-hud-icon" aria-hidden="true">{periodIcon(worldTime.period)}</span>

--- a/web-v3/src/components/WorldFeaturesPopout.tsx
+++ b/web-v3/src/components/WorldFeaturesPopout.tsx
@@ -139,6 +139,7 @@ function ContainerPanel({
                   <button
                     type="button"
                     className="feat-take"
+                    aria-label={`Take ${item.name}`}
                     onClick={() => onCommand(`get ${item.keyword} from ${feature.keyword}`)}
                   >
                     Take

--- a/web-v3/src/components/panels/AdminPanel.tsx
+++ b/web-v3/src/components/panels/AdminPanel.tsx
@@ -70,6 +70,7 @@ function TeleportBrowser({
         type="text"
         className="admin-input teleport-filter"
         placeholder="Filter zones, rooms, players..."
+        aria-label="Filter zones, rooms, players"
         value={filter}
         onChange={(e) => onSetFilter(e.target.value)}
         autoFocus
@@ -108,9 +109,10 @@ function TeleportBrowser({
             <button
               type="button"
               className={`teleport-zone-header ${isExpanded ? "teleport-zone-header-expanded" : ""}`}
+              aria-expanded={isExpanded}
               onClick={() => setExpandedZone(expandedZone === z.zone ? null : z.zone)}
             >
-              <span className="teleport-zone-arrow">{isExpanded ? "\u25BE" : "\u25B8"}</span>
+              <span className="teleport-zone-arrow" aria-hidden="true">{isExpanded ? "\u25BE" : "\u25B8"}</span>
               <span className="teleport-zone-name">{z.zone}</span>
               <span className="teleport-zone-count">{roomCount} rooms</span>
             </button>
@@ -180,6 +182,7 @@ function MobTemplateBrowser({
         type="text"
         className="admin-input teleport-filter"
         placeholder="Filter mob templates..."
+        aria-label="Filter mob templates"
         value={filter}
         onChange={(e) => onSetFilter(e.target.value)}
       />
@@ -190,9 +193,10 @@ function MobTemplateBrowser({
             <button
               type="button"
               className={`teleport-zone-header ${isExpanded ? "teleport-zone-header-expanded" : ""}`}
+              aria-expanded={isExpanded}
               onClick={() => setExpandedZone(expandedZone === z.zone ? null : z.zone)}
             >
-              <span className="teleport-zone-arrow">{isExpanded ? "\u25BE" : "\u25B8"}</span>
+              <span className="teleport-zone-arrow" aria-hidden="true">{isExpanded ? "\u25BE" : "\u25B8"}</span>
               <span className="teleport-zone-name">{z.zone}</span>
               <span className="teleport-zone-count">{z.mobs.length} mobs</span>
             </button>
@@ -281,6 +285,7 @@ function TargetBrowser({
         type="text"
         className="admin-input teleport-filter"
         placeholder="Filter live targets..."
+        aria-label="Filter live targets"
         value={filter}
         onChange={(e) => onSetFilter(e.target.value)}
       />
@@ -549,7 +554,7 @@ export function AdminPanel({
 
           <div className="admin-main-pane">
           {activeFeedback && feedbackVisible && (
-            <p className={`admin-feedback-banner admin-feedback-banner-${activeFeedback.type}`}>
+            <p className={`admin-feedback-banner admin-feedback-banner-${activeFeedback.type}`} role="status" aria-live="polite">
               {activeFeedback.message}
             </p>
           )}

--- a/web-v3/src/components/panels/AuctionPanel.tsx
+++ b/web-v3/src/components/panels/AuctionPanel.tsx
@@ -108,7 +108,7 @@ export function AuctionPanel({ listings, inventory, playerName, isDemo, feedback
 
   return (
     <div className="ah-board">
-      {message && <p className={`ah-toast ah-toast-${messageKind}`}>{message}</p>}
+      {message && <p className={`ah-toast ah-toast-${messageKind}`} role="status" aria-live="polite">{message}</p>}
 
       {/* ───────── Browse (left) ───────── */}
       <div className="ah-browse">
@@ -117,6 +117,7 @@ export function AuctionPanel({ listings, inventory, playerName, isDemo, feedback
             type="text"
             className="ah-search"
             placeholder="Search items or sellers…"
+            aria-label="Search items or sellers"
             value={filter}
             onChange={(e) => setFilter(e.target.value)}
           />
@@ -236,6 +237,7 @@ export function AuctionPanel({ listings, inventory, playerName, isDemo, feedback
             inputMode="numeric"
             className="ah-price-input"
             placeholder="Gold"
+            aria-label="Listing price in gold"
             value={priceDraft}
             onChange={(e) => setPriceDraft(e.target.value)}
           />

--- a/web-v3/src/components/panels/BankPanel.tsx
+++ b/web-v3/src/components/panels/BankPanel.tsx
@@ -67,6 +67,7 @@ export function BankPanel({ bankState, serverAssets, onCommand }: BankPanelProps
             type="number"
             className="bank-gold-input"
             placeholder="Amount"
+            aria-label="Gold amount"
             min={1}
             value={goldAmount}
             onChange={(e) => setGoldAmount(e.target.value)}
@@ -128,6 +129,7 @@ export function BankPanel({ bankState, serverAssets, onCommand }: BankPanelProps
             type="text"
             className="bank-item-input"
             placeholder="Item keyword"
+            aria-label="Item keyword"
             value={itemKeyword}
             onChange={(e) => setItemKeyword(e.target.value)}
             onKeyDown={(e) => {

--- a/web-v3/src/components/panels/CharacterPanel.tsx
+++ b/web-v3/src/components/panels/CharacterPanel.tsx
@@ -318,7 +318,7 @@ export function CharacterPanel({
               <span className="cc-ctl-name">Auto Peek</span>
               <span className="cc-switch"><span className="cc-switch-thumb" /></span>
             </button>
-            <div className="cc-ctl cc-ctl-wimpy" title="Auto-flee combat when HP drops to this %.">
+            <div className="cc-ctl cc-ctl-wimpy" role="group" aria-label="Wimpy threshold" title="Auto-flee combat when HP drops to this %.">
               <span className="cc-ctl-leaf" aria-hidden="true" />
               <span className="cc-ctl-name">Wimpy</span>
               <button

--- a/web-v3/src/components/panels/ChatBoardPanel.tsx
+++ b/web-v3/src/components/panels/ChatBoardPanel.tsx
@@ -146,6 +146,7 @@ export function ChatBoardPanel({
             style={{ ...rectStyle(CHANNEL_RECTS[channel.id] ?? FEED_RECT), ["--chat-accent" as string]: CHANNEL_ACCENTS[channel.id] ?? "var(--chat-accent-say)" }}
             onClick={() => onChannelChange(channel.id)}
             aria-selected={isActive}
+            aria-controls="cb-channel-feed"
             aria-label={channel.label}
             title={channel.label}
           />
@@ -155,6 +156,7 @@ export function ChatBoardPanel({
       {/* ── Message feed (over the painted chalkboard) ────────── */}
       <div
         ref={feedRef}
+        id="cb-channel-feed"
         className="cb-feed"
         style={rectStyle(FEED_RECT)}
         role="log"

--- a/web-v3/src/components/panels/CombatPanel.tsx
+++ b/web-v3/src/components/panels/CombatPanel.tsx
@@ -152,6 +152,7 @@ export function CombatPanel({
                               ? `${skill.name} — not enough mana (${skill.manaCost})`
                               : `Cast ${skill.name} (${skill.manaCost} mana)`
                         }
+                        aria-label={`${skill.name}, ${skill.manaCost} mana${!isReady ? `, on cooldown (${cooldownSeconds}s)` : !hasEnoughMana ? ", not enough mana" : ""}`}
                         disabled={isDisabled}
                         onClick={() => onCastSkill(skill.id, skill.cooldownMs)}
                       >

--- a/web-v3/src/components/panels/CraftingPanel.tsx
+++ b/web-v3/src/components/panels/CraftingPanel.tsx
@@ -123,6 +123,7 @@ export function CraftingPanel({
               type="button"
               role="tab"
               aria-selected={tab === t.key}
+              aria-controls="cr-recipe-list"
               className={`cr-tab${tab === t.key ? " cr-tab-active" : ""}`}
               onClick={() => { setTab(t.key); setSelectedId(""); }}
             >
@@ -130,7 +131,7 @@ export function CraftingPanel({
             </button>
           ))}
         </div>
-        <div className="cr-recipe-list">
+        <div id="cr-recipe-list" className="cr-recipe-list">
           {filtered.length === 0 ? (
             <p className="cr-empty">No recipes known in this craft.</p>
           ) : (

--- a/web-v3/src/components/panels/DicePanel.tsx
+++ b/web-v3/src/components/panels/DicePanel.tsx
@@ -315,7 +315,7 @@ export function DicePanel({ diceResult, lotteryInfo, uiFeedbackFeed, gold, asset
       <div className="dice-stat dice-stat-bet">{formatGold(bet)}</div>
 
       {/* Velvet roll stage */}
-      <div className="dice-velvet" aria-live="polite">
+      <div className="dice-velvet" role="status" aria-live="polite">
         {activeDie && (
           <Die
             die={activeDie}
@@ -373,6 +373,8 @@ export function DicePanel({ diceResult, lotteryInfo, uiFeedbackFeed, gold, asset
               key={amount}
               type="button"
               className={`dice-bet-chip${bet === amount ? " is-active" : ""}`}
+              aria-pressed={bet === amount}
+              aria-label={`Bet ${amount.toLocaleString()} gold`}
               onClick={() => setBetDraft(`${amount}`)}
             >
               {amount >= 1000 ? `${amount / 1000}K` : amount}
@@ -383,7 +385,7 @@ export function DicePanel({ diceResult, lotteryInfo, uiFeedbackFeed, gold, asset
           {rolling ? "Rolling…" : coolingDown ? `Wait ${Math.ceil(cooldownLeft / 1000)}s` : "ROLL"}
         </button>
         {activeFeedback && (
-          <p className={`dice-feedback dice-feedback-${activeFeedback.type}`}>{activeFeedback.message}</p>
+          <p className={`dice-feedback dice-feedback-${activeFeedback.type}`} role="status" aria-live="polite">{activeFeedback.message}</p>
         )}
       </div>
 

--- a/web-v3/src/components/panels/DungeonPanel.tsx
+++ b/web-v3/src/components/panels/DungeonPanel.tsx
@@ -28,7 +28,7 @@ export function DungeonPanel({ dungeonInfo, dungeonCatalog, uiFeedbackFeed, onCo
       </div>
 
       {activeFeedback && (
-        <p className={`systems-local-message systems-local-message-${activeFeedback.type}`}>
+        <p className={`systems-local-message systems-local-message-${activeFeedback.type}`} role="status" aria-live="polite">
           {activeFeedback.message}
         </p>
       )}
@@ -94,6 +94,7 @@ export function DungeonPanel({ dungeonInfo, dungeonCatalog, uiFeedbackFeed, onCo
                       key={difficulty.id}
                       type="button"
                       className={`systems-choice-card ${chosenDifficulty === difficulty.id ? "systems-choice-card-active" : ""}`}
+                      aria-pressed={chosenDifficulty === difficulty.id}
                       onClick={() => setSelectedDifficulty(difficulty.id)}
                     >
                       <span className="systems-choice-title">{difficulty.label}</span>

--- a/web-v3/src/components/panels/EquipmentPanel.tsx
+++ b/web-v3/src/components/panels/EquipmentPanel.tsx
@@ -113,7 +113,16 @@ export function EquipmentPanel({
                 <li
                   key={def.id}
                   className={`paperdoll-list-item ${item ? "paperdoll-list-item-filled" : "paperdoll-list-item-empty"}`}
+                  role={item ? "button" : undefined}
+                  tabIndex={item ? 0 : undefined}
+                  aria-label={item ? `${def.displayName}: ${item.name} — examine` : undefined}
                   onClick={() => { if (item) onExamineItem(item, thumb, def.id); }}
+                  onKeyDown={(e) => {
+                    if (item && (e.key === "Enter" || e.key === " ")) {
+                      e.preventDefault();
+                      onExamineItem(item, thumb, def.id);
+                    }
+                  }}
                 >
                   <div className="paperdoll-card-thumb">
                     {thumb ? (

--- a/web-v3/src/components/panels/FriendsBoardPanel.tsx
+++ b/web-v3/src/components/panels/FriendsBoardPanel.tsx
@@ -131,7 +131,7 @@ export function FriendsBoardPanel({
           <span className="fb-col-actions" role="columnheader">Actions</span>
         </div>
 
-        <div className="fb-body">
+        <div className="fb-body" role="rowgroup">
           {!canChat ? (
             <p className="fb-empty">{connected ? "Log in to see your friends." : "Reconnect to load social data."}</p>
           ) : sortedFriends.length === 0 && recentNotes.length === 0 ? (
@@ -152,7 +152,7 @@ export function FriendsBoardPanel({
                 const wp = whoByName.get(f.name.toLowerCase());
                 return (
                   <div key={f.name} className={`fb-row${f.online ? "" : " is-offline"}`} role="row">
-                    <span className="fb-col-portrait">
+                    <span className="fb-col-portrait" role="cell">
                       <span className="fb-portrait">
                         <span className={`fb-dot fb-portrait-dot ${f.online ? "is-online" : "is-offline"}`} aria-hidden="true" />
                         {wp?.sprite
@@ -160,13 +160,13 @@ export function FriendsBoardPanel({
                           : <span className="fb-sprite-empty" aria-hidden="true" />}
                       </span>
                     </span>
-                    <span className="fb-col-name">
+                    <span className="fb-col-name" role="cell">
                       <span className="fb-name">{f.name}</span>
                       {wp?.title && <span className="fb-title">{wp.title}</span>}
                     </span>
-                    <span className="fb-col-loc">{f.online ? (f.zone ?? "—") : "Offline"}</span>
-                    <span className="fb-col-level">{f.level ?? wp?.level ?? "—"}</span>
-                    <span className="fb-col-actions">
+                    <span className="fb-col-loc" role="cell">{f.online ? (f.zone ?? "—") : "Offline"}</span>
+                    <span className="fb-col-level" role="cell">{f.level ?? wp?.level ?? "—"}</span>
+                    <span className="fb-col-actions" role="cell">
                       <button type="button" className="whoboard-action" title={`Examine ${f.name}`} aria-label={`Examine ${f.name}`} onClick={() => examineFriend(f)}>
                         {examineArt ? <img src={examineArt} alt="" aria-hidden="true" /> : <span className="whoboard-action-glyph" aria-hidden="true">❦</span>}
                       </button>

--- a/web-v3/src/components/panels/GroupBoardPanel.tsx
+++ b/web-v3/src/components/panels/GroupBoardPanel.tsx
@@ -118,11 +118,11 @@ export function GroupBoardPanel({
                 <div className="gp-member-bars">
                   <div className="gp-bar">
                     <span className="gp-bar-key">HP</span>
-                    <div className="gp-bar-track"><span className="gp-bar-fill gp-bar-hp" style={{ width: `${hpPct}%` }} /><span className="gp-bar-text">{m.hp} / {m.maxHp}</span></div>
+                    <div className="gp-bar-track" role="progressbar" aria-label={`${m.name} health`} aria-valuenow={m.hp} aria-valuemin={0} aria-valuemax={m.maxHp}><span className="gp-bar-fill gp-bar-hp" style={{ width: `${hpPct}%` }} /><span className="gp-bar-text">{m.hp} / {m.maxHp}</span></div>
                   </div>
                   <div className="gp-bar">
                     <span className="gp-bar-key">MP</span>
-                    <div className="gp-bar-track"><span className="gp-bar-fill gp-bar-mana" style={{ width: `${manaPct}%` }} /><span className="gp-bar-text">{m.mana} / {m.maxMana}</span></div>
+                    <div className="gp-bar-track" role="progressbar" aria-label={`${m.name} mana`} aria-valuenow={m.mana} aria-valuemin={0} aria-valuemax={m.maxMana}><span className="gp-bar-fill gp-bar-mana" style={{ width: `${manaPct}%` }} /><span className="gp-bar-text">{m.mana} / {m.maxMana}</span></div>
                   </div>
                 </div>
                 {iAmLeader && !isMe && (

--- a/web-v3/src/components/panels/GuildBoardPanel.tsx
+++ b/web-v3/src/components/panels/GuildBoardPanel.tsx
@@ -179,6 +179,7 @@ export function GuildBoardPanel({
                       className={`gb-member${selected === m.name ? " is-selected" : ""}${m.online ? "" : " is-offline"}`}
                       onClick={() => setSelected(selected === m.name ? null : m.name)}
                       aria-pressed={selected === m.name}
+                      aria-label={`${m.name}${m.level !== null ? `, level ${m.level}` : ""}, ${rankLabel(m.rank)}, ${m.online ? "online" : "offline"}`}
                     >
                       <span className="gb-member-num">{i + 1}.</span>
                       <span className={`gb-member-dot ${m.online ? "is-online" : "is-offline"}`} aria-hidden="true" />

--- a/web-v3/src/components/panels/HousingPanel.tsx
+++ b/web-v3/src/components/panels/HousingPanel.tsx
@@ -12,9 +12,9 @@ interface HousingPanelProps {
   onSendCommand: (cmd: string) => void;
 }
 
-const DIRECTIONS: Array<{ key: string; label: string }> = [
-  { key: "n", label: "N" }, { key: "s", label: "S" }, { key: "e", label: "E" },
-  { key: "w", label: "W" }, { key: "u", label: "Up" }, { key: "d", label: "Down" },
+const DIRECTIONS: Array<{ key: string; label: string; name: string }> = [
+  { key: "n", label: "N", name: "North" }, { key: "s", label: "S", name: "South" }, { key: "e", label: "E", name: "East" },
+  { key: "w", label: "W", name: "West" }, { key: "u", label: "Up", name: "Up" }, { key: "d", label: "Down", name: "Down" },
 ];
 
 /**
@@ -129,15 +129,15 @@ export function HousingPanel({
       {/* ── Buy bar (bottom) ─────────────────────────────────── */}
       <div className="hb-buybar">
         {activeFeedback && (
-          <span className={`hb-feedback hb-feedback-${activeFeedback.type}`}>{activeFeedback.message}</span>
+          <span className={`hb-feedback hb-feedback-${activeFeedback.type}`} role="status" aria-live="polite">{activeFeedback.message}</span>
         )}
         {choosingDir ? (
           <div className="hb-dir-picker">
             <span className="hb-dir-label">Attach where?</span>
             {DIRECTIONS.map((d) => (
-              <button key={d.key} type="button" className="hb-dir-btn" onClick={() => expand(d.key)}>{d.label}</button>
+              <button key={d.key} type="button" className="hb-dir-btn" aria-label={d.name} onClick={() => expand(d.key)}>{d.label}</button>
             ))}
-            <button type="button" className="hb-dir-cancel" onClick={() => setChoosingDir(false)}>✕</button>
+            <button type="button" className="hb-dir-cancel" aria-label="Cancel" onClick={() => setChoosingDir(false)}>✕</button>
           </div>
         ) : (
           <button type="button" className="hb-buy-btn" disabled={!canBuy} onClick={onBuy}>{buyLabel}</button>

--- a/web-v3/src/components/panels/InventoryPanel.tsx
+++ b/web-v3/src/components/panels/InventoryPanel.tsx
@@ -353,7 +353,7 @@ export function InventoryPanel({
                   </button>
                 </div>
                 {containerContents && containerContents.keyword === container.keyword && containerContents.items.length > 0 && (
-                  <ul className="container-items">
+                  <ul className="container-items" aria-label={`Contents of ${container.name}`}>
                     {containerContents.items.map((ci, idx) => (
                       <li key={`${ci.keyword}-${idx}`} className="container-item">
                         <span className="container-item-name">{ci.name}</span>

--- a/web-v3/src/components/panels/LeaderboardPanel.tsx
+++ b/web-v3/src/components/panels/LeaderboardPanel.tsx
@@ -63,6 +63,9 @@ export function LeaderboardPanel({ leaderboard, onCommand }: Props) {
                 <p className="leaderboard-empty-note">No entries yet — be the first to rank!</p>
               ) : (
                 <table className="leaderboard-table">
+                  <caption className="sr-only">
+                    {data.label} rankings — columns: rank, player, score
+                  </caption>
                   <tbody>
                     {data.entries.map((e) => (
                       <tr key={e.rank} className="leaderboard-row">

--- a/web-v3/src/components/panels/LotteryPanel.tsx
+++ b/web-v3/src/components/panels/LotteryPanel.tsx
@@ -67,7 +67,7 @@ export function LotteryPanel({ lotteryInfo, uiFeedbackFeed, onCommand }: Lottery
           <button type="button" className="lot-qty-step" onClick={() => setQty((q) => clamp(q - 10))} aria-label="Minus ten">−10</button>
           <button type="button" className="lot-qty-step" onClick={() => setQty((q) => clamp(q - 1))} aria-label="Minus one">−</button>
           {Array.from({ length: cap }, (_, i) => i + 1).map((n) => (
-            <button key={n} type="button" className={`lot-qty-num${qty === n ? " is-active" : ""}`} onClick={() => setQty(n)}>{n}</button>
+            <button key={n} type="button" className={`lot-qty-num${qty === n ? " is-active" : ""}`} aria-pressed={qty === n} onClick={() => setQty(n)}>{n}</button>
           ))}
           <button type="button" className="lot-qty-step" onClick={() => setQty((q) => clamp(q + 1))} aria-label="Plus one">+</button>
           <button type="button" className="lot-qty-step" onClick={() => setQty((q) => clamp(q + 10))} aria-label="Plus ten">+10</button>

--- a/web-v3/src/components/panels/MailPanel.tsx
+++ b/web-v3/src/components/panels/MailPanel.tsx
@@ -210,8 +210,16 @@ export function MailPanel({
   }
 
   // Inbox list
+  const confirmDeleteFrom = confirmDeleteIndex !== null
+    ? inbox.find((m) => m.index === confirmDeleteIndex)?.from ?? null
+    : null;
   return (
     <div className="mail-panel" aria-label="Mail">
+      <span className="sr-only" role="status" aria-live="polite">
+        {confirmDeleteFrom
+          ? `Activate again to confirm deleting the message from ${confirmDeleteFrom}.`
+          : ""}
+      </span>
       <div className="mail-toolbar">
         <span className="mail-inbox-label">
           Inbox ({inbox.length}){unreadCount > 0 && <span className="mail-unread-badge">{unreadCount} new</span>}

--- a/web-v3/src/components/panels/MonsterManualPanel.tsx
+++ b/web-v3/src/components/panels/MonsterManualPanel.tsx
@@ -87,6 +87,11 @@ export function MonsterManualPanel({
   // Tracks whether the current conversation has produced any node yet, so the
   // initial "…" wait isn't mistaken for the conversation having ended.
   const dialogueSeenRef = useRef(false);
+  // Move keyboard focus into the dialog when it opens.
+  const cardRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    cardRef.current?.focus();
+  }, []);
 
   // Fire the matching fetch when deep-linked from an indicator. The initial
   // `view` (above) already shows the right subpanel; the setView calls here
@@ -185,6 +190,8 @@ export function MonsterManualPanel({
       onClick={close}
     >
       <div
+        ref={cardRef}
+        tabIndex={-1}
         className={`mm-card${skinned ? " mm-card-skinned" : ""} ${c ? TIER_CLASS[c.rating] ?? "" : ""}`}
         style={bg ? { ["--mm-bg" as string]: `url("${bg}")` } : undefined}
         onClick={(e) => e.stopPropagation()}
@@ -238,7 +245,7 @@ export function MonsterManualPanel({
                 <div className="mm-assess">
                   <div className="mm-winbar" aria-label="Estimated win chance">
                     <span className="mm-winbar-label">Win chance</span>
-                    <div className="mm-winbar-track" role="progressbar" aria-valuenow={c.winChancePct} aria-valuemin={0} aria-valuemax={100}>
+                    <div className="mm-winbar-track" role="progressbar" aria-label="Win chance" aria-valuenow={c.winChancePct} aria-valuemin={0} aria-valuemax={100}>
                       <span className="mm-winbar-fill" style={{ width: `${c.winChancePct}%` }} />
                     </div>
                     <span className="mm-winbar-pct">{c.winChancePct}%</span>

--- a/web-v3/src/components/panels/PlayPanel.tsx
+++ b/web-v3/src/components/panels/PlayPanel.tsx
@@ -36,7 +36,7 @@ export function PlayPanel({ preLogin, terminalOverlayRef, terminalVisible, termi
             <CombatLog messages={combatLogMessages} />
           </div>
           <div className="terminal-card terminal-card-text-mode">
-            <div ref={terminalOverlayRef} className={overlayClass} aria-hidden={false} />
+            <div ref={terminalOverlayRef} className={overlayClass} />
           </div>
         </>
       ) : (

--- a/web-v3/src/components/panels/PlayerExaminePanel.tsx
+++ b/web-v3/src/components/panels/PlayerExaminePanel.tsx
@@ -146,7 +146,7 @@ export function PlayerExaminePanel({
 
           {/* Inline inventory picker for Give. */}
           {giveOpen && (
-            <div className="mm-give">
+            <div className="mm-give" role="group" aria-label="Give an item">
               {inventory.length === 0 ? (
                 <p className="mm-give-empty">Your pack is empty.</p>
               ) : (

--- a/web-v3/src/components/panels/ProfessionsPanel.tsx
+++ b/web-v3/src/components/panels/ProfessionsPanel.tsx
@@ -69,7 +69,14 @@ export function ProfessionsPanel({ connected, hasCharacterProfile, skills, onLoa
                   <span className="prof-xp-text">
                     {isMax ? "Mastered" : `XP: ${s.xp.toLocaleString()} / ${s.xpToNext.toLocaleString()}`}
                   </span>
-                  <span className={`prof-bar prof-bar-${s.type}`}>
+                  <span
+                    className={`prof-bar prof-bar-${s.type}`}
+                    role="progressbar"
+                    aria-label={`${s.name} experience`}
+                    aria-valuenow={pct}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                  >
                     <span className="prof-bar-fill" style={{ width: `${pct}%` }} />
                   </span>
                 </span>

--- a/web-v3/src/components/panels/QuestOfferPanel.tsx
+++ b/web-v3/src/components/panels/QuestOfferPanel.tsx
@@ -19,7 +19,7 @@ export function QuestOfferPanel({
   if (questsAvailable.length === 0) {
     return (
       <div className="quest-offer-empty">
-        <span className="quest-empty-icon">{"✦"}</span>
+        <span className="quest-empty-icon" aria-hidden="true">{"✦"}</span>
         <p className="empty-note">No quests on offer here.</p>
       </div>
     );
@@ -94,7 +94,7 @@ function QuestOfferCard({
       <ul className="quest-available-objectives">
         {quest.objectives.map((obj, idx) => (
           <li key={idx} className="quest-available-objective">
-            <span className="quest-available-obj-icon">{"○"}</span>
+            <span className="quest-available-obj-icon" aria-hidden="true">{"○"}</span>
             <span>{obj.description}</span>
             <span className="quest-available-obj-count">
               {obj.current}/{obj.count}
@@ -137,7 +137,7 @@ function QuestOfferCard({
         </div>
       )}
       {locked && (
-        <p className="quest-offer-locked">{quest.lockedReason}</p>
+        <p className="quest-offer-locked" id={`quest-offer-locked-${quest.id}`}>{quest.lockedReason}</p>
       )}
       {quest.readyToTurnIn ? (
         <button
@@ -153,6 +153,7 @@ function QuestOfferCard({
           className="quest-accept-button"
           onClick={() => onAccept(quest.id)}
           disabled={locked}
+          aria-describedby={locked ? `quest-offer-locked-${quest.id}` : undefined}
         >
           Accept Quest
         </button>

--- a/web-v3/src/components/panels/QuestPanel.tsx
+++ b/web-v3/src/components/panels/QuestPanel.tsx
@@ -106,7 +106,7 @@ export function QuestPanel({
               className={`quest-notification quest-notification-${n.event}`}
               role="status"
             >
-              <span className="quest-notification-icon">
+              <span className="quest-notification-icon" aria-hidden="true">
                 {n.event === "complete" ? "\u2726" : "\u25B2"}
               </span>
               <span className="quest-notification-text">
@@ -117,7 +117,7 @@ export function QuestPanel({
                 type="button"
                 className="quest-notification-dismiss"
                 onClick={() => onDismissQuestNotification(n.id)}
-                aria-label="Dismiss notification"
+                aria-label={`Dismiss ${n.questName} notification`}
               >
                 {"\u00D7"}
               </button>
@@ -156,7 +156,7 @@ export function QuestPanel({
         >
           {quests.length === 0 ? (
             <div className="quest-empty-state">
-              <span className="quest-empty-icon">{"\u2726"}</span>
+              <span className="quest-empty-icon" aria-hidden="true">{"\u2726"}</span>
               <p className="empty-note">
                 {hasCharacterProfile
                   ? "No active quests. Talk to NPCs to discover available quests."
@@ -188,7 +188,7 @@ export function QuestPanel({
                       onClick={() => setExpandedQuestId(isExpanded ? null : quest.id)}
                       aria-expanded={isExpanded}
                     >
-                      <span className="quest-item-icon">{allDone ? "\u2713" : "\u2726"}</span>
+                      <span className="quest-item-icon" aria-hidden="true">{allDone ? "\u2713" : "\u2726"}</span>
                       <span className="quest-item-name">{quest.name}</span>
                       {readyToTurnIn && (
                         <span className="quest-item-ready-badge">Ready to turn in</span>
@@ -201,7 +201,14 @@ export function QuestPanel({
                     {/* Mini progress bar visible when collapsed */}
                     {!isExpanded && (
                       <div className="quest-item-mini-progress">
-                        <div className="meter-track quest-mini-track">
+                        <div
+                          className="meter-track quest-mini-track"
+                          role="progressbar"
+                          aria-label={`${quest.name} progress`}
+                          aria-valuenow={Math.round(Math.min(100, overallProgress * 100))}
+                          aria-valuemin={0}
+                          aria-valuemax={100}
+                        >
                           <span
                             className={`meter-fill ${allDone ? "meter-fill-quest-done" : "meter-fill-quest"}`}
                             style={{ width: `${Math.min(100, overallProgress * 100)}%` }}
@@ -225,7 +232,7 @@ export function QuestPanel({
                                 className={`quest-objective ${done ? "quest-objective-done" : ""}`}
                               >
                                 <div className="quest-objective-header">
-                                  <span className="quest-objective-check">
+                                  <span className="quest-objective-check" aria-hidden="true">
                                     {done ? "\u2713" : "\u25CB"}
                                   </span>
                                   <span className="quest-objective-text">{obj.description}</span>
@@ -234,7 +241,14 @@ export function QuestPanel({
                                   </span>
                                 </div>
                                 {!done && (
-                                  <div className="meter-track quest-objective-track">
+                                  <div
+                                    className="meter-track quest-objective-track"
+                                    role="progressbar"
+                                    aria-label={`${obj.description} progress`}
+                                    aria-valuenow={obj.current}
+                                    aria-valuemin={0}
+                                    aria-valuemax={obj.required}
+                                  >
                                     <span
                                       className="meter-fill meter-fill-quest"
                                       style={{ width: `${progress}%` }}
@@ -284,14 +298,14 @@ export function QuestPanel({
             {questsAvailable.map((quest) => (
               <li key={quest.id} className="quest-available-card">
                 <div className="quest-available-header">
-                  <span className="quest-available-icon">{"\u2726"}</span>
+                  <span className="quest-available-icon" aria-hidden="true">{"\u2726"}</span>
                   <span className="quest-available-name">{quest.name}</span>
                 </div>
                 <p className="quest-available-description">{quest.description}</p>
                 <ul className="quest-available-objectives">
                   {quest.objectives.map((obj, idx) => (
                     <li key={idx} className="quest-available-objective">
-                      <span className="quest-available-obj-icon">{"\u25CB"}</span>
+                      <span className="quest-available-obj-icon" aria-hidden="true">{"\u25CB"}</span>
                       <span>{obj.description}</span>
                       <span className="quest-available-obj-count">0/{obj.count}</span>
                     </li>
@@ -332,7 +346,7 @@ export function QuestPanel({
             <div className="quest-timed-board">
               {dailyQuests.streakDays > 0 && (
                 <div className="quest-streak-banner">
-                  <span className="quest-streak-icon">{"\u2605"}</span>
+                  <span className="quest-streak-icon" aria-hidden="true">{"\u2605"}</span>
                   <span className="quest-streak-text">{dailyQuests.streakDays}-day streak!</span>
                 </div>
               )}
@@ -344,7 +358,7 @@ export function QuestPanel({
             </div>
           ) : (
             <div className="quest-empty-state">
-              <span className="quest-empty-icon">{"\u2726"}</span>
+              <span className="quest-empty-icon" aria-hidden="true">{"\u2726"}</span>
               <p className="empty-note">No daily quests are available right now.</p>
             </div>
           )}
@@ -366,7 +380,7 @@ export function QuestPanel({
             </ul>
           ) : (
             <div className="quest-empty-state">
-              <span className="quest-empty-icon">{"\u2726"}</span>
+              <span className="quest-empty-icon" aria-hidden="true">{"\u2726"}</span>
               <p className="empty-note">No weekly quests are available right now.</p>
             </div>
           )}
@@ -383,7 +397,7 @@ export function QuestPanel({
           {autoQuest && autoQuest.active ? (
             <div className="quest-bounty-card">
               <div className="quest-bounty-header">
-                <span className="quest-bounty-icon">{"\u2694"}</span>
+                <span className="quest-bounty-icon" aria-hidden="true">{"\u2694"}</span>
                 <span className="quest-bounty-title">
                   Hunt: {autoQuest.targetMobName ?? "Unknown"}
                 </span>
@@ -398,7 +412,14 @@ export function QuestPanel({
                       {autoQuest.killsCompleted ?? 0}/{autoQuest.killsRequired}
                     </span>
                   </div>
-                  <div className="meter-track">
+                  <div
+                    className="meter-track"
+                    role="progressbar"
+                    aria-label={`Defeat ${autoQuest.targetMobName} progress`}
+                    aria-valuenow={autoQuest.killsCompleted ?? 0}
+                    aria-valuemin={0}
+                    aria-valuemax={autoQuest.killsRequired}
+                  >
                     <span
                       className={`meter-fill ${(autoQuest.killsCompleted ?? 0) >= autoQuest.killsRequired ? "meter-fill-quest-done" : "meter-fill-quest"}`}
                       style={{ width: `${Math.min(100, ((autoQuest.killsCompleted ?? 0) / autoQuest.killsRequired) * 100)}%` }}
@@ -422,7 +443,7 @@ export function QuestPanel({
             </div>
           ) : (
             <div className="quest-empty-state">
-              <span className="quest-empty-icon">{"\u2694"}</span>
+              <span className="quest-empty-icon" aria-hidden="true">{"\u2694"}</span>
               <p className="empty-note">
                 {autoQuest && !autoQuest.active
                   ? "No active bounty. Request one to get started."
@@ -450,7 +471,7 @@ export function QuestPanel({
           {globalQuest && globalQuest.active ? (
             <div className="quest-global-card">
               <div className="quest-global-header">
-                <span className="quest-global-icon">{"\u2604"}</span>
+                <span className="quest-global-icon" aria-hidden="true">{"\u2604"}</span>
                 <span className="quest-global-title">
                   {globalQuest.objective ?? "Global Quest"}
                 </span>
@@ -466,7 +487,14 @@ export function QuestPanel({
                       {globalQuest.playerProgress ?? 0}/{globalQuest.targetCount}
                     </span>
                   </div>
-                  <div className="meter-track">
+                  <div
+                    className="meter-track"
+                    role="progressbar"
+                    aria-label="Global quest progress"
+                    aria-valuenow={globalQuest.playerProgress ?? 0}
+                    aria-valuemin={0}
+                    aria-valuemax={globalQuest.targetCount}
+                  >
                     <span
                       className={`meter-fill ${globalQuest.completed ? "meter-fill-quest-done" : "meter-fill-quest"}`}
                       style={{ width: `${Math.min(100, ((globalQuest.playerProgress ?? 0) / globalQuest.targetCount) * 100)}%` }}
@@ -496,7 +524,7 @@ export function QuestPanel({
             </div>
           ) : (
             <div className="quest-empty-state">
-              <span className="quest-empty-icon">{"\u2604"}</span>
+              <span className="quest-empty-icon" aria-hidden="true">{"\u2604"}</span>
               <p className="empty-note">No global quest is active right now.</p>
             </div>
           )}
@@ -522,7 +550,14 @@ function DailyQuestRow({ quest }: { quest: DailyQuestEntry }) {
         </span>
       </div>
       {!quest.completed && (
-        <div className="meter-track quest-timed-track">
+        <div
+          className="meter-track quest-timed-track"
+          role="progressbar"
+          aria-label={`${quest.description} progress`}
+          aria-valuenow={quest.current}
+          aria-valuemin={0}
+          aria-valuemax={quest.required}
+        >
           <span
             className="meter-fill meter-fill-quest"
             style={{ width: `${progress}%` }}

--- a/web-v3/src/components/panels/StylistPanel.tsx
+++ b/web-v3/src/components/panels/StylistPanel.tsx
@@ -58,7 +58,7 @@ export function StylistPanel({ stylistState, serverAssets, onCommand }: StylistP
             >
               {race.image && <img className="sty-card-portrait" src={race.image} alt="" loading="lazy" />}
               <div className="sty-card-text">
-                <span className="sty-card-name">{race.displayName}{isCurrent && <span className="sty-card-tag">current</span>}</span>
+                <span className="sty-card-name">{race.displayName}{isCurrent && <span className="sty-card-tag">current<span className="sr-only"> race</span></span>}</span>
                 {race.description && <span className="sty-card-desc">{race.description}</span>}
                 {mods.length > 0 && (
                   <span className="sty-card-mods">

--- a/web-v3/src/components/panels/SystemsPanel.tsx
+++ b/web-v3/src/components/panels/SystemsPanel.tsx
@@ -199,9 +199,9 @@ export function SystemsPanel({
         ))}
       </div>
 
-      {localMessage && <p className="systems-local-message">{localMessage}</p>}
+      {localMessage && <p className="systems-local-message" role="status" aria-live="polite">{localMessage}</p>}
       {activeFeedback && (
-        <p className={`systems-local-message systems-local-message-${activeFeedback.type}`}>
+        <p className={`systems-local-message systems-local-message-${activeFeedback.type}`} role="status" aria-live="polite">
           {activeFeedback.message}
         </p>
       )}

--- a/web-v3/src/components/panels/WhoBoardPanel.tsx
+++ b/web-v3/src/components/panels/WhoBoardPanel.tsx
@@ -84,6 +84,8 @@ export function WhoBoardPanel({
     else { setSort(field); setSortDir("asc"); }
   };
   const sortMark = (field: WhoSortField) => (sort === field ? (sortDir === "asc" ? " ▴" : " ▾") : "");
+  const ariaSort = (field: WhoSortField): "ascending" | "descending" | undefined =>
+    sort === field ? (sortDir === "asc" ? "ascending" : "descending") : undefined;
 
   const examineArt = serverAssets["who_examine_btn"];
   const tellArt = serverAssets["who_tell_btn"];
@@ -95,10 +97,10 @@ export function WhoBoardPanel({
       <div className="whoboard-grid" role="table" aria-label="Players online">
         <div className="whoboard-head" role="row">
           <span className="whoboard-col-portrait" role="columnheader" aria-label="Sprite" />
-          <button type="button" role="columnheader" className="whoboard-th whoboard-col-name" onClick={() => toggleSort("name")}>Name{sortMark("name")}</button>
-          <button type="button" role="columnheader" className="whoboard-th whoboard-col-class" onClick={() => toggleSort("class")}>Class{sortMark("class")}</button>
-          <button type="button" role="columnheader" className="whoboard-th whoboard-col-race" onClick={() => toggleSort("race")}>Race{sortMark("race")}</button>
-          <button type="button" role="columnheader" className="whoboard-th whoboard-col-level" onClick={() => toggleSort("level")}>Level{sortMark("level")}</button>
+          <button type="button" role="columnheader" aria-sort={ariaSort("name")} className="whoboard-th whoboard-col-name" onClick={() => toggleSort("name")}>Name<span aria-hidden="true">{sortMark("name")}</span></button>
+          <button type="button" role="columnheader" aria-sort={ariaSort("class")} className="whoboard-th whoboard-col-class" onClick={() => toggleSort("class")}>Class<span aria-hidden="true">{sortMark("class")}</span></button>
+          <button type="button" role="columnheader" aria-sort={ariaSort("race")} className="whoboard-th whoboard-col-race" onClick={() => toggleSort("race")}>Race<span aria-hidden="true">{sortMark("race")}</span></button>
+          <button type="button" role="columnheader" aria-sort={ariaSort("level")} className="whoboard-th whoboard-col-level" onClick={() => toggleSort("level")}>Level<span aria-hidden="true">{sortMark("level")}</span></button>
           <span className="whoboard-col-actions" role="columnheader">Actions</span>
         </div>
 
@@ -185,7 +187,7 @@ export function WhoBoardPanel({
           <option value="">All Classes</option>
           {classes.map((c) => <option key={c} value={c}>{c}</option>)}
         </select>
-        <button type="button" className="whoboard-refresh" onClick={onRequestWho} disabled={!canChat} title="Refresh">⟳</button>
+        <button type="button" className="whoboard-refresh" onClick={onRequestWho} disabled={!canChat} title="Refresh" aria-label="Refresh roster">⟳</button>
       </div>
     </div>
   );

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -26426,6 +26426,12 @@ html:has(.game-shell),
   box-shadow: 0 0 0 2px rgb(201 162 74 / 55%);
 }
 
+/* Equipment paperdoll rows became keyboard-focusable (role=button). */
+.paperdoll-list-item:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgb(184 216 232 / 60%);
+}
+
 /* Text selection (1.4.1 / legibility) — browser default inverts the
    jewel-tone palette unpredictably; keep selection on-theme. */
 ::selection {

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -22,8 +22,12 @@
   --text-disabled: #7f89a8;
   --text-heading: #d4ddf5;
   --text-bright: #dde6ff;
-  --text-placeholder: #8f9cbe;
+  --text-placeholder: #98a5c6; /* ≥4.5:1 on input surfaces (was #8f9cbe at ~4.2:1) */
   --text-white: #fff;
+  /* Aliases referenced throughout the sheet; previously undefined, which
+     made muted text and focus borders fall back to inherited colors. */
+  --text-muted: var(--text-tertiary);
+  --accent-primary: var(--color-primary-pale-blue);
 
   /* ── Semantic / gameplay ─────────────────────────────── */
   --color-hp-light: #c5d8a8;
@@ -26391,5 +26395,54 @@ html:has(.game-shell),
 @media (prefers-reduced-motion: reduce) {
   .canvas-command-send-img {
     transition: none;
+  }
+}
+
+/* ════ Accessibility ══════════════════════════════════════════
+   Cross-cutting WCAG 2.1 AA affordances. Kept at the end of the
+   sheet so equal-specificity rules here win by cascade order. */
+
+/* Focus visibility (2.4.7) — inputs and controls that removed the
+   native outline without providing a replacement indicator. Cool
+   ring for glass-morphism surfaces, warm ring for parchment art. */
+.audio-slider:focus-visible,
+.video-modal-player:focus-visible,
+.cmd-palette-input:focus-visible,
+.canvas-command-input:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgb(184 216 232 / 60%);
+}
+
+.cr-search:focus-visible,
+.terminal-dock-input:focus-visible,
+.puzzle-inscribe-input:focus-visible,
+.terminal-screen-skinned .canvas-command-input:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgb(150 104 38 / 65%);
+}
+
+.cc-select:focus-visible,
+.cc-scribe-text:focus-visible {
+  box-shadow: 0 0 0 2px rgb(201 162 74 / 55%);
+}
+
+/* Text selection (1.4.1 / legibility) — browser default inverts the
+   jewel-tone palette unpredictably; keep selection on-theme. */
+::selection {
+  background-color: rgb(168 151 210 / 55%);
+  color: var(--text-bright);
+}
+
+/* Reduced motion (2.3.3) — global kill switch backing up the
+   per-component guards. Durations collapse to near-zero so
+   animationend/transitionend handlers still fire. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -14201,7 +14201,7 @@ body {
 }
 
 .login-demo-divider {
-  font-size: 11px;
+  font-size: 12px;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--text-muted, rgb(168 151 210 / 60%));
@@ -14221,7 +14221,7 @@ body {
 
 .login-demo-hint {
   margin: 0;
-  font-size: 11px;
+  font-size: 12px;
   text-align: center;
   color: var(--text-muted, rgb(168 151 210 / 65%));
   line-height: 1.4;
@@ -14926,7 +14926,7 @@ body {
   border-radius: 999px;
   background: rgb(168 210 178 / 30%);
   color: rgb(232 248 232);
-  font-size: 10px;
+  font-size: 12px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   font-weight: 600;
@@ -14970,7 +14970,7 @@ body {
 }
 
 .demo-claim-field-label {
-  font-size: 11px;
+  font-size: 12px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-muted, rgb(168 151 210 / 70%));
@@ -20119,7 +20119,7 @@ html:has(.game-shell),
 }
 
 .quest-complete-toast-eyebrow {
-  font-size: 11px;
+  font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.12em;
   color: color-mix(in srgb, var(--c-soft-gold, #f0c674) 70%, var(--c-text-secondary, #8890b0));
@@ -20171,7 +20171,7 @@ html:has(.game-shell),
 }
 
 .quest-complete-toast-reward-label {
-  font-size: 11px;
+  font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--c-text-secondary, #8890b0);
@@ -20198,7 +20198,7 @@ html:has(.game-shell),
 }
 
 .quest-complete-toast-reward-icon {
-  font-size: 10px;
+  font-size: 12px;
   opacity: 0.85;
 }
 
@@ -20283,7 +20283,7 @@ html:has(.game-shell),
 }
 
 .combat-victory-toast-eyebrow {
-  font-size: 11px;
+  font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.12em;
   color: color-mix(in srgb, var(--c-dusty-rose, #c97f7f) 75%, var(--c-text-secondary, #8890b0));
@@ -20324,7 +20324,7 @@ html:has(.game-shell),
 }
 
 .combat-victory-toast-reward-label {
-  font-size: 11px;
+  font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--c-text-secondary, #8890b0);
@@ -20361,7 +20361,7 @@ html:has(.game-shell),
 
 .combat-victory-toast-loot-bullet {
   color: color-mix(in srgb, var(--c-moss-green, #b5bd68) 80%, var(--c-text-primary, #d8dcef));
-  font-size: 10px;
+  font-size: 12px;
   flex: 0 0 auto;
 }
 
@@ -20470,7 +20470,7 @@ html:has(.game-shell),
 }
 
 .flee-toast-eyebrow {
-  font-size: 11px;
+  font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.12em;
   color: color-mix(in srgb, var(--c-pale-blue, #81a2be) 80%, var(--c-text-secondary, #8890b0));


### PR DESCRIPTION
## Summary

Iterative accessibility hardening of the `web-v3` client driven by repeated audit/critique passes — five parallel WCAG 2.1 AA audits (shell, panels x2, canvas/HUD, global CSS), a fix wave, then a keyboard/screen-reader UX critique plus a verification audit, and a second fix wave. All changes are non-structural: ARIA semantics, keyboard support, focus management, screen-reader text, motion/contrast affordances. **No layout or painted-art chrome changes.** Two deliberate, owner-approved visual exceptions: a barely-perceptible placeholder-color token nudge (`#8f9cbe` -> `#98a5c6`) to clear 4.5:1 contrast, and bumping all sub-12px type to 12px.

## Commits

1. **Shell** — command-input labeling, APG combobox/listbox pattern for the command palette (arrow-key selection now announced via `aria-activedescendant`), `inert` terminal overlay while closed, focus return from the room-sign zoom, decorative art marked `aria-hidden`, progressbar on combat-target HP, live search counts, meaningful alt text.
2. **Global CSS** — defined the previously-missing `--text-muted`/`--accent-primary` tokens that 20+ rules referenced, `:focus-visible` rings for every control that stripped the native outline, global `prefers-reduced-motion` kill switch (111 of 145 animations were unguarded; durations collapse to 0.01ms so animationend handlers still fire), on-theme `::selection`, placeholder contrast nudge.
3. **Canvas + HUD** — login modal labels with error association (`aria-invalid`/`aria-describedby`/`role=alert`), per-step dialog names, `aria-pressed` race/class cards, HP/MP progressbar roles in painted and fallback vitals, quickbar labels with live cooldown remaining, honest group/pressed semantics in the spellbook (replacing broken menu/tablist roles), navigation landmark on the compass.
4. **Panels (~30 files)** — progressbar roles on every width-styled meter, `role=status` live regions on dynamic feedback, keyboard access for pointer-only controls (equipment paperdoll rows, character-picker forget), `aria-sort` on sortable boards, rowgroup/cell roles on the friends div-table, sr-only leaderboard captions, `aria-expanded`/`aria-controls`/`aria-pressed` wiring, labels for placeholder-only inputs.
5. **Round 2 (critique + verification fixes)** — focus restoration on the canvas modals (mob detail / image preview / video) with window-level Escape, drawer moves focus in on open and back to the kiosk on close, sr-only "skill ready" cooldown announcements, login grid usage hints, `aria-busy` reconnect banner, focus ring for paperdoll rows.
6. **Type bump (owner-approved)** — all eleven sub-12px font sizes raised to 12px (toast eyebrows/reward labels, login demo divider/hint, demo banner tag, claim field label, reward icon, loot bullet).

## Verification

- `bun run lint`, `tsc -b`, `vite build` clean; all 27 web tests pass.
- Round-2 verification audit confirmed ARIA validity (combobox ids, progressbar values, inert/aria-hidden pairing, reduced-motion event safety) and a final regression check passed every item.

## Deliberately out of scope (would change structure)

- Visible `<thead>` for the leaderboard table (solved invisibly with an sr-only caption instead)
- A text-mode narration layer for the PixiJS canvas — the terminal overlay remains the accessible game surface and the canvas declares it via its accessible name

🤖 Generated with [Claude Code](https://claude.com/claude-code)
