### PR TITLE
feat(build): worktree-stable ports for the demo task

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,8 @@
 ## Commands
 
 ```bash
-./gradlew run            # Start server (telnet :4000, web :8080)
-./gradlew demo           # Start server + auto-launch browser demo
+./gradlew run            # Start server (fixed ports: telnet :4000, web :8080)
+./gradlew demo           # Start server + auto-launch browser demo (worktree-stable ports)
 ./gradlew ktlintCheck    # Lint — run before every PR
 ./gradlew test           # Full test suite — run before committing
 ./gradlew buildWeb       # Build web client (requires bun) — auto-runs with run/demo
@@ -24,6 +24,8 @@
 ```
 
 Override config: `-Pconfig.<key>=<value>` (e.g. `-Pconfig.ambonmud.persistence.backend=POSTGRES`).
+
+**Parallel worktrees:** `demo` derives its ports from the checkout directory name (telnet `14000 + hash%1000`, web `18000 + hash%1000`, probing upward if busy) and prints them in a startup banner, so agents in different worktrees can each run a test server without colliding on :4000/:8080. Pin the offset with `AMBONMUD_PORT_OFFSET=<0-999>`, or override outright with `-Pconfig.ambonMUD.server.telnetPort=/webPort=`. Prefer `demo` over `run` for test servers in worktrees.
 
 Multi-instance: `runEngine1`/`runEngine2` (gRPC :9091/:9092), `runGateway1`/`runGateway2` (telnet :4000/:4001).
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -187,6 +187,7 @@ tasks.register<JavaExec>("demo") {
     doFirst {
         val offset = portOffsetEnv.orNull?.toIntOrNull()?.let { Math.floorMod(it, 1000) }
             ?: Math.floorMod(worktreeName.hashCode(), 1000)
+
         fun freePortFrom(start: Int): Int {
             var candidate = start
             repeat(50) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,6 @@
 import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
+import java.io.IOException
+import java.net.ServerSocket
 import java.time.Duration
 
 plugins {
@@ -161,13 +163,51 @@ tasks.named<JavaExec>("run") {
 
 tasks.register<JavaExec>("demo") {
     group = "application"
-    description = "Runs AmbonMUD and opens the browser demo client."
+    description = "Runs AmbonMUD and opens the browser demo client (worktree-stable ports)."
     mainClass.set(application.mainClass)
     classpath = project.extensions.getByType(org.gradle.api.tasks.SourceSetContainer::class.java)["main"].runtimeClasspath
     standardInput = System.`in`
     systemProperty("config.override.ambonMUD.demo.autoLaunchBrowser", "true")
     applyConfigOverrides()
     jvmArgs("-Djava.net.preferIPv4Stack=true")
+
+    // Parallel-worktree support: derive stable telnet/web ports from the
+    // checkout directory name so several clones can run demo servers side by
+    // side without fighting over :4000/:8080. The same worktree always gets
+    // the same ports (restarts stay predictable; stale processes are easy to
+    // attribute), probing upward if a port is genuinely taken. Explicit
+    // -Pconfig.ambonMUD.server.telnetPort/webPort overrides win outright, and
+    // AMBONMUD_PORT_OFFSET=<0-999> pins the offset. `run` keeps the fixed
+    // defaults. The in-app browser auto-launch reads the final config, so the
+    // demo client always opens at the right URL.
+    val explicitTelnet = project.hasProperty("config.ambonMUD.server.telnetPort")
+    val explicitWeb = project.hasProperty("config.ambonMUD.server.webPort")
+    val worktreeName = rootDir.name
+    val portOffsetEnv = providers.environmentVariable("AMBONMUD_PORT_OFFSET")
+    doFirst {
+        val offset = portOffsetEnv.orNull?.toIntOrNull()?.let { Math.floorMod(it, 1000) }
+            ?: Math.floorMod(worktreeName.hashCode(), 1000)
+        fun freePortFrom(start: Int): Int {
+            var candidate = start
+            repeat(50) {
+                try {
+                    ServerSocket(candidate).use { return candidate }
+                } catch (_: IOException) {
+                    candidate += 1
+                }
+            }
+            throw GradleException("No free port found in $start..${start + 49}")
+        }
+        val exec = this as JavaExec
+        val telnetPort = if (explicitTelnet) null else freePortFrom(14000 + offset)
+        val webPort = if (explicitWeb) null else freePortFrom(18000 + offset)
+        telnetPort?.let { exec.systemProperty("config.override.ambonMUD.server.telnetPort", it) }
+        webPort?.let { exec.systemProperty("config.override.ambonMUD.server.webPort", it) }
+        println(
+            "AmbonMUD demo [$worktreeName] — telnet :${telnetPort ?: "(explicit override)"}, " +
+                "web http://localhost:${webPort ?: "(explicit override)"}",
+        )
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Repurposes the `demo` task for parallel-worktree development: it now derives **worktree-stable ports** from the checkout directory name instead of always claiming telnet :4000 / web :8080, so multiple Claude agents (or humans) can each run a test server from their own worktree simultaneously.

## How it works

- `demo` computes `offset = hash(rootDir.name) % 1000`, then probes upward from `14000 + offset` (telnet) and `18000 + offset` (web) until each port is free, injects the results as Hoplite config overrides, and prints a banner:
  ```
  AmbonMUD demo [AmbonMUD] — telnet :14543, web http://localhost:18543
  ```
- **Deterministic over random**: the same worktree gets the same ports across restarts, so reconnects are predictable and a stale process on "your" port is immediately attributable.
- Explicit `-Pconfig.ambonMUD.server.telnetPort=` / `webPort=` overrides win outright; `AMBONMUD_PORT_OFFSET=<0-999>` pins the offset for explicit assignment on shared remote machines.
- Port selection happens in `doFirst`, so it re-executes on every run and is configuration-cache safe.
- `run` keeps the fixed 4000/8080 defaults — docs, CI, and muscle memory unchanged.
- The in-app browser auto-launch reads the final config, so the demo client still opens at the correct URL with zero extra wiring.

CLAUDE.md gains a "Parallel worktrees" note steering agents to `demo` for test servers.

## Verification

Ran two concurrent `demo` instances from this checkout:
- First: `telnet :14543, web http://localhost:18543` — both ports listening, web client served HTTP 200.
- Second: probed past the busy pair to `telnet :14544, web http://localhost:18544` — also fully up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
