### PR TITLE
fix(enchant): default missing skill state to level 1, not 0

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/EnchantHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/EnchantHandler.kt
@@ -106,7 +106,7 @@ class EnchantHandler(
 
         outbound.send(OutboundEvent.SendInfo(sessionId, "[ Available Enchantments ]"))
         for ((id, def) in definitions) {
-            val skillLevel = player.craftingSkills[def.skill]?.level ?: 0
+            val skillLevel = player.craftingSkills.getOrDefault(def.skill, dev.ambon.domain.crafting.CraftingSkillState()).level
             val meetsSkill = skillLevel >= def.skillRequired
             val skillTag = if (meetsSkill) "" else " [skill too low]"
             val slots = if (def.targetSlots.isEmpty()) "any" else def.targetSlots.joinToString("/")

--- a/src/main/kotlin/dev/ambon/engine/crafting/EnchantSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/crafting/EnchantSystem.kt
@@ -68,9 +68,10 @@ class EnchantSystem(
             return EnchantResult.WrongSlot(definition.displayName, definition.targetSlots)
         }
 
-        // Check skill level
-        val skillState = playerSkills[definition.skill]
-        val skillLevel = skillState?.level ?: 0
+        // Check skill level. Missing state defaults to a fresh CraftingSkillState (level 1),
+        // matching CraftingSystem — otherwise skillRequired-1 enchantments are unreachable
+        // for players who have never enchanted before.
+        val skillLevel = playerSkills.getOrDefault(definition.skill, dev.ambon.domain.crafting.CraftingSkillState()).level
         if (skillLevel < definition.skillRequired) {
             return EnchantResult.SkillTooLow(definition.skill, definition.skillRequired, skillLevel)
         }
@@ -147,8 +148,8 @@ class EnchantSystem(
             .filter { (_, def) ->
                 // Slot matches
                 (def.targetSlots.isEmpty() || slot.name in def.targetSlots) &&
-                    // Skill sufficient
-                    (playerSkills[def.skill]?.level ?: 0) >= def.skillRequired &&
+                    // Skill sufficient (missing state = fresh level-1 state, as in CraftingSystem)
+                    playerSkills.getOrDefault(def.skill, dev.ambon.domain.crafting.CraftingSkillState()).level >= def.skillRequired &&
                     // Materials available
                     def.materials.all { mat ->
                         val matItemId = ItemId(mat.itemId)

--- a/src/test/kotlin/dev/ambon/engine/crafting/EnchantSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/crafting/EnchantSystemTest.kt
@@ -147,6 +147,30 @@ class EnchantSystemTest {
         }
 
         @Test
+        fun `enchant succeeds with no prior enchanting skill state`() {
+            // A player who has never enchanted has no "enchanting" entry in craftingSkills.
+            // Missing state must default to a fresh level-1 state (as CraftingSystem does),
+            // or skillRequired-1 enchantments can never be learned at all.
+            items.addToInventory(sid, sword())
+            items.addToInventory(sid, essence())
+
+            val result = enchantSystem.enchant(sid, "sword", "keen_edge", mutableMapOf())
+
+            assertTrue(result is EnchantResult.Success)
+        }
+
+        @Test
+        fun `auto-select finds a skillRequired-1 enchantment with no prior skill state`() {
+            items.addToInventory(sid, sword())
+            items.addToInventory(sid, essence())
+
+            val result = enchantSystem.enchant(sid, "sword", null, mutableMapOf())
+
+            assertTrue(result is EnchantResult.Success)
+            assertEquals("Keen Edge", (result as EnchantResult.Success).enchantmentName)
+        }
+
+        @Test
         fun `enchant adds stat bonuses`() {
             items.addToInventory(sid, sword())
             items.addToInventory(sid, essence())


### PR DESCRIPTION
## Summary

A player who has never enchanted has no `enchanting` entry in `craftingSkills`. `EnchantSystem` treated that missing state as **level 0**, while `CraftingSystem` defaults missing state to a fresh `CraftingSkillState()` (**level 1**). Since enchanting skill can only be raised *by enchanting*, every `skillRequired: 1` enchantment was permanently unreachable for new players — `enchant` always answered "skill too low (need 1, have 0)" and `enchantments` tagged everything `[skill too low]`.

Found while playtesting the Auringold Academy MUD-school content (the jnoecker/Ambon `feature/mud-school` PR), which adds the first live enchantment definitions.

## Changes

- `EnchantSystem.enchant()`: missing skill state now defaults to `CraftingSkillState()` (level 1), matching `CraftingSystem`
- `EnchantSystem.selectBestEnchantment()`: same default in the auto-select filter
- `EnchantHandler` listing: same default, so `enchantments` no longer mislabels learnable workings
- Regression tests: enchant + auto-select succeed with an empty skill map for `skillRequired: 1`

## Testing

- `./gradlew ktlintCheck test --tests "*Enchant*"` — green (the new tests fail against the old behavior)
