### PR TITLE
perf(web): code-split the client — 28% less critical-path JS

### DIFF
--- a/web-v3/.gitignore
+++ b/web-v3/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# ANALYZE=1 bun run build output (rollup-plugin-visualizer)
+stats.json
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/web-v3/bun.lock
+++ b/web-v3/bun.lock
@@ -21,6 +21,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
+        "rollup-plugin-visualizer": "^7.0.1",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
         "vite": "^7.3.1",
@@ -264,6 +265,8 @@
 
     "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
@@ -276,11 +279,15 @@
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
+    "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
+
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001774", "", {}, "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -298,9 +305,17 @@
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
+    "default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
+
+    "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
+
+    "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
+
     "earcut": ["earcut@3.0.2", "", {}, "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.302", "", {}, "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg=="],
+
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
@@ -350,6 +365,10 @@
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
+
     "gifuct-js": ["gifuct-js@2.1.2", "", { "dependencies": { "js-binary-schema-parser": "^2.0.3" } }, "sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
@@ -368,9 +387,17 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
+    "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-in-ssh": ["is-in-ssh@1.0.0", "", {}, "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw=="],
+
+    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
+
+    "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -412,6 +439,8 @@
 
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
 
+    "open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
+
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
@@ -434,6 +463,8 @@
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
+    "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
+
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
@@ -448,6 +479,10 @@
 
     "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
 
+    "rollup-plugin-visualizer": ["rollup-plugin-visualizer@7.0.1", "", { "dependencies": { "open": "^11.0.0", "picomatch": "^4.0.2", "source-map": "^0.7.4", "yargs": "^18.0.0" }, "peerDependencies": { "rolldown": "1.x || ^1.0.0-beta || ^1.0.0-rc", "rollup": "2.x || 3.x || 4.x" }, "optionalPeers": ["rolldown", "rollup"], "bin": { "rollup-plugin-visualizer": "dist/bin/cli.js" } }, "sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg=="],
+
+    "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -456,7 +491,13 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
@@ -486,7 +527,17 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
+    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
+
+    "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
@@ -505,6 +556,8 @@
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.3", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA=="],
 

--- a/web-v3/package.json
+++ b/web-v3/package.json
@@ -27,6 +27,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "rollup-plugin-visualizer": "^7.0.1",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
     "vite": "^7.3.1"

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Suspense, lazy, useEffect, useMemo, useRef, useState } from "react";
 import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 import { GameShell } from "./components/GameShell";
 import { Drawer } from "./components/Drawer";
@@ -9,33 +9,38 @@ import { TrainerPanel } from "./components/TrainerPanel";
 import { TradePanel } from "./components/TradePanel";
 import { WorldFeaturesPopout } from "./components/WorldFeaturesPopout";
 import { featureArt, pickFocusedFeature } from "./components/worldFeatures";
-import { ChatBoardPanel } from "./components/panels/ChatBoardPanel";
-import { WhoBoardPanel } from "./components/panels/WhoBoardPanel";
-import { GuildBoardPanel } from "./components/panels/GuildBoardPanel";
-import { FriendsBoardPanel } from "./components/panels/FriendsBoardPanel";
-import { GroupBoardPanel } from "./components/panels/GroupBoardPanel";
-import { PlayerExaminePanel } from "./components/panels/PlayerExaminePanel";
-import { CharacterPanel } from "./components/panels/CharacterPanel";
 import { SpellbookPanel } from "./components/SpellbookPanel";
-import { QuestPanel } from "./components/panels/QuestPanel";
-import { QuestOfferPanel } from "./components/panels/QuestOfferPanel";
-import { InventoryPanel } from "./components/panels/InventoryPanel";
-import { EquipmentPanel } from "./components/panels/EquipmentPanel";
-import { MailPanel } from "./components/panels/MailPanel";
-import { MonsterManualPanel } from "./components/panels/MonsterManualPanel";
-import { ItemManualPanel } from "./components/panels/ItemManualPanel";
-import { CraftingPanel } from "./components/panels/CraftingPanel";
-import { ProfessionsPanel } from "./components/panels/ProfessionsPanel";
-import { HousingPanel } from "./components/panels/HousingPanel";
-import { BankPanel } from "./components/panels/BankPanel";
-import { StylistPanel } from "./components/panels/StylistPanel";
-import { InnPanel } from "./components/panels/InnPanel";
-import { AuctionPanel } from "./components/panels/AuctionPanel";
-import { DungeonPanel } from "./components/panels/DungeonPanel";
-import { LotteryPanel } from "./components/panels/LotteryPanel";
-import { DicePanel } from "./components/panels/DicePanel";
-import { AdminPanel } from "./components/panels/AdminPanel";
-import { CombatLogPanel } from "./components/panels/CombatLogPanel";
+
+// Drawer panels and field-manual overlays are only reachable after login, so
+// they load on demand (React.lazy) instead of riding in the entry chunk.
+// vite.config.ts groups them into a shared "panels" chunk (one fetch on first
+// drawer open) with the staff-only AdminPanel split out separately.
+const ChatBoardPanel = lazy(() => import("./components/panels/ChatBoardPanel").then((m) => ({ default: m.ChatBoardPanel })));
+const WhoBoardPanel = lazy(() => import("./components/panels/WhoBoardPanel").then((m) => ({ default: m.WhoBoardPanel })));
+const GuildBoardPanel = lazy(() => import("./components/panels/GuildBoardPanel").then((m) => ({ default: m.GuildBoardPanel })));
+const FriendsBoardPanel = lazy(() => import("./components/panels/FriendsBoardPanel").then((m) => ({ default: m.FriendsBoardPanel })));
+const GroupBoardPanel = lazy(() => import("./components/panels/GroupBoardPanel").then((m) => ({ default: m.GroupBoardPanel })));
+const PlayerExaminePanel = lazy(() => import("./components/panels/PlayerExaminePanel").then((m) => ({ default: m.PlayerExaminePanel })));
+const CharacterPanel = lazy(() => import("./components/panels/CharacterPanel").then((m) => ({ default: m.CharacterPanel })));
+const QuestPanel = lazy(() => import("./components/panels/QuestPanel").then((m) => ({ default: m.QuestPanel })));
+const QuestOfferPanel = lazy(() => import("./components/panels/QuestOfferPanel").then((m) => ({ default: m.QuestOfferPanel })));
+const InventoryPanel = lazy(() => import("./components/panels/InventoryPanel").then((m) => ({ default: m.InventoryPanel })));
+const EquipmentPanel = lazy(() => import("./components/panels/EquipmentPanel").then((m) => ({ default: m.EquipmentPanel })));
+const MailPanel = lazy(() => import("./components/panels/MailPanel").then((m) => ({ default: m.MailPanel })));
+const MonsterManualPanel = lazy(() => import("./components/panels/MonsterManualPanel").then((m) => ({ default: m.MonsterManualPanel })));
+const ItemManualPanel = lazy(() => import("./components/panels/ItemManualPanel").then((m) => ({ default: m.ItemManualPanel })));
+const CraftingPanel = lazy(() => import("./components/panels/CraftingPanel").then((m) => ({ default: m.CraftingPanel })));
+const ProfessionsPanel = lazy(() => import("./components/panels/ProfessionsPanel").then((m) => ({ default: m.ProfessionsPanel })));
+const HousingPanel = lazy(() => import("./components/panels/HousingPanel").then((m) => ({ default: m.HousingPanel })));
+const BankPanel = lazy(() => import("./components/panels/BankPanel").then((m) => ({ default: m.BankPanel })));
+const StylistPanel = lazy(() => import("./components/panels/StylistPanel").then((m) => ({ default: m.StylistPanel })));
+const InnPanel = lazy(() => import("./components/panels/InnPanel").then((m) => ({ default: m.InnPanel })));
+const AuctionPanel = lazy(() => import("./components/panels/AuctionPanel").then((m) => ({ default: m.AuctionPanel })));
+const DungeonPanel = lazy(() => import("./components/panels/DungeonPanel").then((m) => ({ default: m.DungeonPanel })));
+const LotteryPanel = lazy(() => import("./components/panels/LotteryPanel").then((m) => ({ default: m.LotteryPanel })));
+const DicePanel = lazy(() => import("./components/panels/DicePanel").then((m) => ({ default: m.DicePanel })));
+const AdminPanel = lazy(() => import("./components/panels/AdminPanel").then((m) => ({ default: m.AdminPanel })));
+const CombatLogPanel = lazy(() => import("./components/panels/CombatLogPanel").then((m) => ({ default: m.CombatLogPanel })));
 import { HelpContent } from "./components/HelpContent";
 import { TerminalOverlay } from "./components/TerminalOverlay";
 import { Atlas } from "./components/Atlas";
@@ -1151,6 +1156,8 @@ function App() {
         }
         initialHeight={drawerPanel === "chatboard" || drawerPanel === "whoboard" || drawerPanel === "guildboard" || drawerPanel === "friendsboard" || drawerPanel === "groupboard" || drawerPanel === "help" || drawerPanel === "stylist" || drawerPanel === "housing" || drawerPanel === "lottery" || drawerPanel === "dice" || drawerPanel === "auction" || drawerPanel === "crafting" || drawerPanel === "professions" ? 0.94 : undefined}
       >
+        {/* Panels are lazy chunks; the drawer chrome shows while one loads. */}
+        <Suspense fallback={null}>
         {drawerPanel === "character" && (
           <CharacterPanel
             connected={connected}
@@ -1760,6 +1767,7 @@ function App() {
             )}
           </article>
         )}
+        </Suspense>
       </Drawer>
 
       {/* Trade is its own modal-like overlay */}
@@ -1936,6 +1944,7 @@ function App() {
 
       {/* Staff admin panel (the STAFF pill lives on the canvas, in GameShell). */}
       {state.character.isStaff && showAdminPanel && (
+        <Suspense fallback={null}>
         <AdminPanel
           onCommand={(command) => {
             sendCommand(command);
@@ -1953,6 +1962,7 @@ function App() {
           feedbackFeed={state.uiFeedbackFeed}
           serverAssets={state.serverAssets}
         />
+        </Suspense>
       )}
 
       {/* Toast */}
@@ -2009,6 +2019,7 @@ function App() {
       {/* Monster manual — bestiary page for a clicked creature (consolidates the
           old look + consider + attack popouts). */}
       {monster && (
+        <Suspense fallback={null}>
         <MonsterManualPanel
           key={monster.id ?? monster.name}
           monster={monster}
@@ -2030,10 +2041,12 @@ function App() {
           onShop={() => { sendCommand("list"); openPanel("shop"); }}
           onVideo={(url) => setVideoUrl(url)}
         />
+        </Suspense>
       )}
 
       {/* Player examine — Who-board "Examine" opens the player in the manual style. */}
       {examinePlayer && (
+        <Suspense fallback={null}>
         <PlayerExaminePanel
           key={examinePlayer.name}
           player={examinePlayer}
@@ -2046,10 +2059,12 @@ function App() {
             openPanel("chatboard");
           }}
         />
+        </Suspense>
       )}
 
       {/* Player field-manual card for a player clicked in the room (full context menu). */}
       {roomPlayer && (
+        <Suspense fallback={null}>
         <PlayerExaminePanel
           key={roomPlayer.name}
           player={roomPlayer}
@@ -2063,10 +2078,12 @@ function App() {
           onCommand={sendCommand}
           onTellPlayer={() => { /* room context uses the inline composer */ }}
         />
+        </Suspense>
       )}
 
       {/* Item card — parchment "field manual" page for a clicked room item. */}
       {item && (
+        <Suspense fallback={null}>
         <ItemManualPanel
           key={item.id ?? item.name}
           item={item}
@@ -2077,10 +2094,12 @@ function App() {
           onZoomImage={(url) => setImagePreviewUrl(url)}
           onVideo={(url) => setVideoUrl(url)}
         />
+        </Suspense>
       )}
 
       {/* Inn — key-on-a-hook recall modal (click away to dismiss). */}
       {showInn && (
+        <Suspense fallback={null}>
         <InnPanel
           roomTitle={state.room.title}
           recall={state.recallState}
@@ -2088,6 +2107,7 @@ function App() {
           onSetRecall={() => { sendCommand("rest"); setShowInn(false); }}
           onClose={() => setShowInn(false)}
         />
+        </Suspense>
       )}
 
       {/* Consider — verbal threat assessment for a mob (typed `consider`). Hidden

--- a/web-v3/src/canvas/PixiCanvas.tsx
+++ b/web-v3/src/canvas/PixiCanvas.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useRef } from "react";
+import { memo, useEffect, useRef } from "react";
 import { Application } from "pixi.js";
 import { SceneManager } from "./SceneManager";
 
-export function PixiCanvas() {
+// memo: props-less component under GameShell, which re-renders on every
+// vitals/room/combat update — the canvas itself never needs to.
+export const PixiCanvas = memo(function PixiCanvas() {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const appRef = useRef<Application | null>(null);
   const sceneRef = useRef<SceneManager | null>(null);
@@ -76,4 +78,4 @@ export function PixiCanvas() {
       style={{ width: "100%", height: "100%", minHeight: 200 }}
     />
   );
-}
+});

--- a/web-v3/src/hooks/useTerminal.ts
+++ b/web-v3/src/hooks/useTerminal.ts
@@ -1,8 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { RefObject } from "react";
-import { FitAddon } from "@xterm/addon-fit";
-import { Terminal } from "@xterm/xterm";
-import "@xterm/xterm/css/xterm.css";
+import type { FitAddon } from "@xterm/addon-fit";
+import type { Terminal } from "@xterm/xterm";
 
 interface TerminalHosts {
   /** Off-screen stash the xterm element lives in while the GUI is in charge. */
@@ -60,6 +59,14 @@ const INK_THEME = {
 export function useTerminal({ hiddenHostRef, overlayHostRef }: TerminalHosts) {
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
+  // Server bytes that arrive before the lazy-loaded xterm module is ready.
+  // xterm (~330 kB) is the entry chunk's second-largest dependency, so it is
+  // fetched with a dynamic import the moment the hook mounts; the buffer
+  // bridges the sub-second gap so no output is lost.
+  const pendingWritesRef = useRef<string[]>([]);
+  // Theme requested before the instance exists (parchment art can arrive
+  // via Server.Assets while xterm is still downloading).
+  const inkThemeRef = useRef(false);
   const [open, setOpen] = useState(false);
   // Translucent when first summoned (game stays visible behind the log);
   // turns opaque once the user starts typing and commits to terminal mode.
@@ -85,27 +92,44 @@ export function useTerminal({ hiddenHostRef, overlayHostRef }: TerminalHosts) {
   useEffect(() => {
     if (!hiddenHostRef.current) return;
 
-    const term = new Terminal({
-      cursorBlink: false,
-      disableStdin: true,
-      fontFamily: '"JetBrains Mono", "Cascadia Mono", monospace',
-      fontSize: 14,
-      rows: 30,
-      scrollback: 5000,
-      convertEol: false,
-      allowTransparency: true,
-      theme: DARK_THEME,
-    });
+    let disposed = false;
+    let term: Terminal | null = null;
 
-    const fitAddon = new FitAddon();
-    term.loadAddon(fitAddon);
-    term.open(hiddenHostRef.current);
+    (async () => {
+      const [{ Terminal: XTerminal }, { FitAddon: XFitAddon }] = await Promise.all([
+        import("@xterm/xterm"),
+        import("@xterm/addon-fit"),
+        import("@xterm/xterm/css/xterm.css"),
+      ]);
+      if (disposed || !hiddenHostRef.current) return;
 
-    terminalRef.current = term;
-    fitAddonRef.current = fitAddon;
+      term = new XTerminal({
+        cursorBlink: false,
+        disableStdin: true,
+        fontFamily: '"JetBrains Mono", "Cascadia Mono", monospace',
+        fontSize: 14,
+        rows: 30,
+        scrollback: 5000,
+        convertEol: false,
+        allowTransparency: true,
+        theme: inkThemeRef.current ? INK_THEME : DARK_THEME,
+      });
+
+      const fitAddon = new XFitAddon();
+      term.loadAddon(fitAddon);
+      term.open(hiddenHostRef.current);
+
+      terminalRef.current = term;
+      fitAddonRef.current = fitAddon;
+
+      const pending = pendingWritesRef.current;
+      pendingWritesRef.current = [];
+      for (const chunk of pending) term.write(chunk);
+    })();
 
     return () => {
-      term.dispose();
+      disposed = true;
+      term?.dispose();
       fitAddonRef.current = null;
       terminalRef.current = null;
     };
@@ -152,26 +176,37 @@ export function useTerminal({ hiddenHostRef, overlayHostRef }: TerminalHosts) {
     }
   }, [open, fit, hiddenHostRef, overlayHostRef]);
 
+  /** Queue output until the lazily-imported xterm instance exists. */
+  const writeOrBuffer = useCallback((text: string) => {
+    const term = terminalRef.current;
+    if (term) {
+      term.write(text);
+    } else if (pendingWritesRef.current.length < 5000) {
+      pendingWritesRef.current.push(text);
+    }
+  }, []);
+
   /** Raw server output — ANSI escapes pass straight through to xterm. */
   const write = useCallback((text: string) => {
-    terminalRef.current?.write(text);
-  }, []);
+    writeOrBuffer(text);
+  }, [writeOrBuffer]);
 
   /** Local echo of a command the player sent, like a telnet client shows. */
   const echoCommand = useCallback((command: string) => {
-    terminalRef.current?.write(`${command}\r\n`);
-  }, []);
+    writeOrBuffer(`${command}\r\n`);
+  }, [writeOrBuffer]);
 
   /** Dim client-side status line (connection lost, reconnecting, ...). */
   const writeSystem = useCallback((message: string) => {
-    terminalRef.current?.write(`\r\n\x1b[2m${message}\x1b[0m\r\n`);
-  }, []);
+    writeOrBuffer(`\r\n\x1b[2m${message}\x1b[0m\r\n`);
+  }, [writeOrBuffer]);
 
   /** xterm tracks its own selection (not window.getSelection). */
   const hasSelection = useCallback(() => terminalRef.current?.hasSelection() ?? false, []);
 
   /** Dark ink on parchment when the scroll art is present; light-on-dark otherwise. */
   const setInkTheme = useCallback((enabled: boolean) => {
+    inkThemeRef.current = enabled;
     const term = terminalRef.current;
     if (term) term.options.theme = enabled ? INK_THEME : DARK_THEME;
   }, []);

--- a/web-v3/vite.config.ts
+++ b/web-v3/vite.config.ts
@@ -1,18 +1,53 @@
 import { resolve } from "node:path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { visualizer } from "rollup-plugin-visualizer";
 
 // https://vite.dev/config/
 export default defineConfig({
   base: "/",
-  plugins: [react()],
+  plugins: [
+    react(),
+    // Bundle breakdown: ANALYZE=1 bun run build → stats.json (raw-data
+    // template) with per-module sizes. Emits nothing in normal builds.
+    ...(process.env.ANALYZE
+      ? [visualizer({ filename: "stats.json", template: "raw-data" })]
+      : []),
+  ],
   build: {
     outDir: resolve(__dirname, "../src/main/resources/web-v3"),
     emptyOutDir: true,
     rollupOptions: {
       output: {
-        manualChunks: {
-          pixi: ["pixi.js"],
+        manualChunks(id: string) {
+          const path = id.replace(/\\/g, "/");
+          if (path.includes("node_modules")) {
+            // Pixi (and its earcut dependency) stay their own chunk.
+            if (path.includes("/pixi.js/") || path.includes("/earcut/")) return "pixi";
+            // Framework chunk: cache survives app-code deploys.
+            if (/\/node_modules\/(react|react-dom|scheduler)\//.test(path)) return "vendor";
+            // xterm is dynamically imported (useTerminal) — keep it isolated.
+            if (path.includes("/@xterm/")) return "xterm";
+            return undefined;
+          }
+          // All drawer panels are React.lazy'd from App; bundle them as one
+          // on-demand chunk (single fetch on first drawer open), with the
+          // staff-only AdminPanel split out so players never download it.
+          if (path.includes("/src/components/panels/")) {
+            return path.includes("AdminPanel") ? "panel-admin" : "panels";
+          }
+          // Modules shared by the entry AND the panels must not be colocated
+          // into "panels" (rollup's default would do that, which turns the
+          // panels chunk into a static dependency of the entry and defeats
+          // the lazy split — every panel would execute at startup again).
+          if (
+            /\/src\/(utils|constants|imageDefaults|types)\.ts/.test(path) ||
+            path.includes("/src/canvas/GameStateBridge") ||
+            path.includes("/src/components/Icons")
+          ) {
+            return "shared";
+          }
+          return undefined;
         },
       },
     },


### PR DESCRIPTION
## Summary

Code-splits the web client to cut critical-path JavaScript by ~28% (gzip 432 kB → 313 kB) and stop shipping code players may never run. No visual or behavioral changes.

## Before / after

| Chunk | Before (gzip) | After (gzip) | Loading |
|---|---|---|---|
| index (app) | 275 kB | 92 kB | sync |
| vendor (react) | — | 60 kB | sync, long-cache |
| pixi | 157 kB | 157 kB | sync |
| shared | — | 4 kB | sync |
| xterm | (in index) | 83 kB | **async after boot** |
| panels | (in index) | 32 kB | **on first drawer open** |
| panel-admin | (in index) | 5 kB | **staff only** |

## Changes

- **Measurement first**: added `rollup-plugin-visualizer` behind `ANALYZE=1 bun run build` (emits `stats.json`, gitignored). The index breakdown showed react-dom (29%), xterm (17%), and the 26 drawer panels (16%) as the big movers.
- **Panels → React.lazy**: all drawer panels and field-manual overlays load on demand, grouped by `manualChunks` into one `panels` chunk; the staff-only AdminPanel gets its own chunk that regular players never download. Suspense boundaries sit inside the Drawer (chrome stays visible during load) and around each overlay.
- **xterm → dynamic import** in `useTerminal`, with a write buffer so server bytes arriving during the sub-second load gap aren't lost, and ink-theme requests are remembered until the instance exists.
- **Vendor chunk** for react/react-dom/scheduler — framework bytes survive app deploys in cache.
- **Shared-module pinning**: rollup colocated `GameStateBridge`/`Icons`/`utils`/`constants`/`imageDefaults` into the panels chunk (26 importers), which silently made panels a *static* dependency of the entry — every panel executed at startup despite the lazy split. Pinning them to a small `shared` chunk severs that edge; verified zero static imports of dynamic chunks in the built entry.
- `PixiCanvas` wrapped in `memo` (props-less child of the busiest re-render path).

## Verification (live browser via gstack)

- Startup fetches exactly `index + vendor + pixi + shared`, with xterm arriving async — no panels chunk.
- Started a demo character, opened the Character kiosk: `panels-*.js` fetched at that moment, drawer rendered fully from it.
- Zero console errors throughout; `bun run lint`, `tsc -b`, and all 27 web tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
