### PR TITLE
feat(a11y): first-class screen-reader mode across server and web client

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -539,6 +539,7 @@ class GmcpEmitter(
                 autolootEnabled = player.autolootEnabled,
                 autopeekEnabled = player.autopeekEnabled,
                 wimpyThresholdPct = player.wimpyThresholdPct,
+                screenReaderEnabled = player.screenReaderEnabled,
                 title = player.activeTitle,
                 isDemo = player.playerId == null,
             ),
@@ -2835,6 +2836,8 @@ class GmcpEmitter(
         val autolootEnabled: Boolean,
         val autopeekEnabled: Boolean,
         val wimpyThresholdPct: Int,
+        /** Screen-reader mode: strips decorative output server-side; web client mirrors it in the UI. */
+        val screenReaderEnabled: Boolean,
         /** The player's currently-equipped achievement title, or null when none is set. */
         val title: String?,
         /**

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -32,6 +32,8 @@ sealed interface Command {
 
     data object ScreenReaderOff : Command
 
+    data object ScreenReaderToggle : Command
+
     data object AutolootOn : Command
 
     data object AutolootOff : Command
@@ -1752,7 +1754,7 @@ object CommandParser {
             "ansi off" -> Command.AnsiOff
             "screenreader on" -> Command.ScreenReaderOn
             "screenreader off" -> Command.ScreenReaderOff
-            "screenreader" -> Command.ScreenReaderOn // toggle handled by router
+            "screenreader" -> Command.ScreenReaderToggle
             "autoloot on" -> Command.AutolootOn
             "autoloot off" -> Command.AutolootOff
             "autoloot status", "autoloot" -> Command.AutolootStatus

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/UiHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/UiHandler.kt
@@ -49,8 +49,9 @@ class UiHandler(
         router.on<Command.Quit> { sid, _ -> outbound.send(OutboundEvent.Close(sid, "Goodbye!")) }
         router.on<Command.AnsiOn> { sid, _ -> handleAnsiOn(sid) }
         router.on<Command.AnsiOff> { sid, _ -> handleAnsiOff(sid) }
-        router.on<Command.ScreenReaderOn> { sid, _ -> handleScreenReaderToggle(sid, true) }
-        router.on<Command.ScreenReaderOff> { sid, _ -> handleScreenReaderToggle(sid, false) }
+        router.on<Command.ScreenReaderOn> { sid, _ -> handleScreenReader(sid) { true } }
+        router.on<Command.ScreenReaderOff> { sid, _ -> handleScreenReader(sid) { false } }
+        router.on<Command.ScreenReaderToggle> { sid, _ -> handleScreenReader(sid) { current -> !current } }
         router.on<Command.AutolootOn> { sid, _ -> handleAutoloot(sid, ToggleAction.ON) }
         router.on<Command.AutolootOff> { sid, _ -> handleAutoloot(sid, ToggleAction.OFF) }
         router.on<Command.AutolootStatus> { sid, _ -> handleAutoloot(sid, ToggleAction.STATUS) }
@@ -178,12 +179,20 @@ class UiHandler(
         outbound.send(OutboundEvent.SendInfo(sessionId, msg))
     }
 
-    private suspend fun handleScreenReaderToggle(sessionId: SessionId, requestedOn: Boolean) {
+    /**
+     * `screenreader on`/`off` set the mode idempotently (so UI switches can
+     * drive it deterministically); bare `screenreader` toggles. The new state
+     * rides the Char.Name GMCP packet so the web client mirrors it.
+     */
+    private suspend fun handleScreenReader(
+        sessionId: SessionId,
+        resolve: (current: Boolean) -> Boolean,
+    ) {
         val me = players.get(sessionId) ?: return
-        // "screenreader" (bare) maps to ScreenReaderOn; if already on, toggle off
-        val enabled = if (requestedOn) !me.screenReaderEnabled else false
+        val enabled = resolve(me.screenReaderEnabled)
         outbound.send(OutboundEvent.SetScreenReader(sessionId, enabled))
         players.setScreenReaderEnabled(sessionId, enabled)
+        gmcpEmitter?.sendCharName(sessionId, me)
         val status = if (enabled) "enabled" else "disabled"
         outbound.send(OutboundEvent.SendInfo(sessionId, "Screen reader mode $status."))
     }

--- a/src/test/kotlin/dev/ambon/engine/WebClientParityTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/WebClientParityTest.kt
@@ -166,6 +166,7 @@ class WebClientParityTest {
         "AnsiOff" to "ansi",
         "ScreenReaderOn" to "screenreader",
         "ScreenReaderOff" to "screenreader",
+        "ScreenReaderToggle" to "screenreader",
         "AutolootOn" to "autoloot",
         "AutolootOff" to "autoloot",
         "AutolootStatus" to "autoloot",

--- a/src/test/kotlin/dev/ambon/engine/commands/ScreenReaderCommandParserTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/ScreenReaderCommandParserTest.kt
@@ -16,13 +16,13 @@ class ScreenReaderCommandParserTest {
 
     @Test
     fun `parses bare screenreader as toggle`() {
-        assertEquals(Command.ScreenReaderOn, CommandParser.parse("screenreader"))
+        assertEquals(Command.ScreenReaderToggle, CommandParser.parse("screenreader"))
     }
 
     @Test
     fun `screenreader is case insensitive`() {
         assertEquals(Command.ScreenReaderOn, CommandParser.parse("SCREENREADER ON"))
         assertEquals(Command.ScreenReaderOff, CommandParser.parse("SCREENREADER OFF"))
-        assertEquals(Command.ScreenReaderOn, CommandParser.parse("Screenreader"))
+        assertEquals(Command.ScreenReaderToggle, CommandParser.parse("Screenreader"))
     }
 }

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -9,6 +9,7 @@ import { TrainerPanel } from "./components/TrainerPanel";
 import { TradePanel } from "./components/TradePanel";
 import { WorldFeaturesPopout } from "./components/WorldFeaturesPopout";
 import { featureArt, pickFocusedFeature } from "./components/worldFeatures";
+import { GameNarrator } from "./components/GameNarrator";
 import { SpellbookPanel } from "./components/SpellbookPanel";
 
 // Drawer panels and field-manual overlays are only reachable after login, so
@@ -280,7 +281,11 @@ function App() {
     writeSystem,
     hasSelection: terminalHasSelection,
     setInkTheme,
-  } = useTerminal({ hiddenHostRef: terminalHiddenRef, overlayHostRef: terminalOverlayRef });
+  } = useTerminal({
+    hiddenHostRef: terminalHiddenRef,
+    overlayHostRef: terminalOverlayRef,
+    screenReaderMode: state.character.screenReaderEnabled,
+  });
 
   // Parchment scroll art → dark ink palette; absent art → light-on-dark.
   const terminalParchmentBg = state.serverAssets["terminal_parchment_bg"] ?? null;
@@ -2272,6 +2277,16 @@ function App() {
       <div ref={terminalHiddenRef} className="terminal-hidden" aria-hidden="true" />
 
       <p className="sr-only" aria-live="polite">{liveMessage}</p>
+
+      {/* Spoken narration (rooms, low HP, tells) for screen-reader mode. */}
+      <GameNarrator
+        enabled={state.character.screenReaderEnabled}
+        room={state.room}
+        exits={sortedExits}
+        vitals={state.vitals}
+        tells={state.chatByChannel.tell}
+        chatBoardOpen={state.activePopout === "chatboard"}
+      />
     </>
   );
 }

--- a/web-v3/src/canvas/GameStateBridge.ts
+++ b/web-v3/src/canvas/GameStateBridge.ts
@@ -159,7 +159,7 @@ export const gameStateRef: { current: GameStateSnapshot } = {
     combatTarget: null,
     inCombat: false,
     effects: [],
-    character: { name: "-", gender: "", race: "", className: "", level: null, sprite: null, isStaff: false, title: null, autolootEnabled: false, autopeekEnabled: false, wimpyThresholdPct: 10, isDemo: false },
+    character: { name: "-", gender: "", race: "", className: "", level: null, sprite: null, isStaff: false, title: null, autolootEnabled: false, autopeekEnabled: false, screenReaderEnabled: false, wimpyThresholdPct: 10, isDemo: false },
     mobInfo: [],
     groupInfo: { leader: null, members: [] },
     dialogue: null,

--- a/web-v3/src/canvas/PixiCanvas.tsx
+++ b/web-v3/src/canvas/PixiCanvas.tsx
@@ -74,7 +74,7 @@ export const PixiCanvas = memo(function PixiCanvas() {
       ref={containerRef}
       className="pixi-canvas-host"
       role="img"
-      aria-label="Game world canvas — room visuals, mobs, and combat rendered here. Use the terminal for accessible text output."
+      aria-label="Game world canvas — room visuals, mobs, and combat rendered here. Screen reader players: turn on Screen Reader in the Character panel (or type the screenreader command) for spoken room and event updates plus an accessible terminal log."
       style={{ width: "100%", height: "100%", minHeight: 200 }}
     />
   );

--- a/web-v3/src/components/GameNarrator.tsx
+++ b/web-v3/src/components/GameNarrator.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useRef, useState } from "react";
+import type { ChatMessage, RoomState, Vitals } from "../types";
+
+interface GameNarratorProps {
+  /** Mirrors the server-persisted screen-reader setting (Char.Name GMCP). */
+  enabled: boolean;
+  room: RoomState;
+  /** Sorted [direction, targetRoomId] pairs for the current room. */
+  exits: Array<[string, string]>;
+  vitals: Vitals;
+  /** Tell-channel history; new entries are announced while the chat board is closed. */
+  tells: ChatMessage[];
+  /** Suppresses tell announcements while the chat board's own log is on screen. */
+  chatBoardOpen: boolean;
+}
+
+/** Announce a low-health warning when HP falls to this fraction of max. */
+const LOW_HP_FRACTION = 0.25;
+/** Clear spoken text after a beat so SR cursor navigation doesn't re-read it. */
+const POLITE_CLEAR_MS = 8000;
+const URGENT_CLEAR_MS = 5000;
+
+function roomSentence(room: RoomState, exits: Array<[string, string]>): string {
+  const exitNames = exits.map(([direction]) => direction);
+  return `${room.title}. Exits: ${exitNames.length > 0 ? exitNames.join(", ") : "none"}.`;
+}
+
+/**
+ * Spoken game narration for screen-reader players. The PixiJS canvas renders
+ * room movement, health, and social context purely visually; when screen-reader
+ * mode is on, this component mirrors those beats into sr-only live regions:
+ *
+ *  - room changes (and an orienting announcement when the mode turns on):
+ *    title + available exits, polite
+ *  - health dropping to 25% of max: assertive alert
+ *  - incoming tells while the chat board is closed: polite
+ *
+ * Combat blow-by-blow intentionally stays out — CombatLog already maintains a
+ * `role="log"` live region, and duplicating it here would double-announce.
+ * The regions render even while disabled so assistive tech registers them
+ * before the first announcement.
+ */
+export function GameNarrator({ enabled, room, exits, vitals, tells, chatBoardOpen }: GameNarratorProps) {
+  const [polite, setPolite] = useState("");
+  const [urgent, setUrgent] = useState("");
+  const lastRoomIdRef = useRef<string | null>(room.id);
+  const wasLowRef = useRef(false);
+  // Pre-seed with history so enabling the mode doesn't replay old tells.
+  const seenTellsRef = useRef<Set<string>>(new Set(tells.map((t) => t.id)));
+
+  // Auto-clear so the regions hold no stale text for SR cursor passes.
+  useEffect(() => {
+    if (!polite) return;
+    const timer = window.setTimeout(() => setPolite(""), POLITE_CLEAR_MS);
+    return () => window.clearTimeout(timer);
+  }, [polite]);
+
+  useEffect(() => {
+    if (!urgent) return;
+    const timer = window.setTimeout(() => setUrgent(""), URGENT_CLEAR_MS);
+    return () => window.clearTimeout(timer);
+  }, [urgent]);
+
+  // Orient the player with the current room when the mode turns on.
+  useEffect(() => {
+    if (!enabled || room.id === null || room.title === "-") return;
+    const timer = window.setTimeout(() => setPolite(roomSentence(room, exits)), 0);
+    return () => window.clearTimeout(timer);
+    // Announce only on the enabled flip, not on every room/exit change (the
+    // movement effect below owns those).
+  }, [enabled]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Movement: announce the new room once per room-id change.
+  useEffect(() => {
+    const prev = lastRoomIdRef.current;
+    lastRoomIdRef.current = room.id;
+    if (!enabled || room.id === null || room.id === prev || room.title === "-") return;
+    if (prev === null) return; // first room is covered by the orientation effect
+    const timer = window.setTimeout(() => setPolite(roomSentence(room, exits)), 0);
+    return () => window.clearTimeout(timer);
+  }, [enabled, room, exits]);
+
+  // Health: single assertive warning when HP crosses below the threshold.
+  useEffect(() => {
+    const low = vitals.maxHp > 0 && vitals.hp > 0 && vitals.hp / vitals.maxHp <= LOW_HP_FRACTION;
+    const was = wasLowRef.current;
+    wasLowRef.current = low;
+    if (!enabled || !low || was) return;
+    const timer = window.setTimeout(
+      () => setUrgent(`Health low: ${vitals.hp} of ${vitals.maxHp}.`),
+      0,
+    );
+    return () => window.clearTimeout(timer);
+  }, [enabled, vitals.hp, vitals.maxHp]);
+
+  // Private messages: speak tells that arrive while the chat board is closed.
+  useEffect(() => {
+    const seen = seenTellsRef.current;
+    const fresh = tells.filter((t) => !seen.has(t.id));
+    for (const t of tells) seen.add(t.id);
+    if (!enabled || chatBoardOpen || fresh.length === 0) return;
+    const latest = fresh[fresh.length - 1];
+    const timer = window.setTimeout(
+      () => setPolite(`Tell from ${latest.sender}: ${latest.message}`),
+      0,
+    );
+    return () => window.clearTimeout(timer);
+  }, [enabled, chatBoardOpen, tells]);
+
+  return (
+    <>
+      <p className="sr-only" role="status" aria-live="polite" aria-atomic="true">{polite}</p>
+      <p className="sr-only" role="alert" aria-atomic="true">{urgent}</p>
+    </>
+  );
+}

--- a/web-v3/src/components/panels/CharacterPanel.tsx
+++ b/web-v3/src/components/panels/CharacterPanel.tsx
@@ -166,6 +166,7 @@ export function CharacterPanel({
 
   const autolootEnabled = character.autolootEnabled;
   const autopeekEnabled = character.autopeekEnabled;
+  const screenReaderEnabled = character.screenReaderEnabled;
   const wimpyPct = wimpyDraft ?? character.wimpyThresholdPct ?? 0;
 
   const commitWimpy = (n: number) => {
@@ -316,6 +317,19 @@ export function CharacterPanel({
             >
               <span className="cc-ctl-leaf" aria-hidden="true" />
               <span className="cc-ctl-name">Auto Peek</span>
+              <span className="cc-switch"><span className="cc-switch-thumb" /></span>
+            </button>
+            <button
+              type="button"
+              className={`cc-ctl cc-ctl-toggle${screenReaderEnabled ? " is-on" : ""}`}
+              role="switch"
+              aria-checked={screenReaderEnabled}
+              disabled={!connected}
+              title="Spoken room, combat, and message updates; plain-text server output; accessible terminal log."
+              onClick={() => onCommand(screenReaderEnabled ? "screenreader off" : "screenreader on")}
+            >
+              <span className="cc-ctl-leaf" aria-hidden="true" />
+              <span className="cc-ctl-name">Screen Reader</span>
               <span className="cc-switch"><span className="cc-switch-thumb" /></span>
             </button>
             <div className="cc-ctl cc-ctl-wimpy" role="group" aria-label="Wimpy threshold" title="Auto-flee combat when HP drops to this %.">

--- a/web-v3/src/constants.ts
+++ b/web-v3/src/constants.ts
@@ -95,7 +95,7 @@ export const DEFAULT_STATUS_VAR_LABELS: StatusVarLabels = {
   xp: "XP",
 };
 
-export const EMPTY_CHAR: CharacterInfo = { name: "-", gender: "", race: "", className: "", level: null, sprite: null, isStaff: false, title: null, autolootEnabled: false, autopeekEnabled: false, wimpyThresholdPct: 10, isDemo: false };
+export const EMPTY_CHAR: CharacterInfo = { name: "-", gender: "", race: "", className: "", level: null, sprite: null, isStaff: false, title: null, autolootEnabled: false, autopeekEnabled: false, screenReaderEnabled: false, wimpyThresholdPct: 10, isDemo: false };
 export const DEFAULT_SERVER_FEATURES: ServerFeatures = {
   dailyQuests: false,
   weeklyQuests: false,

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -380,6 +380,7 @@ export function applyGmcpPackage(
         title: typeof packet.title === "string" ? packet.title : null,
         autolootEnabled: packet.autolootEnabled === true,
         autopeekEnabled: packet.autopeekEnabled === true,
+        screenReaderEnabled: packet.screenReaderEnabled === true,
         wimpyThresholdPct: typeof packet.wimpyThresholdPct === "number" ? packet.wimpyThresholdPct : 10,
         isDemo: packet.isDemo === true,
       });

--- a/web-v3/src/hooks/useTerminal.ts
+++ b/web-v3/src/hooks/useTerminal.ts
@@ -8,6 +8,13 @@ interface TerminalHosts {
   hiddenHostRef: RefObject<HTMLDivElement | null>;
   /** Overlay host the element reparents into while the overlay is open. */
   overlayHostRef: RefObject<HTMLDivElement | null>;
+  /**
+   * Mirrors the server-persisted screen-reader setting. Enables xterm's
+   * accessibility buffer — without it the canvas-rendered terminal exposes
+   * NOTHING to assistive tech, so the log would be unreadable to the very
+   * players it is meant to serve.
+   */
+  screenReaderMode?: boolean;
 }
 
 // Both themes keep the cell background transparent (allowTransparency) so the
@@ -56,7 +63,7 @@ const INK_THEME = {
  * return value carries no refs — the react-hooks/refs lint rule forbids
  * accessing hook-returned ref carriers during render.
  */
-export function useTerminal({ hiddenHostRef, overlayHostRef }: TerminalHosts) {
+export function useTerminal({ hiddenHostRef, overlayHostRef, screenReaderMode = false }: TerminalHosts) {
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   // Server bytes that arrive before the lazy-loaded xterm module is ready.
@@ -67,6 +74,9 @@ export function useTerminal({ hiddenHostRef, overlayHostRef }: TerminalHosts) {
   // Theme requested before the instance exists (parchment art can arrive
   // via Server.Assets while xterm is still downloading).
   const inkThemeRef = useRef(false);
+  // Same deferred pattern for screen-reader mode (Char.Name GMCP can land
+  // before the lazy xterm module finishes loading).
+  const srModeRef = useRef(screenReaderMode);
   const [open, setOpen] = useState(false);
   // Translucent when first summoned (game stays visible behind the log);
   // turns opaque once the user starts typing and commits to terminal mode.
@@ -113,6 +123,7 @@ export function useTerminal({ hiddenHostRef, overlayHostRef }: TerminalHosts) {
         convertEol: false,
         allowTransparency: true,
         theme: inkThemeRef.current ? INK_THEME : DARK_THEME,
+        screenReaderMode: srModeRef.current,
       });
 
       const fitAddon = new XFitAddon();
@@ -134,6 +145,16 @@ export function useTerminal({ hiddenHostRef, overlayHostRef }: TerminalHosts) {
       terminalRef.current = null;
     };
   }, [hiddenHostRef]);
+
+  // Follow the server-persisted screen-reader flag at runtime (xterm builds or
+  // tears down its accessibility tree when the option flips).
+  useEffect(() => {
+    srModeRef.current = screenReaderMode;
+    const term = terminalRef.current;
+    if (term && term.options.screenReaderMode !== screenReaderMode) {
+      term.options.screenReaderMode = screenReaderMode;
+    }
+  }, [screenReaderMode]);
 
   // Refit on window resize and once fonts settle (mono metrics change cols).
   useEffect(() => {

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -212,6 +212,12 @@ export interface CharacterInfo {
   autolootEnabled: boolean;
   /** When true, room descriptions gain a peek paragraph naming adjacent rooms. */
   autopeekEnabled: boolean;
+  /**
+   * Screen-reader mode (server-persisted). The server strips decorative box
+   * art from the text stream; the client enables xterm's accessibility buffer
+   * and the spoken game narrator.
+   */
+  screenReaderEnabled: boolean;
   /** Wimpy auto-flee threshold (HP%). 0 = disabled. */
   wimpyThresholdPct: number;
   /**


### PR DESCRIPTION
## Summary

Makes screen-reader support a first-class, end-to-end feature. The server has long had a `screenreader` command (ANSI/box-art stripping via `ScreenReaderFilter`, persisted per player) — but the web client never surfaced it, and **xterm.js without `screenReaderMode` exposes no accessible DOM at all**, so the terminal log the client points assistive tech toward was literally unreadable by it.

## What a vision-impaired player gets now

1. **Discoverable toggle**: a "Screen Reader" switch in the Character panel (next to Auto Loot / Auto Peek), plus the canvas's accessible name now tells SR users where to find it. The setting is server-persisted, so it follows the player across browsers and devices.
2. **Readable terminal**: xterm's `screenReaderMode` follows the flag — the session-long log in the terminal overlay becomes a real accessible buffer instead of opaque canvas pixels. Server-side stripping removes box-drawing art from that stream at the same time.
3. **Spoken game narration** (new `GameNarrator`, sr-only live regions, active only when the mode is on):
   - Room movement: title + available exits, with an orientation announcement when the mode turns on
   - A single assertive low-health warning when HP crosses 25%
   - Incoming tells while the chat board is closed
   - Combat blow-by-blow deliberately stays with the existing `CombatLog` `role=log` region — no double-announcing

## Server changes

- `screenreader on` / `screenreader off` are now **idempotent sets** (previously `on` *toggled*, which made programmatic control impossible); bare `screenreader` keeps the toggle (new `Command.ScreenReaderToggle`).
- `screenReaderEnabled` rides the `Char.Name` GMCP payload (same rails as `autolootEnabled`), and a Char update is emitted on change so the client mirrors state immediately.

## Implementation notes

- xterm loads lazily (perf split from #1293); the mode uses the same deferred-ref pattern as the ink theme so a Char.Name packet arriving before the module finishes loading still applies.
- Narrator regions render even while disabled so AT registers them before the first announcement; spoken text auto-clears so SR cursor passes don't re-read stale lines.
- Rebased cleanly onto the painted-login redesign (#1294).

## Verification

- Full `./gradlew test` suite passes; parser/parity tests updated for the new toggle variant.
- `bun run lint`, `tsc -b`, `vite build`, all 27 web tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
