### PR TITLE
fix(web): gate painted login scenes on the art actually loading

### DIFF
--- a/web-v3/src/canvas/LoginModal.tsx
+++ b/web-v3/src/canvas/LoginModal.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { CSSProperties, FormEvent } from "react";
 import type { LoginClassOption, LoginErrorState, LoginPromptState, LoginRaceOption } from "../types";
 import { ArtScene } from "./ArtScene";
-import { ART_FIT_LANDSCAPE, ART_FIT_PORTRAIT, useMediaFits } from "./loginArtFit";
+import { ART_FIT_LANDSCAPE, ART_FIT_PORTRAIT, useArtImage, useMediaFits } from "./loginArtFit";
 
 interface LoginModalProps {
   loginPrompt: LoginPromptState;
@@ -48,14 +48,25 @@ export function LoginModal({ loginPrompt, loginError, serverAssets, onSubmit }: 
 
   const isWide = loginPrompt.state === "raceSelection" || loginPrompt.state === "classSelection";
 
-  const landscapeArt = (key: string): string | null =>
-    artFitsLandscape ? (serverAssets[key] ?? null) : null;
-  const portraitArt = (key: string): string | null =>
-    artFitsPortrait ? (serverAssets[key] ?? null) : null;
+  // One painted scene per login step; the portrait scenes use the looser gate.
+  const SCENE_ART: Record<string, { key: string; portrait?: boolean }> = {
+    name: { key: "login_bg" },
+    password: { key: "login_password_bg" },
+    newPassword: { key: "login_set_password_bg" },
+    confirmCreate: { key: "login_confirm_bg" },
+    raceSelection: { key: "login_race_bg", portrait: true },
+    classSelection: { key: "login_class_bg", portrait: true },
+  };
+  const scene = SCENE_ART[loginPrompt.state];
+  const sceneFits = scene?.portrait ? artFitsPortrait : artFitsLandscape;
+  // Gated on the image actually loading: a URL that 404s or is blocked
+  // client-side must fall back to the CSS UI, not render a black scene.
+  const sceneArt = useArtImage(scene && sceneFits ? serverAssets[scene.key] ?? null : null);
 
-  const backgroundImage = serverAssets["login_bg"] ?? null;
-  const artVars = backgroundImage
-    ? ({ "--login-art": `url("${backgroundImage}")` } as CSSProperties)
+  // Decorative blurred backdrop behind the fallback modal steps.
+  const backdropArt = useArtImage(serverAssets["login_bg"] ?? null);
+  const artVars = backdropArt
+    ? ({ "--login-art": `url("${backdropArt}")` } as CSSProperties)
     : undefined;
 
   const stepDialogLabel: Record<string, string> = {
@@ -67,7 +78,7 @@ export function LoginModal({ loginPrompt, loginError, serverAssets, onSubmit }: 
   };
 
   if (loginPrompt.state === "name") {
-    const art = landscapeArt("login_bg");
+    const art = sceneArt;
     if (art) {
       return (
         <ArtScene url={art} stageClass="login-art-stage--wide" label="Welcome to AmbonMUD">
@@ -178,7 +189,7 @@ export function LoginModal({ loginPrompt, loginError, serverAssets, onSubmit }: 
   }
 
   if (loginPrompt.state === "password") {
-    const art = landscapeArt("login_password_bg");
+    const art = sceneArt;
     if (art) {
       return (
         <ArtScene url={art} stageClass="login-art-stage--book login-art-stage--password" label="Welcome back — enter your password">
@@ -214,7 +225,7 @@ export function LoginModal({ loginPrompt, loginError, serverAssets, onSubmit }: 
   }
 
   if (loginPrompt.state === "newPassword") {
-    const art = landscapeArt("login_set_password_bg");
+    const art = sceneArt;
     if (art) {
       return (
         <ArtScene url={art} stageClass="login-art-stage--wide login-art-stage--setpw" label="Choose a password">
@@ -250,7 +261,7 @@ export function LoginModal({ loginPrompt, loginError, serverAssets, onSubmit }: 
   }
 
   if (loginPrompt.state === "confirmCreate") {
-    const art = landscapeArt("login_confirm_bg");
+    const art = sceneArt;
     if (art) {
       return (
         <ArtScene url={art} stageClass="login-art-stage--book login-art-stage--confirm" label="Create a new character?">
@@ -277,7 +288,7 @@ export function LoginModal({ loginPrompt, loginError, serverAssets, onSubmit }: 
   }
 
   if (loginPrompt.state === "raceSelection") {
-    const art = portraitArt("login_race_bg");
+    const art = sceneArt;
     if (art) {
       return (
         <SlotArtScene
@@ -297,7 +308,7 @@ export function LoginModal({ loginPrompt, loginError, serverAssets, onSubmit }: 
   }
 
   if (loginPrompt.state === "classSelection") {
-    const art = portraitArt("login_class_bg");
+    const art = sceneArt;
     if (art) {
       return (
         <SlotArtScene
@@ -318,7 +329,7 @@ export function LoginModal({ loginPrompt, loginError, serverAssets, onSubmit }: 
 
   return (
     <div
-      className={`login-modal-backdrop${backgroundImage ? " login-modal-backdrop--art" : ""}`}
+      className={`login-modal-backdrop${backdropArt ? " login-modal-backdrop--art" : ""}`}
       style={artVars}
     >
       <div

--- a/web-v3/src/canvas/loginArtFit.ts
+++ b/web-v3/src/canvas/loginArtFit.ts
@@ -18,3 +18,32 @@ export function useMediaFits(query: string): boolean {
   }, [query]);
   return fits;
 }
+
+/** Module-level result cache: each art URL is probed at most once per session. */
+const artImageStatus = new Map<string, "ready" | "failed">();
+
+/**
+ * Gate a painted-scene URL on the image actually loading. For full-scene art
+ * the background is load-bearing — rendering the painted variant against a URL
+ * that 404s, is blocked by an extension, or whose CDN is unreachable produces
+ * a black screen with floating controls. Returns the URL only once the image
+ * has decoded; on failure (or while loading) returns null so callers keep the
+ * CSS fallback. Required by ART_CONTRACT.md's degradation rules.
+ */
+export function useArtImage(url: string | null): string | null {
+  const [, setProbedCount] = useState(0);
+  useEffect(() => {
+    if (!url || artImageStatus.has(url)) return;
+    let cancelled = false;
+    const img = new Image();
+    const settle = (status: "ready" | "failed") => {
+      artImageStatus.set(url, status);
+      if (!cancelled) setProbedCount((n) => n + 1);
+    };
+    img.onload = () => settle("ready");
+    img.onerror = () => settle("failed");
+    img.src = url;
+    return () => { cancelled = true; };
+  }, [url]);
+  return url && artImageStatus.get(url) === "ready" ? url : null;
+}

--- a/web-v3/src/components/CharacterPicker.tsx
+++ b/web-v3/src/components/CharacterPicker.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 import { ArtScene } from "../canvas/ArtScene";
-import { ART_FIT_LANDSCAPE, useMediaFits } from "../canvas/loginArtFit";
+import { ART_FIT_LANDSCAPE, useArtImage, useMediaFits } from "../canvas/loginArtFit";
 
 interface CharacterPickerProps {
   characters: string[];
@@ -14,6 +14,8 @@ interface CharacterPickerProps {
 export function CharacterPicker({ characters, backgroundImage, onSelect, onRemoveCharacter, onNewCharacter }: CharacterPickerProps) {
   const [confirmRemove, setConfirmRemove] = useState<string | null>(null);
   const artFits = useMediaFits(ART_FIT_LANDSCAPE);
+  // Gated on the image actually loading — failed art falls back to the CSS dialog.
+  const art = useArtImage(artFits ? backgroundImage : null);
 
   const handleRemove = useCallback((name: string, e: React.MouseEvent | React.PointerEvent | React.KeyboardEvent) => {
     e.stopPropagation();
@@ -52,10 +54,10 @@ export function CharacterPicker({ characters, backgroundImage, onSelect, onRemov
     </div>
   ));
 
-  if (backgroundImage && artFits) {
+  if (art) {
     return (
       <ArtScene
-        url={backgroundImage}
+        url={art}
         stageClass="login-art-stage--book login-art-stage--picker"
         label="Welcome back — choose a character"
       >

--- a/web-v3/src/components/DemoBanner.tsx
+++ b/web-v3/src/components/DemoBanner.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { FormEvent } from "react";
 import { ArtScene } from "../canvas/ArtScene";
-import { ART_FIT_LANDSCAPE, useMediaFits } from "../canvas/loginArtFit";
+import { ART_FIT_LANDSCAPE, useArtImage, useMediaFits } from "../canvas/loginArtFit";
 
 interface DemoBannerProps {
   /**
@@ -36,6 +36,8 @@ export function DemoBanner({ autoOpen = false, openRequestId = 0, backgroundImag
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const artFits = useMediaFits(ART_FIT_LANDSCAPE);
+  // Gated on the image actually loading — failed art falls back to the CSS dialog.
+  const art = useArtImage(artFits ? backgroundImage : null);
 
   // Render-time derivation: auto-opens once when autoOpen flips true, and stays
   // closed if the user dismisses it. Manual reopening (banner button or the
@@ -72,7 +74,7 @@ export function DemoBanner({ autoOpen = false, openRequestId = 0, backgroundImag
     setDismissedAuto(true);
   }, [name, password, onClaim]);
 
-  const artOpen = open && backgroundImage && artFits;
+  const artOpen = open && art !== null;
 
   return (
     <>
@@ -90,9 +92,9 @@ export function DemoBanner({ autoOpen = false, openRequestId = 0, backgroundImag
         </button>
       </div>
 
-      {artOpen && backgroundImage && (
+      {artOpen && art && (
         <ArtScene
-          url={backgroundImage}
+          url={art}
           stageClass="login-art-stage--book login-art-stage--claim"
           label="Save your demo character"
         >


### PR DESCRIPTION
## Summary

Hardens the painted login flow (#1294) against art that fails to load. The scenes switched variants on the asset **key** existing in `Server.Assets`, but never verified the **image** loads. For full-scene art the background is load-bearing — a URL that 404s, is blocked by a browser extension (VPN/adblock), or whose CDN is unreachable rendered a **black screen with floating controls** instead of the CSS fallback the art contract requires. Observed in the wild on a session where the art requests didn't complete (likely extension interference compounded by a lost WebGL context).

## Changes

- New `useArtImage(url)` in `loginArtFit.ts`: probes each art URL once per session (module-level cache) via an `Image()` preload; returns the URL only after the image decodes, `null` while loading or on failure.
- `LoginModal` (all six scenes + the decorative blurred backdrop behind the fallback modal steps), `CharacterPicker` (welcome-back), and `DemoBanner` (claim window) now route their art through the gate — failed art falls back to the CSS UI; successful art swaps in the painted scene.
- Internal cleanup in `LoginModal`: per-state art selection consolidated into a single `SCENE_ART` map + one gated hook call.

## Verification

- With `login_bg` deliberately pointed at a nonexistent file: the name screen renders the CSS hero (previously: black screen).
- With the real URL restored: the painted scene renders as before.
- `bun run lint` + `./gradlew buildWeb` green.
