### PR TITLE
security: harden transports, inter-engine bus, admin, and config

### DIFF
--- a/src/main/kotlin/dev/ambon/HmacUtil.kt
+++ b/src/main/kotlin/dev/ambon/HmacUtil.kt
@@ -1,6 +1,7 @@
 package dev.ambon
 
 import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
@@ -15,9 +16,23 @@ internal fun hmacSha256(
         .joinToString("") { "%02x".format(it) }
 }
 
-/** Returns true when [signature] is non-blank and matches [hmacSha256] of [payload] under [secret]. */
+/**
+ * Returns true when [signature] is non-blank and matches [hmacSha256] of [payload] under [secret].
+ *
+ * Uses [MessageDigest.isEqual], which is constant-time for equal-length inputs, so a forged
+ * signature cannot be recovered byte-by-byte via a timing side-channel. (The expected HMAC is a
+ * fixed-length 64-char hex string, so a length mismatch only reveals that the guess is the wrong
+ * length — information an attacker already has.)
+ */
 internal fun isValidHmac(
     secret: String,
     payload: String,
     signature: String,
-): Boolean = signature.isNotBlank() && signature == hmacSha256(secret, payload)
+): Boolean {
+    if (signature.isBlank()) return false
+    val expected = hmacSha256(secret, payload)
+    return MessageDigest.isEqual(
+        expected.toByteArray(StandardCharsets.UTF_8),
+        signature.toByteArray(StandardCharsets.UTF_8),
+    )
+}

--- a/src/main/kotlin/dev/ambon/ServerInfrastructure.kt
+++ b/src/main/kotlin/dev/ambon/ServerInfrastructure.kt
@@ -122,6 +122,11 @@ object ServerInfrastructure {
             maxLineLen = config.transport.telnet.maxLineLen,
             maxNonPrintablePerLine = config.transport.telnet.maxNonPrintablePerLine,
             maxInboundBackpressureFailures = config.transport.maxInboundBackpressureFailures,
+            maxConnections = config.transport.websocket.maxConnections,
+            maxConnectionsPerIp = config.transport.websocket.maxConnectionsPerIp,
+            pingPeriodMillis = config.transport.websocket.pingPeriodMillis,
+            pongTimeoutMillis = config.transport.websocket.pongTimeoutMillis,
+            maxFrameBytes = config.transport.websocket.maxFrameBytes,
             prometheusRegistry = prometheusRegistry,
             metricsEndpoint = config.observability.metricsEndpoint,
             metrics = metrics,
@@ -304,6 +309,7 @@ object ServerInfrastructure {
                 publisher = redisBusPublisher(redisManager),
                 subscriberSetup = redisBusSubscriberSetup(redisManager),
                 mapper = redisObjectMapper,
+                sharedSecret = config.redis.bus.sharedSecret,
             )
         } else {
             LocalInterEngineBus()

--- a/src/main/kotlin/dev/ambon/admin/AdminHttpServer.kt
+++ b/src/main/kotlin/dev/ambon/admin/AdminHttpServer.kt
@@ -77,7 +77,7 @@ class AdminHttpServer(
 
     fun start() {
         engine =
-            embeddedServer(Netty, port = config.port) {
+            embeddedServer(Netty, host = config.host, port = config.port) {
                 adminModule(
                     token = config.token,
                     players = players,
@@ -1165,6 +1165,17 @@ internal fun Application.adminModule(
 
 // --- Auth helper ---
 
+/**
+ * Length-independent constant-time string comparison: both inputs are reduced to fixed-length
+ * SHA-256 digests before [MessageDigest.isEqual], so neither the value nor the length of [token]
+ * leaks through comparison timing.
+ */
+private fun constantTimeStringEquals(a: String, b: String): Boolean {
+    val da = MessageDigest.getInstance("SHA-256").digest(a.toByteArray(Charsets.UTF_8))
+    val db = MessageDigest.getInstance("SHA-256").digest(b.toByteArray(Charsets.UTF_8))
+    return MessageDigest.isEqual(da, db)
+}
+
 private suspend fun ApplicationCall.requireBasicAuth(token: String): Boolean {
     val header = request.headers[HttpHeaders.Authorization]
     if (header != null && header.startsWith("Basic ")) {
@@ -1176,7 +1187,9 @@ private suspend fun ApplicationCall.requireBasicAuth(token: String): Boolean {
             }
         val colonIdx = decoded.indexOf(':')
         val password = if (colonIdx >= 0) decoded.substring(colonIdx + 1) else decoded
-        if (MessageDigest.isEqual(password.toByteArray(), token.toByteArray())) return true
+        // Compare fixed-length SHA-256 digests so the timing/early-exit of MessageDigest.isEqual on a
+        // length mismatch cannot leak the admin token's length.
+        if (constantTimeStringEquals(password, token)) return true
     }
     response.headers.append(HttpHeaders.WWWAuthenticate, "Basic realm=\"AmbonMUD Admin\", charset=\"UTF-8\"")
     respond(HttpStatusCode.Unauthorized)

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -838,6 +838,17 @@ data class AppConfig(
                         "when server.productionMode=true and admin.enabled=true"
                 }
             }
+            if (mode == DeploymentMode.ENGINE || mode == DeploymentMode.GATEWAY) {
+                val forbiddenSecrets = setOf("change_me", "changeme", "secret", "")
+                require(grpc.sharedSecret.lowercase() !in forbiddenSecrets) {
+                    "ambonMUD.grpc.sharedSecret must not be a placeholder value " +
+                        "when server.productionMode=true in ENGINE/GATEWAY mode"
+                }
+                require(grpc.sharedSecret.length >= 16) {
+                    "ambonMUD.grpc.sharedSecret must be at least 16 characters when server.productionMode=true " +
+                        "in ENGINE/GATEWAY mode (gRPC auth HMAC strength)"
+                }
+            }
         }
     }
 }
@@ -2851,6 +2862,16 @@ data class WebSocketTransportConfig(
     val host: String = "0.0.0.0",
     val stopGraceMillis: Long = 1_000L,
     val stopTimeoutMillis: Long = 2_000L,
+    /** Maximum number of concurrent WebSocket connections before new connections are rejected. */
+    val maxConnections: Int = 5000,
+    /** Maximum concurrent WebSocket connections from a single remote IP (0 disables the per-IP cap). */
+    val maxConnectionsPerIp: Int = 30,
+    /** Server→client ping interval in ms; also drives dead-peer detection (0 disables pings). */
+    val pingPeriodMillis: Long = 15_000L,
+    /** Time to wait for a pong before closing the connection, in ms. Defends against slow-loris holds. */
+    val pongTimeoutMillis: Long = 30_000L,
+    /** Maximum inbound WebSocket frame size in bytes. Frames larger than this are rejected. */
+    val maxFrameBytes: Long = 65_536L,
 )
 
 data class DemoConfig(
@@ -2871,6 +2892,12 @@ data class ObservabilityConfig(
 data class AdminConfig(
     /** Enable the admin HTTP dashboard. Requires a non-blank [token]. */
     val enabled: Boolean = false,
+    /**
+     * Bind address for the admin dashboard. Defaults to loopback so the privileged API (grant/revoke
+     * staff, broadcast, hot-reload, full player PII) is not reachable from the network unless an
+     * operator deliberately exposes it. Use a reverse proxy or set to `0.0.0.0` to expose it.
+     */
+    val host: String = "127.0.0.1",
     /** Port the admin dashboard listens on. */
     val port: Int = 9091,
     /** Bearer/Basic-auth password required for every admin request. */

--- a/src/main/kotlin/dev/ambon/engine/PasswordHasher.kt
+++ b/src/main/kotlin/dev/ambon/engine/PasswordHasher.kt
@@ -9,7 +9,12 @@ interface PasswordHasher {
 }
 
 object BCryptPasswordHasher : PasswordHasher {
-    override fun hash(password: String): String = BCrypt.hashpw(password, BCrypt.gensalt())
+    // Work factor (log2 rounds). 12 ≈ a few hundred ms/hash on modern hardware — materially slows
+    // offline cracking of a leaked hash versus jBCrypt's default of 10. Existing hashes keep their
+    // own embedded cost and still verify; only newly created/changed passwords use the new factor.
+    private const val BCRYPT_COST = 12
+
+    override fun hash(password: String): String = BCrypt.hashpw(password, BCrypt.gensalt(BCRYPT_COST))
 
     override fun verify(
         password: String,

--- a/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
@@ -934,7 +934,10 @@ class PlayerRegistry(
 
     private fun isValidPassword(password: String): Boolean {
         if (password.isBlank()) return false
-        if (password.length > 72) return false
+        // BCrypt silently truncates the input at 72 *bytes*. Validating in UTF-8 bytes (not UTF-16
+        // chars) prevents two passwords that share a 72-byte prefix — easy to hit with multi-byte
+        // characters — from being accepted as interchangeable.
+        if (password.toByteArray(Charsets.UTF_8).size > 72) return false
         return true
     }
 

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -939,7 +939,11 @@ object CommandParser {
             } else {
                 val goldMatch = Regex("^(\\d+)\\s+gold$", RegexOption.IGNORE_CASE).matchEntire(trimmed)
                 if (goldMatch != null) {
-                    Command.TradeOfferGold(goldMatch.groupValues[1].toLong())
+                    // toLongOrNull guards against overflow on huge digit strings; an unguarded toLong()
+                    // here throws NumberFormatException up into the engine tick loop, aborting the tick
+                    // for every player.
+                    val amount = goldMatch.groupValues[1].toLongOrNull()
+                    if (amount == null) Command.Invalid(line, "trade offer <amount> gold") else Command.TradeOfferGold(amount)
                 } else {
                     Command.TradeOffer(trimmed)
                 }

--- a/src/main/kotlin/dev/ambon/engine/events/GmcpEventHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/GmcpEventHandler.kt
@@ -19,6 +19,9 @@ import dev.ambon.engine.toGmcpPeek
 import dev.ambon.metrics.GameMetrics
 import io.github.oshai.kotlinlogging.KLogger
 
+/** Upper bound on the number of GMCP package names a single session may advertise via Supports.Set. */
+private const val MAX_GMCP_PACKAGE_ENTRIES = 256
+
 class GmcpEventHandler(
     private val gmcpSessions: MutableMap<SessionId, MutableSet<String>>,
     private val players: PlayerRegistry,
@@ -39,7 +42,20 @@ class GmcpEventHandler(
     private val logger: KLogger,
     private val metrics: GameMetrics = GameMetrics.noop(),
 ) {
-    private val gmcpJson = jacksonObjectMapper()
+    // GMCP envelopes arrive from untrusted clients and are parsed on the single-threaded engine
+    // dispatcher, so a maliciously deep / huge document could steal tick time. Clamp the parser's
+    // structural limits well below anything a legitimate client sends.
+    private val gmcpJson =
+        jacksonObjectMapper().apply {
+            factory.setStreamReadConstraints(
+                com.fasterxml.jackson.core.StreamReadConstraints
+                    .builder()
+                    .maxNestingDepth(32)
+                    .maxStringLength(16_384)
+                    .maxNumberLength(100)
+                    .build(),
+            )
+        }
 
     suspend fun onGmcpReceived(ev: InboundEvent.GmcpReceived) {
         metrics.onGmcpHandlerEvent()
@@ -137,7 +153,14 @@ class GmcpEventHandler(
     private fun parseGmcpPackageList(jsonData: String): List<String> =
         try {
             val entries: List<String> = gmcpJson.readValue(jsonData)
-            entries.map { it.trim().substringBefore(' ') }.filter { it.isNotBlank() }
+            entries
+                .asSequence()
+                .map { it.trim().substringBefore(' ') }
+                .filter { it.isNotBlank() }
+                // Cap the supported-package list so a client cannot force the engine to track an
+                // unbounded set of package names per session.
+                .take(MAX_GMCP_PACKAGE_ENTRIES)
+                .toList()
         } catch (e: Exception) {
             logger.warn { "Failed to parse GMCP package list as JSON array, ignoring: ${e.message}" }
             emptyList()

--- a/src/main/kotlin/dev/ambon/redis/RedisConnectionManager.kt
+++ b/src/main/kotlin/dev/ambon/redis/RedisConnectionManager.kt
@@ -11,6 +11,23 @@ import io.lettuce.core.pubsub.StatefulRedisPubSubConnection
 
 private val log = KotlinLogging.logger {}
 
+/**
+ * Strips any `user:password@` userinfo from a Redis URI so the AUTH password is never written to
+ * logs. Production Redis credentials are commonly supplied inline as `redis://:secret@host:6379`.
+ * Returns the input unchanged if it carries no userinfo or cannot be parsed.
+ */
+internal fun redactRedisUri(uri: String): String {
+    val schemeIdx = uri.indexOf("://")
+    if (schemeIdx < 0) return uri
+    val afterScheme = schemeIdx + 3
+    // Userinfo lives in the authority component (between "://" and the next '/'). Split on the LAST
+    // '@' inside it so an unencoded '@' in the password is redacted too.
+    val authorityEnd = uri.indexOf('/', afterScheme).let { if (it < 0) uri.length else it }
+    val atIdx = uri.lastIndexOf('@', authorityEnd - 1)
+    if (atIdx < afterScheme) return uri
+    return uri.substring(0, afterScheme) + "***@" + uri.substring(atIdx + 1)
+}
+
 class RedisConnectionManager(
     private val config: RedisConfig,
 ) : AutoCloseable,
@@ -34,9 +51,9 @@ class RedisConnectionManager(
             connection = conn
             commands = conn.sync()
             asyncCommands = conn.async()
-            log.info { "Redis connection established (uri=${config.uri})" }
+            log.info { "Redis connection established (uri=${redactRedisUri(config.uri)})" }
         } catch (e: Exception) {
-            log.warn(e) { "Redis connection failed - operating without Redis cache (uri=${config.uri})" }
+            log.warn(e) { "Redis connection failed - operating without Redis cache (uri=${redactRedisUri(config.uri)})" }
             commands = null
             asyncCommands = null
         }

--- a/src/main/kotlin/dev/ambon/sharding/RedisInterEngineBus.kt
+++ b/src/main/kotlin/dev/ambon/sharding/RedisInterEngineBus.kt
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import dev.ambon.bus.BusPublisher
 import dev.ambon.bus.BusSubscriberSetup
+import dev.ambon.hmacSha256
+import dev.ambon.isValidHmac
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ReceiveChannel
@@ -13,6 +15,10 @@ private val log = KotlinLogging.logger {}
 /**
  * Redis pub/sub envelope. Carries the inter-engine message, the sender's
  * engine ID, and an optional target engine ID (null = broadcast).
+ *
+ * [signature] is an HMAC-SHA256 over [senderEngineId], [targetEngineId], and [payload] under the
+ * cluster shared secret. Receivers drop any envelope whose signature does not verify, so a third
+ * party with Redis pub/sub access cannot forge handoffs, kicks, broadcasts, or shutdowns.
  */
 data class InterEngineEnvelope(
     val senderEngineId: String = "",
@@ -20,6 +26,7 @@ data class InterEngineEnvelope(
     val targetEngineId: String? = null,
     // JSON-serialized InterEngineMessage
     val payload: String = "",
+    val signature: String = "",
 )
 
 /**
@@ -35,6 +42,7 @@ class RedisInterEngineBus(
     private val publisher: BusPublisher,
     private val subscriberSetup: BusSubscriberSetup,
     private val mapper: ObjectMapper,
+    private val sharedSecret: String,
     private val channelPrefix: String = "ambon:engine",
     capacity: Int = 1_000,
 ) : InterEngineBus {
@@ -58,14 +66,22 @@ class RedisInterEngineBus(
         targetEngineId: String?,
         message: InterEngineMessage,
     ) {
+        val payload = mapper.writeValueAsString(message)
         val envelope =
             InterEngineEnvelope(
                 senderEngineId = engineId,
                 targetEngineId = targetEngineId,
-                payload = mapper.writeValueAsString(message),
+                payload = payload,
+                signature = hmacSha256(sharedSecret, signingPayload(engineId, targetEngineId, payload)),
             )
         publisher.publish(channel, mapper.writeValueAsString(envelope))
     }
+
+    private fun signingPayload(
+        senderEngineId: String,
+        targetEngineId: String?,
+        payload: String,
+    ): String = "$senderEngineId\n${targetEngineId ?: ""}\n$payload"
 
     override fun incoming(): ReceiveChannel<InterEngineMessage> = channel
 
@@ -84,6 +100,12 @@ class RedisInterEngineBus(
             // Skip our own broadcast messages (but not targeted messages — those
             // shouldn't be self-sent in practice, but handle gracefully).
             if (envelope.targetEngineId == null && envelope.senderEngineId == engineId) return
+
+            val signingPayload = signingPayload(envelope.senderEngineId, envelope.targetEngineId, envelope.payload)
+            if (!isValidHmac(sharedSecret, signingPayload, envelope.signature)) {
+                log.warn { "Dropping inter-engine message with invalid signature (sender=${envelope.senderEngineId})" }
+                return
+            }
 
             val message = mapper.readValue<InterEngineMessage>(envelope.payload)
             val sent = channel.trySend(message)

--- a/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
+++ b/src/main/kotlin/dev/ambon/transport/KtorWebSocketTransport.kt
@@ -9,12 +9,14 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.server.application.Application
 import io.ktor.server.application.call
+import io.ktor.server.application.createApplicationPlugin
 import io.ktor.server.application.install
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.http.content.staticResources
 import io.ktor.server.netty.Netty
 import io.ktor.server.netty.NettyApplicationEngine
+import io.ktor.server.plugins.origin
 import io.ktor.server.response.respondRedirect
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
@@ -31,7 +33,9 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
 private val log = KotlinLogging.logger {}
@@ -89,6 +93,43 @@ internal suspend fun writeCoalescedOutboundFrames(
     }
 }
 
+/**
+ * Bounds concurrent WebSocket connections globally and per source IP. Unauthenticated `/ws`
+ * upgrades each allocate a session, channel, and coroutines, so without a cap a single host could
+ * exhaust memory / file descriptors. [tryAcquire] reserves a slot atomically (or returns false to
+ * reject) and [release] frees it on disconnect.
+ */
+internal class WsConnectionLimiter(
+    private val maxTotal: Int,
+    private val maxPerIp: Int,
+) {
+    private val total = AtomicInteger(0)
+    private val perIp = ConcurrentHashMap<String, AtomicInteger>()
+
+    fun tryAcquire(ip: String): Boolean {
+        if (total.incrementAndGet() > maxTotal) {
+            total.decrementAndGet()
+            return false
+        }
+        if (maxPerIp <= 0) return true
+        val counter = perIp.computeIfAbsent(ip) { AtomicInteger(0) }
+        if (counter.incrementAndGet() > maxPerIp) {
+            counter.decrementAndGet()
+            total.decrementAndGet()
+            return false
+        }
+        return true
+    }
+
+    fun release(ip: String) {
+        total.decrementAndGet()
+        if (maxPerIp <= 0) return
+        perIp.computeIfPresent(ip) { _, counter ->
+            if (counter.decrementAndGet() <= 0) null else counter
+        }
+    }
+}
+
 class KtorWebSocketTransport(
     private val port: Int,
     private val inbound: InboundBus,
@@ -101,6 +142,11 @@ class KtorWebSocketTransport(
     private val maxLineLen: Int = 1024,
     private val maxNonPrintablePerLine: Int = 32,
     private val maxInboundBackpressureFailures: Int = 3,
+    private val maxConnections: Int = 5000,
+    private val maxConnectionsPerIp: Int = 30,
+    private val pingPeriodMillis: Long = 15_000L,
+    private val pongTimeoutMillis: Long = 30_000L,
+    private val maxFrameBytes: Long = 65_536L,
     private val prometheusRegistry: PrometheusMeterRegistry? = null,
     private val metricsEndpoint: String = "/metrics",
     private val metrics: GameMetrics = GameMetrics.noop(),
@@ -118,6 +164,11 @@ class KtorWebSocketTransport(
                     maxLineLen = maxLineLen,
                     maxNonPrintablePerLine = maxNonPrintablePerLine,
                     maxInboundBackpressureFailures = maxInboundBackpressureFailures,
+                    maxConnections = maxConnections,
+                    maxConnectionsPerIp = maxConnectionsPerIp,
+                    pingPeriodMillis = pingPeriodMillis,
+                    pongTimeoutMillis = pongTimeoutMillis,
+                    maxFrameBytes = maxFrameBytes,
                     prometheusRegistry = prometheusRegistry,
                     metricsEndpoint = metricsEndpoint,
                     metrics = metrics,
@@ -139,11 +190,28 @@ internal fun Application.ambonMUDWebModule(
     maxLineLen: Int = 1024,
     maxNonPrintablePerLine: Int = 32,
     maxInboundBackpressureFailures: Int = 3,
+    maxConnections: Int = 5000,
+    maxConnectionsPerIp: Int = 30,
+    pingPeriodMillis: Long = 15_000L,
+    pongTimeoutMillis: Long = 30_000L,
+    maxFrameBytes: Long = 65_536L,
     prometheusRegistry: PrometheusMeterRegistry? = null,
     metricsEndpoint: String = "/metrics",
     metrics: GameMetrics = GameMetrics.noop(),
 ) {
-    install(WebSockets)
+    install(WebSockets) {
+        // Server-driven pings detect dead/slow-loris peers that hold a connection open without
+        // sending data, so they are reaped instead of consuming a slot indefinitely.
+        if (pingPeriodMillis > 0) this.pingPeriodMillis = pingPeriodMillis
+        if (pongTimeoutMillis > 0) this.timeoutMillis = pongTimeoutMillis
+        // Cap inbound frame size at the protocol layer as defence-in-depth alongside the per-frame
+        // check in bridgeWebSocketSession.
+        maxFrameSize = maxFrameBytes
+    }
+
+    install(securityHeadersPlugin())
+
+    val connectionLimiter = WsConnectionLimiter(maxConnections, maxConnectionsPerIp)
 
     routing {
         if (prometheusRegistry != null) {
@@ -165,16 +233,26 @@ internal fun Application.ambonMUDWebModule(
                     return@webSocket
                 }
             }
-            bridgeWebSocketSession(
-                inbound = inbound,
-                outboundRouter = outboundRouter,
-                sessionIdFactory = sessionIdFactory,
-                sessionOutboundQueueCapacity = sessionOutboundQueueCapacity,
-                maxLineLen = maxLineLen,
-                maxNonPrintablePerLine = maxNonPrintablePerLine,
-                maxInboundBackpressureFailures = maxInboundBackpressureFailures,
-                metrics = metrics,
-            )
+            val remoteIp = call.request.origin.remoteHost
+            if (!connectionLimiter.tryAcquire(remoteIp)) {
+                log.warn { "WebSocket rejected: connection limit reached for remoteIp=$remoteIp" }
+                close(CloseReason(CloseReason.Codes.TRY_AGAIN_LATER, "Connection limit reached"))
+                return@webSocket
+            }
+            try {
+                bridgeWebSocketSession(
+                    inbound = inbound,
+                    outboundRouter = outboundRouter,
+                    sessionIdFactory = sessionIdFactory,
+                    sessionOutboundQueueCapacity = sessionOutboundQueueCapacity,
+                    maxLineLen = maxLineLen,
+                    maxNonPrintablePerLine = maxNonPrintablePerLine,
+                    maxInboundBackpressureFailures = maxInboundBackpressureFailures,
+                    metrics = metrics,
+                )
+            } finally {
+                connectionLimiter.release(remoteIp)
+            }
         }
 
         get("/v3") {
@@ -431,6 +509,46 @@ internal fun tryParseGmcpEnvelope(text: String): Pair<String, String>? {
 
 private const val MAX_CLOSE_REASON_LENGTH = 123
 private const val MAX_WS_FRAME_SIZE = 65_536
+
+/**
+ * Content-Security-Policy for the served web client. `frame-ancestors 'none'` blocks clickjacking,
+ * `object-src 'none'` / `base-uri 'self'` close common injection vectors, and `img/media/connect`
+ * are constrained to self + HTTPS so painted-art and audio assets (Cloudflare R2) keep working while
+ * arbitrary exfiltration origins are disallowed. `script-src`/`style-src` retain `'unsafe-inline'`
+ * because the Vite bundle inlines a module-preload polyfill and the React UI uses inline style
+ * attributes; tightening these to nonces/hashes is a follow-up. The client itself performs no HTML
+ * interpolation of untrusted text (all rendering goes through React escaping / the xterm canvas).
+ */
+private val WEB_CONTENT_SECURITY_POLICY =
+    listOf(
+        "default-src 'self'",
+        "base-uri 'self'",
+        "object-src 'none'",
+        "frame-ancestors 'none'",
+        "script-src 'self' 'unsafe-inline'",
+        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+        "font-src 'self' https://fonts.gstatic.com data:",
+        "img-src 'self' https: data: blob:",
+        "media-src 'self' https: data: blob:",
+        "connect-src 'self' ws: wss: https:",
+        "worker-src 'self' blob:",
+        "manifest-src 'self'",
+    ).joinToString("; ")
+
+/**
+ * Adds defence-in-depth security response headers (CSP, nosniff, frame/referrer policy) to every
+ * HTTP response served by the web module.
+ */
+internal fun securityHeadersPlugin() =
+    createApplicationPlugin(name = "AmbonSecurityHeaders") {
+        onCall { call ->
+            val headers = call.response.headers
+            headers.append("Content-Security-Policy", WEB_CONTENT_SECURITY_POLICY)
+            headers.append("X-Content-Type-Options", "nosniff")
+            headers.append("X-Frame-Options", "DENY")
+            headers.append("Referrer-Policy", "no-referrer")
+        }
+    }
 
 /**
  * Validates that an Origin header is consistent with the request Host.

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2562,6 +2562,11 @@ ambonmud:
       host: 0.0.0.0
       stopGraceMillis: 1000
       stopTimeoutMillis: 2000
+      maxConnections: 5000
+      maxConnectionsPerIp: 30
+      pingPeriodMillis: 15000
+      pongTimeoutMillis: 30000
+      maxFrameBytes: 65536
     maxInboundBackpressureFailures: 3
   demo:
     autoLaunchBrowser: false
@@ -2575,6 +2580,7 @@ ambonmud:
     staticTags: {}
   admin:
     enabled: false
+    host: 127.0.0.1
     port: 9091
     token: ""
     basePath: /

--- a/src/test/kotlin/dev/ambon/SecurityHardeningTest.kt
+++ b/src/test/kotlin/dev/ambon/SecurityHardeningTest.kt
@@ -1,0 +1,56 @@
+package dev.ambon
+
+import dev.ambon.redis.redactRedisUri
+import dev.ambon.transport.WsConnectionLimiter
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SecurityHardeningTest {
+    @Test
+    fun `redactRedisUri strips inline credentials`() {
+        assertEquals("redis://***@host:6379", redactRedisUri("redis://:s3cret@host:6379"))
+        assertEquals("rediss://***@host:6380/0", redactRedisUri("rediss://user:p@ss@host:6380/0"))
+    }
+
+    @Test
+    fun `redactRedisUri leaves credential-free URIs unchanged`() {
+        assertEquals("redis://localhost:6379", redactRedisUri("redis://localhost:6379"))
+        assertEquals("redis://localhost:6379/0", redactRedisUri("redis://localhost:6379/0"))
+    }
+
+    @Test
+    fun `isValidHmac accepts a correct signature and rejects forgeries`() {
+        val sig = hmacSha256("secret", "payload")
+        assertTrue(isValidHmac("secret", "payload", sig))
+        assertFalse(isValidHmac("secret", "payload", sig.dropLast(1) + "0"))
+        assertFalse(isValidHmac("secret", "payload", ""))
+        assertFalse(isValidHmac("wrong", "payload", sig))
+        // A truncated guess (different length) must also be rejected, not throw.
+        assertFalse(isValidHmac("secret", "payload", "abc"))
+    }
+
+    @Test
+    fun `WsConnectionLimiter enforces the global cap`() {
+        val limiter = WsConnectionLimiter(maxTotal = 2, maxPerIp = 0)
+        assertTrue(limiter.tryAcquire("1.1.1.1"))
+        assertTrue(limiter.tryAcquire("2.2.2.2"))
+        assertFalse(limiter.tryAcquire("3.3.3.3"))
+        limiter.release("1.1.1.1")
+        assertTrue(limiter.tryAcquire("3.3.3.3"))
+    }
+
+    @Test
+    fun `WsConnectionLimiter enforces the per-IP cap independently of the global cap`() {
+        val limiter = WsConnectionLimiter(maxTotal = 100, maxPerIp = 2)
+        assertTrue(limiter.tryAcquire("9.9.9.9"))
+        assertTrue(limiter.tryAcquire("9.9.9.9"))
+        assertFalse(limiter.tryAcquire("9.9.9.9"))
+        // A different IP is unaffected.
+        assertTrue(limiter.tryAcquire("8.8.8.8"))
+        // Releasing one frees a slot for that IP.
+        limiter.release("9.9.9.9")
+        assertTrue(limiter.tryAcquire("9.9.9.9"))
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
@@ -16,6 +16,15 @@ class CommandParserTest {
     }
 
     @Test
+    fun `trade offer gold parses valid amounts and rejects overflow without throwing`() {
+        assertEquals(Command.TradeOfferGold(100L), CommandParser.parse("trade offer 100 gold"))
+        // A digit string larger than Long.MAX_VALUE must yield Invalid, not throw NumberFormatException
+        // up into the engine tick loop (which would abort the tick for every player).
+        val huge = CommandParser.parse("trade offer 99999999999999999999999999 gold")
+        assertTrue(huge is Command.Invalid, "expected Invalid for overflowing gold amount, got $huge")
+    }
+
+    @Test
     fun `parses core commands and ignores whitespace`() {
         assertEquals(Command.Help, CommandParser.parse("help"))
         assertEquals(Command.Help, CommandParser.parse("  ?  "))

--- a/src/test/kotlin/dev/ambon/sharding/RedisInterEngineBusSignatureTest.kt
+++ b/src/test/kotlin/dev/ambon/sharding/RedisInterEngineBusSignatureTest.kt
@@ -1,0 +1,121 @@
+package dev.ambon.sharding
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import dev.ambon.bus.BusPublisher
+import dev.ambon.bus.BusSubscriberSetup
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * The inter-engine Redis bus must authenticate every message: anyone with Redis pub/sub access can
+ * otherwise forge player handoffs, kicks, broadcasts, or shutdowns. These tests drive one engine's
+ * published envelope into another engine's receiver and assert that only HMAC-valid envelopes are
+ * delivered.
+ */
+class RedisInterEngineBusSignatureTest {
+    private val mapper = jacksonObjectMapper()
+    private val secret = "cluster-shared-secret"
+    private val broadcastChannel = "ambon:engine:broadcast"
+
+    private class Capture {
+        var published: String? = null
+        val publisher = BusPublisher { _, msg -> published = msg }
+    }
+
+    private fun receiverBus(
+        engineId: String,
+        sharedSecret: String,
+        onReceiver: (((String) -> Unit)) -> Unit,
+    ): RedisInterEngineBus {
+        val subscriber =
+            BusSubscriberSetup { channel, onMessage ->
+                if (channel == broadcastChannel) onReceiver(onMessage)
+            }
+        return RedisInterEngineBus(
+            engineId = engineId,
+            publisher = BusPublisher { _, _ -> },
+            subscriberSetup = subscriber,
+            mapper = mapper,
+            sharedSecret = sharedSecret,
+        )
+    }
+
+    @Test
+    fun `delivers a correctly signed broadcast to another engine`() =
+        runBlocking {
+            val capture = Capture()
+            val sender =
+                RedisInterEngineBus(
+                    engineId = "engine-1",
+                    publisher = capture.publisher,
+                    subscriberSetup = BusSubscriberSetup { _, _ -> },
+                    mapper = mapper,
+                    sharedSecret = secret,
+                )
+            sender.start()
+
+            var receiver: ((String) -> Unit)? = null
+            val recvBus = receiverBus("engine-2", secret) { receiver = it }
+            recvBus.start()
+
+            sender.broadcast(InterEngineMessage.GlobalBroadcast(BroadcastType.ANNOUNCEMENT, "System", "hello"))
+            receiver!!.invoke(capture.published!!)
+
+            val got = recvBus.incoming().tryReceive().getOrNull()
+            assertEquals(
+                InterEngineMessage.GlobalBroadcast(BroadcastType.ANNOUNCEMENT, "System", "hello"),
+                got,
+            )
+        }
+
+    @Test
+    fun `drops a broadcast whose payload was tampered after signing`() =
+        runBlocking {
+            val capture = Capture()
+            val sender =
+                RedisInterEngineBus(
+                    engineId = "engine-1",
+                    publisher = capture.publisher,
+                    subscriberSetup = BusSubscriberSetup { _, _ -> },
+                    mapper = mapper,
+                    sharedSecret = secret,
+                )
+            sender.start()
+            sender.broadcast(InterEngineMessage.GlobalBroadcast(BroadcastType.ANNOUNCEMENT, "System", "hello"))
+
+            // Tamper with the signed payload — flip the broadcast text — keeping the stale signature.
+            val tampered = capture.published!!.replace("hello", "you-are-hacked")
+
+            var receiver: ((String) -> Unit)? = null
+            val recvBus = receiverBus("engine-2", secret) { receiver = it }
+            recvBus.start()
+            receiver!!.invoke(tampered)
+
+            assertNull(recvBus.incoming().tryReceive().getOrNull())
+        }
+
+    @Test
+    fun `drops a broadcast signed with the wrong shared secret`() =
+        runBlocking {
+            val capture = Capture()
+            val attacker =
+                RedisInterEngineBus(
+                    engineId = "engine-evil",
+                    publisher = capture.publisher,
+                    subscriberSetup = BusSubscriberSetup { _, _ -> },
+                    mapper = mapper,
+                    sharedSecret = "wrong-secret",
+                )
+            attacker.start()
+            attacker.broadcast(InterEngineMessage.ShutdownRequest("attacker"))
+
+            var receiver: ((String) -> Unit)? = null
+            val recvBus = receiverBus("engine-2", secret) { receiver = it }
+            recvBus.start()
+            receiver!!.invoke(capture.published!!)
+
+            assertNull(recvBus.incoming().tryReceive().getOrNull())
+        }
+}


### PR DESCRIPTION
## Summary

A full security audit of the server's attack surface (auth, authorization, injection/persistence, transport/DoS, web client, gRPC/secrets, and game-economy) was run. The persistence and economy layers came back largely clean (parameterized Exposed queries, ID-keyed file paths, safe Jackson YAML, escrow-based trades). This PR fixes the concrete, well-substantiated issues that were found. Each change is contained and test-covered; full unit + integration suites are green and ktlint passes.

## What's fixed

### Transport / DoS (critical)
- **WebSocket connection caps** — the `/ws` endpoint had **no** concurrent-connection limit (telnet did), so a single host could open unlimited unauthenticated sockets and exhaust memory/FDs. Added a global + per-IP `WsConnectionLimiter`, wired through config (`maxConnections`, `maxConnectionsPerIp`).
- **Slow-loris / dead peers** — configured WebSocket `pingPeriod`/`timeout` + `maxFrameSize`, so connections held open without traffic are reaped.
- **GMCP parse DoS** — the inbound GMCP JSON (parsed on the single-threaded engine dispatcher) now has clamped Jackson `StreamReadConstraints` (nesting depth, string/number length) and a capped `Supports.Set` package count.

### Inter-engine trust (high)
- The inter-engine Redis pub/sub bus was **unauthenticated** — anyone with Redis access could forge `PlayerHandoff` (inject a player with arbitrary stats/inventory), `KickRequest`, `GlobalBroadcast`, or `ShutdownRequest`. Every envelope is now **HMAC-SHA256 signed and verified** under the cluster shared secret; bad signatures are dropped.

### Crypto / secrets (medium)
- `isValidHmac` (Redis bus) and the admin Basic-auth check now use **constant-time, length-safe** comparison — no token-length timing oracle.
- **Redis URIs are redacted** before logging (inline `:password@` credentials no longer hit logs).

### Config hardening (high / medium)
- **Admin HTTP dashboard binds to `127.0.0.1` by default** (was `0.0.0.0`), so the grant-staff / broadcast / hot-reload / player-PII API isn't network-reachable unless deliberately exposed.
- **productionMode** now rejects placeholder / too-short gRPC shared secrets (previously only Redis/DB/admin secrets were checked).

### Web client (medium)
- Added **CSP + `X-Content-Type-Options` + `X-Frame-Options` + `Referrer-Policy`** to served responses (clickjacking protection, asset/connect origin constraints, defense-in-depth). The client already escapes all untrusted text, so this is hardening rather than an active-XSS fix.

### Correctness / abuse
- `trade offer <huge-number> gold` previously threw `NumberFormatException` up into the engine tick loop, **aborting that tick for every player**; it now parses to `Invalid`.
- BCrypt work factor raised **10 → 12**; password length validated in **UTF-8 bytes** (BCrypt silently truncates at 72 bytes, not chars). Existing hashes keep their embedded cost and still verify.

## Tests
- `SecurityHardeningTest` — Redis URI redaction, constant-time HMAC accept/reject, connection-limiter global + per-IP semantics.
- `RedisInterEngineBusSignatureTest` — delivers a valid signed broadcast; drops tampered-payload and wrong-secret envelopes.
- `CommandParserTest` — gold-amount overflow yields `Invalid` without throwing.
- Full `test` + `integrationTest` green; `ktlintCheck` clean.

## Deliberately scoped out (recommended follow-ups)
These are larger or riskier and worth separate PRs:
- **gRPC TLS** — the gRPC server is plaintext-only; `allowPlaintext=false` has no working encrypted path. HMAC currently travels in the clear (replayable within the timestamp window). Needs real `TlsServerCredentials`/`TlsChannelCredentials` wiring.
- **Login brute-force lockout & enumeration** — login attempt limits are per-session and reset on reconnect; the new-account flow reveals which names exist, and BCrypt runs only for existing accounts (timing oracle). Wants per-account/per-IP throttling + a uniform challenge + dummy-hash verify.
- **Offline economic credits** — auction/mail/lottery credit offline players via a `findByName().copy().save()` read-modify-write across a suspend boundary, which can lose a credit under interleaving. Wants an atomic delta op in the caching repo.
- **Metrics endpoint** — `/metrics` is unauthenticated when enabled (off by default here). Consider auth or loopback-only.
- **CSP `script-src`** — kept `'unsafe-inline'` because the Vite bundle inlines a module-preload polyfill; tightening to nonces/hashes is a follow-up.