### PR TITLE
Rare & conditional mob system

### DIFF
--- a/docs/WORLD_YAML_SPEC.md
+++ b/docs/WORLD_YAML_SPEC.md
@@ -195,8 +195,10 @@ Independently of `condition`, the server may spawn any COMBAT mob as a rare
 cosmetic **variant** — a tinted/overlaid version with a flavor name prefix
 (e.g. *Shadow-touched giant rat*) and a modest HP/XP/loot bump. This guarantees
 explorers always have richer sightings to find even when no rare mob was
-hand-authored. Variants roll on live spawns (zone reset, post-death respawn,
-conditional spawn), not at cold start, and announce with reach scaled by rarity.
+hand-authored. Variants roll on every spawn — cold start (so a freshly-booted
+world is already seeded with a few to discover), zone reset, post-death respawn,
+and conditional spawn. Spawns into an occupied world announce with reach scaled
+by rarity; cold-start variants spawn silently, since nobody is connected yet.
 
 Set `rareVariants: false` to opt a mob out — appropriate for unique named bosses
 or strictly-themed creatures whose appearance should never be altered. The

--- a/docs/WORLD_YAML_SPEC.md
+++ b/docs/WORLD_YAML_SPEC.md
@@ -143,6 +143,8 @@ respawnSeconds: <long > 0, optional - seconds after death before this mob respaw
                 omit to rely on zone-wide reset only>
 image:          <string, optional - relative path under /images/>
 video:          <string, optional - relative path under /videos/, shown in context menu>
+rareVariants:   <bool, optional, default true - whether the server may spawn rare cosmetic variants of this mob>
+condition:      <SpawnCondition, optional - gates when this mob appears; see "Conditional spawning" below>
 ```
 
 `respawnSeconds` notes:
@@ -150,6 +152,7 @@ video:          <string, optional - relative path under /videos/, shown in conte
 - The respawn is silently cancelled if the zone resets first (the mob is already back in the registry).
 - If the origin room no longer exists at respawn time the respawn is silently skipped.
 - Players in the origin room see an arrival message when the mob reappears.
+- Ignored for condition-gated mobs (see below): their respawn is governed entirely by their condition.
 
 `Drop` entry:
 
@@ -157,6 +160,48 @@ video:          <string, optional - relative path under /videos/, shown in conte
 itemId: <item-id string, required>
 chance: <double in [0.0, 1.0], required>
 ```
+
+#### Conditional spawning (`condition`)
+
+A mob may be gated to only appear under specific world conditions — the classic
+"only seen at night", "only during a storm", or "only in winter" creature. When
+`condition` is present (and gates anything), the mob is **not** placed at world
+start; instead its entire lifecycle is owned by the conditional spawn handler:
+
+```yaml
+condition:
+  time:    [NIGHT]            # any of DAWN, DAY, DUSK, NIGHT; omit for any time
+  weather: [STORM, RAIN]      # any of the configured weather ids; omit for any weather
+  seasons: [WINTER]           # any of SPRING, SUMMER, AUTUMN, WINTER; omit for any season
+  events:  [blood_moon]       # any one of these world-event flags must be active; omit for none
+  chance:  0.25               # per-opportunity appearance probability (0.0–1.0); default 1.0
+```
+
+Semantics:
+- **Facets are AND-ed; values within a facet are OR-ed.** The example means
+  "at night, during a storm or rain, in winter".
+- An omitted facet means "any". A `condition` whose facets are all empty and
+  whose `chance` is `1.0` behaves like no condition at all.
+- While the gates hold, the handler rolls `chance` periodically; on success the
+  mob appears (with an arrival message, and a zone-wide shout for the sighting).
+- When any gate stops holding, the mob **fades out** at the next check — but
+  never while it is fighting a player.
+- Weather-gated mobs naturally only appear where players are present, because
+  per-zone weather only advances in zones that have occupants.
+
+#### Rare cosmetic variants (`rareVariants`)
+
+Independently of `condition`, the server may spawn any COMBAT mob as a rare
+cosmetic **variant** — a tinted/overlaid version with a flavor name prefix
+(e.g. *Shadow-touched giant rat*) and a modest HP/XP/loot bump. This guarantees
+explorers always have richer sightings to find even when no rare mob was
+hand-authored. Variants roll on live spawns (zone reset, post-death respawn,
+conditional spawn), not at cold start, and announce with reach scaled by rarity.
+
+Set `rareVariants: false` to opt a mob out — appropriate for unique named bosses
+or strictly-themed creatures whose appearance should never be altered. The
+archetype palette and base chance are operator-configurable under
+`ambonmud.engine.mobVariants` in `application.yaml`.
 
 `Behavior` entry:
 

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -1171,8 +1171,9 @@ data class MobVariantsConfig(
     val enabled: Boolean = true,
     /**
      * Base probability that an eligible mob rolls as a rare variant on each
-     * dynamic spawn opportunity (zone reset, post-death respawn, conditional
-     * spawn). Cold-start spawns are never rolled — variants are live sightings.
+     * spawn opportunity — cold start, zone reset, post-death respawn, and
+     * conditional spawn — so a freshly-booted world is already seeded with a
+     * few sightings to discover. Raise it for a denser initial population.
      */
     val chance: Double = 0.04,
     /** Variant archetypes keyed by ID, selected by [MobVariantDefinition.weight]. */

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -183,6 +183,15 @@ data class AppConfig(
         validateMobTier("standard", engine.mob.tiers.standard)
         validateMobTier("elite", engine.mob.tiers.elite)
         validateMobTier("boss", engine.mob.tiers.boss)
+
+        require(engine.season.cycleLengthMs > 0L) { "ambonMUD.engine.season.cycleLengthMs must be > 0" }
+        require(engine.mobVariants.chance in 0.0..1.0) { "ambonMUD.engine.mobVariants.chance must be in 0.0..1.0" }
+        engine.mobVariants.variants.forEach { (id, v) ->
+            require(v.weight >= 0.0) { "ambonMUD.engine.mobVariants.variants.$id.weight must be >= 0" }
+            require(v.announce in setOf("ROOM", "ZONE", "SERVER")) {
+                "ambonMUD.engine.mobVariants.variants.$id.announce must be ROOM, ZONE, or SERVER"
+            }
+        }
     }
 
     private fun validateEngineCombat() {
@@ -1142,6 +1151,154 @@ data class WorldTimeConfig(
     val nightHour: Int = 21,
 )
 
+data class SeasonConfig(
+    /**
+     * Real-time milliseconds for one full game year (all four seasons). Each
+     * season lasts a quarter of this. Default: 4 hours (1 hour per season).
+     */
+    val cycleLengthMs: Long = 14_400_000L,
+)
+
+/**
+ * Server-generated rare cosmetic variants. Every COMBAT-role mob can spawn as a
+ * rare variant (unless an author opts it out) so explorers always have richer
+ * sightings to find, even when content authors don't hand-author rare mobs.
+ *
+ * Variants are purely cosmetic plus a modest stat bump — a tint/overlay, a name
+ * prefix, and small HP/XP/loot multipliers.
+ */
+data class MobVariantsConfig(
+    val enabled: Boolean = true,
+    /**
+     * Base probability that an eligible mob rolls as a rare variant on each
+     * dynamic spawn opportunity (zone reset, post-death respawn, conditional
+     * spawn). Cold-start spawns are never rolled — variants are live sightings.
+     */
+    val chance: Double = 0.04,
+    /** Variant archetypes keyed by ID, selected by [MobVariantDefinition.weight]. */
+    val variants: Map<String, MobVariantDefinition> = DEFAULT_VARIANTS,
+) {
+    companion object {
+        val DEFAULT_VARIANTS: Map<String, MobVariantDefinition> = mapOf(
+            "albino" to MobVariantDefinition(
+                displayName = "Albino",
+                namePrefix = "Albino ",
+                tint = "#f5f0ff",
+                rarity = "uncommon",
+                weight = 3.0,
+                hpMultiplier = 1.2,
+                xpMultiplier = 1.3,
+                lootMultiplier = 1.2,
+                announce = "ZONE",
+            ),
+            "verdant" to MobVariantDefinition(
+                displayName = "Verdant",
+                namePrefix = "Verdant ",
+                tint = "#5fd17a",
+                rarity = "uncommon",
+                weight = 2.5,
+                hpMultiplier = 1.2,
+                xpMultiplier = 1.3,
+                lootMultiplier = 1.2,
+                announce = "ZONE",
+            ),
+            "shadow" to MobVariantDefinition(
+                displayName = "Shadow-touched",
+                namePrefix = "Shadow-touched ",
+                tint = "#6a4aa0",
+                overlay = "swirl",
+                rarity = "uncommon",
+                weight = 2.5,
+                hpMultiplier = 1.25,
+                xpMultiplier = 1.4,
+                lootMultiplier = 1.25,
+                announce = "ZONE",
+            ),
+            "ember" to MobVariantDefinition(
+                displayName = "Ember",
+                namePrefix = "Ember ",
+                tint = "#ff6a3c",
+                overlay = "embers",
+                rarity = "rare",
+                weight = 1.4,
+                hpMultiplier = 1.5,
+                xpMultiplier = 1.7,
+                lootMultiplier = 1.5,
+                announce = "ZONE",
+            ),
+            "glimmering" to MobVariantDefinition(
+                displayName = "Glimmering",
+                namePrefix = "Glimmering ",
+                tint = "#ffe8a3",
+                overlay = "sparkle",
+                rarity = "rare",
+                weight = 1.2,
+                hpMultiplier = 1.5,
+                xpMultiplier = 1.8,
+                lootMultiplier = 1.6,
+                announce = "ZONE",
+            ),
+            "frostbound" to MobVariantDefinition(
+                displayName = "Frostbound",
+                namePrefix = "Frostbound ",
+                tint = "#a3e4ff",
+                overlay = "frost",
+                rarity = "rare",
+                weight = 1.2,
+                hpMultiplier = 1.5,
+                xpMultiplier = 1.7,
+                lootMultiplier = 1.5,
+                announce = "ZONE",
+            ),
+            "spectral" to MobVariantDefinition(
+                displayName = "Spectral",
+                namePrefix = "Spectral ",
+                tint = "#bfeaff",
+                overlay = "mist",
+                rarity = "legendary",
+                weight = 0.4,
+                hpMultiplier = 2.0,
+                xpMultiplier = 2.5,
+                lootMultiplier = 2.0,
+                announce = "SERVER",
+            ),
+            "ancient" to MobVariantDefinition(
+                displayName = "Ancient",
+                namePrefix = "Ancient ",
+                tint = "#caa86a",
+                overlay = "swirl",
+                rarity = "legendary",
+                weight = 0.3,
+                hpMultiplier = 2.2,
+                xpMultiplier = 2.6,
+                lootMultiplier = 2.2,
+                announce = "SERVER",
+            ),
+        )
+    }
+}
+
+/** A single server-generated rare variant archetype. */
+data class MobVariantDefinition(
+    val displayName: String = "",
+    /** Prepended to the base mob name, e.g. "Shadow-touched ". */
+    val namePrefix: String = "",
+    /** CSS hex tint applied to the client sprite (multiply). Empty = no tint. */
+    val tint: String = "",
+    /** Client particle/overlay hint: swirl|embers|sparkle|frost|mist. Empty = none. */
+    val overlay: String = "",
+    /** uncommon|rare|legendary — flavor + default announce loudness. */
+    val rarity: String = "uncommon",
+    /** Relative selection weight among all variants. Higher = more common. */
+    val weight: Double = 1.0,
+    val hpMultiplier: Double = 1.0,
+    val xpMultiplier: Double = 1.0,
+    /** Multiplies drop chances (and gold) for this variant. */
+    val lootMultiplier: Double = 1.0,
+    /** Announcement scope on appearance: ROOM|ZONE|SERVER. */
+    val announce: String = "ZONE",
+)
+
 data class WeatherConfig(
     /** Minimum real-time ms between weather transitions per zone. */
     val minTransitionMs: Long = 300_000L,
@@ -1654,8 +1811,10 @@ data class EngineConfig(
     val bank: BankConfig = BankConfig(),
     val stylist: StylistConfig = StylistConfig(),
     val worldTime: WorldTimeConfig = WorldTimeConfig(),
+    val season: SeasonConfig = SeasonConfig(),
     val weather: WeatherConfig = WeatherConfig(),
     val worldEvents: WorldEventsConfig = WorldEventsConfig(),
+    val mobVariants: MobVariantsConfig = MobVariantsConfig(),
     val environment: EnvironmentConfig = EnvironmentConfig(),
     val friends: FriendsConfig = FriendsConfig(),
     val debug: EngineDebugConfig = EngineDebugConfig(),

--- a/src/main/kotlin/dev/ambon/domain/mob/MobState.kt
+++ b/src/main/kotlin/dev/ambon/domain/mob/MobState.kt
@@ -41,6 +41,17 @@ data class MobState(
     val threatMultiplier: Double = 0.0,
     override val level: Int = 1,
     override val role: MobRole = MobRole.COMBAT,
+    /** Server-generated rare variant id (e.g. "shadow"), or null for an ordinary mob. */
+    val variantId: String? = null,
+    /** Variant display label (e.g. "Shadow-touched") for UI; null when not a variant. */
+    val variantName: String? = null,
+    /** CSS hex tint the client multiplies onto the sprite; null/empty = none. */
+    val tint: String? = null,
+    /** Client particle/overlay hint: swirl|embers|sparkle|frost|mist; null/empty = none. */
+    val overlay: String? = null,
 ) : MobTemplate {
     val isPet: Boolean get() = ownerSessionId != null
+
+    /** True when this mob is a server-generated rare variant. */
+    val isVariant: Boolean get() = variantId != null
 }

--- a/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
@@ -63,6 +63,8 @@ data class MobTemplateDef(
     val tier: MobTierConfig? = null,
     /** Which stats the author explicitly set. Overrides stay fixed even when scaling shifts level. */
     val overrides: MobStatOverrides = MobStatOverrides(),
+    /** Whether the server may spawn rare cosmetic variants of this mob. */
+    val variantEligible: Boolean = true,
 ) : MobTemplate
 
 /**

--- a/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/MobSpawn.kt
@@ -65,6 +65,12 @@ data class MobTemplateDef(
     val overrides: MobStatOverrides = MobStatOverrides(),
     /** Whether the server may spawn rare cosmetic variants of this mob. */
     val variantEligible: Boolean = true,
+    /**
+     * When non-null, gates this mob's appearance on world conditions (time,
+     * weather, season, events, random chance). A condition where
+     * [SpawnCondition.isUnconditional] is true behaves like no condition at all.
+     */
+    val spawnCondition: SpawnCondition? = null,
 ) : MobTemplate
 
 /**

--- a/src/main/kotlin/dev/ambon/domain/world/SpawnCondition.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/SpawnCondition.kt
@@ -1,0 +1,57 @@
+package dev.ambon.domain.world
+
+import dev.ambon.engine.Season
+import dev.ambon.engine.TimePeriod
+
+/**
+ * An authored gate controlling when a mob is present in the world. A mob with a
+ * non-trivial condition has its entire spawn lifecycle owned by
+ * [dev.ambon.engine.ConditionalSpawnHandler]: it appears when every specified
+ * facet is satisfied (and a per-opportunity [chance] roll succeeds) and fades
+ * out — never mid-combat — once any facet stops holding.
+ *
+ * Each facet is independent: an empty set means "any". Specified facets are
+ * AND-ed together (time AND weather AND season AND an event flag), so
+ * `time=[NIGHT], weather=[STORM]` means "only at night during a storm".
+ */
+data class SpawnCondition(
+    /** Times of day during which the mob may appear. Empty = any time. */
+    val timePeriods: Set<TimePeriod> = emptySet(),
+    /** Weather type ids (e.g. "STORM", "SNOW") during which the mob may appear. Empty = any. */
+    val weather: Set<String> = emptySet(),
+    /** Seasons during which the mob may appear. Empty = any season. */
+    val seasons: Set<Season> = emptySet(),
+    /** World-event flags, any one of which must be active. Empty = no event requirement. */
+    val eventFlags: Set<String> = emptySet(),
+    /**
+     * Probability the mob actually appears on each spawn opportunity (a periodic
+     * check while the other gates hold). 1.0 = appears as soon as the gates do;
+     * lower values make it a rare, intermittent sighting.
+     */
+    val chance: Double = 1.0,
+) {
+    /** True when this condition gates nothing — i.e. the mob spawns like any ordinary mob. */
+    val isUnconditional: Boolean
+        get() = timePeriods.isEmpty() &&
+            weather.isEmpty() &&
+            seasons.isEmpty() &&
+            eventFlags.isEmpty() &&
+            chance >= 1.0
+
+    /**
+     * Whether the continuous gates (everything except the random [chance]) are
+     * currently satisfied. [chance] is rolled separately, per spawn opportunity.
+     */
+    fun gatesSatisfied(
+        period: TimePeriod,
+        weatherId: String,
+        season: Season,
+        activeEventFlags: Set<String>,
+    ): Boolean {
+        if (timePeriods.isNotEmpty() && period !in timePeriods) return false
+        if (weather.isNotEmpty() && weatherId !in weather) return false
+        if (seasons.isNotEmpty() && season !in seasons) return false
+        if (eventFlags.isNotEmpty() && eventFlags.none { it in activeEventFlags }) return false
+        return true
+    }
+}

--- a/src/main/kotlin/dev/ambon/domain/world/data/MobFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/MobFile.kt
@@ -49,4 +49,11 @@ data class MobFile(
      * variants (e.g. unique named bosses or strictly-themed creatures).
      */
     val rareVariants: Boolean = true,
+    /**
+     * Optional spawn condition gating when this mob appears: time of day,
+     * weather, season, world-event flags, and/or a random `chance`. When set to
+     * a non-trivial condition, the mob's entire spawn lifecycle is owned by the
+     * conditional spawn handler (it fades out when the condition ends).
+     */
+    val condition: SpawnConditionFile? = null,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/data/MobFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/MobFile.kt
@@ -43,4 +43,10 @@ data class MobFile(
     val spells: Map<String, MobSpellFile> = emptyMap(),
     /** If set, this spell replaces the mob's default melee attack. Must reference a key in [spells]. */
     val defaultAttack: String? = null,
+    /**
+     * Whether the server may spawn rare cosmetic variants of this mob. Defaults
+     * to true for combat mobs; set false to opt a mob out of auto-generated
+     * variants (e.g. unique named bosses or strictly-themed creatures).
+     */
+    val rareVariants: Boolean = true,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/data/SpawnConditionFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/SpawnConditionFile.kt
@@ -1,0 +1,27 @@
+package dev.ambon.domain.world.data
+
+/**
+ * YAML shape of a mob's spawn condition. Parsed into
+ * [dev.ambon.domain.world.SpawnCondition] by the world loader. All facets are
+ * optional; an omitted facet means "any". Example:
+ *
+ * ```yaml
+ * condition:
+ *   time: [NIGHT]
+ *   weather: [STORM]
+ *   seasons: [WINTER]
+ *   chance: 0.25
+ * ```
+ */
+data class SpawnConditionFile(
+    /** Times of day: DAWN, DAY, DUSK, NIGHT. */
+    val time: List<String> = emptyList(),
+    /** Weather type ids: CLEAR, RAIN, STORM, FOG, SNOW, WIND, … */
+    val weather: List<String> = emptyList(),
+    /** Seasons: SPRING, SUMMER, AUTUMN, WINTER. */
+    val seasons: List<String> = emptyList(),
+    /** World-event flags, any one of which activates the condition. */
+    val events: List<String> = emptyList(),
+    /** Per-opportunity appearance probability (0.0–1.0). Defaults to 1.0. */
+    val chance: Double = 1.0,
+)

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -474,6 +474,7 @@ object WorldLoader {
                         tier = tier,
                         overrides = overrides,
                         variantEligible = mf.rareVariants,
+                        spawnCondition = parseSpawnCondition(mf.condition, mobId.value),
                     )
 
                 expandPlacements(mobId, placementSources, zone, mergedSpawns)
@@ -1742,6 +1743,45 @@ object WorldLoader {
                 "$context has invalid category '$category'; valid values: $VALID_MOB_CATEGORIES",
             )
         }
+    }
+
+    private fun parseSpawnCondition(
+        file: dev.ambon.domain.world.data.SpawnConditionFile?,
+        mobId: String,
+    ): dev.ambon.domain.world.SpawnCondition? {
+        if (file == null) return null
+        require(file.chance in 0.0..1.0) {
+            "Mob '$mobId' condition.chance must be in 0.0..1.0, got ${file.chance}"
+        }
+        val periods = file.time.map { raw ->
+            try {
+                dev.ambon.engine.TimePeriod.valueOf(raw.trim().uppercase())
+            } catch (e: IllegalArgumentException) {
+                throw WorldLoadException(
+                    "Mob '$mobId' condition.time has invalid value '$raw'; valid: ${dev.ambon.engine.TimePeriod.entries.joinToString {
+                        it.name
+                    }}",
+                )
+            }
+        }.toSet()
+        val seasons = file.seasons.map { raw ->
+            try {
+                dev.ambon.engine.Season.valueOf(raw.trim().uppercase())
+            } catch (e: IllegalArgumentException) {
+                throw WorldLoadException(
+                    "Mob '$mobId' condition.seasons has invalid value '$raw'; valid: ${dev.ambon.engine.Season.entries.joinToString {
+                        it.name
+                    }}",
+                )
+            }
+        }.toSet()
+        return dev.ambon.domain.world.SpawnCondition(
+            timePeriods = periods,
+            weather = file.weather.map { it.trim().uppercase() }.filter { it.isNotEmpty() }.toSet(),
+            seasons = seasons,
+            eventFlags = file.events.map { it.trim() }.filter { it.isNotEmpty() }.toSet(),
+            chance = file.chance,
+        )
     }
 
     private fun parseCraftingStationType(

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -473,6 +473,7 @@ object WorldLoader {
                         },
                         tier = tier,
                         overrides = overrides,
+                        variantEligible = mf.rareVariants,
                     )
 
                 expandPlacements(mobId, placementSources, zone, mergedSpawns)

--- a/src/main/kotlin/dev/ambon/engine/ConditionalSpawnHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/ConditionalSpawnHandler.kt
@@ -1,0 +1,134 @@
+package dev.ambon.engine
+
+import dev.ambon.bus.OutboundBus
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.world.MobSpawn
+import dev.ambon.domain.world.World
+import dev.ambon.engine.behavior.BehaviorTreeSystem
+import dev.ambon.engine.events.OutboundEvent
+import java.time.Clock
+import java.util.Random
+
+/**
+ * True when [this] spawn's lifecycle is owned by [ConditionalSpawnHandler] —
+ * i.e. its template carries a non-trivial spawn condition. Such spawns are
+ * skipped by the cold-start, zone-reset, and post-death respawn paths.
+ */
+internal fun MobSpawn.isConditional(world: World): Boolean {
+    val cond = world.mobTemplate(templateId)?.spawnCondition
+    return cond != null && !cond.isUnconditional
+}
+
+/**
+ * Owns the entire spawn lifecycle of condition-gated mobs (a mob authored with a
+ * non-trivial [dev.ambon.domain.world.SpawnCondition] — night-only, storm-only,
+ * winter-only, intermittent-random, etc.). Such spawns are deliberately excluded
+ * from the cold-start spawn, zone reset, and post-death respawn paths so this
+ * handler is their single source of truth.
+ *
+ * On a throttled cadence it re-evaluates each conditional spawn:
+ * - **gates satisfied, mob absent** → roll [dev.ambon.domain.world.SpawnCondition.chance];
+ *   on success spawn it (possibly as a rare variant) and announce its arrival.
+ * - **gates no longer satisfied, mob present** → fade it out — but never while it
+ *   is fighting a player (a mob yanked mid-swing forfeits the kill and feels broken).
+ *
+ * Runs exclusively on the single-threaded engine dispatcher.
+ */
+internal class ConditionalSpawnHandler(
+    private val world: World,
+    private val mobs: MobRegistry,
+    private val players: PlayerRegistry,
+    private val outbound: OutboundBus,
+    private val gmcpEmitter: GmcpEmitter,
+    private val mobSystem: MobSystem,
+    private val behaviorTreeSystem: BehaviorTreeSystem,
+    private val mobRemovalCoordinator: MobRemovalCoordinator,
+    private val variantRoller: MobVariantRoller,
+    private val period: () -> TimePeriod,
+    private val season: () -> Season,
+    private val weatherForZone: (String) -> String,
+    private val activeEventFlags: () -> Set<String>,
+    private val isMobInCombat: (MobId) -> Boolean,
+    private val clock: Clock,
+    private val checkIntervalMs: Long = 10_000L,
+    private val rng: Random = Random(),
+) {
+    private var conditionalSpawns: List<MobSpawn> = computeConditionalSpawns()
+    private var nextCheckMs: Long = clock.millis()
+
+    /** The spawn ids this handler owns — used to filter them out of the unconditional spawn paths. */
+    fun ownedSpawnIds(): Set<MobId> = conditionalSpawns.mapTo(hashSetOf()) { it.id }
+
+    /** Re-scans the world for conditional spawns. Call after a hot reload. */
+    fun refresh() {
+        conditionalSpawns = computeConditionalSpawns()
+        nextCheckMs = clock.millis()
+    }
+
+    private fun computeConditionalSpawns(): List<MobSpawn> =
+        world.mobSpawns.filter { spawn ->
+            val cond = world.mobTemplate(spawn.templateId)?.spawnCondition
+            cond != null && !cond.isUnconditional
+        }
+
+    /** Called once per engine tick; re-evaluates conditional spawns on a throttled cadence. */
+    suspend fun tick() {
+        if (conditionalSpawns.isEmpty()) return
+        val now = clock.millis()
+        if (now < nextCheckMs) return
+        nextCheckMs = now + checkIntervalMs
+
+        val currentPeriod = period()
+        val currentSeason = season()
+        val flags = activeEventFlags()
+        for (spawn in conditionalSpawns) {
+            val cond = world.mobTemplate(spawn.templateId)?.spawnCondition ?: continue
+            if (world.rooms[spawn.roomId] == null) continue
+            val gatesOk = cond.gatesSatisfied(currentPeriod, weatherForZone(spawn.roomId.zone), currentSeason, flags)
+            val alive = mobs.get(spawn.id) != null
+            when {
+                alive && !gatesOk -> {
+                    if (!isMobInCombat(spawn.id)) fadeOut(spawn.id)
+                }
+                !alive && gatesOk -> {
+                    if (rng.nextDouble() < cond.chance) spawnConditional(spawn)
+                }
+            }
+        }
+    }
+
+    private suspend fun spawnConditional(spawn: MobSpawn) {
+        val template = world.mobTemplate(spawn.templateId) ?: return
+        val variant = variantRoller.roll(template)
+        val referenceLevel = highestPlayerLevelInZone(players, spawn.roomId.zone)
+        val mob = spawnToMobState(spawn, world, referenceLevel, variant)
+        mobs.upsert(mob)
+        mobSystem.onMobSpawned(spawn.id)
+        behaviorTreeSystem.onMobSpawned(spawn.id)
+        for (p in players.playersInRoom(spawn.roomId)) {
+            outbound.send(OutboundEvent.SendText(p.sessionId, "${mob.name} appears."))
+            gmcpEmitter.sendRoomAddMob(p.sessionId, mob)
+        }
+        // A rare creature finally showing up is loud news; variants carry their
+        // own rarity-scaled announce, plain conditional mobs get a zone shout.
+        if (variant != null) {
+            announceMobVariant(outbound, players, mob, variant.def)
+        } else {
+            val msg = "A creature seldom seen stirs in ${spawn.roomId.zone} — ${mob.name} has appeared!"
+            for (p in players.playersInZone(spawn.roomId.zone)) {
+                outbound.send(OutboundEvent.SendInfo(p.sessionId, msg))
+            }
+        }
+    }
+
+    private suspend fun fadeOut(mobId: MobId) {
+        val mob = mobs.get(mobId) ?: return
+        val roomId = mob.roomId
+        val name = mob.name
+        mobRemovalCoordinator.removeMobExternally(mobId)
+        for (p in players.playersInRoom(roomId)) {
+            outbound.send(OutboundEvent.SendText(p.sessionId, "$name fades from view, leaving no trace."))
+        }
+        gmcpEmitter.broadcastRoomRemoveMob(roomId, mobId.value, players)
+    }
+}

--- a/src/main/kotlin/dev/ambon/engine/ConditionalSpawnHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/ConditionalSpawnHandler.kt
@@ -56,9 +56,6 @@ internal class ConditionalSpawnHandler(
     private var conditionalSpawns: List<MobSpawn> = computeConditionalSpawns()
     private var nextCheckMs: Long = clock.millis()
 
-    /** The spawn ids this handler owns — used to filter them out of the unconditional spawn paths. */
-    fun ownedSpawnIds(): Set<MobId> = conditionalSpawns.mapTo(hashSetOf()) { it.id }
-
     /** Re-scans the world for conditional spawns. Call after a hot reload. */
     fun refresh() {
         conditionalSpawns = computeConditionalSpawns()

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -1611,8 +1611,13 @@ class GameEngine(
     init {
         // Condition-gated spawns (night-only, storm-only, …) are owned entirely
         // by ConditionalSpawnHandler; they are not present at cold start.
+        //
+        // Ordinary spawns roll for a rare variant here too, so the freshly-booted
+        // world is already seeded with a few sightings to discover — no fanfare,
+        // since nobody is connected yet; explorers simply stumble onto them.
         world.mobSpawns.filterNot { it.isConditional(world) }.forEach { spawn ->
-            mobs.upsert(spawnToMobState(spawn, world))
+            val variant = world.mobTemplate(spawn.templateId)?.let { mobVariantRoller.roll(it) }
+            mobs.upsert(spawnToMobState(spawn, world, variant = variant))
         }
         items.loadSpawns(world.itemSpawns)
         shopRegistry.register(world.shopDefinitions)

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -257,6 +257,9 @@ class GameEngine(
                 // until the first relog. See issue #1045.
                 emitDungeonCatalog(sid)
                 players.get(sid)?.let { p -> emitLotteryInfo(sid, p.name) }
+                // Seed the client's time-of-day + season immediately; otherwise it
+                // wouldn't learn the season until the next quarter-year rollover.
+                gmcpEmitter.sendWorldTime(sid, worldTimePayload())
                 // Push daily/weekly/global quest state so the client doesn't
                 // need a manual refresh button. See issue #1091.
                 dailyQuestSystem?.let { dqs ->
@@ -792,6 +795,11 @@ class GameEngine(
         clock = clock,
     )
 
+    private val seasonSystem = SeasonSystem(
+        config = engineConfig.season,
+        clock = clock,
+    )
+
     private val weatherSystem = WeatherSystem(
         config = engineConfig.weather,
         clock = clock,
@@ -829,6 +837,7 @@ class GameEngine(
         }
 
     private var lastTimePeriod: TimePeriod = worldTimeSystem.period()
+    private var lastSeason: Season = seasonSystem.season()
 
     private val abilitySystem: AbilitySystem =
         AbilitySystem(
@@ -1753,18 +1762,18 @@ class GameEngine(
                         )
                     }
 
-                    // Tick world time — broadcast on period change
+                    // Tick world time + season — broadcast on either change
                     val newPeriod = worldTimeSystem.tick(lastTimePeriod)
-                    if (newPeriod != null) {
-                        lastTimePeriod = newPeriod
-                        gmcpEmitter.broadcastWorldTime(
-                            GmcpEmitter.WorldTimePayload(
-                                period = newPeriod.name,
-                                hour = worldTimeSystem.gameHour(),
-                                minute = worldTimeSystem.gameMinute(),
-                            ),
-                            players,
-                        )
+                    val newSeason = seasonSystem.tick(lastSeason)
+                    if (newPeriod != null) lastTimePeriod = newPeriod
+                    if (newSeason != null) {
+                        lastSeason = newSeason
+                        for (p in players.allPlayers()) {
+                            outbound.send(OutboundEvent.SendInfo(p.sessionId, "[Season] ${newSeason.description}"))
+                        }
+                    }
+                    if (newPeriod != null || newSeason != null) {
+                        gmcpEmitter.broadcastWorldTime(worldTimePayload(), players)
                     }
 
                     // Snapshot all players once for the remainder of this tick to avoid
@@ -2084,6 +2093,18 @@ class GameEngine(
 
         // Issue a new resume token for the next potential disconnect
         issueResumeToken(newSessionId)
+    }
+
+    /** Builds the current `World.Time` payload, including the active season. */
+    private fun worldTimePayload(): GmcpEmitter.WorldTimePayload {
+        val season = seasonSystem.season()
+        return GmcpEmitter.WorldTimePayload(
+            period = worldTimeSystem.period().name,
+            hour = worldTimeSystem.gameHour(),
+            minute = worldTimeSystem.gameMinute(),
+            season = season.name,
+            seasonDescription = season.description,
+        )
     }
 
     /** Issue a resume token to the client after successful login/resume. */

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -499,6 +499,8 @@ class GameEngine(
         )
     }
 
+    private val mobVariantRoller = MobVariantRoller(config = engineConfig.mobVariants)
+
     private val zoneResetHandler by lazy {
         ZoneResetHandler(
             world = world,
@@ -512,6 +514,7 @@ class GameEngine(
             behaviorTreeSystem = behaviorTreeSystem,
             gmcpEmitter = gmcpEmitter,
             clock = clock,
+            variantRoller = mobVariantRoller,
             isMobInCombat = { mobId -> combatSystem.isMobInCombat(mobId) },
         )
     }
@@ -2422,7 +2425,8 @@ class GameEngine(
                 if (mobs.get(spawn.id) != null) return@scheduleIn
                 if (world.rooms[spawn.roomId] == null) return@scheduleIn
                 val referenceLevel = highestPlayerLevelInZone(players, spawn.roomId.zone)
-                val respawned = spawnToMobState(spawn, world, referenceLevel)
+                val variant = world.mobTemplate(spawn.templateId)?.let { mobVariantRoller.roll(it) }
+                val respawned = spawnToMobState(spawn, world, referenceLevel, variant)
                 mobs.upsert(respawned)
                 mobSystem.onMobSpawned(spawn.id)
                 behaviorTreeSystem.onMobSpawned(spawn.id)
@@ -2430,6 +2434,7 @@ class GameEngine(
                     outbound.send(OutboundEvent.SendText(p.sessionId, "${respawned.name} appears."))
                     gmcpEmitter.sendRoomAddMob(p.sessionId, respawned)
                 }
+                if (variant != null) announceMobVariant(outbound, players, respawned, variant.def)
             }
         }
     }

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -519,6 +519,26 @@ class GameEngine(
         )
     }
 
+    private val conditionalSpawnHandler by lazy {
+        ConditionalSpawnHandler(
+            world = world,
+            mobs = mobs,
+            players = players,
+            outbound = outbound,
+            gmcpEmitter = gmcpEmitter,
+            mobSystem = mobSystem,
+            behaviorTreeSystem = behaviorTreeSystem,
+            mobRemovalCoordinator = mobRemovalCoordinator,
+            variantRoller = mobVariantRoller,
+            period = { worldTimeSystem.period() },
+            season = { seasonSystem.season() },
+            weatherForZone = { zone -> weatherSystem.weatherForZone(zone) },
+            activeEventFlags = { worldEventSystem.activeFlags() },
+            isMobInCombat = { mobId -> combatSystem.isMobInCombat(mobId) },
+            clock = clock,
+        )
+    }
+
     /**
      * GMCP packages each session has opted into (e.g. "Char.Vitals", "Room.Info").
      *
@@ -1202,6 +1222,7 @@ class GameEngine(
                 onZoneScheduleRefresh = {
                     zoneResetHandler.refreshSchedule()
                     timedRespawnHandler.refresh()
+                    conditionalSpawnHandler.refresh()
                 },
             )
         } else {
@@ -1588,7 +1609,9 @@ class GameEngine(
     private lateinit var engineScope: CoroutineScope
 
     init {
-        world.mobSpawns.forEach { spawn ->
+        // Condition-gated spawns (night-only, storm-only, …) are owned entirely
+        // by ConditionalSpawnHandler; they are not present at cold start.
+        world.mobSpawns.filterNot { it.isConditional(world) }.forEach { spawn ->
             mobs.upsert(spawnToMobState(spawn, world))
         }
         items.loadSpawns(world.itemSpawns)
@@ -1917,6 +1940,9 @@ class GameEngine(
 
                     // Reset zones when their lifespan elapses.
                     zoneResetHandler.tick()
+
+                    // Spawn/fade condition-gated mobs (night/storm/season/random).
+                    conditionalSpawnHandler.tick()
 
                     // Restore item spawns / features that declare their own respawnSeconds.
                     timedRespawnHandler.tick()
@@ -2420,6 +2446,9 @@ class GameEngine(
         val spawn = world.mobSpawns.find { it.id == mobId }
         val template = spawn?.let { world.mobTemplate(it.templateId) }
         val respawnMs = template?.respawnSeconds?.let { it * 1_000L }
+        // Conditional mobs respawn through ConditionalSpawnHandler when their
+        // gates next hold, not via the unconditional post-death timer.
+        if (spawn != null && spawn.isConditional(world)) return
         if (spawn != null && template != null && respawnMs != null) {
             scheduler.scheduleIn(respawnMs) {
                 if (mobs.get(spawn.id) != null) return@scheduleIn

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -2558,6 +2558,10 @@ class GmcpEmitter(
                 }
             },
             ownerName = mob.ownerName,
+            variant = mob.variantId,
+            variantName = mob.variantName,
+            tint = mob.tint,
+            overlay = mob.overlay,
         )
     }
 
@@ -2725,6 +2729,14 @@ class GmcpEmitter(
         val category: String = "humanoid",
         val effects: List<MobEffectPayload>? = null,
         val ownerName: String? = null,
+        /** Server-generated rare variant id (e.g. "shadow"), or null for ordinary mobs. */
+        val variant: String? = null,
+        /** Variant display label (e.g. "Shadow-touched"). */
+        val variantName: String? = null,
+        /** CSS hex tint the client multiplies onto the sprite. */
+        val tint: String? = null,
+        /** Client particle/overlay hint: swirl|embers|sparkle|frost|mist. */
+        val overlay: String? = null,
     )
 
     private data class MobEffectPayload(

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -1687,6 +1687,8 @@ class GmcpEmitter(
         val period: String,
         val hour: Int,
         val minute: Int,
+        val season: String = "",
+        val seasonDescription: String = "",
     )
 
     data class WorldWeatherPayload(

--- a/src/main/kotlin/dev/ambon/engine/MobVariantRoller.kt
+++ b/src/main/kotlin/dev/ambon/engine/MobVariantRoller.kt
@@ -1,0 +1,52 @@
+package dev.ambon.engine
+
+import dev.ambon.config.MobVariantDefinition
+import dev.ambon.config.MobVariantsConfig
+import dev.ambon.domain.mob.MobRole
+import dev.ambon.domain.world.MobTemplateDef
+import java.util.Random
+
+/** A variant archetype selected for a specific spawn, paired with its id. */
+data class RolledMobVariant(
+    val id: String,
+    val def: MobVariantDefinition,
+)
+
+/**
+ * Decides whether a freshly-spawned mob should become a server-generated rare
+ * cosmetic variant, and which archetype. Used at every *dynamic* spawn site
+ * (zone reset, post-death respawn, conditional spawn) so explorers keep finding
+ * rich variations even when content authors don't hand-author rare mobs.
+ *
+ * Cold-start spawns are intentionally never rolled here — variants are meant to
+ * be live sightings, not a server that boots pre-stocked with rares.
+ */
+class MobVariantRoller(
+    private val config: MobVariantsConfig,
+    private val rng: Random = Random(),
+) {
+    /**
+     * Rolls a variant for [template], or returns null (the common case) when the
+     * feature is disabled, the mob is ineligible, or the rarity roll misses.
+     */
+    fun roll(template: MobTemplateDef): RolledMobVariant? {
+        if (!config.enabled) return null
+        if (template.role != MobRole.COMBAT) return null
+        if (!template.variantEligible) return null
+        if (config.variants.isEmpty()) return null
+        if (rng.nextDouble() >= config.chance) return null
+        return weightedPick()
+    }
+
+    private fun weightedPick(): RolledMobVariant? {
+        val entries = config.variants.entries.filter { it.value.weight > 0.0 }
+        if (entries.isEmpty()) return null
+        val total = entries.sumOf { it.value.weight }
+        var roll = rng.nextDouble() * total
+        for (entry in entries) {
+            roll -= entry.value.weight
+            if (roll <= 0.0) return RolledMobVariant(entry.key, entry.value)
+        }
+        return RolledMobVariant(entries.last().key, entries.last().value)
+    }
+}

--- a/src/main/kotlin/dev/ambon/engine/MobVariantRoller.kt
+++ b/src/main/kotlin/dev/ambon/engine/MobVariantRoller.kt
@@ -14,12 +14,10 @@ data class RolledMobVariant(
 
 /**
  * Decides whether a freshly-spawned mob should become a server-generated rare
- * cosmetic variant, and which archetype. Used at every *dynamic* spawn site
- * (zone reset, post-death respawn, conditional spawn) so explorers keep finding
- * rich variations even when content authors don't hand-author rare mobs.
- *
- * Cold-start spawns are intentionally never rolled here — variants are meant to
- * be live sightings, not a server that boots pre-stocked with rares.
+ * cosmetic variant, and which archetype. Used at every spawn site — cold start,
+ * zone reset, post-death respawn, and conditional spawn — so explorers keep
+ * finding rich variations even when content authors don't hand-author rare mobs,
+ * and a freshly-booted world already holds a few sightings to discover.
  */
 class MobVariantRoller(
     private val config: MobVariantsConfig,

--- a/src/main/kotlin/dev/ambon/engine/SeasonSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/SeasonSystem.kt
@@ -1,0 +1,48 @@
+package dev.ambon.engine
+
+import dev.ambon.config.SeasonConfig
+import java.time.Clock
+
+/**
+ * Tracks an accelerated game-world seasonal cycle.
+ *
+ * One full game year (4 seasons) maps to [SeasonConfig.cycleLengthMs] of real
+ * time, so each season lasts a quarter of that. The cycle order is
+ * SPRING → SUMMER → AUTUMN → WINTER, mirroring [WorldTimeSystem]'s day/night clock.
+ *
+ * Content authors gate mob spawns on the current [Season] via spawn conditions;
+ * see [dev.ambon.domain.world.SpawnCondition].
+ */
+class SeasonSystem(
+    private val config: SeasonConfig,
+    private val clock: Clock,
+) {
+    private val startMs: Long = clock.millis()
+
+    /** Returns the current [Season] derived from elapsed real time. */
+    fun season(): Season {
+        val elapsed = clock.millis() - startMs
+        val yearProgress = (elapsed % config.cycleLengthMs).toDouble() / config.cycleLengthMs
+        val index = (yearProgress * Season.entries.size).toInt().coerceIn(0, Season.entries.size - 1)
+        return Season.entries[index]
+    }
+
+    /**
+     * Called each engine tick. Returns the new [Season] if it changed since
+     * [lastSeason], or null if unchanged.
+     */
+    fun tick(lastSeason: Season): Season? {
+        val current = season()
+        return if (current != lastSeason) current else null
+    }
+}
+
+enum class Season(
+    val displayName: String,
+    val description: String,
+) {
+    SPRING("Spring", "Tender green unfurls as the world wakes from its slumber."),
+    SUMMER("Summer", "The land basks under a long, golden sun."),
+    AUTUMN("Autumn", "Leaves turn to fire and the air carries a crisp chill."),
+    WINTER("Winter", "Frost grips the world and snow muffles every footfall."),
+}

--- a/src/main/kotlin/dev/ambon/engine/ZoneResetHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/ZoneResetHandler.kt
@@ -266,14 +266,22 @@ internal class ZoneResetHandler(
             world.rooms.keys
                 .filterTo(linkedSetOf()) { roomId -> roomId.zone == zone }
 
+        // Conditional spawns are owned by ConditionalSpawnHandler; the reset
+        // neither removes nor repopulates their slots (only their gates do).
         val zoneMobSpawns =
             world.mobSpawns
-                .filter { spawn -> idZone(spawn.id.value) == zone }
+                .filter { spawn -> idZone(spawn.id.value) == zone && !spawn.isConditional(world) }
+        // Ids of conditional spawns in this zone — excluded from removal so a live
+        // night/storm/season mob survives the reset and stays handler-owned.
+        val conditionalIds =
+            world.mobSpawns
+                .filter { spawn -> idZone(spawn.id.value) == zone && spawn.isConditional(world) }
+                .mapTo(hashSetOf()) { spawn -> spawn.id }
         val activeZoneMobIds =
             mobs
                 .all()
                 .map { mob -> mob.id }
-                .filter { mobId -> idZone(mobId.value) == zone }
+                .filter { mobId -> idZone(mobId.value) == zone && mobId !in conditionalIds }
 
         val zoneMobIds =
             (zoneMobSpawns.map { spawn -> spawn.id } + activeZoneMobIds)

--- a/src/main/kotlin/dev/ambon/engine/ZoneResetHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/ZoneResetHandler.kt
@@ -1,6 +1,7 @@
 package dev.ambon.engine
 
 import dev.ambon.bus.OutboundBus
+import dev.ambon.config.MobVariantDefinition
 import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.idZone
@@ -51,6 +52,7 @@ internal fun spawnToMobState(
     spawn: MobSpawn,
     world: World,
     referencePlayerLevel: Int? = null,
+    variant: RolledMobVariant? = null,
 ): MobState {
     val template = world.mobTemplate(spawn.templateId)
         ?: error("No template '${spawn.templateId.value}' for spawn '${spawn.id.value}'")
@@ -67,16 +69,31 @@ internal fun spawnToMobState(
             null
         }
 
-    val maxHp = resolved?.hp ?: template.maxHp
+    val baseHp = resolved?.hp ?: template.maxHp
     val damage = resolved?.damage ?: template.damage
     val armor = resolved?.armor ?: template.armor
-    val xpReward = resolved?.xpReward ?: template.xpReward
-    val goldMin = resolved?.goldMin ?: template.goldMin
-    val goldMax = resolved?.goldMax ?: template.goldMax
+    val baseXp = resolved?.xpReward ?: template.xpReward
+    val baseGoldMin = resolved?.goldMin ?: template.goldMin
+    val baseGoldMax = resolved?.goldMax ?: template.goldMax
+
+    // Apply the rare-variant overlay: a name prefix, cosmetic tint/overlay, and
+    // a modest HP/XP/loot bump. Ordinary mobs (variant == null) are unchanged.
+    val def = variant?.def
+    val name = (def?.namePrefix ?: "") + template.name
+    val maxHp = scaleStat(baseHp, def?.hpMultiplier)
+    val xpReward = scaleStat(baseXp, def?.xpMultiplier)
+    val goldMin = scaleStat(baseGoldMin, def?.lootMultiplier)
+    val goldMax = scaleStat(baseGoldMax, def?.lootMultiplier)
+    val drops =
+        if (def == null || def.lootMultiplier == 1.0) {
+            template.drops
+        } else {
+            template.drops.map { it.copy(chance = (it.chance * def.lootMultiplier).coerceAtMost(1.0)) }
+        }
 
     return MobState(
         id = spawn.id,
-        name = template.name,
+        name = name,
         description = template.description,
         roomId = spawn.roomId,
         hp = maxHp,
@@ -84,7 +101,7 @@ internal fun spawnToMobState(
         damage = damage,
         armor = armor,
         xpReward = xpReward,
-        drops = template.drops,
+        drops = drops,
         goldMin = goldMin,
         goldMax = goldMax,
         dialogue = template.dialogue,
@@ -101,7 +118,44 @@ internal fun spawnToMobState(
         defaultAttack = template.defaultAttack,
         level = effectiveLevel,
         role = template.role,
+        variantId = variant?.id,
+        variantName = def?.displayName?.takeIf { it.isNotEmpty() },
+        tint = def?.tint?.takeIf { it.isNotEmpty() },
+        overlay = def?.overlay?.takeIf { it.isNotEmpty() },
     )
+}
+
+private fun scaleStat(base: Int, multiplier: Double?): Int =
+    if (multiplier == null || multiplier == 1.0) base else Math.round(base * multiplier).toInt()
+
+private fun scaleStat(base: Long, multiplier: Double?): Long =
+    if (multiplier == null || multiplier == 1.0) base else Math.round(base * multiplier)
+
+/**
+ * Broadcasts the arrival of a rare variant [mob], with reach scaled by the
+ * variant's configured [MobVariantDefinition.announce] loudness (ROOM/ZONE/SERVER).
+ */
+internal suspend fun announceMobVariant(
+    outbound: OutboundBus,
+    players: PlayerRegistry,
+    mob: MobState,
+    def: MobVariantDefinition,
+) {
+    val zone = mob.roomId.zone
+    when (def.announce) {
+        "SERVER" -> {
+            val msg = "[Legendary] A ${mob.name} has appeared somewhere in $zone — a sighting for the ages!"
+            for (p in players.allPlayers()) outbound.send(OutboundEvent.SendInfo(p.sessionId, msg))
+        }
+        "ZONE" -> {
+            val msg = "A rare creature stirs nearby — ${mob.name} has appeared!"
+            for (p in players.playersInZone(zone)) outbound.send(OutboundEvent.SendInfo(p.sessionId, msg))
+        }
+        else -> {
+            val msg = "${mob.name} shimmers into view, unmistakably rare."
+            for (p in players.playersInRoom(mob.roomId)) outbound.send(OutboundEvent.SendInfo(p.sessionId, msg))
+        }
+    }
 }
 
 /**
@@ -130,6 +184,7 @@ internal class ZoneResetHandler(
     private val behaviorTreeSystem: BehaviorTreeSystem,
     private val gmcpEmitter: GmcpEmitter,
     private val clock: Clock,
+    private val variantRoller: MobVariantRoller,
     /**
      * Whether a mob is currently fighting a player. Mobs in combat survive
      * zone resets (#1222); wired to [CombatSystem.isMobInCombat] by GameEngine.
@@ -236,11 +291,16 @@ internal class ZoneResetHandler(
         }
 
         val referenceLevel = highestPlayerLevelInZone(players, zone)
+        val freshVariants = mutableListOf<Pair<MobState, MobVariantDefinition>>()
         for (spawn in zoneMobSpawns) {
             if (spawn.id in survivingMobIds) continue
-            mobs.upsert(spawnToMobState(spawn, world, referenceLevel))
+            val template = world.mobTemplate(spawn.templateId)
+            val variant = template?.let { variantRoller.roll(it) }
+            val mob = spawnToMobState(spawn, world, referenceLevel, variant)
+            mobs.upsert(mob)
             mobSystem.onMobSpawned(spawn.id)
             behaviorTreeSystem.onMobSpawned(spawn.id)
+            if (variant != null) freshVariants.add(mob to variant.def)
         }
 
         val zoneItemSpawns =
@@ -269,6 +329,11 @@ internal class ZoneResetHandler(
         for (player in playersInZone) {
             gmcpEmitter.sendRoomMobs(player.sessionId, mobs.mobsInRoom(player.roomId))
             gmcpEmitter.sendRoomItems(player.sessionId, items.itemsInRoom(player.roomId))
+        }
+
+        // Announce any rare variants the reset rolled into existence.
+        for ((mob, def) in freshVariants) {
+            announceMobVariant(outbound, players, mob, def)
         }
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2215,6 +2215,9 @@ ambonmud:
       dayHour: 7
       duskHour: 18
       nightHour: 20
+    season:
+      # One full game year (all four seasons). 2 hours = 30 min per season.
+      cycleLengthMs: 7200000
     weather:
       minTransitionMs: 180000
       maxTransitionMs: 600000
@@ -2249,6 +2252,12 @@ ambonmud:
           weight: 1
           particleHint: wind
           icon: 💨
+    # Server-generated rare cosmetic variants. The archetype set (albino, ember,
+    # shadow-touched, spectral, …) is defined in code; override `variants` here to
+    # replace it wholesale. Leaving it unset keeps the built-in palette.
+    mobVariants:
+      enabled: true
+      chance: 0.04
     environment:
       defaultTheme:
         moteColors:

--- a/src/main/resources/world/academy.yaml
+++ b/src/main/resources/world/academy.yaml
@@ -997,6 +997,26 @@ mobs:
       - itemId: elixir_of_clarity
         chance: 0.8
     image: d52cfe6cecc852edbd03d7b0862021db49872a7fb953f1d034bbe205fcd33769.png
+  midnight_moth:
+    name: a luminous midnight moth
+    spawns:
+      - room: proving_grounds
+    tier: weak
+    level: 2
+    category: elemental
+    # A fleeting nocturnal sighting: only ever appears at night, and even then
+    # only some of the time. When dawn breaks it fades from view. Showcases the
+    # conditional spawn system (see docs/WORLD_YAML_SPEC.md).
+    condition:
+      time: [NIGHT, DUSK]
+      chance: 0.5
+    behavior:
+      template: wander
+    drops:
+      - itemId: arcane_fragment
+        chance: 0.6
+      - itemId: spider_silk
+        chance: 0.4
 items:
   leather_hood:
     displayName: a leather hood

--- a/src/test/kotlin/dev/ambon/domain/world/SpawnConditionTest.kt
+++ b/src/test/kotlin/dev/ambon/domain/world/SpawnConditionTest.kt
@@ -1,0 +1,44 @@
+package dev.ambon.domain.world
+
+import dev.ambon.engine.Season
+import dev.ambon.engine.TimePeriod
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SpawnConditionTest {
+    @Test
+    fun `empty condition is unconditional`() {
+        assertTrue(SpawnCondition().isUnconditional)
+        assertFalse(SpawnCondition(timePeriods = setOf(TimePeriod.NIGHT)).isUnconditional)
+        assertFalse(SpawnCondition(chance = 0.5).isUnconditional)
+    }
+
+    @Test
+    fun `single facet gates correctly`() {
+        val night = SpawnCondition(timePeriods = setOf(TimePeriod.NIGHT))
+        assertTrue(night.gatesSatisfied(TimePeriod.NIGHT, "CLEAR", Season.SUMMER, emptySet()))
+        assertFalse(night.gatesSatisfied(TimePeriod.DAY, "CLEAR", Season.SUMMER, emptySet()))
+    }
+
+    @Test
+    fun `facets are AND-ed`() {
+        val cond = SpawnCondition(
+            timePeriods = setOf(TimePeriod.NIGHT),
+            weather = setOf("STORM"),
+            seasons = setOf(Season.WINTER),
+        )
+        assertTrue(cond.gatesSatisfied(TimePeriod.NIGHT, "STORM", Season.WINTER, emptySet()))
+        // Each mismatch alone fails the whole condition.
+        assertFalse(cond.gatesSatisfied(TimePeriod.DAY, "STORM", Season.WINTER, emptySet()))
+        assertFalse(cond.gatesSatisfied(TimePeriod.NIGHT, "CLEAR", Season.WINTER, emptySet()))
+        assertFalse(cond.gatesSatisfied(TimePeriod.NIGHT, "STORM", Season.SUMMER, emptySet()))
+    }
+
+    @Test
+    fun `event flags require any one active`() {
+        val cond = SpawnCondition(eventFlags = setOf("harvest_moon", "blood_moon"))
+        assertFalse(cond.gatesSatisfied(TimePeriod.NIGHT, "CLEAR", Season.AUTUMN, emptySet()))
+        assertTrue(cond.gatesSatisfied(TimePeriod.NIGHT, "CLEAR", Season.AUTUMN, setOf("blood_moon")))
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/ConditionalSpawnHandlerTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/ConditionalSpawnHandlerTest.kt
@@ -1,0 +1,155 @@
+package dev.ambon.engine
+
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.config.MobVariantsConfig
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.mob.MobRole
+import dev.ambon.domain.world.MobSpawn
+import dev.ambon.domain.world.MobTemplateDef
+import dev.ambon.domain.world.Room
+import dev.ambon.domain.world.SpawnCondition
+import dev.ambon.domain.world.World
+import dev.ambon.engine.behavior.BehaviorTreeSystem
+import dev.ambon.engine.dialogue.DialogueSystem
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.engine.status.StatusEffectRegistry
+import dev.ambon.engine.status.StatusEffectSystem
+import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.MutableClock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ConditionalSpawnHandlerTest {
+    private val roomId = RoomId("z:a")
+    private val owlId = MobId("z:owl")
+
+    /** Mutable world conditions the handler's lambdas read each tick. */
+    private class Conditions(
+        var period: TimePeriod = TimePeriod.DAY,
+        var weather: String = "CLEAR",
+        var inCombat: Boolean = false,
+    )
+
+    private class Harness(
+        val handler: ConditionalSpawnHandler,
+        val mobs: MobRegistry,
+        val clock: MutableClock,
+        val conditions: Conditions,
+    )
+
+    private fun buildHarness(
+        condition: SpawnCondition,
+        startPeriod: TimePeriod = TimePeriod.DAY,
+    ): Harness {
+        val clock = MutableClock(0L)
+        val outbound = LocalOutboundBus()
+        val mobs = MobRegistry()
+        val items = ItemRegistry()
+        val template = MobTemplateDef(
+            id = owlId,
+            name = "snowy owl",
+            role = MobRole.COMBAT,
+            spawnCondition = condition,
+        )
+        val world = World(
+            rooms = mapOf(roomId to Room(roomId, "A", "desc", emptyMap())),
+            startRoom = roomId,
+            mobTemplates = mapOf(owlId to template),
+            mobSpawns = listOf(MobSpawn(id = owlId, templateId = owlId, roomId = roomId)),
+        )
+        val players = PlayerRegistry(
+            startRoom = world.startRoom,
+            repo = InMemoryPlayerRepository(),
+            items = items,
+            clock = clock,
+        )
+        val behaviorTreeSystem = BehaviorTreeSystem(world, mobs, players, outbound, clock)
+        val mobSystem = MobSystem()
+        val combatSystem = CombatSystem(players, mobs, items, outbound, clock)
+        val dialogueSystem = DialogueSystem(mobs, players, outbound)
+        val statusEffectSystem = StatusEffectSystem(StatusEffectRegistry(), players, mobs, outbound, clock)
+        val gmcpEmitter = GmcpEmitter(outbound = outbound, supportsPackage = { _, _ -> false })
+        val mobRemovalCoordinator = MobRemovalCoordinator(
+            combatSystem = combatSystem,
+            dialogueSystem = dialogueSystem,
+            behaviorTreeSystem = behaviorTreeSystem,
+            mobs = mobs,
+            mobSystem = mobSystem,
+            statusEffectSystem = statusEffectSystem,
+        )
+        val conditions = Conditions(period = startPeriod)
+        val handler = ConditionalSpawnHandler(
+            world = world,
+            mobs = mobs,
+            players = players,
+            outbound = outbound,
+            gmcpEmitter = gmcpEmitter,
+            mobSystem = mobSystem,
+            behaviorTreeSystem = behaviorTreeSystem,
+            mobRemovalCoordinator = mobRemovalCoordinator,
+            variantRoller = MobVariantRoller(MobVariantsConfig(enabled = false)),
+            period = { conditions.period },
+            season = { Season.WINTER },
+            weatherForZone = { conditions.weather },
+            activeEventFlags = { emptySet() },
+            isMobInCombat = { conditions.inCombat },
+            clock = clock,
+            checkIntervalMs = 1_000L,
+        )
+        return Harness(handler, mobs, clock, conditions)
+    }
+
+    @Test
+    fun `mob is absent at start when gated`() {
+        val h = buildHarness(SpawnCondition(timePeriods = setOf(TimePeriod.NIGHT)))
+        assertNull(h.mobs.get(owlId))
+    }
+
+    @Test
+    fun `mob appears when gates open and fades when they close`() = runTest {
+        val h = buildHarness(SpawnCondition(timePeriods = setOf(TimePeriod.NIGHT)))
+        // Day: still absent after a check.
+        h.handler.tick()
+        assertNull(h.mobs.get(owlId))
+
+        // Night: appears on the next check.
+        h.conditions.period = TimePeriod.NIGHT
+        h.clock.advance(1_000L)
+        h.handler.tick()
+        assertNotNull(h.mobs.get(owlId))
+
+        // Back to day: fades out.
+        h.conditions.period = TimePeriod.DAY
+        h.clock.advance(1_000L)
+        h.handler.tick()
+        assertNull(h.mobs.get(owlId))
+    }
+
+    @Test
+    fun `mob mid-combat is not yanked when gates close`() = runTest {
+        val h = buildHarness(SpawnCondition(timePeriods = setOf(TimePeriod.NIGHT)), startPeriod = TimePeriod.NIGHT)
+        h.handler.tick()
+        assertNotNull(h.mobs.get(owlId))
+
+        h.conditions.inCombat = true
+        h.conditions.period = TimePeriod.DAY
+        h.clock.advance(1_000L)
+        h.handler.tick()
+        assertNotNull(h.mobs.get(owlId))
+    }
+
+    @Test
+    fun `chance zero never spawns even when gates are open`() = runTest {
+        val h = buildHarness(
+            SpawnCondition(timePeriods = setOf(TimePeriod.NIGHT), chance = 0.0),
+            startPeriod = TimePeriod.NIGHT,
+        )
+        h.handler.tick()
+        assertNull(h.mobs.get(owlId))
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/GameEngineColdStartVariantTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GameEngineColdStartVariantTest.kt
@@ -1,0 +1,54 @@
+package dev.ambon.engine
+
+import dev.ambon.config.EngineConfig
+import dev.ambon.config.MobVariantsConfig
+import dev.ambon.test.GameEngineHarness
+import dev.ambon.test.MutableClock
+import dev.ambon.test.TestWorlds
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Cold-start seeding of rare variants. The world should already hold a few
+ * variant sightings the moment it boots — so explorers find them right away —
+ * rather than only after the first zone reset or respawn.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class GameEngineColdStartVariantTest {
+    @Test
+    fun `cold start rolls rare variants into the freshly-booted world`() = runTest {
+        val harness = GameEngineHarness.start(
+            scope = this,
+            world = TestWorlds.testWorld,
+            clock = MutableClock(0L),
+            // chance = 1.0 makes every eligible COMBAT mob a variant deterministically.
+            engineConfig = EngineConfig(mobVariants = MobVariantsConfig(chance = 1.0)),
+        )
+        try {
+            val mob = harness.mobs.all().single()
+            assertTrue(mob.isVariant, "an eligible cold-start mob should roll a variant when chance = 1.0")
+            assertNotNull(mob.variantId)
+        } finally {
+            harness.close()
+        }
+    }
+
+    @Test
+    fun `cold start leaves mobs ordinary when variants are disabled`() = runTest {
+        val harness = GameEngineHarness.start(
+            scope = this,
+            world = TestWorlds.testWorld,
+            clock = MutableClock(0L),
+            engineConfig = EngineConfig(mobVariants = MobVariantsConfig(enabled = false)),
+        )
+        try {
+            assertFalse(harness.mobs.all().single().isVariant)
+        } finally {
+            harness.close()
+        }
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/MobVariantRollerTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/MobVariantRollerTest.kt
@@ -1,0 +1,66 @@
+package dev.ambon.engine
+
+import dev.ambon.config.MobVariantDefinition
+import dev.ambon.config.MobVariantsConfig
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.mob.MobRole
+import dev.ambon.domain.world.MobTemplateDef
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.Random
+
+class MobVariantRollerTest {
+    private fun template(
+        role: MobRole = MobRole.COMBAT,
+        eligible: Boolean = true,
+    ): MobTemplateDef =
+        MobTemplateDef(
+            id = MobId("rat"),
+            name = "giant rat",
+            role = role,
+            variantEligible = eligible,
+        )
+
+    private val oneVariant = mapOf(
+        "shadow" to MobVariantDefinition(displayName = "Shadow-touched", namePrefix = "Shadow-touched ", weight = 1.0),
+    )
+
+    @Test
+    fun `disabled config never rolls`() {
+        val roller = MobVariantRoller(MobVariantsConfig(enabled = false, chance = 1.0, variants = oneVariant))
+        assertNull(roller.roll(template()))
+    }
+
+    @Test
+    fun `non-combat mobs are never variants`() {
+        val roller = MobVariantRoller(MobVariantsConfig(chance = 1.0, variants = oneVariant))
+        assertNull(roller.roll(template(role = MobRole.VENDOR)))
+    }
+
+    @Test
+    fun `author opt-out is honored`() {
+        val roller = MobVariantRoller(MobVariantsConfig(chance = 1.0, variants = oneVariant))
+        assertNull(roller.roll(template(eligible = false)))
+    }
+
+    @Test
+    fun `chance 0 never rolls and chance 1 always rolls`() {
+        assertNull(MobVariantRoller(MobVariantsConfig(chance = 0.0, variants = oneVariant)).roll(template()))
+        val rolled = MobVariantRoller(MobVariantsConfig(chance = 1.0, variants = oneVariant)).roll(template())
+        assertNotNull(rolled)
+        assertEquals("shadow", rolled!!.id)
+    }
+
+    @Test
+    fun `weighted pick stays within the configured set`() {
+        val roller = MobVariantRoller(MobVariantsConfig(chance = 1.0), rng = Random(42L))
+        repeat(50) {
+            val rolled = roller.roll(template())
+            assertNotNull(rolled)
+            assertTrue(MobVariantsConfig.DEFAULT_VARIANTS.containsKey(rolled!!.id))
+        }
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/SeasonSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/SeasonSystemTest.kt
@@ -1,0 +1,51 @@
+package dev.ambon.engine
+
+import dev.ambon.config.SeasonConfig
+import dev.ambon.test.MutableClock
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class SeasonSystemTest {
+    // 40 seconds = 1 game year, so each season lasts 10 seconds.
+    private val config = SeasonConfig(cycleLengthMs = 40_000L)
+
+    @Test
+    fun `starts in spring`() {
+        val clock = MutableClock(0L)
+        val system = SeasonSystem(config, clock)
+        assertEquals(Season.SPRING, system.season())
+    }
+
+    @Test
+    fun `advances through all four seasons in order`() {
+        val clock = MutableClock(0L)
+        val system = SeasonSystem(config, clock)
+        clock.advance(10_000L)
+        assertEquals(Season.SUMMER, system.season())
+        clock.advance(10_000L)
+        assertEquals(Season.AUTUMN, system.season())
+        clock.advance(10_000L)
+        assertEquals(Season.WINTER, system.season())
+    }
+
+    @Test
+    fun `wraps back to spring after a full year`() {
+        val clock = MutableClock(0L)
+        val system = SeasonSystem(config, clock)
+        clock.advance(40_000L)
+        assertEquals(Season.SPRING, system.season())
+    }
+
+    @Test
+    fun `tick returns new season only on change`() {
+        val clock = MutableClock(0L)
+        val system = SeasonSystem(config, clock)
+        assertNull(system.tick(Season.SPRING))
+        clock.advance(10_000L)
+        assertEquals(Season.SUMMER, system.tick(Season.SPRING))
+        assertNotNull(system.tick(Season.SPRING))
+        assertNull(system.tick(Season.SUMMER))
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/SpawnToMobStateVariantTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/SpawnToMobStateVariantTest.kt
@@ -1,0 +1,43 @@
+package dev.ambon.engine
+
+import dev.ambon.config.MobVariantDefinition
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SpawnToMobStateVariantTest {
+    private val world = dev.ambon.test.TestWorlds.okSmall
+    private val spawn = world.mobSpawns.first { world.mobTemplate(it.templateId)?.role?.isCombatant == true }
+
+    @Test
+    fun `no variant leaves the mob unchanged`() {
+        val plain = spawnToMobState(spawn, world)
+        assertNull(plain.variantId)
+        assertNull(plain.tint)
+        assertEquals(world.mobTemplate(spawn.templateId)!!.name, plain.name)
+    }
+
+    @Test
+    fun `variant applies name prefix, tint, overlay and stat bumps`() {
+        val base = spawnToMobState(spawn, world)
+        val def = MobVariantDefinition(
+            displayName = "Shadow-touched",
+            namePrefix = "Shadow-touched ",
+            tint = "#6a4aa0",
+            overlay = "swirl",
+            hpMultiplier = 2.0,
+            xpMultiplier = 2.0,
+        )
+        val variant = spawnToMobState(spawn, world, variant = RolledMobVariant("shadow", def))
+
+        assertEquals("shadow", variant.variantId)
+        assertEquals("Shadow-touched", variant.variantName)
+        assertEquals("#6a4aa0", variant.tint)
+        assertEquals("swirl", variant.overlay)
+        assertTrue(variant.name.startsWith("Shadow-touched "))
+        assertEquals(base.maxHp * 2, variant.maxHp)
+        assertEquals(variant.maxHp, variant.hp)
+        assertEquals(base.xpReward * 2, variant.xpReward)
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/ZoneResetCombatExemptionTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/ZoneResetCombatExemptionTest.kt
@@ -107,6 +107,7 @@ class ZoneResetCombatExemptionTest {
             behaviorTreeSystem = behaviorTreeSystem,
             gmcpEmitter = gmcpEmitter,
             clock = clock,
+            variantRoller = MobVariantRoller(dev.ambon.config.MobVariantsConfig(enabled = false)),
             isMobInCombat = { mobId -> combatSystem.isMobInCombat(mobId) },
         )
         // Populate the world's initial mob spawns (GameEngine does this at boot).

--- a/src/test/kotlin/dev/ambon/engine/ZoneResetHandlerRefreshTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/ZoneResetHandlerRefreshTest.kt
@@ -86,6 +86,7 @@ class ZoneResetHandlerRefreshTest {
             behaviorTreeSystem = behaviorTreeSystem,
             gmcpEmitter = gmcpEmitter,
             clock = clock,
+            variantRoller = MobVariantRoller(dev.ambon.config.MobVariantsConfig(enabled = false)),
         )
     }
 

--- a/src/test/kotlin/dev/ambon/test/TestFixtures.kt
+++ b/src/test/kotlin/dev/ambon/test/TestFixtures.kt
@@ -6,6 +6,7 @@ import dev.ambon.config.BankConfig
 import dev.ambon.config.ClassDefinitionConfig
 import dev.ambon.config.ClassEngineConfig
 import dev.ambon.config.EconomyConfig
+import dev.ambon.config.EngineConfig
 import dev.ambon.config.RaceDefinitionConfig
 import dev.ambon.config.RaceEngineConfig
 import dev.ambon.domain.ids.RoomId
@@ -368,6 +369,7 @@ class GameEngineHarness private constructor(
             tickMillis: Long = 10L,
             progression: PlayerProgression = PlayerProgression(),
             metrics: GameMetrics = GameMetrics.noop(),
+            engineConfig: EngineConfig = EngineConfig(),
         ): GameEngineHarness {
             val classRegistry =
                 PlayerClassRegistry().also { reg ->
@@ -401,6 +403,7 @@ class GameEngineHarness private constructor(
                     mobs = mobs,
                     items = items,
                     metrics = metrics,
+                    engineConfig = engineConfig,
                     classRegistryOverride = classRegistry,
                     raceRegistryOverride = raceRegistry,
                 )

--- a/src/test/kotlin/dev/ambon/world/load/WorldLoaderConditionTest.kt
+++ b/src/test/kotlin/dev/ambon/world/load/WorldLoaderConditionTest.kt
@@ -1,0 +1,35 @@
+package dev.ambon.world.load
+
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.world.load.WorldLoader
+import dev.ambon.engine.Season
+import dev.ambon.engine.TimePeriod
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class WorldLoaderConditionTest {
+    private val world = WorldLoader.loadFromResource("world/ok_conditional_mob.yaml")
+
+    @Test
+    fun `parses spawn condition facets`() {
+        val template = world.mobTemplate(MobId("ok_conditional:stormwraith"))!!
+        val cond = template.spawnCondition!!
+        assertEquals(setOf(TimePeriod.NIGHT), cond.timePeriods)
+        assertEquals(setOf("STORM"), cond.weather)
+        assertEquals(setOf(Season.WINTER), cond.seasons)
+        assertEquals(0.25, cond.chance)
+        assertFalse(cond.isUnconditional)
+        // Author opt-out flows through.
+        assertFalse(template.variantEligible)
+    }
+
+    @Test
+    fun `unconditioned mob has no spawn condition and stays variant-eligible`() {
+        val template = world.mobTemplate(MobId("ok_conditional:rat"))!!
+        assertNull(template.spawnCondition)
+        assertTrue(template.variantEligible)
+    }
+}

--- a/src/test/resources/world/ok_conditional_mob.yaml
+++ b/src/test/resources/world/ok_conditional_mob.yaml
@@ -1,0 +1,20 @@
+zone: ok_conditional
+lifespan: 1
+startRoom: a
+mobs:
+  rat:
+    name: "a small rat"
+    room: a
+  stormwraith:
+    name: "a storm wraith"
+    room: a
+    rareVariants: false
+    condition:
+      time: [NIGHT]
+      weather: [STORM]
+      seasons: [WINTER]
+      chance: 0.25
+rooms:
+  a:
+    title: "Room A"
+    description: "The only room."

--- a/web-v3/src/canvas/scenes/WorldScene.ts
+++ b/web-v3/src/canvas/scenes/WorldScene.ts
@@ -80,6 +80,14 @@ function statusIconSize(mobSize: number): number {
   return clamp(mobSize * STATUS_ICON_RATIO, STATUS_ICON_MIN, STATUS_ICON_MAX);
 }
 
+/** Parses a server "#rrggbb" tint into a PixiJS numeric color, or null if absent/invalid. */
+function parseHexTint(tint: string | null | undefined): number | null {
+  if (!tint) return null;
+  const hex = tint.replace("#", "").trim();
+  if (!/^[0-9a-fA-F]{6}$/.test(hex)) return null;
+  return parseInt(hex, 16);
+}
+
 function drawRoleIcons(g: Graphics, cx: number, cy: number, info: MobInfo, spriteSize: number) {
   const icons: number[] = [];
   // quest indicators are handled by sprites now
@@ -1882,7 +1890,7 @@ export class WorldScene {
     }
   }
 
-  private rebuildMobs(mobs: Array<{ id: string; templateKey: string; name: string; description?: string; hp: number; maxHp: number; image?: string | null; video?: string | null; category?: string }>) {
+  private rebuildMobs(mobs: Array<{ id: string; templateKey: string; name: string; description?: string; hp: number; maxHp: number; image?: string | null; video?: string | null; category?: string; variant?: string | null; tint?: string | null; overlay?: string | null }>) {
     for (const { sprite, label, labelBg, hitArea } of this.mobSprites.values()) {
       this.container.removeChild(sprite);
       this.container.removeChild(labelBg);
@@ -1938,16 +1946,19 @@ export class WorldScene {
       sprite.width = BASE_SPRITE_SIZE;
       sprite.height = BASE_SPRITE_SIZE;
       sprite.anchor.set(0.5);
-      sprite.tint = 0xf0c674;
+      // Rare variants carry a cosmetic tint the server multiplies onto the
+      // sprite; ordinary mobs keep the default placeholder gold.
+      const variantTint = parseHexTint(mob.tint);
+      sprite.tint = variantTint ?? 0xf0c674;
 
       const mobImage = mob.image ?? gameStateRef.current.serverAssets[`default_mob_${mob.category ?? "humanoid"}`] ?? null;
       if (mobImage) {
-        this.loadSpriteTexture(sprite, mobImage);
+        this.loadSpriteTexture(sprite, mobImage, variantTint ?? 0xffffff);
       }
 
       const label = new Text({
-        text: mob.name,
-        style: { fontFamily: "JetBrains Mono, Cascadia Mono, monospace", fontSize: MOB_LABEL_FONT_SIZE, fill: MOB_LABEL_COLOR, dropShadow: { color: 0x000000, alpha: 0.4, blur: 2, distance: 1 } },
+        text: mob.variant ? `✦ ${mob.name}` : mob.name,
+        style: { fontFamily: "JetBrains Mono, Cascadia Mono, monospace", fontSize: MOB_LABEL_FONT_SIZE, fill: variantTint ?? MOB_LABEL_COLOR, dropShadow: { color: 0x000000, alpha: 0.4, blur: 2, distance: 1 } },
       });
       label.anchor.set(0.5, 0);
 
@@ -2332,11 +2343,11 @@ export class WorldScene {
     }
   }
 
-  private async loadSpriteTexture(sprite: Sprite, imagePath: string) {
+  private async loadSpriteTexture(sprite: Sprite, imagePath: string, tintOnLoad = 0xffffff) {
     try {
       const texture = await Assets.load(imagePath);
       sprite.texture = texture;
-      sprite.tint = 0xffffff;
+      sprite.tint = tintOnLoad;
     } catch {
       // Keep placeholder tint
     }

--- a/web-v3/src/components/WorldAtmosphereHud.tsx
+++ b/web-v3/src/components/WorldAtmosphereHud.tsx
@@ -26,6 +26,26 @@ function periodLabel(period: string): string {
   }
 }
 
+function seasonIcon(season: string): string {
+  switch (season) {
+    case "SPRING": return "\u{1F338}";
+    case "SUMMER": return "\u{1F31E}";
+    case "AUTUMN": return "\u{1F342}";
+    case "WINTER": return "⛄";
+    default: return "";
+  }
+}
+
+function seasonLabel(season: string): string {
+  switch (season) {
+    case "SPRING": return "Spring";
+    case "SUMMER": return "Summer";
+    case "AUTUMN": return "Autumn";
+    case "WINTER": return "Winter";
+    default: return season;
+  }
+}
+
 function weatherIcon(weather: string): string {
   switch (weather) {
     case "RAIN": return "\u2602";
@@ -51,6 +71,7 @@ function weatherLabel(weather: string): string {
 
 export function WorldAtmosphereHud({ worldTime, worldWeather, worldEvents }: Props) {
   const hasTime = worldTime !== null;
+  const hasSeason = worldTime !== null && !!worldTime.season && seasonIcon(worldTime.season) !== "";
   const hasWeather = worldWeather !== null && worldWeather.weather !== "CLEAR";
   const hasEvents = worldEvents.length > 0;
 
@@ -62,6 +83,12 @@ export function WorldAtmosphereHud({ worldTime, worldWeather, worldEvents }: Pro
         <span className="atmosphere-hud-chip" title={`${periodLabel(worldTime.period)} — ${String(worldTime.hour).padStart(2, "0")}:${String(worldTime.minute).padStart(2, "0")}`}>
           <span className="atmosphere-hud-icon" aria-hidden="true">{periodIcon(worldTime.period)}</span>
           <span className="atmosphere-hud-label">{String(worldTime.hour).padStart(2, "0")}:{String(worldTime.minute).padStart(2, "0")}</span>
+        </span>
+      )}
+      {hasSeason && worldTime && (
+        <span className="atmosphere-hud-chip" title={worldTime.seasonDescription || seasonLabel(worldTime.season ?? "")}>
+          <span className="atmosphere-hud-icon" aria-hidden="true">{seasonIcon(worldTime.season ?? "")}</span>
+          <span className="atmosphere-hud-label">{seasonLabel(worldTime.season ?? "")}</span>
         </span>
       )}
       {hasWeather && (

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -2014,6 +2014,8 @@ export function applyGmcpPackage(
         period: typeof packet.period === "string" ? packet.period : "DAY",
         hour: safeNumber(packet.hour),
         minute: safeNumber(packet.minute),
+        season: typeof packet.season === "string" ? packet.season : "",
+        seasonDescription: typeof packet.seasonDescription === "string" ? packet.seasonDescription : "",
       });
       break;
     }

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -702,6 +702,10 @@ export function applyGmcpPackage(
             category: typeof entry.category === "string" ? entry.category : "humanoid",
             effects: parseMobEffects(entry.effects),
             ownerName: typeof entry.ownerName === "string" ? entry.ownerName : null,
+            variant: typeof entry.variant === "string" ? entry.variant : null,
+            variantName: typeof entry.variantName === "string" ? entry.variantName : null,
+            tint: typeof entry.tint === "string" ? entry.tint : null,
+            overlay: typeof entry.overlay === "string" ? entry.overlay : null,
           })),
       );
       break;
@@ -725,6 +729,10 @@ export function applyGmcpPackage(
           category: typeof packet.category === "string" ? packet.category : "humanoid",
           effects: parseMobEffects(packet.effects),
           ownerName: typeof packet.ownerName === "string" ? packet.ownerName : null,
+          variant: typeof packet.variant === "string" ? packet.variant : null,
+          variantName: typeof packet.variantName === "string" ? packet.variantName : null,
+          tint: typeof packet.tint === "string" ? packet.tint : null,
+          overlay: typeof packet.overlay === "string" ? packet.overlay : null,
         },
       ]);
       break;

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -393,6 +393,14 @@ export interface RoomMob {
   effects?: StatusEffect[];
   /** Character name of the pet's owner, or undefined for regular mobs. */
   ownerName?: string | null;
+  /** Server-generated rare variant id (e.g. "shadow"), or null for ordinary mobs. */
+  variant?: string | null;
+  /** Variant display label (e.g. "Shadow-touched"), for tooltips/labels. */
+  variantName?: string | null;
+  /** CSS hex tint multiplied onto the sprite (e.g. "#6a4aa0"); null = none. */
+  tint?: string | null;
+  /** Particle/overlay hint: swirl|embers|sparkle|frost|mist; null = none. */
+  overlay?: string | null;
 }
 
 export interface StatusEffect {

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -9,6 +9,10 @@ export interface WorldTime {
   period: string;
   hour: number;
   minute: number;
+  /** Current season (SPRING|SUMMER|AUTUMN|WINTER), or "" if the server didn't send one. */
+  season?: string;
+  /** Flavor description of the season, shown as a tooltip. */
+  seasonDescription?: string;
 }
 
 export interface WorldWeather {


### PR DESCRIPTION
## What

Adds a **rare & conditional mob system** with three independent axes, built on the existing `MobFile → MobTemplateDef → MobSpawn → MobState` pipeline and the time/weather/event tick loop. Motivated by an upcoming "level by exploring & documenting mobs" progression (that leveling system is **out of scope** here).

### 1. Seasonal cycle clock
`SeasonSystem` mirrors the day/night `WorldTimeSystem`: one game year cycles SPRING→SUMMER→AUTUMN→WINTER over a configurable real-time period. Season rides the `World.Time` GMCP package, is seeded on login, and announces on change.

### 2. Authorable condition-gated spawning
Mobs can declare a `condition` in YAML — any combination of **time of day, weather, season, world-event flags, and a random `chance`**. A new `ConditionalSpawnHandler` owns their entire lifecycle: it spawns them when the gates open (rolling `chance` per opportunity, possibly as a rare variant) and **fades them out when the gates close — never mid-combat**. Conditional spawns are excluded from the cold-start / zone-reset / post-death respawn paths so the handler is their single owner, and they survive zone resets while gated.

### 3. Server-generated rare variants
Every COMBAT mob can spawn as a rare cosmetic **variant** (tint + overlay + name prefix + modest HP/XP/loot bump) so explorers always find richer sightings even when no rare mob was hand-authored. A `MobVariantRoller` rolls a small chance on each *dynamic* spawn (zone reset, respawn, conditional spawn) — never at cold start, so variants read as live sightings. Authors opt a mob out with `rareVariants: false`. Variant metadata rides the `Room.Mobs` GMCP payload; the web client multiplies the tint onto the sprite, tints the label, and adds a ✦ rarity marker. Appearances announce with reach scaled by rarity (room → zone → server).

## Decisions
- Seasons: real in-game cycling clock (not real-calendar dates).
- Variants: cosmetic + small stat bump; all COMBAT mobs eligible (opt-out).
- Condition ends: mob fades out when unwatched, never yanked mid-combat.
- Variant palette: themed archetype set (albino, verdant, shadow, ember, glimmering, frostbound, spectral, ancient) with rarity weights.
- Fanfare: zone/server announcements scaled by rarity.

## Authoring
```yaml
mobs:
  storm_wraith:
    name: a storm wraith
    rareVariants: false        # opt out of auto-variants
    condition:
      time: [NIGHT]
      weather: [STORM]
      seasons: [WINTER]
      chance: 0.25
```
See `docs/WORLD_YAML_SPEC.md` § Conditional spawning / Rare variants. A live example (a night-only luminous midnight moth) is wired into the bundled Academy zone.

## Config
- `ambonmud.engine.season.cycleLengthMs`
- `ambonmud.engine.mobVariants.{enabled,chance,variants}`

## Testing
- New unit tests: `SeasonSystemTest`, `MobVariantRollerTest`, `SpawnToMobStateVariantTest`, `SpawnConditionTest`, `ConditionalSpawnHandlerTest`, `WorldLoaderConditionTest`.
- Existing zone-reset/hot-reload tests updated for the new roller param.
- `./gradlew ktlintCheck test integrationTest` green; web `bun run lint` + `bun run build` green; server boots clean against the bundled world (telnet + web bound, zero exceptions).

## Checklist
- [x] Season clock + config foundation
- [x] Rare variant generation (server-side + GMCP)
- [x] Authorable conditional spawning + lifecycle
- [x] Web client rendering (tint + variant marker)
- [x] Docs (WORLD_YAML_SPEC) + showcase content + full lint/test pass