### PR TITLE
fix(web): make PixiJS render under hardened CSP (unsafe-eval polyfill)

### DIFF
--- a/web-v3/src/canvas/PixiCanvas.tsx
+++ b/web-v3/src/canvas/PixiCanvas.tsx
@@ -1,5 +1,11 @@
 import { memo, useEffect, useRef } from "react";
 import { Application } from "pixi.js";
+// Side-effect import: swaps Pixi's eval/new-Function-based shader & uniform sync
+// for polyfills and stubs the unsafe-eval check. Required because the served
+// web client runs under a hardened CSP (script-src lacks 'unsafe-eval', see
+// KtorWebSocketTransport.WEB_CONTENT_SECURITY_POLICY); without this Pixi's
+// renderer init throws and the canvas never comes up.
+import "pixi.js/unsafe-eval";
 import { SceneManager } from "./SceneManager";
 
 // memo: props-less component under GameShell, which re-renders on every


### PR DESCRIPTION
## Problem

On the demo server (mud.ambon.dev) the world canvas fails to render. Console shows:

```
CSP: blocked a JavaScript eval (script-src) ... (Missing 'unsafe-eval')
Uncaught (in promise) Error: Current environment does not allow unsafe-eval,
  please use pixi.js/unsafe-eval module to enable support.
WebGL context was lost.
```

## Root cause

The security hardening in #1300 tightened the served client's CSP to `script-src 'self' 'unsafe-inline'` — dropping `'unsafe-eval'`. PixiJS v8 uses `eval`/`new Function` to compile its shader and uniform-sync code, so `Application.init()` throws under the new policy and the PixiJS canvas never comes up.

## Fix

Add a side-effect import of `pixi.js/unsafe-eval` before the renderer is created in `PixiCanvas.tsx`. Despite the name, this module **removes** Pixi's reliance on eval: `selfInstall()` swaps the eval-based shader / uniform / UBO / particle sync paths for polyfills and stubs out `_unsafeEvalCheck`. Pixi then runs cleanly under the tightened CSP.

This keeps the hardened CSP from #1300 fully intact — strictly better than re-adding `'unsafe-eval'`.

## Verification

- `bun run lint` — clean
- `bun run build` — succeeds; pixi chunk rehashed, polyfill bundled
- Single-file source change; built assets are gitignored

## Follow-up to verify in-browser

Load mud.ambon.dev after deploy: the eval CSP violation and "WebGL context was lost" errors should be gone and the world canvas should render.