### PR TITLE
fix(web): render rare-variant tints (albino/verdant) on canvas + bestiary; CSP-safe data: sprites

### DIFF
--- a/web-v3/src/canvas/scenes/BattleScene.ts
+++ b/web-v3/src/canvas/scenes/BattleScene.ts
@@ -1,4 +1,4 @@
-import { Container, Graphics, Sprite, Text, Texture, Assets } from "pixi.js";
+import { Container, Graphics, Sprite, Text, Texture } from "pixi.js";
 import { gameStateRef, canvasCallbacks } from "../GameStateBridge";
 import { canvasEvents } from "../CanvasEventBus";
 import { AbilityVisualSystem } from "../systems/AbilityVisualSystem";
@@ -6,6 +6,7 @@ import { CombatAnimator } from "../systems/CombatAnimator";
 import { GainPopupSystem } from "../systems/GainPopup";
 import { StatusEffectDisplay } from "../systems/StatusEffectDisplay";
 import { SpellProjectileSystem } from "../systems/SpellProjectile";
+import { loadTexture } from "../textureLoader";
 
 const BASE_SPRITE_SIZE = 248;
 const MIN_SPRITE_SIZE = 184;
@@ -704,7 +705,7 @@ export class BattleScene {
 
       const petImage = pet.image ?? gameStateRef.current.serverAssets[`default_mob_${pet.category ?? "humanoid"}`] ?? null;
       if (petImage) {
-        Assets.load(petImage).then((tex: unknown) => {
+        loadTexture(petImage).then((tex: unknown) => {
           if (tex && typeof tex === "object" && "baseTexture" in (tex as Record<string, unknown>)) {
             sprite.texture = tex as Texture;
           } else if (tex instanceof Texture) {
@@ -739,7 +740,7 @@ export class BattleScene {
     }
     if (!imagePath) return;
     try {
-      const texture = await Assets.load(imagePath);
+      const texture = await loadTexture(imagePath);
       if (token !== this.bgLoadToken) return;
       const sprite = new Sprite(texture);
       sprite.width = this.width;
@@ -769,7 +770,7 @@ export class BattleScene {
 
     if (spritePath) {
       try {
-        const texture = await Assets.load(spritePath);
+        const texture = await loadTexture(spritePath);
         sprite.texture = texture;
         sprite.width = BASE_SPRITE_SIZE;
         sprite.height = BASE_SPRITE_SIZE;
@@ -797,7 +798,7 @@ export class BattleScene {
 
     if (imagePath) {
       try {
-        const texture = await Assets.load(imagePath);
+        const texture = await loadTexture(imagePath);
         sprite.texture = texture;
         sprite.width = BASE_SPRITE_SIZE;
         sprite.height = BASE_SPRITE_SIZE;

--- a/web-v3/src/canvas/scenes/WorldScene.ts
+++ b/web-v3/src/canvas/scenes/WorldScene.ts
@@ -1,4 +1,4 @@
-import { Container, Graphics, Sprite, Text, Texture, Assets } from "pixi.js";
+import { Container, Graphics, Sprite, Text, Texture, Assets, ColorMatrixFilter } from "pixi.js";
 import { gameStateRef, canvasCallbacks, pendingCastRef } from "../GameStateBridge";
 import { StatusEffectDisplay } from "../systems/StatusEffectDisplay";
 import { Minimap } from "../systems/Minimap";
@@ -8,6 +8,7 @@ import { SkyRenderer } from "../systems/SkyRenderer";
 import { WeatherParticles } from "../systems/WeatherParticles";
 import type { MobInfo } from "../../types";
 import { ROOM_SURFACE_WIDGETS } from "../../featureMetadata";
+import { loadTexture } from "../textureLoader";
 
 /** Resolves a global asset key to its server-provided URL, with a hardcoded fallback. */
 function assetUrl(key: string, fallbackFilename: string): string {
@@ -88,6 +89,38 @@ function parseHexTint(tint: string | null | undefined): number | null {
   return parseInt(hex, 16);
 }
 
+/**
+ * Builds a luminance-colorize ColorMatrixFilter for a rare-variant tint.
+ *
+ * PixiJS's `sprite.tint` is a *multiply*, which can only darken toward the tint
+ * — so a pale tint like albino's `#f5f0ff` leaves the sprite essentially
+ * unchanged. Colorizing instead (desaturate to luminance, then scale by the
+ * tint) makes a near-white tint read as a pale/ghostly creature and a saturated
+ * tint as a richly recolored one. A small gain/lift keeps pale variants from
+ * coming out muddy, and `alpha` leaves a touch of the original texture so the
+ * creature still reads through the wash.
+ */
+function makeVariantColorize(tint: number): ColorMatrixFilter {
+  const tr = ((tint >> 16) & 0xff) / 255;
+  const tg = ((tint >> 8) & 0xff) / 255;
+  const tb = (tint & 0xff) / 255;
+  // Rec. 601 luma weights.
+  const lr = 0.299;
+  const lg = 0.587;
+  const lb = 0.114;
+  const gain = 1.15;
+  const lift = 0.1;
+  const filter = new ColorMatrixFilter();
+  filter.matrix = [
+    lr * tr * gain, lg * tr * gain, lb * tr * gain, 0, tr * lift,
+    lr * tg * gain, lg * tg * gain, lb * tg * gain, 0, tg * lift,
+    lr * tb * gain, lg * tb * gain, lb * tb * gain, 0, tb * lift,
+    0, 0, 0, 1, 0,
+  ];
+  filter.alpha = 0.92;
+  return filter;
+}
+
 function drawRoleIcons(g: Graphics, cx: number, cy: number, info: MobInfo, spriteSize: number) {
   const icons: number[] = [];
   // quest indicators are handled by sprites now
@@ -143,7 +176,7 @@ export class WorldScene {
   // Representative mob data (rep id → fields needed to open the field manual),
   // so a click on a floating dialogue/quest indicator can build the same panel
   // entry as a click on the mob sprite. Rebuilt alongside the mob sprites.
-  private mobDataById = new Map<string, { id: string; name: string; description?: string; image?: string | null; video?: string | null }>();
+  private mobDataById = new Map<string, { id: string; name: string; description?: string; image?: string | null; video?: string | null; variantName?: string | null; tint?: string | null }>();
 
   private shopBadge: Container;
   private shopSprite: Sprite | null = null;
@@ -1890,7 +1923,7 @@ export class WorldScene {
     }
   }
 
-  private rebuildMobs(mobs: Array<{ id: string; templateKey: string; name: string; description?: string; hp: number; maxHp: number; image?: string | null; video?: string | null; category?: string; variant?: string | null; tint?: string | null; overlay?: string | null }>) {
+  private rebuildMobs(mobs: Array<{ id: string; templateKey: string; name: string; description?: string; hp: number; maxHp: number; image?: string | null; video?: string | null; category?: string; variant?: string | null; variantName?: string | null; tint?: string | null; overlay?: string | null }>) {
     for (const { sprite, label, labelBg, hitArea } of this.mobSprites.values()) {
       this.container.removeChild(sprite);
       this.container.removeChild(labelBg);
@@ -1946,14 +1979,23 @@ export class WorldScene {
       sprite.width = BASE_SPRITE_SIZE;
       sprite.height = BASE_SPRITE_SIZE;
       sprite.anchor.set(0.5);
-      // Rare variants carry a cosmetic tint the server multiplies onto the
-      // sprite; ordinary mobs keep the default placeholder gold.
+      // Rare variants carry a cosmetic tint. A multiply `sprite.tint` can't
+      // express pale variants (it only darkens), so we colorize via a filter
+      // instead and leave the sprite tint white. Ordinary mobs keep the default
+      // placeholder gold until their texture loads. The filter also colorizes
+      // the white placeholder, so a variant reads correctly even before (or if)
+      // its art loads.
       const variantTint = parseHexTint(mob.tint);
-      sprite.tint = variantTint ?? 0xf0c674;
+      if (variantTint != null) {
+        sprite.filters = [makeVariantColorize(variantTint)];
+        sprite.tint = 0xffffff;
+      } else {
+        sprite.tint = 0xf0c674;
+      }
 
       const mobImage = mob.image ?? gameStateRef.current.serverAssets[`default_mob_${mob.category ?? "humanoid"}`] ?? null;
       if (mobImage) {
-        this.loadSpriteTexture(sprite, mobImage, variantTint ?? 0xffffff);
+        this.loadSpriteTexture(sprite, mobImage);
       }
 
       const label = new Text({
@@ -2245,7 +2287,7 @@ export class WorldScene {
     if (!imagePath) return;
 
     try {
-      const texture = await Assets.load(imagePath);
+      const texture = await loadTexture(imagePath);
       if (token !== this.bgLoadToken) return;
       const sprite = new Sprite(texture);
       sprite.width = this.width;
@@ -2323,7 +2365,7 @@ export class WorldScene {
     }
 
     try {
-      const texture = await Assets.load(resolvedPath);
+      const texture = await loadTexture(resolvedPath);
       const sprite = new Sprite(texture);
       sprite.width = BASE_SPRITE_SIZE;
       sprite.height = BASE_SPRITE_SIZE;
@@ -2345,7 +2387,10 @@ export class WorldScene {
 
   private async loadSpriteTexture(sprite: Sprite, imagePath: string, tintOnLoad = 0xffffff) {
     try {
-      const texture = await Assets.load(imagePath);
+      const texture = await loadTexture(imagePath);
+      // A rebuild (room change, mob list update) can destroy this sprite while
+      // the texture is still decoding; don't write to a freed object.
+      if (sprite.destroyed) return;
       sprite.texture = texture;
       sprite.tint = tintOnLoad;
     } catch {
@@ -2764,6 +2809,8 @@ export class WorldScene {
       isStaff,
       canAttack,
       intent,
+      variantName: mob.variantName ?? null,
+      tint: mob.tint ?? null,
     });
     // Auto-fetch the threat assessment so the manual fills in its stats.
     if (canAttack) canvasCallbacks.sendCommand?.(`consider ${mob.name}`);

--- a/web-v3/src/canvas/systems/AbilityVisualSystem.ts
+++ b/web-v3/src/canvas/systems/AbilityVisualSystem.ts
@@ -1,5 +1,6 @@
-import { Container, Graphics, Sprite, Texture, Assets } from "pixi.js";
+import { Container, Graphics, Sprite, Texture } from "pixi.js";
 import type { AbilityVisualArchetype, CombatEventData, SkillVisual } from "../../types";
+import { loadTexture } from "../textureLoader";
 
 /**
  * Per-archetype combat visual renderer. Driven by the skill's `visual.archetype`
@@ -214,7 +215,7 @@ export class AbilityVisualSystem {
       if (cached) {
         proj.sprite = this.attachSprite(cached, color);
       } else if (cached !== null) {
-        Assets.load(imagePath).then((tex: unknown) => {
+        loadTexture(imagePath).then((tex: unknown) => {
           const texture = tex instanceof Texture ? tex : null;
           this.textureCache.set(imagePath, texture);
           if (texture && this.projectiles.includes(proj)) {
@@ -245,7 +246,7 @@ export class AbilityVisualSystem {
     if (cached) {
       pulse.sprite = this.attachSprite(cached, 0xffffff);
     } else if (cached !== null) {
-      Assets.load(imagePath).then((tex: unknown) => {
+      loadTexture(imagePath).then((tex: unknown) => {
         const texture = tex instanceof Texture ? tex : null;
         this.textureCache.set(imagePath, texture);
         if (texture && this.iconPulses.includes(pulse)) {

--- a/web-v3/src/canvas/systems/Minimap.ts
+++ b/web-v3/src/canvas/systems/Minimap.ts
@@ -1,4 +1,5 @@
-import { Assets, Container, Graphics, Rectangle, Sprite, Texture } from "pixi.js";
+import { Container, Graphics, Rectangle, Sprite, Texture } from "pixi.js";
+import { loadTexture } from "../textureLoader";
 import { canvasCallbacks, gameStateRef } from "../GameStateBridge";
 import { MAP_OFFSETS } from "../../constants";
 
@@ -807,7 +808,7 @@ export class Minimap {
         const url = sa[k];
         if (!url) return;
         try {
-          const tex = await Assets.load(url);
+          const tex = await loadTexture(url);
           if (this.destroyed) return;
           // Auto-trim the transparent margin off room/quest glyphs so the
           // artwork fills the node; the parchment scrap is left untouched.

--- a/web-v3/src/canvas/textureLoader.ts
+++ b/web-v3/src/canvas/textureLoader.ts
@@ -1,0 +1,22 @@
+import { Assets, Texture } from "pixi.js";
+
+/**
+ * Loads a Texture from a URL, transparently handling base64 `data:` images.
+ *
+ * The hardened Content-Security-Policy `connect-src` directive blocks the
+ * `data:` scheme, and PixiJS's `Assets.load()` *fetches* its URL — so a data-URL
+ * sprite (mob/pet portrait, room art, ability icon shipped inline by the server)
+ * would fail to load and fall back to a flat colored placeholder. The `img-src`
+ * directive *does* permit `data:`, and an `<img>` element is governed by
+ * `img-src`, so we decode data URLs through one instead. Ordinary http(s) and
+ * app-relative URLs defer to `Assets.load()`, preserving its caching.
+ */
+export async function loadTexture(path: string): Promise<Texture> {
+  if (path.startsWith("data:")) {
+    const img = new Image();
+    img.src = path;
+    await img.decode();
+    return Texture.from(img);
+  }
+  return Assets.load(path);
+}

--- a/web-v3/src/components/panels/MonsterManualPanel.tsx
+++ b/web-v3/src/components/panels/MonsterManualPanel.tsx
@@ -155,6 +155,10 @@ export function MonsterManualPanel({
 
   const { info, name } = monster;
   const skinned = !!bg; // a monster_manual_bg frame is registered
+  // Rare-variant colorize: a valid "#rrggbb" tint washes the portrait the same
+  // way the canvas sprite is colorized, so albino/verdant/etc. read consistently
+  // in the field manual. Invalid/absent tints leave the portrait untouched.
+  const variantTint = monster.tint && /^#[0-9a-fA-F]{6}$/.test(monster.tint) ? monster.tint : null;
   // Only show stats once the consider result is for *this* creature.
   const c = consider && (consider.mobId === monster.id || consider.mobName === name) ? consider : null;
   const level = c?.mobLevel ?? monster.level;
@@ -210,10 +214,16 @@ export function MonsterManualPanel({
         {c && <span className="mm-badge">{c.ratingLabel}</span>}
 
         {/* Framed art (left) */}
-        <figure className="mm-figure">
+        <figure
+          className={`mm-figure${variantTint ? " mm-figure-variant" : ""}`}
+          style={variantTint ? { ["--mm-variant-tint" as string]: variantTint } : undefined}
+        >
           {monster.image ? (
             <>
               <img className="mm-image" src={monster.image} alt={name} />
+              {/* Colorize wash: grayscale (on .mm-image) × tint (multiply) mirrors
+                  the canvas luminance-colorize, so pale variants stay pale. */}
+              {variantTint && <span className="mm-variant-wash" aria-hidden="true" />}
               <button
                 type="button"
                 className="mm-zoom"
@@ -233,7 +243,14 @@ export function MonsterManualPanel({
         <div className="mm-content">
           <header className="mm-head">
             <div className="mm-titles">
-              <h2 className="mm-name">{name}</h2>
+              <h2 className="mm-name">
+                {name}
+                {monster.variantName && (
+                  <span className="mm-variant-name" style={variantTint ? { color: variantTint } : undefined}>
+                    ✦ {monster.variantName}
+                  </span>
+                )}
+              </h2>
               {/* Level/category only matters for things you can fight. */}
               {monster.canAttack && (level != null || category) && (
                 <span className="mm-meta">

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -21149,6 +21149,23 @@ html:has(.game-shell),
   min-height: 220px;
 }
 
+/* Rare-variant colorize for the portrait. Desaturating the art and multiplying
+   a colored wash over it reproduces the canvas luminance-colorize: a pale tint
+   (albino) leaves the creature pale, a saturated tint (verdant) recolors it.
+   A plain multiply over full-colour art would only darken and lose albino. */
+.mm-figure-variant .mm-image {
+  filter: grayscale(0.9) brightness(1.08);
+}
+
+.mm-variant-wash {
+  position: absolute;
+  inset: 0;
+  border-radius: 10px;
+  background: var(--mm-variant-tint, transparent);
+  mix-blend-mode: multiply;
+  pointer-events: none;
+}
+
 .mm-zoom {
   position: absolute;
   right: 8px;
@@ -21200,6 +21217,19 @@ html:has(.game-shell),
   font-weight: 700;
   line-height: 1.1;
   color: #2e2212;
+}
+
+/* Rare-variant label beside the creature name (e.g. "✦ Albino"). Colored to the
+   variant's tint via inline style, with a shadow so pale tints stay legible. */
+.mm-variant-name {
+  display: inline-block;
+  margin-left: 8px;
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  vertical-align: middle;
+  text-shadow: 0 1px 1px rgb(0 0 0 / 55%);
 }
 
 .mm-meta {

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -520,6 +520,10 @@ export interface MonsterEntry {
   isStaff: boolean;
   /** Whether an Attack button + threat assessment apply (false for pets). */
   canAttack: boolean;
+  /** Rare-variant display label (e.g. "Albino"), shown as a badge; null = ordinary. */
+  variantName?: string | null;
+  /** CSS hex tint (e.g. "#5fd17a") used to colorize the manual portrait; null = none. */
+  tint?: string | null;
   /**
    * Deep-link the manual straight to a subpanel when opened from one of the
    * creature's floating indicators: "talk" → dialogue view, "quest" → quest


### PR DESCRIPTION
## Why
Follow-up to the rare & conditional mob system (#1301). Reported symptoms: rare mobs don't show green/white in the monster manual, the on-screen color variant is inconsistent, and the console shows a CSP `connect-src` violation loading a `data:image/png;base64,…`. These turned out to be **three distinct client-side bugs**.

## What changed (all `web-v3`, no server changes)

**1. Pale variants now render (the "albino doesn't work" bug).**
The canvas applied the variant color as a PixiJS `sprite.tint`, which is a *multiply* — it can only darken toward the tint. Albino's near-white `#f5f0ff` therefore left the sprite unchanged (spectral/frostbound/glimmering were weak for the same reason). Replaced it with a luminance-colorize `ColorMatrixFilter` (desaturate → scale by tint, small gain/lift, 0.92 alpha) that can both lighten and darken. The filter also colorizes the white placeholder, so a variant looks right even before/if its art loads.

**2. The monster manual now tints.**
`MonsterEntry` carried no variant data and the portrait was a plain untinted `<img>`. Threaded `tint` + `variantName` into the bestiary entry, colorized the portrait with the same luminance model in CSS (`grayscale(.9)` × tint `multiply` wash), and added a `✦ <variant>` label beside the name.

**3. `data:` sprite URLs failed under the hardened CSP.**
`Assets.load()` fetches its URL, and `connect-src 'self' ws: wss: https:` blocks the `data:` scheme (only `img-src` permits it) — so inline base64 sprites fell back to flat colored squares, which also made on-canvas variants look wrong. Added a shared `loadTexture()` that decodes `data:` URLs through an `<img>` element (governed by `img-src`) and otherwise defers to `Assets.load` (preserving caching). Routed every server-provided image load through it: world/battle mob, pet, player & enemy sprites, room/battle backgrounds, ability icons, and minimap glyphs. **No CSP loosening.**

## Validation
- `tsc -b` ✅ · `eslint .` ✅ · `vite build` ✅
- Manual canvas/bestiary verification still recommended against a world that ships variant mobs (and `data:` sprite art).

## Notes
- The `overlay` particle hint (swirl/embers/…) is still unrendered — out of scope here.
🤖 Generated with [Claude Code](https://claude.com/claude-code)