### PR TITLE
fix(web): variant tints lighten (albino) not just darken; battle scene + bestiary

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -588,6 +588,8 @@ class GameEngine(
                         maxHp = mob.maxHp,
                         image = mob.image,
                         category = mob.category,
+                        tint = mob.tint,
+                        variantName = mob.variantName,
                     )
                 }
             },

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -36,6 +36,10 @@ data class CombatTargetInfo(
     val maxHp: Int,
     val image: String? = null,
     val category: String = "humanoid",
+    /** CSS hex tint for a rare variant (e.g. "#f5f0ff"), or null for ordinary mobs. */
+    val tint: String? = null,
+    /** Variant display label (e.g. "Albino"), or null for ordinary mobs. */
+    val variantName: String? = null,
 )
 
 /** Input DTO for building a Server.Who GMCP payload. */
@@ -236,6 +240,8 @@ class GmcpEmitter(
                 targetMaxHp = target?.maxHp,
                 targetImage = target?.image,
                 targetCategory = target?.category,
+                targetTint = target?.tint,
+                targetVariant = target?.variantName,
             ),
         )
     }
@@ -2675,6 +2681,8 @@ class GmcpEmitter(
         val targetMaxHp: Int?,
         val targetImage: String?,
         val targetCategory: String?,
+        val targetTint: String?,
+        val targetVariant: String?,
     )
 
     @Suppress("unused") // Jackson serializes all fields

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -1180,10 +1180,12 @@ class GmcpEmitterTest {
         runTest {
             val target = CombatTargetInfo(
                 id = "mob-1",
-                name = "Goblin",
+                name = "Albino Goblin",
                 hp = 15,
                 maxHp = 30,
                 image = "/images/goblin.png",
+                tint = "#f5f0ff",
+                variantName = "Albino",
             )
             val e = combatEmitter(target, "Char")
             e.sendCharCombat(sid)
@@ -1192,10 +1194,12 @@ class GmcpEmitterTest {
             val data = events[0]
             assertEquals("Char.Combat", data.gmcpPackage)
             assertTrue(data.jsonData.contains("\"targetId\":\"mob-1\""))
-            assertTrue(data.jsonData.contains("\"targetName\":\"Goblin\""))
+            assertTrue(data.jsonData.contains("\"targetName\":\"Albino Goblin\""))
             assertTrue(data.jsonData.contains("\"targetHp\":15"))
             assertTrue(data.jsonData.contains("\"targetMaxHp\":30"))
             assertTrue(data.jsonData.contains("\"targetImage\":\"/images/goblin.png\""))
+            assertTrue(data.jsonData.contains("\"targetTint\":\"#f5f0ff\""))
+            assertTrue(data.jsonData.contains("\"targetVariant\":\"Albino\""))
         }
 
     @Test

--- a/web-v3/src/canvas/scenes/BattleScene.ts
+++ b/web-v3/src/canvas/scenes/BattleScene.ts
@@ -7,6 +7,7 @@ import { GainPopupSystem } from "../systems/GainPopup";
 import { StatusEffectDisplay } from "../systems/StatusEffectDisplay";
 import { SpellProjectileSystem } from "../systems/SpellProjectile";
 import { loadTexture } from "../textureLoader";
+import { parseHexTint, makeVariantColorize } from "../variantTint";
 
 const BASE_SPRITE_SIZE = 248;
 const MIN_SPRITE_SIZE = 184;
@@ -63,6 +64,7 @@ export class BattleScene {
 
   private lastPlayerSpritePath: string | null = null;
   private lastEnemyImage: string | null = null;
+  private lastEnemyTint: string | null = null;
   private lastTargetId: string | null = null;
   private lastPartyKey = "";
   private lastPetsKey = "";
@@ -212,9 +214,11 @@ export class BattleScene {
     const enemyCategory = combatTarget?.targetCategory ?? "humanoid";
     const enemyImage = combatTarget?.targetImage ?? gameStateRef.current.serverAssets[`default_mob_${enemyCategory}`] ?? null;
     const targetId = combatTarget?.targetId ?? null;
-    if (enemyImage !== this.lastEnemyImage) {
+    const enemyTint = combatTarget?.targetTint ?? null;
+    if (enemyImage !== this.lastEnemyImage || enemyTint !== this.lastEnemyTint) {
       this.lastEnemyImage = enemyImage;
-      this.loadEnemySprite(enemyImage);
+      this.lastEnemyTint = enemyTint;
+      this.loadEnemySprite(enemyImage, enemyTint);
     }
 
     // If the combat target changed to a different mob, cancel any in-progress
@@ -227,7 +231,7 @@ export class BattleScene {
         if (this.enemySprite) {
           this.enemySprite.alpha = 1;
           this.enemySprite.scale.set(1);
-          this.enemySprite.tint = this.lastEnemyImage ? 0xffffff : ENEMY_TINT;
+          this.enemySprite.tint = (this.lastEnemyImage || this.lastEnemyTint) ? 0xffffff : ENEMY_TINT;
         }
         if (!this.fadingIn) {
           this.container.alpha = 1;
@@ -350,7 +354,7 @@ export class BattleScene {
       if (this.enemySprite) {
         this.enemySprite.alpha = 1;
         this.enemySprite.scale.set(1);
-        this.enemySprite.tint = this.lastEnemyImage ? 0xffffff : ENEMY_TINT;
+        this.enemySprite.tint = (this.lastEnemyImage || this.lastEnemyTint) ? 0xffffff : ENEMY_TINT;
       }
       this.enemyLabel.alpha = 1;
       this.enemyHpBar.alpha = 1;
@@ -685,7 +689,7 @@ export class BattleScene {
     }
   }
 
-  private rebuildBattlePets(pets: Array<{ id: string; name: string; hp: number; maxHp: number; image?: string | null; category?: string }>) {
+  private rebuildBattlePets(pets: Array<{ id: string; name: string; hp: number; maxHp: number; image?: string | null; category?: string; tint?: string | null }>) {
     for (const { sprite, label, hpBar } of this.petMembers) {
       this.container.removeChild(sprite);
       this.container.removeChild(label);
@@ -701,7 +705,14 @@ export class BattleScene {
       sprite.width = SMALL_SPRITE;
       sprite.height = SMALL_SPRITE;
       sprite.anchor.set(0.5);
-      sprite.tint = PET_TINT;
+      // Rare-variant pets colorize like world/enemy sprites; others keep the flat purple tint.
+      const variantTint = parseHexTint(pet.tint);
+      if (variantTint != null) {
+        sprite.filters = [makeVariantColorize(variantTint)];
+        sprite.tint = 0xffffff;
+      } else {
+        sprite.tint = PET_TINT;
+      }
 
       const petImage = pet.image ?? gameStateRef.current.serverAssets[`default_mob_${pet.category ?? "humanoid"}`] ?? null;
       if (petImage) {
@@ -781,7 +792,7 @@ export class BattleScene {
     }
   }
 
-  private async loadEnemySprite(imagePath: string | null) {
+  private async loadEnemySprite(imagePath: string | null, tint?: string | null) {
     if (this.enemySprite) {
       this.container.removeChild(this.enemySprite);
       this.enemySprite.destroy();
@@ -792,7 +803,15 @@ export class BattleScene {
     sprite.width = BASE_SPRITE_SIZE;
     sprite.height = BASE_SPRITE_SIZE;
     sprite.anchor.set(0.5);
-    sprite.tint = ENEMY_TINT;
+    // A rare variant gets a luminance-colorize filter (lightens *and* darkens),
+    // matching the world scene; ordinary mobs keep the flat gold placeholder tint.
+    const variantTint = parseHexTint(tint);
+    if (variantTint != null) {
+      sprite.filters = [makeVariantColorize(variantTint)];
+      sprite.tint = 0xffffff;
+    } else {
+      sprite.tint = ENEMY_TINT;
+    }
     this.container.addChildAt(sprite, 1);
     this.enemySprite = sprite;
 
@@ -802,7 +821,8 @@ export class BattleScene {
         sprite.texture = texture;
         sprite.width = BASE_SPRITE_SIZE;
         sprite.height = BASE_SPRITE_SIZE;
-        sprite.tint = 0xffffff;
+        // The colorize filter (if any) recolors the loaded art; otherwise show it as-is.
+        if (variantTint == null) sprite.tint = 0xffffff;
       } catch {
         // Keep placeholder
       }

--- a/web-v3/src/canvas/scenes/WorldScene.ts
+++ b/web-v3/src/canvas/scenes/WorldScene.ts
@@ -1,4 +1,4 @@
-import { Container, Graphics, Sprite, Text, Texture, Assets, ColorMatrixFilter } from "pixi.js";
+import { Container, Graphics, Sprite, Text, Texture, Assets } from "pixi.js";
 import { gameStateRef, canvasCallbacks, pendingCastRef } from "../GameStateBridge";
 import { StatusEffectDisplay } from "../systems/StatusEffectDisplay";
 import { Minimap } from "../systems/Minimap";
@@ -9,6 +9,7 @@ import { WeatherParticles } from "../systems/WeatherParticles";
 import type { MobInfo } from "../../types";
 import { ROOM_SURFACE_WIDGETS } from "../../featureMetadata";
 import { loadTexture } from "../textureLoader";
+import { parseHexTint, makeVariantColorize } from "../variantTint";
 
 /** Resolves a global asset key to its server-provided URL, with a hardcoded fallback. */
 function assetUrl(key: string, fallbackFilename: string): string {
@@ -79,46 +80,6 @@ const ROLE_SHOP_COLOR = 0x81a2be;
 /** Responsive size for a status indicator icon given the host mob's sprite size. */
 function statusIconSize(mobSize: number): number {
   return clamp(mobSize * STATUS_ICON_RATIO, STATUS_ICON_MIN, STATUS_ICON_MAX);
-}
-
-/** Parses a server "#rrggbb" tint into a PixiJS numeric color, or null if absent/invalid. */
-function parseHexTint(tint: string | null | undefined): number | null {
-  if (!tint) return null;
-  const hex = tint.replace("#", "").trim();
-  if (!/^[0-9a-fA-F]{6}$/.test(hex)) return null;
-  return parseInt(hex, 16);
-}
-
-/**
- * Builds a luminance-colorize ColorMatrixFilter for a rare-variant tint.
- *
- * PixiJS's `sprite.tint` is a *multiply*, which can only darken toward the tint
- * — so a pale tint like albino's `#f5f0ff` leaves the sprite essentially
- * unchanged. Colorizing instead (desaturate to luminance, then scale by the
- * tint) makes a near-white tint read as a pale/ghostly creature and a saturated
- * tint as a richly recolored one. A small gain/lift keeps pale variants from
- * coming out muddy, and `alpha` leaves a touch of the original texture so the
- * creature still reads through the wash.
- */
-function makeVariantColorize(tint: number): ColorMatrixFilter {
-  const tr = ((tint >> 16) & 0xff) / 255;
-  const tg = ((tint >> 8) & 0xff) / 255;
-  const tb = (tint & 0xff) / 255;
-  // Rec. 601 luma weights.
-  const lr = 0.299;
-  const lg = 0.587;
-  const lb = 0.114;
-  const gain = 1.15;
-  const lift = 0.1;
-  const filter = new ColorMatrixFilter();
-  filter.matrix = [
-    lr * tr * gain, lg * tr * gain, lb * tr * gain, 0, tr * lift,
-    lr * tg * gain, lg * tg * gain, lb * tg * gain, 0, tg * lift,
-    lr * tb * gain, lg * tb * gain, lb * tb * gain, 0, tb * lift,
-    0, 0, 0, 1, 0,
-  ];
-  filter.alpha = 0.92;
-  return filter;
 }
 
 function drawRoleIcons(g: Graphics, cx: number, cy: number, info: MobInfo, spriteSize: number) {

--- a/web-v3/src/canvas/variantTint.ts
+++ b/web-v3/src/canvas/variantTint.ts
@@ -1,0 +1,52 @@
+import { ColorMatrixFilter } from "pixi.js";
+
+/** Parses a server "#rrggbb" tint into a PixiJS numeric color, or null if absent/invalid. */
+export function parseHexTint(tint: string | null | undefined): number | null {
+  if (!tint) return null;
+  const hex = tint.replace("#", "").trim();
+  if (!/^[0-9a-fA-F]{6}$/.test(hex)) return null;
+  return parseInt(hex, 16);
+}
+
+/**
+ * How strongly the variant recolor replaces the original art (0 = original art,
+ * 1 = fully recolored). Kept moderate so the creature's shading still reads
+ * through and saturated tints (verdant) recolor rather than flood. The CSS
+ * bestiary wash uses the same value — keep them in sync.
+ */
+export const VARIANT_TINT_STRENGTH = 0.6;
+
+/**
+ * Builds a "lighten toward the tint" ColorMatrixFilter for a rare-variant tint.
+ *
+ * The earlier model (and PixiJS's `sprite.tint`) only ever *darkened*: a pale
+ * tint like albino's near-white `#f5f0ff` left a dark creature dark — so albino
+ * showed no change — while a saturated tint like verdant flooded the whole
+ * sprite. This instead desaturates to luminance and *screens* the tint over it:
+ *
+ *   out_c = tint_c + luma · (1 − tint_c)
+ *
+ * which is a linear color matrix. A near-white tint lifts the creature to a
+ * pale/ghostly read; a saturated tint recolors it while keeping its shading.
+ * `filter.alpha` blends back a little of the original so detail survives and
+ * the effect is a wash, not a repaint.
+ */
+export function makeVariantColorize(tint: number): ColorMatrixFilter {
+  const tr = ((tint >> 16) & 0xff) / 255;
+  const tg = ((tint >> 8) & 0xff) / 255;
+  const tb = (tint & 0xff) / 255;
+  // Rec. 601 luma weights.
+  const lr = 0.299;
+  const lg = 0.587;
+  const lb = 0.114;
+  const filter = new ColorMatrixFilter();
+  // Screen of a per-channel constant tint over the grayscale luminance.
+  filter.matrix = [
+    lr * (1 - tr), lg * (1 - tr), lb * (1 - tr), 0, tr,
+    lr * (1 - tg), lg * (1 - tg), lb * (1 - tg), 0, tg,
+    lr * (1 - tb), lg * (1 - tb), lb * (1 - tb), 0, tb,
+    0, 0, 0, 1, 0,
+  ];
+  filter.alpha = VARIANT_TINT_STRENGTH;
+  return filter;
+}

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -340,6 +340,8 @@ export function applyGmcpPackage(
           targetMaxHp: typeof packet.targetMaxHp === "number" ? packet.targetMaxHp : null,
           targetImage: typeof packet.targetImage === "string" ? packet.targetImage : null,
           targetCategory: typeof packet.targetCategory === "string" ? packet.targetCategory : null,
+          targetTint: typeof packet.targetTint === "string" ? packet.targetTint : null,
+          targetVariant: typeof packet.targetVariant === "string" ? packet.targetVariant : null,
         });
       }
       break;

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -21149,12 +21149,14 @@ html:has(.game-shell),
   min-height: 220px;
 }
 
-/* Rare-variant colorize for the portrait. Desaturating the art and multiplying
-   a colored wash over it reproduces the canvas luminance-colorize: a pale tint
-   (albino) leaves the creature pale, a saturated tint (verdant) recolors it.
-   A plain multiply over full-colour art would only darken and lose albino. */
+/* Rare-variant colorize for the portrait — mirrors the canvas screen-colorize
+   in variantTint.ts. Desaturate the art to luminance, then *screen* a colored
+   wash over it so a pale tint (albino) lifts the creature to a pale/ghostly
+   read and a saturated tint (verdant) recolors it without flooding. A plain
+   multiply would only darken: albino vanished and verdant turned to mud. The
+   wash opacity matches VARIANT_TINT_STRENGTH so canvas and bestiary agree. */
 .mm-figure-variant .mm-image {
-  filter: grayscale(0.9) brightness(1.08);
+  filter: grayscale(0.85);
 }
 
 .mm-variant-wash {
@@ -21162,7 +21164,8 @@ html:has(.game-shell),
   inset: 0;
   border-radius: 10px;
   background: var(--mm-variant-tint, transparent);
-  mix-blend-mode: multiply;
+  mix-blend-mode: screen;
+  opacity: 0.6;
   pointer-events: none;
 }
 

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -475,6 +475,10 @@ export interface CombatTarget {
   targetMaxHp: number | null;
   targetImage: string | null;
   targetCategory: string | null;
+  /** CSS hex tint for a rare variant (e.g. "#f5f0ff"); null = ordinary mob. */
+  targetTint: string | null;
+  /** Variant display label (e.g. "Albino"); null = ordinary mob. */
+  targetVariant: string | null;
 }
 
 export type ConsiderRating =


### PR DESCRIPTION
## Why
Follow-up to #1304. The user reported albino variants still don't render: the **albino eel shows no tint anywhere**, and the **verdant crab floods flat green** in the Monster Manual.

Both are the same root cause #1304 didn't fully fix: the colorize could only **darken**. The canvas used a luminance-*preserving* matrix and the bestiary used a `mix-blend-mode: multiply` wash — so a near-white albino tint (`#f5f0ff`) left a dark creature dark (invisible), while a saturated verdant tint (`#5fd17a`) flooded the whole portrait.

## What changed

**1. Lighten-toward-tint colorize model (the core fix).**
New shared `web-v3/src/canvas/variantTint.ts` with a screen-style blend, expressible as a linear `ColorMatrixFilter`:

```
out_c = tint_c + luma · (1 − tint_c)
```

A pale tint now lifts the creature to a pale/ghostly read; a saturated tint recolors it while keeping its shading. `VARIANT_TINT_STRENGTH` (0.6) is the single knob, shared by canvas and CSS. WorldScene now imports from the shared module instead of its private copy.

**2. Bestiary CSS mirrors it.** `.mm-variant-wash` switched from `multiply` → `mix-blend-mode: screen` at the same strength; portrait desaturated to luminance. Albino reads pale, verdant reads as a gentle green wash — not a flood.

**3. Battle scene now renders variant tints (#1304 never touched it).**
- Server `Char.Combat` carries `targetTint`/`targetVariant` (`CombatTargetInfo`, `CharCombatPayload`, `GameEngine` target builder).
- Client parses them into `CombatTarget`; `BattleScene.loadEnemySprite` + `rebuildBattlePets` apply the shared colorize, so variant **enemies and pets** show their tint in combat instead of the default gold/purple.

## Validation
- `tsc -b` ✅ · `eslint` ✅ · `vite build` ✅ · `ktlintCheck` ✅ · `GmcpEmitterTest` ✅ (extended to assert `targetTint`/`targetVariant`)
- Numeric check: albino `#f5f0ff` over a dark eel → pale lavender-grey; verdant `#5fd17a` over the crab → soft green with shading preserved.
- **Visual re-test still recommended** against a world with variant mobs (world canvas, battle, bestiary).

## Tuning
If the effect reads slightly strong or weak, adjust the single `VARIANT_TINT_STRENGTH` constant in `variantTint.ts` (and the matching `.mm-variant-wash` opacity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)