### PR TITLE
fix(web): preload painted art to kill purple fallback flash

### DIFF
--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -172,6 +172,10 @@ function TrainerAutoLoad({ onCommand }: { onCommand: (cmd: string) => void }) {
   return <p className="empty-note">Loading trainer data&hellip;</p>;
 }
 
+// URLs already handed to the browser for prefetching, so the preload effect
+// never recreates an Image for art it has seen this session.
+const preloadedArt = new Set<string>();
+
 function App() {
   const resumeTokenRef = useRef<string | null>(null);
   const pendingAuthCharRef = useRef<string | null>(null);
@@ -354,6 +358,23 @@ function App() {
       disconnect();
     };
   }, [connect, disconnect, reconnect]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Warm the browser cache for painted panel art the moment Server.Assets lands.
+  // Skins are applied as CSS background-images, so a panel only starts fetching
+  // its PNG when it first paints — until the bytes arrive the element shows its
+  // fallback (the purple jewel-tone gradient for drawers/admin/etc.), which reads
+  // as a flash. Server.Assets arrives at login, well before any in-game panel
+  // opens, so a fire-and-forget preload here means those panels paint warm. Skip
+  // inline data: URIs (already resolved, nothing to fetch).
+  useEffect(() => {
+    for (const url of Object.values(state.serverAssets)) {
+      if (typeof url !== "string" || url.startsWith("data:") || preloadedArt.has(url)) continue;
+      preloadedArt.add(url);
+      const img = new Image();
+      img.decoding = "async";
+      img.src = url;
+    }
+  }, [state.serverAssets]);
 
   const sendCommand = (raw: string) => {
     const command = raw.trim();

--- a/web-v3/src/main.tsx
+++ b/web-v3/src/main.tsx
@@ -2,6 +2,26 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 
+// Preload the painted background for whichever login screen shows first, so it
+// paints warm instead of flashing its fallback. The art is a CSS background and
+// only arrives via Server.Assets ~immediately before the login prompt, leaving
+// no time to fetch before first paint; kicking the request off here (before
+// React mounts, well ahead of the websocket connect) closes that gap. Returning
+// players land on the welcome-back picker, everyone else on the name screen.
+// Bundled login art always resolves to /images/global_assets/ regardless of the
+// world/config overlay (see GmcpEmitter asset resolution), so the path is fixed.
+try {
+  const tokens = JSON.parse(localStorage.getItem("ambonmud_auth_tokens") ?? "{}") as Record<string, string>;
+  const key = Object.keys(tokens).length > 0 ? "login_picker_bg" : "login_bg";
+  const link = document.createElement("link");
+  link.rel = "preload";
+  link.as = "image";
+  link.href = `/images/global_assets/${key}.png`;
+  document.head.appendChild(link);
+} catch {
+  // localStorage unavailable / blocked — skip the preload, the app still works.
+}
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />


### PR DESCRIPTION
## Problem

The unskinned **purple** versions of panels (login, welcome-back, drawers, admin, inn, etc.) flash briefly before the painted art appears.

## Root cause

Painted art is applied as a CSS `background-image` (`var(--skin-bg)` / `var(--login-art)`). The browser only starts downloading the PNG **when the element first paints**, so until the bytes arrive the element shows its CSS fallback:

- In-game panels layer the image over a **purple jewel-tone gradient** (`background: var(--skin-bg, none), linear-gradient(...)`) → the purple flash.
- Login/welcome scenes fall back to the dark `login-art-root` → a briefer dark→painted pop.

The server already sends `Server.Assets` *before* the login prompt, so the URLs are present at first render — the gap is purely **image-download latency on a cold cache**, not a data-timing race.

## Fix — warm the cache before panels paint

- **`App.tsx`**: when `Server.Assets` lands (at login, before any in-game panel opens), fire-and-forget `new Image()` preloads for every asset URL. Drawers/admin/inn/etc. open later, so they paint warm. Skips inline `data:` URIs; dedupes per session.
- **`main.tsx`**: the login/welcome backgrounds render almost immediately after `Server.Assets` arrives, so they get no head start from the in-app preload. Before React mounts, inject a `<link rel="preload" as="image">` for the one background that will show first — welcome-back picker (`login_picker_bg`) for returning players (detected via the same `ambonmud_auth_tokens` localStorage key the app uses), else the name screen (`login_bg`). Bundled login art always resolves to `/images/global_assets/`, so the path is fixed.

Placing the conditional preload in the bundled module (not an inline HTML script) keeps it CSP-robust against the planned `script-src` nonce tightening, and preloading exactly one background avoids unused-preload console warnings.

## Validation

- `bun run lint` ✅
- `bunx tsc -b` ✅
- `bun run build` ✅

Worth a quick manual check on `./gradlew demo`: hard-reload (empty cache) and confirm the login/welcome screen and an in-game panel (e.g. inventory) no longer flash purple.