### PR TITLE
feat(web): painted portrait frame for the bestiary (masks variant colorize seam)

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -3425,6 +3425,10 @@ data class ImagesConfig(
             "friends_bg" to "global_assets/friends_bg.png",
             "group_bg" to "global_assets/group_bg.png",
             "command_reference_bg" to "global_assets/command_reference_bg.png",
+            // Bestiary portrait frame — painted ornamental border overlaid on the
+            // monster-manual portrait. Its opaque edge masks the rectangular
+            // rare-variant colorize seam. Transparent center, ~2:3 portrait.
+            "monster_manual_portrait_frame" to "global_assets/monster_manual_portrait_frame.png",
             "stylist_bg" to "global_assets/stylist_bg.png",
             "housing_bg" to "global_assets/housing_bg.png",
             "lottery_bg" to "global_assets/lottery_bg.png",

--- a/web-v3/src/components/panels/MonsterManualPanel.tsx
+++ b/web-v3/src/components/panels/MonsterManualPanel.tsx
@@ -155,6 +155,10 @@ export function MonsterManualPanel({
 
   const { info, name } = monster;
   const skinned = !!bg; // a monster_manual_bg frame is registered
+  // Optional painted portrait frame. Overlaid on the figure, its opaque border
+  // masks the rectangular rare-variant colorize seam (and frames every portrait
+  // when registered). Absent → the plain bordered portrait shows through.
+  const portraitFrame = serverAssets["monster_manual_portrait_frame"];
   // Rare-variant colorize: a valid "#rrggbb" tint washes the portrait the same
   // way the canvas sprite is colorized, so albino/verdant/etc. read consistently
   // in the field manual. Invalid/absent tints leave the portrait untouched.
@@ -215,7 +219,7 @@ export function MonsterManualPanel({
 
         {/* Framed art (left) */}
         <figure
-          className={`mm-figure${variantTint ? " mm-figure-variant" : ""}`}
+          className={`mm-figure${variantTint ? " mm-figure-variant" : ""}${portraitFrame ? " mm-figure-framed" : ""}`}
           style={variantTint ? { ["--mm-variant-tint" as string]: variantTint } : undefined}
         >
           {monster.image ? (
@@ -224,6 +228,8 @@ export function MonsterManualPanel({
               {/* Colorize wash: grayscale (on .mm-image) × tint (multiply) mirrors
                   the canvas luminance-colorize, so pale variants stay pale. */}
               {variantTint && <span className="mm-variant-wash" aria-hidden="true" />}
+              {/* Painted frame sits above the art + wash, masking the colorize seam. */}
+              {portraitFrame && <img className="mm-portrait-frame" src={portraitFrame} alt="" aria-hidden="true" />}
               <button
                 type="button"
                 className="mm-zoom"

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -21169,6 +21169,35 @@ html:has(.game-shell),
   pointer-events: none;
 }
 
+/* Painted portrait frame (asset monster_manual_portrait_frame). Overlaid above
+   the art + variant wash so its opaque ornamental border masks the rectangular
+   colorize seam; the transparent center lets the creature show through. The zoom
+   button renders after this in the DOM, so it stays clickable. */
+.mm-portrait-frame {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: fill;
+  pointer-events: none;
+}
+
+/* Unskinned card: lock the figure to the frame art's ~2:3 portrait so the
+   painted border isn't stretched. (In the skinned card the figure is already
+   sized by its painted slot, so the frame simply overlays it.) */
+.mm-card:not(.mm-card-skinned) .mm-figure-framed {
+  flex: 0 0 auto;
+  aspect-ratio: 2 / 3;
+  align-self: center;
+}
+
+/* The frame's border already supplies the edge — drop the portrait's own
+   border/radius so they don't double up under the painted frame. */
+.mm-figure-framed .mm-image {
+  border: none;
+  box-shadow: none;
+}
+
 .mm-zoom {
   position: absolute;
   right: 8px;


### PR DESCRIPTION
## Why
Follow-on to #1305. The rare-variant colorize (screen wash) leaves a rectangular **seam** at the portrait edge in the monster manual. This adds a painted ornamental frame, overlaid on the portrait, whose opaque border masks that seam.

## Asset
New global asset key **`monster_manual_portrait_frame`** → `global_assets/monster_manual_portrait_frame.png`.
- ~2:3 portrait PNG, transparent center, painted border on the outer ~10–12%.
- Purely additive: when the asset isn't registered/uploaded, the plain bordered portrait shows through (CSS fallback preserved).

## What changed
- **AppConfig**: register `monster_manual_portrait_frame` in `DEFAULT_GLOBAL_ASSETS` (delivered to the client via the existing `Server.Assets` GMCP map).
- **MonsterManualPanel**: read the asset from `serverAssets`, overlay it on `.mm-figure` above `.mm-variant-wash`, tag the figure `.mm-figure-framed`.
- **CSS**: frame overlay (`object-fit: fill`, `pointer-events: none` so the zoom button stays clickable); the unskinned figure locks to the art's ~2:3 portrait so the border isn't stretched; the portrait's own border/shadow is dropped under the frame so edges don't double up.

## Validation
`ktlintCheck` ✅ · AppConfig/ImagesConfig tests ✅ · `tsc -b` ✅ · `eslint` ✅ · `vite build` ✅
Visual confirmation pending the generated frame art.

🤖 Generated with [Claude Code](https://claude.com/claude-code)