### PR TITLE
feat(web): show bestiary portrait frame only for variants

### DIFF
--- a/web-v3/src/components/panels/MonsterManualPanel.tsx
+++ b/web-v3/src/components/panels/MonsterManualPanel.tsx
@@ -155,14 +155,15 @@ export function MonsterManualPanel({
 
   const { info, name } = monster;
   const skinned = !!bg; // a monster_manual_bg frame is registered
-  // Optional painted portrait frame. Overlaid on the figure, its opaque border
-  // masks the rectangular rare-variant colorize seam (and frames every portrait
-  // when registered). Absent → the plain bordered portrait shows through.
-  const portraitFrame = serverAssets["monster_manual_portrait_frame"];
   // Rare-variant colorize: a valid "#rrggbb" tint washes the portrait the same
   // way the canvas sprite is colorized, so albino/verdant/etc. read consistently
   // in the field manual. Invalid/absent tints leave the portrait untouched.
   const variantTint = monster.tint && /^#[0-9a-fA-F]{6}$/.test(monster.tint) ? monster.tint : null;
+  // Optional painted portrait frame, shown *only* for variants: its opaque border
+  // masks the rectangular colorize seam and makes a rare creature feel special,
+  // while ordinary mobs keep the painted card's own alcove. Absent asset → the
+  // plain bordered portrait shows through.
+  const portraitFrame = variantTint ? serverAssets["monster_manual_portrait_frame"] : undefined;
   // Only show stats once the consider result is for *this* creature.
   const c = consider && (consider.mobId === monster.id || consider.mobName === name) ? consider : null;
   const level = c?.mobLevel ?? monster.level;


### PR DESCRIPTION
## Why
Follow-up to #1307. The painted monster-manual card already has its own portrait alcove, so framing **every** entry fought it. Restricting `monster_manual_portrait_frame` to rare variants makes the frame do double duty — mask the colorize seam **and** make a rare creature feel special — while ordinary mobs keep the card's built-in alcove.

## What changed
One gating change in `MonsterManualPanel`: `portraitFrame` now resolves to the asset **only when the creature has a valid variant tint**. The existing `.mm-figure-framed` class and the overlay `<img>` already key off `portraitFrame`, so they follow automatically — no other edits needed.

## Validation
`tsc -b` ✅ · `eslint` ✅ · `vite build` ✅ (web-only; no server change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)