### PR TITLE
fix(web): kill welcome-back purple flash via synchronous art-cache seed

### DIFF
--- a/web-v3/src/canvas/loginArtFit.ts
+++ b/web-v3/src/canvas/loginArtFit.ts
@@ -54,6 +54,17 @@ const artImageStatus = new Map<string, "ready" | "failed">();
  */
 export function useArtImage(url: string | null): string | null {
   const [, setProbedCount] = useState(0);
+  // Synchronous HTTP-cache seed: when the art is already cached (warmed by the
+  // preloads in main.tsx / App.tsx), a freshly-constructed Image reports
+  // `complete` with a non-zero natural size the instant we assign src. Marking
+  // it ready here — before the first paint — lets a warm scene render painted
+  // immediately instead of flashing the CSS fallback for the frame it takes the
+  // async onload below to settle. Cold art falls through to that async probe.
+  if (url && !artImageStatus.has(url)) {
+    const probe = new Image();
+    probe.src = url;
+    if (probe.complete && probe.naturalWidth > 0) artImageStatus.set(url, "ready");
+  }
   useEffect(() => {
     if (!url || artImageStatus.has(url)) return;
     let cancelled = false;

--- a/web-v3/src/main.tsx
+++ b/web-v3/src/main.tsx
@@ -7,19 +7,23 @@ import App from "./App.tsx";
 // only arrives via Server.Assets ~immediately before the login prompt, leaving
 // no time to fetch before first paint; kicking the request off here (before
 // React mounts, well ahead of the websocket connect) closes that gap. Returning
-// players land on the welcome-back picker, everyone else on the name screen.
-// Bundled login art always resolves to /images/global_assets/ regardless of the
-// world/config overlay (see GmcpEmitter asset resolution), so the path is fixed.
+// players land on the welcome-back picker, everyone else on the name screen, and
+// each scene swaps to its phone-portrait companion on a portrait viewport — so
+// preload the variant the first paint will actually use. Bundled login art
+// always resolves to /images/global_assets/ regardless of the world/config
+// overlay (see GmcpEmitter asset resolution), so the path is fixed.
 try {
   const tokens = JSON.parse(localStorage.getItem("ambonmud_auth_tokens") ?? "{}") as Record<string, string>;
-  const key = Object.keys(tokens).length > 0 ? "login_picker_bg" : "login_bg";
+  const base = Object.keys(tokens).length > 0 ? "login_picker_bg" : "login_bg";
+  const portrait = window.matchMedia("(orientation: portrait)").matches;
+  const key = portrait ? `${base}_portrait` : base;
   const link = document.createElement("link");
   link.rel = "preload";
   link.as = "image";
   link.href = `/images/global_assets/${key}.png`;
   document.head.appendChild(link);
 } catch {
-  // localStorage unavailable / blocked — skip the preload, the app still works.
+  // localStorage / matchMedia unavailable — skip the preload, the app still works.
 }
 
 createRoot(document.getElementById('root')!).render(


### PR DESCRIPTION
Follow-up to #1306. That PR warmed the HTTP cache and fixed the login (name) screen, but the **welcome-back** screens — the saved-character picker (`login_picker_bg`) and the returning-user password step (`login_password_bg`, "Welcome back, X") — still flashed their purple CSS fallback.

## Root cause

`useArtImage` (in `loginArtFit.ts`) gates a painted scene on the image loading, but only ever marks art `"ready"` from an **async `img.onload`**. So the *first* render of any scene returns `null` → the CSS fallback (purple) paints for at least one frame, even when the image is already in cache. The async probe then flips it to the painted scene.

The name screen merely *hid* this: `login_bg` is preloaded during HTML parse (main.tsx), so its `onload` settles sub-frame. The welcome-back screens mount later/fresh, where one fallback frame is plainly visible.

## Fix

- **`useArtImage`** now seeds its ready status **synchronously from the HTTP cache** during render: a freshly-constructed `Image` reports `complete` with a non-zero `naturalWidth` the instant `src` is assigned for a cached URL. So warm art (picker, password, name) renders painted on the *first* frame; cold art still falls through to the existing async `onload` probe (and its 404/blocked → CSS-fallback degradation per ART_CONTRACT).
- **`main.tsx`** now preloads the *orientation-correct* companion of the first screen (`…_portrait` on portrait viewports), so phone returning players get the picker warm too.

`App.tsx` already preloads the full `Server.Assets` map at connect (from #1306), so later steps (password, confirm, race/class) are cache-warm by the time the sync seed probes them.

## Validation

- `bun run lint` ✅
- `bunx tsc -b` ✅
- `bun run build` ✅

Manual check on `./gradlew demo`, hard-reload (empty cache): confirm neither the saved-character picker nor the "Welcome back, X" password screen flashes purple before the painted art. Worth checking once with a saved character (picker path) and once with a fresh name → existing account (password path).