### PR TITLE
fix(web): bestiary portrait no longer paints a square behind translucent mobs

### DIFF
--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -21142,11 +21142,17 @@ html:has(.game-shell),
   border-radius: 10px;
   border: 2px solid #4a3825;
   box-shadow: inset 0 0 0 2px rgb(255 248 230 / 40%), 0 4px 12px rgb(0 0 0 / 35%);
-  background: #2a3242;
+  /* No opaque fill: a translucent sprite (e.g. a ghost) must composite against
+     whatever is behind it (card paper / painted frame), not a flat rectangle.
+     A solid colour here is what turned see-through pixels into a slate square
+     in the bestiary while the canvas battle scene kept them translucent. The
+     empty-placeholder state keeps the backdrop instead. */
+  background: transparent;
 }
 
 .mm-image-empty {
   min-height: 220px;
+  background: #2a3242;
 }
 
 /* Rare-variant colorize for the portrait — mirrors the canvas screen-colorize


### PR DESCRIPTION
## Problem

A translucent mob (e.g. a ghost / "wandering spirit") renders correctly translucent in the world/battle canvas, but in the **Monster Manual / bestiary** the see-through areas show up as an opaque **square**.

## Cause

The bestiary portrait is a plain `<img class="mm-image">` that had:

```css
.mm-image { object-fit: cover; background: #2a3242; }
```

The `<img>` fills its rectangular figure box, so a translucent PNG lets that solid `#2a3242` fill show through wherever the sprite is transparent → a slate square. (The recent painted portrait frame masked the *edges* of that rectangle but not the fill inside it.)

The canvas battle scene doesn't do this because the sprite is a PixiJS `Sprite` composited over the live scene with normal alpha blending — no rectangular fill behind it.

## Fix

- `.mm-image` → `background: transparent` so translucent sprites composite against the card paper / painted frame.
- Move the backdrop to `.mm-image-empty`, the state that actually wants one.

The skinned card (`.mm-card-skinned .mm-image`) already used `background: none`, so only the unskinned base rule needed the change.

## Verification

Ran `./gradlew demo` and loaded the client. In the live browser:
- `.mm-image` computed `background-color` → `rgba(0, 0, 0, 0)` (transparent; was `rgb(42, 50, 66)`)
- `.mm-image.mm-image-empty` → `rgb(42, 50, 66)` (backdrop preserved for the empty placeholder)

CSS-only change.