### PR TITLE
feat(engine): demo characters get a random race + selectable class

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/events/LoginFlowHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/events/LoginFlowHandler.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
+import kotlin.random.Random
 
 private val log = KotlinLogging.logger {}
 
@@ -150,6 +151,7 @@ internal class LoginFlowHandler(
     private val demoDefaultRace: String = "HUMAN",
     private val demoDefaultClass: String = "WARRIOR",
     private val demoNameGenerator: dev.ambon.engine.DemoNameGenerator = dev.ambon.engine.DemoNameGenerator(),
+    private val random: Random = Random.Default,
     internal val onAfterLogin: suspend (SessionId) -> Unit = {},
     /**
      * Called on the paths where the client just authenticated with a password
@@ -522,8 +524,8 @@ internal class LoginFlowHandler(
                     sessionId = sid,
                     name = result.name,
                     defaultAnsiEnabled = result.defaultAnsiEnabled,
-                    race = demoDefaultRace,
-                    playerClass = demoDefaultClass,
+                    race = raceRegistry.all().randomOrNull(random)?.id ?: demoDefaultRace,
+                    playerClass = availableClasses.randomOrNull(random)?.id ?: demoDefaultClass,
                 )
                 when (createResult) {
                     dev.ambon.engine.CreateResult.Ok -> {

--- a/src/test/kotlin/dev/ambon/engine/GameEngineLoginFlowTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GameEngineLoginFlowTest.kt
@@ -1047,6 +1047,22 @@ class GameEngineLoginFlowTest {
                 "demo character must not be persisted to the repository",
             )
 
+            // Demo characters get a random race and a random *selectable* class,
+            // not the hardcoded HUMAN/WARRIOR defaults.
+            val validRaces = testRaceEngineConfig().definitions.keys
+            val selectableClasses =
+                testClassEngineConfig().definitions
+                    .filterValues { it.selectable }
+                    .keys
+            assertTrue(
+                player.race in validRaces,
+                "demo race ${player.race} should be one of $validRaces",
+            )
+            assertTrue(
+                player.playerClass in selectableClasses,
+                "demo class ${player.playerClass} should be a selectable class in $selectableClasses",
+            )
+
             h.close()
         }
 


### PR DESCRIPTION
## What

Demo (guest) characters — created when a player types `demo` at the login prompt — now get a **random race** and a **random selectable class** instead of the hardcoded `HUMAN`/`WARRIOR` defaults.

## Why

Default-everything demos always looked identical. Randomizing showcases more of the game (races + classes) each time someone tries a demo.

## How

In `LoginFlowHandler`'s `DemoCharacter` result handler:
- Race: `raceRegistry.all().randomOrNull(random)?.id`
- Class: `availableClasses.randomOrNull(random)?.id` — reuses the existing selectable-class list, which already respects the `debugClassesEnabled` flag (so hidden classes like Swarm/Akathavae stay out unless debug is on).
- Falls back to the configured `defaultRace`/`defaultClass` only if a registry is empty (defensive).

Plain `kotlin.random.Random` (injectable, defaults to `Random.Default`), matching the precedent in `DemoNameGenerator` — demo creation is intentionally non-deterministic.

Normal interactive character creation is unchanged.

## Tests

Extended the existing demo-spawn test in `GameEngineLoginFlowTest` to assert the demo's race is a valid registry race and its class is one of the selectable classes. Full suite green (`./gradlew test`, ktlint clean).