### PR TITLE
feat(map): floor-aware minimap layout (mapZ), stair badges, and layout diagnostics

### DIFF
--- a/src/main/kotlin/dev/ambon/admin/AdminHttpServer.kt
+++ b/src/main/kotlin/dev/ambon/admin/AdminHttpServer.kt
@@ -909,6 +909,7 @@ internal fun Application.adminModule(
                 "ambient" to room.ambient,
                 "mapX" to room.mapX,
                 "mapY" to room.mapY,
+                "mapZ" to room.mapZ,
             )
             call.respondText(json.writeValueAsString(dto), ContentType.Application.Json)
         }

--- a/src/main/kotlin/dev/ambon/domain/world/Room.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/Room.kt
@@ -49,6 +49,13 @@ data class Room(
     val mapX: Int = 0,
     /** Precomputed minimap Y coordinate (assigned by WorldLoader BFS). */
     val mapY: Int = 0,
+    /**
+     * Precomputed minimap floor (z layer). Rooms horizontally connected to the
+     * zone start room are floor 0; areas reachable only through up/down exits
+     * sit one floor above/below their stair partner. Clients render one floor
+     * at a time, following the player.
+     */
+    val mapZ: Int = 0,
     /** Whether this room's zone has custom graphical assets (non-placeholder images). */
     val graphical: Boolean = false,
     /** Terrain type — drives default background and weather suppression. */

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -1856,29 +1856,40 @@ object WorldLoader {
         Direction.SOUTH to (0 to 1),
         Direction.EAST to (1 to 0),
         Direction.WEST to (-1 to 0),
-        Direction.UP to (1 to -1),
-        Direction.DOWN to (-1 to 1),
+    )
+
+    /** A room's resolved minimap cell: (x, y) within floor z of its zone. */
+    private data class MapCell(
+        val x: Int,
+        val y: Int,
+        val z: Int,
     )
 
     /**
-     * Assigns 2D minimap coordinates to every room via per-zone BFS.
+     * Assigns minimap coordinates (x, y, floor z) to every room via per-zone BFS.
      *
-     * Each zone is laid out independently, starting from the zone's declared start room at (0,0).
-     * Only horizontal exits (N/S/E/W) are traversed during BFS — up/down exits are treated as
-     * portals rather than spatial moves, so they don't scatter rooms diagonally or cause grid
-     * collisions with unrelated branches. Rooms reachable only via up/down are placed in a
-     * second pass relative to their horizontal neighbors.
+     * Each zone is laid out independently. Rooms split into *floors*: the connected
+     * components of the horizontal (N/S/E/W) exit graph. The floor containing the
+     * zone's start room is laid out first, from (0,0) on z=0. Up/down exits are
+     * treated as stairs between floors rather than spatial moves: each floor that
+     * connects to an already-placed floor through a vertical exit is anchored at
+     * its stair partner's (x, y) on z±1 and then BFS-laid-out on its own layer, so
+     * upstairs/downstairs areas keep their internal shape without scattering
+     * diagonally into the ground floor. Floors with no vertical link to anything
+     * placed (authoring oddities) fall back to z=0 near the origin, with a warning.
      *
-     * When two rooms would occupy the same grid cell (non-euclidean exit topology), the later
-     * arrival is placed at the nearest unoccupied cell via a spiral search.
+     * When two rooms would occupy the same cell of the same floor (non-euclidean
+     * exit topology), the later arrival is placed at the nearest unoccupied cell
+     * via a spiral search — and a warning names both rooms, since the resulting
+     * map draws that exit as a diagonal. Zone authors can keep maps clean by
+     * laying out each floor so its horizontal exits are euclidean-consistent.
      */
     private fun assignMapCoordinates(
         rooms: Map<RoomId, Room>,
         zoneStartRooms: Map<String, RoomId>,
     ): Map<RoomId, Room> {
-        // Group rooms by zone
         val roomsByZone = rooms.keys.groupBy { it.zone }
-        val coords = HashMap<RoomId, Pair<Int, Int>>(rooms.size)
+        val coords = HashMap<RoomId, MapCell>(rooms.size)
 
         data class Pending(
             val roomId: RoomId,
@@ -1890,72 +1901,127 @@ object WorldLoader {
 
         for ((zone, roomIds) in roomsByZone) {
             val zoneRoomSet = roomIds.toHashSet()
-            val occupied = HashMap<Pair<Int, Int>, RoomId>()
+            // Occupancy is tracked per floor: floor z → (x, y) → room.
+            val occupied = HashMap<Int, HashMap<Pair<Int, Int>, RoomId>>()
+
+            fun layer(z: Int) = occupied.getOrPut(z) { HashMap() }
+
             val startId = zoneStartRooms[zone] ?: roomIds.first()
 
-            // Phase 1: BFS using only horizontal exits (N/S/E/W).
-            val queue = ArrayDeque<Pending>()
-            queue.addLast(Pending(startId, 0, 0))
+            // Lays out one floor (horizontal connected component) by BFS from an
+            // anchor room at the given cell, warning on any collision-displacement.
+            fun layoutFloor(
+                anchorId: RoomId,
+                anchorX: Int,
+                anchorY: Int,
+                z: Int,
+            ) {
+                val grid = layer(z)
+                val queue = ArrayDeque<Pending>()
+                queue.addLast(Pending(anchorId, anchorX, anchorY))
+                while (queue.isNotEmpty()) {
+                    val (roomId, desiredX, desiredY) = queue.removeFirst()
+                    if (coords.containsKey(roomId)) continue
 
-            while (queue.isNotEmpty()) {
-                val (roomId, desiredX, desiredY) = queue.removeFirst()
-                if (coords.containsKey(roomId)) continue
+                    val pos = findFreePosition(desiredX, desiredY, grid)
+                    if (pos != (desiredX to desiredY)) {
+                        logger.warn(
+                            "Minimap layout: zone '{}' room '{}' displaced from ({},{}) to ({},{}) on floor {} — " +
+                                "cell occupied by '{}'; this exit will draw diagonally on the map",
+                            zone,
+                            roomId.value,
+                            desiredX,
+                            desiredY,
+                            pos.first,
+                            pos.second,
+                            z,
+                            grid[desiredX to desiredY]?.value,
+                        )
+                    }
+                    coords[roomId] = MapCell(pos.first, pos.second, z)
+                    grid[pos] = roomId
 
-                val pos = findFreePosition(desiredX, desiredY, occupied)
-                coords[roomId] = pos
-                occupied[pos] = roomId
-
-                val room = rooms[roomId] ?: continue
-                for ((dir, targetId) in room.exits) {
-                    if (dir !in horizontalDirs) continue
-                    if (coords.containsKey(targetId)) continue
-                    if (targetId !in zoneRoomSet) continue
-                    val (dx, dy) = DIRECTION_OFFSETS[dir] ?: continue
-                    queue.addLast(Pending(targetId, pos.first + dx, pos.second + dy))
+                    val room = rooms[roomId] ?: continue
+                    for ((dir, targetId) in room.exits) {
+                        if (dir !in horizontalDirs) continue
+                        if (coords.containsKey(targetId)) continue
+                        if (targetId !in zoneRoomSet) continue
+                        val (dx, dy) = DIRECTION_OFFSETS[dir] ?: continue
+                        queue.addLast(Pending(targetId, pos.first + dx, pos.second + dy))
+                    }
                 }
             }
 
-            // Phase 2: Place rooms not reached by horizontal BFS (reachable only via up/down,
-            // or completely unreachable dead-ends). Try to position relative to an already-placed
-            // horizontal neighbor; fall back to placing near any connected neighbor.
+            // Phase 1: the start room's floor is the zone's ground floor (z=0).
+            layoutFloor(startId, 0, 0, 0)
+
+            // Phase 2: repeatedly anchor unplaced floors through their stairs.
+            // A placed room with an up/down exit to an unplaced room seeds that
+            // room's whole floor at the partner's (x, y) one layer up/down.
+            var progressed = true
+            while (progressed) {
+                progressed = false
+                for (placedId in roomIds) {
+                    val cell = coords[placedId] ?: continue
+                    val room = rooms[placedId] ?: continue
+                    for ((dir, targetId) in room.exits) {
+                        val dz = when (dir) {
+                            Direction.UP -> 1
+                            Direction.DOWN -> -1
+                            else -> continue
+                        }
+                        if (targetId in coords || targetId !in zoneRoomSet) continue
+                        layoutFloor(targetId, cell.x, cell.y, cell.z + dz)
+                        progressed = true
+                    }
+                }
+            }
+
+            // Phase 3: rooms with no static inbound path — typically hidden behind
+            // puzzle-revealed exits. Anchor each through its own outgoing exits back
+            // to a placed neighbor (reversing the offset, or sitting a floor away
+            // from a stair partner), repeating until stable.
+            var anchoredSome = true
+            while (anchoredSome) {
+                anchoredSome = false
+                for (unreachedId in roomIds) {
+                    if (coords.containsKey(unreachedId)) continue
+                    val room = rooms[unreachedId] ?: continue
+                    for ((dir, neighborId) in room.exits) {
+                        val n = coords[neighborId] ?: continue
+                        when (dir) {
+                            in horizontalDirs -> {
+                                val (dx, dy) = DIRECTION_OFFSETS[dir] ?: continue
+                                layoutFloor(unreachedId, n.x - dx, n.y - dy, n.z)
+                            }
+                            Direction.UP -> layoutFloor(unreachedId, n.x, n.y, n.z - 1)
+                            Direction.DOWN -> layoutFloor(unreachedId, n.x, n.y, n.z + 1)
+                            else -> continue
+                        }
+                        anchoredSome = true
+                        break
+                    }
+                }
+            }
+
+            // Phase 4: truly disconnected rooms. Park them on z=0 near the origin
+            // so they at least render somewhere, and say so.
             for (unreachedId in roomIds) {
                 if (coords.containsKey(unreachedId)) continue
-                val room = rooms[unreachedId] ?: continue
-                var placed = false
-                // Prefer horizontal neighbors for placement (they have reliable offsets)
-                for ((dir, neighborId) in room.exits) {
-                    val neighborPos = coords[neighborId] ?: continue
-                    if (dir in horizontalDirs) {
-                        val (dx, dy) = DIRECTION_OFFSETS[dir] ?: continue
-                        val desiredPos = findFreePosition(neighborPos.first - dx, neighborPos.second - dy, occupied)
-                        coords[unreachedId] = desiredPos
-                        occupied[desiredPos] = unreachedId
-                        placed = true
-                        break
-                    }
-                }
-                // Fall back to placing near any connected neighbor
-                if (!placed) {
-                    for ((_, neighborId) in room.exits) {
-                        val neighborPos = coords[neighborId] ?: continue
-                        val desiredPos = findFreePosition(neighborPos.first, neighborPos.second, occupied)
-                        coords[unreachedId] = desiredPos
-                        occupied[desiredPos] = unreachedId
-                        placed = true
-                        break
-                    }
-                }
-                if (!placed) {
-                    val pos = findFreePosition(0, 0, occupied)
-                    coords[unreachedId] = pos
-                    occupied[pos] = unreachedId
-                }
+                logger.warn(
+                    "Minimap layout: zone '{}' room '{}' is not connected to the start room by any " +
+                        "horizontal or vertical path — parking its floor at the origin of floor 0",
+                    zone,
+                    unreachedId.value,
+                )
+                val pos = findFreePosition(0, 0, layer(0))
+                layoutFloor(unreachedId, pos.first, pos.second, 0)
             }
         }
 
         return rooms.mapValues { (id, room) ->
-            val (x, y) = coords[id] ?: (0 to 0)
-            room.copy(mapX = x, mapY = y)
+            val cell = coords[id] ?: MapCell(0, 0, 0)
+            room.copy(mapX = cell.x, mapY = cell.y, mapZ = cell.z)
         }
     }
 

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -12,7 +12,6 @@ import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.items.ItemSlot
 import dev.ambon.domain.mob.MobState
-import dev.ambon.domain.world.Direction
 import dev.ambon.domain.world.Room
 import dev.ambon.domain.world.World
 import dev.ambon.engine.abilities.AbilityDefinition
@@ -267,6 +266,7 @@ class GmcpEmitter(
                 station = room.station,
                 mapX = room.mapX,
                 mapY = room.mapY,
+                mapZ = room.mapZ,
                 housing = isHousing,
                 housingOwner = housingOwner,
                 graphical = room.graphical,
@@ -288,15 +288,15 @@ class GmcpEmitter(
 
     /**
      * Send the full room layout for a zone so the client can render a fog-of-war
-     * map with cloud-reveal as the player explores. Only horizontal exits (N/S/E/W)
-     * are included — vertical transitions are handled by floor buttons.
+     * map with cloud-reveal as the player explores. Each room carries its floor
+     * (`z`); clients draw one floor at a time. Up/down exits are included so the
+     * map can badge stairs, but clients must not treat them as positional edges.
      */
     suspend fun sendZoneMap(
         sessionId: SessionId,
         zone: String,
         rooms: Collection<Room>,
     ) {
-        val horizontalDirs = setOf(Direction.NORTH, Direction.SOUTH, Direction.EAST, Direction.WEST)
         emit(
             sessionId,
             "Zone.Map",
@@ -307,8 +307,9 @@ class GmcpEmitter(
                         id = r.id.value,
                         x = r.mapX,
                         y = r.mapY,
+                        z = r.mapZ,
                         exits = r.exits.entries
-                            .filter { (dir, target) -> dir in horizontalDirs && target.zone == zone }
+                            .filter { (_, target) -> target.zone == zone }
                             .associate { (dir, target) -> dir.name.lowercase() to target.value },
                     )
                 },
@@ -2707,6 +2708,7 @@ class GmcpEmitter(
         val id: String,
         val x: Int,
         val y: Int,
+        val z: Int,
         val exits: Map<String, String>,
     )
 
@@ -2723,6 +2725,7 @@ class GmcpEmitter(
         val station: String? = null,
         val mapX: Int = 0,
         val mapY: Int = 0,
+        val mapZ: Int = 0,
         val housing: Boolean = false,
         val housingOwner: String? = null,
         val graphical: Boolean = false,

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -1962,6 +1962,7 @@ class GmcpEmitterTest {
         exits: Map<Direction, RoomId> = emptyMap(),
         mapX: Int = 0,
         mapY: Int = 0,
+        mapZ: Int = 0,
     ) = Room(
         id = RoomId(id),
         title = "Room",
@@ -1969,10 +1970,11 @@ class GmcpEmitterTest {
         exits = exits,
         mapX = mapX,
         mapY = mapY,
+        mapZ = mapZ,
     )
 
     @Test
-    fun `sendZoneMap emits rooms with horizontal exits only`() =
+    fun `sendZoneMap emits same-zone exits with floor coordinates`() =
         runTest {
             val e = emitter("Zone.Map")
             val rooms = listOf(
@@ -1987,6 +1989,7 @@ class GmcpEmitterTest {
                     mapY = 0,
                 ),
                 zoneRoom("z:b", mapX = 0, mapY = -1),
+                zoneRoom("z:c", mapX = 0, mapY = 0, mapZ = 1),
             )
             e.sendZoneMap(sid, "z", rooms)
             val data = drainGmcp()
@@ -1995,13 +1998,14 @@ class GmcpEmitterTest {
             val json = data[0].jsonData
             // North exit to same zone should be present
             assertTrue(json.contains("\"north\":\"z:b\""), "Expected north exit. got=$json")
-            // Up exit should be filtered out
-            assertTrue(!json.contains("\"up\""), "Up exit should be excluded. got=$json")
+            // Up exit to same zone should be present (clients badge stairs from it)
+            assertTrue(json.contains("\"up\":\"z:c\""), "Expected up exit. got=$json")
             // Cross-zone exit should be filtered out
             assertTrue(!json.contains("other:x"), "Cross-zone exit should be excluded. got=$json")
-            // Coordinates should be present
+            // Coordinates should be present, including the floor
             assertTrue(json.contains("\"x\":0"), "Expected x coordinate. got=$json")
             assertTrue(json.contains("\"y\":-1"), "Expected y=-1 coordinate. got=$json")
+            assertTrue(json.contains("\"z\":1"), "Expected z=1 floor on the attic room. got=$json")
         }
 
     @Test

--- a/src/test/kotlin/dev/ambon/test/TestFixtures.kt
+++ b/src/test/kotlin/dev/ambon/test/TestFixtures.kt
@@ -69,6 +69,7 @@ object TestWorlds {
     val okAchievementGate: World by lazy { WorldLoader.loadFromResource("world/ok_achievement_gate.yaml") }
     val okFleeGate: World by lazy { WorldLoader.loadFromResource("world/ok_flee_gate.yaml") }
     val okTimedRespawn: World by lazy { WorldLoader.loadFromResource("world/ok_timed_respawn.yaml") }
+    val okFloors: World by lazy { WorldLoader.loadFromResource("world/ok_floors.yaml") }
 }
 
 object TestPasswordHasher : PasswordHasher {

--- a/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
@@ -65,19 +65,58 @@ class WorldLoaderTest {
         val rooms = world.rooms
 
         // The test_world has a hub with rooms in multiple directions.
-        // Verify no two rooms in the same zone share coordinates.
+        // Verify no two rooms in the same zone share a cell of the same floor.
         val coordsByZone = rooms.values.groupBy { it.id.zone }
         for ((zone, zoneRooms) in coordsByZone) {
-            val seen = mutableSetOf<Pair<Int, Int>>()
+            val seen = mutableSetOf<Triple<Int, Int, Int>>()
             for (room in zoneRooms) {
-                val coord = room.mapX to room.mapY
+                val coord = Triple(room.mapX, room.mapY, room.mapZ)
                 assertTrue(
                     seen.add(coord),
-                    "Zone '$zone' has coordinate collision at (${ room.mapX }, ${ room.mapY }) " +
+                    "Zone '$zone' has coordinate collision at (${ room.mapX }, ${ room.mapY }, floor ${room.mapZ}) " +
                         "for room '${room.id.value}' — another room already occupies this position",
                 )
             }
         }
+    }
+
+    @Test
+    fun `assigns floors through up and down stairs`() {
+        val world = dev.ambon.test.TestWorlds.okFloors
+
+        fun room(id: String) = world.rooms.getValue(RoomId("ok_floors:$id"))
+        val hall = room("hall")
+        val study = room("study")
+        val atticLanding = room("attic_landing")
+        val atticStore = room("attic_store")
+        val cellar = room("cellar")
+
+        // Ground floor: the start room's horizontal component sits on z=0.
+        assertEquals(0, hall.mapZ, "hall floor")
+        assertEquals(0, study.mapZ, "study floor")
+
+        // The attic floor anchors directly above its stair partner...
+        assertEquals(1, atticLanding.mapZ, "attic landing floor")
+        assertEquals(hall.mapX, atticLanding.mapX, "attic landing x")
+        assertEquals(hall.mapY, atticLanding.mapY, "attic landing y")
+
+        // ...and lays out its own rooms on its own layer.
+        assertEquals(1, atticStore.mapZ, "attic store floor")
+        assertEquals(atticLanding.mapX + 1, atticStore.mapX, "attic store east of landing")
+        assertEquals(atticLanding.mapY, atticStore.mapY, "attic store y")
+
+        // The cellar hangs below its stair partner.
+        assertEquals(-1, cellar.mapZ, "cellar floor")
+        assertEquals(study.mapX, cellar.mapX, "cellar x")
+        assertEquals(study.mapY, cellar.mapY, "cellar y")
+
+        // A room with no static inbound exit (revealed by a puzzle at runtime)
+        // anchors through its own outgoing exit — its west exit to the study
+        // places it one cell east of the study on the same floor.
+        val nook = room("hidden_nook")
+        assertEquals(0, nook.mapZ, "hidden nook floor")
+        assertEquals(study.mapX + 1, nook.mapX, "hidden nook x")
+        assertEquals(study.mapY, nook.mapY, "hidden nook y")
     }
 
     @Test
@@ -802,14 +841,14 @@ class WorldLoaderTest {
             val world = WorldFactory.demoWorld(resources = productionZones)
             val coordsByZone = world.rooms.values.groupBy { it.id.zone }
             for ((zone, zoneRooms) in coordsByZone) {
-                val seen = mutableMapOf<Pair<Int, Int>, String>()
+                val seen = mutableMapOf<Triple<Int, Int, Int>, String>()
                 for (room in zoneRooms) {
-                    val coord = room.mapX to room.mapY
+                    val coord = Triple(room.mapX, room.mapY, room.mapZ)
                     val existing = seen.put(coord, room.id.value)
                     assertNull(
                         existing,
                     ) {
-                        "Zone '$zone' coordinate collision at (${room.mapX}, ${room.mapY}): " +
+                        "Zone '$zone' coordinate collision at (${room.mapX}, ${room.mapY}, floor ${room.mapZ}): " +
                             "'${room.id.value}' collides with '$existing'"
                     }
                 }

--- a/src/test/resources/world/ok_floors.yaml
+++ b/src/test/resources/world/ok_floors.yaml
@@ -1,0 +1,36 @@
+zone: ok_floors
+startRoom: hall
+rooms:
+  hall:
+    title: "Hall"
+    description: "A ground-floor hall with a stair going up."
+    exits:
+      n: study
+      u: attic_landing
+  study:
+    title: "Study"
+    description: "A ground-floor study with a trapdoor."
+    exits:
+      s: hall
+      d: cellar
+  attic_landing:
+    title: "Attic Landing"
+    description: "The top of the stair."
+    exits:
+      d: hall
+      e: attic_store
+  attic_store:
+    title: "Attic Store"
+    description: "Boxes under the eaves."
+    exits:
+      w: attic_landing
+  cellar:
+    title: "Cellar"
+    description: "Cool and dark beneath the study."
+    exits:
+      u: study
+  hidden_nook:
+    title: "Hidden Nook"
+    description: "A room with no static way in — revealed by a puzzle at runtime."
+    exits:
+      w: study

--- a/web-v3/src/canvas/GameStateBridge.ts
+++ b/web-v3/src/canvas/GameStateBridge.ts
@@ -92,7 +92,7 @@ export const canvasCallbacks: {
   openVideo: ((videoUrl: string) => void) | null;
   dismissDialogue: (() => void) | null;
   openQuestOffers: ((mobKeyword: string) => void) | null;
-  loadZoneMap: ((zone: string, rooms: Array<{ id: string; x: number; y: number; exits: Record<string, string> }>) => void) | null;
+  loadZoneMap: ((zone: string, rooms: Array<{ id: string; x: number; y: number; z: number; exits: Record<string, string> }>) => void) | null;
   openMobDetail: ((detail: { name: string; description: string; image: string | null }) => void) | null;
   openImagePreview: ((url: string) => void) | null;
   /** Open the monster-manual / bestiary panel for a clicked creature. */

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -163,8 +163,8 @@ interface GmcpContext {
   setPuzzle: Dispatch<SetStateAction<PuzzleState | null>>;
   setPuzzleResult: Dispatch<SetStateAction<PuzzleResult | null>>;
   setChatByChannel: Dispatch<SetStateAction<Record<ChatChannel, ChatMessage[]>>>;
-  updateMap: (roomId: string, exits: Record<string, string>, title: string, image: string | null, mapX: number, mapY: number, housing?: boolean, terrain?: string | null) => void;
-  loadZoneMap: (zone: string, rooms: Array<{ id: string; x: number; y: number; exits: Record<string, string> }>) => void;
+  updateMap: (roomId: string, exits: Record<string, string>, title: string, image: string | null, mapX: number, mapY: number, mapZ: number, housing?: boolean, terrain?: string | null) => void;
+  loadZoneMap: (zone: string, rooms: Array<{ id: string; x: number; y: number; z: number; exits: Record<string, string> }>) => void;
   pushCombatEvent: (event: CombatEventData) => void;
   setCharStats: Dispatch<SetStateAction<CharStats | null>>;
   setQuests: Dispatch<SetStateAction<QuestEntry[]>>;
@@ -418,6 +418,7 @@ export function applyGmcpPackage(
 
       const mapX = typeof packet.mapX === "number" ? packet.mapX : 0;
       const mapY = typeof packet.mapY === "number" ? packet.mapY : 0;
+      const mapZ = typeof packet.mapZ === "number" ? packet.mapZ : 0;
 
       const title = typeof packet.title === "string" && packet.title.length > 0 ? packet.title : "-";
       const description = typeof packet.description === "string" ? packet.description : "";
@@ -459,11 +460,11 @@ export function applyGmcpPackage(
           ctx.setQuestsAvailable([]);
           ctx.setTrainer(null);
         }
-        return { id, title, description, exits, image, video, music, ambient, station, trainer, mapX, mapY, housing, housingOwner, graphical, terrain, bank, stylist, tavern, dungeon, auction, housingBroker, inn, canDepart, peek };
+        return { id, title, description, exits, image, video, music, ambient, station, trainer, mapX, mapY, mapZ, housing, housingOwner, graphical, terrain, bank, stylist, tavern, dungeon, auction, housingBroker, inn, canDepart, peek };
       });
 
       if (id) {
-        ctx.updateMap(id, exits, title === "-" ? "" : title, image, mapX, mapY, housing, terrain);
+        ctx.updateMap(id, exits, title === "-" ? "" : title, image, mapX, mapY, mapZ, housing, terrain);
       }
       break;
     }
@@ -478,6 +479,7 @@ export function applyGmcpPackage(
               id: typeof r.id === "string" ? r.id : "",
               x: typeof r.x === "number" ? r.x : 0,
               y: typeof r.y === "number" ? r.y : 0,
+              z: typeof r.z === "number" ? r.z : 0,
               exits: r.exits && typeof r.exits === "object" ? (r.exits as Record<string, string>) : {},
             }))
         : [];

--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -187,10 +187,11 @@ export interface MiniMapBridge {
     image: string | null,
     mapX: number,
     mapY: number,
+    mapZ: number,
     housing?: boolean,
     terrain?: string | null,
   ) => void;
-  loadZoneMap: (zone: string, rooms: Array<{ id: string; x: number; y: number; exits: Record<string, string> }>) => void;
+  loadZoneMap: (zone: string, rooms: Array<{ id: string; x: number; y: number; z: number; exits: Record<string, string> }>) => void;
   resetMap: () => void;
 }
 

--- a/web-v3/src/hooks/useMiniMap.ts
+++ b/web-v3/src/hooks/useMiniMap.ts
@@ -149,6 +149,43 @@ function drawProceduralRoom(
   }
 }
 
+/** Small ▲/▼ stair chevrons beside a room's right edge. `highlight` > 0 swaps
+ *  the ink for pulsing quest-gold (the trail's "take these stairs" cue). */
+function drawStairBadges(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  cy: number,
+  half: number,
+  hasUp: boolean,
+  hasDown: boolean,
+  highlight: number,
+) {
+  const bx = cx + half + 5;
+  const s = Math.max(3, Math.min(6, half * 0.45));
+  ctx.save();
+  ctx.fillStyle = highlight > 0 ? QUEST_MARKER : INK;
+  ctx.globalAlpha = highlight > 0 ? highlight : 0.9;
+  if (hasUp) {
+    const y0 = hasDown ? cy - s - 1 : cy;
+    ctx.beginPath();
+    ctx.moveTo(bx, y0 - s);
+    ctx.lineTo(bx - s, y0 + s * 0.7);
+    ctx.lineTo(bx + s, y0 + s * 0.7);
+    ctx.closePath();
+    ctx.fill();
+  }
+  if (hasDown) {
+    const y0 = hasUp ? cy + s + 1 : cy;
+    ctx.beginPath();
+    ctx.moveTo(bx, y0 + s);
+    ctx.lineTo(bx - s, y0 - s * 0.7);
+    ctx.lineTo(bx + s, y0 - s * 0.7);
+    ctx.closePath();
+    ctx.fill();
+  }
+  ctx.restore();
+}
+
 /** Procedural quest marker (fallback when no minimap_quest asset). */
 function drawProceduralQuest(ctx: CanvasRenderingContext2D, cx: number, cy: number, half: number, pulse: number) {
   ctx.save();
@@ -198,6 +235,17 @@ function renderMap(
 
   if (!currentId) return;
 
+  // One floor at a time, following the player. Rooms on other floors stay off
+  // the chart; stairs between floors render as ▲/▼ badges instead of edges.
+  const floor = visited.get(currentId)?.z ?? 0;
+  let multiFloor = false;
+  for (const node of visited.values()) {
+    if (node.z !== floor) {
+      multiFloor = true;
+      break;
+    }
+  }
+
   // Scroll parchment bounds — nodes must stay within these
   const scrollLeft = width * SCROLL_INSET_LEFT;
   const scrollRight = width * (1 - SCROLL_INSET_RIGHT);
@@ -230,6 +278,7 @@ function renderMap(
 
   // Connecting lines — only between two visible rooms; off-map exits get a tick.
   for (const node of visited.values()) {
+    if (node.z !== floor) continue;
     const sx = nodeX(node);
     const sy = nodeY(node);
     const sIn = inScrollBounds(sx, sy);
@@ -237,6 +286,7 @@ function renderMap(
       if (dir === "up" || dir === "down") continue;
       const target = visited.get(targetId);
       const offset = MAP_OFFSETS[dir];
+      if (target && target.z !== floor) continue;
       if (target) {
         const tx = nodeX(target);
         const ty = nodeY(target);
@@ -260,7 +310,10 @@ function renderMap(
     }
   }
 
-  // Quest path trail — BFS from current room to nearest quest target
+  // Quest path trail — BFS from current room to nearest quest target. The path
+  // may climb or descend stairs; segments on other floors aren't drawn, and the
+  // stair room where the trail leaves this floor gets a pulsing gold badge.
+  const stairHops = new Set<string>();
   if (currentId && questTargetRoomIds.size > 0 && !questTargetRoomIds.has(currentId)) {
     const pathEdges = bfsQuestPath(currentId, questTargetRoomIds, visited);
     if (pathEdges.length > 0) {
@@ -273,6 +326,8 @@ function renderMap(
         const fromNode = visited.get(fromId);
         const toNode = visited.get(toId);
         if (!fromNode || !toNode) continue;
+        if (fromNode.z === floor && toNode.z !== floor) stairHops.add(fromId);
+        if (fromNode.z !== floor || toNode.z !== floor) continue;
         const sx = nodeX(fromNode);
         const sy = nodeY(fromNode);
         const tx = nodeX(toNode);
@@ -300,7 +355,12 @@ function renderMap(
   }
 
   // Nodes — terrain-aware glyph stamps (with procedural inked-rect fallback)
+  const reducedMotionPulse = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  const stairPulse = reducedMotionPulse
+    ? 0.8
+    : 0.45 + 0.4 * (0.5 + 0.5 * Math.sin(Date.now() / PATH_SHIMMER_PERIOD * Math.PI * 2));
   for (const [id, node] of visited.entries()) {
+    if (node.z !== floor) continue;
     const x = nodeX(node);
     const y = nodeY(node);
     if (!inScrollBounds(x, y)) continue;
@@ -319,6 +379,14 @@ function renderMap(
 
     const drew = drawGlyph(ctx, key, x, y, size, 1);
     if (!drew) drawProceduralRoom(ctx, x, y, size / 2, isCurrent, isVisited, isHousing);
+
+    // Stair badges — ▲/▼ beside rooms with vertical exits; gold-pulsing when
+    // the quest trail wants the player to take these stairs.
+    const hasUp = "up" in node.exits;
+    const hasDown = "down" in node.exits;
+    if (hasUp || hasDown) {
+      drawStairBadges(ctx, x, y, size / 2, hasUp, hasDown, stairHops.has(id) ? stairPulse : 0);
+    }
 
     // Quest objective marker
     if (!isCurrent && questTargetRoomIds.has(id)) {
@@ -354,6 +422,7 @@ function renderMap(
   for (const targetId of questTargetRoomIds) {
     const targetNode = visited.get(targetId);
     if (!targetNode) continue;
+    if (targetNode.z !== floor) continue; // off-floor targets are routed via the stair badge
     const tx = nodeX(targetNode);
     const ty = nodeY(targetNode);
     if (inScrollBounds(tx, ty)) continue; // already visible
@@ -390,11 +459,25 @@ function renderMap(
     ctx.restore();
   }
 
+  // Floor tag — only when the zone actually has more than one floor.
+  if (multiFloor) {
+    const label = floor === 0 ? "ground floor" : floor > 0 ? `floor +${floor}` : `floor ${floor}`;
+    ctx.font = "bold 11px 'JetBrains Mono', 'Cascadia Mono', monospace";
+    ctx.textAlign = "left";
+    ctx.textBaseline = "top";
+    ctx.lineWidth = 3;
+    ctx.strokeStyle = LABEL_OUTLINE;
+    ctx.strokeText(label, scrollLeft + 10, scrollTop + 8);
+    ctx.fillStyle = LABEL_VISITED;
+    ctx.fillText(label, scrollLeft + 10, scrollTop + 8);
+  }
+
   // Restore from scroll-bounds clip
   ctx.restore();
 }
 
-/** BFS from currentId to the nearest quest target. Returns edge pairs [from, to]. */
+/** BFS from currentId to the nearest quest target, stairs included.
+ *  Returns edge pairs [from, to]. */
 function bfsQuestPath(
   currentId: string,
   targets: Set<string>,
@@ -410,8 +493,7 @@ function bfsQuestPath(
     const id = queue.shift()!;
     const node = visited.get(id);
     if (!node) continue;
-    for (const [dir, neighborId] of Object.entries(node.exits)) {
-      if (dir === "up" || dir === "down") continue;
+    for (const neighborId of Object.values(node.exits)) {
       if (seen.has(neighborId) || !visited.has(neighborId)) continue;
       seen.add(neighborId);
       parent.set(neighborId, id);
@@ -463,11 +545,15 @@ export function useMiniMap() {
     const visited = visitedRef.current;
     const current = currentRoomIdRef.current ? visited.get(currentRoomIdRef.current) : undefined;
 
+    // Fit and pan bounds consider only the player's current floor — rooms on
+    // other floors aren't drawn, so they shouldn't stretch the zoom either.
+    const floor = current?.z ?? 0;
     let minX = Infinity;
     let maxX = -Infinity;
     let minY = Infinity;
     let maxY = -Infinity;
     for (const node of visited.values()) {
+      if (node.z !== floor) continue;
       if (node.x < minX) minX = node.x;
       if (node.x > maxX) maxX = node.x;
       if (node.y < minY) minY = node.y;
@@ -630,12 +716,12 @@ export function useMiniMap() {
   }, [drawMap]);
 
   const updateMap = useCallback(
-    (roomId: string, exits: Record<string, string>, title: string, image: string | null, mapX: number, mapY: number, housing?: boolean, terrain?: string | null) => {
+    (roomId: string, exits: Record<string, string>, title: string, image: string | null, mapX: number, mapY: number, mapZ: number, housing?: boolean, terrain?: string | null) => {
       currentRoomIdRef.current = roomId;
       const rooms = visitedRef.current;
 
       if (!rooms.has(roomId)) {
-        rooms.set(roomId, { x: mapX, y: mapY, exits, title, image, housing, terrain: terrain ?? undefined });
+        rooms.set(roomId, { x: mapX, y: mapY, z: mapZ, exits, title, image, housing, terrain: terrain ?? undefined });
       } else {
         const node = rooms.get(roomId)!;
         node.exits = exits;
@@ -645,15 +731,16 @@ export function useMiniMap() {
         if (terrain) node.terrain = terrain;
         node.x = mapX;
         node.y = mapY;
+        node.z = mapZ;
       }
 
-      // Pre-place unvisited horizontal neighbors (N/S/E/W only).
+      // Pre-place unvisited horizontal neighbors (N/S/E/W only) on the same floor.
       for (const [dir, targetId] of Object.entries(exits)) {
         if (dir === "up" || dir === "down") continue;
         if (rooms.has(targetId)) continue;
         const offset = MAP_OFFSETS[dir];
         if (!offset) continue;
-        rooms.set(targetId, { x: mapX + offset.dx, y: mapY + offset.dy, exits: {}, title: "", image: null });
+        rooms.set(targetId, { x: mapX + offset.dx, y: mapY + offset.dy, z: mapZ, exits: {}, title: "", image: null });
       }
 
       drawMap();
@@ -663,7 +750,7 @@ export function useMiniMap() {
 
   /** Pre-populate the map with all rooms in a zone as fog nodes. */
   const loadZoneMap = useCallback(
-    (zone: string, rooms: Array<{ id: string; x: number; y: number; exits: Record<string, string> }>) => {
+    (zone: string, rooms: Array<{ id: string; x: number; y: number; z: number; exits: Record<string, string> }>) => {
       const map = visitedRef.current;
       map.clear();
       currentRoomIdRef.current = null;
@@ -673,7 +760,7 @@ export function useMiniMap() {
       zoomRef.current = 0;
 
       for (const r of rooms) {
-        map.set(r.id, { x: r.x, y: r.y, exits: r.exits, title: "", image: null });
+        map.set(r.id, { x: r.x, y: r.y, z: r.z, exits: r.exits, title: "", image: null });
       }
       drawMap();
 

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -244,6 +244,8 @@ export interface RoomState {
   trainer?: string | null;
   mapX: number;
   mapY: number;
+  /** Minimap floor (z layer) — 0 unless the server says otherwise. */
+  mapZ?: number;
   housing?: boolean;
   housingOwner?: string | null;
   /** Whether the current zone has custom graphical assets. */
@@ -417,6 +419,8 @@ export interface StatusEffect {
 export interface MapRoom {
   x: number;
   y: number;
+  /** Floor (z layer) — the expanded chart renders one floor at a time. */
+  z: number;
   exits: Record<string, string>;
   title: string;
   image: string | null;


### PR DESCRIPTION
## Why

Up/down exits had no visual language on the expanded map: rooms reachable only through stairs were spiral-dropped beside their partner and rendered as floating, unconnected squares, and any grid collision silently produced diagonal-spaghetti edges. Zone authors had to lay out worlds defensively with no feedback about where the map would degrade.

## What

**Server**
- `WorldLoader.assignMapCoordinates` now models each zone as a stack of **floors**: the horizontal (N/S/E/W) component containing the start room is floor 0, and each component linked by an up/down exit anchors at its stair partner's (x, y) one floor above/below, then BFS-lays-out on its own occupancy layer — multi-room basements/attics keep their internal shape.
- Rooms with no static inbound path (e.g. behind puzzle-revealed exits) anchor through their own outgoing exits instead of being parked at the origin.
- **Diagnostics:** collision displacements and disconnected rooms log warnings naming both rooms, so a single boot shows exactly where a hand layout degrades.
- `Room.mapZ` flows through `Room.Info` / `Zone.Map` GMCP (Zone.Map now also carries same-zone vertical exits for stair badges) and the admin room endpoint.

**Web client (expanded chart)**
- Renders one floor at a time, following the player; fit/pan bounds consider only the current floor.
- ▲/▼ stair badges on rooms with vertical exits, fog rooms included.
- Quest trail routes through stairs — when the path leaves the current floor, the stair room's badge pulses gold instead of the trail dead-ending.
- A `ground floor / floor +1 / floor −1` tag appears only in zones that span multiple floors.

The compact Pixi minimap needed no changes (it already lays out locally and has floor buttons).

## Testing

- New `ok_floors.yaml` fixture: attic/cellar anchoring above/below stair partners, upper-floor internal layout, same-floor stairs, and puzzle-hidden room anchoring.
- Collision assertions (unit + production-world integration) now key on (x, y, floor).
- `sendZoneMap` emitter test covers the new payload (vertical exits + `z`).
- `./gradlew ktlintCheck test integrationTest` and web `tsc -b` + `eslint` all green.