### PR TITLE
fix(web): SW cache poisoning (unstyled pages) + login art holding frame (kills purple flash)

### DIFF
--- a/web-v3/public/sw.js
+++ b/web-v3/public/sw.js
@@ -1,5 +1,9 @@
-// AmbonMUD Service Worker — cache static assets for offline splash + faster loads
-const CACHE_NAME = "ambonmud-v1";
+// AmbonMUD Service Worker — cache static assets for offline splash + faster loads.
+// Bump CACHE_NAME whenever caching behavior changes: activate purges older
+// versions, which also self-heals clients whose v1 cache captured error
+// responses (the old fetch handler cached 404s/opaque bodies, permanently
+// breaking styling for that browser).
+const CACHE_NAME = "ambonmud-v2";
 const STATIC_ASSETS = ["/", "/icons/icon.svg"];
 
 self.addEventListener("install", (event) => {
@@ -18,35 +22,68 @@ self.addEventListener("activate", (event) => {
   self.clients.claim();
 });
 
+// Only complete, successful, same-origin responses may enter the cache.
+// Caching anything else (404 during a server restart, an opaque error) pins
+// the failure: cache-first would then serve the broken response forever.
+const cacheable = (response) => Boolean(response && response.ok && response.type === "basic");
+
 self.addEventListener("fetch", (event) => {
   const url = new URL(event.request.url);
+  if (url.origin !== self.location.origin) return;
 
-  // Never cache WebSocket or GMCP traffic
-  if (url.protocol === "ws:" || url.protocol === "wss:") return;
-
-  // Network-first for HTML (always get latest app shell)
+  // Network-first for HTML, and re-cache the shell on every successful
+  // navigation. A shell frozen at install time references hashed bundles that
+  // stop existing after a redeploy, so a stale offline fallback renders an
+  // unstyled page.
   if (event.request.mode === "navigate") {
     event.respondWith(
-      fetch(event.request).catch(() => caches.match("/"))
+      fetch(event.request)
+        .then((response) => {
+          if (cacheable(response)) {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put("/", clone));
+          }
+          return response;
+        })
+        .catch(() => caches.match("/"))
     );
     return;
   }
 
-  // Cache-first for static assets (JS, CSS, images, fonts)
-  if (
-    url.pathname.startsWith("/assets/") ||
-    url.pathname.startsWith("/icons/") ||
-    url.pathname.startsWith("/images/")
-  ) {
+  // Content-hashed bundles are immutable: cache-first.
+  if (url.pathname.startsWith("/assets/")) {
     event.respondWith(
-      caches.match(event.request).then((cached) =>
-        cached || fetch(event.request).then((response) => {
-          const clone = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
-          return response;
-        })
+      caches.match(event.request).then(
+        (cached) =>
+          cached ||
+          fetch(event.request).then((response) => {
+            if (cacheable(response)) {
+              const clone = response.clone();
+              caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+            }
+            return response;
+          })
       )
     );
     return;
+  }
+
+  // Art and icons are mutable (R2 art can change under a stable URL):
+  // stale-while-revalidate paints warm from cache and refreshes in the
+  // background so updated art lands on the next load.
+  if (url.pathname.startsWith("/icons/") || url.pathname.startsWith("/images/")) {
+    event.respondWith(
+      caches.open(CACHE_NAME).then((cache) =>
+        cache.match(event.request).then((cached) => {
+          const refresh = fetch(event.request)
+            .then((response) => {
+              if (cacheable(response)) cache.put(event.request, response.clone());
+              return response;
+            })
+            .catch(() => cached);
+          return cached || refresh;
+        })
+      )
+    );
   }
 });

--- a/web-v3/src/canvas/LoginModal.tsx
+++ b/web-v3/src/canvas/LoginModal.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { CSSProperties, FormEvent } from "react";
 import type { LoginClassOption, LoginErrorState, LoginPromptState, LoginRaceOption } from "../types";
 import { ArtScene } from "./ArtScene";
-import { ART_FIT_PORTRAIT, useArtImage, useMediaFits, useOrientedArt } from "./loginArtFit";
+import { ART_FIT_PORTRAIT, useArtImage, useArtImageState, useMediaFits, useOrientedArt } from "./loginArtFit";
 
 interface LoginModalProps {
   loginPrompt: LoginPromptState;
@@ -24,10 +24,6 @@ export function LoginModal({ loginPrompt, loginError, serverAssets, onSubmit }: 
     setInputValue("");
     setShowPassword(false);
   }
-
-  useEffect(() => {
-    inputRef.current?.focus();
-  }, [loginPrompt.state]);
 
   const handleSubmit = useCallback((e: FormEvent) => {
     e.preventDefault();
@@ -62,14 +58,23 @@ export function LoginModal({ loginPrompt, loginError, serverAssets, onSubmit }: 
   const isSlotScene = scene?.slots === true;
   // Gated on the image actually loading: a URL that 404s or is blocked
   // client-side must fall back to the CSS UI, not render a black scene.
-  const slotArt = useArtImage(scene && isSlotScene && artFitsPortrait ? serverAssets[scene.key] ?? null : null);
+  const slotArtState = useArtImageState(scene && isSlotScene && artFitsPortrait ? serverAssets[scene.key] ?? null : null);
   const oriented = useOrientedArt(
     scene && !isSlotScene ? serverAssets[scene.key] ?? null : null,
     scene && !isSlotScene && scene.portraitKey ? serverAssets[scene.portraitKey] ?? null : null,
   );
-  const sceneArt = isSlotScene ? slotArt : oriented.url;
+  const sceneArt = isSlotScene ? slotArtState.url : oriented.url;
+  /** True while the step's art is still loading — hold a dark frame, don't flash the CSS dialog. */
+  const scenePending = isSlotScene ? slotArtState.pending : oriented.pending;
   /** True when the phone-portrait companion (941×1672 stage) is active. */
   const phoneScene = !isSlotScene && oriented.phone;
+
+  // Refocus when the step changes, and again when the art settles — while the
+  // holding frame (or a late-arriving painted scene swap) is up, the input the
+  // step-change pass tried to focus doesn't exist yet.
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, [loginPrompt.state, sceneArt, scenePending]);
 
   // Decorative blurred backdrop behind the fallback modal steps.
   const backdropArt = useArtImage(serverAssets["login_bg"] ?? null);
@@ -84,6 +89,13 @@ export function LoginModal({ loginPrompt, loginError, serverAssets, onSubmit }: 
     raceSelection: "Choose your race",
     classSelection: "Choose your class",
   };
+
+  // The step's painted scene is still loading (typically one or two frames
+  // from the service-worker cache): hold a dark frame instead of flashing the
+  // CSS dialog before the art swaps in.
+  if (!sceneArt && scenePending) {
+    return <div className="login-art-root" aria-hidden="true" />;
+  }
 
   if (loginPrompt.state === "name") {
     const art = sceneArt;

--- a/web-v3/src/canvas/loginArtFit.ts
+++ b/web-v3/src/canvas/loginArtFit.ts
@@ -25,41 +25,62 @@ const ORIENTATION_PORTRAIT = "(orientation: portrait)";
  * Pick between a landscape scene and its phone-portrait companion by viewport
  * orientation, falling back to whichever fits when the preferred one is
  * absent, and gating the winner on the image actually loading. `phone` is
- * true when the portrait companion (941×1672 stage) was selected.
+ * true when the portrait companion (941×1672 stage) was selected. `pending`
+ * mirrors [useArtImageState]: true while the probe is still in flight, so
+ * callers can hold a neutral frame instead of flashing their CSS fallback.
  */
 export function useOrientedArt(
   landscapeUrl: string | null,
   portraitUrl: string | null,
-): { url: string | null; phone: boolean } {
+): { url: string | null; phone: boolean; pending: boolean } {
   const fitsLandscape = useMediaFits(ART_FIT_LANDSCAPE);
   const fitsPortrait = useMediaFits(ART_FIT_PORTRAIT);
   const portraitViewport = useMediaFits(ORIENTATION_PORTRAIT);
   const landscape = fitsLandscape ? landscapeUrl : null;
   const portrait = fitsPortrait ? portraitUrl : null;
   const wanted = portraitViewport ? (portrait ?? landscape) : (landscape ?? portrait);
-  const url = useArtImage(wanted);
-  return { url, phone: url !== null && wanted === portrait };
+  const { url, pending } = useArtImageState(wanted);
+  return { url, phone: url !== null && wanted === portrait, pending };
 }
 
 /** Module-level result cache: each art URL is probed at most once per session. */
 const artImageStatus = new Map<string, "ready" | "failed">();
 
 /**
+ * How long callers may hold a neutral "art incoming" frame before giving up
+ * and showing their CSS fallback. Warm art (HTTP or service-worker cache)
+ * settles in a frame or two; this only bites on a genuinely slow cold fetch,
+ * where a usable fallback UI beats a blank screen. If the art lands later it
+ * still swaps in.
+ */
+const ART_PENDING_GRACE_MS = 2500;
+
+/**
  * Gate a painted-scene URL on the image actually loading. For full-scene art
  * the background is load-bearing — rendering the painted variant against a URL
  * that 404s, is blocked by an extension, or whose CDN is unreachable produces
- * a black screen with floating controls. Returns the URL only once the image
- * has decoded; on failure (or while loading) returns null so callers keep the
- * CSS fallback. Required by ART_CONTRACT.md's degradation rules.
+ * a black screen with floating controls. `url` is non-null only once the image
+ * has decoded; on failure it stays null so callers keep the CSS fallback,
+ * per ART_CONTRACT.md's degradation rules.
+ *
+ * `pending` is true while the probe is still in flight (bounded by
+ * [ART_PENDING_GRACE_MS]). The service worker intercepts same-origin image
+ * requests, which makes even cache-warm loads settle asynchronously — one or
+ * two frames after first render — so callers that paint their CSS fallback
+ * immediately flash it. While `pending`, render a neutral holding frame
+ * instead.
  */
-export function useArtImage(url: string | null): string | null {
+export function useArtImageState(url: string | null): { url: string | null; pending: boolean } {
   const [, setProbedCount] = useState(0);
-  // Synchronous HTTP-cache seed: when the art is already cached (warmed by the
-  // preloads in main.tsx / App.tsx), a freshly-constructed Image reports
-  // `complete` with a non-zero natural size the instant we assign src. Marking
-  // it ready here — before the first paint — lets a warm scene render painted
-  // immediately instead of flashing the CSS fallback for the frame it takes the
-  // async onload below to settle. Cold art falls through to that async probe.
+  // Grace expiry is keyed to the URL it timed out on, so switching to a new
+  // URL starts un-expired without needing a state reset.
+  const [expiredUrl, setExpiredUrl] = useState<string | null>(null);
+  // Synchronous HTTP-cache seed: when the art is already in the renderer's
+  // memory cache, a freshly-constructed Image reports `complete` with a
+  // non-zero natural size the instant we assign src. Marking it ready here —
+  // before the first paint — lets such art render painted immediately. Art
+  // served from the HTTP disk cache or through the service worker settles via
+  // the async probe below instead.
   if (url && !artImageStatus.has(url)) {
     const probe = new Image();
     probe.src = url;
@@ -78,5 +99,19 @@ export function useArtImage(url: string | null): string | null {
     img.src = url;
     return () => { cancelled = true; };
   }, [url]);
-  return url && artImageStatus.get(url) === "ready" ? url : null;
+  useEffect(() => {
+    if (!url || artImageStatus.has(url)) return;
+    const timer = window.setTimeout(() => setExpiredUrl(url), ART_PENDING_GRACE_MS);
+    return () => window.clearTimeout(timer);
+  }, [url]);
+  const status = url ? artImageStatus.get(url) : undefined;
+  return {
+    url: url && status === "ready" ? url : null,
+    pending: url !== null && status === undefined && expiredUrl !== url,
+  };
+}
+
+/** [useArtImageState] without the pending signal, for decorative callers. */
+export function useArtImage(url: string | null): string | null {
+  return useArtImageState(url).url;
 }

--- a/web-v3/src/components/CharacterPicker.tsx
+++ b/web-v3/src/components/CharacterPicker.tsx
@@ -17,7 +17,7 @@ export function CharacterPicker({ characters, backgroundImage, backgroundImagePo
   const [confirmRemove, setConfirmRemove] = useState<string | null>(null);
   // Orientation-aware art pick, gated on the image actually loading —
   // failed art falls back to the CSS dialog.
-  const { url: art, phone } = useOrientedArt(backgroundImage, backgroundImagePortrait);
+  const { url: art, phone, pending } = useOrientedArt(backgroundImage, backgroundImagePortrait);
 
   const handleRemove = useCallback((name: string, e: React.MouseEvent | React.PointerEvent | React.KeyboardEvent) => {
     e.stopPropagation();
@@ -55,6 +55,12 @@ export function CharacterPicker({ characters, backgroundImage, backgroundImagePo
       </button>
     </div>
   ));
+
+  // Art is still loading (typically one or two frames from the service-worker
+  // cache): hold a dark frame instead of flashing the CSS dialog.
+  if (!art && pending) {
+    return <div className="login-art-root" aria-hidden="true" />;
+  }
 
   if (art) {
     return (


### PR DESCRIPTION
## Problem

Despite #1306 / #1309, the welcome-back picker and sign-in steps still flash their purple CSS dialog before the painted art, and hard refreshes sometimes produce a fully **unstyled page**.

## Root cause: the PWA service worker (#791), not the hardening

The security hardening (#1300) is **not** the culprit — its CSP already allows Google Fonts, R2 art, and inline styles. Both symptoms trace to `sw.js`:

1. **Cache poisoning (the unstyled page).** The fetch handler cached responses without checking they succeeded. A `/assets/*.css` request caught mid-redeploy (404) was written into the cache and then served **forever** by the cache-first path — the cache name never rotated, so the breakage persisted across reloads.
2. **Frozen offline shell.** The navigate fallback (`caches.match("/")`) was only written at SW-install time. After a redeploy it references hashed bundles that no longer exist, so any transient network failure on navigation rendered an ancient shell with 404ing CSS/JS.
3. **The purple flash survived #1309 because of the SW.** The synchronous art-cache seed only works for memory-cache hits. The SW intercepts every same-origin `/images/` request, making even fully cache-warm image loads settle **asynchronously** — so on a fresh page load the picker/sign-in steps always painted their CSS (purple) dialog for the frame(s) before `onload` settled.

## Fix

### `sw.js`
- Only cache `response.ok` same-origin responses (a 404 can never be pinned again).
- Refresh the cached app shell on every successful navigation.
- `/images/` + `/icons/`: stale-while-revalidate (paints warm, updated R2 art lands next load). Content-hashed `/assets/`: cache-first, unchanged.
- `CACHE_NAME` bumped to `ambonmud-v2` — activation purges v1, **self-healing every client that already has a poisoned cache** on next visit.

### Login art (`loginArtFit.ts`, `LoginModal.tsx`, `CharacterPicker.tsx`)
- `useArtImageState` now exposes a bounded `pending` signal (2.5 s grace window) alongside the gated URL; `useOrientedArt` passes it through.
- While the step's art is pending, the picker and login steps render a **dark holding frame** (`login-art-root`, same color as the page background) instead of the CSS dialog — warm art settles in a frame or two, so nothing visible flashes.
- ART_CONTRACT degradation is preserved: missing/404/blocked art still falls back to the CSS UI (immediately on error, or after the grace window on a genuinely slow cold fetch — no indefinite blank screen).
- The input-focus effect re-runs when the holding frame resolves, so the name/password fields still autofocus.

## Validation

- `bun run lint` ✅
- `bunx tsc -b` ✅
- `bun run build` ✅

Manual check worth doing on `./gradlew demo`: welcome-back picker and password step with a warm cache (no purple frame), DevTools → Application → clear the old `ambonmud-v1` cache appears purged after the new SW activates, and an offline reload still shows the shell.
