### PR TITLE
feat(events): recurring world-event windows + World.Events seeded at login

### DIFF
--- a/docs/WORLD_YAML_SPEC.md
+++ b/docs/WORLD_YAML_SPEC.md
@@ -194,6 +194,11 @@ Semantics:
   never while it is fighting a player.
 - Weather-gated mobs naturally only appear where players are present, because
   per-zone weather only advances in zones that have occupants.
+- Event flags come from `ambonMUD.engine.worldEvents` definitions (config, not
+  zone YAML). An event may be bounded by real-world dates and/or carry a
+  `recurrence` window (e.g. ten minutes of every hour) so gated mobs appear
+  during normal play; activations broadcast the event's start/end messages and
+  update the `world` command + `World.Events` GMCP.
 
 #### Rare cosmetic variants (`rareVariants`)
 

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -142,6 +142,7 @@ data class AppConfig(
         validateEngineAkathavae()
         validateEngineWorldTime()
         validateEngineWeather()
+        validateEngineWorldEvents()
         validateEngineEnchanting()
         validateEngineFactions()
         validateEngineDailyQuests()
@@ -495,6 +496,28 @@ data class AppConfig(
         engine.weather.types.forEach { (id, def) ->
             require(def.weight > 0) {
                 "ambonMUD.engine.weather.types[$id].weight must be positive"
+            }
+        }
+    }
+
+    private fun validateEngineWorldEvents() {
+        engine.worldEvents.definitions.forEach { (id, def) ->
+            val path = "ambonMUD.engine.worldEvents.definitions[$id]"
+            for ((field, value) in listOf("startDate" to def.startDate, "endDate" to def.endDate)) {
+                if (value.isNotEmpty()) {
+                    require(runCatching { java.time.LocalDate.parse(value) }.isSuccess) {
+                        "$path.$field must be an ISO date (yyyy-MM-dd), got '$value'"
+                    }
+                }
+            }
+            def.recurrence?.let { rec ->
+                rec.periodMs.requirePositive("$path.recurrence.periodMs")
+                require(rec.durationMs in 1 until rec.periodMs) {
+                    "$path.recurrence.durationMs must be in 1..${rec.periodMs - 1} (less than periodMs), got ${rec.durationMs}"
+                }
+                require(rec.offsetMs >= 0) {
+                    "$path.recurrence.offsetMs must be >= 0, got ${rec.offsetMs}"
+                }
             }
         }
     }
@@ -1406,6 +1429,23 @@ data class WeatherTypeDefinition(
     val icon: String = "",
 )
 
+/**
+ * Optional repeating window for a world event. When present, the event is
+ * active only during the first [durationMs] of every [periodMs] cycle
+ * (cycles are anchored to the Unix epoch, shifted by [offsetMs]), further
+ * bounded by the definition's date range. This is what makes an event
+ * observable during normal play — e.g. ten minutes out of every hour —
+ * rather than a one-shot calendar window.
+ */
+data class WorldEventRecurrence(
+    /** Full cycle length in milliseconds (e.g. 3600000 = hourly). */
+    val periodMs: Long = 0,
+    /** Active window at the start of each cycle. Must be < periodMs. */
+    val durationMs: Long = 0,
+    /** Shifts the cycle anchor, e.g. to stagger multiple events. */
+    val offsetMs: Long = 0,
+)
+
 data class WorldEventDefinition(
     val displayName: String = "",
     val description: String = "",
@@ -1419,6 +1459,8 @@ data class WorldEventDefinition(
     val startMessage: String = "",
     /** Announcement broadcast when event ends. */
     val endMessage: String = "",
+    /** Repeating active window within the date range; null = active for the whole range. */
+    val recurrence: WorldEventRecurrence? = null,
 )
 
 data class WorldEventsConfig(

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -261,6 +261,15 @@ class GameEngine(
                 // Seed the client's time-of-day + season immediately; otherwise it
                 // wouldn't learn the season until the next quarter-year rollover.
                 gmcpEmitter.sendWorldTime(sid, worldTimePayload())
+                // Seed active world events too — World.Events is otherwise only
+                // broadcast on activation edges, so a login mid-event would show
+                // nothing until the event ends or the next one begins.
+                gmcpEmitter.sendWorldEvents(
+                    sid,
+                    worldEventSystem.activeEvents().map { (id, def) ->
+                        GmcpEmitter.WorldEventPayload(id, def.displayName, def.description)
+                    },
+                )
                 // Push daily/weekly/global quest state so the client doesn't
                 // need a manual refresh button. See issue #1091.
                 dailyQuestSystem?.let { dqs ->

--- a/src/main/kotlin/dev/ambon/engine/WorldEventSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/WorldEventSystem.kt
@@ -44,12 +44,13 @@ class WorldEventSystem(
      * that just activated or deactivated.
      */
     fun tick(): EventTickResult {
-        val today = LocalDate.ofInstant(clock.instant(), ZoneOffset.UTC)
+        val now = clock.instant()
+        val today = LocalDate.ofInstant(now, ZoneOffset.UTC)
         val activated = mutableListOf<String>()
         val deactivated = mutableListOf<String>()
 
         for ((id, def) in config.definitions) {
-            val shouldBeActive = isActiveOn(def, today)
+            val shouldBeActive = isActiveOn(def, today) && isInRecurrenceWindow(def, now.toEpochMilli())
             val wasActive = id in currentlyActive
 
             if (shouldBeActive && !wasActive) {
@@ -71,6 +72,16 @@ class WorldEventSystem(
         val start = if (def.startDate.isNotEmpty()) LocalDate.parse(def.startDate) else LocalDate.MIN
         val end = if (def.endDate.isNotEmpty()) LocalDate.parse(def.endDate) else LocalDate.MAX
         return !date.isBefore(start) && !date.isAfter(end)
+    }
+
+    /**
+     * A recurring event is active only during the first `durationMs` of each
+     * `periodMs` cycle (epoch-anchored, shifted by `offsetMs`); without a
+     * recurrence the date range alone governs activation.
+     */
+    private fun isInRecurrenceWindow(def: WorldEventDefinition, nowMs: Long): Boolean {
+        val rec = def.recurrence ?: return true
+        return Math.floorMod(nowMs - rec.offsetMs, rec.periodMs) < rec.durationMs
     }
 
     data class EventTickResult(

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2309,6 +2309,30 @@ ambonmud:
           weight: 1
           particleHint: wind
           icon: 💨
+    # World events: named happenings that broadcast start/end messages, surface
+    # in the `world` command + World.Events GMCP, and set flags that gate
+    # conditional mob spawns (`condition.events` in zone YAML) and quests.
+    # Each definition supports:
+    #   startDate/endDate  — ISO dates (yyyy-MM-dd) bounding the event; both empty = unbounded.
+    #   recurrence         — optional repeating window WITHIN the date range, for events
+    #                        players can encounter during normal play:
+    #                          periodMs:   full cycle length (e.g. 3600000 = hourly)
+    #                          durationMs: active window at the start of each cycle (< periodMs)
+    #                          offsetMs:   shifts the cycle anchor (stagger multiple events)
+    #   flags              — flag ids matched by spawn conditions / quest gates.
+    #   startMessage/endMessage — broadcast to all players on activation edges.
+    # No events ship by default; world overlays (e.g. the Auringold config) define them.
+    # worldEvents:
+    #   definitions:
+    #     wandering_star:
+    #       displayName: The Wandering Star
+    #       description: A vagrant star drifts low; strange things glimmer beneath it.
+    #       flags: [wandering_star]
+    #       recurrence:
+    #         periodMs: 3600000
+    #         durationMs: 600000
+    #       startMessage: A wandering star slips loose and drifts low over the world.
+    #       endMessage: The wandering star climbs back into the firmament.
     # Server-generated rare cosmetic variants. The archetype set (albino, ember,
     # shadow-touched, spectral, …) is defined in code; override `variants` here to
     # replace it wholesale. Leaving it unset keeps the built-in palette.

--- a/src/test/kotlin/dev/ambon/config/AppConfigLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/config/AppConfigLoaderTest.kt
@@ -66,6 +66,57 @@ class AppConfigLoaderTest {
     }
 
     @Test
+    fun `validation rejects world event recurrence with duration not less than period`() {
+        val invalid = AppConfig(
+            engine = EngineConfig(
+                worldEvents = WorldEventsConfig(
+                    definitions = mapOf(
+                        "star" to WorldEventDefinition(
+                            displayName = "Star",
+                            recurrence = WorldEventRecurrence(periodMs = 1000L, durationMs = 1000L),
+                        ),
+                    ),
+                ),
+            ),
+            world = validWorld,
+        )
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
+
+    @Test
+    fun `validation rejects world event with malformed date`() {
+        val invalid = AppConfig(
+            engine = EngineConfig(
+                worldEvents = WorldEventsConfig(
+                    definitions = mapOf("star" to WorldEventDefinition(startDate = "April 1")),
+                ),
+            ),
+            world = validWorld,
+        )
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
+
+    @Test
+    fun `validation accepts dated world event with recurrence`() {
+        val valid = AppConfig(
+            engine = EngineConfig(
+                worldEvents = WorldEventsConfig(
+                    definitions = mapOf(
+                        "star" to WorldEventDefinition(
+                            displayName = "Star",
+                            startDate = "2026-04-01",
+                            endDate = "2026-05-01",
+                            recurrence = WorldEventRecurrence(periodMs = 3_600_000L, durationMs = 600_000L),
+                        ),
+                    ),
+                ),
+            ),
+            world = validWorld,
+        )
+        valid.validated() // should not throw
+    }
+
+    @Test
     fun `validated rejects combat room feedback when feedback is disabled`() {
         val invalid =
             AppConfig(

--- a/src/test/kotlin/dev/ambon/engine/WorldEventSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/WorldEventSystemTest.kt
@@ -1,6 +1,7 @@
 package dev.ambon.engine
 
 import dev.ambon.config.WorldEventDefinition
+import dev.ambon.config.WorldEventRecurrence
 import dev.ambon.config.WorldEventsConfig
 import dev.ambon.test.MutableClock
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -113,6 +114,85 @@ class WorldEventSystemTest {
         val result2 = system.tick()
         assertTrue(result2.activated.isEmpty())
         assertTrue(result2.deactivated.isEmpty())
+    }
+
+    // Active for the first 10 minutes of every hour, epoch-anchored.
+    private val recurringDef = WorldEventDefinition(
+        displayName = "Wandering Star",
+        description = "A star drifts low.",
+        flags = listOf("wandering_star"),
+        recurrence = WorldEventRecurrence(periodMs = 3_600_000L, durationMs = 600_000L),
+    )
+
+    @Test
+    fun `recurring event activates at window start and deactivates after duration`() {
+        // 2026-04-01T00:00Z is on an exact hour boundary → window open.
+        val clock = clockAtDate("2026-04-01")
+        val config = WorldEventsConfig(definitions = mapOf("star" to recurringDef))
+        val system = WorldEventSystem(config, clock)
+
+        assertTrue(system.tick().activated.contains("star"))
+        assertTrue(system.hasFlag("wandering_star"))
+
+        // 10 minutes later the window closes.
+        clock.advance(600_000L)
+        assertTrue(system.tick().deactivated.contains("star"))
+        assertFalse(system.hasFlag("wandering_star"))
+    }
+
+    @Test
+    fun `recurring event reactivates on the next cycle`() {
+        val clock = clockAtDate("2026-04-01")
+        val config = WorldEventsConfig(definitions = mapOf("star" to recurringDef))
+        val system = WorldEventSystem(config, clock)
+
+        system.tick() // active
+        clock.advance(600_000L)
+        system.tick() // window closed
+        assertFalse(system.activeEventIds().contains("star"))
+
+        // Advance to the top of the next hour.
+        clock.advance(3_000_000L)
+        assertTrue(system.tick().activated.contains("star"))
+    }
+
+    @Test
+    fun `recurring event stays inactive mid-cycle`() {
+        // 30 minutes past the hour: outside the 10-minute window.
+        val clock = clockAtDate("2026-04-01")
+        clock.advance(1_800_000L)
+        val config = WorldEventsConfig(definitions = mapOf("star" to recurringDef))
+        val system = WorldEventSystem(config, clock)
+
+        assertTrue(system.tick().activated.isEmpty())
+        assertFalse(system.hasFlag("wandering_star"))
+    }
+
+    @Test
+    fun `offset shifts the recurrence window`() {
+        // Offset by 30 minutes: window is hh,30..hh,40.
+        val offsetDef = recurringDef.copy(
+            recurrence = WorldEventRecurrence(periodMs = 3_600_000L, durationMs = 600_000L, offsetMs = 1_800_000L),
+        )
+        val clock = clockAtDate("2026-04-01")
+        val config = WorldEventsConfig(definitions = mapOf("star" to offsetDef))
+        val system = WorldEventSystem(config, clock)
+
+        assertTrue(system.tick().activated.isEmpty())
+
+        clock.advance(1_800_000L)
+        assertTrue(system.tick().activated.contains("star"))
+    }
+
+    @Test
+    fun `recurrence respects the date range`() {
+        // Recurring window is open, but the date range hasn't started.
+        val datedRecurring = recurringDef.copy(startDate = "2026-05-01")
+        val clock = clockAtDate("2026-04-01")
+        val config = WorldEventsConfig(definitions = mapOf("star" to datedRecurring))
+        val system = WorldEventSystem(config, clock)
+
+        assertTrue(system.tick().activated.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
## Why

The `condition.events` spawn gate (the fourth facet alongside time/weather/seasons) was effectively unreachable in normal play: world events supported only real-world date ranges, so an event was either a one-shot calendar window or permanently active — and no world shipped any definitions, so nothing ever fired. Players could also log in mid-event and see nothing: `sendWorldEvents` existed but had no call sites, so `World.Events` GMCP only ever went out on activation edges.

## What

**Recurring event windows.** `WorldEventDefinition` gains an optional `recurrence` (`periodMs`, `durationMs`, `offsetMs`): the event is active for the first `durationMs` of every `periodMs` cycle (epoch-anchored, shiftable via `offsetMs` to stagger multiple events), still bounded by the existing `startDate`/`endDate` range. Each occurrence broadcasts the event's start/end messages, updates `World.Events` GMCP, and flips the flags that gate conditional mob spawns and quests — so "ten minutes out of every hour" events are now possible and observable.

**Login seeding.** `GameEngine.onAfterLogin` now sends the active event set via the previously-dead `sendWorldEvents`, alongside the existing world-time seed — a mid-event login shows the event immediately.

**Validation.** New `validateEngineWorldEvents()`: `startDate`/`endDate` must parse as ISO dates (previously a malformed date crashed inside the engine tick), and recurrence must satisfy `periodMs > 0`, `0 < durationMs < periodMs`, `offsetMs >= 0`.

**Docs.** `application.yaml` documents the `worldEvents` schema (commented example); `WORLD_YAML_SPEC.md`'s conditional-spawning section notes where `condition.events` flags come from.

## Content counterpart

The Auringold world defines its first event — **the Wandering Star**, hourly for ten minutes — and an event-gated academy creature (a stray starfall on the almanac terrace, with Keeper Brontide teaching it): https://github.com/jnoecker/Ambon/pull/3. Merge this PR first; that one depends on the `recurrence` key.

## Validation

- New `WorldEventSystemTest` cases: window activation, deactivation after duration, re-activation next cycle, offset shift, mid-cycle inactivity, date-range interaction.
- New `AppConfigLoaderTest` cases: rejects `durationMs >= periodMs`, rejects malformed dates, accepts a dated recurring event.
- `ktlintCheck`, full `test`, and `integrationTest` all green.
