### PR TITLE
fix(web): paint login scene art via <img> (kills black hard-refresh login)

### DIFF
--- a/web-v3/src/canvas/ArtScene.tsx
+++ b/web-v3/src/canvas/ArtScene.tsx
@@ -1,10 +1,18 @@
-import type { CSSProperties, ReactNode } from "react";
+import type { ReactNode } from "react";
 
 /**
  * Shared painted-login-scene scaffolding: a fixed full-viewport root with the
  * scene art as a blurred cover underlay (cinematic letterbox), plus an
  * aspect-locked stage the callers seat live controls into with percentage
  * insets (see the login-art block in styles.css and docs/ART_CONTRACT.md).
+ *
+ * The art is painted by real <img> elements, not a CSS `background-image`.
+ * useArtImageState gates this scene on a probe Image loading, but a hard
+ * refresh bypasses the service worker for the markup preload/subresources, so
+ * the CSS-background fetch could diverge from that probe — leaving the probe
+ * "ready" (controls revealed) while the background painted black. Painting
+ * through an <img> uses the exact loading path the probe already proved works,
+ * so the revealed scene and its pixels can no longer come apart.
  */
 export function ArtScene({ url, stageClass, label, children }: {
   url: string;
@@ -13,15 +21,12 @@ export function ArtScene({ url, stageClass, label, children }: {
   children: ReactNode;
 }) {
   return (
-    <div
-      className="login-art-root"
-      role="dialog"
-      aria-modal="true"
-      aria-label={label}
-      style={{ "--login-art": `url("${url}")` } as CSSProperties}
-    >
-      <div className="login-art-underlay" aria-hidden="true" />
-      <main className={`login-art-stage ${stageClass}`}>{children}</main>
+    <div className="login-art-root" role="dialog" aria-modal="true" aria-label={label}>
+      <img className="login-art-underlay" src={url} alt="" aria-hidden="true" draggable={false} />
+      <main className={`login-art-stage ${stageClass}`}>
+        <img className="login-art-stage-img" src={url} alt="" aria-hidden="true" draggable={false} />
+        {children}
+      </main>
     </div>
   );
 }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -14942,21 +14942,36 @@ body {
 }
 
 /* Cinematic letterbox: the same art, blurred and dimmed, fills the gaps the
-   aspect-locked stage leaves at off-ratio viewports. */
+   aspect-locked stage leaves at off-ratio viewports. Painted via an <img>
+   (not a CSS background) so the scene's pixels load through the same path the
+   art probe gates on — see ArtScene.tsx. */
 .login-art-underlay {
   position: absolute;
   inset: 0;
-  background: var(--login-art) center / cover no-repeat;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
   filter: blur(18px) brightness(0.62) saturate(1.05);
   transform: scale(1.06);
 }
 
 .login-art-stage {
   position: relative;
-  background: var(--login-art) center / 100% 100% no-repeat;
   container-type: size;     /* cqh/cqw type scales with the stage, not the viewport */
   border-radius: 6px;
   box-shadow: 0 18px 60px rgb(0 0 0 / 55%);
+}
+
+/* The sharp scene art, filling the aspect-locked stage behind the seated
+   controls. The stage is locked to the art's ratio, so object-fit: fill
+   (the old `background-size: 100% 100%`) shows it undistorted. */
+.login-art-stage-img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: fill;
+  border-radius: inherit;
 }
 
 /* Stage aspect variants — width is capped on both axes so the art never crops. */


### PR DESCRIPTION
## Problem

On a **hard refresh** of the demo, the login screen comes up mostly black with only the saved-character picker cards (or other login controls) floating on it. A normal refresh fixes it; every hard refresh reproduces it.

![bug: picker cards on a black scene](https://example.invalid)

This survived #1313, which bumped the SW cache and added the dark holding frame.

## Root cause

The painted login flow reveals each scene once a probe `Image` loads (`useArtImageState`), but paints the pixels with a **separate** CSS `background-image: var(--login-art)`. Those are two independent resource loads.

A hard refresh bypasses the service worker for the markup preload (`main.tsx` `<link rel=preload>`) and subresources, so the probe and the CSS-background fetch can diverge: the probe settles **ready** and reveals the controls while the CSS background paints **nothing** → controls on a black scene. A normal refresh keeps the SW in control for all three loads, so they stay consistent.

The screenshot proves it independent of the exact trigger: the positioned `lpk-list` cards over a fully-black `login-art-root` can only be the painted picker `ArtScene` rendering (probe said ready) with its stage `background: var(--login-art)` painting black.

## Fix

Paint the underlay and stage with real `<img>` elements instead of a CSS background. The probe is itself an `Image`, so painting through an `<img>` uses the exact loading path the gate already proves works — the revealed scene and its pixels can no longer come apart.

- `ArtScene.tsx`: render `<img class="login-art-underlay">` (blurred cover) and `<img class="login-art-stage-img">` (sharp, behind the seated controls); drop the `--login-art` inline var.
- `styles.css`: `.login-art-underlay`/`.login-art-stage` no longer use `background: var(--login-art)`; new `.login-art-stage-img` rule. Stage is aspect-locked to the art, so `object-fit: fill` matches the old `background-size: 100% 100%`.
- `useArtImageState`/holding-frame/fallback logic is unchanged — only how the resolved art paints.
- The decorative `.login-modal-backdrop--art::before` fallback backdrop still uses `--login-art` (separate, not the bug).

## Validation

- `bunx tsc -b` ✅ · `bun run lint` ✅ · `bun run build` ✅
- `./gradlew demo` — name-entry and welcome-back picker scenes both paint correctly (screenshots verified locally).

Hard-refresh + SW-bypass is browser-specific and can't be reproduced headlessly, but the fix removes the gate/paint divergence by construction.