### PR TITLE
feat(jukebox): next-up queue slot + painted panel chrome

### DIFF
--- a/docs/ART_CONTRACT.md
+++ b/docs/ART_CONTRACT.md
@@ -30,7 +30,7 @@ the *values* (paths/filenames) are what deployments override.
 
 | Family | Convention | Examples |
 |---|---|---|
-| Panel frames | `<panel>_bg` | `admin_bg`, `chat_bg`, `who_bg`, `guild_bg`, `friends_bg`, `group_bg`, `auction_bg`, `crafting_bg`, `professions_bg`, `housing_bg`, `stylist_bg`, `lottery_bg`, `dice_bg`, `bank_bg`, `puzzle_bg`, `command_reference_bg`, `character_bg`, `character_scribe_bg` |
+| Panel frames | `<panel>_bg` | `admin_bg`, `chat_bg`, `who_bg`, `guild_bg`, `friends_bg`, `group_bg`, `auction_bg`, `crafting_bg`, `professions_bg`, `housing_bg`, `stylist_bg`, `lottery_bg`, `dice_bg`, `jukebox_bg`, `bank_bg`, `puzzle_bg`, `command_reference_bg`, `character_bg`, `character_scribe_bg` |
 | Control overlays | `<panel>_<control>_btn` / `<scope>_<control>` | `staff_action_btn`, `staff_action_btn_active`, `who_examine_btn`, `who_tell_btn`, `who_friend_btn`, `char_btn_achievements`, `char_btn_prestige`, `char_btn_professions` |
 | Multi-piece sets | `<panel>_<piece>` | Character "Woodland Fae Cabinet": `character_niche` (full art), `character_frame` / `character_plaque` / `character_charm` (**9-slice** carved frames) |
 | World-feature art | `feature_*`, `door_*`, `lever_*`, `container_bg`, `sign_bg` | `door_frame` + `door_leaf` + `door_lock` + `door_portal` (static frame, swinging leaf, warded-seal lock, doorway vortex), `lever_plate` + `lever_handle` |

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -2375,8 +2375,8 @@ data class CommandsConfig(
             ),
             "gamble" to CommandMetadata("gamble/dice <amount>", "Roll d100 against the house (requires a tavern)", "social"),
             "jukebox" to CommandMetadata(
-                usage = "jukebox [list] | jukebox play <number>",
-                description = "List the room's jukebox songs or pay to play one for everyone",
+                usage = "jukebox [list] | jukebox play <number> | jukebox queue <number>",
+                description = "List the room's jukebox songs, pay to play one, or queue the next track",
                 category = "social",
             ),
             "ansi" to CommandMetadata("ansi on/off", "Toggle color output", "utility"),

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -2999,9 +2999,10 @@ class GameEngine(
     /**
      * Drives playing jukebox tracks: broadcasts lyric lines as they come due
      * (spread across each track's duration — flavour for players without audio),
-     * then announces tracks that just ended and reverts their rooms to default
-     * music via a cleared `Jukebox.Info`. Cheap when nothing is playing (the
-     * common case): both polls return empty.
+     * then announces tracks that just ended. A queued successor (paid via
+     * `jukebox queue`) takes over immediately; otherwise the room reverts to its
+     * default music via a cleared `Jukebox.Info`. Cheap when nothing is playing
+     * (the common case): both polls return empty.
      */
     private suspend fun tickJukebox() {
         for ((roomId, lines) in jukeboxSystem.pollDueLyrics()) {
@@ -3009,25 +3010,42 @@ class GameEngine(
                 broadcastToRoom(players, outbound, roomId, "♪ $line ♪")
             }
         }
-        for ((roomId, ended) in jukeboxSystem.pollExpired()) {
+        for ((roomId, transition) in jukeboxSystem.pollExpired()) {
             broadcastToRoom(
                 players,
                 outbound,
                 roomId,
-                "The jukebox winds down as \"${ended.song.title}\" comes to an end.",
+                "The jukebox winds down as \"${transition.ended.song.title}\" comes to an end.",
             )
+            val started = transition.started
+            if (started != null) {
+                val byline = started.song.artist?.let { " by $it" } ?: ""
+                broadcastToRoom(
+                    players,
+                    outbound,
+                    roomId,
+                    "The jukebox whirs back to life with \"${started.song.title}\"$byline, queued by ${started.buyerName}.",
+                )
+                started.song.description?.let { broadcastToRoom(players, outbound, roomId, it) }
+            }
             gmcpEmitter?.let { emitter ->
                 val playlist = world.rooms[roomId]?.jukebox ?: emptyList()
-                val payload = emitter.buildJukeboxInfo(playlist, nowPlaying = null, remainingSeconds = 0)
+                val payload = emitter.buildJukeboxInfo(
+                    playlist,
+                    nowPlaying = started,
+                    remainingSeconds = started?.let { jukeboxSystem.secondsRemaining(it) } ?: 0,
+                    queued = jukeboxSystem.queuedSong(roomId),
+                )
                 emitter.broadcastJukeboxInfo(roomId, payload, players)
             }
-            // Inline music links for non-web clients revert to the room's default
-            // (see PlayerState.audioLinksEnabled), mirroring the GMCP revert above.
-            val defaultMusic = world.rooms[roomId]?.music
+            // Inline music links for non-web clients follow the promoted track, or
+            // revert to the room's default (see PlayerState.audioLinksEnabled),
+            // mirroring the GMCP push above.
+            val music = started?.song?.url ?: world.rooms[roomId]?.music
             for (occupant in players.playersInRoom(roomId)) {
                 if (occupant.audioLinksEnabled) {
-                    occupant.lastEmittedMusicUrl = defaultMusic
-                    defaultMusic?.let { outbound.send(OutboundEvent.SendInfo(occupant.sessionId, "[music] $it")) }
+                    occupant.lastEmittedMusicUrl = music
+                    music?.let { outbound.send(OutboundEvent.SendInfo(occupant.sessionId, "[music] $it")) }
                 }
             }
         }

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -1681,21 +1681,34 @@ class GmcpEmitter(
         val secondsRemaining: Int,
     )
 
+    /** The paid-for track queued to start when the current one ends. */
+    data class JukeboxQueuedPayload(
+        val number: Int,
+        val title: String,
+        val artist: String? = null,
+        /** Name of the player who paid to queue it. */
+        val buyer: String,
+    )
+
     data class JukeboxInfoPayload(
         val songs: List<JukeboxSongPayload>,
         /** Null when nothing is playing; the room then uses its default music. */
         val nowPlaying: JukeboxNowPlayingPayload? = null,
+        /** Null when the single next-up queue slot is free. */
+        val queued: JukeboxQueuedPayload? = null,
     )
 
     /**
-     * Builds a `Jukebox.Info` payload from a room's [playlist] and the optionally
+     * Builds a `Jukebox.Info` payload from a room's [playlist], the optionally
      * playing [nowPlaying] track ([remainingSeconds] is the caller's clock-derived
-     * countdown). A null [nowPlaying] means the room is on its default music.
+     * countdown), and the optionally [queued] next-up track. A null [nowPlaying]
+     * means the room is on its default music.
      */
     fun buildJukeboxInfo(
         playlist: List<JukeboxSong>,
         nowPlaying: JukeboxNowPlaying?,
         remainingSeconds: Int,
+        queued: JukeboxQueuedSong? = null,
     ): JukeboxInfoPayload =
         JukeboxInfoPayload(
             songs = playlist.mapIndexed { index, song ->
@@ -1717,6 +1730,14 @@ class GmcpEmitter(
                     url = np.song.url,
                     buyer = np.buyerName,
                     secondsRemaining = remainingSeconds,
+                )
+            },
+            queued = queued?.let { q ->
+                JukeboxQueuedPayload(
+                    number = q.songIndex + 1,
+                    title = q.song.title,
+                    artist = q.song.artist,
+                    buyer = q.buyerName,
                 )
             },
         )

--- a/src/main/kotlin/dev/ambon/engine/JukeboxSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/JukeboxSystem.kt
@@ -34,6 +34,23 @@ data class JukeboxNowPlaying(
     }
 }
 
+/** A paid-for track waiting its turn; it starts the moment the current track ends. */
+data class JukeboxQueuedSong(
+    val song: JukeboxSong,
+    /** 0-based index into the room's playlist. */
+    val songIndex: Int,
+    /** Name of the player who paid to queue it. */
+    val buyerName: String,
+)
+
+/** What changed in a room when [JukeboxSystem.pollExpired] retired a track. */
+data class JukeboxTransition(
+    /** The track that just finished. */
+    val ended: JukeboxNowPlaying,
+    /** The queued successor that took over, or null if the room reverts to default music. */
+    val started: JukeboxNowPlaying?,
+)
+
 /** Outcome of a `jukebox play` attempt. */
 sealed interface JukeboxPlayResult {
     /** The track started; [nowPlaying] is the room's new state. */
@@ -65,23 +82,74 @@ sealed interface JukeboxPlayResult {
     ) : JukeboxPlayResult
 }
 
+/** Outcome of a `jukebox queue` attempt. */
+sealed interface JukeboxQueueResult {
+    /** The track was paid for and queued; it starts when [current] ends. */
+    data class Queued(
+        val entry: JukeboxQueuedSong,
+        val current: JukeboxNowPlaying,
+    ) : JukeboxQueueResult
+
+    /** Nothing was playing, so the track was paid for and started immediately. */
+    data class StartedInstead(
+        val nowPlaying: JukeboxNowPlaying,
+    ) : JukeboxQueueResult
+
+    /** The jukebox feature is disabled server-wide. */
+    data object Disabled : JukeboxQueueResult
+
+    /** This room has no jukebox playlist. */
+    data object NoJukebox : JukeboxQueueResult
+
+    /** The requested song number was out of range; [count] songs are available. */
+    data class NoSuchSong(
+        val count: Int,
+    ) : JukeboxQueueResult
+
+    /** The player cannot afford the track. */
+    data class InsufficientGold(
+        val need: Long,
+        val have: Long,
+    ) : JukeboxQueueResult
+
+    /** The requester's own song is playing — they can't also claim the next slot. */
+    data class OwnSongPlaying(
+        val current: JukeboxNowPlaying,
+    ) : JukeboxQueueResult
+
+    /** The single queue slot is already taken by [entry]. */
+    data class AlreadyQueued(
+        val entry: JukeboxQueuedSong,
+    ) : JukeboxQueueResult
+}
+
 /**
- * Tracks each room's currently-playing jukebox track. State is transient (in
- * memory, reset on restart) — a paid song locks the room for its authored
- * [JukeboxSong.durationSeconds], then the room reverts to its default music.
+ * Tracks each room's currently-playing jukebox track plus a single queued
+ * successor. State is transient (in memory, reset on restart) — a paid song
+ * locks the room for its authored [JukeboxSong.durationSeconds], then the
+ * queued track (if any) takes over, otherwise the room reverts to its default
+ * music.
+ *
+ * Queueing is the anti-monopoly valve: while a track plays, any player *except
+ * the one who paid for it* can pay to reserve the single next-up slot ([queue]),
+ * so whoever is quickest on the draw can't chain-control the room's music.
  *
  * The engine drives the lifecycle by polling each tick: [pollDueLyrics] surfaces
  * lyric lines to broadcast (spread evenly across the track — flavour for players
- * without audio), then [pollExpired] removes and returns finished tracks so the
- * engine can announce the end and re-emit default music. Reads ([nowPlaying])
- * treat an expired-but-not-yet-polled track as already over. All time comes from
- * the injected [clock] (never wall-clock) so tests can drive it with `MutableClock`.
+ * without audio), then [pollExpired] removes finished tracks and promotes their
+ * queued successors, returning a [JukeboxTransition] per room so the engine can
+ * announce the change and re-emit music. Reads ([nowPlaying]) treat an
+ * expired-but-not-yet-polled track as already over. All time comes from the
+ * injected [clock] (never wall-clock) so tests can drive it with `MutableClock`.
  */
 class JukeboxSystem(
     private val clock: Clock,
     private val enabled: Boolean = true,
 ) {
     private val playing = mutableMapOf<RoomId, JukeboxNowPlaying>()
+
+    /** Per-room queued successor track — a single slot (see [queue]). */
+    private val queuedSongs = mutableMapOf<RoomId, JukeboxQueuedSong>()
 
     /** Per-room count of lyric lines already handed out for the current track. */
     private val lyricsSent = mutableMapOf<RoomId, Int>()
@@ -94,6 +162,9 @@ class JukeboxSystem(
         if (current.endsAtMs <= clock.millis()) return null
         return current
     }
+
+    /** The track queued to play next in [roomId], or null if the slot is free. */
+    fun queuedSong(roomId: RoomId): JukeboxQueuedSong? = queuedSongs[roomId]
 
     /** The override music URL for [roomId] while a track plays, else null (use room default). */
     fun overrideMusic(roomId: RoomId): String? = nowPlaying(roomId)?.song?.url
@@ -121,11 +192,64 @@ class JukeboxSystem(
         if (current != null) {
             return JukeboxPlayResult.Busy(current, current.remainingSeconds(clock.millis()))
         }
+        // A lapsed track with a queued successor still owns the box for the tick
+        // gap until pollExpired promotes it — don't let a play jump the queue.
+        val lapsed = playing[roomId]
+        if (lapsed != null && queuedSongs.containsKey(roomId)) {
+            return JukeboxPlayResult.Busy(lapsed, 0)
+        }
 
         val song = playlist.getOrNull(songIndex) ?: return JukeboxPlayResult.NoSuchSong(playlist.size)
         if (currentGold < song.cost) return JukeboxPlayResult.InsufficientGold(song.cost, currentGold)
 
         deductGold(song.cost)
+        return JukeboxPlayResult.Success(start(roomId, song, songIndex, buyerName))
+    }
+
+    /**
+     * Attempts to queue [songIndex] (0-based) from [playlist] to play right after
+     * the current track in [roomId]. One slot per room, and the buyer of the
+     * *playing* track can't take it — that way someone else always gets the next
+     * pick and one player can't chain-control the room's music. Queueing while
+     * nothing plays simply starts the song. Gold is charged up front via
+     * [deductGold].
+     */
+    fun queue(
+        roomId: RoomId,
+        playlist: List<JukeboxSong>,
+        songIndex: Int,
+        buyerName: String,
+        currentGold: Long,
+        deductGold: (Long) -> Unit,
+    ): JukeboxQueueResult {
+        if (!enabled) return JukeboxQueueResult.Disabled
+        if (playlist.isEmpty()) return JukeboxQueueResult.NoJukebox
+
+        val song = playlist.getOrNull(songIndex) ?: return JukeboxQueueResult.NoSuchSong(playlist.size)
+        val current = nowPlaying(roomId)
+        if (current != null && current.buyerName == buyerName) {
+            return JukeboxQueueResult.OwnSongPlaying(current)
+        }
+        queuedSongs[roomId]?.let { return JukeboxQueueResult.AlreadyQueued(it) }
+        if (currentGold < song.cost) return JukeboxQueueResult.InsufficientGold(song.cost, currentGold)
+
+        deductGold(song.cost)
+        if (current == null) {
+            // Nothing playing — no need to wait, the song starts right now.
+            return JukeboxQueueResult.StartedInstead(start(roomId, song, songIndex, buyerName))
+        }
+        val entry = JukeboxQueuedSong(song = song, songIndex = songIndex, buyerName = buyerName)
+        queuedSongs[roomId] = entry
+        return JukeboxQueueResult.Queued(entry, current)
+    }
+
+    /** Records [song] as playing in [roomId] starting now, resetting lyric progress. */
+    private fun start(
+        roomId: RoomId,
+        song: JukeboxSong,
+        songIndex: Int,
+        buyerName: String,
+    ): JukeboxNowPlaying {
         val now = clock.millis()
         val nowPlaying =
             JukeboxNowPlaying(
@@ -137,7 +261,7 @@ class JukeboxSystem(
             )
         playing[roomId] = nowPlaying
         lyricsSent.remove(roomId)
-        return JukeboxPlayResult.Success(nowPlaying)
+        return nowPlaying
     }
 
     /**
@@ -164,23 +288,31 @@ class JukeboxSystem(
     }
 
     /**
-     * Removes and returns the tracks that have ended since the last call, keyed
-     * by room. The engine announces each ending and re-emits the room's default
-     * music to its occupants. Called once per tick.
+     * Removes the tracks that have ended since the last call and promotes each
+     * room's queued successor (if any), returning a [JukeboxTransition] per room.
+     * The engine announces each ending — and the takeover, when
+     * [JukeboxTransition.started] is non-null — then re-emits music to the room's
+     * occupants. Called once per tick.
      */
-    fun pollExpired(): Map<RoomId, JukeboxNowPlaying> {
+    fun pollExpired(): Map<RoomId, JukeboxTransition> {
         val now = clock.millis()
         val due = playing.filterValues { it.endsAtMs <= now }
-        for (roomId in due.keys) {
+        if (due.isEmpty()) return emptyMap()
+        val transitions = mutableMapOf<RoomId, JukeboxTransition>()
+        for ((roomId, ended) in due) {
             playing.remove(roomId)
             lyricsSent.remove(roomId)
+            val next = queuedSongs.remove(roomId)
+            val started = next?.let { start(roomId, it.song, it.songIndex, it.buyerName) }
+            transitions[roomId] = JukeboxTransition(ended = ended, started = started)
         }
-        return due
+        return transitions
     }
 
     /** Clears all state. For tests / world reloads. */
     fun clear() {
         playing.clear()
+        queuedSongs.clear()
         lyricsSent.clear()
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -243,6 +243,14 @@ sealed interface Command {
         val song: Int,
     ) : Command
 
+    /**
+     * `jukebox queue <n>`/`jb queue <n>` — pay to queue the n-th song (1-based) to
+     * play next. One slot, and not for whoever's song is currently playing.
+     */
+    data class JukeboxQueue(
+        val song: Int,
+    ) : Command
+
     // ---- Bank commands ----
 
     sealed interface Bank : Command {
@@ -1159,7 +1167,7 @@ object CommandParser {
             }
         }?.let { return it }
 
-        // jukebox: "jukebox play <n>" then bare "jukebox" (alias jb). Play must match first.
+        // jukebox: "jukebox play/queue <n>" then bare "jukebox" (alias jb). Subcommands must match first.
         matchPrefix(line, listOf("jukebox play", "jb play")) { rest ->
             val n = rest.trim().toIntOrNull()
             if (n == null || n < 1) {
@@ -1169,12 +1177,21 @@ object CommandParser {
             }
         }?.let { return it }
 
+        matchPrefix(line, listOf("jukebox queue", "jb queue")) { rest ->
+            val n = rest.trim().toIntOrNull()
+            if (n == null || n < 1) {
+                Command.Invalid(line, "jukebox queue <number>")
+            } else {
+                Command.JukeboxQueue(n)
+            }
+        }?.let { return it }
+
         matchPrefix(line, listOf("jukebox", "jb")) { rest ->
             val sub = rest.trim().lowercase()
             if (sub.isEmpty() || sub == "list" || sub == "info") {
                 Command.Jukebox
             } else {
-                Command.Invalid(line, "jukebox [list] | jukebox play <number>")
+                Command.Invalid(line, "jukebox [list] | jukebox play <number> | jukebox queue <number>")
             }
         }?.let { return it }
 

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -299,9 +299,9 @@ internal suspend fun EngineContext.emitStylistGmcp(sessionId: SessionId) {
 
 /**
  * Emits `Jukebox.Info` for the player's current room: its playlist plus whatever
- * track is playing right now (so someone entering mid-song hears it). Sent on
- * every room look/entry; rooms without a jukebox send an empty playlist so the
- * client clears any stale state from the previous room.
+ * track is playing or queued right now (so someone entering mid-song hears it).
+ * Sent on every room look/entry; rooms without a jukebox send an empty playlist
+ * so the client clears any stale state from the previous room.
  */
 internal suspend fun EngineContext.emitJukeboxGmcp(sessionId: SessionId) {
     val emitter = gmcpEmitter ?: return
@@ -310,7 +310,10 @@ internal suspend fun EngineContext.emitJukeboxGmcp(sessionId: SessionId) {
     val room = world.rooms[me.roomId] ?: return
     val nowPlaying = system.nowPlaying(room.id)
     val remaining = nowPlaying?.let { system.secondsRemaining(it) } ?: 0
-    emitter.sendJukeboxInfo(sessionId, emitter.buildJukeboxInfo(room.jukebox, nowPlaying, remaining))
+    emitter.sendJukeboxInfo(
+        sessionId,
+        emitter.buildJukeboxInfo(room.jukebox, nowPlaying, remaining, queued = system.queuedSong(room.id)),
+    )
 }
 
 /**

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/JukeboxHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/JukeboxHandler.kt
@@ -1,9 +1,13 @@
 package dev.ambon.engine.commands.handlers
 
+import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.world.JukeboxSong
+import dev.ambon.engine.JukeboxNowPlaying
 import dev.ambon.engine.JukeboxPlayResult
+import dev.ambon.engine.JukeboxQueueResult
 import dev.ambon.engine.JukeboxSystem
+import dev.ambon.engine.PlayerState
 import dev.ambon.engine.commands.Command
 import dev.ambon.engine.commands.CommandHandler
 import dev.ambon.engine.commands.CommandRouter
@@ -14,7 +18,9 @@ import dev.ambon.engine.events.OutboundEvent
  * The room jukebox: players pay a few gold to play an authored track, which
  * becomes the room's music for everyone present until it ends (then the room
  * reverts to its default music — see [JukeboxSystem]). A playing jukebox is
- * locked until its track finishes.
+ * locked, but anyone *other than* the current track's buyer can pay to queue
+ * the single next-up slot — the anti-monopoly rule that keeps one player from
+ * chain-controlling the room's music.
  */
 class JukeboxHandler(
     private val ctx: EngineContext,
@@ -28,6 +34,7 @@ class JukeboxHandler(
     override fun register(router: CommandRouter) {
         router.on<Command.Jukebox> { sid, _ -> handleList(sid) }
         router.on<Command.JukeboxPlay> { sid, cmd -> handlePlay(sid, cmd) }
+        router.on<Command.JukeboxQueue> { sid, cmd -> handleQueue(sid, cmd) }
     }
 
     private suspend fun handleList(sessionId: SessionId) {
@@ -52,7 +59,16 @@ class JukeboxHandler(
                     OutboundEvent.SendInfo(
                         sessionId,
                         "  Now playing: \"${nowPlaying.song.title}\"${byline(nowPlaying.song)} " +
-                            "(${jukeboxSystem.secondsRemaining(nowPlaying)}s left, queued by ${nowPlaying.buyerName})",
+                            "(${jukeboxSystem.secondsRemaining(nowPlaying)}s left, played by ${nowPlaying.buyerName})",
+                    ),
+                )
+            }
+            val queued = jukeboxSystem.queuedSong(me.roomId)
+            if (queued != null) {
+                outbound.send(
+                    OutboundEvent.SendInfo(
+                        sessionId,
+                        "  Up next: \"${queued.song.title}\"${byline(queued.song)} (queued by ${queued.buyerName})",
                     ),
                 )
             }
@@ -65,7 +81,12 @@ class JukeboxHandler(
                     ),
                 )
             }
-            outbound.send(OutboundEvent.SendInfo(sessionId, "  Use 'jukebox play <number>' to pay for a song."))
+            outbound.send(
+                OutboundEvent.SendInfo(
+                    sessionId,
+                    "  Use 'jukebox play <number>' to pay for a song, or 'jukebox queue <number>' while one plays.",
+                ),
+            )
 
             ctx.emitJukeboxGmcp(sessionId)
         }
@@ -88,63 +109,23 @@ class JukeboxHandler(
 
             when (result) {
                 is JukeboxPlayResult.Success -> {
-                    val song = result.nowPlaying.song
                     ctx.metrics.onGameEvent("jukebox", "play")
                     markVitalsDirty(sessionId)
-
-                    val message =
-                        "You drop ${song.cost} gold into the jukebox; it begins to play \"${song.title}\"${byline(song)}."
-                    outbound.send(OutboundEvent.SendInfo(sessionId, message))
-                    sendScopedFeedback(
-                        sessionId,
-                        gmcpEmitter,
-                        "success",
-                        message,
-                        "jukebox",
-                        code = "PLAYING",
-                        command = "play",
-                    )
-                    broadcastToRoomExcept(
-                        me.roomId,
-                        sessionId,
-                        "${me.name} feeds the jukebox; it begins to play \"${song.title}\"${byline(song)}.",
-                        players,
-                        outbound,
-                    )
-
-                    // Describe the song to everyone present — flavour for players without audio.
-                    song.description?.let { description ->
-                        broadcastToRoom(me.roomId, description, players, outbound)
-                    }
-
-                    // Push the new track + countdown to everyone in the room so their audio swaps.
-                    gmcpEmitter?.let { emitter ->
-                        val payload =
-                            emitter.buildJukeboxInfo(
-                                playlist,
-                                result.nowPlaying,
-                                jukeboxSystem.secondsRemaining(result.nowPlaying),
-                            )
-                        emitter.broadcastJukeboxInfo(me.roomId, payload, players)
-                    }
-
-                    // Inline music links for non-web clients (see PlayerState.audioLinksEnabled),
-                    // so their audio swaps along with the GMCP push above.
-                    for (occupant in players.playersInRoom(me.roomId)) {
-                        if (occupant.audioLinksEnabled && song.url != occupant.lastEmittedMusicUrl) {
-                            occupant.lastEmittedMusicUrl = song.url
-                            outbound.send(OutboundEvent.SendInfo(occupant.sessionId, "[music] ${song.url}"))
-                        }
-                    }
+                    announceTrackStart(me, result.nowPlaying, command = "play")
                 }
 
                 is JukeboxPlayResult.Busy -> {
+                    val hint = if (result.current.buyerName == me.name) {
+                        "Your song is playing — someone else gets to queue the next one."
+                    } else {
+                        "Use 'jukebox queue ${cmd.song}' to line it up next."
+                    }
                     sendErrorWithFeedback(
                         sessionId,
                         outbound,
                         gmcpEmitter,
                         "The jukebox is busy — \"${result.current.song.title}\" has " +
-                            "${result.remainingSeconds}s left. Try again when it ends.",
+                            "${result.remainingSeconds}s left. $hint",
                         "jukebox",
                         code = "BUSY",
                         command = "play",
@@ -189,6 +170,180 @@ class JukeboxHandler(
                     )
             }
         }
+    }
+
+    private suspend fun handleQueue(sessionId: SessionId, cmd: Command.JukeboxQueue) {
+        players.withPlayer(sessionId) { me ->
+            val room = ctx.world.rooms[me.roomId]
+            val playlist = room?.jukebox ?: emptyList()
+
+            val result =
+                jukeboxSystem.queue(
+                    roomId = me.roomId,
+                    playlist = playlist,
+                    songIndex = cmd.song - 1,
+                    buyerName = me.name,
+                    currentGold = me.gold,
+                    deductGold = { cost -> me.gold -= cost },
+                )
+
+            when (result) {
+                is JukeboxQueueResult.Queued -> {
+                    val song = result.entry.song
+                    ctx.metrics.onGameEvent("jukebox", "queue")
+                    markVitalsDirty(sessionId)
+
+                    val message =
+                        "You drop ${song.cost} gold into the jukebox; \"${song.title}\"${byline(song)} will play next."
+                    outbound.send(OutboundEvent.SendInfo(sessionId, message))
+                    sendScopedFeedback(
+                        sessionId,
+                        gmcpEmitter,
+                        "success",
+                        message,
+                        "jukebox",
+                        code = "QUEUED",
+                        command = "queue",
+                    )
+                    broadcastToRoomExcept(
+                        me.roomId,
+                        sessionId,
+                        "${me.name} feeds the jukebox; \"${song.title}\"${byline(song)} will play next.",
+                        players,
+                        outbound,
+                    )
+                    // Refresh everyone's panel so the queued badge appears room-wide.
+                    broadcastJukeboxState(me.roomId)
+                }
+
+                is JukeboxQueueResult.StartedInstead -> {
+                    ctx.metrics.onGameEvent("jukebox", "play")
+                    markVitalsDirty(sessionId)
+                    announceTrackStart(me, result.nowPlaying, command = "queue")
+                }
+
+                is JukeboxQueueResult.OwnSongPlaying -> {
+                    sendErrorWithFeedback(
+                        sessionId,
+                        outbound,
+                        gmcpEmitter,
+                        "Your song \"${result.current.song.title}\" is playing — someone else gets to pick the next one.",
+                        "jukebox",
+                        code = "OWN_SONG_PLAYING",
+                        command = "queue",
+                    )
+                }
+
+                is JukeboxQueueResult.AlreadyQueued -> {
+                    sendErrorWithFeedback(
+                        sessionId,
+                        outbound,
+                        gmcpEmitter,
+                        "\"${result.entry.song.title}\" is already queued next (by ${result.entry.buyerName}).",
+                        "jukebox",
+                        code = "QUEUE_FULL",
+                        command = "queue",
+                    )
+                }
+
+                is JukeboxQueueResult.InsufficientGold -> {
+                    sendErrorWithFeedback(
+                        sessionId,
+                        outbound,
+                        gmcpEmitter,
+                        "You need ${result.need} gold but only have ${result.have}.",
+                        "jukebox",
+                        code = "INSUFFICIENT_GOLD",
+                        command = "queue",
+                    )
+                }
+
+                is JukeboxQueueResult.NoSuchSong -> {
+                    sendErrorWithFeedback(
+                        sessionId,
+                        outbound,
+                        gmcpEmitter,
+                        "There is no song #${cmd.song}. This jukebox has ${result.count} song(s).",
+                        "jukebox",
+                        code = "NO_SUCH_SONG",
+                        command = "queue",
+                    )
+                }
+
+                JukeboxQueueResult.NoJukebox,
+                JukeboxQueueResult.Disabled,
+                ->
+                    sendErrorWithFeedback(
+                        sessionId,
+                        outbound,
+                        gmcpEmitter,
+                        "There is no jukebox here.",
+                        "jukebox",
+                        code = "NO_JUKEBOX",
+                        command = "queue",
+                    )
+            }
+        }
+    }
+
+    /**
+     * Announces [nowPlaying] starting this instant, paid by [me]: feedback to the
+     * buyer, room broadcasts (including the song's flavour description), a
+     * `Jukebox.Info` push so every web client's audio swaps, and inline music
+     * links for non-web clients (see PlayerState.audioLinksEnabled).
+     */
+    private suspend fun announceTrackStart(me: PlayerState, nowPlaying: JukeboxNowPlaying, command: String) {
+        val song = nowPlaying.song
+        val message =
+            "You drop ${song.cost} gold into the jukebox; it begins to play \"${song.title}\"${byline(song)}."
+        outbound.send(OutboundEvent.SendInfo(me.sessionId, message))
+        sendScopedFeedback(
+            me.sessionId,
+            gmcpEmitter,
+            "success",
+            message,
+            "jukebox",
+            code = "PLAYING",
+            command = command,
+        )
+        broadcastToRoomExcept(
+            me.roomId,
+            me.sessionId,
+            "${me.name} feeds the jukebox; it begins to play \"${song.title}\"${byline(song)}.",
+            players,
+            outbound,
+        )
+
+        // Describe the song to everyone present — flavour for players without audio.
+        song.description?.let { description ->
+            broadcastToRoom(me.roomId, description, players, outbound)
+        }
+
+        broadcastJukeboxState(me.roomId)
+
+        // Inline music links for non-web clients (see PlayerState.audioLinksEnabled),
+        // so their audio swaps along with the GMCP push above.
+        for (occupant in players.playersInRoom(me.roomId)) {
+            if (occupant.audioLinksEnabled && song.url != occupant.lastEmittedMusicUrl) {
+                occupant.lastEmittedMusicUrl = song.url
+                outbound.send(OutboundEvent.SendInfo(occupant.sessionId, "[music] ${song.url}"))
+            }
+        }
+    }
+
+    /** Pushes the room's full jukebox state (playlist + now playing + queue) to everyone present. */
+    private suspend fun broadcastJukeboxState(roomId: RoomId) {
+        val emitter = gmcpEmitter ?: return
+        val playlist = ctx.world.rooms[roomId]?.jukebox ?: emptyList()
+        val nowPlaying = jukeboxSystem.nowPlaying(roomId)
+        val payload =
+            emitter.buildJukeboxInfo(
+                playlist,
+                nowPlaying,
+                nowPlaying?.let { jukeboxSystem.secondsRemaining(it) } ?: 0,
+                queued = jukeboxSystem.queuedSong(roomId),
+            )
+        emitter.broadcastJukeboxInfo(roomId, payload, players)
     }
 
     /** " by <artist>" when the song names one, else "". */

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1654,8 +1654,8 @@ ambonmud:
           category: "social"
           staff: false
         jukebox:
-          usage: "jukebox [list] | jukebox play <number>"
-          description: "List the room's jukebox songs or pay to play one for everyone"
+          usage: "jukebox [list] | jukebox play <number> | jukebox queue <number>"
+          description: "List the room's jukebox songs, pay to play one, or queue the next track"
           category: "social"
           staff: false
         ansi:

--- a/src/test/kotlin/dev/ambon/engine/GameEngineJukeboxTickTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GameEngineJukeboxTickTest.kt
@@ -73,6 +73,81 @@ class GameEngineJukeboxTickTest {
         }
 
     @Test
+    fun `a queued track takes over when the current one ends`() =
+        runTest {
+            val clock = MutableClock(0)
+            val world = WorldLoader.loadFromResource("world/ok_jukebox.yaml")
+            val h = GameEngineHarness.start(scope = this, world = world, clock = clock)
+
+            val aliceSid = SessionId(1L)
+            h.loginNewPlayer(aliceSid, "Alice")
+            val beaSid = SessionId(2L)
+            h.loginNewPlayer(beaSid, "Bea")
+            runCurrent()
+            advanceTimeBy(h.tickMillis * 20)
+            runCurrent()
+            val alice = h.players.get(aliceSid)
+            val bea = h.players.get(beaSid)
+            require(alice != null && bea != null) { "Logins did not complete; got=${h.drain()}" }
+            alice.gold = 50L
+            bea.gold = 50L
+            h.players.setAudioLinksEnabled(aliceSid, true)
+            h.drain()
+
+            h.inbound.send(InboundEvent.LineReceived(aliceSid, "jukebox play 1"))
+            advanceTimeBy(h.tickMillis * 5)
+            runCurrent()
+            h.drain()
+            h.inbound.send(InboundEvent.LineReceived(beaSid, "jukebox queue 2"))
+            advanceTimeBy(h.tickMillis * 5)
+            runCurrent()
+            val queueOuts = h.drain()
+            assertTrue(
+                queueOuts.any { it is OutboundEvent.SendInfo && it.text.contains("will play next") },
+                "Expected the queue confirmation. got=$queueOuts",
+            )
+
+            // Jump past the end of the 90s reel: the queued track takes over seamlessly.
+            clock.advance(91_000)
+            advanceTimeBy(h.tickMillis * 2)
+            runCurrent()
+            val outs = h.drain()
+            val texts = outs.filterIsInstance<OutboundEvent.SendText>().map { it.text }
+            assertTrue(
+                texts.any { it.contains("winds down as \"Tavern Reel\"") },
+                "Expected the first track's ending announcement. got=$texts",
+            )
+            assertTrue(
+                texts.any { it.contains("whirs back to life with \"Aineroia's Ascension\"") && it.contains("queued by Bea") },
+                "Expected the takeover announcement. got=$texts",
+            )
+            assertTrue(
+                outs.any {
+                    it is OutboundEvent.SendInfo &&
+                        it.sessionId == aliceSid &&
+                        it.text == "[music] /audio/jukebox/ascension.mp3"
+                },
+                "Expected the inline link to follow the promoted track. got=$outs",
+            )
+
+            // And when the promoted track ends with no successor, the room reverts.
+            clock.advance(181_000)
+            advanceTimeBy(h.tickMillis * 2)
+            runCurrent()
+            val endOuts = h.drain()
+            assertTrue(
+                endOuts.any {
+                    it is OutboundEvent.SendInfo &&
+                        it.sessionId == aliceSid &&
+                        it.text == "[music] /audio/tavern/ambient_loop.mp3"
+                },
+                "Expected the default music after the queue drained. got=$endOuts",
+            )
+
+            h.close()
+        }
+
+    @Test
     fun `inline audio links follow the jukebox track and revert when it ends`() =
         runTest {
             val clock = MutableClock(0)

--- a/src/test/kotlin/dev/ambon/engine/JukeboxSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/JukeboxSystemTest.kt
@@ -69,7 +69,8 @@ class JukeboxSystemTest {
         clock.advance(60_000)
         val expired = jb.pollExpired()
         assertEquals(setOf(room), expired.keys)
-        assertEquals("Tavern Reel", expired[room]?.song?.title)
+        assertEquals("Tavern Reel", expired[room]?.ended?.song?.title)
+        assertNull(expired[room]?.started) // nothing queued — the room reverts
         assertTrue(jb.pollExpired().isEmpty()) // already cleared
     }
 
@@ -122,6 +123,165 @@ class JukeboxSystemTest {
         var gold = 100L
         val result = jb.play(room, playlist, 0, "Bob", gold) { gold -= it }
         assertTrue(result is JukeboxPlayResult.Disabled)
+    }
+
+    // ---------- queueing ----------
+
+    @Test
+    fun `another player can queue the next song while one plays`() {
+        val (_, jb) = system()
+        var bobGold = 50L
+        var carolGold = 50L
+        jb.play(room, playlist, 0, "Bob", bobGold) { bobGold -= it }
+
+        val result = jb.queue(room, playlist, 1, "Carol", carolGold) { carolGold -= it }
+
+        assertTrue(result is JukeboxQueueResult.Queued)
+        result as JukeboxQueueResult.Queued
+        assertEquals("Aineroia's Ascension", result.entry.song.title)
+        assertEquals("Carol", result.entry.buyerName)
+        assertEquals("Tavern Reel", result.current.song.title)
+        assertEquals(40L, carolGold)
+        assertEquals("Aineroia's Ascension", jb.queuedSong(room)?.song?.title)
+        // The current track is unaffected.
+        assertEquals("Tavern Reel", jb.nowPlaying(room)?.song?.title)
+    }
+
+    @Test
+    fun `the current track's buyer cannot queue the next song`() {
+        val (_, jb) = system()
+        var gold = 50L
+        jb.play(room, playlist, 0, "Bob", gold) { gold -= it }
+
+        val result = jb.queue(room, playlist, 1, "Bob", gold) { gold -= it }
+
+        assertTrue(result is JukeboxQueueResult.OwnSongPlaying)
+        assertEquals(45L, gold) // not charged beyond the original play
+        assertNull(jb.queuedSong(room))
+    }
+
+    @Test
+    fun `only one song can be queued at a time`() {
+        val (_, jb) = system()
+        var gold = 200L
+        jb.play(room, playlist, 0, "Bob", gold) { gold -= it }
+        jb.queue(room, playlist, 1, "Carol", gold) { gold -= it }
+        val goldBefore = gold
+
+        val result = jb.queue(room, playlist, 0, "Dave", gold) { gold -= it }
+
+        assertTrue(result is JukeboxQueueResult.AlreadyQueued)
+        assertEquals("Carol", (result as JukeboxQueueResult.AlreadyQueued).entry.buyerName)
+        assertEquals(goldBefore, gold) // Dave was not charged
+    }
+
+    @Test
+    fun `queueing with nothing playing starts the song immediately`() {
+        val (_, jb) = system()
+        var gold = 50L
+
+        val result = jb.queue(room, playlist, 1, "Carol", gold) { gold -= it }
+
+        assertTrue(result is JukeboxQueueResult.StartedInstead)
+        assertEquals("Carol", (result as JukeboxQueueResult.StartedInstead).nowPlaying.buyerName)
+        assertEquals(40L, gold)
+        assertEquals("/audio/ascension.mp3", jb.overrideMusic(room))
+        assertNull(jb.queuedSong(room))
+    }
+
+    @Test
+    fun `queueing requires the gold up front`() {
+        val (_, jb) = system()
+        var bobGold = 50L
+        jb.play(room, playlist, 0, "Bob", bobGold) { bobGold -= it }
+        var carolGold = 3L
+
+        val result = jb.queue(room, playlist, 1, "Carol", carolGold) { carolGold -= it }
+
+        assertTrue(result is JukeboxQueueResult.InsufficientGold)
+        assertEquals(3L, carolGold)
+        assertNull(jb.queuedSong(room))
+    }
+
+    @Test
+    fun `out-of-range queue number is rejected`() {
+        val (_, jb) = system()
+        var gold = 100L
+        val result = jb.queue(room, playlist, 7, "Carol", gold) { gold -= it }
+        assertTrue(result is JukeboxQueueResult.NoSuchSong)
+        assertEquals(2, (result as JukeboxQueueResult.NoSuchSong).count)
+    }
+
+    @Test
+    fun `queued song takes over when the current track ends`() {
+        val (clock, jb) = system()
+        var gold = 200L
+        jb.play(room, playlist, 0, "Bob", gold) { gold -= it }
+        jb.queue(room, playlist, 1, "Carol", gold) { gold -= it }
+
+        clock.advance(60_000)
+        val transitions = jb.pollExpired()
+
+        assertEquals(setOf(room), transitions.keys)
+        val transition = transitions[room]!!
+        assertEquals("Tavern Reel", transition.ended.song.title)
+        assertEquals("Aineroia's Ascension", transition.started?.song?.title)
+        assertEquals("Carol", transition.started?.buyerName)
+        assertNull(jb.queuedSong(room)) // the slot is free again
+        assertEquals("/audio/ascension.mp3", jb.overrideMusic(room))
+        assertEquals(120, jb.nowPlaying(room)?.remainingSeconds(clock.millis()))
+
+        // The promoted track ends on schedule too — with no successor this time.
+        clock.advance(120_000)
+        val next = jb.pollExpired()
+        assertEquals("Aineroia's Ascension", next[room]?.ended?.song?.title)
+        assertNull(next[room]?.started)
+    }
+
+    @Test
+    fun `a play cannot jump a queued successor in the expiry gap`() {
+        val (clock, jb) = system()
+        var gold = 200L
+        jb.play(room, playlist, 0, "Bob", gold) { gold -= it }
+        jb.queue(room, playlist, 1, "Carol", gold) { gold -= it }
+        val goldBefore = gold
+
+        clock.advance(60_000) // the track has lapsed but pollExpired hasn't run yet
+        val result = jb.play(room, playlist, 0, "Dave", gold) { gold -= it }
+
+        assertTrue(result is JukeboxPlayResult.Busy)
+        assertEquals(goldBefore, gold)
+        assertEquals("Aineroia's Ascension", jb.pollExpired()[room]?.started?.song?.title)
+    }
+
+    @Test
+    fun `lyric progress starts fresh for a promoted track`() {
+        // Queue the 100s ballad behind the 60s reel: its first line lands 20s after promotion.
+        val (clock, jb) = system()
+        var gold = 200L
+        val songs = playlist + ballad
+        jb.play(room, songs, 0, "Bob", gold) { gold -= it }
+        jb.queue(room, songs, 2, "Carol", gold) { gold -= it }
+
+        clock.advance(60_000)
+        jb.pollExpired()
+
+        assertTrue(jb.pollDueLyrics().isEmpty()) // fresh track: nothing due at t=0
+        clock.advance(20_000)
+        assertEquals(mapOf(room to listOf("line one")), jb.pollDueLyrics())
+    }
+
+    @Test
+    fun `clear drops the queued song`() {
+        val (_, jb) = system()
+        var gold = 200L
+        jb.play(room, playlist, 0, "Bob", gold) { gold -= it }
+        jb.queue(room, playlist, 1, "Carol", gold) { gold -= it }
+
+        jb.clear()
+
+        assertNull(jb.queuedSong(room))
+        assertNull(jb.nowPlaying(room))
     }
 
     // ---------- lyrics ----------

--- a/src/test/kotlin/dev/ambon/engine/WebClientParityTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/WebClientParityTest.kt
@@ -135,6 +135,7 @@ class WebClientParityTest {
         "DiceRules" to "gamble",
         "Jukebox" to "jukebox",
         "JukeboxPlay" to "jukebox",
+        "JukeboxQueue" to "jukebox",
         // Quests
         "QuestLog" to "quest_log",
         "QuestInfo" to "quest_info",

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
@@ -54,9 +54,13 @@ class CommandParserTest {
         assertEquals(Command.Jukebox, CommandParser.parse("jukebox list"))
         assertEquals(Command.JukeboxPlay(3), CommandParser.parse("jukebox play 3"))
         assertEquals(Command.JukeboxPlay(1), CommandParser.parse("jb play 1"))
-        // Non-numeric or non-positive song number is Invalid, not a play.
+        assertEquals(Command.JukeboxQueue(2), CommandParser.parse("jukebox queue 2"))
+        assertEquals(Command.JukeboxQueue(1), CommandParser.parse("jb queue 1"))
+        // Non-numeric or non-positive song number is Invalid, not a play/queue.
         assertTrue(CommandParser.parse("jukebox play abc") is Command.Invalid)
         assertTrue(CommandParser.parse("jukebox play 0") is Command.Invalid)
+        assertTrue(CommandParser.parse("jukebox queue abc") is Command.Invalid)
+        assertTrue(CommandParser.parse("jukebox queue 0") is Command.Invalid)
     }
 
     @Test

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterJukeboxTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterJukeboxTest.kt
@@ -215,6 +215,146 @@ class CommandRouterJukeboxTest {
         }
 
     @Test
+    fun `another player can queue the next song while one plays`() =
+        runTest {
+            val env = setup()
+            env.player.gold = 50L
+            val quillSid = SessionId(2L)
+            val res = env.players.login(quillSid, "Quill", "password")
+            require(res == LoginResult.Ok) { "Login failed: $res" }
+            val quill = env.players.get(quillSid)!!
+            quill.gold = 20L
+            env.router.handle(env.sid, Command.JukeboxPlay(1))
+            env.outbound.drainAll()
+
+            env.router.handle(quillSid, Command.JukeboxQueue(2))
+
+            assertEquals(15L, quill.gold) // song 2 costs the default 5 gold
+            val outs = env.outbound.drainAll()
+            assertTrue(
+                outs.any { it is OutboundEvent.SendInfo && it.sessionId == quillSid && it.text.contains("will play next") },
+                "Expected the queue confirmation. got=$outs",
+            )
+            assertTrue(
+                outs.any { it is OutboundEvent.SendText && it.sessionId == env.sid && it.text.contains("will play next") },
+                "Expected the room to see the queue announcement. got=$outs",
+            )
+        }
+
+    @Test
+    fun `the current buyer cannot queue the next song`() =
+        runTest {
+            val env = setup()
+            env.player.gold = 50L
+            env.router.handle(env.sid, Command.JukeboxPlay(1))
+            env.outbound.drainAll()
+
+            env.router.handle(env.sid, Command.JukeboxQueue(2))
+
+            assertEquals(45L, env.player.gold) // charged only for the original play
+            val outs = env.outbound.drainAll()
+            assertTrue(
+                outs.any { it is OutboundEvent.SendError && it.text.contains("someone else") },
+                "Expected the own-song rejection. got=$outs",
+            )
+        }
+
+    @Test
+    fun `only one song can be queued at a time`() =
+        runTest {
+            val env = setup()
+            env.player.gold = 50L
+            val quillSid = SessionId(2L)
+            val resQuill = env.players.login(quillSid, "Quill", "password")
+            require(resQuill == LoginResult.Ok) { "Login failed: $resQuill" }
+            val nockSid = SessionId(3L)
+            val resNock = env.players.login(nockSid, "Nock", "password")
+            require(resNock == LoginResult.Ok) { "Login failed: $resNock" }
+            val quill = env.players.get(quillSid)!!
+            val nock = env.players.get(nockSid)!!
+            quill.gold = 20L
+            nock.gold = 20L
+            env.router.handle(env.sid, Command.JukeboxPlay(1))
+            env.router.handle(quillSid, Command.JukeboxQueue(2))
+            env.outbound.drainAll()
+
+            env.router.handle(nockSid, Command.JukeboxQueue(1))
+
+            assertEquals(20L, nock.gold)
+            val outs = env.outbound.drainAll()
+            assertTrue(
+                outs.any { it is OutboundEvent.SendError && it.sessionId == nockSid && it.text.contains("already queued") },
+                "Expected the queue-full rejection. got=$outs",
+            )
+        }
+
+    @Test
+    fun `queueing with nothing playing starts the song immediately`() =
+        runTest {
+            val env = setup()
+            env.player.gold = 50L
+
+            env.router.handle(env.sid, Command.JukeboxQueue(1))
+
+            assertEquals(45L, env.player.gold)
+            val outs = env.outbound.drainAll()
+            assertTrue(
+                outs.any { it is OutboundEvent.SendInfo && it.text.contains("begins to play \"Tavern Reel\"") },
+                "Expected the song to start immediately. got=$outs",
+            )
+        }
+
+    @Test
+    fun `busy play rejection points at the queue command`() =
+        runTest {
+            val env = setup()
+            env.player.gold = 50L
+            val quillSid = SessionId(2L)
+            val res = env.players.login(quillSid, "Quill", "password")
+            require(res == LoginResult.Ok) { "Login failed: $res" }
+            val quill = env.players.get(quillSid)!!
+            quill.gold = 20L
+            env.router.handle(env.sid, Command.JukeboxPlay(1))
+            env.outbound.drainAll()
+
+            env.router.handle(quillSid, Command.JukeboxPlay(2))
+
+            val outs = env.outbound.drainAll()
+            assertTrue(
+                outs.any { it is OutboundEvent.SendError && it.sessionId == quillSid && it.text.contains("jukebox queue 2") },
+                "Expected the busy error to suggest queueing. got=$outs",
+            )
+        }
+
+    @Test
+    fun `list shows the queued track`() =
+        runTest {
+            val env = setup()
+            env.player.gold = 50L
+            val quillSid = SessionId(2L)
+            val res = env.players.login(quillSid, "Quill", "password")
+            require(res == LoginResult.Ok) { "Login failed: $res" }
+            val quill = env.players.get(quillSid)!!
+            quill.gold = 20L
+            env.router.handle(env.sid, Command.JukeboxPlay(1))
+            env.router.handle(quillSid, Command.JukeboxQueue(2))
+            env.outbound.drainAll()
+
+            env.router.handle(env.sid, Command.Jukebox)
+
+            val outs = env.outbound.drainAll()
+            assertTrue(
+                outs.any {
+                    it is OutboundEvent.SendInfo &&
+                        it.sessionId == env.sid &&
+                        it.text.contains("Up next: \"Aineroia's Ascension\"") &&
+                        it.text.contains("queued by Quill")
+                },
+                "Expected the up-next line in the list. got=$outs",
+            )
+        }
+
+    @Test
     fun `jukebox is unavailable outside a jukebox room`() =
         runTest {
             val env = setup()

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -1602,6 +1602,7 @@ function App() {
           <JukeboxPanel
             jukebox={state.jukebox}
             gold={state.vitals.gold}
+            selfName={state.character.name}
             uiFeedbackFeed={state.uiFeedbackFeed}
             assets={state.serverAssets}
             onCommand={sendCommand}

--- a/web-v3/src/components/panels/JukeboxPanel.tsx
+++ b/web-v3/src/components/panels/JukeboxPanel.tsx
@@ -4,10 +4,15 @@ import type { JukeboxState, UiFeedbackEntry } from "../../types";
 interface JukeboxPanelProps {
   jukebox: JukeboxState | null;
   gold: number;
+  /** This player's character name — the current track's buyer can't also queue the next. */
+  selfName: string;
   uiFeedbackFeed: UiFeedbackEntry[];
   assets: Record<string, string>;
   onCommand: (command: string) => void;
 }
+
+/** Songs per page — one per painted scroll when the `jukebox_bg` art is present. */
+const PAGE_SIZE = 4;
 
 function formatDuration(seconds: number): string {
   const s = Math.max(0, Math.floor(seconds));
@@ -15,13 +20,15 @@ function formatDuration(seconds: number): string {
 }
 
 /**
- * Room jukebox. Lists the room's playlist; the player pays a few gold to play a
- * song, which becomes the room's music for everyone until it ends. While a track
- * is playing the jukebox is locked (every Play button disabled) and a now-playing
- * banner counts down to the revert.
+ * Room jukebox. Lists the room's playlist four songs to a page (each seated on a
+ * painted scroll when skinned); the player pays a few gold to play a song, which
+ * becomes the room's music for everyone until it ends. While a track plays the
+ * box is locked, but anyone except the track's buyer can pay to queue the single
+ * next-up slot — the bottom-right plaque shows the queued song's number.
  */
-export function JukeboxPanel({ jukebox, gold, uiFeedbackFeed, assets, onCommand }: JukeboxPanelProps) {
+export function JukeboxPanel({ jukebox, gold, selfName, uiFeedbackFeed, assets, onCommand }: JukeboxPanelProps) {
   const [now, setNow] = useState(() => Date.now());
+  const [page, setPage] = useState(0);
 
   useEffect(() => {
     const timer = window.setInterval(() => setNow(Date.now()), 1000);
@@ -35,41 +42,78 @@ export function JukeboxPanel({ jukebox, gold, uiFeedbackFeed, assets, onCommand 
 
   const songs = jukebox?.songs ?? [];
   const nowPlaying = jukebox?.nowPlaying ?? null;
+  const queued = jukebox?.queued ?? null;
   const remaining = nowPlaying
     ? Math.max(0, nowPlaying.secondsRemaining - Math.floor((now - nowPlaying.receivedAt) / 1000))
     : 0;
   const busy = nowPlaying !== null && remaining > 0;
+  const mineIsPlaying = busy && nowPlaying?.buyer === selfName;
 
-  const bg = assets.jukebox_bg;
-  const style = bg ? { ["--jukebox-bg" as string]: `url(${bg})` } : undefined;
+  const pages = Math.max(1, Math.ceil(songs.length / PAGE_SIZE));
+  const safePage = Math.min(page, pages - 1);
+  const pageSongs = songs.slice(safePage * PAGE_SIZE, safePage * PAGE_SIZE + PAGE_SIZE);
+
+  const skinned = Boolean(assets.jukebox_bg);
 
   return (
-    <div className={`jukebox-panel${bg ? " jukebox-panel-skinned" : ""}`} style={style}>
-      {nowPlaying && (
-        <div className="jukebox-nowplaying" aria-live="polite">
-          <span className="jukebox-np-eq" aria-hidden="true"><i /><i /><i /></span>
+    <div className={`jukebox-panel${skinned ? " jukebox-panel-skinned" : ""}`}>
+      <div className="jukebox-nowplaying">
+        {nowPlaying && busy ? (
+          <>
+            <span className="jukebox-np-eq" aria-hidden="true"><i /><i /><i /></span>
+            <div className="jukebox-np-text">
+              <div className="jukebox-np-title" aria-live="polite">
+                {nowPlaying.title}
+                {nowPlaying.artist ? <span className="jukebox-np-artist"> — {nowPlaying.artist}</span> : null}
+              </div>
+              <div className="jukebox-np-sub">
+                Played by {nowPlaying.buyer} · {formatDuration(remaining)} left
+              </div>
+              {queued ? (
+                <div className="jukebox-np-next">Up next: “{queued.title}” — queued by {queued.buyer}</div>
+              ) : nowPlaying.description ? (
+                <div className="jukebox-np-desc">{nowPlaying.description}</div>
+              ) : null}
+            </div>
+          </>
+        ) : (
           <div className="jukebox-np-text">
-            <div className="jukebox-np-title">
-              {nowPlaying.title}
-              {nowPlaying.artist ? <span className="jukebox-np-artist"> — {nowPlaying.artist}</span> : null}
-            </div>
-            <div className="jukebox-np-sub">
-              Queued by {nowPlaying.buyer} · {busy ? `${formatDuration(remaining)} left` : "ending…"}
-            </div>
-            {nowPlaying.description ? <div className="jukebox-np-desc">{nowPlaying.description}</div> : null}
+            <div className="jukebox-np-title" aria-live="polite">The jukebox sits quiet.</div>
+            <div className="jukebox-np-sub">Drop a coin to set the room’s music.</div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
 
       {songs.length === 0 ? (
         <p className="jukebox-empty">This jukebox has no songs loaded.</p>
       ) : (
         <ul className="jukebox-list">
-          {songs.map((song) => {
+          {pageSongs.map((song) => {
             const canAfford = gold >= song.cost;
-            const playing = nowPlaying?.number === song.number && busy;
+            const playing = busy && nowPlaying?.number === song.number;
+            const isQueued = queued !== null && queued.number === song.number;
+            const verb = busy ? "queue" : "play";
+            const actionable = !playing && !isQueued && !(busy && (mineIsPlaying || queued !== null));
+            const label = playing ? "Playing" : isQueued ? "Queued" : busy ? "Queue" : "Play";
+            const tooltip = playing
+              ? "This song is playing now"
+              : isQueued
+                ? `Queued next by ${queued?.buyer ?? "someone"}`
+                : busy && mineIsPlaying
+                  ? "Your song is playing — someone else gets to queue the next one"
+                  : busy && queued !== null
+                    ? "A song is already queued next"
+                    : !canAfford
+                      ? "Not enough gold"
+                      : busy
+                        ? `Queue "${song.title}" to play next`
+                        : `Play "${song.title}" for everyone`;
             return (
-              <li key={song.number} className={`jukebox-song${playing ? " is-playing" : ""}`}>
+              <li
+                key={song.number}
+                className={`jukebox-song${playing ? " is-playing" : ""}${isQueued ? " is-queued" : ""}`}
+              >
+                <span className="jukebox-song-num" aria-hidden="true">{song.number}</span>
                 <div className="jukebox-song-main">
                   <span className="jukebox-song-title">{song.title}</span>
                   {song.artist ? <span className="jukebox-song-artist"> — {song.artist}</span> : null}
@@ -81,17 +125,11 @@ export function JukeboxPanel({ jukebox, gold, uiFeedbackFeed, assets, onCommand 
                   <button
                     type="button"
                     className="jukebox-play-btn"
-                    disabled={busy || !canAfford}
-                    title={
-                      busy
-                        ? "The jukebox is busy until the current song ends"
-                        : canAfford
-                          ? `Play "${song.title}" for everyone`
-                          : "Not enough gold"
-                    }
-                    onClick={() => onCommand(`jukebox play ${song.number}`)}
+                    disabled={!actionable || !canAfford}
+                    title={tooltip}
+                    onClick={() => onCommand(`jukebox ${verb} ${song.number}`)}
                   >
-                    {playing ? "Playing" : "Play"}
+                    {label}
                   </button>
                 </div>
               </li>
@@ -100,9 +138,40 @@ export function JukeboxPanel({ jukebox, gold, uiFeedbackFeed, assets, onCommand 
         </ul>
       )}
 
+      {pages > 1 && (
+        <div className="jukebox-pager">
+          <button
+            type="button"
+            className="jukebox-pager-btn"
+            onClick={() => setPage(Math.max(0, safePage - 1))}
+            disabled={safePage === 0}
+            aria-label="Previous songs"
+          >
+            ‹
+          </button>
+          <span className="jukebox-pager-info">{safePage + 1} / {pages}</span>
+          <button
+            type="button"
+            className="jukebox-pager-btn"
+            onClick={() => setPage(Math.min(pages - 1, safePage + 1))}
+            disabled={safePage === pages - 1}
+            aria-label="More songs"
+          >
+            ›
+          </button>
+        </div>
+      )}
+
       {activeFeedback && (
         <p className={`jukebox-feedback jukebox-feedback-${activeFeedback.type}`}>{activeFeedback.message}</p>
       )}
+
+      {/* Seated on the painted corner plaque when skinned; hidden in the flow layout
+          (the banner's "Up next" line carries the same information). */}
+      <div className="jukebox-next-plaque" aria-hidden="true">
+        <span className="jukebox-next-label">Up next</span>
+        <span className="jukebox-next-num">{queued ? `#${queued.number}` : "—"}</span>
+      </div>
     </div>
   );
 }

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -2482,7 +2482,17 @@ export function applyGmcpPackage(
               receivedAt: Date.now(),
             }
           : null;
-      ctx.setJukebox({ songs, nowPlaying });
+      const q = packet.queued as Partial<Record<string, unknown>> | null | undefined;
+      const queued =
+        q && typeof q.title === "string"
+          ? {
+              number: safeNumber(q.number, 0),
+              title: q.title,
+              artist: typeof q.artist === "string" ? q.artist : null,
+              buyer: typeof q.buyer === "string" ? q.buyer : "",
+            }
+          : null;
+      ctx.setJukebox({ songs, nowPlaying, queued });
       break;
     }
 

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -27325,13 +27325,8 @@ html:has(.game-shell),
   margin: 0 auto;
 }
 
-/* When painted art is supplied, seat it behind the list (CSS fallback otherwise). */
-.jukebox-panel-skinned {
-  background-image: var(--jukebox-bg);
-  background-size: cover;
-  background-position: center;
-  border-radius: var(--radius-lg);
-}
+/* The painted-frame layout lives in the "painted jukebox_bg frame" section
+   below; the drawer sheet itself paints the art (--skin-bg). */
 
 .jukebox-nowplaying {
   display: flex;
@@ -27374,6 +27369,7 @@ html:has(.game-shell),
 .jukebox-np-artist { color: var(--text-muted); font-weight: 400; }
 .jukebox-np-sub { font-size: 0.78rem; color: var(--text-muted); }
 .jukebox-np-desc { margin-top: 2px; font-size: 0.78rem; font-style: italic; color: var(--text-muted); }
+.jukebox-np-next { margin-top: 2px; font-size: 0.78rem; font-weight: 600; color: var(--accent-primary); }
 
 .jukebox-list {
   list-style: none;
@@ -27399,6 +27395,29 @@ html:has(.game-shell),
   border-color: var(--accent-primary);
   box-shadow: 0 0 0 1px var(--accent-primary) inset;
 }
+
+.jukebox-song.is-queued {
+  border-color: var(--color-gold-bright);
+  box-shadow: 0 0 0 1px var(--color-gold-bright) inset;
+}
+
+.jukebox-song-num {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.7em;
+  height: 1.7em;
+  margin-top: 1px;
+  border-radius: 50%;
+  border: 1px solid var(--glass-edge);
+  background: var(--surface-chip);
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.jukebox-song-main { flex: 1; min-width: 0; }
 
 .jukebox-song-title { color: var(--text-primary); font-weight: 600; }
 .jukebox-song-artist { color: var(--text-muted); }
@@ -27440,7 +27459,338 @@ html:has(.game-shell),
 
 .jukebox-empty { color: var(--text-muted); text-align: center; padding: var(--space-4); }
 
+.jukebox-pager {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+}
+
+.jukebox-pager-btn {
+  appearance: none;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1px solid var(--glass-edge);
+  background: var(--surface-chip);
+  color: var(--text-primary);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.jukebox-pager-btn:hover:not(:disabled) { border-color: var(--accent-primary); color: var(--accent-primary); }
+.jukebox-pager-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.jukebox-pager-info { font-size: 0.8rem; color: var(--text-muted); font-variant-numeric: tabular-nums; }
+
+/* Corner plaque only exists on the painted frame; the flow layout's banner
+   already carries the up-next line. */
+.jukebox-next-plaque { display: none; }
+
 .jukebox-feedback { margin: 0; font-size: 0.82rem; }
 .jukebox-feedback-error { color: var(--color-error); }
 .jukebox-feedback-success { color: var(--color-success); }
 .jukebox-feedback-info { color: var(--text-muted); }
+
+/* ============================================================
+   Jukebox — painted `jukebox_bg` frame (clockwork music-hall
+   cabinet, 4:3). The drawer sheet stretches the art full-bleed
+   and live content seats onto the painted boxes; percentage
+   insets measured off the painting:
+     scroll 1          y 16.0→29.0%, x 26.5→76.0%  → now-playing banner
+     scrolls 2–5       y 29.3→84.5%, x 26.5→76.0%  → song rows, 4 per page
+     bottom plaque     y 88.0→95.5%, x 33.0→72.0%  → feedback line
+                       (the pager docks at its right end when >1 page)
+     corner plaque     y 87.5→96.0%, x 81.5→96.5%  → up-next song number
+     close medallion   painted ✕ at top-right ~(94.6%, 4.7%)
+   ≥768px only: on phones the drawer keeps its default chrome and
+   the panel renders the flow layout, art-free. Without art the
+   sheet falls back to a gradient and stays fully usable.
+   ============================================================ */
+@media (min-width: 768px) {
+  .drawer-sheet.drawer-sheet-jukebox {
+    width: auto;
+    height: min(94vh, 71vw);
+    max-height: 94vh;
+    aspect-ratio: 4 / 3;
+    background-image:
+      var(--skin-bg, none),
+      radial-gradient(ellipse at 50% 30%, rgb(48 32 22 / 97%), rgb(16 11 24 / 98%));
+    background-size: 100% 100%, auto;
+    background-position: center, center;
+    background-repeat: no-repeat, no-repeat;
+  }
+
+  .drawer-sheet-jukebox .drawer-title { display: none; }
+  .drawer-sheet-jukebox .drawer-handle-zone { display: none; }
+
+  .drawer-sheet-jukebox .drawer-header {
+    position: absolute;
+    top: 1.8%;
+    right: 1.8%;
+    left: auto;
+    z-index: 6;
+    padding: 0;
+    min-height: 0;
+    border-bottom: none;
+  }
+
+  /* Ghost the stock close button so the painted medallion shows through;
+     it stays a full-size hit target and lights up on hover/focus. */
+  .drawer-sheet-jukebox .drawer-close {
+    border-color: transparent;
+    background: transparent;
+    color: rgb(244 230 200 / 70%);
+    text-shadow: 0 1px 2px rgb(20 10 4 / 60%);
+  }
+
+  .drawer-sheet-jukebox .drawer-close:hover,
+  .drawer-sheet-jukebox .drawer-close:focus-visible {
+    color: #f8ecd2;
+    background: rgb(120 84 30 / 30%);
+  }
+
+  .drawer-sheet-jukebox .drawer-body {
+    position: relative;
+    padding: 0;
+    overflow: hidden;
+  }
+
+  .jukebox-panel-skinned {
+    position: absolute;
+    inset: 0;
+    display: block;
+    padding: 0;
+    max-width: none;
+    margin: 0;
+    font-family: var(--font-display);
+
+    /* Parchment ink palette — the glass-theme tokens are too pale on paper. */
+    --jb-ink: #3a2c18;
+    --jb-ink-strong: #1f3c6e;
+    --jb-ink-soft: rgb(74 56 30 / 80%);
+    --jb-ink-accent: #7c2d2d;
+    --jb-gold: #7c5a14;
+  }
+
+  /* Now playing — seated on the top scroll. */
+  .jukebox-panel-skinned .jukebox-nowplaying {
+    position: absolute;
+    inset: 16% 24% 71% 26.5%;
+    padding: 0 1.5%;
+    overflow: hidden;
+    background: none;
+    border: none;
+    border-radius: 0;
+  }
+
+  .jukebox-panel-skinned .jukebox-np-text { min-width: 0; }
+  .jukebox-panel-skinned .jukebox-np-eq i { background: var(--jb-ink-strong); }
+
+  .jukebox-panel-skinned .jukebox-np-title {
+    overflow: hidden;
+    color: var(--jb-ink-strong);
+    font-size: clamp(0.78rem, 1.6vw, 1.2rem);
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .jukebox-panel-skinned .jukebox-np-artist { color: var(--jb-ink-soft); }
+
+  .jukebox-panel-skinned .jukebox-np-sub {
+    color: var(--jb-ink-accent);
+    font-size: clamp(0.62rem, 1.25vw, 0.95rem);
+  }
+
+  .jukebox-panel-skinned .jukebox-np-next {
+    color: var(--jb-ink-accent);
+    font-size: clamp(0.62rem, 1.25vw, 0.95rem);
+  }
+
+  .jukebox-panel-skinned .jukebox-np-desc {
+    overflow: hidden;
+    color: var(--jb-ink-soft);
+    font-size: clamp(0.6rem, 1.15vw, 0.88rem);
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  /* Song rows — one per painted scroll, four to a page. */
+  .jukebox-panel-skinned .jukebox-list {
+    position: absolute;
+    inset: 29.3% 24% 15.5% 26.5%;
+    gap: 0;
+    overflow: hidden;
+  }
+
+  .jukebox-panel-skinned .jukebox-song {
+    flex: 0 0 25%;
+    height: 25%;
+    align-items: center;
+    padding: 0 1.5%;
+    background: none;
+    border: none;
+    border-radius: 0;
+  }
+
+  .jukebox-panel-skinned .jukebox-song.is-playing,
+  .jukebox-panel-skinned .jukebox-song.is-queued { box-shadow: none; }
+
+  .jukebox-panel-skinned .jukebox-song-num {
+    width: 2em;
+    min-width: 2em;
+    height: 2em;
+    margin-top: 0;
+    border: 1px solid rgb(110 78 26 / 60%);
+    background: radial-gradient(circle at 35% 30%, rgb(252 242 216 / 92%), rgb(206 178 126 / 92%));
+    color: #4a3414;
+    font-size: clamp(0.62rem, 1.25vw, 0.95rem);
+    font-weight: 700;
+    box-shadow: 0 1px 3px rgb(60 38 10 / 35%);
+  }
+
+  .jukebox-panel-skinned .jukebox-song-title {
+    color: var(--jb-ink-strong);
+    font-size: clamp(0.72rem, 1.5vw, 1.12rem);
+  }
+
+  .jukebox-panel-skinned .jukebox-song-artist {
+    color: var(--jb-ink-soft);
+    font-size: clamp(0.62rem, 1.2vw, 0.9rem);
+  }
+
+  .jukebox-panel-skinned .jukebox-song-desc {
+    overflow: hidden;
+    color: var(--jb-ink-soft);
+    font-size: clamp(0.58rem, 1.1vw, 0.85rem);
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .jukebox-panel-skinned .jukebox-song-dur {
+    color: var(--jb-ink-strong);
+    font-size: clamp(0.62rem, 1.3vw, 1rem);
+  }
+
+  .jukebox-panel-skinned .jukebox-song-cost {
+    color: var(--jb-gold);
+    font-size: clamp(0.62rem, 1.3vw, 0.95rem);
+  }
+
+  .jukebox-panel-skinned .jukebox-song-cost.is-short { color: #9c2f23; }
+
+  /* Gilded play/queue buttons, echoing the painted brass-and-enamel chips. */
+  .jukebox-panel-skinned .jukebox-play-btn {
+    min-width: 5.4em;
+    padding: 0.32em 0.9em;
+    border-radius: 0.55em;
+    border: 1px solid rgb(216 178 96 / 80%);
+    background: linear-gradient(170deg, #3f6db4, #274a86);
+    color: #f2e8cf;
+    font-family: var(--font-display);
+    font-size: clamp(0.62rem, 1.25vw, 0.95rem);
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    box-shadow: inset 0 1px 0 rgb(255 255 255 / 25%), 0 2px 6px rgb(40 24 8 / 45%);
+    text-shadow: 0 1px 2px rgb(10 20 40 / 55%);
+  }
+
+  .jukebox-panel-skinned .jukebox-play-btn:hover:not(:disabled) {
+    color: #fff;
+    border-color: rgb(244 214 140 / 95%);
+    filter: brightness(1.12);
+  }
+
+  .jukebox-panel-skinned .jukebox-song.is-playing .jukebox-play-btn {
+    background: linear-gradient(170deg, #3f9a52, #1f6b33);
+    opacity: 1;
+  }
+
+  .jukebox-panel-skinned .jukebox-song.is-queued .jukebox-play-btn {
+    background: linear-gradient(170deg, #b3892b, #7c5c14);
+    opacity: 1;
+  }
+
+  .jukebox-panel-skinned .jukebox-empty {
+    position: absolute;
+    inset: 29.3% 24% 15.5% 26.5%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--jb-ink-soft);
+    font-style: italic;
+  }
+
+  /* Feedback — centered on the bottom plaque (the keyhole sits to its left). */
+  .jukebox-panel-skinned .jukebox-feedback {
+    position: absolute;
+    inset: 88% 28% 4.5% 33%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    color: var(--jb-ink);
+    font-size: clamp(0.6rem, 1.2vw, 0.92rem);
+    text-align: center;
+  }
+
+  .jukebox-panel-skinned .jukebox-feedback-error { color: #9c2f23; }
+  .jukebox-panel-skinned .jukebox-feedback-success { color: #1d5a32; }
+  .jukebox-panel-skinned .jukebox-feedback-info { color: var(--jb-ink-soft); }
+
+  /* Pager docks at the right end of the bottom plaque; the feedback line
+     yields the overlap when both render. */
+  .jukebox-panel-skinned .jukebox-pager {
+    position: absolute;
+    top: 88%;
+    right: 28.5%;
+    bottom: 4.5%;
+    gap: clamp(4px, 0.6vw, 10px);
+  }
+
+  .jukebox-panel-skinned:has(.jukebox-pager) .jukebox-feedback { right: 42%; }
+
+  .jukebox-panel-skinned .jukebox-pager-btn {
+    width: clamp(18px, 1.9vw, 28px);
+    height: clamp(18px, 1.9vw, 28px);
+    border-color: rgb(110 78 26 / 60%);
+    background: radial-gradient(circle at 35% 30%, rgb(252 242 216 / 92%), rgb(206 178 126 / 92%));
+    color: #4a3414;
+  }
+
+  .jukebox-panel-skinned .jukebox-pager-btn:hover:not(:disabled) {
+    border-color: #7c5a14;
+    color: #1f3c6e;
+  }
+
+  .jukebox-panel-skinned .jukebox-pager-info {
+    color: var(--jb-ink);
+    font-size: clamp(0.58rem, 1.1vw, 0.85rem);
+  }
+
+  /* Up-next song number — seated on the small corner plaque (bottom right). */
+  .jukebox-panel-skinned .jukebox-next-plaque {
+    position: absolute;
+    inset: 87.5% 3.5% 4% 81.5%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    color: var(--jb-ink-soft);
+  }
+
+  .jukebox-panel-skinned .jukebox-next-label {
+    font-size: clamp(0.46rem, 0.85vw, 0.66rem);
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+  }
+
+  .jukebox-panel-skinned .jukebox-next-num {
+    color: var(--jb-ink-strong);
+    font-size: clamp(0.85rem, 1.9vw, 1.45rem);
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+}

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -1314,10 +1314,21 @@ export interface JukeboxNowPlaying {
   receivedAt: number;
 }
 
+/** The paid-for track queued to start when the current one ends (Jukebox.Info.queued). */
+export interface JukeboxQueued {
+  number: number;
+  title: string;
+  artist: string | null;
+  /** Name of the player who paid to queue it. */
+  buyer: string;
+}
+
 /** Room jukebox state from the Jukebox.Info GMCP package. */
 export interface JukeboxState {
   songs: JukeboxSong[];
   nowPlaying: JukeboxNowPlaying | null;
+  /** Null when the single next-up queue slot is free. */
+  queued: JukeboxQueued | null;
 }
 
 export interface GuildHallRoom {


### PR DESCRIPTION
## What

Two follow-ups to the room jukebox (#1316):

### 1. Next-up queue slot (anti-monopoly)

While a track plays, any player **except the one whose song is playing** can pay to reserve the single next-up slot — so nobody can chain-control the room's music by re-feeding the box the instant their song ends.

- `jukebox queue <n>` / `jb queue <n>`: charges up front, one slot per room.
  - Current buyer → `OWN_SONG_PLAYING` ("someone else gets to pick the next one").
  - Slot taken → `QUEUE_FULL` (names the queued track + buyer).
  - Nothing playing → starts immediately (same flow as `play`).
- `JukeboxSystem.pollExpired()` now returns ended→started transitions; the engine tick announces the takeover, broadcasts the new track's description, and swaps inline `[music]` links. `play()` can't jump a pending queue in the one-tick expiry gap.
- `Jukebox.Info` gains a `queued` payload (number/title/artist/buyer), included on room entry, `jukebox` list, queue, and promotion.
- Busy `play` errors hint at the queue command; `jukebox` list prints the "Up next" line (telnet parity).

### 2. Painted chrome (`jukebox_bg`)

Implements the clockwork music-hall cabinet concept per `docs/ART_CONTRACT.md` (drawer-skin pattern, like Aineroia's Dice):

- Drawer sheet aspect-locks 4:3 and stretches the art full-bleed; stock chrome hides ≥768px with the close button ghosted over the painted ✕ medallion. Phones keep the default drawer + flow layout (no cropped-art misalignment).
- **Top scroll** = now-playing banner (played-by + countdown, up-next line when queued).
- **Scrolls 2–5** = songs, **paginated 4 per page** so rows always sit on the painted scrolls (pager docks at the right end of the bottom plaque when >1 page).
- **Bottom plaque** = scoped feedback line.
- **Small corner plaque** (bottom right) = queued song's number ("Up next #3", em-dash when free).
- Buttons: blue **Play** (idle), green **Playing**, amber **Queued**; others become **Queue** while busy, disabled with explanatory tooltips when you're the current buyer or the slot is taken.
- Unskinned glass fallback fully works (pager, number badges, up-next line included); missing/404 art degrades per the contract.

The `jukebox_bg` key was already registered in `DEFAULT_GLOBAL_ASSETS`; the painted frame still needs the Arcanum upload (content-hashed file + overlay mapping) to appear in production.

## Testing

- `JukeboxSystemTest`: queue/own-song/slot-full/idle-start/gold-up-front, promotion on expiry, expiry-gap guard, lyric reset for promoted tracks, clear().
- `CommandRouterJukeboxTest`: queue command flows incl. broadcasts, busy-hint, list up-next.
- `GameEngineJukeboxTickTest`: queued track takes over on tick — announcements + `[music]` swap, then reverts when the queue drains.
- `CommandParserTest`, `WebClientParityTest`, command-manifest sync updated.
- `./gradlew ktlintCheck test integrationTest` ✅ (2474 tests) · `bun run lint` + `tsc -b && vite build` ✅
