### PR TITLE
feat(web): phone-portrait painted frames for lottery, dice, and jukebox

### DIFF
--- a/docs/ART_CONTRACT.md
+++ b/docs/ART_CONTRACT.md
@@ -31,6 +31,7 @@ the *values* (paths/filenames) are what deployments override.
 | Family | Convention | Examples |
 |---|---|---|
 | Panel frames | `<panel>_bg` | `admin_bg`, `chat_bg`, `who_bg`, `guild_bg`, `friends_bg`, `group_bg`, `auction_bg`, `crafting_bg`, `professions_bg`, `housing_bg`, `stylist_bg`, `lottery_bg`, `dice_bg`, `jukebox_bg`, `bank_bg`, `puzzle_bg`, `command_reference_bg`, `character_bg`, `character_scribe_bg` |
+| Phone-portrait companions | `<key>_portrait` | `login_bg_portrait` (+ the other login scenes), `lottery_bg_portrait`, `dice_bg_portrait`, `jukebox_bg_portrait` — a 941×1672 *recomposition* of the landscape art (not a crop); the client prefers it on portrait viewports |
 | Control overlays | `<panel>_<control>_btn` / `<scope>_<control>` | `staff_action_btn`, `staff_action_btn_active`, `who_examine_btn`, `who_tell_btn`, `who_friend_btn`, `char_btn_achievements`, `char_btn_prestige`, `char_btn_professions` |
 | Multi-piece sets | `<panel>_<piece>` | Character "Woodland Fae Cabinet": `character_niche` (full art), `character_frame` / `character_plaque` / `character_charm` (**9-slice** carved frames) |
 | World-feature art | `feature_*`, `door_*`, `lever_*`, `container_bg`, `sign_bg` | `door_frame` + `door_leaf` + `door_lock` + `door_portal` (static frame, swinging leaf, warded-seal lock, doorway vortex), `lever_plate` + `lever_handle` |
@@ -160,6 +161,17 @@ multi-piece sets noted above). It is plain CSS + React.
 10. **Ship the art** — Arcanum uploads the hashed file to R2 and adds the key to the overlay's
     `globalAssets`. Until then the panel renders its CSS fallback everywhere except environments
     that bundle the PNG.
+
+### Phone-portrait companions (drawer skins)
+
+Drawer-skinned panels (lottery, dice, jukebox) carry a second painting for portrait
+viewports: a **941×1672 recomposition** (the login-scene portrait stage) registered as
+`<panel>_bg_portrait` and passed to the `Drawer` as `skinBgPortrait` (exposed to CSS as
+`--skin-bg-portrait`). The skin CSS scopes the landscape frame to
+`(min-width: 768px) and (orientation: landscape)` and seats a **second inset map** under
+`(orientation: portrait)` — same measuring convention, measured off the portrait painting.
+Components stay orientation-agnostic except where the art changes capacity (the jukebox
+pages 4 songs on the landscape frame's scrolls, 6 on the portrait frame's).
 
 ### Fallback hierarchy
 

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -3438,6 +3438,10 @@ data class ImagesConfig(
             "duel_arena_widget" to "global_assets/duel_arena_widget.png",
             "jukebox_widget" to "global_assets/jukebox_widget.png",
             "jukebox_bg" to "global_assets/jukebox_bg.png",
+            // Phone-portrait companion (941×1672, 7 scrolls); the drawer prefers
+            // it on portrait viewports. Absent/404 → gradient under the same
+            // seated layout, like the landscape frame.
+            "jukebox_bg_portrait" to "global_assets/jukebox_bg_portrait.png",
             "puzzle_kiosk" to "global_assets/puzzle_kiosk.png",
             "feature_door" to "global_assets/feature_door.png",
             "feature_container" to "global_assets/feature_container.png",
@@ -3502,6 +3506,10 @@ data class ImagesConfig(
             "housing_bg" to "global_assets/housing_bg.png",
             "lottery_bg" to "global_assets/lottery_bg.png",
             "dice_bg" to "global_assets/dice_bg.png",
+            // Phone-portrait companions (941×1672) for the fortune hall and the
+            // dice table; the drawer prefers them on portrait viewports.
+            "lottery_bg_portrait" to "global_assets/lottery_bg_portrait.png",
+            "dice_bg_portrait" to "global_assets/dice_bg_portrait.png",
             // Aineroia's Dice — the six children, each with a themed die sprite
             // and an illustrated max face, plus the Luneqrae coin's two sides.
             // All optional; each die falls back to a themed CSS render.

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -1216,6 +1216,15 @@ function App() {
                           ? state.serverAssets["mail_bg"]
                           : undefined
         }
+        skinBgPortrait={
+          drawerPanel === "lottery"
+            ? state.serverAssets["lottery_bg_portrait"]
+            : drawerPanel === "dice"
+            ? state.serverAssets["dice_bg_portrait"]
+            : drawerPanel === "jukebox"
+            ? state.serverAssets["jukebox_bg_portrait"]
+            : undefined
+        }
         initialHeight={drawerPanel === "chatboard" || drawerPanel === "whoboard" || drawerPanel === "guildboard" || drawerPanel === "friendsboard" || drawerPanel === "groupboard" || drawerPanel === "help" || drawerPanel === "stylist" || drawerPanel === "housing" || drawerPanel === "lottery" || drawerPanel === "dice" || drawerPanel === "jukebox" || drawerPanel === "auction" || drawerPanel === "crafting" || drawerPanel === "professions" ? 0.94 : undefined}
       >
         {/* Panels are lazy chunks; the drawer chrome shows while one loads. */}

--- a/web-v3/src/components/Drawer.tsx
+++ b/web-v3/src/components/Drawer.tsx
@@ -12,6 +12,9 @@ interface DrawerProps {
   variant?: "default" | "satchel" | "equipment" | "shop" | "trainer" | "journal" | "questboard" | "grimoire" | "mail" | "feature" | "tome" | "vault" | "cabinet" | "board" | "starframe" | "archive" | "stainedglass" | "codex" | "boudoir" | "estate" | "fortune" | "dicetable" | "jukebox" | "auctionhouse" | "forge" | "professions" | "chart";
   /** Optional background art for a skinned variant (server asset). */
   skinBg?: string;
+  /** Optional phone-portrait companion art (941×1672); the skin CSS prefers it
+   *  on portrait viewports via the --skin-bg-portrait variable. */
+  skinBgPortrait?: string;
   /** Height (as a fraction of the viewport) the drawer snaps to when it opens. */
   initialHeight?: number;
 }
@@ -22,7 +25,7 @@ const DISMISS_THRESHOLD = 0.3;
 const DRAG_VELOCITY_DISMISS = 800; // px/s
 const ANIMATION_MS = 300;
 
-export function Drawer({ open, title, onClose, children, variant = "default", skinBg, initialHeight = SNAP_HALF }: DrawerProps) {
+export function Drawer({ open, title, onClose, children, variant = "default", skinBg, skinBgPortrait, initialHeight = SNAP_HALF }: DrawerProps) {
   const [height, setHeight] = useState(initialHeight);
   const [dragging, setDragging] = useState(false);
   const [renderPhase, setRenderPhase] = useState<"hidden" | "animating" | "open">(open ? "open" : "hidden");
@@ -169,6 +172,7 @@ export function Drawer({ open, title, onClose, children, variant = "default", sk
           ["--drawer-height" as string]: `${height * 100}vh`,
           ["--drawer-transition" as string]: transition,
           ...(skinBg ? { ["--skin-bg" as string]: `url("${skinBg}")` } : {}),
+          ...(skinBgPortrait ? { ["--skin-bg-portrait" as string]: `url("${skinBgPortrait}")` } : {}),
         }}
       >
         <div

--- a/web-v3/src/components/panels/JukeboxPanel.tsx
+++ b/web-v3/src/components/panels/JukeboxPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useMediaFits } from "../../canvas/loginArtFit";
 import type { JukeboxState, UiFeedbackEntry } from "../../types";
 
 interface JukeboxPanelProps {
@@ -11,8 +12,10 @@ interface JukeboxPanelProps {
   onCommand: (command: string) => void;
 }
 
-/** Songs per page — one per painted scroll when the `jukebox_bg` art is present. */
-const PAGE_SIZE = 4;
+/** Songs per page — one per painted scroll: the landscape frame has 4 song
+ *  scrolls under the now-playing banner, the phone-portrait frame has 6. */
+const LANDSCAPE_PAGE_SIZE = 4;
+const PORTRAIT_PAGE_SIZE = 6;
 
 function formatDuration(seconds: number): string {
   const s = Math.max(0, Math.floor(seconds));
@@ -49,9 +52,11 @@ export function JukeboxPanel({ jukebox, gold, selfName, uiFeedbackFeed, assets, 
   const busy = nowPlaying !== null && remaining > 0;
   const mineIsPlaying = busy && nowPlaying?.buyer === selfName;
 
-  const pages = Math.max(1, Math.ceil(songs.length / PAGE_SIZE));
+  const portraitViewport = useMediaFits("(orientation: portrait)");
+  const pageSize = portraitViewport ? PORTRAIT_PAGE_SIZE : LANDSCAPE_PAGE_SIZE;
+  const pages = Math.max(1, Math.ceil(songs.length / pageSize));
   const safePage = Math.min(page, pages - 1);
-  const pageSongs = songs.slice(safePage * PAGE_SIZE, safePage * PAGE_SIZE + PAGE_SIZE);
+  const pageSongs = songs.slice(safePage * pageSize, safePage * pageSize + pageSize);
 
   const skinned = Boolean(assets.jukebox_bg);
 

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -25004,7 +25004,7 @@ html:has(.game-shell),
   position: relative;
 }
 
-@media (min-width: 768px) {
+@media (min-width: 768px) and (orientation: landscape) {
   .drawer-sheet.drawer-sheet-fortune {
     width: auto;
     height: min(94vh, 71vw);
@@ -25183,6 +25183,54 @@ html:has(.game-shell),
 }
 .lot-buy-btn:hover { filter: brightness(1.14); transform: translateY(-1px); }
 
+/* ── Phone-portrait fortune hall — `lottery_bg_portrait` (941×1672).
+   The sheet aspect-locks to the portrait painting (bottom-anchored,
+   horizontally centered) and the live values move to its slots; painted
+   icons/labels sit left in each stacked box, values seat in the clear
+   space. Regions measured off the portrait painting:
+     jackpot box      y 23.0→36.0%  → value right of the painted coins
+     countdown box    y 37.5→47.0%  → value under the painted label
+     owned box        y 48.5→56.0%  → value right of the painted label
+     total sold       y 58.0→66.5% (left half)
+     ticket limit     y 68.0→75.5% (left half)
+     ticket cost      y 58.0→75.5% (right half)
+     buy panel        y 77.5→95.5%  → controls under the painted heading
+   Without the portrait art the gradient paints under the same layout. */
+@media (orientation: portrait) {
+  .drawer-sheet.drawer-sheet-fortune {
+    top: auto;
+    right: auto;
+    bottom: env(safe-area-inset-bottom, 0);
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(100vw, 52.9vh);
+    height: auto;
+    max-height: none;
+    aspect-ratio: 941 / 1672;
+    padding-bottom: 0;
+    background-image:
+      var(--skin-bg-portrait, var(--skin-bg, none)),
+      radial-gradient(ellipse at 50% 30%, rgb(24 22 56 / 96%), rgb(10 10 28 / 98%));
+    background-size: 100% 100%, auto;
+  }
+
+  .lot-jackpot { left: 36%; top: 27%; width: 45%; }
+  .lot-countdown { left: 38%; top: 42.3%; width: 42%; }
+  .lot-owned { left: 60%; top: 50.8%; width: 20%; }
+  .lot-total { left: 33.5%; top: 62.3%; width: 14.5%; }
+  .lot-cost { left: 68.5%; top: 62%; width: 13%; }
+  .lot-limit { left: 30%; top: 72.6%; width: 18%; }
+  .lot-limit-unit { display: none; } /* the painted label already says it */
+
+  .lot-buy { left: 17.5%; right: 17.5%; top: 81.5%; bottom: 3.5%; gap: clamp(2px, 0.5vh, 6px); }
+  .lot-buy-sub { display: none; } /* the painted BUY TICKETS heading covers it */
+  .lot-qty { flex-wrap: wrap; justify-content: center; }
+  .lot-qty-step,
+  .lot-qty-num { min-width: clamp(20px, 6.4vw, 30px); padding: 3px 2px; }
+  .lot-summary { font-size: clamp(0.6rem, 2.6vw, 0.8rem); }
+  .lot-buy-btn { padding: clamp(5px, 0.9vh, 9px) clamp(22px, 10vw, 48px); font-size: clamp(0.82rem, 3.6vw, 1.1rem); }
+}
+
 /* ============================================================
    Aineroia's Dice — painted `dice_bg` frame (1280×960, 4:3).
    The six children tumble in the purple velvet and settle into
@@ -25216,7 +25264,7 @@ html:has(.game-shell),
   position: relative;
 }
 
-@media (min-width: 768px) {
+@media (min-width: 768px) and (orientation: landscape) {
   .drawer-sheet.drawer-sheet-dicetable {
     width: auto;
     height: min(94vh, 71vw);
@@ -25706,6 +25754,70 @@ html:has(.game-shell),
   10% { opacity: 1; }
   80% { opacity: 1; }
   100% { opacity: 0; }
+}
+
+/* ── Phone-portrait dice table — `dice_bg_portrait` (941×1672).
+   Vine-framed carnival stand. Regions measured off the portrait painting:
+     Your Gold strip   y 16.0→22.0% (value between painted coin + pouch)
+     How to Play       y 24.0→48.0% (left wood panel)
+     bet parchment     y 24.0→47.5% (right; Place-Your-Bet controls)
+     stat boxes        y 50.0→59.0% (WIN TARGET / PAYOUT / CURRENT BET)
+     velvet tray       y 60.5→79.0% (active die top, settled strip lower,
+                       running total on the painted TOTAL plaque)
+     green panel       y 83.5→94.0% (result banner; jester sits right)
+   Without the portrait art the gradient paints under the same layout. */
+@media (orientation: portrait) {
+  .drawer-sheet.drawer-sheet-dicetable {
+    top: auto;
+    right: auto;
+    bottom: env(safe-area-inset-bottom, 0);
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(100vw, 52.9vh);
+    height: auto;
+    max-height: none;
+    aspect-ratio: 941 / 1672;
+    padding-bottom: 0;
+    background-image:
+      var(--skin-bg-portrait, var(--skin-bg, none)),
+      radial-gradient(ellipse at 50% 30%, rgb(22 20 50 / 96%), rgb(9 9 24 / 98%));
+    background-size: 100% 100%, auto;
+  }
+
+  .dice-gold { left: 14%; top: 18.8%; width: 15%; }
+
+  .dice-howto { left: 9.5%; top: 28.5%; width: 37%; bottom: 53.5%; font-size: clamp(0.58rem, 2.6vw, 0.82rem); }
+
+  .dice-bet { left: 56%; top: 26.5%; width: 31%; bottom: 54.5%; gap: clamp(3px, 0.7vh, 8px); }
+
+  .dice-stat { top: 54%; }
+  .dice-stat-target { left: 7.5%; width: 24.5%; }
+  .dice-stat-payout { left: 34%; width: 24.5%; }
+  .dice-stat-bet { left: 60.5%; width: 31.5%; }
+
+  .dice-velvet { left: 24%; top: 62%; width: 52%; height: 8.5%; }
+  .dice-total { left: 39%; top: 74.4%; width: 22%; }
+
+  /* The felt band dissolves: the settled-dice strip seats inside the velvet
+     tray and the banner moves to the green bottom panel. */
+  .dice-felt {
+    position: absolute;
+    inset: 0;
+    padding: 0;
+    display: block;
+    pointer-events: none;
+  }
+  .dice-tray { position: absolute; left: 13%; right: 13%; top: 70.6%; min-height: 0; }
+  .dice-banner {
+    position: absolute;
+    left: 10%;
+    top: 85.5%;
+    width: 46%;
+    bottom: 8%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
 }
 
 /* ============================================================
@@ -27504,11 +27616,12 @@ html:has(.game-shell),
                        (the pager docks at its right end when >1 page)
      corner plaque     y 87.5→96.0%, x 81.5→96.5%  → up-next song number
      close medallion   painted ✕ at top-right ~(94.6%, 4.7%)
-   ≥768px only: on phones the drawer keeps its default chrome and
-   the panel renders the flow layout, art-free. Without art the
-   sheet falls back to a gradient and stays fully usable.
+   Landscape ≥768px only — portrait viewports use the 7-scroll
+   `jukebox_bg_portrait` companion (block below); landscape phones
+   keep the default chrome + flow layout. Without art the sheet
+   falls back to a gradient and stays fully usable.
    ============================================================ */
-@media (min-width: 768px) {
+@media (min-width: 768px) and (orientation: landscape) {
   .drawer-sheet.drawer-sheet-jukebox {
     width: auto;
     height: min(94vh, 71vw);
@@ -27790,6 +27903,302 @@ html:has(.game-shell),
   .jukebox-panel-skinned .jukebox-next-num {
     color: var(--jb-ink-strong);
     font-size: clamp(0.85rem, 1.9vw, 1.45rem);
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+/* ── Phone-portrait jukebox — `jukebox_bg_portrait` (941×1672, 7 scrolls).
+   Same cabinet recomposed tall. Regions measured off the portrait painting:
+     scroll 1          y 16.0→23.8%, x 24.5→77.0%  → now-playing banner
+     scrolls 2–7       y 24.3→77.1%, x 24.5→77.0%  → song rows, 6 per page
+                       (rows go two-line: title, then duration·cost·button;
+                       artist + description are dropped for space)
+     bottom plaque     y 81.5→93.0%, x 23.0→77.0%  → feedback on top, pager
+                       bottom-left, "Up next #n" bottom-right
+     close medallion   painted ✕ at top-right ~(92%, 3.4%)
+   Without the portrait art the gradient paints under the same layout. */
+@media (orientation: portrait) {
+  .drawer-sheet.drawer-sheet-jukebox {
+    top: auto;
+    right: auto;
+    bottom: env(safe-area-inset-bottom, 0);
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(100vw, 52.9vh);
+    height: auto;
+    max-height: none;
+    aspect-ratio: 941 / 1672;
+    padding-bottom: 0;
+    background-image:
+      var(--skin-bg-portrait, var(--skin-bg, none)),
+      radial-gradient(ellipse at 50% 28%, rgb(48 32 22 / 97%), rgb(16 11 24 / 98%));
+    background-size: 100% 100%, auto;
+    background-position: center, center;
+    background-repeat: no-repeat, no-repeat;
+  }
+
+  .drawer-sheet-jukebox .drawer-title { display: none; }
+  .drawer-sheet-jukebox .drawer-handle-zone { display: none; }
+
+  .drawer-sheet-jukebox .drawer-header {
+    position: absolute;
+    top: 1.4%;
+    right: 2%;
+    left: auto;
+    z-index: 6;
+    padding: 0;
+    min-height: 0;
+    border-bottom: none;
+  }
+
+  .drawer-sheet-jukebox .drawer-close {
+    border-color: transparent;
+    background: transparent;
+    color: rgb(244 230 200 / 70%);
+    text-shadow: 0 1px 2px rgb(20 10 4 / 60%);
+  }
+
+  .drawer-sheet-jukebox .drawer-close:hover,
+  .drawer-sheet-jukebox .drawer-close:focus-visible {
+    color: #f8ecd2;
+    background: rgb(120 84 30 / 30%);
+  }
+
+  .drawer-sheet-jukebox .drawer-body {
+    position: relative;
+    padding: 0;
+    overflow: hidden;
+  }
+
+  .jukebox-panel-skinned {
+    position: absolute;
+    inset: 0;
+    display: block;
+    padding: 0;
+    max-width: none;
+    margin: 0;
+    font-family: var(--font-display);
+
+    /* Parchment ink palette — shared with the landscape frame. */
+    --jb-ink: #3a2c18;
+    --jb-ink-strong: #1f3c6e;
+    --jb-ink-soft: rgb(74 56 30 / 80%);
+    --jb-ink-accent: #7c2d2d;
+    --jb-gold: #7c5a14;
+  }
+
+  /* Now playing — seated on the top scroll. */
+  .jukebox-panel-skinned .jukebox-nowplaying {
+    position: absolute;
+    inset: 16% 23% 76.2% 24.5%;
+    padding: 0 2%;
+    overflow: hidden;
+    gap: 3%;
+    background: none;
+    border: none;
+    border-radius: 0;
+  }
+
+  .jukebox-panel-skinned .jukebox-np-text { min-width: 0; }
+  .jukebox-panel-skinned .jukebox-np-eq i { background: var(--jb-ink-strong); }
+
+  .jukebox-panel-skinned .jukebox-np-title {
+    overflow: hidden;
+    color: var(--jb-ink-strong);
+    font-size: clamp(0.74rem, 3.4vw, 1.05rem);
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .jukebox-panel-skinned .jukebox-np-artist { display: none; }
+
+  .jukebox-panel-skinned .jukebox-np-sub {
+    color: var(--jb-ink-accent);
+    font-size: clamp(0.6rem, 2.7vw, 0.85rem);
+  }
+
+  .jukebox-panel-skinned .jukebox-np-next {
+    overflow: hidden;
+    color: var(--jb-ink-accent);
+    font-size: clamp(0.6rem, 2.7vw, 0.85rem);
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .jukebox-panel-skinned .jukebox-np-desc { display: none; }
+
+  /* Song rows — one per painted scroll, six to a page, two lines each. */
+  .jukebox-panel-skinned .jukebox-list {
+    position: absolute;
+    inset: 24.3% 23% 22.9% 24.5%;
+    gap: 0;
+    overflow: hidden;
+  }
+
+  .jukebox-panel-skinned .jukebox-song {
+    flex: 0 0 16.6667%;
+    height: 16.6667%;
+    flex-wrap: wrap;
+    align-items: center;
+    align-content: center;
+    row-gap: 2px;
+    padding: 0 2%;
+    background: none;
+    border: none;
+    border-radius: 0;
+  }
+
+  .jukebox-panel-skinned .jukebox-song.is-playing,
+  .jukebox-panel-skinned .jukebox-song.is-queued { box-shadow: none; }
+
+  .jukebox-panel-skinned .jukebox-song-num {
+    width: 1.8em;
+    min-width: 1.8em;
+    height: 1.8em;
+    margin-top: 0;
+    border: 1px solid rgb(110 78 26 / 60%);
+    background: radial-gradient(circle at 35% 30%, rgb(252 242 216 / 92%), rgb(206 178 126 / 92%));
+    color: #4a3414;
+    font-size: clamp(0.6rem, 2.7vw, 0.85rem);
+    font-weight: 700;
+    box-shadow: 0 1px 3px rgb(60 38 10 / 35%);
+  }
+
+  .jukebox-panel-skinned .jukebox-song-main { flex: 1 1 0; min-width: 0; }
+
+  .jukebox-panel-skinned .jukebox-song-title {
+    display: block;
+    overflow: hidden;
+    color: var(--jb-ink-strong);
+    font-size: clamp(0.68rem, 3.1vw, 0.98rem);
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .jukebox-panel-skinned .jukebox-song-artist { display: none; }
+  .jukebox-panel-skinned .jukebox-song-desc { display: none; }
+
+  .jukebox-panel-skinned .jukebox-song-meta {
+    flex: 1 1 100%;
+    justify-content: flex-end;
+    gap: 4%;
+  }
+
+  .jukebox-panel-skinned .jukebox-song-dur {
+    color: var(--jb-ink-strong);
+    font-size: clamp(0.58rem, 2.6vw, 0.82rem);
+  }
+
+  .jukebox-panel-skinned .jukebox-song-cost {
+    color: var(--jb-gold);
+    font-size: clamp(0.58rem, 2.6vw, 0.82rem);
+  }
+
+  .jukebox-panel-skinned .jukebox-song-cost.is-short { color: #9c2f23; }
+
+  .jukebox-panel-skinned .jukebox-play-btn {
+    min-width: 4.6em;
+    padding: 0.26em 0.7em;
+    border-radius: 0.55em;
+    border: 1px solid rgb(216 178 96 / 80%);
+    background: linear-gradient(170deg, #3f6db4, #274a86);
+    color: #f2e8cf;
+    font-family: var(--font-display);
+    font-size: clamp(0.58rem, 2.6vw, 0.82rem);
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    box-shadow: inset 0 1px 0 rgb(255 255 255 / 25%), 0 2px 6px rgb(40 24 8 / 45%);
+    text-shadow: 0 1px 2px rgb(10 20 40 / 55%);
+  }
+
+  .jukebox-panel-skinned .jukebox-song.is-playing .jukebox-play-btn {
+    background: linear-gradient(170deg, #3f9a52, #1f6b33);
+    opacity: 1;
+  }
+
+  .jukebox-panel-skinned .jukebox-song.is-queued .jukebox-play-btn {
+    background: linear-gradient(170deg, #b3892b, #7c5c14);
+    opacity: 1;
+  }
+
+  .jukebox-panel-skinned .jukebox-empty {
+    position: absolute;
+    inset: 24.3% 23% 22.9% 24.5%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--jb-ink-soft);
+    font-style: italic;
+  }
+
+  /* Bottom plaque: feedback line on top; pager bottom-left, up-next bottom-right. */
+  .jukebox-panel-skinned .jukebox-feedback {
+    position: absolute;
+    inset: 81.5% 23% 12.5% 23%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    color: var(--jb-ink);
+    font-size: clamp(0.58rem, 2.6vw, 0.82rem);
+    text-align: center;
+  }
+
+  .jukebox-panel-skinned .jukebox-feedback-error { color: #9c2f23; }
+  .jukebox-panel-skinned .jukebox-feedback-success { color: #1d5a32; }
+  .jukebox-panel-skinned .jukebox-feedback-info { color: var(--jb-ink-soft); }
+
+  .jukebox-panel-skinned .jukebox-pager {
+    position: absolute;
+    top: 88%;
+    bottom: 7.5%;
+    left: 23.5%;
+    gap: clamp(4px, 1.5vw, 9px);
+  }
+
+  .jukebox-panel-skinned .jukebox-pager-btn {
+    width: clamp(20px, 7vw, 28px);
+    height: clamp(20px, 7vw, 28px);
+    border-color: rgb(110 78 26 / 60%);
+    background: radial-gradient(circle at 35% 30%, rgb(252 242 216 / 92%), rgb(206 178 126 / 92%));
+    color: #4a3414;
+  }
+
+  .jukebox-panel-skinned .jukebox-pager-btn:hover:not(:disabled) {
+    border-color: #7c5a14;
+    color: #1f3c6e;
+  }
+
+  .jukebox-panel-skinned .jukebox-pager-info {
+    color: var(--jb-ink);
+    font-size: clamp(0.56rem, 2.5vw, 0.78rem);
+  }
+
+  /* Up-next number rides the plaque's bottom-right corner as a single row. */
+  .jukebox-panel-skinned .jukebox-next-plaque {
+    position: absolute;
+    top: 88%;
+    right: 23.5%;
+    bottom: 7.5%;
+    left: auto;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.45em;
+    color: var(--jb-ink-soft);
+  }
+
+  .jukebox-panel-skinned .jukebox-next-label {
+    font-size: clamp(0.5rem, 2.2vw, 0.68rem);
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .jukebox-panel-skinned .jukebox-next-num {
+    color: var(--jb-ink-strong);
+    font-size: clamp(0.78rem, 3.4vw, 1.1rem);
     font-weight: 700;
     font-variant-numeric: tabular-nums;
   }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -27609,13 +27609,14 @@ html:has(.game-shell),
    Jukebox — painted `jukebox_bg` frame (clockwork music-hall
    cabinet, 4:3). The drawer sheet stretches the art full-bleed
    and live content seats onto the painted boxes; percentage
-   insets measured off the painting:
-     scroll 1          y 16.0→29.0%, x 26.5→76.0%  → now-playing banner
-     scrolls 2–5       y 29.3→84.5%, x 26.5→76.0%  → song rows, 4 per page
-     bottom plaque     y 88.0→95.5%, x 33.0→72.0%  → feedback line
+   insets measured off the shipped painting (in-game screenshot):
+     scroll 1          y 16.4→29.4%, x 28.5→75.5%  → now-playing banner
+     scrolls 2–5       y 31.3→78.0%, x 28.5→75.5%  → song rows, 4 per page
+                       (painted scroll pitch ≈ 11.7%)
+     bottom plaque     y 79.5→89.2%, x 31.5→71.0%  → feedback line
                        (the pager docks at its right end when >1 page)
-     corner plaque     y 87.5→96.0%, x 81.5→96.5%  → up-next song number
-     close medallion   painted ✕ at top-right ~(94.6%, 4.7%)
+     corner plaque     y 81.5→88.0%, x 81.0→90.0%  → up-next song number
+     close medallion   painted ✕ centered ~(94.3%, 5.8%)
    Landscape ≥768px only — portrait viewports use the 7-scroll
    `jukebox_bg_portrait` companion (block below); landscape phones
    keep the default chrome + flow layout. Without art the sheet
@@ -27640,8 +27641,8 @@ html:has(.game-shell),
 
   .drawer-sheet-jukebox .drawer-header {
     position: absolute;
-    top: 1.8%;
-    right: 1.8%;
+    top: 2.4%;
+    right: 2.4%;
     left: auto;
     z-index: 6;
     padding: 0;
@@ -27650,8 +27651,10 @@ html:has(.game-shell),
   }
 
   /* Ghost the stock close button so the painted medallion shows through;
-     it stays a full-size hit target and lights up on hover/focus. */
+     sized up to cover the medallion as a hit target, lit on hover/focus. */
   .drawer-sheet-jukebox .drawer-close {
+    width: clamp(34px, 4vw, 52px);
+    height: clamp(34px, 4vw, 52px);
     border-color: transparent;
     background: transparent;
     color: rgb(244 230 200 / 70%);
@@ -27680,17 +27683,17 @@ html:has(.game-shell),
     font-family: var(--font-display);
 
     /* Parchment ink palette — the glass-theme tokens are too pale on paper. */
-    --jb-ink: #3a2c18;
-    --jb-ink-strong: #1f3c6e;
-    --jb-ink-soft: rgb(74 56 30 / 80%);
-    --jb-ink-accent: #7c2d2d;
-    --jb-gold: #7c5a14;
+    --jb-ink: #2c2110;
+    --jb-ink-strong: #1a3260;
+    --jb-ink-soft: rgb(56 40 18 / 92%);
+    --jb-ink-accent: #6e2222;
+    --jb-gold: #6b4c0e;
   }
 
   /* Now playing — seated on the top scroll. */
   .jukebox-panel-skinned .jukebox-nowplaying {
     position: absolute;
-    inset: 16% 24% 71% 26.5%;
+    inset: 17% 24.5% 71% 28.5%;
     padding: 0 1.5%;
     overflow: hidden;
     background: none;
@@ -27704,7 +27707,8 @@ html:has(.game-shell),
   .jukebox-panel-skinned .jukebox-np-title {
     overflow: hidden;
     color: var(--jb-ink-strong);
-    font-size: clamp(0.78rem, 1.6vw, 1.2rem);
+    font-size: clamp(0.88rem, 1.85vw, 1.4rem);
+    font-weight: 700;
     white-space: nowrap;
     text-overflow: ellipsis;
   }
@@ -27713,18 +27717,20 @@ html:has(.game-shell),
 
   .jukebox-panel-skinned .jukebox-np-sub {
     color: var(--jb-ink-accent);
-    font-size: clamp(0.62rem, 1.25vw, 0.95rem);
+    font-size: clamp(0.68rem, 1.4vw, 1.05rem);
+    font-weight: 600;
   }
 
   .jukebox-panel-skinned .jukebox-np-next {
     color: var(--jb-ink-accent);
-    font-size: clamp(0.62rem, 1.25vw, 0.95rem);
+    font-size: clamp(0.68rem, 1.4vw, 1.05rem);
+    font-weight: 600;
   }
 
   .jukebox-panel-skinned .jukebox-np-desc {
     overflow: hidden;
     color: var(--jb-ink-soft);
-    font-size: clamp(0.6rem, 1.15vw, 0.88rem);
+    font-size: clamp(0.64rem, 1.3vw, 0.98rem);
     white-space: nowrap;
     text-overflow: ellipsis;
   }
@@ -27732,7 +27738,7 @@ html:has(.game-shell),
   /* Song rows — one per painted scroll, four to a page. */
   .jukebox-panel-skinned .jukebox-list {
     position: absolute;
-    inset: 29.3% 24% 15.5% 26.5%;
+    inset: 31.3% 24.5% 22% 28.5%;
     gap: 0;
     overflow: hidden;
   }
@@ -27758,37 +27764,40 @@ html:has(.game-shell),
     border: 1px solid rgb(110 78 26 / 60%);
     background: radial-gradient(circle at 35% 30%, rgb(252 242 216 / 92%), rgb(206 178 126 / 92%));
     color: #4a3414;
-    font-size: clamp(0.62rem, 1.25vw, 0.95rem);
+    font-size: clamp(0.66rem, 1.35vw, 1rem);
     font-weight: 700;
     box-shadow: 0 1px 3px rgb(60 38 10 / 35%);
   }
 
   .jukebox-panel-skinned .jukebox-song-title {
     color: var(--jb-ink-strong);
-    font-size: clamp(0.72rem, 1.5vw, 1.12rem);
+    font-size: clamp(0.8rem, 1.7vw, 1.28rem);
+    font-weight: 700;
   }
 
   .jukebox-panel-skinned .jukebox-song-artist {
     color: var(--jb-ink-soft);
-    font-size: clamp(0.62rem, 1.2vw, 0.9rem);
+    font-size: clamp(0.66rem, 1.35vw, 1rem);
   }
 
   .jukebox-panel-skinned .jukebox-song-desc {
     overflow: hidden;
     color: var(--jb-ink-soft);
-    font-size: clamp(0.58rem, 1.1vw, 0.85rem);
+    font-size: clamp(0.62rem, 1.25vw, 0.95rem);
     white-space: nowrap;
     text-overflow: ellipsis;
   }
 
   .jukebox-panel-skinned .jukebox-song-dur {
     color: var(--jb-ink-strong);
-    font-size: clamp(0.62rem, 1.3vw, 1rem);
+    font-size: clamp(0.7rem, 1.45vw, 1.08rem);
+    font-weight: 700;
   }
 
   .jukebox-panel-skinned .jukebox-song-cost {
     color: var(--jb-gold);
-    font-size: clamp(0.62rem, 1.3vw, 0.95rem);
+    font-size: clamp(0.7rem, 1.45vw, 1.05rem);
+    font-weight: 700;
   }
 
   .jukebox-panel-skinned .jukebox-song-cost.is-short { color: #9c2f23; }
@@ -27802,7 +27811,7 @@ html:has(.game-shell),
     background: linear-gradient(170deg, #3f6db4, #274a86);
     color: #f2e8cf;
     font-family: var(--font-display);
-    font-size: clamp(0.62rem, 1.25vw, 0.95rem);
+    font-size: clamp(0.66rem, 1.35vw, 1rem);
     font-weight: 700;
     letter-spacing: 0.04em;
     box-shadow: inset 0 1px 0 rgb(255 255 255 / 25%), 0 2px 6px rgb(40 24 8 / 45%);
@@ -27827,7 +27836,7 @@ html:has(.game-shell),
 
   .jukebox-panel-skinned .jukebox-empty {
     position: absolute;
-    inset: 29.3% 24% 15.5% 26.5%;
+    inset: 31.3% 24.5% 22% 28.5%;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -27838,13 +27847,13 @@ html:has(.game-shell),
   /* Feedback — centered on the bottom plaque (the keyhole sits to its left). */
   .jukebox-panel-skinned .jukebox-feedback {
     position: absolute;
-    inset: 88% 28% 4.5% 33%;
+    inset: 80.5% 29% 11.5% 31.5%;
     display: flex;
     align-items: center;
     justify-content: center;
     overflow: hidden;
     color: var(--jb-ink);
-    font-size: clamp(0.6rem, 1.2vw, 0.92rem);
+    font-size: clamp(0.64rem, 1.3vw, 1rem);
     text-align: center;
   }
 
@@ -27856,13 +27865,13 @@ html:has(.game-shell),
      yields the overlap when both render. */
   .jukebox-panel-skinned .jukebox-pager {
     position: absolute;
-    top: 88%;
-    right: 28.5%;
-    bottom: 4.5%;
+    top: 80.5%;
+    right: 29.5%;
+    bottom: 11.5%;
     gap: clamp(4px, 0.6vw, 10px);
   }
 
-  .jukebox-panel-skinned:has(.jukebox-pager) .jukebox-feedback { right: 42%; }
+  .jukebox-panel-skinned:has(.jukebox-pager) .jukebox-feedback { right: 40%; }
 
   .jukebox-panel-skinned .jukebox-pager-btn {
     width: clamp(18px, 1.9vw, 28px);
@@ -27885,7 +27894,7 @@ html:has(.game-shell),
   /* Up-next song number — seated on the small corner plaque (bottom right). */
   .jukebox-panel-skinned .jukebox-next-plaque {
     position: absolute;
-    inset: 87.5% 3.5% 4% 81.5%;
+    inset: 81.5% 10% 12% 81%;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -27894,15 +27903,15 @@ html:has(.game-shell),
   }
 
   .jukebox-panel-skinned .jukebox-next-label {
-    font-size: clamp(0.46rem, 0.85vw, 0.66rem);
-    font-weight: 600;
+    font-size: clamp(0.5rem, 0.95vw, 0.72rem);
+    font-weight: 700;
     letter-spacing: 0.14em;
     text-transform: uppercase;
   }
 
   .jukebox-panel-skinned .jukebox-next-num {
     color: var(--jb-ink-strong);
-    font-size: clamp(0.85rem, 1.9vw, 1.45rem);
+    font-size: clamp(0.95rem, 2.1vw, 1.6rem);
     font-weight: 700;
     font-variant-numeric: tabular-nums;
   }
@@ -27981,11 +27990,11 @@ html:has(.game-shell),
     font-family: var(--font-display);
 
     /* Parchment ink palette — shared with the landscape frame. */
-    --jb-ink: #3a2c18;
-    --jb-ink-strong: #1f3c6e;
-    --jb-ink-soft: rgb(74 56 30 / 80%);
-    --jb-ink-accent: #7c2d2d;
-    --jb-gold: #7c5a14;
+    --jb-ink: #2c2110;
+    --jb-ink-strong: #1a3260;
+    --jb-ink-soft: rgb(56 40 18 / 92%);
+    --jb-ink-accent: #6e2222;
+    --jb-gold: #6b4c0e;
   }
 
   /* Now playing — seated on the top scroll. */


### PR DESCRIPTION
## What

Phones get the painted chrome. The three drawer-skinned game panels — **Lottery**, **Aineroia's Dice**, and the **Jukebox** — were landscape-only: portrait phones either cover-cropped the landscape art under misaligned slots (lottery/dice) or fell back to the plain flow layout (jukebox). Each now has a phone-portrait companion frame, following the login-scene precedent.

### Mechanism (per `docs/ART_CONTRACT.md`, now documented there)

- Three new registry keys in `DEFAULT_GLOBAL_ASSETS`: `lottery_bg_portrait`, `dice_bg_portrait`, `jukebox_bg_portrait` — 941×1672 recompositions (the established portrait stage), riding the existing `Server.Assets` map.
- `Drawer` takes an optional `skinBgPortrait` prop → `--skin-bg-portrait` CSS variable; App passes it for the three panels.
- Landscape frames are now scoped to `(min-width: 768px) and (orientation: landscape)`; each panel gains an `(orientation: portrait)` block that bottom-anchors and aspect-locks the sheet to the portrait painting (`width: min(100vw, 52.9vh)`, safe-area aware, horizontally centered) with a **second inset map** measured off the portrait art.

### Per panel

- **Lottery**: values seat into the stacked boxes (jackpot beside the painted coins, countdown under the painted label, owned/sold/cost/limit into their slots). The buy panel goes compact: painted headings replace the sub-label, the quantity row wraps, redundant unit text drops.
- **Dice**: gold value between the painted coin and pouch, how-to text in the wood panel, bet controls on the parchment, stats into WIN TARGET / PAYOUT / CURRENT BET. The landscape's two-stage velvet→felt flow collapses into the single painted tray: active die tumbles up top, settled dice line up on a strip above the painted TOTAL plaque (running total seated on it), and the result banner moves to the green bottom panel.
- **Jukebox**: the 7-scroll portrait frame seats the now-playing banner on scroll 1 and **6 songs per page** on scrolls 2–7 (vs 4 on the landscape frame — `useMediaFits` picks the page size). Rows go two-line compact (title, then duration · cost · button; artist/description drop). The bottom plaque holds the feedback line with the pager bottom-left and "UP NEXT #n" bottom-right.

### Fallbacks

- Landscape phones (<768px landscape) keep their previous behavior.
- Missing/404 portrait art → gradient under the same seated layout (the established dice-table precedent); the `--skin-bg-portrait` var falls back to the landscape art only when the portrait key is absent entirely.

Until Arcanum publishes the three portrait paintings (content-hashed upload + overlay mapping), the keys 404 and the gradient fallback shows. Inset maps are measured off the concept blanks and may need a nudge once real art is in place.

## Testing

- `./gradlew ktlintCheck test` ✅ (registry-only Kotlin change)
- `bun run lint` + `tsc -b && vite build` ✅
