### PR TITLE
fix(web): stop orphaned music loops from racing playMusic calls

### DIFF
--- a/web-v3/src/hooks/useAudioEngine.ts
+++ b/web-v3/src/hooks/useAudioEngine.ts
@@ -50,10 +50,16 @@ interface TrackState {
   pulseGain: GainNode | null;
   url: string | null;
   buffer: AudioBuffer | null;
+  /**
+   * Monotonic ticket for in-flight startTrack calls. Each call takes the next
+   * number and re-checks it after every await; a mismatch means a newer call
+   * superseded this one and owns the audio graph now.
+   */
+  seq: number;
 }
 
 function emptyTrack(): TrackState {
-  return { source: null, gain: null, filter: null, pulseGain: null, url: null, buffer: null };
+  return { source: null, gain: null, filter: null, pulseGain: null, url: null, buffer: null, seq: 0 };
 }
 
 interface CombatFxState {
@@ -168,23 +174,37 @@ export function useAudioEngine(): AudioEngine {
     const track = trackRef.current;
     if (!track) return;
 
-    // Same URL already playing — nothing to do
+    // Same URL already playing (or already being started) — nothing to do
     if (url === track.url) return;
+
+    // Take a ticket. Two quick calls (fast room moves, or Room.Info +
+    // Jukebox.Info landing back-to-back at login) both reach the awaits below
+    // concurrently; without this, the loser would still build and start its
+    // source — an orphaned loop nothing ever stops, heard under all later
+    // music. After every await the ticket is re-checked and stale calls bail.
+    const mySeq = ++track.seq;
 
     // Fade out old track
     if (track.source) {
       stopTrack(track);
     }
+    // Claim the slot now so a duplicate call for the same URL dedupes while
+    // the buffer is still fetching. Failure paths release the claim.
+    track.url = url;
 
-    if (!url) {
-      track.url = null;
-      return;
-    }
+    if (!url) return;
 
     const ctx = getCtx();
-    if (!ctx) return;
+    if (!ctx) {
+      if (track.seq === mySeq) track.url = null;
+      return;
+    }
     if (ctx.state === "suspended") {
-      try { await ctx.resume(); } catch { return; }
+      try { await ctx.resume(); } catch {
+        if (track.seq === mySeq) track.url = null;
+        return;
+      }
+      if (trackRef.current !== track || track.seq !== mySeq) return;
     }
 
     let buffer = bufferCache.current.get(url);
@@ -193,12 +213,14 @@ export function useAudioEngine(): AudioEngine {
         buffer = await fetchAudioBuffer(ctx, url);
         bufferCache.current.set(url, buffer);
       } catch {
+        if (track.seq === mySeq) track.url = null;
         return;
       }
     }
 
-    // Check that another call hasn't already replaced this track
-    if (trackRef.current !== track) return;
+    // A newer call superseded this one while awaiting (or stopAll swapped the
+    // track object) — it owns the audio graph now.
+    if (trackRef.current !== track || track.seq !== mySeq) return;
 
     // Build audio graph: source → filter → pulseGain → gain → destination
     // For music tracks, filter + pulseGain are used by combat effects.


### PR DESCRIPTION
## Bug

Reported: music gets stuck — after moving fast through an area, or logging in while a jukebox song is playing, you keep hearing the zone music or an adjacent room's music **forever**, regardless of where you move.

## Root cause

A race in `useAudioEngine.startTrack`:

1. The "fade out old track" step runs **before** the function's awaits (`ctx.resume()`, buffer fetch/decode).
2. The stale-call guard after the fetch compared `trackRef.current !== track` — an **object identity** that only changes on `stopAll()`. For ordinary back-to-back `playMusic` calls it never trips.

So two rapid calls — fast room moves with uncached music, or `Room.Info` + `Jukebox.Info` arriving milliseconds apart on login/room-entry (routine since the jukebox shipped) — would interleave like this: call A starts fetching track M; call B arrives (no source to stop yet — A hasn't started one), fetches track J; A's fetch resolves, passes the broken guard, **starts M**; B's fetch resolves, passes the guard, starts J and overwrites the track state. **M's source is now orphaned**: a looping `AudioBufferSourceNode` at full volume that no later `playMusic` can reach. That's the unkillable zone music.

## Fix

`TrackState` gains a monotonic ticket (`seq`). Every `startTrack` call increments it on entry and re-checks it after **every** await — a superseded call bails before building its audio graph, so only the newest call ever starts a source. The track also claims its URL up front (so a duplicate call for the same URL dedupes while the buffer is still in flight), with failure paths (no ctx, resume rejected, fetch failed) releasing the claim. The object-identity check is kept for the `stopAll()` replacement case.

The deliberate behaviors are unchanged: same-URL calls still no-op (no audible re-seek on `Jukebox.Info` re-emissions), and the jukebox late-joiner position-sync still computes its offset after the fetch.

## Testing

- `bun run lint` + `tsc -b && vite build` ✅
- No web unit-test harness exists for the Web Audio graph; verified by interleaving analysis above. Manual repro: sprint through rooms with distinct (uncached) music, and log in while a jukebox track plays — no residual loop under the new room's music.
