### PR TITLE
fix(web): portrait dice settle across the top instead of the velvet tray

### DIFF
--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -25799,10 +25799,15 @@ html:has(.game-shell),
   .dice-total { left: 39%; top: 74.4%; width: 22%; }
 
   /* The felt band dissolves: the settled-dice strip seats inside the velvet
-     tray and the banner moves to the green bottom panel. */
+     tray and the banner moves to the green bottom panel. The landscape rule's
+     width/height would otherwise survive `inset: 0` and pin a shrunken felt to
+     the top-left (left+width beats right; top+height beats bottom), stranding
+     the tray and banner at the top of the frame. */
   .dice-felt {
     position: absolute;
     inset: 0;
+    width: auto;
+    height: auto;
     padding: 0;
     display: block;
     pointer-events: none;


### PR DESCRIPTION
## Bug

On phones (portrait), rolling Aineroia's Dice left the six settled dice **stacked across the top of the painted frame** instead of seating in the velvet tray above the green result panel. The result banner rode up with them.

## Root cause

The phone-portrait dice block (#1324) dissolves `.dice-felt` to cover the whole board so the tray and banner can be re-seated against board-relative percentages:

```css
.dice-felt { position: absolute; inset: 0; ... }
```

But `inset` does not reset `width`/`height`, so the landscape rule's `width: 62%; height: 15.5%` survived. With `left`+`width` specified, `right` is ignored (same for `top`+`height` vs `bottom`), so the felt collapsed to a ~242x107 box pinned at the board's **top-left**. `.dice-tray { top: 70.6%; }` and `.dice-banner { top: 85.5%; }` then resolved against that box — dice and banner in the top ~250px of the frame.

## Fix

Reset `width: auto; height: auto` in the portrait override so `inset: 0` actually spans the board. One rule, plus a comment explaining the trap.

## Verification

- 390x844 portrait, full roll: felt measures the full board (390x692); settled dice land at 70.6% (velvet tray, total on its plaque), banner at 85.5% (green panel) — confirmed with a region-mapped stand-in for `dice_bg_portrait` (941x1672).
- Desktop landscape: felt geometry unchanged (top 76.5%, height 15.5%, tray inside felt).
- Checked the lottery and jukebox portrait blocks for the same `inset`-vs-`width`/`height` trap — both clean (jukebox resets `max-width: none`; lottery overrides each offset explicitly).
- `bun run lint` passes.