### PR TITLE
fix(web): seat the login name field inside its painted frame

### DIFF
--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -15003,7 +15003,7 @@ body {
    fill hides the placeholder text baked into the art. */
 .login-art-input {
   position: absolute;
-  inset: 61.23% 51.56% 32.81% 29.95%;
+  inset: 61.13% 52.21% 34.86% 30.27%;
   border: none;
   border-radius: 0.5em;
   padding: 0 0.85em;
@@ -15011,7 +15011,7 @@ body {
   box-shadow: inset 0 2px 7px rgb(73 47 12 / 30%);
   font-family: var(--font-display);
   font-weight: 600;
-  font-size: 3.1cqh;
+  font-size: 2.6cqh;
   color: #45300f;
   caret-color: #6b4a16;
 }
@@ -15081,6 +15081,8 @@ body {
    Image-space bounds for every painted control, measured off each PNG and
    expressed as percentage insets (top right bottom left = bounds ÷ art size).
 
+   login_bg 1536×1024: input (465,626)-(734,667) — the painted box interior
+     runs x 464-735, y 624-666; the field sits just inside its frame bars.
    login_password_bg 1448×1086: chip (700,470)-(972,545) · input (300,612)-(810,704)
      · wand (815,615)-(885,700) · login (932,600)-(1158,705) · error (290,735)-(1160,792)
    login_set_password_bg 1536×1024: chip (860,488)-(1077,543) · input (318,590)-(835,694)
@@ -15376,7 +15378,7 @@ body {
 /* ── Phone-portrait companions (941×1672) ──────────────────────────────
    Measured element bounds in art space (see the landscape comment block
    above for the convention):
-   login_bg_portrait: input (163,1102)-(352,1162) · create/login (165,1180)-(415,1262)
+   login_bg_portrait: input (175,1089)-(411,1140) · create/login (165,1180)-(415,1262)
      · start demo (525,1180)-(805,1262) · error (150,1035)-(365,…)
    login_password_bg_portrait: chip (260,800)-(680,935) · input (190,1005)-(645,1070)
      · wand (650,1008)-(715,1068) · login (225,1165)-(720,1265) · error (190,1095)-(720,…)
@@ -15395,7 +15397,7 @@ body {
    so the cascade resolves the name scene vs the password scenes. */
 
 .login-art-stage--phone .login-art-input {
-  inset: 65.91% 62.59% 30.50% 17.32%;
+  inset: 65.13% 56.32% 31.82% 18.60%;
   font-size: 1.9cqh;
 }
 


### PR DESCRIPTION
## Summary
Fixes #1318.

The character-name input on the painted login scene overflowed the frame baked into the art:
- **Landscape (`login_bg.png` 1536×1024):** the input's bottom edge ran ~20px past the painted box interior onto the bottom frame bar, and it clipped into the right frame bar. Re-measured interior: x 464–735, y 624–666 (was seated at (460,627)–(744,688)).
- **Phone portrait (`login_bg_portrait.png` 941×1672):** the input stopped ~60px short of the frame's right edge and overlapped the bottom bar. Re-measured interior: x 173–413, y 1087–1141.

New insets seat the field just inside the frame bars on both stages, and the display type is trimmed from 3.1cqh → 2.6cqh to fit the shallower field. Measurements were taken directly off the art PNGs (luminance profiling of the frame bars) and verified by overlaying the new boxes on the art. Since the stage is aspect-locked to the art and the insets are percentages, the fit holds at all viewport sizes.

CSS-only change; `bun run build` passes locally.