### PR TITLE
fix(web): raise the welcome-back name cards to the inset panel line

### DIFF
--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -15087,7 +15087,9 @@ body {
      · wand (840,592)-(930,700) · set (955,592)-(1255,692) · error (300,725)-(1240,782)
    login_confirm_bg 1448×1086: chip (650,505)-(910,580) · yes (372,750)-(668,845)
      · no (776,750)-(1080,845) · error (350,868)-(1100,925)
-   login_picker_bg 1448×1086: list (425,555)-(1030,760) · create (525,835)-(930,897)
+   login_picker_bg 1448×1086: list (425,505)-(1030,760) · create (525,835)-(930,897)
+     — the list opens at the faint inset panel line right under the painted
+     subtitle (panel interior y 505-763), so the name cards sit close to it
    login_race_bg 1122×1402: 3×3 cells, cols x 240-408/469-657/718-906,
      rows y 328-493/502-695/728-898 · detail (235,985)-(905,1160)
      · choose (390,1240)-(735,1315) · error (300,200)-(820,252)
@@ -15178,7 +15180,7 @@ body {
   overflow-y: auto;
 }
 
-.lpk-list { inset: 51.10% 28.87% 30.02% 29.35%; }
+.lpk-list { inset: 46.50% 28.87% 30.02% 29.35%; }
 .lpk-create { inset: 76.89% 35.77% 17.40% 36.26%; }
 
 /* Re-tint the glass entry rows for parchment. */


### PR DESCRIPTION
## Summary
Fixes #1317.

On the Welcome Back (saved-character picker) scene, the name-card list opened 50px below the faint inset panel painted into `login_picker_bg.png`, leaving a dead band between the subtitle and the first card.

High-pass filtering the art shows the panel's faint top line at y≈505 — right under the painted subtitle (the spot marked in the issue) — while the list was seated at y 555. The list top inset moves 51.10% → 46.50% (y 505/1086) so the cards now start at the line; left/right/bottom edges were already correct, and the phone-portrait variant already sits flush so it's unchanged.

CSS-only change; `bun run build` passes locally.