### PR TITLE
fix: register musicbox command (unbreak main CI)

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -2379,6 +2379,11 @@ data class CommandsConfig(
                 description = "List the room's jukebox songs, pay to play one, or queue the next track",
                 category = "social",
             ),
+            "musicbox" to CommandMetadata(
+                usage = "musicbox [list] | musicbox play | musicbox stop",
+                description = "Open the room's music box and wind up its one song — free, and it follows you until it ends",
+                category = "social",
+            ),
             "ansi" to CommandMetadata("ansi on/off", "Toggle color output", "utility"),
             "screenreader" to CommandMetadata("screenreader [on/off]", "Toggle screen reader mode", "utility"),
             "audio" to CommandMetadata(

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1658,6 +1658,11 @@ ambonmud:
           description: "List the room's jukebox songs, pay to play one, or queue the next track"
           category: "social"
           staff: false
+        musicbox:
+          usage: "musicbox [list] | musicbox play | musicbox stop"
+          description: "Open the room's music box and wind up its one song — free, and it follows you until it ends"
+          category: "social"
+          staff: false
         ansi:
           usage: "ansi on/off"
           description: "Toggle color output"

--- a/src/test/kotlin/dev/ambon/engine/WebClientParityTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/WebClientParityTest.kt
@@ -136,6 +136,9 @@ class WebClientParityTest {
         "Jukebox" to "jukebox",
         "JukeboxPlay" to "jukebox",
         "JukeboxQueue" to "jukebox",
+        "MusicBox" to "musicbox",
+        "MusicBoxPlay" to "musicbox",
+        "MusicBoxStop" to "musicbox",
         // Quests
         "QuestLog" to "quest_log",
         "QuestInfo" to "quest_info",


### PR DESCRIPTION
**Unbreaks `main`** — CI has been red since the music box merge (#1336) on `WebClientParityTest > every Command subtype is mapped or explicitly excluded`.

The music box added `musicbox`/`mb` commands but didn't register them in the command-manifest plumbing the parity tests guard:

- `WebClientParityTest.parserToManifest` — added `MusicBox` / `MusicBoxPlay` / `MusicBoxStop` → `"musicbox"`.
- `CommandsConfig.defaultCommandEntries()` (`AppConfig.kt`) — added the `musicbox` entry (required by the same map's target check).
- `application.yaml` — added the matching `musicbox` entry (kept in lockstep with the code defaults by `CommandManifestSyncTest`).

Verified locally: `WebClientParityTest` and `CommandManifestSyncTest` pass. (The only other local failure was `KtorWebSocketTransportTest`'s index-page test, which is an artifact of skipping the `bun` web build locally — CI builds it.)