### PR TITLE
feat(musicbox): collectible lyric-sheet souvenirs

### DIFF
--- a/src/main/kotlin/dev/ambon/domain/items/Item.kt
+++ b/src/main/kotlin/dev/ambon/domain/items/Item.kt
@@ -64,4 +64,13 @@ data class Item(
             else -> ItemType.MISC
         }
     }
+
+    /**
+     * True when the item is bound to its owner — it cannot be dropped, sold,
+     * given, traded, banked, or mailed. Quest items and keepsakes both bind.
+     */
+    fun isBound(): Boolean = questItem || itemType == ItemType.KEEPSAKE
+
+    /** Human-readable noun for why a [isBound] item is stuck ("quest item" / "keepsake"). */
+    fun boundKind(): String = if (questItem) "quest item" else "keepsake"
 }

--- a/src/main/kotlin/dev/ambon/domain/items/ItemType.kt
+++ b/src/main/kotlin/dev/ambon/domain/items/ItemType.kt
@@ -2,8 +2,10 @@ package dev.ambon.domain.items
 
 /**
  * Broad categorization used by the client to group inventory items and by
- * the server to gate certain actions (quest items cannot be dropped, sold,
- * given, or stored in containers).
+ * the server to gate certain actions. Both [QUEST] and [KEEPSAKE] items are
+ * "bound" — they cannot be dropped, sold, given, traded, banked, or mailed
+ * (see [Item.isBound]). Keepsakes are personal souvenirs (e.g. a music-box
+ * lyric sheet); they bind the same way but read as keepsakes, not quest items.
  *
  * When an item does not declare [Item.itemType] explicitly, a value is
  * inferred via [Item.resolvedType] from the item's other properties.
@@ -13,6 +15,7 @@ enum class ItemType {
     CONSUMABLE,
     QUEST,
     TREASURE,
+    KEEPSAKE,
     MISC,
     ;
 

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/AuctionHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/AuctionHandler.kt
@@ -106,8 +106,8 @@ class AuctionHandler(
 
         players.withPlayer(sessionId) { me ->
             val carried = items.peekInventoryItem(sessionId, cmd.itemKeyword)
-            if (carried != null && carried.item.questItem) {
-                val message = "You can't auction ${carried.item.displayName} — it's a quest item."
+            if (carried != null && carried.item.isBound()) {
+                val message = "You can't auction ${carried.item.displayName} — it's a ${carried.item.boundKind()}."
                 sendErrorWithFeedback(sessionId, outbound, gmcpEmitter, message, "auction", code = "QUEST_ITEM", command = "sell")
                 return
             }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ItemHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ItemHandler.kt
@@ -298,11 +298,11 @@ class ItemHandler(
                 }
             }
             val carried = items.peekInventoryItem(me.sessionId, cmd.keyword)
-            if (carried != null && carried.item.questItem) {
+            if (carried != null && carried.item.isBound()) {
                 outbound.send(
                     OutboundEvent.SendError(
                         sessionId,
-                        "You can't drop ${carried.item.displayName} — it's a quest item.",
+                        "You can't drop ${carried.item.displayName} — it's a ${carried.item.boundKind()}.",
                     ),
                 )
                 return
@@ -416,11 +416,11 @@ class ItemHandler(
             players.withPlayer(targetSid) { target ->
                 if (!requireSameRoom(sessionId, me, target, outbound)) return
                 val owned = items.peekOwnedItem(me.sessionId, cmd.keyword)
-                if (owned != null && owned.item.questItem) {
+                if (owned != null && owned.item.isBound()) {
                     outbound.send(
                         OutboundEvent.SendError(
                             sessionId,
-                            "You can't give away ${owned.item.displayName} — it's a quest item.",
+                            "You can't give away ${owned.item.displayName} — it's a ${owned.item.boundKind()}.",
                         ),
                     )
                     return

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/MailHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/MailHandler.kt
@@ -233,12 +233,12 @@ class MailHandler(
                 outbound.send(OutboundEvent.SendPrompt(sessionId))
                 return
             }
-            if (removed.item.questItem) {
+            if (removed.item.isBound()) {
                 items.addToInventory(sessionId, removed)
                 outbound.send(
                     OutboundEvent.SendError(
                         sessionId,
-                        "You can't mail ${removed.item.displayName} — it's a quest item. Mail not sent.",
+                        "You can't mail ${removed.item.displayName} — it's a ${removed.item.boundKind()}. Mail not sent.",
                     ),
                 )
                 outbound.send(OutboundEvent.SendPrompt(sessionId))

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/MusicBoxHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/MusicBoxHandler.kt
@@ -1,6 +1,10 @@
 package dev.ambon.engine.commands.handlers
 
+import dev.ambon.domain.ids.ItemId
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.items.Item
+import dev.ambon.domain.items.ItemInstance
+import dev.ambon.domain.items.ItemType
 import dev.ambon.domain.world.MusicBox
 import dev.ambon.engine.MusicBoxSystem
 import dev.ambon.engine.commands.Command
@@ -126,6 +130,10 @@ class MusicBoxHandler(
                 outbound,
             )
 
+            // Souvenir: the first time you play a given song, the box prints you a
+            // keepsake lyric sheet (collect-once, bound, valueless). Replays are quiet.
+            grantLyricSheet(sessionId, box)
+
             ctx.emitMusicBoxGmcp(sessionId)
             // Inline music link for non-web clients (see PlayerState.audioLinksEnabled).
             if (me.audioLinksEnabled && box.url != me.lastEmittedMusicUrl) {
@@ -133,6 +141,58 @@ class MusicBoxHandler(
                 outbound.send(OutboundEvent.SendInfo(sessionId, "[music] ${box.url}"))
             }
         }
+    }
+
+    /**
+     * Tuck a keepsake [lyricSheet] for [box] into the player's inventory the first
+     * time they hear the song. Dedup is by the sheet's deterministic id, so playing
+     * the same song again (or one that shares a title in another room) is a no-op.
+     */
+    private suspend fun grantLyricSheet(
+        sessionId: SessionId,
+        box: MusicBox,
+    ) {
+        val sheet = lyricSheet(box)
+        if (ctx.items.inventory(sessionId).any { it.id == sheet.id }) return
+        ctx.items.addToInventory(sessionId, sheet)
+        gmcpEmitter?.sendCharItemsAdd(sessionId, sheet)
+        outbound.send(
+            OutboundEvent.SendInfo(
+                sessionId,
+                "The music box prints a little card — you tuck a lyric sheet for \"${box.title}\" into your satchel.",
+            ),
+        )
+    }
+
+    /**
+     * Builds the keepsake lyric-sheet item for [box]: a valueless, bound souvenir
+     * whose description is the song's title, artist, and full lyrics — so both the
+     * web examine panel and a telnet `look sheet` read the words back. The id is
+     * derived from the title so the same song always maps to the same sheet.
+     */
+    private fun lyricSheet(box: MusicBox): ItemInstance {
+        val slug = box.title.lowercase().replace(Regex("[^a-z0-9]+"), "-").trim('-').ifEmpty { "song" }
+        val header = box.artist?.let { "\"${box.title}\" — $it" } ?: "\"${box.title}\""
+        val description =
+            buildString {
+                append("A printed lyric sheet — a keepsake from a music box.\n\n")
+                append(header)
+                if (box.lyrics.isNotEmpty()) {
+                    append("\n\n")
+                    append(box.lyrics.joinToString("\n"))
+                }
+            }
+        return ItemInstance(
+            id = ItemId("lyric-sheet:$slug"),
+            item =
+                Item(
+                    keyword = "sheet",
+                    displayName = "a lyric sheet for \"${box.title}\"",
+                    description = description,
+                    basePrice = 0,
+                    itemType = ItemType.KEEPSAKE,
+                ),
+        )
     }
 
     private suspend fun handleStop(sessionId: SessionId) {

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ShopHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ShopHandler.kt
@@ -175,11 +175,11 @@ class ShopHandler(
                 outbound.send(OutboundEvent.SendError(sessionId, "You don't have '$keyword'."))
                 return
             }
-            if (invItem.item.questItem) {
+            if (invItem.item.isBound()) {
                 outbound.send(
                     OutboundEvent.SendError(
                         sessionId,
-                        "You can't sell ${invItem.item.displayName} — it's a quest item.",
+                        "You can't sell ${invItem.item.displayName} — it's a ${invItem.item.boundKind()}.",
                     ),
                 )
                 return

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/TradeHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/TradeHandler.kt
@@ -85,11 +85,11 @@ class TradeHandler(
         }
 
         val carried = items.peekInventoryItem(sessionId, cmd.itemKeyword)
-        if (carried != null && carried.item.questItem) {
+        if (carried != null && carried.item.isBound()) {
             outbound.send(
                 OutboundEvent.SendError(
                     sessionId,
-                    "You can't trade ${carried.item.displayName} — it's a quest item.",
+                    "You can't trade ${carried.item.displayName} — it's a ${carried.item.boundKind()}.",
                 ),
             )
             return

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldFeaturesHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldFeaturesHandler.kt
@@ -172,11 +172,11 @@ class WorldFeaturesHandler(
     ): Unit = withPlayerAndRoom(sessionId, players, world) { me, room ->
         val feature = requireOpenContainer(sessionId, room, containerKeyword, worldState, outbound) ?: return
         val carried = items.peekInventoryItem(sessionId, itemKeyword)
-        if (carried != null && carried.item.questItem) {
+        if (carried != null && carried.item.isBound()) {
             outbound.send(
                 OutboundEvent.SendError(
                     sessionId,
-                    "You can't stash ${carried.item.displayName} — it's a quest item.",
+                    "You can't stash ${carried.item.displayName} — it's a ${carried.item.boundKind()}.",
                 ),
             )
             return

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterMusicBoxTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterMusicBoxTest.kt
@@ -1,0 +1,103 @@
+package dev.ambon.engine.commands
+
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.items.ItemType
+import dev.ambon.domain.world.load.WorldLoader
+import dev.ambon.engine.CombatSystem
+import dev.ambon.engine.LoginResult
+import dev.ambon.engine.MobRegistry
+import dev.ambon.engine.MusicBoxSystem
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.MutableClock
+import dev.ambon.test.drainAll
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CommandRouterMusicBoxTest {
+    private class TestEnv(
+        val outbound: LocalOutboundBus,
+        val router: CommandRouter,
+        val items: ItemRegistry,
+        val sid: SessionId,
+    )
+
+    private suspend fun setup(): TestEnv {
+        val world = WorldLoader.loadFromResource("world/ok_musicbox.yaml")
+        val items = ItemRegistry()
+        items.loadSpawns(world.itemSpawns)
+        val players = dev.ambon.test.buildTestPlayerRegistry(world.startRoom, InMemoryPlayerRepository(), items)
+        val mobs = MobRegistry()
+        val outbound = LocalOutboundBus()
+        val combat = CombatSystem(players, mobs, items, outbound)
+        val clock = MutableClock(0)
+        val router = buildTestRouter(
+            world = world,
+            players = players,
+            mobs = mobs,
+            items = items,
+            combat = combat,
+            outbound = outbound,
+            clock = clock,
+            musicBoxSystem = MusicBoxSystem(clock = clock, enabled = true),
+        )
+        val sid = SessionId(1L)
+        require(players.login(sid, "Hummer", "password") == LoginResult.Ok)
+        outbound.drainAll()
+        return TestEnv(outbound, router, items, sid)
+    }
+
+    private fun lyricSheets(
+        items: ItemRegistry,
+        sid: SessionId,
+    ) = items.inventory(sid).filter { it.item.itemType == ItemType.KEEPSAKE }
+
+    @Test
+    fun `playing the music box tucks a lyric sheet into the inventory`() =
+        runTest {
+            val env = setup()
+
+            env.router.handle(env.sid, Command.MusicBoxPlay)
+
+            val sheets = lyricSheets(env.items, env.sid)
+            assertEquals(1, sheets.size, "expected exactly one lyric sheet")
+            val sheet = sheets.first().item
+            assertTrue(sheet.displayName.contains("Scuttlefish's Lullaby"), "wrong sheet: ${sheet.displayName}")
+            assertTrue(sheet.description.contains("scuttlefish sings soft"), "sheet should carry the lyrics")
+            assertEquals(0, sheet.basePrice, "a keepsake should be valueless")
+        }
+
+    @Test
+    fun `replaying the same song does not add a second sheet`() =
+        runTest {
+            val env = setup()
+
+            env.router.handle(env.sid, Command.MusicBoxPlay)
+            env.router.handle(env.sid, Command.MusicBoxPlay)
+
+            assertEquals(1, lyricSheets(env.items, env.sid).size, "replays must not duplicate the sheet")
+        }
+
+    @Test
+    fun `a lyric sheet is a bound keepsake that cannot be dropped`() =
+        runTest {
+            val env = setup()
+            env.router.handle(env.sid, Command.MusicBoxPlay)
+            env.outbound.drainAll()
+
+            env.router.handle(env.sid, Command.Drop("sheet"))
+
+            val outs = env.outbound.drainAll()
+            assertTrue(
+                outs.any { it is OutboundEvent.SendError && it.text.contains("keepsake") },
+                "expected a keepsake drop rejection, got=$outs",
+            )
+            assertEquals(1, lyricSheets(env.items, env.sid).size, "the sheet should still be in the satchel")
+        }
+}

--- a/src/test/kotlin/dev/ambon/engine/commands/RouterTestHelper.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/RouterTestHelper.kt
@@ -22,6 +22,7 @@ import dev.ambon.engine.HousingSystem
 import dev.ambon.engine.JukeboxSystem
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.MobRemovalCoordinator
+import dev.ambon.engine.MusicBoxSystem
 import dev.ambon.engine.PetSystem
 import dev.ambon.engine.PlayerClassRegistry
 import dev.ambon.engine.PlayerProgression
@@ -50,6 +51,7 @@ import dev.ambon.engine.commands.handlers.HousingHandler
 import dev.ambon.engine.commands.handlers.ItemHandler
 import dev.ambon.engine.commands.handlers.JukeboxHandler
 import dev.ambon.engine.commands.handlers.MailHandler
+import dev.ambon.engine.commands.handlers.MusicBoxHandler
 import dev.ambon.engine.commands.handlers.NavigationHandler
 import dev.ambon.engine.commands.handlers.PetHandler
 import dev.ambon.engine.commands.handlers.PrestigeHandler
@@ -123,6 +125,7 @@ internal fun buildTestRouter(
     markVitalsDirty: (SessionId) -> Unit = {},
     playerRepo: PlayerRepository? = null,
     jukeboxSystem: JukeboxSystem? = null,
+    musicBoxSystem: MusicBoxSystem? = null,
 ): CommandRouter {
     val router = CommandRouter(outbound = outbound, players = players)
     val resolvedAkathavaeSystem = akathavaeSystem ?: AkathavaeSystem(
@@ -158,6 +161,7 @@ internal fun buildTestRouter(
         akathavaeSystem = resolvedAkathavaeSystem,
         puzzleSystem = puzzleSystem,
         jukeboxSystem = jukeboxSystem,
+        musicBoxSystem = musicBoxSystem,
     )
     val puzzleHandler = puzzleSystem?.let { PuzzleHandler(ctx = ctx, puzzleSystem = it) }
     listOfNotNull(
@@ -197,6 +201,7 @@ internal fun buildTestRouter(
         enchantSystem?.let { EnchantHandler(ctx = ctx, enchantSystem = it) },
         bankConfig?.let { BankHandler(ctx = ctx, bankConfig = it) },
         jukeboxSystem?.let { JukeboxHandler(ctx = ctx, jukeboxSystem = it, markVitalsDirty = markVitalsDirty) },
+        musicBoxSystem?.let { MusicBoxHandler(ctx = ctx, musicBoxSystem = it) },
         stylistConfig?.let {
             StylistHandler(
                 ctx = ctx,

--- a/web-v3/src/components/panels/InventoryPanel.tsx
+++ b/web-v3/src/components/panels/InventoryPanel.tsx
@@ -32,7 +32,7 @@ interface ItemStack {
   instances: ItemSummary[];
 }
 
-type SectionKey = "equipment" | "consumable" | "quest" | "treasure" | "misc";
+type SectionKey = "equipment" | "consumable" | "quest" | "treasure" | "keepsake" | "misc";
 
 interface Section {
   key: SectionKey;
@@ -56,6 +56,7 @@ function groupAndCategorize(items: ItemSummary[]): Section[] {
     consumable: new Map(),
     quest: new Map(),
     treasure: new Map(),
+    keepsake: new Map(),
     misc: new Map(),
   };
 
@@ -78,6 +79,7 @@ function groupAndCategorize(items: ItemSummary[]): Section[] {
     { key: "consumable", title: "Consumables", hint: null },
     { key: "quest", title: "Quest Items", hint: "Soulbound — cannot be dropped or sold." },
     { key: "treasure", title: "Valuables", hint: "Sell to a shopkeeper for gold." },
+    { key: "keepsake", title: "Keepsakes", hint: "Souvenirs — kept, not traded. Open one to read it." },
     { key: "misc", title: "Other", hint: null },
   ];
 
@@ -101,6 +103,8 @@ function categoryChipLabel(type: ItemType): string {
       return "Quest";
     case "treasure":
       return "Sell";
+    case "keepsake":
+      return "Keepsake";
     case "misc":
       return "Misc";
   }
@@ -156,14 +160,14 @@ export function InventoryPanel({
   const renderStack = (stack: ItemStack, type: ItemType) => {
     const item = stack.lead;
     const count = stack.instances.length;
-    const isQuest = type === "quest" || !!item.questItem;
+    const isBound = type === "quest" || type === "keepsake" || !!item.questItem;
     const isVendorFodder = type === "treasure" && !item.slot && !item.consumable;
     const image = resolveItemImage(item);
 
     const rowClasses = [
       "inventory-item-row",
       `inventory-item-row-${type}`,
-      isQuest ? "inventory-item-row-quest" : "",
+      isBound ? "inventory-item-row-quest" : "",
       isVendorFodder ? "inventory-item-row-vendor" : "",
     ]
       .filter(Boolean)
@@ -235,7 +239,7 @@ export function InventoryPanel({
                 {actionAsset("action_equip") ?? <WearItemIcon className="inventory-action-icon" />}
               </button>
             )}
-            {containerContents && !isQuest && (
+            {containerContents && !isBound && (
               <button
                 type="button"
                 className="inventory-action-btn inventory-action-btn-icon inventory-action-put"
@@ -247,7 +251,7 @@ export function InventoryPanel({
                 {actionAsset("action_store") ?? <span className="inventory-action-glyph" aria-hidden="true">⊞</span>}
               </button>
             )}
-            {players.length > 0 && !isQuest && (
+            {players.length > 0 && !isBound && (
               <button
                 type="button"
                 className={`inventory-action-btn inventory-action-btn-icon${givePickerStackKey === stack.key ? " inventory-action-btn-active" : ""}`}
@@ -260,7 +264,7 @@ export function InventoryPanel({
                 {actionAsset("action_give") ?? <GiveItemIcon className="inventory-action-icon" />}
               </button>
             )}
-            {!isQuest && (
+            {!isBound && (
               <button
                 type="button"
                 className="inventory-action-btn inventory-action-btn-icon"
@@ -272,7 +276,7 @@ export function InventoryPanel({
                 {actionAsset("action_drop") ?? <DropItemIcon className="inventory-action-icon" />}
               </button>
             )}
-            {isQuest && (
+            {isBound && (
               <span
                 className="inventory-item-soulbound"
                 title="Quest items cannot be dropped, given, sold, or traded."

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -21324,6 +21324,9 @@ html:has(.game-shell),
   font-size: 1.02rem;
   line-height: 1.5;
   color: #3a2c1a;
+  /* Preserve authored line breaks (e.g. a lyric sheet's verses); prose with no
+     newlines renders unchanged. */
+  white-space: pre-line;
 }
 
 .mm-desc::first-letter {

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -284,6 +284,7 @@ export type ItemType =
   | "consumable"
   | "quest"
   | "treasure"
+  | "keepsake"
   | "misc";
 
 export interface ItemSummary {


### PR DESCRIPTION
Lyrics you can **collect**. Playing a music box mints a keepsake "lyric sheet" into your inventory — a little in-universe printout, like a souvenir of the song.

## How it works
- **Auto-grant on first play.** `musicbox play` drops a lyric sheet (`a lyric sheet for "The Word of Ambon"`) the first time you hear a given song. Collect-once — replays are quiet (dedup by a title-derived id).
- **It's a keepsake, not clutter.** Value 0, bound to you: can't be sold, dropped, traded, banked, or mailed. Groups under a new **Keepsakes** section in the inventory.
- **Readable.** The sheet's description is the title, artist, and full lyrics — so clicking it opens the parchment field-manual panel with the verses, and a telnet `look sheet` prints them too. No new subsystem, no new panel.

## Implementation
- New `ItemType.KEEPSAKE` + `Item.isBound()`/`boundKind()`. The seven existing quest-item gating sites (drop/give/sell/trade/auction/mail/container) now check `isBound()` and name the reason ("quest item" vs "keepsake"), so keepsakes lock exactly where quest items do.
- `MusicBoxHandler` mints the sheet on play (dynamic item — item instances embed their full data, so no per-song YAML).
- Web: `keepsake` item type + "Keepsakes" category; examine panel preserves lyric line breaks (`white-space: pre-line`).

## Testing
- `CommandRouterMusicBoxTest`: grant on first play, dedup on replay, keepsake drop-rejection.
- Reran shop/trade/mail/jukebox tests — quest-item gating unchanged. `ktlintCheck` + web `tsc`/`eslint` clean.
- Built against grpc 1.81.0 (current `main`), so it compiles on this Intel Mac; CI covers Linux.

## Notes / possible follow-ups
- Scope is **music box only** (player-scoped, natural souvenir), per discussion. Jukebox songs also have lyrics if we later want them collectable.
- Could add a keepsake-specific chip color and a dedicated examine frame later; for now keepsakes reuse the bound-item styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)