### PR TITLE
feat(musicbox): customizable keepsake image per music box

### DIFF
--- a/docs/WORLD_YAML_SPEC.md
+++ b/docs/WORLD_YAML_SPEC.md
@@ -131,11 +131,13 @@ musicBox: <single song object, optional - see `musicBox` notes>
     durationSeconds: 243                 # required, > 0 - the play length
     artist: "TRADITIONAL"                # optional
     description: "A palm-sized walnut-and-brass music box on the desk."  # optional lore flavour
+    image: items/lyric-sheet.png         # optional - keepsake art, resolved under the zone images base
     lyrics:                              # optional - shown on the device, spread over the duration
       - "Born beyond the veil"
       - "Where brass sang slow"
   ```
 - Lyric timing is computed on the client from the song's start, `durationSeconds`, and line count (lines spread evenly; pacing need not match the sung pacing). On the open device the current line is lit and scrolls; while the device is closed each line pops as a brief 🎵 toast so an exploring player can keep up. The personal song plays over the room's jukebox/default music for the player who started it. Lyrics are capped at one line per 3 seconds of duration; lines must be non-blank.
+- The first time a player winds up a given music box, a collectible **lyric-sheet keepsake** is minted into their inventory (a bound souvenir holding the title, artist, and full lyrics; replays are quiet). `image` sets that keepsake's picture — an optional filename resolved under the zone images base, exactly like room/item art. When omitted, the keepsake falls back to the web client's generic item default.
 
 `dungeon` notes:
 - When `true`, shows a Dungeon badge on the web client canvas that opens the dungeon kiosk panel.

--- a/src/main/kotlin/dev/ambon/domain/world/MusicBox.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/MusicBox.kt
@@ -15,6 +15,11 @@ package dev.ambon.domain.world
  * the player's device, spread evenly across the duration (the open device scrolls
  * them; while closed they pop as transient toasts so an exploring player can keep
  * up). [description] is optional lore flavour shown on the device.
+ *
+ * [image] is the fully-resolved image URL for the collectible lyric-sheet keepsake
+ * minted on first play (the WorldLoader prefixes the authored filename with the
+ * zone's images base, like room/item art); null falls back to the client's generic
+ * item default.
  */
 data class MusicBox(
     val title: String,
@@ -23,4 +28,5 @@ data class MusicBox(
     val artist: String? = null,
     val description: String? = null,
     val lyrics: List<String> = emptyList(),
+    val image: String? = null,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/data/RoomFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/RoomFile.kt
@@ -72,7 +72,10 @@ data class JukeboxSongFile(
  * Playing it is free and player-scoped — the song follows the player out of the
  * room. [lyrics] lines are surfaced on the player's device, spread evenly across
  * the duration, so the count must leave at least a few seconds between lines
- * (validated at load). [artist]/[description] are optional flavour.
+ * (validated at load). [artist]/[description] are optional flavour. [image] is an
+ * optional filename (resolved against the zone images base, like room/item art)
+ * for the collectible lyric-sheet keepsake minted on first play; when omitted the
+ * keepsake falls back to the client's generic item default.
  */
 data class MusicBoxFile(
     val title: String,
@@ -81,4 +84,5 @@ data class MusicBoxFile(
     val artist: String? = null,
     val description: String? = null,
     val lyrics: List<String> = emptyList(),
+    val image: String? = null,
 )

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -262,7 +262,7 @@ object WorldLoader {
                         music = (rf.music ?: audioDefaults?.music)?.let { "$audioBase$it" },
                         ambient = (rf.ambient ?: audioDefaults?.ambient)?.let { "$audioBase$it" },
                         jukebox = parseJukebox(rf.jukebox, audioBase, id),
-                        musicBox = parseMusicBox(rf.musicBox, audioBase, id),
+                        musicBox = parseMusicBox(rf.musicBox, audioBase, imagesBase, id),
                         graphical = zoneGraphical,
                         terrain = (rf.terrain ?: zoneTerrain ?: "outside").also {
                             validateTerrain(it, "room '${id.value}'")
@@ -1805,6 +1805,7 @@ object WorldLoader {
     private fun parseMusicBox(
         box: MusicBoxFile?,
         audioBase: String,
+        imagesBase: String,
         roomId: RoomId,
     ): MusicBox? {
         if (box == null) return null
@@ -1834,6 +1835,7 @@ object WorldLoader {
             artist = box.artist,
             description = box.description,
             lyrics = box.lyrics,
+            image = box.image?.trim()?.takeUnless { it.isEmpty() }?.let { "$imagesBase$it" },
         )
     }
 

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/MusicBoxHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/MusicBoxHandler.kt
@@ -191,6 +191,7 @@ class MusicBoxHandler(
                     description = description,
                     basePrice = 0,
                     itemType = ItemType.KEEPSAKE,
+                    image = box.image,
                 ),
         )
     }

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterMusicBoxTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterMusicBoxTest.kt
@@ -74,6 +74,21 @@ class CommandRouterMusicBoxTest {
         }
 
     @Test
+    fun `the lyric sheet carries the music box's resolved keepsake image`() =
+        runTest {
+            val env = setup()
+
+            env.router.handle(env.sid, Command.MusicBoxPlay)
+
+            val sheet = lyricSheets(env.items, env.sid).first().item
+            assertEquals(
+                "/images/items/lyric-sheet-lullaby.png",
+                sheet.image,
+                "the keepsake should carry the music box's image, resolved against the images base",
+            )
+        }
+
+    @Test
     fun `replaying the same song does not add a second sheet`() =
         runTest {
             val env = setup()

--- a/src/test/resources/world/ok_musicbox.yaml
+++ b/src/test/resources/world/ok_musicbox.yaml
@@ -12,6 +12,7 @@ rooms:
       durationSeconds: 60
       artist: "Scuttlefish"
       description: "A soft tune the old fortune-teller used to hum."
+      image: items/lyric-sheet-lullaby.png
       lyrics:
         - "Down where the lantern-light is low"
         - "the scuttlefish sings soft and slow"


### PR DESCRIPTION
## Summary
Makes the lyric-sheet keepsake image (minted on first music box play, #1340) customizable per music box.

Previously the keepsake was minted with no image, so it always showed the web client's generic item default. Now a room's `musicBox` block accepts an optional `image:` filename — resolved against the zone images base, exactly like room/item art — that becomes the keepsake's picture. Omitting it preserves the old fallback (generic item default), so existing worlds are unchanged.

## Changes
- `MusicBoxFile` + `MusicBox` gain an `image` field.
- `WorldLoader.parseMusicBox()` resolves the filename against `imagesBase` (trims/ignores blanks).
- `MusicBoxHandler.lyricSheet()` sets `Item.image = box.image` on the keepsake; it flows to the client via the existing `Char.Items.Add` GMCP payload and `resolveItemImage()`.
- `docs/WORLD_YAML_SPEC.md` documents the field; `ok_musicbox.yaml` fixture + a new test assert the resolved image lands on the keepsake.

## Usage
```yaml
musicBox:
  title: "Scuttlefish's Lullaby"
  file: musicbox/lullaby.mp3
  durationSeconds: 60
  image: items/lyric-sheet-lullaby.png   # optional keepsake art
  lyrics: [ ... ]
```

## Testing
- `ktlintCheck` + `CommandRouterMusicBoxTest` + `WorldLoaderTest` pass locally (JDK 21).
- `buildWeb` skipped locally (no `bun` on this machine); no web-client source changed, so CI covers it.