### PR TITLE
fix(webclient): examine button targets items by unique id

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
@@ -460,27 +460,8 @@ class NavigationHandler(
         val me = players.get(sessionId) ?: return
         val roomId = me.roomId
 
-        // The web client targets a specific item via "#<itemId>" so that
-        // similarly-named items (e.g. distinct keepsakes sharing a keyword)
-        // resolve unambiguously rather than always matching the first one.
-        if (cmd.target.startsWith("#")) {
-            val itemId = cmd.target.substring(1)
-            val match = (
-                ctx.items.inventory(sessionId) +
-                    ctx.items.equipment(sessionId).values +
-                    ctx.items.itemsInRoom(roomId)
-            ).firstOrNull { it.id.value == itemId }
-            if (match != null) {
-                val desc = match.item.description.ifEmpty { "You see nothing special about ${match.item.displayName}." }
-                outbound.send(OutboundEvent.SendText(sessionId, "${match.item.displayName}: $desc"))
-                sendItemLookTarget(sessionId, match, desc)
-                return
-            }
-            val msg = "You don't see that item."
-            outbound.send(OutboundEvent.SendError(sessionId, msg))
-            gmcpEmitter?.sendUiFeedback(sessionId, "error", msg, code = "TARGET_NOT_FOUND", scope = "navigation", command = "look")
-            return
-        }
+        // Note: the "#<itemId>" selector the web client sends to disambiguate
+        // similarly-named items is handled transparently by matchesKeyword below.
 
         // Try mob first
         val mob = ctx.mobs.findInRoomByKeyword(roomId, cmd.target).firstOrNull()

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
@@ -460,6 +460,28 @@ class NavigationHandler(
         val me = players.get(sessionId) ?: return
         val roomId = me.roomId
 
+        // The web client targets a specific item via "#<itemId>" so that
+        // similarly-named items (e.g. distinct keepsakes sharing a keyword)
+        // resolve unambiguously rather than always matching the first one.
+        if (cmd.target.startsWith("#")) {
+            val itemId = cmd.target.substring(1)
+            val match = (
+                ctx.items.inventory(sessionId) +
+                    ctx.items.equipment(sessionId).values +
+                    ctx.items.itemsInRoom(roomId)
+            ).firstOrNull { it.id.value == itemId }
+            if (match != null) {
+                val desc = match.item.description.ifEmpty { "You see nothing special about ${match.item.displayName}." }
+                outbound.send(OutboundEvent.SendText(sessionId, "${match.item.displayName}: $desc"))
+                sendItemLookTarget(sessionId, match, desc)
+                return
+            }
+            val msg = "You don't see that item."
+            outbound.send(OutboundEvent.SendError(sessionId, msg))
+            gmcpEmitter?.sendUiFeedback(sessionId, "error", msg, code = "TARGET_NOT_FOUND", scope = "navigation", command = "look")
+            return
+        }
+
         // Try mob first
         val mob = ctx.mobs.findInRoomByKeyword(roomId, cmd.target).firstOrNull()
         if (mob != null) {

--- a/src/main/kotlin/dev/ambon/engine/items/ItemMatching.kt
+++ b/src/main/kotlin/dev/ambon/engine/items/ItemMatching.kt
@@ -33,10 +33,22 @@ internal fun itemMatchModes(input: String): List<ItemMatchMode> =
         listOf(ItemMatchMode.EXACT)
     }
 
+/**
+ * The web client targets a specific item instance with the selector "#<itemId>"
+ * so that similarly-named items (e.g. distinct keepsakes sharing a keyword)
+ * resolve unambiguously instead of always hitting the first keyword match.
+ *
+ * Returns the bare item id when [input] is such a selector, or null otherwise.
+ */
+fun itemIdSelector(input: String): String? = if (input.startsWith("#")) input.substring(1) else null
+
 internal fun findMatchingItemIndex(
     items: List<ItemInstance>,
     input: String,
 ): Int {
+    itemIdSelector(input)?.let { id ->
+        return items.indexOfFirst { it.id.value == id }
+    }
     for (mode in itemMatchModes(input)) {
         val idx = items.indexOfFirst { mode.matches(it.item, input) }
         if (idx >= 0) return idx
@@ -53,8 +65,10 @@ internal fun findMatchingItemIndex(
  *
  * This is the canonical matching logic — use it instead of ad-hoc comparisons.
  */
-fun ItemInstance.matchesKeyword(input: String): Boolean =
-    itemMatchModes(input).any { it.matches(item, input) }
+fun ItemInstance.matchesKeyword(input: String): Boolean {
+    itemIdSelector(input)?.let { return id.value == it }
+    return itemMatchModes(input).any { it.matches(item, input) }
+}
 
 /** Same as [ItemInstance.matchesKeyword] but operates on a bare [Item]. */
 fun Item.matchesKeyword(input: String): Boolean =

--- a/src/main/kotlin/dev/ambon/engine/items/ItemRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/items/ItemRegistry.kt
@@ -339,8 +339,12 @@ class ItemRegistry {
         sessionId: SessionId,
         keyword: String,
     ): EquipResult {
+        // "#<itemId>" targets one exact instance (web client); resolve it directly.
+        itemIdSelector(keyword)?.let { id ->
+            return equipFromInventoryWithMatcher(sessionId) { it.id.value == id }
+        }
         for (mode in itemMatchModes(keyword)) {
-            val result = equipFromInventoryWithMatcher(sessionId, keyword, mode)
+            val result = equipFromInventoryWithMatcher(sessionId) { mode.matches(it.item, keyword) }
             if (result !is EquipResult.NotFound) return result
         }
         return EquipResult.NotFound
@@ -348,8 +352,7 @@ class ItemRegistry {
 
     private fun equipFromInventoryWithMatcher(
         sessionId: SessionId,
-        keyword: String,
-        mode: ItemMatchMode,
+        matches: (ItemInstance) -> Boolean,
     ): EquipResult {
         val inv = inventoryItems[sessionId] ?: return EquipResult.NotFound
         var firstNonWearable: ItemInstance? = null
@@ -358,7 +361,7 @@ class ItemRegistry {
         // Pass 1: prefer a matching item whose target slot is empty. Only if no
         // such item exists do we fall through to auto-swap.
         for ((idx, instance) in inv.withIndex()) {
-            if (!mode.matches(instance.item, keyword)) continue
+            if (!matches(instance)) continue
 
             val slot = instance.item.slot
             if (slot == null) {
@@ -672,6 +675,8 @@ class ItemRegistry {
         sessionId: SessionId,
         keyword: String,
     ): MatchedOwnedItem? {
+        itemIdSelector(keyword)?.let { return findOwnedItemMatchById(sessionId, ItemId(it)) }
+
         val inv = inventoryItems[sessionId]
         val equipped = equippedItems[sessionId]
 

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterItemsTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterItemsTest.kt
@@ -631,4 +631,67 @@ class CommandRouterItemsTest {
                 "Use should not be blocked by combat. got=$outs",
             )
         }
+
+    @Test
+    fun `look at id targets exact item when keyword is shared`() =
+        runTest {
+            val h = CommandRouterHarness.create()
+            val sid = SessionId(91L)
+            h.loginPlayer(sid, "Collector")
+
+            // Two distinct keepsakes share the "keepsake" keyword but differ by id/description.
+            h.items.addToInventory(
+                sid,
+                ItemInstance(
+                    ItemId("test:keepsake-a"),
+                    Item(keyword = "keepsake", displayName = "a seashell keepsake", description = "It smells of salt."),
+                ),
+            )
+            h.items.addToInventory(
+                sid,
+                ItemInstance(
+                    ItemId("test:keepsake-b"),
+                    Item(keyword = "keepsake", displayName = "a pinecone keepsake", description = "It smells of pine."),
+                ),
+            )
+
+            // Bare keyword is ambiguous and resolves to the first item.
+            h.router.handle(sid, Command.LookAt("keepsake"))
+            assertTrue(
+                h.drain().any { it is OutboundEvent.SendText && it.text.contains("a seashell keepsake") },
+                "Keyword look should resolve to the first keepsake.",
+            )
+
+            // The "#<id>" form resolves the second keepsake unambiguously.
+            h.router.handle(sid, Command.LookAt("#test:keepsake-b"))
+            val outs = h.drain()
+            assertTrue(
+                outs.any {
+                    it is OutboundEvent.SendText &&
+                        it.text.contains("a pinecone keepsake") &&
+                        it.text.contains("It smells of pine.")
+                },
+                "Id look should resolve the exact keepsake. got=$outs",
+            )
+            assertTrue(
+                outs.none { it is OutboundEvent.SendText && it.text.contains("seashell") },
+                "Id look must not leak the other keepsake's description. got=$outs",
+            )
+        }
+
+    @Test
+    fun `look at unknown id reports item not found`() =
+        runTest {
+            val h = CommandRouterHarness.create()
+            val sid = SessionId(92L)
+            h.loginPlayer(sid, "Collector")
+
+            h.router.handle(sid, Command.LookAt("#test:does-not-exist"))
+
+            val outs = h.drain()
+            assertTrue(
+                outs.any { it is OutboundEvent.SendError && it.text.contains("don't see that item") },
+                "Unknown id should report not found. got=$outs",
+            )
+        }
 }

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterItemsTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterItemsTest.kt
@@ -690,8 +690,83 @@ class CommandRouterItemsTest {
 
             val outs = h.drain()
             assertTrue(
-                outs.any { it is OutboundEvent.SendError && it.text.contains("don't see that item") },
+                outs.any { it is OutboundEvent.SendError && it.text.contains("don't see") },
                 "Unknown id should report not found. got=$outs",
             )
+        }
+
+    @Test
+    fun `wear by id equips the exact item when keyword is shared`() =
+        runTest {
+            val h = CommandRouterHarness.create()
+            val sid = SessionId(93L)
+            h.loginPlayer(sid, "Dresser")
+
+            // Two amulets share the "amulet" keyword but differ by id.
+            h.items.addToInventory(
+                sid,
+                ItemInstance(
+                    ItemId("test:amulet-copper"),
+                    Item(keyword = "amulet", displayName = "a copper amulet", slot = ItemSlot.NECK),
+                ),
+            )
+            h.items.addToInventory(
+                sid,
+                ItemInstance(
+                    ItemId("test:amulet-silver"),
+                    Item(keyword = "amulet", displayName = "a silver amulet", slot = ItemSlot.NECK),
+                ),
+            )
+
+            h.router.handle(sid, Command.Wear("#test:amulet-silver"))
+
+            assertEquals("test:amulet-silver", h.items.equipment(sid).getValue(ItemSlot.NECK).id.value)
+            assertEquals("test:amulet-copper", h.items.inventory(sid).single().id.value)
+        }
+
+    @Test
+    fun `drop by id drops the exact item when keyword is shared`() =
+        runTest {
+            val h = CommandRouterHarness.create()
+            val sid = SessionId(94L)
+            h.loginPlayer(sid, "Dropper")
+
+            h.items.addToInventory(
+                sid,
+                ItemInstance(ItemId("test:gem-ruby"), Item(keyword = "gem", displayName = "a ruby")),
+            )
+            h.items.addToInventory(
+                sid,
+                ItemInstance(ItemId("test:gem-pearl"), Item(keyword = "gem", displayName = "a pearl")),
+            )
+
+            h.router.handle(sid, Command.Drop("#test:gem-pearl"))
+
+            assertEquals("test:gem-ruby", h.items.inventory(sid).single().id.value)
+            assertEquals("test:gem-pearl", h.items.itemsInRoom(h.world.startRoom).single().id.value)
+        }
+
+    @Test
+    fun `give by id gives the exact item when keyword is shared`() =
+        runTest {
+            val h = CommandRouterHarness.create()
+            val giver = SessionId(95L)
+            val receiver = SessionId(96L)
+            h.loginPlayer(giver, "Giver")
+            h.loginPlayer(receiver, "Taker")
+
+            h.items.addToInventory(
+                giver,
+                ItemInstance(ItemId("test:coin-gold"), Item(keyword = "coin", displayName = "a gold coin")),
+            )
+            h.items.addToInventory(
+                giver,
+                ItemInstance(ItemId("test:coin-copper"), Item(keyword = "coin", displayName = "a copper coin")),
+            )
+
+            h.router.handle(giver, Command.Give("#test:coin-copper", "Taker"))
+
+            assertEquals("test:coin-gold", h.items.inventory(giver).single().id.value)
+            assertEquals("test:coin-copper", h.items.inventory(receiver).single().id.value)
         }
 }

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -1312,9 +1312,9 @@ function App() {
             roomFeatures={state.roomFeatures}
             containerContents={state.containerContents}
             serverAssets={state.serverAssets}
-            onWearItem={(name) => sendCommand(`wear ${name}`)}
-            onDropItem={(name) => sendCommand(`drop ${name}`)}
-            onGiveItem={(keyword, player) => sendCommand(`give ${keyword} ${player}`)}
+            onWearItem={(sel) => sendCommand(`wear ${sel}`)}
+            onDropItem={(sel) => sendCommand(`drop ${sel}`)}
+            onGiveItem={(sel, player) => sendCommand(`give ${sel} ${player}`)}
             onExamineItem={(it, image) => {
               // Fetch the full look; the response (Room.LookTarget) is routed
               // into the item card by the effect below.

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -1319,7 +1319,7 @@ function App() {
               // Fetch the full look; the response (Room.LookTarget) is routed
               // into the item card by the effect below.
               pendingExamineRef.current = { image };
-              sendCommand(`look ${it.keyword}`);
+              sendCommand(it.id ? `look #${it.id}` : `look ${it.keyword}`);
               window.setTimeout(() => { pendingExamineRef.current = null; }, 2500);
             }}
             onCommand={sendCommand}
@@ -1336,7 +1336,7 @@ function App() {
             slotDefs={state.equipmentSlotDefs}
             onExamineItem={(it, image, slot) => {
               pendingExamineRef.current = { image, equippedSlot: slot };
-              sendCommand(`look ${it.keyword}`);
+              sendCommand(it.id ? `look #${it.id}` : `look ${it.keyword}`);
               window.setTimeout(() => { pendingExamineRef.current = null; }, 2500);
             }}
           />
@@ -1443,7 +1443,7 @@ function App() {
             })}
             onShowSellItem={(it, image) => {
               pendingExamineRef.current = { image };
-              sendCommand(`look ${it.keyword}`);
+              sendCommand(it.id ? `look #${it.id}` : `look ${it.keyword}`);
               window.setTimeout(() => { pendingExamineRef.current = null; }, 2500);
             }}
           />

--- a/web-v3/src/components/panels/InventoryPanel.tsx
+++ b/web-v3/src/components/panels/InventoryPanel.tsx
@@ -13,9 +13,10 @@ interface InventoryPanelProps {
   containerContents: ContainerContents | null;
   /** Resolved server assets, for the optional action-button icons. */
   serverAssets: Record<string, string>;
-  onWearItem: (itemName: string) => void;
-  onDropItem: (itemName: string) => void;
-  onGiveItem: (itemKeyword: string, playerName: string) => void;
+  /** Receives a server item selector (see {@link itemSelector}), not a display name. */
+  onWearItem: (itemSelector: string) => void;
+  onDropItem: (itemSelector: string) => void;
+  onGiveItem: (itemSelector: string, playerName: string) => void;
   /** Open the parchment item card (same window as clicking a ground item). */
   onExamineItem: (item: ItemSummary, image: string | null) => void;
   onCommand: (command: string) => void;
@@ -39,6 +40,16 @@ interface Section {
   title: string;
   hint: string | null;
   stacks: ItemStack[];
+}
+
+/**
+ * Builds the command selector for an item. Prefers the unique instance id
+ * ("#<id>") so similarly-named items (e.g. distinct keepsakes sharing a
+ * keyword) resolve unambiguously; falls back to the keyword for older servers
+ * that don't send an id.
+ */
+function itemSelector(item: ItemSummary): string {
+  return item.id ? `#${item.id}` : item.keyword;
 }
 
 function resolveItemType(item: ItemSummary): ItemType {
@@ -222,7 +233,7 @@ export function InventoryPanel({
                 aria-label={`Use ${item.name}`}
                 title={`Use ${item.name}${item.useEffect ? ` - ${item.useEffect}` : ""}`}
                 disabled={!canManageItems}
-                onClick={() => onCommand(`use ${item.keyword}`)}
+                onClick={() => onCommand(`use ${itemSelector(item)}`)}
               >
                 {actionAsset("action_use") ?? <span className="inventory-action-glyph" aria-hidden="true">✚</span>}
               </button>
@@ -234,7 +245,7 @@ export function InventoryPanel({
                 aria-label={`Equip ${item.name}`}
                 title={equipHint ? `Equip ${item.name}` : `Wear ${item.name}`}
                 disabled={!canManageItems}
-                onClick={() => onWearItem(item.name)}
+                onClick={() => onWearItem(itemSelector(item))}
               >
                 {actionAsset("action_equip") ?? <WearItemIcon className="inventory-action-icon" />}
               </button>
@@ -246,7 +257,7 @@ export function InventoryPanel({
                 aria-label={`Store ${item.name} in ${containerContents.name}`}
                 title={`Store ${item.name} in ${containerContents.name}`}
                 disabled={!canManageItems}
-                onClick={() => onCommand(`put ${item.keyword} in ${containerContents.keyword}`)}
+                onClick={() => onCommand(`put ${itemSelector(item)} in ${containerContents.keyword}`)}
               >
                 {actionAsset("action_store") ?? <span className="inventory-action-glyph" aria-hidden="true">⊞</span>}
               </button>
@@ -271,7 +282,7 @@ export function InventoryPanel({
                 title={count > 1 ? `Drop one ${item.name}` : `Drop ${item.name}`}
                 aria-label={count > 1 ? `Drop one ${item.name}` : `Drop ${item.name}`}
                 disabled={!canManageItems}
-                onClick={() => onDropItem(item.name)}
+                onClick={() => onDropItem(itemSelector(item))}
               >
                 {actionAsset("action_drop") ?? <DropItemIcon className="inventory-action-icon" />}
               </button>
@@ -297,7 +308,7 @@ export function InventoryPanel({
                 role="option"
                 className="inventory-give-option"
                 onClick={() => {
-                  onGiveItem(item.keyword, player.name);
+                  onGiveItem(itemSelector(item), player.name);
                   setGivePickerStackKey(null);
                 }}
               >


### PR DESCRIPTION
## Problem

The web client inventory panel identified items by **keyword** when building commands. Items that share a keyword — most visibly the new musicbox **keepsakes**, but also any similarly-named items — all resolved to the *first* keyword match. The examine pane was the reported symptom (every keepsake showed the same name/description), but the same latent bug affected the use, wear/equip, drop, give, and store buttons.

## Fix

A single `#<itemId>` selector convention, resolved centrally:

- **Matching layer** (`ItemMatching.kt`): new `itemIdSelector(input)` helper; `findMatchingItemIndex` and `ItemInstance.matchesKeyword` resolve `#<id>` to the exact instance by `ItemId`, falling back to keyword matching otherwise. This covers look, drop, store, sell, bank, and mail automatically.
- **Owned-item paths** (`ItemRegistry.kt`): `findOwnedItemMatch` (use, give) delegates to the existing id lookup for `#<id>`; `equipFromInventory` (wear) was refactored to match on a predicate so it can target an exact instance.
- **Look handler** (`NavigationHandler.handleLookAt`): the earlier dedicated id block was removed — look already routes through `matchesKeyword`, so the shared mechanism now handles it (one path, not two).

Client side, every inventory action button builds its selector through `InventoryPanel.itemSelector(item)`, which prefers the unique `id` (already delivered via the `Char.Items` GMCP payload) and falls back to the keyword for older servers. The examine handlers in `App.tsx` send `look #<id>` the same way.

Client response routing is unaffected — it displays whatever name/description the server returns, with no name-based matching that could re-collide.

### Out of scope

The container-contents **Take**/**Examine** buttons still match by keyword: the server does not emit per-item ids for world-container contents (`ContainerContents.items` is `{name, keyword}` only), so id targeting there would need a separate GMCP + world-container change.

## Tests

New cases in `CommandRouterItemsTest` prove `#<id>` resolves the exact item among same-keyword items and never leaks the other's data:
- `look at id targets exact item when keyword is shared`
- `wear by id equips the exact item when keyword is shared`
- `drop by id drops the exact item when keyword is shared`
- `give by id gives the exact item when keyword is shared`
- `look at unknown id reports item not found`

Full `./gradlew test` suite passes, `ktlintCheck` is clean, and the web client builds clean (`tsc -b && vite build`).