### PR TITLE
fix(audio): unlock AudioContext on iOS via user gesture

### DIFF
--- a/web-v3/src/hooks/useAudioEngine.ts
+++ b/web-v3/src/hooks/useAudioEngine.ts
@@ -142,6 +142,27 @@ export function useAudioEngine(): AudioEngine {
     }
   }, []);
 
+  // iOS Safari only lets an AudioContext produce sound if it is created and/or
+  // resumed inside a real user-gesture handler. Our playback is almost always
+  // kicked off by a GMCP/WebSocket event (room music, ambient, dialogue voice),
+  // which is never a gesture — so the context would stay suspended forever and
+  // every channel is silent. Calling this from a tap handler unlocks it; the
+  // one-sample silent buffer is the belt-and-suspenders unlock older iOS wants.
+  const unlockCtx = useCallback(async () => {
+    const ctx = getCtx();
+    if (!ctx) return;
+    if (ctx.state === "suspended") {
+      try { await ctx.resume(); } catch { return; }
+    }
+    try {
+      const buffer = ctx.createBuffer(1, 1, ctx.sampleRate);
+      const source = ctx.createBufferSource();
+      source.buffer = buffer;
+      source.connect(ctx.destination);
+      source.start(0);
+    } catch { /* ok */ }
+  }, [getCtx]);
+
   const stopTrack = useCallback((track: TrackState, fadeDuration = CROSSFADE_MS) => {
     if (track.source && track.gain) {
       const src = track.source;
@@ -473,15 +494,17 @@ export function useAudioEngine(): AudioEngine {
   const toggle = useCallback(() => {
     const next = !prefsRef.current.enabled;
     updatePrefs({ enabled: next });
-    if (next && ctxRef.current?.state === "suspended") {
-      ctxRef.current.resume();
-    }
-    // If disabling, also kill combat effects
-    if (!next) {
+    if (next) {
+      // Runs inside the toggle's tap handler — the one reliable moment to
+      // unlock audio on iOS. (The old guard checked ctxRef.current, but the
+      // context usually doesn't exist yet here, so it never fired.)
+      void unlockCtx();
+    } else {
+      // If disabling, also kill combat effects
       stopPulseLfo();
       combatActiveRef.current = false;
     }
-  }, [updatePrefs, stopPulseLfo]);
+  }, [updatePrefs, stopPulseLfo, unlockCtx]);
 
   const setMusicVolume = useCallback((v: number) => {
     updatePrefs({ musicVolume: Math.max(0, Math.min(1, v)) });
@@ -494,6 +517,21 @@ export function useAudioEngine(): AudioEngine {
   const setVoiceVolume = useCallback((v: number) => {
     updatePrefs({ voiceVolume: Math.max(0, Math.min(1, v)) });
   }, [updatePrefs]);
+
+  // When audio was already enabled in a previous session, a page reload has no
+  // user gesture yet, so the context can't be unlocked until the player taps
+  // something. Resume it on the first interaction anywhere (iOS requirement).
+  useEffect(() => {
+    const handler = () => {
+      if (prefsRef.current.enabled) void unlockCtx();
+    };
+    window.addEventListener("pointerdown", handler);
+    window.addEventListener("touchend", handler);
+    return () => {
+      window.removeEventListener("pointerdown", handler);
+      window.removeEventListener("touchend", handler);
+    };
+  }, [unlockCtx]);
 
   // Cleanup on unmount
   useEffect(() => {


### PR DESCRIPTION
## Problem

On iPhone, music / ambiance / speech are all silent even with audio toggled on and volumes up. Everything works on desktop.

## Root cause

iOS Safari only lets a Web \`AudioContext\` produce sound if the context is **created and/or resumed inside a real user-gesture handler** (a tap). Desktop browsers resume freely from any code path once the page has been interacted with — hence the platform split.

In \`useAudioEngine.ts\` the context is created lazily on first playback, and first playback is almost always driven by a **GMCP/WebSocket event** (\`Room.Info\` music/ambient, \`Dialogue.Node\` voiceUrl), routed through \`App.tsx\` \`useEffect\`s — never a gesture. So on iPhone the context is created + \`resume()\`d outside a gesture and stays \`suspended\` forever.

The audio toggle button *looked* like it should help, but its old guard checked \`ctxRef.current?.state === "suspended"\` — and the context usually doesn't exist yet at that point, so the one reliable gesture was wasted.

## Fix

- **`unlockCtx()`** — creates + resumes the context and plays a one-sample silent buffer (the belt-and-suspenders iOS unlock).
- **`toggle()`** now calls `unlockCtx()` inside the tap handler when enabling audio.
- **One-time global `pointerdown`/`touchend` listener** so sessions that load with audio already enabled (persisted in localStorage) unlock on the first interaction anywhere — a reload has no gesture yet.

## Testing

- `bun run lint` ✅
- `bunx tsc --noEmit` ✅
- `bun run build` ✅

⚠️ Not yet verified on real iOS hardware — the surest validation is a manual test on iPhone or `/ios-qa` on a device. Every audio path I could find originates from a WebSocket event rather than a gesture, which is the textbook iOS failure mode, so I'm confident in the diagnosis.