### PR TITLE
fix(webclient): retry transient painted-art load failures

### DIFF
--- a/web-v3/public/sw.js
+++ b/web-v3/public/sw.js
@@ -3,7 +3,7 @@
 // versions, which also self-heals clients whose v1 cache captured error
 // responses (the old fetch handler cached 404s/opaque bodies, permanently
 // breaking styling for that browser).
-const CACHE_NAME = "ambonmud-v2";
+const CACHE_NAME = "ambonmud-v3";
 const STATIC_ASSETS = ["/", "/icons/icon.svg"];
 
 self.addEventListener("install", (event) => {
@@ -22,14 +22,48 @@ self.addEventListener("activate", (event) => {
   self.clients.claim();
 });
 
-// Only complete, successful, same-origin responses may enter the cache.
-// Caching anything else (404 during a server restart, an opaque error) pins
-// the failure: cache-first would then serve the broken response forever.
-const cacheable = (response) => Boolean(response && response.ok && response.type === "basic");
+// Only complete, successful responses we can inspect may enter the cache.
+// Same-origin fetches are "basic"; cross-origin art fetched with CORS is
+// "cors" (its status is readable). Opaque no-cors responses are excluded on
+// purpose: their status is unreadable (always 0), so caching one would pin a
+// 404/error and serve the broken response forever.
+const cacheable = (response) =>
+  Boolean(response && response.ok && (response.type === "basic" || response.type === "cors"));
+
+// Painted art (panel skins, keepsakes, minimap textures) — mutable PNG/WebP/…
+// served either locally from /images/ or cross-origin from the R2 CDN.
+const ART_EXT = /\.(?:png|jpe?g|webp|avif|gif|svg)(?:\?.*)?$/i;
+const isArt = (request, url) => request.destination === "image" || ART_EXT.test(url.pathname);
 
 self.addEventListener("fetch", (event) => {
   const url = new URL(event.request.url);
-  if (url.origin !== self.location.origin) return;
+
+  if (url.origin !== self.location.origin) {
+    // Cross-origin painted art (R2 CDN). Give it the same stale-while-revalidate
+    // self-healing as local /images/ so a cached copy survives a flaky network
+    // and a transient first-load failure isn't permanent for the session. The
+    // SW can't read an opaque no-cors response's status, so revalidate with a
+    // CORS request we *can* inspect and cache; if the origin sends no CORS
+    // headers that fetch rejects, fall back to a plain (opaque, uncached) fetch
+    // so art still loads. Always end in a real network fetch — never return
+    // undefined, which would break the image.
+    if (event.request.method === "GET" && isArt(event.request, url)) {
+      event.respondWith(
+        caches.open(CACHE_NAME).then((cache) =>
+          cache.match(event.request, { ignoreVary: true }).then((cached) => {
+            const revalidate = fetch(new Request(url.href, { mode: "cors", credentials: "omit" }))
+              .then((response) => {
+                if (cacheable(response)) cache.put(event.request, response.clone());
+                return response;
+              })
+              .catch(() => fetch(event.request)); // no CORS available — opaque, uncached
+            return cached || revalidate;
+          })
+        )
+      );
+    }
+    return;
+  }
 
   // Network-first for HTML, and re-cache the shell on every successful
   // navigation. A shell frozen at install time references hashed bundles that

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -370,14 +370,36 @@ function App() {
   // as a flash. Server.Assets arrives at login, well before any in-game panel
   // opens, so a fire-and-forget preload here means those panels paint warm. Skip
   // inline data: URIs (already resolved, nothing to fetch).
+  //
+  // A transient failure during the login burst (CDN cold edge, a dropped
+  // connection, an HTTP/2 stream reset) used to pin the art off for the whole
+  // session: the URL was marked seen before the load resolved and never
+  // re-attempted, so the panel stuck on its gradient fallback until a full page
+  // refresh. Now each preload retries with backoff, and a terminal failure
+  // drops the URL from the seen-set so a later Server.Assets emit tries again.
   useEffect(() => {
+    let cancelled = false;
+    const warm = (url: string, attempt: number) => {
+      const img = new Image();
+      img.decoding = "async";
+      img.onerror = () => {
+        if (cancelled) return;
+        if (attempt < 4) {
+          const delay = 500 * 2 ** attempt; // 0.5s, 1s, 2s, 4s
+          window.setTimeout(() => { if (!cancelled) warm(url, attempt + 1); }, delay);
+        } else {
+          // Give up warming for now, but let a future Server.Assets emit retry.
+          preloadedArt.delete(url);
+        }
+      };
+      img.src = url;
+    };
     for (const url of Object.values(state.serverAssets)) {
       if (typeof url !== "string" || url.startsWith("data:") || preloadedArt.has(url)) continue;
       preloadedArt.add(url);
-      const img = new Image();
-      img.decoding = "async";
-      img.src = url;
+      warm(url, 0);
     }
+    return () => { cancelled = true; };
   }, [state.serverAssets]);
 
   const sendCommand = (raw: string) => {

--- a/web-v3/src/canvas/systems/Minimap.ts
+++ b/web-v3/src/canvas/systems/Minimap.ts
@@ -107,6 +107,7 @@ export class Minimap {
   // Server-asset textures + the sprites that use them.
   private texCache = new Map<string, Texture>();
   private assetsLoaded = false;
+  private assetsLoading = false;
   private destroyed = false;
   private paperSprite: Sprite | null = null;
   private expandSprite: Sprite | null = null;
@@ -359,8 +360,10 @@ export class Minimap {
     if (!roomId) return;
 
     // Load the optional minimap textures once Server.Assets GMCP arrives.
-    if (!this.assetsLoaded && Object.keys(gameStateRef.current.serverAssets).length > 0) {
-      this.assetsLoaded = true;
+    // loadAssets() only latches assetsLoaded once every present key resolves, so
+    // a transient failure leaves it clear and the next room change retries the
+    // failed textures rather than pinning the procedural fallback for the session.
+    if (!this.assetsLoaded && !this.assetsLoading && Object.keys(gameStateRef.current.serverAssets).length > 0) {
       this.loadAssets();
     }
 
@@ -802,20 +805,34 @@ export class Minimap {
 
   /** Load all optional minimap textures from Server.Assets, then redraw. */
   private async loadAssets() {
+    if (this.assetsLoading) return;
+    this.assetsLoading = true;
     const sa = gameStateRef.current.serverAssets;
+    let allOk = true;
     await Promise.all(
       ASSET_KEYS.map(async (k) => {
         const url = sa[k];
-        if (!url) return;
+        if (!url) return; // no art supplied for this key — not a failure
+        if (this.texCache.has(k)) return; // already loaded on an earlier pass
         try {
           const tex = await loadTexture(url);
           if (this.destroyed) return;
           // Auto-trim the transparent margin off room/quest glyphs so the
           // artwork fills the node; the parchment scrap is left untouched.
           this.texCache.set(k, k === A_BG ? tex : (this.trimTexture(tex) ?? tex));
-        } catch { /* keep the procedural fallback for this key */ }
+        } catch {
+          // Transient failure (CDN/network): leave it uncached and don't latch
+          // assetsLoaded, so the next updateRoom() retries this key instead of
+          // pinning the procedural fallback for the whole session.
+          allOk = false;
+        }
       }),
     );
+
+    this.assetsLoading = false;
+    // Only consider the textures fully loaded once every present key resolved;
+    // a partial failure keeps the flag clear so a later room change retries.
+    if (allOk) this.assetsLoaded = true;
 
     // The whole Pixi app may have been torn down while assets were loading;
     // bail before touching the (now destroyed) container.


### PR DESCRIPTION
## Problem

Sometimes on game load, some painted images fail to load and never recover until a full page refresh.

## Root cause

Nothing in the client retried a failed image load, so a transient fetch failure during the login burst (CDN cold edge, dropped connection, HTTP/2 stream reset) became permanent for the lifetime of the page. Because art URLs are stable/content-hashed, a React re-render reuses the identical URL and the browser never re-fetches; the element stays on its CSS gradient fallback. A refresh works because it re-issues every request from scratch.

The service worker (`public/sw.js`) refuses to cache error responses, but it only intercepted **same-origin** requests — most painted art is served cross-origin from Cloudflare R2, so it bypassed the SW entirely and had no caching/retry safety net.

## Changes

**1. Preload retry (`App.tsx`)** — the preload added each URL to the module-level `preloadedArt` set *before* the `new Image()` load resolved, with no `onerror`, so a transient failure was never re-attempted. Now it retries with backoff (0.5/1/2/4s); a terminal failure drops the URL from the set so a later `Server.Assets` emit re-attempts it. Effect cleanup cancels pending retries.

**2. Minimap retry (`Minimap.ts`)** — it set `assetsLoaded = true` immediately (before the async `loadTexture` calls settled) and swallowed failures in an empty `catch`, pinning the procedural fallback. Now it only latches `assetsLoaded` once every present asset key resolves successfully; a partial failure leaves the flag clear so the next `updateRoom()` retries just the failed keys (already-cached keys are skipped). An `assetsLoading` in-flight guard prevents overlapping load passes.

**3. Service worker covers cross-origin CDN art (`sw.js`)** — extends stale-while-revalidate to cross-origin art so a cached copy survives a flaky network and a transient first-load failure stops being permanent. The SW can't read an opaque no-cors response's status, so it revalidates with a CORS request it *can* inspect (`cacheable` now accepts `type === 'cors'`) and only caches a verified 2xx. If the origin sends no CORS headers the CORS fetch rejects and it falls back to a plain opaque fetch that still loads but isn't cached — so art never breaks even without CORS. `CACHE_NAME` bumped to `v3` to purge older caches on activate.

Together: the preload/minimap retries make the first load more likely to succeed and warm the cache; the SW then keeps successfully-loaded art resilient to later network blips.

## Testing

- `bun run lint` — clean
- `bunx tsc -b` — clean

## Follow-up to confirm

The SW's CORS revalidation only caches cross-origin art if **R2 sends `Access-Control-Allow-Origin`**. If it doesn't, art still loads fine (opaque fallback) but won't be cached cross-origin — verify R2's CORS config to get the full caching benefit.