### PR TITLE
fix(webclient): stagger gathering node & item nameplates to avoid overlap

### DIFF
--- a/web-v3/src/canvas/scenes/WorldScene.ts
+++ b/web-v3/src/canvas/scenes/WorldScene.ts
@@ -1634,21 +1634,28 @@ export class WorldScene {
       const nodeSpacing = Math.min(itemSize + 16, itemAreaWidth / Math.max(1, nodeCount));
       const totalNodeWidth = (nodeCount - 1) * nodeSpacing;
       let nodeX = w / 2 - totalNodeWidth / 2;
+      // Vertical stagger so adjacent node labels don't collide, mirroring the
+      // mob label stagger. Cycles through up to 3 rows for 3+ nodes.
+      const nodeStaggerStep = nodeCount > 1 ? Math.min(32, itemSize * 0.26) : 0;
+      const nodeStaggerRows = Math.min(nodeCount, 3);
+      let nodeIdx = 0;
       for (const { sprite, label, labelBg, hitArea } of this.nodeSprites) {
+        const thisNodeY = nodeY + (nodeIdx % nodeStaggerRows) * nodeStaggerStep;
         sprite.x = nodeX;
-        sprite.y = nodeY;
+        sprite.y = thisNodeY;
         sprite.width = itemSize;
         sprite.height = itemSize;
         label.x = nodeX;
-        label.y = nodeY + itemSize / 2 + 4;
+        label.y = thisNodeY + itemSize / 2 + 4;
         drawLabelPill(labelBg, label);
 
         hitArea.clear();
         hitArea.rect(0, 0, itemSize, itemSize);
         hitArea.fill({ color: 0x000000, alpha: 0.001 });
         hitArea.x = nodeX - itemSize / 2;
-        hitArea.y = nodeY - itemSize / 2;
+        hitArea.y = thisNodeY - itemSize / 2;
         nodeX += nodeSpacing;
+        nodeIdx += 1;
       }
     }
 

--- a/web-v3/src/canvas/scenes/WorldScene.ts
+++ b/web-v3/src/canvas/scenes/WorldScene.ts
@@ -1610,20 +1610,27 @@ export class WorldScene {
       const itemSpacing = Math.min(itemSize + 16, itemAreaWidth / Math.max(1, itemCount));
       const totalItemWidth = (itemCount - 1) * itemSpacing;
       let itemX = w / 2 - totalItemWidth / 2;
+      // Vertical stagger so adjacent item labels don't collide, mirroring the
+      // mob label stagger. Cycles through up to 3 rows for 3+ items.
+      const itemStaggerStep = itemCount > 1 ? Math.min(32, itemSize * 0.26) : 0;
+      const itemStaggerRows = Math.min(itemCount, 3);
+      let itemIdx = 0;
       for (const { sprite, label, labelBg, hitArea } of this.itemSprites) {
+        const thisItemY = itemY + (itemIdx % itemStaggerRows) * itemStaggerStep;
         sprite.x = itemX;
-        sprite.y = itemY;
+        sprite.y = thisItemY;
         sprite.width = itemSize;
         sprite.height = itemSize;
         label.x = itemX;
-        label.y = itemY + itemSize / 2 + 4;
+        label.y = thisItemY + itemSize / 2 + 4;
         drawLabelPill(labelBg, label);
         hitArea.clear();
         hitArea.rect(0, 0, itemSize, itemSize);
         hitArea.fill({ color: 0x000000, alpha: 0.001 });
         hitArea.x = itemX - itemSize / 2;
-        hitArea.y = itemY - itemSize / 2;
+        hitArea.y = thisItemY - itemSize / 2;
         itemX += itemSpacing;
+        itemIdx += 1;
       }
     }
 


### PR DESCRIPTION
## Summary
Gathering nodes and room items were laid out in a single horizontal row with every nameplate at the same Y, so tightly-packed entities had colliding labels in the web client. Mobs already avoided this by cycling through up to 3 vertically-staggered rows.

This applies the same stagger to both gathering nodes and room items in `WorldScene.ts`: each entity's Y is offset by `(idx % 3) * step`, where `step = min(32, itemSize * 0.26)`, mirroring the existing mob logic. Sprite, label, and hit area all shift together so click targets stay aligned.

## Testing
- `bunx tsc --noEmit` — clean
- `bun run lint` — clean