### PR TITLE
fix(webclient): pin painted-panel labels to a solid serif (grey-text on hard refresh)

### DIFF
--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -1,6 +1,14 @@
 :root {
   /* ── Fonts ────────────────────────────────────────────── */
   --font-display: "Cormorant Garamond", "Georgia", serif;
+  /* Solid-serif companion for short labels painted directly onto parchment
+     (creature names, saved-character names). Cormorant Garamond is a delicate
+     high-contrast serif: at label sizes its thin strokes read as washed-out
+     grey, and because it loads cross-origin from Google Fonts a hard refresh
+     can swap between it and the heavier Georgia fallback, so the same label
+     looks grey on one load and black on the next. These labels pin the heavier
+     system serif (no web font, no swap) so they always read solid and dark. */
+  --font-display-solid: "Georgia", "Times New Roman", serif;
   --font-body: "Nunito Sans", "Segoe UI", sans-serif;
   --font-mono: "JetBrains Mono", "Cascadia Mono", monospace;
 
@@ -15198,7 +15206,7 @@ body {
   box-shadow: none;
   backdrop-filter: none;
   color: #45300f;
-  font-family: var(--font-display);
+  font-family: var(--font-display-solid);
   font-weight: 700;
   font-size: 2.6cqh;
 }
@@ -21273,7 +21281,7 @@ html:has(.game-shell),
 
 .mm-name {
   margin: 0;
-  font-family: var(--font-display);
+  font-family: var(--font-display-solid);
   font-size: 1.7rem;
   font-weight: 700;
   line-height: 1.1;
@@ -21294,7 +21302,7 @@ html:has(.game-shell),
 }
 
 .mm-meta {
-  font-family: var(--font-display);
+  font-family: var(--font-display-solid);
   font-size: 0.92rem;
   color: #6b5640;
   letter-spacing: 0.02em;


### PR DESCRIPTION
## Problem

Painted-panel labels — saved-character names on the welcome-back scene and the creature name on the Monster Manual — intermittently render **grey instead of black**, usually after a hard refresh and usually fixed by a normal refresh.

## Root cause (reproduced)

The text *color* is correct. What changes is the **font face**. These labels use `var(--font-display)` = **Cormorant Garamond**, a delicate high-contrast serif loaded cross-origin from Google Fonts with `display=swap`, no `preload`, and outside the service worker.

I reproduced it in a browser harness:
- Cormorant Garamond (loaded) → thin strokes read as **washed-out grey**.
- Georgia fallback → heavy strokes read as **solid black**.
- Weight 700 vs 400 within Cormorant barely differs — the dramatic flip is *Cormorant present vs. absent*.

On a hard reload the service worker is bypassed and the asset burst hits the network cold, so whether Cormorant is active (grey) or the page is still on the Georgia fallback (black) is non-deterministic — the same label looks grey on one load and black on the next.

## Fix

Per the chosen direction ("match the black fallback"), these labels now pin a new `--font-display-solid` token (`Georgia, "Times New Roman", serif` — a system serif, no web font, no swap) so they always render solid and dark regardless of network/cache state.

Applied to:
- `.mm-name`, `.mm-meta` (Monster Manual creature name + level/category)
- `.login-art-picker-list .character-picker-btn` (saved-character names on the painted welcome-back scene)

## Verification

- Browser harness: with Cormorant loaded, the patched labels resolve to `Georgia, "Times New Roman", serif` and match the solid-black fallback (no grey).
- `bun run lint` clean, `bun run build` clean.

## Notes / follow-up

- Scoped to the two reported surfaces. The same `--font-display-solid` token can be rolled out to other painted panels (auction, crafting, etc.) and to the Monster Manual description if you want the whole card to read solid — easy to extend.
- This does **not** change the broader cross-origin font-load fragility on hard refresh (other Cormorant text can still FOUT-flip weight). If you want that addressed too, self-hosting the fonts (same-origin + preload + SW cache) is the durable follow-up.