### PR TITLE
fix(webclient): self-host fonts instead of Google Fonts CDN

### DIFF
--- a/web-v3/bun.lock
+++ b/web-v3/bun.lock
@@ -5,6 +5,9 @@
     "": {
       "name": "web-v3",
       "dependencies": {
+        "@fontsource/cormorant-garamond": "^5.2.11",
+        "@fontsource/jetbrains-mono": "^5.2.8",
+        "@fontsource/nunito-sans": "^5.2.7",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "pixi.js": "^8.16.0",
@@ -136,6 +139,12 @@
     "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@fontsource/cormorant-garamond": ["@fontsource/cormorant-garamond@5.2.11", "", {}, "sha512-5JjpN023lhA5soijgVT0BdRGzmlijm402ppjccMd6h+vRE0mX2lJnE+41UPfnlidrkV9/rCo1mf58WZlHnB0CA=="],
+
+    "@fontsource/jetbrains-mono": ["@fontsource/jetbrains-mono@5.2.8", "", {}, "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ=="],
+
+    "@fontsource/nunito-sans": ["@fontsource/nunito-sans@5.2.7", "", {}, "sha512-Vh+xhMsrH1eA9Q83Va82su3rDmNilYg+ur/TfHAOyr5kTpCOWMB8B1tDoJvSe+yJPpZ2jEWtnBHGqI2LUPVxUA=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 

--- a/web-v3/index.html
+++ b/web-v3/index.html
@@ -12,12 +12,8 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16.png" />
     <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Nunito+Sans:wght@400;600;700;800&display=swap"
-      rel="stylesheet"
-    />
+    <!-- Fonts are self-hosted and bundled (see src/main.tsx), not loaded from
+         Google Fonts, so a hard refresh can't orphan them on a flaky CDN. -->
     <title>AmbonMUD</title>
   </head>
   <body>

--- a/web-v3/package.json
+++ b/web-v3/package.json
@@ -11,6 +11,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fontsource/cormorant-garamond": "^5.2.11",
+    "@fontsource/jetbrains-mono": "^5.2.8",
+    "@fontsource/nunito-sans": "^5.2.7",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "pixi.js": "^8.16.0",

--- a/web-v3/src/main.tsx
+++ b/web-v3/src/main.tsx
@@ -1,5 +1,23 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+// Self-hosted fonts, replacing the Google Fonts <link> in index.html. Bundled
+// into the build and served same-origin from /assets/, so a hard refresh can't
+// orphan them on a flaky cross-origin CDN (the failure mode that made painted
+// text flip grey/black), and the service worker's cache-first /assets/ rule
+// already covers them with no SW change. Weights match the old request exactly
+// (normal style only — it had no italics); the @fontsource static packages
+// register the canonical family names ("Cormorant Garamond", etc.) the CSS and
+// canvas/xterm code already reference, so nothing else changes.
+import "@fontsource/cormorant-garamond/500.css";
+import "@fontsource/cormorant-garamond/600.css";
+import "@fontsource/cormorant-garamond/700.css";
+import "@fontsource/nunito-sans/400.css";
+import "@fontsource/nunito-sans/600.css";
+import "@fontsource/nunito-sans/700.css";
+import "@fontsource/nunito-sans/800.css";
+import "@fontsource/jetbrains-mono/400.css";
+import "@fontsource/jetbrains-mono/500.css";
+import "@fontsource/jetbrains-mono/600.css";
 import App from "./App.tsx";
 
 // Preload the painted background for whichever login screen shows first, so it


### PR DESCRIPTION
## Why

Follow-up to #1347. That PR pinned the worst-hit painted labels to a system serif to stop them flipping grey/black on hard refresh. The underlying fragility was that **all** the UI fonts (Cormorant Garamond, Nunito Sans, JetBrains Mono) loaded cross-origin from Google Fonts via a `<link>` in `index.html` — no preload, outside the service worker. On a hard reload the SW is bypassed and the asset burst hits the network cold, so the font load could fail/lag transiently and text rendered in the fallback face.

This removes that dependency entirely so every Cormorant heading (not just the two surfaces #1347 patched) renders reliably.

## What

- Self-host via `@fontsource` packages, imported in `src/main.tsx`.
- Remove the Google Fonts `<link>` + the two `preconnect`s from `index.html`.

Fonts now bundle into `/assets/` and serve **same-origin**, so a hard refresh fetches them from the app's own origin (up, since the page loaded) instead of a flaky cross-origin CDN, and the service worker's existing **cache-first `/assets/` rule covers them with no SW change**.

### Why the *static* (not variable) packages
The `@fontsource-variable/*` packages register the family under a `"… Variable"` name, which wouldn't match the bare names the CSS tokens, direct CSS rules, ~50 PixiJS canvas labels, and xterm all reference. The static packages keep the canonical names (`Cormorant Garamond`, `Nunito Sans`, `JetBrains Mono`), so **nothing else changes**. Weights match the old request exactly (500/600/700, 400/600/700/800, 400/500/600; normal style, no italics).

## Verification

Against the production build (`vite preview`), in a browser:
- **Zero** requests to `fonts.googleapis.com` / `fonts.gstatic.com`.
- All three families register under canonical names; `document.fonts.load('700 24px "Cormorant Garamond"')` resolves and fetches `/assets/cormorant-garamond-latin-700-normal-*.woff2` from same-origin.
- `bun run lint` + `bun run build` clean.

## Notes

- Build emits all subset woff2 (unicode-range gated, same as Google's CSS); browsers only download `latin` for these weights. Build output is gitignored.
- Leaves the stale `package-lock.json` untouched — the build uses bun (`bun run build`, `bun.lock` is the gradle `buildWeb` input); that npm lockfile hasn't been updated since March and isn't the source of truth.
- Optional future polish: an explicit `<link rel=preload>` for the display weight (skipped because Vite content-hashes the filename).