### PR TITLE
feat(engine): racial passive ability subsystem (9 races)

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -197,6 +197,22 @@ data class AppConfig(
                     "$prefix.triggerHealthPct must be 1..100 for low-health ability '$kind'"
                 }
             }
+            // Fields whose absence makes the ability silently do nothing at runtime (the system
+            // bails out early when they are missing) are required up front so a misconfigured race
+            // fails fast at boot rather than no-op'ing mid-fight.
+            when (kind) {
+                dev.ambon.domain.RacialAbilityKind.AURELIA_DAZZLE ->
+                    require(!ability.stunStatusId.isNullOrBlank()) {
+                        "$prefix.stunStatusId is required for '$kind'"
+                    }
+                dev.ambon.domain.RacialAbilityKind.MYCORAE_SPORES,
+                dev.ambon.domain.RacialAbilityKind.ARCHAE_DRENGARIAE,
+                ->
+                    require(!ability.petTemplateKey.isNullOrBlank()) {
+                        "$prefix.petTemplateKey is required for '$kind'"
+                    }
+                else -> Unit
+            }
         }
     }
 

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -199,18 +199,49 @@ data class AppConfig(
             }
             // Fields whose absence makes the ability silently do nothing at runtime (the system
             // bails out early when they are missing) are required up front so a misconfigured race
-            // fails fast at boot rather than no-op'ing mid-fight.
+            // fails fast at boot rather than no-op'ing mid-fight. References must also resolve to a
+            // real definition of the right shape — the most likely production slip is carrying the
+            // racialAbility block into an overlay but forgetting its pet template / status effect.
             when (kind) {
-                dev.ambon.domain.RacialAbilityKind.AURELIA_DAZZLE ->
-                    require(!ability.stunStatusId.isNullOrBlank()) {
-                        "$prefix.stunStatusId is required for '$kind'"
+                dev.ambon.domain.RacialAbilityKind.AURELIA_DAZZLE -> {
+                    val statusId = ability.stunStatusId
+                    require(!statusId.isNullOrBlank()) { "$prefix.stunStatusId is required for '$kind'" }
+                    val def = engine.statusEffects.definitions[statusId]
+                    require(def != null) {
+                        "$prefix.stunStatusId '$statusId' is not a defined status effect " +
+                            "(ambonMUD.engine.statusEffects.definitions)"
                     }
+                    require(def.effectType == "stun") {
+                        "$prefix.stunStatusId '$statusId' must have effectType 'stun' to stun enemies, " +
+                            "got '${def.effectType}'"
+                    }
+                }
+                dev.ambon.domain.RacialAbilityKind.LITHAE_STONEFORM -> {
+                    // stoneStatusId is optional (the root is a nicety on top of disengage), but if
+                    // set it must resolve to a real 'root' effect, else the player stays mobile.
+                    val statusId = ability.stoneStatusId
+                    if (!statusId.isNullOrBlank()) {
+                        val def = engine.statusEffects.definitions[statusId]
+                        require(def != null) {
+                            "$prefix.stoneStatusId '$statusId' is not a defined status effect " +
+                                "(ambonMUD.engine.statusEffects.definitions)"
+                        }
+                        require(def.effectType == "root") {
+                            "$prefix.stoneStatusId '$statusId' must have effectType 'root' to root the player, " +
+                                "got '${def.effectType}'"
+                        }
+                    }
+                }
                 dev.ambon.domain.RacialAbilityKind.MYCORAE_SPORES,
                 dev.ambon.domain.RacialAbilityKind.ARCHAE_DRENGARIAE,
-                ->
-                    require(!ability.petTemplateKey.isNullOrBlank()) {
-                        "$prefix.petTemplateKey is required for '$kind'"
+                -> {
+                    val templateKey = ability.petTemplateKey
+                    require(!templateKey.isNullOrBlank()) { "$prefix.petTemplateKey is required for '$kind'" }
+                    require(engine.pets.definitions.containsKey(templateKey)) {
+                        "$prefix.petTemplateKey '$templateKey' is not a defined pet template " +
+                            "(ambonMUD.engine.pets.definitions)"
                     }
+                }
                 else -> Unit
             }
         }

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -133,6 +133,7 @@ data class AppConfig(
         validateEngineHousing()
         validateEngineCharacterCreation()
         validateEngineClasses()
+        validateEngineRaces()
         validateEngineStats()
         validateEngineAbilities()
         validateEngineStatusEffects()
@@ -169,6 +170,31 @@ data class AppConfig(
             if (dq.weeklySlots > 0) {
                 require(dq.weeklyPool.size >= dq.weeklySlots) {
                     "ambonMUD.engine.dailyQuests.weeklyPool must have at least ${dq.weeklySlots} entries (weeklySlots)"
+                }
+            }
+        }
+    }
+
+    private fun validateEngineRaces() {
+        val validKinds = dev.ambon.domain.RacialAbilityKind.entries.map { it.name }.toSet()
+        engine.races.definitions.forEach { (raceId, raceDef) ->
+            val ability = raceDef.racialAbility ?: return@forEach
+            val prefix = "ambonMUD.engine.races.definitions.$raceId.racialAbility"
+            require(ability.kind.uppercase() in validKinds) {
+                "$prefix.kind must be one of $validKinds, got '${ability.kind}'"
+            }
+            require(ability.cooldownMs >= 0L) { "$prefix.cooldownMs must be >= 0" }
+            require(ability.triggerHealthPct in 0..100) { "$prefix.triggerHealthPct must be 0..100" }
+            require(ability.damageMultiplier >= 0.0) { "$prefix.damageMultiplier must be >= 0" }
+            require(ability.aoeDamagePctOfMaxHp >= 0.0) { "$prefix.aoeDamagePctOfMaxHp must be >= 0" }
+            require(ability.regenPctOfMaxHp >= 0.0) { "$prefix.regenPctOfMaxHp must be >= 0" }
+            require(ability.petCountMin >= 1) { "$prefix.petCountMin must be >= 1" }
+            require(ability.petCountMax >= ability.petCountMin) { "$prefix.petCountMax must be >= petCountMin" }
+            require(ability.phaseTicks >= 1) { "$prefix.phaseTicks must be >= 1" }
+            val kind = dev.ambon.domain.RacialAbilityKind.valueOf(ability.kind.uppercase())
+            if (kind.trigger == dev.ambon.domain.RacialTrigger.LOW_HEALTH) {
+                require(ability.triggerHealthPct in 1..100) {
+                    "$prefix.triggerHealthPct must be 1..100 for low-health ability '$kind'"
                 }
             }
         }
@@ -2563,6 +2589,33 @@ data class RaceDefinitionConfig(
     val abilities: List<String> = emptyList(),
     val image: String = "",
     val statMods: Map<String, Int> = emptyMap(),
+    /** Optional race-specific passive ability (low-health / lethal-blow trigger). */
+    val racialAbility: RacialAbilityConfig? = null,
+)
+
+/**
+ * Tunable knobs for a race's passive ability. [kind] selects the mechanic (must match a
+ * `RacialAbilityKind` name); the remaining fields are read only by the kinds that use them.
+ */
+data class RacialAbilityConfig(
+    val kind: String = "",
+    val displayName: String = "",
+    val cooldownMs: Long = 120_000L,
+    val triggerHealthPct: Int = 0,
+    val aoeDamagePctOfMaxHp: Double = 0.0,
+    val damageMultiplier: Double = 1.0,
+    val buffDurationMs: Long = 0L,
+    val stunStatusId: String? = null,
+    val petTemplateKey: String? = null,
+    val petCountMin: Int = 1,
+    val petCountMax: Int = 1,
+    val petDurationMs: Long = 0L,
+    val regenPctOfMaxHp: Double = 0.0,
+    val stoneStatusId: String? = null,
+    val stoneDurationMs: Long = 0L,
+    val phaseTicks: Int = 2,
+    val selfMessage: String = "",
+    val roomMessage: String = "",
 )
 
 data class RaceEngineConfig(

--- a/src/main/kotlin/dev/ambon/domain/RaceDef.kt
+++ b/src/main/kotlin/dev/ambon/domain/RaceDef.kt
@@ -9,4 +9,6 @@ data class RaceDef(
     val abilities: List<String> = emptyList(),
     val image: String = "",
     val statMods: StatMap = StatMap.EMPTY,
+    /** Optional race-specific passive ability triggered by low health or a would-be-lethal blow. */
+    val racialAbility: RacialAbility? = null,
 )

--- a/src/main/kotlin/dev/ambon/domain/RacialAbility.kt
+++ b/src/main/kotlin/dev/ambon/domain/RacialAbility.kt
@@ -1,0 +1,92 @@
+package dev.ambon.domain
+
+/**
+ * When a racial passive ability fires.
+ *
+ * - [LOW_HEALTH] effects fire reactively after the player survives a hit and their HP has dropped
+ *   to or below [RacialAbility.triggerHealthPct] of max. They turn a losing fight around.
+ * - [LETHAL_BLOW] effects intercept an incoming attack that *would* reduce the player to 0 HP and
+ *   transform or negate it, so the player cheats death once per cooldown.
+ */
+enum class RacialTrigger {
+    LOW_HEALTH,
+    LETHAL_BLOW,
+}
+
+/**
+ * The distinct race-specific passive abilities. Each kind maps to one bespoke mechanic resolved by
+ * `RacialAbilitySystem`; the [trigger] determines which combat hook invokes it. Config supplies the
+ * tunable numbers (thresholds, cooldowns, multipliers) — the kind only selects the behaviour.
+ */
+enum class RacialAbilityKind(val trigger: RacialTrigger) {
+    /** Pyrae: explode in flames, dealing area damage to every enemy in combat with the player. */
+    PYRAE_IMMOLATE(RacialTrigger.LOW_HEALTH),
+
+    /** Lustriae: slip through time for an extra attack; survive if that attack kills the attacker. */
+    LUSTRIAE_TIMESLIP(RacialTrigger.LETHAL_BLOW),
+
+    /** Aurelia: a dazzling bioluminescent burst that stuns nearby enemies for a few rounds. */
+    AURELIA_DAZZLE(RacialTrigger.LOW_HEALTH),
+
+    /** Lithae: petrify into stone form — disengage, become untargetable, regenerate, can't move. */
+    LITHAE_STONEFORM(RacialTrigger.LETHAL_BLOW),
+
+    /** Mycorae: release spores that spawn a few short-lived taunting mushroom pets. */
+    MYCORAE_SPORES(RacialTrigger.LOW_HEALTH),
+
+    /** Kitsarae: nullify a killing blow and convert it into a heal of equal magnitude. */
+    KITSARAE_REVERSAL(RacialTrigger.LETHAL_BLOW),
+
+    /** Archae: call the Drengariae — a short-lived combat pet that fights alongside the player. */
+    ARCHAE_DRENGARIAE(RacialTrigger.LOW_HEALTH),
+
+    /** Ophirae: draconic fury — outgoing damage is multiplied for a short duration. */
+    OPHIRAE_WRATH(RacialTrigger.LOW_HEALTH),
+
+    /** Aetherae: phase out of existence, ignoring the killing blow and the next round's damage. */
+    AETHERAE_PHASE(RacialTrigger.LETHAL_BLOW),
+}
+
+/**
+ * A resolved racial passive ability attached to a [RaceDef]. All numeric knobs are config-driven so
+ * the same nine mechanics can be retuned per deployment without code changes. Fields not relevant to
+ * a given [kind] keep their harmless defaults.
+ */
+data class RacialAbility(
+    val kind: RacialAbilityKind,
+    val displayName: String,
+    /** Cooldown before the ability can fire again. Persisted on the player so a relog can't reset it. */
+    val cooldownMs: Long,
+    /** LOW_HEALTH only: fires once the player's HP is at or below this percent (1..100) of max. */
+    val triggerHealthPct: Int = 0,
+    /** Pyrae: AoE damage dealt to each enemy, as a fraction of the player's max HP. */
+    val aoeDamagePctOfMaxHp: Double = 0.0,
+    /** Ophirae: outgoing-damage multiplier while the wrath buff is active. */
+    val damageMultiplier: Double = 1.0,
+    /** Ophirae: how long the wrath buff lasts. */
+    val buffDurationMs: Long = 0L,
+    /** Aurelia: status-effect id (of effectType "stun") applied to enemies. Duration lives on the effect. */
+    val stunStatusId: String? = null,
+    /** Mycorae/Archae: pet template key to summon. */
+    val petTemplateKey: String? = null,
+    /** Mycorae: inclusive lower bound on the number of pets spawned. */
+    val petCountMin: Int = 1,
+    /** Mycorae: inclusive upper bound on the number of pets spawned. */
+    val petCountMax: Int = 1,
+    /** Mycorae/Archae: how long the summoned pets live before despawning. */
+    val petDurationMs: Long = 0L,
+    /** Lithae: HP restored on entering stone form, as a fraction of max HP. */
+    val regenPctOfMaxHp: Double = 0.0,
+    /** Lithae: status-effect id (of effectType "root") applied to self so the player can't move. */
+    val stoneStatusId: String? = null,
+    /** Lithae: how long the player stays untargetable in stone form. */
+    val stoneDurationMs: Long = 0L,
+    /** Aetherae: number of combat rounds the player stays phased/untargetable after the blow. */
+    val phaseTicks: Int = 2,
+    /** Message shown to the triggering player. */
+    val selfMessage: String = "",
+    /** Message broadcast to others in the room ({player} is substituted). */
+    val roomMessage: String = "",
+) {
+    val trigger: RacialTrigger get() = kind.trigger
+}

--- a/src/main/kotlin/dev/ambon/domain/RacialAbility.kt
+++ b/src/main/kotlin/dev/ambon/domain/RacialAbility.kt
@@ -18,7 +18,9 @@ enum class RacialTrigger {
  * `RacialAbilitySystem`; the [trigger] determines which combat hook invokes it. Config supplies the
  * tunable numbers (thresholds, cooldowns, multipliers) — the kind only selects the behaviour.
  */
-enum class RacialAbilityKind(val trigger: RacialTrigger) {
+enum class RacialAbilityKind(
+    val trigger: RacialTrigger,
+) {
     /** Pyrae: explode in flames, dealing area damage to every enemy in combat with the player. */
     PYRAE_IMMOLATE(RacialTrigger.LOW_HEALTH),
 

--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -818,6 +818,10 @@ class CombatSystem(
         broadcastToRoom(players, outbound, mob.roomId, hitText, exclude = sessionId)
         if (mob.hp <= 0) {
             handleMobDeath(sessionId, mob)
+            // handleMobDeath drops this mob from playerTarget, so the mob-attack phase's later
+            // prompt sweep won't cover it. Prompt here (like the player/pet kill paths) so a racial
+            // proc that ends combat still leaves the triggering client with a fresh prompt.
+            outbound.send(OutboundEvent.SendPrompt(sessionId))
         }
     }
 
@@ -1059,9 +1063,12 @@ class CombatSystem(
                 continue
             }
 
-            // Stunned mobs (e.g. Aurelia's dazzle) forfeit their attack but stay in combat.
+            // Stunned mobs (e.g. Aurelia's dazzle) forfeit their attack but stay in combat. Still
+            // advance the tick and prompt targeting players, otherwise prompt-driven clients look
+            // idle through every stunned round even though combat is ongoing.
             if (statusEffects?.hasMobEffect(mob.id, "stun") == true) {
                 mobState.nextTickAtMs = now + config.tickMillis
+                promptPlayersTargeting(mobState.mobId)
                 continue
             }
 
@@ -1090,6 +1097,7 @@ class CombatSystem(
                     }
                 if (phasedPresent) {
                     mobState.nextTickAtMs = now + config.tickMillis
+                    promptPlayersTargeting(mobState.mobId)
                     continue
                 }
                 removeMobFromCombat(mobState.mobId)
@@ -1152,15 +1160,19 @@ class CombatSystem(
             }
 
             mobState.nextTickAtMs = now + config.tickMillis
-            // Send prompt to all players targeting this mob
-            for ((sid, mid) in playerTarget) {
-                if (mid == mobState.mobId) {
-                    outbound.send(OutboundEvent.SendPrompt(sid))
-                }
-            }
+            promptPlayersTargeting(mobState.mobId)
             ran++
         }
         return ran
+    }
+
+    /** Sends a prompt to every player whose current combat target is [mobId]. */
+    private suspend fun promptPlayersTargeting(mobId: MobId) {
+        for ((sid, mid) in playerTarget) {
+            if (mid == mobId) {
+                outbound.send(OutboundEvent.SendPrompt(sid))
+            }
+        }
     }
 
     /**

--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -97,7 +97,8 @@ class CombatSystem(
     private val classRegistry: PlayerClassRegistry? = null,
     private val petSystem: PetSystem? = null,
     private val racialAbilitySystem: RacialAbilitySystem? = null,
-) : GameSystem, RacialCombatBridge {
+) : GameSystem,
+    RacialCombatBridge {
     /** Callback for combat events; wired by GameEngine after construction. */
     var onCombatEvent: suspend (SessionId, CombatEvent) -> Unit = { _, _ -> }
 

--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -96,7 +96,8 @@ class CombatSystem(
     private val callbacks: CombatSystemCallbacks = CombatSystemCallbacks(),
     private val classRegistry: PlayerClassRegistry? = null,
     private val petSystem: PetSystem? = null,
-) : GameSystem {
+    private val racialAbilitySystem: RacialAbilitySystem? = null,
+) : GameSystem, RacialCombatBridge {
     /** Callback for combat events; wired by GameEngine after construction. */
     var onCombatEvent: suspend (SessionId, CombatEvent) -> Unit = { _, _ -> }
 
@@ -791,6 +792,79 @@ class CombatSystem(
         }
     }
 
+    // ── RacialCombatBridge ───────────────────────────────────────────────
+    // Combat-internal operations the RacialAbilitySystem invokes (Pyrae AoE, Lustriae extra swing,
+    // Lithae disengage, room broadcasts). See RacialCombatBridge for contracts.
+
+    override fun enemiesInCombatWith(sessionId: SessionId): List<MobState> {
+        val player = players.get(sessionId) ?: return emptyList()
+        return threatTable.mobsThreatenedBy(sessionId)
+            .mapNotNull { mobs.get(it) }
+            .filter { !it.isPet && it.hp > 0 && it.roomId == player.roomId }
+    }
+
+    override suspend fun dealRacialDamage(
+        sessionId: SessionId,
+        mob: MobState,
+        damage: Int,
+        hitText: String,
+    ) {
+        val player = players.get(sessionId) ?: return
+        mob.takeDamage(damage)
+        dirtyNotifier.mobHpDirty(mob.id)
+        threatTable.addThreat(mob.id, sessionId, damage.toDouble() * threatMultiplier(player))
+        outbound.send(OutboundEvent.SendText(sessionId, hitText))
+        broadcastToRoom(players, outbound, mob.roomId, hitText, exclude = sessionId)
+        if (mob.hp <= 0) {
+            handleMobDeath(sessionId, mob)
+        }
+    }
+
+    override suspend fun extraMeleeSwing(
+        sessionId: SessionId,
+        mob: MobState,
+    ): Boolean {
+        val player = players.get(sessionId) ?: return false
+        if (mob.hp <= 0) return true
+        val stats = resolvePlayerStats(player, items, statusEffects, classRegistry)
+        val equip = items.equipmentBonuses(sessionId, classRegistry?.get(player.playerClass))
+        val swing = rollPlayerMeleeSwing(player, stats, equip, mob.armor)
+        val damage = swing.final
+        mob.takeDamage(damage)
+        dirtyNotifier.mobHpDirty(mob.id)
+        threatTable.addThreat(mob.id, sessionId, damage.toDouble() * threatMultiplier(player))
+        val hitText = "You slip through time and strike ${mob.name} for $damage damage!"
+        outbound.send(OutboundEvent.SendText(sessionId, hitText))
+        onCombatEvent(
+            sessionId,
+            CombatEvent.MeleeHit(
+                targetName = mob.name,
+                targetId = mob.id.value,
+                damage = damage,
+                sourceIsPlayer = true,
+                text = hitText,
+            ),
+        )
+        broadcastToRoom(players, outbound, mob.roomId, hitText, exclude = sessionId)
+        val killed = mob.hp <= 0
+        if (killed) {
+            handleMobDeath(sessionId, mob)
+        }
+        return killed
+    }
+
+    override fun disengageFromCombat(sessionId: SessionId) {
+        removePlayerFromCombat(sessionId)
+    }
+
+    override suspend fun broadcastToRoomExcept(
+        sessionId: SessionId,
+        text: String,
+    ) {
+        val player = players.get(sessionId) ?: return
+        broadcastToRoom(players, outbound, player.roomId, text, exclude = sessionId)
+    }
+
     @Suppress("CyclomaticComplexity", "LongMethod")
     suspend fun tick(maxCombatsPerTick: Int = 20): Int {
         val now = clock.millis()
@@ -847,7 +921,9 @@ class CombatSystem(
             if (!stunned && !player.isAkathavae) {
                 val playerStats = resolvePlayerStats(player, items, statusEffects, classRegistry)
                 val swing = rollPlayerMeleeSwing(player, playerStats, playerBonuses, mob.armor)
-                val effectivePlayerDamage = swing.final
+                // Ophirae wrath (and any future damage buff) multiplies outgoing melee damage.
+                val effectivePlayerDamage =
+                    (swing.final * player.outgoingDamageMultiplier(now)).roundToInt().coerceAtLeast(1)
                 val playerFeedbackSuffix =
                     combatFeedbackSuffix(
                         roll = swing.raw,
@@ -909,57 +985,62 @@ class CombatSystem(
                 if (now < mobCombatState.nextTickAtMs) continue
                 val mob = mobs.get(mobId) ?: continue
                 if (mob.hp <= 0) continue
-                val pet = petSystem.getActivePet(sessionId) ?: continue
-                if (pet.roomId != mob.roomId) continue
+                // Every pet the owner controls attacks (a single companion is the common case; the
+                // Mycorae spore swarm and other multi-summons all act, and tank pets each build
+                // threat so a wall of mushrooms actually holds aggro).
+                for (pet in petSystem.getPets(sessionId)) {
+                    if (mob.hp <= 0) break
+                    if (pet.roomId != mob.roomId) continue
 
-                val autoSkill =
-                    if (petSystem.isManualGraceActive(sessionId, now)) {
-                        null
-                    } else {
-                        selectPetSkill(pet, now)
+                    val autoSkill =
+                        if (petSystem.isManualGraceActive(sessionId, now)) {
+                            null
+                        } else {
+                            selectPetSkill(pet, now)
+                        }
+
+                    if (autoSkill != null) {
+                        executePetSkill(pet, autoSkill, mob, sessionId, now)
+                        onPetSkillCast(sessionId)
+                        continue
                     }
 
-                if (autoSkill != null) {
-                    executePetSkill(pet, autoSkill, mob, sessionId, now)
-                    onPetSkillCast(sessionId)
-                    continue
-                }
+                    val petRoll = rollRange(rng, pet.damage.min, pet.damage.max)
+                    val petDamage = (petRoll - mob.armor).coerceAtLeast(1)
+                    mob.takeDamage(petDamage)
+                    dirtyNotifier.mobHpDirty(mob.id)
+                    val petHitText = "${pet.name} hits ${mob.name} for $petDamage damage."
+                    outbound.send(OutboundEvent.SendText(sessionId, petHitText))
+                    onCombatEvent(
+                        sessionId,
+                        CombatEvent.PetHit(
+                            petName = pet.name,
+                            targetName = mob.name,
+                            targetId = mob.id.value,
+                            damage = petDamage,
+                            text = petHitText,
+                        ),
+                    )
+                    broadcastToRoom(
+                        players,
+                        outbound,
+                        mob.roomId,
+                        petHitText,
+                        exclude = sessionId,
+                    )
 
-                val petRoll = rollRange(rng, pet.damage.min, pet.damage.max)
-                val petDamage = (petRoll - mob.armor).coerceAtLeast(1)
-                mob.takeDamage(petDamage)
-                dirtyNotifier.mobHpDirty(mob.id)
-                val petHitText = "${pet.name} hits ${mob.name} for $petDamage damage."
-                outbound.send(OutboundEvent.SendText(sessionId, petHitText))
-                onCombatEvent(
-                    sessionId,
-                    CombatEvent.PetHit(
-                        petName = pet.name,
-                        targetName = mob.name,
-                        targetId = mob.id.value,
-                        damage = petDamage,
-                        text = petHitText,
-                    ),
-                )
-                broadcastToRoom(
-                    players,
-                    outbound,
-                    mob.roomId,
-                    petHitText,
-                    exclude = sessionId,
-                )
-
-                // Tank pets generate threat so mobs target them instead of the player.
-                if (pet.threatMultiplier > 0.0) {
-                    val petSid = petSystem.getPetSessionId(pet.id)
-                    if (petSid != null) {
-                        threatTable.addThreat(mob.id, petSid, petDamage.toDouble() * pet.threatMultiplier)
+                    // Tank pets generate threat so mobs target them instead of the player.
+                    if (pet.threatMultiplier > 0.0) {
+                        val petSid = petSystem.getPetSessionId(pet.id)
+                        if (petSid != null) {
+                            threatTable.addThreat(mob.id, petSid, petDamage.toDouble() * pet.threatMultiplier)
+                        }
                     }
-                }
 
-                if (mob.hp <= 0) {
-                    handleMobDeath(sessionId, mob)
-                    outbound.send(OutboundEvent.SendPrompt(sessionId))
+                    if (mob.hp <= 0) {
+                        handleMobDeath(sessionId, mob)
+                        outbound.send(OutboundEvent.SendPrompt(sessionId))
+                    }
                 }
             }
         }
@@ -977,12 +1058,19 @@ class CombatSystem(
                 continue
             }
 
-            // Pick target = highest threat in same room (includes pet synthetic SIDs)
+            // Stunned mobs (e.g. Aurelia's dazzle) forfeit their attack but stay in combat.
+            if (statusEffects?.hasMobEffect(mob.id, "stun") == true) {
+                mobState.nextTickAtMs = now + config.tickMillis
+                continue
+            }
+
+            // Pick target = highest threat in same room (includes pet synthetic SIDs), skipping
+            // players who are currently untargetable (Aetherae phase / Lithae stone form).
             val targetSid =
                 threatTable.topThreatInRoom(mobState.mobId) { sid ->
                     val p = players.get(sid)
                     if (p != null) {
-                        p.roomId == mob.roomId
+                        p.roomId == mob.roomId && !p.isUntargetable(now)
                     } else {
                         // Check if it's a tank pet in the same room
                         val pet = petSystem?.getPetBySession(sid)
@@ -991,7 +1079,18 @@ class CombatSystem(
                 }
 
             if (targetSid == null) {
-                // No valid targets — mob exits combat
+                // No targetable foe. If a phased player is still present and holding threat, the mob
+                // simply whiffs this round rather than leaving combat — so it resumes attacking once
+                // the phase ends. Otherwise the room is genuinely clear and the mob disengages.
+                val phasedPresent =
+                    threatTable.playersThreateningMob(mobState.mobId).any { sid ->
+                        val p = players.get(sid)
+                        p != null && p.roomId == mob.roomId && p.isUntargetable(now)
+                    }
+                if (phasedPresent) {
+                    mobState.nextTickAtMs = now + config.tickMillis
+                    continue
+                }
                 removeMobFromCombat(mobState.mobId)
                 continue
             }
@@ -1002,33 +1101,51 @@ class CombatSystem(
                 executeMobMeleeOnPet(mob, targetPet, targetSid)
             } else {
                 val target = players.get(targetSid) ?: continue
+                val preHitHp = target.hp
 
                 // Pick a spell from the mob's pool (excluding defaultAttack), or fall back.
                 val chosenSpell = selectMobSpell(mob, now)
-                if (chosenSpell != null) {
-                    executeMobSpell(chosenSpell, mob, target, targetSid, now)
-                } else {
-                    // Use defaultAttack spell or standard melee.
-                    val defaultSpell = mob.defaultAttack?.let { id -> mob.spells.find { it.id == id } }
-                    if (defaultSpell != null) {
-                        executeMobSpell(defaultSpell, mob, target, targetSid, now)
+                val blowDamage =
+                    if (chosenSpell != null) {
+                        executeMobSpell(chosenSpell, mob, target, targetSid, now)
                     } else {
-                        executeMobMelee(mob, target, targetSid)
+                        // Use defaultAttack spell or standard melee.
+                        val defaultSpell = mob.defaultAttack?.let { id -> mob.spells.find { it.id == id } }
+                        if (defaultSpell != null) {
+                            executeMobSpell(defaultSpell, mob, target, targetSid, now)
+                        } else {
+                            executeMobMelee(mob, target, targetSid)
+                        }
                     }
-                }
 
                 if (target.hp <= 0) {
-                    metrics.onPlayerDeath()
-                    removePlayerFromCombat(targetSid)
-                    handlePlayerDeath(
-                        sessionId = targetSid,
-                        playerName = target.name,
-                        roomId = target.roomId,
-                        deathMessage = "You have been slain by ${mob.name}.",
-                        roomMessage = "${target.name} has been slain by ${mob.name}.",
-                        killerName = mob.name,
-                    )
+                    // Give a lethal-blow racial passive the chance to cheat death before we kill them.
+                    val survived =
+                        racialAbilitySystem?.tryPreventLethalBlow(
+                            sessionId = targetSid,
+                            player = target,
+                            attacker = mob,
+                            blowDamage = blowDamage,
+                            preHitHp = preHitHp,
+                            nowMs = now,
+                        ) ?: false
+                    if (survived) {
+                        outbound.send(OutboundEvent.SendPrompt(targetSid))
+                    } else {
+                        metrics.onPlayerDeath()
+                        removePlayerFromCombat(targetSid)
+                        handlePlayerDeath(
+                            sessionId = targetSid,
+                            playerName = target.name,
+                            roomId = target.roomId,
+                            deathMessage = "You have been slain by ${mob.name}.",
+                            roomMessage = "${target.name} has been slain by ${mob.name}.",
+                            killerName = mob.name,
+                        )
+                    }
                 } else {
+                    // Survived the hit — fire a low-health racial passive before wimpy auto-flee.
+                    racialAbilitySystem?.onPlayerSurvivedHit(targetSid, target, now)
                     checkWimpyAutoFlee(targetSid, target)
                 }
             }
@@ -1089,6 +1206,8 @@ class CombatSystem(
     /**
      * Executes a mob spell against a target player (or as a self-heal/buff).
      * Handles dodge checks for offensive spells, damage, healing, and status effects.
+     * Returns the damage dealt to the player (0 for dodges, heals, and pure-buff spells) so the
+     * caller can resolve lethal-blow racial passives that need to know the killing blow's magnitude.
      */
     private suspend fun executeMobSpell(
         spell: MobSpell,
@@ -1096,7 +1215,8 @@ class CombatSystem(
         target: PlayerState,
         targetSid: SessionId,
         now: Long,
-    ) {
+    ): Int {
+        var damageDealtToPlayer = 0
         // Record cooldown
         if (spell.cooldownMs > 0L) {
             mobSpellCooldowns.getOrPut(mob.id) { mutableMapOf() }[spell.id] = now + spell.cooldownMs
@@ -1122,7 +1242,7 @@ class CombatSystem(
                         text = dodgeText,
                     ),
                 )
-                return
+                return 0
             }
         }
 
@@ -1135,6 +1255,7 @@ class CombatSystem(
             }
             val shieldAbsorbed = spellRoll - spellDamage
             target.takeDamage(spellDamage)
+            damageDealtToPlayer = spellDamage
             dirtyNotifier.playerVitalsDirty(targetSid)
 
             val msg = spell.message
@@ -1243,14 +1364,15 @@ class CombatSystem(
                 )
             }
         }
+        return damageDealtToPlayer
     }
 
-    /** Standard melee attack — the original mob attack path. */
+    /** Standard melee attack — the original mob attack path. Returns the damage dealt (0 on a dodge). */
     private suspend fun executeMobMelee(
         mob: MobState,
         target: PlayerState,
         targetSid: SessionId,
-    ) {
+    ): Int {
         val targetStats = resolvePlayerStats(target, items, statusEffects, classRegistry)
         val dodgePct =
             ((targetStats[config.bindings.dodgeStat] - PlayerState.BASE_STAT) * config.bindings.dodgePerPoint)
@@ -1267,7 +1389,7 @@ class CombatSystem(
                     text = dodgeText,
                 ),
             )
-            return
+            return 0
         }
         val mobRoll = rollRange(rng, mob.damage.min, mob.damage.max)
         // Equipment armor mitigates incoming mob damage with the same multiplicative
@@ -1328,6 +1450,7 @@ class CombatSystem(
                 exclude = targetSid,
             )
         }
+        return mobDamage
     }
 
     /**

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -772,6 +772,14 @@ class GameEngine(
         clock = clock,
         imagesBaseUrl = imagesBaseUrl,
     )
+    private val racialAbilitySystem =
+        RacialAbilitySystem(
+            raceRegistry = raceRegistry,
+            outbound = outbound,
+            dirtyNotifier = dirtyNotifier,
+            statusEffects = statusEffectSystem,
+            tickMillis = engineConfig.combat.tickMillis,
+        )
     private val combatSystem =
         CombatSystem(
             players = players,
@@ -799,6 +807,7 @@ class GameEngine(
             ),
             classRegistry = classRegistry,
             petSystem = petSystem,
+            racialAbilitySystem = racialAbilitySystem,
         )
 
     private val akathavaeSystem =
@@ -1089,6 +1098,43 @@ class GameEngine(
         combatSystem.onCombatEvent = { sid, event -> gmcpEmitter.sendCombatEvent(sid, event) }
         combatSystem.onPlayerEnteredCombat = { sid -> dialogueSystem.endConversation(sid) }
         combatSystem.onPetSkillCast = { sid -> emitPetSkills(sid, petSystem.getActivePet(sid)) }
+        // Racial passive abilities reach back into combat (AoE, extra swings, disengage) via the
+        // bridge, and summon their pets through this callback so pet stats scale to the owner and
+        // the new mob is broadcast to the room immediately.
+        racialAbilitySystem.combatBridge = combatSystem
+        racialAbilitySystem.summonRacialPet = { sid, templateKey, durationMs, replaceExisting ->
+            val player = players.get(sid)
+            if (player == null) {
+                null
+            } else {
+                val classDef = classRegistry.get(player.playerClass)
+                val playerStats = resolvePlayerStats(player, items, statusEffectSystem, classRegistry)
+                val equipBonuses = items.equipmentBonuses(sid, classDef)
+                val dmgRange = combatSystem.damageRangeForDisplay(player, playerStats, equipBonuses.attack)
+                val ownerStats = PetSystem.OwnerStats(
+                    maxHp = player.maxHp,
+                    damageMin = dmgRange.first,
+                    damageMax = dmgRange.last,
+                    armor = equipBonuses.armor,
+                )
+                val pet = petSystem.summon(
+                    sid,
+                    templateKey,
+                    player.roomId,
+                    ownerStats,
+                    durationMs,
+                    player.name,
+                    replaceExisting,
+                )
+                if (pet != null) {
+                    gmcpEmitter.broadcastRoomAddMob(player.roomId, pet, players)
+                    val mobsInRoom = mobs.mobsInRoom(player.roomId)
+                    val mobInfoEntries = gmcpEmitter.buildMobInfoEntries(mobsInRoom)
+                    gmcpEmitter.broadcastRoomMobInfo(player.roomId, mobInfoEntries, players)
+                }
+                pet
+            }
+        }
         combatSystem.onXpGained = { sid, amount, source -> gmcpEmitter.sendCharGain(sid, "xp", amount, source) }
         combatSystem.onGoldGained = { sid, amount, source -> gmcpEmitter.sendCharGain(sid, "gold", amount, source) }
         combatSystem.onPlayerDeath = { sid -> cleanupOnPlayerDeath(sid) }

--- a/src/main/kotlin/dev/ambon/engine/PetSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/PetSystem.kt
@@ -72,11 +72,12 @@ class PetSystem(
         owner: OwnerStats,
         durationMs: Long = 0L,
         ownerName: String? = null,
+        replaceExisting: Boolean = true,
     ): MobState? {
         val template = config.definitions[templateKey] ?: return null
 
-        // Dismiss existing pet
-        dismissAll(ownerSid)
+        // Dismiss existing pet unless the caller wants pets to coexist (e.g. a swarm of summons).
+        if (replaceExisting) dismissAll(ownerSid)
 
         val hpRatio = template.hpRatio.coerceAtMost(config.maxHpRatio)
         val dmgRatio = template.damageRatio.coerceAtMost(config.maxDamageRatio)

--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -81,6 +81,22 @@ data class PlayerState(
     var recallCooldownUntilMs: Long = 0L,
     /** Epoch-ms of the last stat/ability respec. Persisted so the cooldown survives logout. */
     var lastRespecAtMs: Long = 0L,
+    /**
+     * Epoch-ms after which this player's race-specific passive ability can fire again. Persisted
+     * (unlike runtime ability cooldowns) precisely because the racial passive cheats death — a relog
+     * must not reset the cooldown mid-fight and let it be re-triggered. See [RacialAbilitySystem].
+     */
+    var racialAbilityCooldownUntilMs: Long = 0L,
+    /**
+     * Epoch-ms until which the player cannot be selected as a mob's attack target (Aetherae phase,
+     * Lithae stone form). Runtime-only; not persisted.
+     */
+    var untargetableUntilMs: Long = 0L,
+    /** Epoch-ms until which the player's outgoing damage is multiplied by [damageBoostMultiplier]
+     *  (Ophirae wrath). Runtime-only; not persisted. */
+    var damageBoostUntilMs: Long = 0L,
+    /** Outgoing-damage multiplier applied while [damageBoostUntilMs] is in the future. */
+    var damageBoostMultiplier: Double = 1.0,
     var craftingSkills: MutableMap<String, CraftingSkillState> = mutableMapOf(),
     var discoveredRecipes: MutableSet<String> = mutableSetOf(),
     var craftingSpecialization: String? = null,
@@ -244,6 +260,13 @@ fun PlayerState.takeDamage(amount: Int) {
     hp = (hp - amount).coerceAtLeast(0)
 }
 
+/** True while the player can't be picked as a mob's target (Aetherae phase / Lithae stone form). */
+fun PlayerState.isUntargetable(nowMs: Long): Boolean = nowMs < untargetableUntilMs
+
+/** Outgoing-damage multiplier from an active damage buff (Ophirae wrath), else 1.0. */
+fun PlayerState.outgoingDamageMultiplier(nowMs: Long): Double =
+    if (nowMs < damageBoostUntilMs) damageBoostMultiplier else 1.0
+
 /** Increases mana by [amount], clamped to [maxMana]. Returns `true` if mana actually changed. */
 fun PlayerState.healMana(amount: Int): Boolean {
     val new = (mana + amount).coerceAtMost(maxMana)
@@ -333,6 +356,7 @@ fun PlayerRecord.toPlayerState(sessionId: SessionId): PlayerState =
         autopeekEnabled = autopeekEnabled,
         wimpyThresholdPct = wimpyThresholdPct,
         lastRespecAtMs = lastRespecAtMs,
+        racialAbilityCooldownUntilMs = racialAbilityCooldownUntilMs,
     )
 
 /** Converts this runtime state to a [PlayerRecord] for persistence. */
@@ -401,6 +425,7 @@ fun PlayerState.toPlayerRecord(lastSeenEpochMs: Long): PlayerRecord {
         autopeekEnabled = autopeekEnabled,
         wimpyThresholdPct = wimpyThresholdPct,
         lastRespecAtMs = lastRespecAtMs,
+        racialAbilityCooldownUntilMs = racialAbilityCooldownUntilMs,
     )
 }
 

--- a/src/main/kotlin/dev/ambon/engine/RaceRegistryLoader.kt
+++ b/src/main/kotlin/dev/ambon/engine/RaceRegistryLoader.kt
@@ -1,7 +1,10 @@
 package dev.ambon.engine
 
 import dev.ambon.config.RaceEngineConfig
+import dev.ambon.config.RacialAbilityConfig
 import dev.ambon.domain.RaceDef
+import dev.ambon.domain.RacialAbility
+import dev.ambon.domain.RacialAbilityKind
 import dev.ambon.domain.StatMap
 
 object RaceRegistryLoader {
@@ -20,8 +23,31 @@ object RaceRegistryLoader {
                     abilities = defConfig.abilities,
                     image = defConfig.image,
                     statMods = StatMap(defConfig.statMods.mapKeys { (k, _) -> k.uppercase() }),
+                    racialAbility = defConfig.racialAbility?.toDomain(),
                 ),
             )
         }
     }
+
+    private fun RacialAbilityConfig.toDomain(): RacialAbility =
+        RacialAbility(
+            kind = RacialAbilityKind.valueOf(kind.uppercase()),
+            displayName = displayName,
+            cooldownMs = cooldownMs,
+            triggerHealthPct = triggerHealthPct,
+            aoeDamagePctOfMaxHp = aoeDamagePctOfMaxHp,
+            damageMultiplier = damageMultiplier,
+            buffDurationMs = buffDurationMs,
+            stunStatusId = stunStatusId,
+            petTemplateKey = petTemplateKey,
+            petCountMin = petCountMin,
+            petCountMax = petCountMax,
+            petDurationMs = petDurationMs,
+            regenPctOfMaxHp = regenPctOfMaxHp,
+            stoneStatusId = stoneStatusId,
+            stoneDurationMs = stoneDurationMs,
+            phaseTicks = phaseTicks,
+            selfMessage = selfMessage,
+            roomMessage = roomMessage,
+        )
 }

--- a/src/main/kotlin/dev/ambon/engine/RacialAbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/RacialAbilitySystem.kt
@@ -2,6 +2,7 @@ package dev.ambon.engine
 
 import dev.ambon.bus.OutboundBus
 import dev.ambon.domain.RacialAbility
+import dev.ambon.domain.RacialAbilityKind
 import dev.ambon.domain.RacialTrigger
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.mob.MobState
@@ -128,11 +129,11 @@ class RacialAbilitySystem(
         if (onCooldown(player, nowMs)) return
         if (!atOrBelowThreshold(player, ability)) return
         when (ability.kind) {
-            dev.ambon.domain.RacialAbilityKind.PYRAE_IMMOLATE -> fireImmolate(sessionId, player, ability, nowMs)
-            dev.ambon.domain.RacialAbilityKind.AURELIA_DAZZLE -> fireDazzle(sessionId, player, ability, nowMs)
-            dev.ambon.domain.RacialAbilityKind.MYCORAE_SPORES -> fireSpores(sessionId, player, ability, nowMs)
-            dev.ambon.domain.RacialAbilityKind.ARCHAE_DRENGARIAE -> fireDrengariae(sessionId, player, ability, nowMs)
-            dev.ambon.domain.RacialAbilityKind.OPHIRAE_WRATH -> fireWrath(sessionId, player, ability, nowMs)
+            RacialAbilityKind.PYRAE_IMMOLATE -> fireImmolate(sessionId, player, ability, nowMs)
+            RacialAbilityKind.AURELIA_DAZZLE -> fireDazzle(sessionId, player, ability, nowMs)
+            RacialAbilityKind.MYCORAE_SPORES -> fireSpores(sessionId, player, ability, nowMs)
+            RacialAbilityKind.ARCHAE_DRENGARIAE -> fireDrengariae(sessionId, player, ability, nowMs)
+            RacialAbilityKind.OPHIRAE_WRATH -> fireWrath(sessionId, player, ability, nowMs)
             else -> Unit
         }
     }
@@ -231,10 +232,10 @@ class RacialAbilitySystem(
         if (ability.trigger != RacialTrigger.LETHAL_BLOW) return false
         if (onCooldown(player, nowMs)) return false
         return when (ability.kind) {
-            dev.ambon.domain.RacialAbilityKind.KITSARAE_REVERSAL -> fireReversal(player, ability, blowDamage, preHitHp, nowMs)
-            dev.ambon.domain.RacialAbilityKind.LUSTRIAE_TIMESLIP -> fireTimeslip(sessionId, player, ability, attacker, preHitHp, nowMs)
-            dev.ambon.domain.RacialAbilityKind.LITHAE_STONEFORM -> fireStoneform(sessionId, player, ability, preHitHp, nowMs)
-            dev.ambon.domain.RacialAbilityKind.AETHERAE_PHASE -> firePhase(player, ability, preHitHp, nowMs)
+            RacialAbilityKind.KITSARAE_REVERSAL -> fireReversal(player, ability, blowDamage, preHitHp, nowMs)
+            RacialAbilityKind.LUSTRIAE_TIMESLIP -> fireTimeslip(sessionId, player, ability, attacker, preHitHp, nowMs)
+            RacialAbilityKind.LITHAE_STONEFORM -> fireStoneform(sessionId, player, ability, preHitHp, nowMs)
+            RacialAbilityKind.AETHERAE_PHASE -> firePhase(player, ability, preHitHp, nowMs)
             else -> false
         }
     }

--- a/src/main/kotlin/dev/ambon/engine/RacialAbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/RacialAbilitySystem.kt
@@ -1,0 +1,318 @@
+package dev.ambon.engine
+
+import dev.ambon.bus.OutboundBus
+import dev.ambon.domain.RacialAbility
+import dev.ambon.domain.RacialTrigger
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.mob.MobState
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.status.StatusEffectId
+import dev.ambon.engine.status.StatusEffectSystem
+import java.util.Random
+import kotlin.math.roundToInt
+
+/**
+ * Combat-internal operations the [RacialAbilitySystem] can't perform on its own — they touch
+ * threat tables, mob death/loot, and player attack rolls that live inside [CombatSystem].
+ * [CombatSystem] implements this and is injected into the racial system after construction.
+ */
+interface RacialCombatBridge {
+    /** Live (non-pet) enemies currently in combat with [sessionId] in the player's room. */
+    fun enemiesInCombatWith(sessionId: SessionId): List<MobState>
+
+    /** Applies [damage] to [mob] credited to [sessionId] (threat, death/loot, client sync) and
+     *  shows [hitText] to the player and room. */
+    suspend fun dealRacialDamage(
+        sessionId: SessionId,
+        mob: MobState,
+        damage: Int,
+        hitText: String,
+    )
+
+    /** Performs one immediate extra player melee swing against [mob]; returns true if it died. */
+    suspend fun extraMeleeSwing(
+        sessionId: SessionId,
+        mob: MobState,
+    ): Boolean
+
+    /** Fully disengages [sessionId] from PvE combat (clears target + threat). */
+    fun disengageFromCombat(sessionId: SessionId)
+
+    /** Broadcasts [text] to everyone in [sessionId]'s room except the player. */
+    suspend fun broadcastToRoomExcept(
+        sessionId: SessionId,
+        text: String,
+    )
+}
+
+/**
+ * Resolves and applies race-specific passive abilities (see [RacialAbility]). The system owns one
+ * persisted cooldown per player and two combat hooks:
+ *
+ *  - [onPlayerSurvivedHit] fires [RacialTrigger.LOW_HEALTH] abilities after a player survives a blow
+ *    with HP at or below the race's threshold.
+ *  - [tryPreventLethalBlow] gives [RacialTrigger.LETHAL_BLOW] abilities the chance to negate or
+ *    transform a would-be-fatal attack; returning true means the player did not die.
+ *
+ * Abilities currently fire in PvE combat only — PvP death keeps its existing arena-respawn flow.
+ */
+class RacialAbilitySystem(
+    private val raceRegistry: RaceRegistry,
+    private val outbound: OutboundBus,
+    private val dirtyNotifier: DirtyNotifier = DirtyNotifier.NO_OP,
+    private val statusEffects: StatusEffectSystem? = null,
+    private val rng: Random = Random(),
+    private val tickMillis: Long = 1_000L,
+) {
+    /** Combat operations bridge; wired by GameEngine after both systems are constructed. */
+    var combatBridge: RacialCombatBridge? = null
+
+    /**
+     * Summons a racial pet. Wired by GameEngine, which knows how to scale pet stats to the owner and
+     * broadcast the new mob to the room. `replaceExisting=false` lets multiple pets coexist (spores).
+     * Returns the spawned pet, or null if summoning failed.
+     */
+    var summonRacialPet: suspend (SessionId, String, Long, Boolean) -> MobState? = { _, _, _, _ -> null }
+
+    /** Returns the resolved racial ability for [player]'s race, or null if the race has none. */
+    fun abilityFor(player: PlayerState): RacialAbility? = raceRegistry.get(player.race)?.racialAbility
+
+    private fun onCooldown(
+        player: PlayerState,
+        nowMs: Long,
+    ): Boolean = nowMs < player.racialAbilityCooldownUntilMs
+
+    private fun startCooldown(
+        player: PlayerState,
+        ability: RacialAbility,
+        nowMs: Long,
+    ) {
+        player.racialAbilityCooldownUntilMs = nowMs + ability.cooldownMs
+        dirtyNotifier.playerVitalsDirty(player.sessionId)
+    }
+
+    /** Integer cross-multiply (matches wimpy) so a 10% threshold fires at exactly <=10% of max. */
+    private fun atOrBelowThreshold(
+        player: PlayerState,
+        ability: RacialAbility,
+    ): Boolean {
+        if (ability.triggerHealthPct <= 0 || player.maxHp <= 0) return false
+        return player.hp * 100 <= ability.triggerHealthPct * player.maxHp
+    }
+
+    private suspend fun announce(
+        player: PlayerState,
+        ability: RacialAbility,
+    ) {
+        if (ability.selfMessage.isNotEmpty()) {
+            outbound.send(OutboundEvent.SendText(player.sessionId, ability.selfMessage))
+        }
+        if (ability.roomMessage.isNotEmpty()) {
+            combatBridge?.broadcastToRoomExcept(player.sessionId, ability.roomMessage.replace("{player}", player.name))
+        }
+    }
+
+    // ── Low-health trigger ───────────────────────────────────────────────
+
+    /**
+     * Called after [player] survives a mob hit. If their race has a low-health passive that's off
+     * cooldown and their HP is at/below its threshold, the ability fires.
+     */
+    suspend fun onPlayerSurvivedHit(
+        sessionId: SessionId,
+        player: PlayerState,
+        nowMs: Long,
+    ) {
+        val ability = abilityFor(player) ?: return
+        if (ability.trigger != RacialTrigger.LOW_HEALTH) return
+        if (onCooldown(player, nowMs)) return
+        if (!atOrBelowThreshold(player, ability)) return
+        when (ability.kind) {
+            dev.ambon.domain.RacialAbilityKind.PYRAE_IMMOLATE -> fireImmolate(sessionId, player, ability, nowMs)
+            dev.ambon.domain.RacialAbilityKind.AURELIA_DAZZLE -> fireDazzle(sessionId, player, ability, nowMs)
+            dev.ambon.domain.RacialAbilityKind.MYCORAE_SPORES -> fireSpores(sessionId, player, ability, nowMs)
+            dev.ambon.domain.RacialAbilityKind.ARCHAE_DRENGARIAE -> fireDrengariae(sessionId, player, ability, nowMs)
+            dev.ambon.domain.RacialAbilityKind.OPHIRAE_WRATH -> fireWrath(sessionId, player, ability, nowMs)
+            else -> Unit
+        }
+    }
+
+    private suspend fun fireImmolate(
+        sessionId: SessionId,
+        player: PlayerState,
+        ability: RacialAbility,
+        nowMs: Long,
+    ) {
+        val bridge = combatBridge ?: return
+        val enemies = bridge.enemiesInCombatWith(sessionId)
+        if (enemies.isEmpty()) return
+        startCooldown(player, ability, nowMs)
+        announce(player, ability)
+        val damage = (player.maxHp * ability.aoeDamagePctOfMaxHp).roundToInt().coerceAtLeast(1)
+        for (mob in enemies) {
+            bridge.dealRacialDamage(sessionId, mob, damage, "${mob.name} is engulfed in flames for $damage damage!")
+        }
+    }
+
+    private suspend fun fireDazzle(
+        sessionId: SessionId,
+        player: PlayerState,
+        ability: RacialAbility,
+        nowMs: Long,
+    ) {
+        val bridge = combatBridge ?: return
+        val stunId = ability.stunStatusId ?: return
+        val enemies = bridge.enemiesInCombatWith(sessionId)
+        if (enemies.isEmpty()) return
+        startCooldown(player, ability, nowMs)
+        announce(player, ability)
+        for (mob in enemies) {
+            statusEffects?.applyToMob(mob.id, StatusEffectId(stunId), casterLevel = player.level)
+        }
+    }
+
+    private suspend fun fireSpores(
+        sessionId: SessionId,
+        player: PlayerState,
+        ability: RacialAbility,
+        nowMs: Long,
+    ) {
+        val template = ability.petTemplateKey ?: return
+        startCooldown(player, ability, nowMs)
+        announce(player, ability)
+        val span = (ability.petCountMax - ability.petCountMin).coerceAtLeast(0)
+        val count = ability.petCountMin + if (span == 0) 0 else rng.nextInt(span + 1)
+        repeat(count) {
+            summonRacialPet(sessionId, template, ability.petDurationMs, false)
+        }
+    }
+
+    private suspend fun fireDrengariae(
+        sessionId: SessionId,
+        player: PlayerState,
+        ability: RacialAbility,
+        nowMs: Long,
+    ) {
+        val template = ability.petTemplateKey ?: return
+        startCooldown(player, ability, nowMs)
+        announce(player, ability)
+        summonRacialPet(sessionId, template, ability.petDurationMs, false)
+    }
+
+    private suspend fun fireWrath(
+        sessionId: SessionId,
+        player: PlayerState,
+        ability: RacialAbility,
+        nowMs: Long,
+    ) {
+        startCooldown(player, ability, nowMs)
+        player.damageBoostUntilMs = nowMs + ability.buffDurationMs
+        player.damageBoostMultiplier = ability.damageMultiplier
+        dirtyNotifier.playerVitalsDirty(sessionId)
+        announce(player, ability)
+    }
+
+    // ── Lethal-blow trigger ──────────────────────────────────────────────
+
+    /**
+     * Gives a lethal-blow passive a chance to save [player] from an attack that just dropped them to
+     * 0 HP. [blowDamage] is the damage the killing attack dealt and [preHitHp] is the HP they had
+     * before it landed. Returns true if the player survived (the caller must then NOT kill them).
+     */
+    suspend fun tryPreventLethalBlow(
+        sessionId: SessionId,
+        player: PlayerState,
+        attacker: MobState,
+        blowDamage: Int,
+        preHitHp: Int,
+        nowMs: Long,
+    ): Boolean {
+        val ability = abilityFor(player) ?: return false
+        if (ability.trigger != RacialTrigger.LETHAL_BLOW) return false
+        if (onCooldown(player, nowMs)) return false
+        return when (ability.kind) {
+            dev.ambon.domain.RacialAbilityKind.KITSARAE_REVERSAL -> fireReversal(player, ability, blowDamage, preHitHp, nowMs)
+            dev.ambon.domain.RacialAbilityKind.LUSTRIAE_TIMESLIP -> fireTimeslip(sessionId, player, ability, attacker, preHitHp, nowMs)
+            dev.ambon.domain.RacialAbilityKind.LITHAE_STONEFORM -> fireStoneform(sessionId, player, ability, preHitHp, nowMs)
+            dev.ambon.domain.RacialAbilityKind.AETHERAE_PHASE -> firePhase(player, ability, preHitHp, nowMs)
+            else -> false
+        }
+    }
+
+    private suspend fun fireReversal(
+        player: PlayerState,
+        ability: RacialAbility,
+        blowDamage: Int,
+        preHitHp: Int,
+        nowMs: Long,
+    ): Boolean {
+        startCooldown(player, ability, nowMs)
+        // The killing blow becomes a heal of equal magnitude: end at preHitHp + blowDamage.
+        player.hp = (preHitHp + blowDamage).coerceAtMost(player.maxHp).coerceAtLeast(1)
+        dirtyNotifier.playerVitalsDirty(player.sessionId)
+        announce(player, ability)
+        return true
+    }
+
+    private suspend fun fireTimeslip(
+        sessionId: SessionId,
+        player: PlayerState,
+        ability: RacialAbility,
+        attacker: MobState,
+        preHitHp: Int,
+        nowMs: Long,
+    ): Boolean {
+        val bridge = combatBridge ?: return false
+        startCooldown(player, ability, nowMs)
+        announce(player, ability)
+        val killed = bridge.extraMeleeSwing(sessionId, attacker)
+        return if (killed) {
+            // The extra attack felled the foe before its blow could land — the player is unharmed.
+            player.hp = preHitHp.coerceAtLeast(1)
+            dirtyNotifier.playerVitalsDirty(sessionId)
+            outbound.send(
+                OutboundEvent.SendText(sessionId, "Time snaps back into place — ${attacker.name} falls and you stand unscathed."),
+            )
+            true
+        } else {
+            outbound.send(OutboundEvent.SendText(sessionId, "...but it was not enough to fell ${attacker.name}."))
+            false
+        }
+    }
+
+    private suspend fun fireStoneform(
+        sessionId: SessionId,
+        player: PlayerState,
+        ability: RacialAbility,
+        preHitHp: Int,
+        nowMs: Long,
+    ): Boolean {
+        val bridge = combatBridge ?: return false
+        startCooldown(player, ability, nowMs)
+        bridge.disengageFromCombat(sessionId)
+        val regen = (player.maxHp * ability.regenPctOfMaxHp).roundToInt()
+        player.hp = (preHitHp + regen).coerceAtMost(player.maxHp).coerceAtLeast(1)
+        player.untargetableUntilMs = nowMs + ability.stoneDurationMs
+        // A self-applied root (existing movement gate) keeps the petrified player rooted in place.
+        ability.stoneStatusId?.let { statusEffects?.applyToPlayer(sessionId, StatusEffectId(it), casterLevel = player.level) }
+        dirtyNotifier.playerVitalsDirty(sessionId)
+        announce(player, ability)
+        return true
+    }
+
+    private suspend fun firePhase(
+        player: PlayerState,
+        ability: RacialAbility,
+        preHitHp: Int,
+        nowMs: Long,
+    ): Boolean {
+        startCooldown(player, ability, nowMs)
+        // Phase back in with the health held before the blow; stay untargetable for a few rounds so
+        // the next tick's damage is also ignored.
+        player.hp = preHitHp.coerceAtLeast(1)
+        player.untargetableUntilMs = nowMs + ability.phaseTicks * tickMillis
+        dirtyNotifier.playerVitalsDirty(player.sessionId)
+        announce(player, ability)
+        return true
+    }
+}

--- a/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
@@ -108,6 +108,9 @@ data class PlayerRecord(
     val wimpyThresholdPct: Int = 10,
     /** Epoch-ms of the last stat/ability respec. 0 means never respec'd. */
     val lastRespecAtMs: Long = 0L,
+    /** Epoch-ms after which the race-specific passive ability can fire again. Persisted so a relog
+     *  can't reset a death-cheating cooldown mid-fight. */
+    val racialAbilityCooldownUntilMs: Long = 0L,
     /** Persisted dialogue-flag set used to gate quests behind prior conversations. */
     val dialogueFlags: Set<String> = emptySet(),
     /** Zones whose intro cinematic this player has already watched (auto-plays once per zone). */

--- a/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
@@ -89,6 +89,7 @@ object PlayersTable : Table("players") {
     val autopeekEnabled = bool("autopeek_enabled").default(false)
     val wimpyThresholdPct = integer("wimpy_threshold_pct").default(10)
     val lastRespecAtMs = long("last_respec_at_ms").default(0L)
+    val racialAbilityCooldownUntilMs = long("racial_ability_cooldown_until_ms").default(0L)
     val dialogueFlags = text("dialogue_flags").default("[]")
     val seenZoneCinematics = text("seen_zone_cinematics").default("[]")
     val isAkathavae = bool("is_akathavae").default(false)
@@ -159,6 +160,7 @@ object PlayersTable : Table("players") {
             autopeekEnabled = row[autopeekEnabled],
             wimpyThresholdPct = row[wimpyThresholdPct],
             lastRespecAtMs = row[lastRespecAtMs],
+            racialAbilityCooldownUntilMs = row[racialAbilityCooldownUntilMs],
             dialogueFlags = safeReadJson(row[dialogueFlags], dialogueFlagsType, emptySet()),
             seenZoneCinematics = safeReadJson(row[seenZoneCinematics], seenZoneCinematicsType, emptySet()),
             isAkathavae = row[isAkathavae],
@@ -234,6 +236,7 @@ object PlayersTable : Table("players") {
         statement[autopeekEnabled] = record.autopeekEnabled
         statement[wimpyThresholdPct] = record.wimpyThresholdPct
         statement[lastRespecAtMs] = record.lastRespecAtMs
+        statement[racialAbilityCooldownUntilMs] = record.racialAbilityCooldownUntilMs
         statement[dialogueFlags] = jsonMapper.writeValueAsString(record.dialogueFlags)
         statement[seenZoneCinematics] = jsonMapper.writeValueAsString(record.seenZoneCinematics)
         statement[isAkathavae] = record.isAkathavae

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -523,6 +523,16 @@ ambonmud:
           effectType: stun
           durationMs: 2000
           stackBehavior: NONE
+        dazzle_stun:
+          displayName: Dazzled
+          effectType: stun
+          durationMs: 3000
+          stackBehavior: REFRESH
+        stoneform_root:
+          displayName: Stone Form
+          effectType: root
+          durationMs: 4000
+          stackBehavior: NONE
         whirlwind_rage:
           displayName: Whirlwind Rage
           effectType: stat_buff
@@ -2179,6 +2189,109 @@ ambonmud:
             deep granite-grey. Features are heavy and blunt — strong jaw, prominent brow ridge, wide nose. Eyes are
             deep-set in shades of slate, amber, or dark brown. Hair is coarse and thick, typically worn in braids, in
             shades of iron-grey, black, or dark copper. Hands are broad with thick, calloused fingers.
+        # ── Auringold ancestries with race-specific passive abilities ──────────────────────────────
+        # Each ability fires from a combat hook (low-health threshold or a would-be-lethal blow) and
+        # burns a long, persisted cooldown so it can't be cheesed by relogging. See RacialAbilitySystem.
+        PYRAE:
+          displayName: Pyrae
+          description: Flame-born kindred whose blood runs molten; cornered and bleeding, they detonate.
+          racialAbility:
+            kind: PYRAE_IMMOLATE
+            displayName: Immolation
+            cooldownMs: 120000
+            triggerHealthPct: 10
+            aoeDamagePctOfMaxHp: 0.6
+            selfMessage: "Your blood boils over — you erupt in a roar of flame!"
+            roomMessage: "{player} erupts in a roar of flame!"
+        LUSTRIAE:
+          displayName: Lustriae
+          description: Time-touched wanderers who can steal a heartbeat back from the edge of death.
+          racialAbility:
+            kind: LUSTRIAE_TIMESLIP
+            displayName: Timeslip
+            cooldownMs: 150000
+            selfMessage: "Time stutters — you slip a heartbeat sideways and strike again!"
+            roomMessage: "{player} blurs as time stutters around them!"
+        AURELIA:
+          displayName: Aurelia
+          description: Bioluminescent depths-folk who blind their attackers with a dazzling pulse of light.
+          racialAbility:
+            kind: AURELIA_DAZZLE
+            displayName: Dazzling Burst
+            cooldownMs: 120000
+            triggerHealthPct: 15
+            stunStatusId: dazzle_stun
+            selfMessage: "You flare with blinding bioluminescence!"
+            roomMessage: "{player} flares with blinding light!"
+        LITHAE:
+          displayName: Lithae
+          description: Stoneblooded who petrify at death's door, weathering the blow as living rock.
+          racialAbility:
+            kind: LITHAE_STONEFORM
+            displayName: Stone Form
+            cooldownMs: 150000
+            regenPctOfMaxHp: 0.2
+            stoneStatusId: stoneform_root
+            stoneDurationMs: 4000
+            selfMessage: "Your skin hardens to living stone — the blow glances away as you settle, immovable."
+            roomMessage: "{player} turns to living stone!"
+        MYCORAE:
+          displayName: Mycorae
+          description: Fungal symbiotes who scatter living spores that erupt into shrieking guardians.
+          racialAbility:
+            kind: MYCORAE_SPORES
+            displayName: Spore Burst
+            cooldownMs: 120000
+            triggerHealthPct: 25
+            petTemplateKey: spore_mushroom
+            petCountMin: 1
+            petCountMax: 3
+            petDurationMs: 12000
+            selfMessage: "You burst, scattering a cloud of spores that erupt into shrieking mushrooms!"
+            roomMessage: "{player} bursts in a cloud of spores!"
+        KITSARAE:
+          displayName: Kitsarae
+          description: Cultivation-masters who breathe a killing blow inward and turn it into renewed life.
+          racialAbility:
+            kind: KITSARAE_REVERSAL
+            displayName: Cultivated Reversal
+            cooldownMs: 180000
+            selfMessage: "You breathe the lethal force inward — the killing blow becomes life!"
+            roomMessage: "{player} draws a killing blow inward as though it were a breath."
+        ARCHAE:
+          displayName: Archae
+          description: Old-blood faithful who call the frozen war-host of the Drengariae in their hour of need.
+          racialAbility:
+            kind: ARCHAE_DRENGARIAE
+            displayName: Call the Drengariae
+            cooldownMs: 150000
+            triggerHealthPct: 25
+            petTemplateKey: drengariae_soldier
+            petDurationMs: 9000
+            selfMessage: "You cry out to the Drengariae — a frost-clad soldier answers, blade aflame!"
+            roomMessage: "A Drengariae soldier answers {player}'s call, blade wreathed in pale fire!"
+        OPHIRAE:
+          displayName: Ophirae
+          description: Draconic-blooded who turn savage and ruthlessly precise when cornered.
+          racialAbility:
+            kind: OPHIRAE_WRATH
+            displayName: Draconic Wrath
+            cooldownMs: 120000
+            triggerHealthPct: 20
+            damageMultiplier: 1.5
+            buffDurationMs: 6000
+            selfMessage: "Your draconic blood ignites — your strikes turn merciless!"
+            roomMessage: "{player}'s eyes blaze with draconic fury!"
+        AETHERAE:
+          displayName: Aetherae
+          description: Half-real voidkin who phase out of existence to let a killing blow pass through empty air.
+          racialAbility:
+            kind: AETHERAE_PHASE
+            displayName: Phase Shift
+            cooldownMs: 150000
+            phaseTicks: 2
+            selfMessage: "You flicker out of existence — the blow passes through empty air."
+            roomMessage: "{player} flickers and fades out of existence!"
     equipment:
       slots:
         head:
@@ -2383,6 +2496,32 @@ ambonmud:
       maxDamageRatio: 0.8
       maxArmorRatio: 1.0
       definitions:
+        # Mycorae racial summon: a swarm tank. Tiny HP/damage but a very high threat multiplier so a
+        # cluster of mushrooms peels aggro off the player within a round or two and soaks a few hits.
+        spore_mushroom:
+          name: a shrieking mushroom
+          description: A squat, pulsing fungus that hisses spores and draws every angry eye toward itself.
+          hpRatio: 0.15
+          damageRatio: 0.1
+          armorRatio: 0.2
+          baseHp: 8
+          baseMinDamage: 1
+          baseMaxDamage: 3
+          baseArmor: 0
+          threatMultiplier: 6.0
+        # Archae racial summon: a short-lived DPS soldier. No threat multiplier — it fights, it
+        # doesn't tank.
+        drengariae_soldier:
+          name: a Drengariae soldier
+          description: A frost-rimed Alorae warrior wreathed in pale flame, sword drawn against the cold and the dark.
+          hpRatio: 0.4
+          damageRatio: 0.9
+          armorRatio: 0.5
+          baseHp: 25
+          baseMinDamage: 6
+          baseMaxDamage: 12
+          baseArmor: 2
+          threatMultiplier: 0.0
         wolf_companion:
           name: a wolf companion
           # DPS pet: light HP/armor, strong damage.

--- a/src/main/resources/db/migration/V46__racial_ability_cooldown.sql
+++ b/src/main/resources/db/migration/V46__racial_ability_cooldown.sql
@@ -1,0 +1,4 @@
+-- Persisted cooldown for race-specific passive abilities. These abilities can cheat death, so the
+-- cooldown must survive logout/login — otherwise a relog would reset it and let the same fight be
+-- saved twice. Runtime ability cooldowns stay in-memory; only this one is persisted.
+ALTER TABLE players ADD COLUMN racial_ability_cooldown_until_ms BIGINT NOT NULL DEFAULT 0;

--- a/src/test/kotlin/dev/ambon/config/AppConfigLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/config/AppConfigLoaderTest.kt
@@ -599,6 +599,66 @@ class AppConfigLoaderTest {
         valid.validated() // should not throw
     }
 
+    private fun configWithRacialAbility(ability: RacialAbilityConfig): AppConfig =
+        AppConfig(
+            engine = EngineConfig(
+                races = RaceEngineConfig(
+                    definitions = mapOf(
+                        "testrace" to RaceDefinitionConfig(displayName = "Test", racialAbility = ability),
+                    ),
+                ),
+            ),
+            world = validWorld,
+        )
+
+    @Test
+    fun `validation rejects racial ability with unknown kind`() {
+        val invalid = configWithRacialAbility(RacialAbilityConfig(kind = "NOT_A_KIND"))
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
+
+    @Test
+    fun `validation rejects low-health racial ability with no trigger threshold`() {
+        val invalid =
+            configWithRacialAbility(
+                RacialAbilityConfig(kind = "PYRAE_IMMOLATE", triggerHealthPct = 0, aoeDamagePctOfMaxHp = 0.6),
+            )
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
+
+    @Test
+    fun `validation rejects dazzle racial ability without a stun status id`() {
+        val invalid =
+            configWithRacialAbility(
+                RacialAbilityConfig(kind = "AURELIA_DAZZLE", triggerHealthPct = 15, stunStatusId = null),
+            )
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
+
+    @Test
+    fun `validation rejects summon racial ability without a pet template`() {
+        val invalid =
+            configWithRacialAbility(
+                RacialAbilityConfig(kind = "MYCORAE_SPORES", triggerHealthPct = 25, petTemplateKey = null),
+            )
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
+
+    @Test
+    fun `validation accepts a fully configured racial ability`() {
+        val valid =
+            configWithRacialAbility(
+                RacialAbilityConfig(
+                    kind = "MYCORAE_SPORES",
+                    triggerHealthPct = 25,
+                    petTemplateKey = "spore_mushroom",
+                    petCountMin = 1,
+                    petCountMax = 3,
+                ),
+            )
+        valid.validated() // should not throw
+    }
+
     @Test
     fun `multiclass maxClasses decodes JavaScript MAX_SAFE_INTEGER sentinel`() {
         // Regression: prod overlay YAML carried `maxClasses: 9007199254740991` (Number.MAX_SAFE_INTEGER,

--- a/src/test/kotlin/dev/ambon/config/AppConfigLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/config/AppConfigLoaderTest.kt
@@ -607,6 +607,18 @@ class AppConfigLoaderTest {
                         "testrace" to RaceDefinitionConfig(displayName = "Test", racialAbility = ability),
                     ),
                 ),
+                // Seed the definitions a fully-configured ability references so existence checks pass.
+                pets = PetConfig(
+                    definitions = mapOf(
+                        "spore_mushroom" to PetTemplateConfig(name = "a mushroom"),
+                    ),
+                ),
+                statusEffects = StatusEffectEngineConfig(
+                    definitions = mapOf(
+                        "dazzle_stun" to StatusEffectDefinitionConfig(effectType = "stun"),
+                        "stoneform_root" to StatusEffectDefinitionConfig(effectType = "root"),
+                    ),
+                ),
             ),
             world = validWorld,
         )
@@ -640,6 +652,34 @@ class AppConfigLoaderTest {
         val invalid =
             configWithRacialAbility(
                 RacialAbilityConfig(kind = "MYCORAE_SPORES", triggerHealthPct = 25, petTemplateKey = null),
+            )
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
+
+    @Test
+    fun `validation rejects dazzle referencing an undefined status effect`() {
+        val invalid =
+            configWithRacialAbility(
+                RacialAbilityConfig(kind = "AURELIA_DAZZLE", triggerHealthPct = 15, stunStatusId = "no_such_effect"),
+            )
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
+
+    @Test
+    fun `validation rejects dazzle referencing a non-stun status effect`() {
+        // stoneform_root exists in the fixture but is a 'root', not a 'stun' — the dazzle would no-op.
+        val invalid =
+            configWithRacialAbility(
+                RacialAbilityConfig(kind = "AURELIA_DAZZLE", triggerHealthPct = 15, stunStatusId = "stoneform_root"),
+            )
+        assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
+    }
+
+    @Test
+    fun `validation rejects summon referencing an undefined pet template`() {
+        val invalid =
+            configWithRacialAbility(
+                RacialAbilityConfig(kind = "MYCORAE_SPORES", triggerHealthPct = 25, petTemplateKey = "no_such_pet"),
             )
         assertThrows(IllegalArgumentException::class.java) { invalid.validated() }
     }

--- a/src/test/kotlin/dev/ambon/engine/RacialAbilitySystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/RacialAbilitySystemTest.kt
@@ -1,0 +1,369 @@
+package dev.ambon.engine
+
+import dev.ambon.domain.DamageRange
+import dev.ambon.domain.RaceDef
+import dev.ambon.domain.RacialAbility
+import dev.ambon.domain.RacialAbilityKind
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.mob.MobState
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.status.StatusEffectDefinition
+import dev.ambon.engine.status.StatusEffectId
+import dev.ambon.engine.status.StatusEffectSystem
+import dev.ambon.test.CombatTestFixture
+import dev.ambon.test.TEST_ROOM_ID
+import dev.ambon.test.drainAll
+import dev.ambon.test.loginOrFail
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.Random
+
+/**
+ * Covers the racial passive ability subsystem end-to-end through [CombatSystem.tick]: both trigger
+ * types (low-health and would-be-lethal blow), the persisted cooldown gate, and the new
+ * untargetable / mob-stun / damage-boost enforcement.
+ *
+ * The combat fixture uses deterministic bindings, so each player swing is exactly 1 damage and each
+ * mob hit is its flat `DamageRange`. Players have base stats (no dodge), unarmored on both sides.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class RacialAbilitySystemTest {
+    private val raceId = "TESTRACE"
+
+    private fun registryWith(ability: RacialAbility): RaceRegistry =
+        RaceRegistry().also { it.register(RaceDef(id = raceId, displayName = "Test", racialAbility = ability)) }
+
+    private fun enemyMob(
+        damage: DamageRange = DamageRange(1, 1),
+        hp: Int = 200,
+    ): MobState = MobState(
+        id = MobId("zone:goblin"),
+        name = "a goblin",
+        roomId = TEST_ROOM_ID,
+        hp = hp,
+        maxHp = hp,
+        damage = damage,
+    )
+
+    private data class Engagement(
+        val sid: SessionId,
+        val mob: MobState,
+        val combat: CombatSystem,
+    )
+
+    /** Logs a player of the test race into combat with [mob] and returns the live combat handle. */
+    private suspend fun CombatTestFixture.engage(
+        racial: RacialAbilitySystem,
+        statusEffects: StatusEffectSystem? = null,
+        playerMaxHp: Int,
+        playerHp: Int,
+        mob: MobState,
+    ): Engagement {
+        val combat = buildCombat(
+            rng = Random(42),
+            minDamage = 1,
+            maxDamage = 1,
+            statusEffects = statusEffects,
+            racialAbilitySystem = racial,
+        )
+        val sid = SessionId(1L)
+        players.loginOrFail(sid, "Hero")
+        players.get(sid)!!.apply {
+            race = raceId
+            maxHp = playerMaxHp
+            baseMaxHp = playerMaxHp
+            hp = playerHp
+        }
+        mobs.upsert(mob)
+        combat.startCombat(sid, "goblin")
+        outbound.drainAll()
+        return Engagement(sid, mob, combat)
+    }
+
+    // ── Low-health triggers ──────────────────────────────────────────────
+
+    @Test
+    fun `Pyrae immolation deals AoE damage to engaged enemies at low health`() = runTest {
+        val fixture = CombatTestFixture()
+        val racial = fixture.buildRacialAbilities(
+            registryWith(
+                RacialAbility(
+                    kind = RacialAbilityKind.PYRAE_IMMOLATE,
+                    displayName = "Immolation",
+                    cooldownMs = 120_000L,
+                    triggerHealthPct = 10,
+                    aoeDamagePctOfMaxHp = 0.6,
+                    selfMessage = "You erupt in flame!",
+                    roomMessage = "{player} erupts!",
+                ),
+            ),
+        )
+        val (sid, mob, combat) = fixture.engage(racial, playerMaxHp = 100, playerHp = 8, mob = enemyMob(hp = 200))
+
+        fixture.tickCombat(combat)
+        val texts = fixture.outbound.drainAll().filterIsInstance<OutboundEvent.SendText>().map { it.text }
+
+        assertTrue(texts.any { it.contains("engulfed in flames") }, "expected immolation AoE, got: $texts")
+        assertTrue(mob.hp <= 200 - 60, "mob should take >= 60 AoE damage, hp=${mob.hp}")
+        assertTrue(fixture.players.get(sid)!!.racialAbilityCooldownUntilMs > 0L, "cooldown should be set")
+    }
+
+    @Test
+    fun `Aurelia dazzle stuns the enemy so it skips its next attack`() = runTest {
+        val fixture = CombatTestFixture()
+        val statusEffects = fixture.buildStatusEffects(
+            StatusEffectDefinition(StatusEffectId("dazzle_stun"), "Dazzled", "stun", durationMs = 60_000L),
+        )
+        val racial = fixture.buildRacialAbilities(
+            registryWith(
+                RacialAbility(
+                    kind = RacialAbilityKind.AURELIA_DAZZLE,
+                    displayName = "Dazzle",
+                    cooldownMs = 120_000L,
+                    triggerHealthPct = 15,
+                    stunStatusId = "dazzle_stun",
+                ),
+            ),
+            statusEffects = statusEffects,
+        )
+        val (sid, mob, combat) =
+            fixture.engage(racial, statusEffects, playerMaxHp = 100, playerHp = 12, mob = enemyMob(hp = 200))
+
+        // Round 1: player survives the hit (12 -> 11) and dazzles the mob.
+        fixture.tickCombat(combat)
+        fixture.outbound.drainAll()
+        assertTrue(statusEffects.hasMobEffect(mob.id, "stun"), "mob should be stunned by the dazzle")
+        val hpAfterDazzle = fixture.players.get(sid)!!.hp
+
+        // Round 2: the stunned mob forfeits its attack, so the player takes no further damage.
+        fixture.tickCombat(combat)
+        assertEquals(hpAfterDazzle, fixture.players.get(sid)!!.hp, "stunned mob should not damage the player")
+    }
+
+    @Test
+    fun `Ophirae wrath multiplies the player's outgoing damage`() = runTest {
+        val fixture = CombatTestFixture()
+        val racial = fixture.buildRacialAbilities(
+            registryWith(
+                RacialAbility(
+                    kind = RacialAbilityKind.OPHIRAE_WRATH,
+                    displayName = "Wrath",
+                    cooldownMs = 120_000L,
+                    triggerHealthPct = 20,
+                    damageMultiplier = 2.0,
+                    buffDurationMs = 60_000L,
+                ),
+            ),
+        )
+        val (_, _, combat) = fixture.engage(racial, playerMaxHp = 100, playerHp = 18, mob = enemyMob(hp = 200))
+
+        // Round 1: baseline swing is 1; wrath fires after surviving the hit.
+        fixture.tickCombat(combat)
+        fixture.outbound.drainAll()
+
+        // Round 2: the buffed swing should now read 2 damage.
+        fixture.tickCombat(combat)
+        val texts = fixture.outbound.drainAll().filterIsInstance<OutboundEvent.SendText>().map { it.text }
+        assertTrue(texts.any { it.contains("hit a goblin for 2 damage") }, "expected doubled swing, got: $texts")
+    }
+
+    @Test
+    fun `Mycorae spores summon between one and three pets`() = runTest {
+        val fixture = CombatTestFixture()
+        val racial = fixture.buildRacialAbilities(
+            registryWith(
+                RacialAbility(
+                    kind = RacialAbilityKind.MYCORAE_SPORES,
+                    displayName = "Spores",
+                    cooldownMs = 120_000L,
+                    triggerHealthPct = 25,
+                    petTemplateKey = "spore_mushroom",
+                    petCountMin = 1,
+                    petCountMax = 3,
+                    petDurationMs = 12_000L,
+                ),
+            ),
+            rng = Random(7),
+        )
+        val summoned = mutableListOf<String>()
+        racial.summonRacialPet = { _, template, _, _ ->
+            summoned.add(template)
+            null
+        }
+        val (sid, _, combat) = fixture.engage(racial, playerMaxHp = 100, playerHp = 20, mob = enemyMob(hp = 200))
+
+        fixture.tickCombat(combat)
+
+        assertTrue(summoned.size in 1..3, "expected 1..3 spore pets, got ${summoned.size}")
+        assertTrue(summoned.all { it == "spore_mushroom" }, "wrong pet template: $summoned")
+        assertTrue(fixture.players.get(sid)!!.racialAbilityCooldownUntilMs > 0L)
+    }
+
+    // ── Lethal-blow triggers ─────────────────────────────────────────────
+
+    @Test
+    fun `Kitsarae reversal nullifies a killing blow and heals for its magnitude`() = runTest {
+        val fixture = CombatTestFixture()
+        val racial = fixture.buildRacialAbilities(
+            registryWith(
+                RacialAbility(
+                    kind = RacialAbilityKind.KITSARAE_REVERSAL,
+                    displayName = "Reversal",
+                    cooldownMs = 180_000L,
+                ),
+            ),
+        )
+        val (sid, _, combat) =
+            fixture.engage(racial, playerMaxHp = 100, playerHp = 30, mob = enemyMob(damage = DamageRange(50, 50)))
+
+        fixture.tickCombat(combat)
+
+        // 30 HP, 50-damage killing blow -> end at 30 + 50 = 80, still fighting.
+        assertEquals(80, fixture.players.get(sid)!!.hp, "blow should become a heal of equal size")
+        assertTrue(combat.isInCombat(sid), "Kitsarae keeps fighting")
+        assertTrue(fixture.players.get(sid)!!.racialAbilityCooldownUntilMs > 0L)
+    }
+
+    @Test
+    fun `Aetherae phase survives the blow and the mob whiffs while untargetable`() = runTest {
+        val fixture = CombatTestFixture()
+        val racial = fixture.buildRacialAbilities(
+            registryWith(
+                RacialAbility(
+                    kind = RacialAbilityKind.AETHERAE_PHASE,
+                    displayName = "Phase",
+                    cooldownMs = 150_000L,
+                    phaseTicks = 2,
+                ),
+            ),
+        )
+        val (sid, mob, combat) =
+            fixture.engage(racial, playerMaxHp = 100, playerHp = 40, mob = enemyMob(damage = DamageRange(50, 50)))
+
+        // Round 1: lethal blow phased — HP held at pre-hit value, player untargetable.
+        fixture.tickCombat(combat)
+        fixture.outbound.drainAll()
+        assertEquals(40, fixture.players.get(sid)!!.hp, "phase keeps the pre-hit HP")
+        assertTrue(fixture.players.get(sid)!!.untargetableUntilMs > fixture.clock.millis())
+        assertTrue(combat.isInCombat(sid), "Aetherae stays engaged")
+
+        // Round 2: mob can't target the phased player, so it whiffs and stays in combat.
+        fixture.tickCombat(combat)
+        assertEquals(40, fixture.players.get(sid)!!.hp, "untargetable player takes no damage")
+        assertTrue(combat.isMobInCombat(mob.id), "mob stays in combat rather than disengaging")
+    }
+
+    @Test
+    fun `Lithae stone form disengages, regenerates, roots, and turns untargetable`() = runTest {
+        val fixture = CombatTestFixture()
+        val statusEffects = fixture.buildStatusEffects(
+            StatusEffectDefinition(StatusEffectId("stoneform_root"), "Stone Form", "root", durationMs = 4_000L),
+        )
+        val racial = fixture.buildRacialAbilities(
+            registryWith(
+                RacialAbility(
+                    kind = RacialAbilityKind.LITHAE_STONEFORM,
+                    displayName = "Stone Form",
+                    cooldownMs = 150_000L,
+                    regenPctOfMaxHp = 0.2,
+                    stoneStatusId = "stoneform_root",
+                    stoneDurationMs = 4_000L,
+                ),
+            ),
+            statusEffects = statusEffects,
+        )
+        val (sid, _, combat) = fixture.engage(
+            racial,
+            statusEffects,
+            playerMaxHp = 100,
+            playerHp = 30,
+            mob = enemyMob(damage = DamageRange(50, 50)),
+        )
+
+        fixture.tickCombat(combat)
+
+        val player = fixture.players.get(sid)!!
+        assertEquals(50, player.hp, "stone form regenerates 20% of max on top of the negated blow")
+        assertFalse(combat.isInCombat(sid), "stone form disengages combat")
+        assertTrue(statusEffects.hasPlayerEffect(sid, "root"), "stone form roots the player in place")
+        assertTrue(player.untargetableUntilMs > fixture.clock.millis(), "stone form is untargetable")
+    }
+
+    @Test
+    fun `Lustriae timeslip survives when the extra attack kills the attacker`() = runTest {
+        val fixture = CombatTestFixture()
+        val racial = fixture.buildRacialAbilities(
+            registryWith(
+                RacialAbility(
+                    kind = RacialAbilityKind.LUSTRIAE_TIMESLIP,
+                    displayName = "Timeslip",
+                    cooldownMs = 150_000L,
+                ),
+            ),
+        )
+        // Mob at 2 HP: the player's normal swing drops it to 1, the timeslip swing finishes it.
+        val (sid, mob, combat) =
+            fixture.engage(racial, playerMaxHp = 100, playerHp = 30, mob = enemyMob(damage = DamageRange(50, 50), hp = 2))
+
+        fixture.tickCombat(combat)
+
+        assertEquals(30, fixture.players.get(sid)!!.hp, "the negated blow leaves the player at pre-hit HP")
+        assertEquals(0, mob.hp, "the timeslip strike should fell the attacker")
+        assertFalse(combat.isInCombat(sid), "combat ends once the attacker dies")
+    }
+
+    @Test
+    fun `Lustriae timeslip still dies when the extra attack is not enough`() = runTest {
+        val fixture = CombatTestFixture()
+        val racial = fixture.buildRacialAbilities(
+            registryWith(
+                RacialAbility(
+                    kind = RacialAbilityKind.LUSTRIAE_TIMESLIP,
+                    displayName = "Timeslip",
+                    cooldownMs = 150_000L,
+                ),
+            ),
+        )
+        // Mob too healthy for one extra swing to kill — the player dies, but the cooldown still burns.
+        val (sid, _, combat) =
+            fixture.engage(racial, playerMaxHp = 100, playerHp = 30, mob = enemyMob(damage = DamageRange(50, 50), hp = 200))
+
+        fixture.tickCombat(combat)
+        val texts = fixture.outbound.drainAll().filterIsInstance<OutboundEvent.SendText>().map { it.text }
+
+        assertTrue(texts.any { it.contains("slain") }, "player should die, got: $texts")
+        assertTrue(fixture.players.get(sid)!!.racialAbilityCooldownUntilMs > 0L, "timeslip still burns its cooldown")
+    }
+
+    // ── Cooldown gate ────────────────────────────────────────────────────
+
+    @Test
+    fun `a triggered ability does not fire again while on cooldown`() = runTest {
+        val fixture = CombatTestFixture()
+        val racial = fixture.buildRacialAbilities(
+            registryWith(
+                RacialAbility(
+                    kind = RacialAbilityKind.PYRAE_IMMOLATE,
+                    displayName = "Immolation",
+                    cooldownMs = 120_000L,
+                    triggerHealthPct = 10,
+                    aoeDamagePctOfMaxHp = 0.6,
+                ),
+            ),
+        )
+        val (_, _, combat) = fixture.engage(racial, playerMaxHp = 100, playerHp = 8, mob = enemyMob(hp = 500))
+
+        fixture.tickCombat(combat)
+        fixture.outbound.drainAll()
+
+        // Still at low HP a round later, but the cooldown (120s) blocks a re-trigger.
+        fixture.tickCombat(combat)
+        val texts = fixture.outbound.drainAll().filterIsInstance<OutboundEvent.SendText>().map { it.text }
+        assertFalse(texts.any { it.contains("engulfed in flames") }, "immolation must not re-fire on cooldown: $texts")
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/RacialAbilitySystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/RacialAbilitySystemTest.kt
@@ -114,6 +114,36 @@ class RacialAbilitySystemTest {
     }
 
     @Test
+    fun `Pyrae immolation that kills the engaged mob still prompts the player`() = runTest {
+        val fixture = CombatTestFixture()
+        val racial = fixture.buildRacialAbilities(
+            registryWith(
+                RacialAbility(
+                    kind = RacialAbilityKind.PYRAE_IMMOLATE,
+                    displayName = "Immolation",
+                    cooldownMs = 120_000L,
+                    triggerHealthPct = 10,
+                    aoeDamagePctOfMaxHp = 0.6,
+                ),
+            ),
+        )
+        // 60-damage AoE on a 30-HP mob ends the fight during the mob-attack phase. handleMobDeath
+        // clears the player's target, so the late prompt sweep can't cover them — dealRacialDamage
+        // must prompt directly.
+        val (sid, mob, combat) = fixture.engage(racial, playerMaxHp = 100, playerHp = 8, mob = enemyMob(hp = 30))
+
+        fixture.tickCombat(combat)
+        val events = fixture.outbound.drainAll()
+
+        assertTrue(mob.hp <= 0, "immolation should have killed the mob")
+        assertFalse(combat.isInCombat(sid), "the kill should end combat")
+        assertTrue(
+            events.any { it is OutboundEvent.SendPrompt && it.sessionId == sid },
+            "a racial kill that ends combat must still prompt the player",
+        )
+    }
+
+    @Test
     fun `Aurelia dazzle stuns the enemy so it skips its next attack`() = runTest {
         val fixture = CombatTestFixture()
         val statusEffects = fixture.buildStatusEffects(
@@ -140,9 +170,15 @@ class RacialAbilitySystemTest {
         assertTrue(statusEffects.hasMobEffect(mob.id, "stun"), "mob should be stunned by the dazzle")
         val hpAfterDazzle = fixture.players.get(sid)!!.hp
 
-        // Round 2: the stunned mob forfeits its attack, so the player takes no further damage.
+        // Round 2: the stunned mob forfeits its attack, so the player takes no further damage — but
+        // it must still emit a prompt, or prompt-driven clients look idle through the stun.
         fixture.tickCombat(combat)
+        val round2 = fixture.outbound.drainAll()
         assertEquals(hpAfterDazzle, fixture.players.get(sid)!!.hp, "stunned mob should not damage the player")
+        assertTrue(
+            round2.any { it is OutboundEvent.SendPrompt && it.sessionId == sid },
+            "a stunned round should still prompt the engaged player",
+        )
     }
 
     @Test

--- a/src/test/kotlin/dev/ambon/persistence/PersistenceFieldCoverageTest.kt
+++ b/src/test/kotlin/dev/ambon/persistence/PersistenceFieldCoverageTest.kt
@@ -152,6 +152,7 @@ class PersistenceFieldCoverageTest {
                     """{"mobs":{"academy:wandering_wisp":{"firstRecordedAtMs":1700000333000,""" +
                         """"timesRecorded":2,"lastXpAtMs":1700000334000,"source":"illuminated"}},""" +
                         """"items":{},"rooms":{}}""",
+                racialAbilityCooldownUntilMs = 7_777_000L,
             )
 
         @BeforeAll

--- a/src/test/kotlin/dev/ambon/test/CombatTestFixture.kt
+++ b/src/test/kotlin/dev/ambon/test/CombatTestFixture.kt
@@ -18,6 +18,8 @@ import dev.ambon.engine.PetSystem
 import dev.ambon.engine.PlayerClassRegistry
 import dev.ambon.engine.PlayerProgression
 import dev.ambon.engine.PlayerRegistry
+import dev.ambon.engine.RaceRegistry
+import dev.ambon.engine.RacialAbilitySystem
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.engine.status.StatusEffectDefinition
 import dev.ambon.engine.status.StatusEffectRegistry
@@ -89,6 +91,7 @@ class CombatTestFixture(
         classRegistry: PlayerClassRegistry? = null,
         onRoomItemsChanged: suspend (RoomId) -> Unit = { _ -> },
         petSystem: PetSystem? = null,
+        racialAbilitySystem: RacialAbilitySystem? = null,
     ): CombatSystem {
         require(minDamage == maxDamage) {
             "Test fixture damage range collapsed to a single value (was $minDamage..$maxDamage). " +
@@ -122,7 +125,11 @@ class CombatTestFixture(
             ),
             classRegistry = classRegistry,
             petSystem = petSystem,
-        )
+            racialAbilitySystem = racialAbilitySystem,
+        ).also { combat ->
+            // Mirror GameEngine: the racial system reaches back into combat through the bridge.
+            racialAbilitySystem?.combatBridge = combat
+        }
     }
 
     /**
@@ -171,6 +178,22 @@ class CombatTestFixture(
             dirtyNotifier = DirtyNotifier.NO_OP,
         )
     }
+
+    /** Build a [RacialAbilitySystem] wired to this fixture, with [raceRegistry] supplying race defs. */
+    fun buildRacialAbilities(
+        raceRegistry: RaceRegistry,
+        statusEffects: StatusEffectSystem? = null,
+        rng: Random = Random(1),
+        tickMillis: Long = 1_000L,
+    ): RacialAbilitySystem =
+        RacialAbilitySystem(
+            raceRegistry = raceRegistry,
+            outbound = outbound,
+            dirtyNotifier = DirtyNotifier.NO_OP,
+            statusEffects = statusEffects,
+            rng = rng,
+            tickMillis = tickMillis,
+        )
 }
 
 /**


### PR DESCRIPTION
## What

A full vertical slice of a new **racial passive ability** subsystem: config-driven passives that fire from combat hooks and burn a long, persisted cooldown so they can't be cheesed by relogging. The theme is winning close fights without retreating to the sanctum.

### Trigger model
- **Low-health** (fires after the player *survives* a mob hit with HP ≤ a per-race threshold), next to the existing wimpy auto-flee hook.
- **Would-be-lethal blow** (intercepted at the `hp <= 0` death check, before `handlePlayerDeath`).

Both gated by a single **persisted** cooldown (`racialAbilityCooldownUntilMs`, V46 migration) — chosen over runtime-only so a relog mid-fight can't reset a death-cheating ability.

### The nine abilities
| Race | Trigger | Effect |
|------|---------|--------|
| Pyrae | low HP | AoE flame damage to all engaged enemies |
| Aurelia | low HP | stuns engaged enemies (dazzle) |
| Mycorae | low HP | summons 1d3 high-threat tank mushrooms |
| Archae | low HP | summons a short-lived Drengariae DPS soldier |
| Ophirae | low HP | outgoing-damage multiplier buff |
| Kitsarae | lethal | nullifies the blow and heals for its magnitude |
| Lustriae | lethal | extra attack; survives if it kills the attacker |
| Lithae | lethal | stone form: disengage + untargetable + regen + rooted |
| Aetherae | lethal | phases out, ignoring the blow and the next round |

## How
- New `RacialAbilitySystem` owns trigger dispatch, the persisted cooldown, and the per-race effects.
- `CombatSystem` implements a small `RacialCombatBridge` (enemy enumeration, extra swing, AoE damage, disengage) and calls the two hooks from the mob-attack phase.
- New enforcement: **untargetable** (mob target selection skips phased players; a fully-phased target makes the mob whiff a round rather than leave combat) and **damage-boost** runtime state on `PlayerState`. Mob **stun** is now honored in the attack phase. Lithae reuses the existing `root` movement-block via a self-applied status effect.
- Pet attack phase generalized from the single active pet to **all** of an owner's pets, so the spore swarm tanks and the soldier fights.
- `executeMobMelee`/`executeMobSpell` now return damage dealt so the lethal-blow hook knows the killing blow's magnitude (Kitsarae heals for exactly that).

## Config
Schema lives on `RaceDefinitionConfig.racialAbility` in `AppConfig` (validated). The nine races, two status effects (`dazzle_stun`, `stoneform_root`), and two pet templates (`spore_mushroom`, `drengariae_soldier`) are added to the bundled `application.yaml` so the slice is fully runnable in the demo.

> ⚠️ The production world (Auringold) defines its race list via the R2 config overlay, which **replaces** `application.yaml` rather than deep-merging. The same `racialAbility` blocks must be carried into the Auringold overlay for these to take effect in production.

## Scope / follow-ups
- PvE only for now — PvP keeps its existing arena-respawn flow.
- Mushroom taunt relies on a high `threatMultiplier` + a one-round ramp (matches the design intent of a higher Mycorae trigger threshold) rather than seeded initial threat.

## Testing
⚠️ **No JDK is available in this environment**, so I could not run `ktlintCheck`/`test` locally — relying on CI (Temurin 21). Unit tests for each trigger, cooldown persistence, and the untargetable/stun enforcement are included in this PR.