### PR TITLE
fix(combat): surface racial passive procs in the web client

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -1102,6 +1102,9 @@ class GameEngine(
         // bridge, and summon their pets through this callback so pet stats scale to the owner and
         // the new mob is broadcast to the room immediately.
         racialAbilitySystem.combatBridge = combatSystem
+        // Racial procs surface their narrative lines through the same combat-event GMCP path as the
+        // rest of combat, so the web client shows them in the combat log / canvas (not just telnet).
+        racialAbilitySystem.onCombatEvent = { sid, event -> gmcpEmitter.sendCombatEvent(sid, event) }
         racialAbilitySystem.summonRacialPet = { sid, templateKey, durationMs, replaceExisting ->
             val player = players.get(sid)
             if (player == null) {

--- a/src/main/kotlin/dev/ambon/engine/RacialAbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/RacialAbilitySystem.kt
@@ -6,6 +6,7 @@ import dev.ambon.domain.RacialAbilityKind
 import dev.ambon.domain.RacialTrigger
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.mob.MobState
+import dev.ambon.engine.events.CombatEvent
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.status.StatusEffectId
 import dev.ambon.engine.status.StatusEffectSystem
@@ -69,6 +70,14 @@ class RacialAbilitySystem(
     var combatBridge: RacialCombatBridge? = null
 
     /**
+     * Emits a structured combat event for the triggering player. Wired by GameEngine to the same
+     * `Char.Combat.Event` GMCP path the rest of combat uses, so racial procs reach the web client's
+     * scrolling combat log and floating canvas text — a bare [OutboundEvent.SendText] only renders
+     * on telnet and is invisible in the graphical client.
+     */
+    var onCombatEvent: suspend (SessionId, CombatEvent) -> Unit = { _, _ -> }
+
+    /**
      * Summons a racial pet. Wired by GameEngine, which knows how to scale pet stats to the owner and
      * broadcast the new mob to the room. `replaceExisting=false` lets multiple pets coexist (spores).
      * Returns the spawned pet, or null if summoning failed.
@@ -105,12 +114,37 @@ class RacialAbilitySystem(
         player: PlayerState,
         ability: RacialAbility,
     ) {
-        if (ability.selfMessage.isNotEmpty()) {
-            outbound.send(OutboundEvent.SendText(player.sessionId, ability.selfMessage))
-        }
+        emitProc(player.sessionId, ability, ability.selfMessage)
         if (ability.roomMessage.isNotEmpty()) {
             combatBridge?.broadcastToRoomExcept(player.sessionId, ability.roomMessage.replace("{player}", player.name))
         }
+    }
+
+    /**
+     * Surfaces a racial proc's narrative line to the triggering player on both transports: an
+     * [OutboundEvent.SendText] for the telnet/terminal stream, and a [CombatEvent.AbilityCast] so the
+     * web client renders it in the combat log and as floating canvas text. The combat log prefers the
+     * server-rendered [text], so the player sees the exact same line on both clients.
+     */
+    private suspend fun emitProc(
+        sessionId: SessionId,
+        ability: RacialAbility,
+        text: String,
+    ) {
+        if (text.isEmpty()) return
+        outbound.send(OutboundEvent.SendText(sessionId, text))
+        onCombatEvent(
+            sessionId,
+            CombatEvent.AbilityCast(
+                abilityId = "racial:${ability.kind.name.lowercase()}",
+                abilityName = ability.displayName,
+                targetName = null,
+                targetId = null,
+                targetIsPlayer = true,
+                sourceIsPlayer = true,
+                text = text,
+            ),
+        )
     }
 
     // ── Low-health trigger ───────────────────────────────────────────────
@@ -271,12 +305,10 @@ class RacialAbilitySystem(
             // The extra attack felled the foe before its blow could land — the player is unharmed.
             player.hp = preHitHp.coerceAtLeast(1)
             dirtyNotifier.playerVitalsDirty(sessionId)
-            outbound.send(
-                OutboundEvent.SendText(sessionId, "Time snaps back into place — ${attacker.name} falls and you stand unscathed."),
-            )
+            emitProc(sessionId, ability, "Time snaps back into place — ${attacker.name} falls and you stand unscathed.")
             true
         } else {
-            outbound.send(OutboundEvent.SendText(sessionId, "...but it was not enough to fell ${attacker.name}."))
+            emitProc(sessionId, ability, "...but it was not enough to fell ${attacker.name}.")
             false
         }
     }

--- a/src/main/kotlin/dev/ambon/engine/RacialAbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/RacialAbilitySystem.kt
@@ -114,7 +114,9 @@ class RacialAbilitySystem(
         player: PlayerState,
         ability: RacialAbility,
     ) {
-        emitProc(player.sessionId, ability, ability.selfMessage)
+        // A LETHAL_BLOW proc only ever announces on a successful save, so flag it as a death-cheat so
+        // the web client pops a dedicated toast (a turned-around low-health fight just goes to the log).
+        emitProc(player.sessionId, ability, ability.selfMessage, deathCheat = ability.trigger == RacialTrigger.LETHAL_BLOW)
         if (ability.roomMessage.isNotEmpty()) {
             combatBridge?.broadcastToRoomExcept(player.sessionId, ability.roomMessage.replace("{player}", player.name))
         }
@@ -125,18 +127,23 @@ class RacialAbilitySystem(
      * [OutboundEvent.SendText] for the telnet/terminal stream, and a [CombatEvent.AbilityCast] so the
      * web client renders it in the combat log and as floating canvas text. The combat log prefers the
      * server-rendered [text], so the player sees the exact same line on both clients.
+     *
+     * When [deathCheat] is true the ability id is namespaced `racial:save:` (vs `racial:`) so the web
+     * client can pop a triumphant "cheated death" toast for the lethal-blow saves specifically.
      */
     private suspend fun emitProc(
         sessionId: SessionId,
         ability: RacialAbility,
         text: String,
+        deathCheat: Boolean = false,
     ) {
         if (text.isEmpty()) return
         outbound.send(OutboundEvent.SendText(sessionId, text))
+        val idPrefix = if (deathCheat) "racial:save:" else "racial:"
         onCombatEvent(
             sessionId,
             CombatEvent.AbilityCast(
-                abilityId = "racial:${ability.kind.name.lowercase()}",
+                abilityId = "$idPrefix${ability.kind.name.lowercase()}",
                 abilityName = ability.displayName,
                 targetName = null,
                 targetId = null,
@@ -305,7 +312,7 @@ class RacialAbilitySystem(
             // The extra attack felled the foe before its blow could land — the player is unharmed.
             player.hp = preHitHp.coerceAtLeast(1)
             dirtyNotifier.playerVitalsDirty(sessionId)
-            emitProc(sessionId, ability, "Time snaps back into place — ${attacker.name} falls and you stand unscathed.")
+            emitProc(sessionId, ability, "Time snaps back into place — ${attacker.name} falls and you stand unscathed.", deathCheat = true)
             true
         } else {
             emitProc(sessionId, ability, "...but it was not enough to fell ${attacker.name}.")

--- a/src/test/kotlin/dev/ambon/engine/RacialAbilitySystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/RacialAbilitySystemTest.kt
@@ -298,6 +298,34 @@ class RacialAbilitySystemTest {
     }
 
     @Test
+    fun `a lethal-blow save tags its combat event as a death-cheat for the toast`() = runTest {
+        val fixture = CombatTestFixture()
+        val racial = fixture.buildRacialAbilities(
+            registryWith(
+                RacialAbility(
+                    kind = RacialAbilityKind.KITSARAE_REVERSAL,
+                    displayName = "Reversal of Fate",
+                    cooldownMs = 180_000L,
+                    selfMessage = "Death reverses — the blow becomes a healing tide.",
+                ),
+            ),
+        )
+        val combatEvents = mutableListOf<CombatEvent>()
+        racial.onCombatEvent = { _, event -> combatEvents.add(event) }
+        val (_, _, combat) =
+            fixture.engage(racial, playerMaxHp = 100, playerHp = 30, mob = enemyMob(damage = DamageRange(50, 50)))
+
+        fixture.tickCombat(combat)
+
+        // The `racial:save:` prefix is what the web client keys the "cheated death" toast off of; a
+        // low-health proc would instead be `racial:` and only reach the combat log.
+        val save = combatEvents.filterIsInstance<CombatEvent.AbilityCast>()
+            .firstOrNull { it.abilityId == "racial:save:kitsarae_reversal" }
+        assertTrue(save != null, "lethal-blow save should be tagged racial:save:, got: $combatEvents")
+        assertEquals("Death reverses — the blow becomes a healing tide.", save!!.text)
+    }
+
+    @Test
     fun `Aetherae phase survives the blow and the mob whiffs while untargetable`() = runTest {
         val fixture = CombatTestFixture()
         val racial = fixture.buildRacialAbilities(

--- a/src/test/kotlin/dev/ambon/engine/RacialAbilitySystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/RacialAbilitySystemTest.kt
@@ -7,6 +7,7 @@ import dev.ambon.domain.RacialAbilityKind
 import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.mob.MobState
+import dev.ambon.engine.events.CombatEvent
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.status.StatusEffectDefinition
 import dev.ambon.engine.status.StatusEffectId
@@ -111,6 +112,37 @@ class RacialAbilitySystemTest {
         assertTrue(texts.any { it.contains("engulfed in flames") }, "expected immolation AoE, got: $texts")
         assertTrue(mob.hp <= 200 - 60, "mob should take >= 60 AoE damage, hp=${mob.hp}")
         assertTrue(fixture.players.get(sid)!!.racialAbilityCooldownUntilMs > 0L, "cooldown should be set")
+    }
+
+    @Test
+    fun `racial proc emits an AbilityCast combat event so the web client surfaces it`() = runTest {
+        val fixture = CombatTestFixture()
+        val racial = fixture.buildRacialAbilities(
+            registryWith(
+                RacialAbility(
+                    kind = RacialAbilityKind.PYRAE_IMMOLATE,
+                    displayName = "Immolation",
+                    cooldownMs = 120_000L,
+                    triggerHealthPct = 10,
+                    aoeDamagePctOfMaxHp = 0.6,
+                    selfMessage = "You erupt in flame!",
+                ),
+            ),
+        )
+        val combatEvents = mutableListOf<Pair<SessionId, CombatEvent>>()
+        racial.onCombatEvent = { sid, event -> combatEvents.add(sid to event) }
+        val (sid, _, combat) = fixture.engage(racial, playerMaxHp = 100, playerHp = 8, mob = enemyMob(hp = 200))
+
+        fixture.tickCombat(combat)
+
+        // The self message reaches the web client as a combat-log/canvas event carrying the same text,
+        // not just the telnet-only SendText.
+        val cast = combatEvents.map { it.second }.filterIsInstance<CombatEvent.AbilityCast>()
+            .firstOrNull { it.text == "You erupt in flame!" }
+        assertTrue(cast != null, "expected an AbilityCast carrying the self message, got: $combatEvents")
+        assertEquals(sid, combatEvents.first { it.second is CombatEvent.AbilityCast }.first)
+        assertTrue(cast!!.targetIsPlayer, "a self-proc targets the triggering player")
+        assertEquals("racial:pyrae_immolate", cast.abilityId)
     }
 
     @Test

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -53,6 +53,7 @@ import { LevelUpBanner } from "./components/LevelUpBanner";
 import { QuestCompleteToast } from "./components/QuestCompleteToast";
 import { CombatVictoryToast } from "./components/CombatVictoryToast";
 import { FleeToast } from "./components/FleeToast";
+import { RacialProcToast } from "./components/RacialProcToast";
 import { LyricToasts } from "./components/LyricToasts";
 import { buildLyricSources } from "./components/lyricSources";
 import { LoginModal } from "./canvas/LoginModal";
@@ -2369,6 +2370,14 @@ function App() {
         notifications={state.fleeNotifications}
         onDismiss={(id) =>
           state.setFleeNotifications((prev) => prev.filter((n) => n.id !== id))
+        }
+      />
+
+      {/* Racial proc toast — surfaces lethal-blow saves (cheated-death passives). */}
+      <RacialProcToast
+        notifications={state.racialProcNotifications}
+        onDismiss={(id) =>
+          state.setRacialProcNotifications((prev) => prev.filter((n) => n.id !== id))
         }
       />
 

--- a/web-v3/src/components/RacialProcToast.tsx
+++ b/web-v3/src/components/RacialProcToast.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+import type { RacialProcNotification } from "../types";
+
+interface RacialProcToastProps {
+  notifications: RacialProcNotification[];
+  onDismiss: (id: string) => void;
+}
+
+/**
+ * Top-right toast surfaced when a racial passive cheats death (a lethal-blow
+ * save). Mirrors CombatVictoryToast / FleeToast — only the most recent save is
+ * rendered, and it shares the corner slot with them (useGameState clears the
+ * other lists when one fires). Distinct mythic color/icon so it reads as a
+ * race-defining moment, not a kill or a flee.
+ */
+export function RacialProcToast({ notifications, onDismiss }: RacialProcToastProps) {
+  const current = notifications.length > 0 ? notifications[notifications.length - 1] : null;
+  if (!current) return null;
+  return (
+    <RacialProcToastInner
+      key={current.id}
+      notification={current}
+      onDismiss={() => onDismiss(current.id)}
+    />
+  );
+}
+
+interface InnerProps {
+  notification: RacialProcNotification;
+  onDismiss: () => void;
+}
+
+function RacialProcToastInner({ notification, onDismiss }: InnerProps) {
+  const [closing, setClosing] = useState(false);
+
+  useEffect(() => {
+    const fade = window.setTimeout(() => setClosing(true), 4500);
+    return () => window.clearTimeout(fade);
+  }, []);
+
+  useEffect(() => {
+    if (!closing) return;
+    const clear = window.setTimeout(() => onDismiss(), 350);
+    return () => window.clearTimeout(clear);
+  }, [closing, onDismiss]);
+
+  const { abilityName, text } = notification;
+
+  return (
+    <div
+      className={`racial-proc-toast${closing ? " racial-proc-toast-closing" : ""}`}
+      role="status"
+      aria-live="polite"
+      onClick={() => setClosing(true)}
+    >
+      <div className="racial-proc-toast-header">
+        <span className="racial-proc-toast-icon" aria-hidden="true">{"✦"}</span>
+        <div className="racial-proc-toast-titles">
+          <span className="racial-proc-toast-eyebrow">Cheated death</span>
+          <span className="racial-proc-toast-name">{abilityName}</span>
+        </div>
+      </div>
+      <p className="racial-proc-toast-text">{text}</p>
+    </div>
+  );
+}

--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -77,6 +77,7 @@ import type {
   QuestAvailable,
   QuestEntry,
   QuestNotification,
+  RacialProcNotification,
   RoomFeature,
   RoomItem,
   RoomMob,
@@ -232,6 +233,8 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
   const combatVictoryIdRef = useRef(0);
   const [fleeNotifications, setFleeNotifications] = useState<FleeNotification[]>([]);
   const fleeIdRef = useRef(0);
+  const [racialProcNotifications, setRacialProcNotifications] = useState<RacialProcNotification[]>([]);
+  const racialProcIdRef = useRef(0);
   const [duelState, setDuelState] = useState<DuelState | null>(null);
   const [duelChallenge, setDuelChallenge] = useState<DuelChallenge | null>(null);
 
@@ -387,9 +390,25 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
       // Replace (rather than append) so back-to-back kills don't queue stale
       // toasts behind the active one — otherwise the active toast's dismissal
       // resurfaces a prior kill several seconds late. Also clear any active
-      // flee toast: kill and flee share a fixed corner slot, and the freshest
-      // outcome supersedes the stale one.
+      // flee / racial-save toast: they share a fixed corner slot, and the
+      // freshest outcome supersedes the stale one.
       setCombatVictoryNotifications([notification]);
+      setFleeNotifications([]);
+      setRacialProcNotifications([]);
+    }
+    // A racial passive that cheated death (lethal-blow save). The server tags these
+    // abilityCast events `racial:save:*`; low-health procs (`racial:*`) only hit the log.
+    if (event.type === "abilityCast" && event.abilityId?.startsWith("racial:save:") && event.text) {
+      racialProcIdRef.current += 1;
+      const notification: RacialProcNotification = {
+        id: `racial-proc-${racialProcIdRef.current}`,
+        abilityName: event.abilityName ?? "Racial power",
+        text: event.text,
+        receivedAt: Date.now(),
+      };
+      // Freshest outcome wins the shared corner slot, mirroring kill/flee.
+      setRacialProcNotifications([notification]);
+      setCombatVictoryNotifications([]);
       setFleeNotifications([]);
     }
     if (event.type === "flee" && event.targetName) {
@@ -406,6 +425,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
       // cards stack at the same `top:` and overlap.
       setFleeNotifications([notification]);
       setCombatVictoryNotifications([]);
+      setRacialProcNotifications([]);
     }
   }, [pushCombatLogMessage]);
 
@@ -755,6 +775,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     setQuestNotifications([]);
     setCombatVictoryNotifications([]);
     setFleeNotifications([]);
+    setRacialProcNotifications([]);
     setCraftingSkills([]);
     setCraftingRecipes([]);
     setCraftingNodes([]);
@@ -851,6 +872,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     levelUpNotification, setLevelUpNotification,
     combatVictoryNotifications, setCombatVictoryNotifications,
     fleeNotifications, setFleeNotifications,
+    racialProcNotifications, setRacialProcNotifications,
     // Setters needed by App
     setQuestsAvailable,
     // GMCP

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -21119,6 +21119,111 @@ html:has(.game-shell),
   }
 }
 
+/* ── Racial proc toast (cheated-death lethal-blow saves) ──────────────────
+   Shares the top-right corner slot with the victory/flee toasts; `useGameState`
+   clears the other lists when one fires, so the cards never overlap. A mythic
+   gold/lavender treatment sets it apart from a kill (rose) or flee (blue). */
+.racial-proc-toast {
+  position: fixed;
+  top: calc(var(--space-4, 16px) + 56px + 180px);
+  right: var(--space-4, 16px);
+  z-index: 240;
+  width: min(320px, calc(100vw - 32px));
+  padding: 14px 16px;
+  background: linear-gradient(
+    155deg,
+    color-mix(in srgb, var(--c-soft-gold, #f0c674) 26%, var(--c-surface-raised, #1e2340)) 0%,
+    var(--c-surface-raised, #1e2340) 58%,
+    color-mix(in srgb, var(--c-accent-lavender, #b294bb) 20%, var(--c-surface-raised, #1e2340)) 100%
+  );
+  border: 1px solid color-mix(in srgb, var(--c-soft-gold, #f0c674) 50%, transparent);
+  border-radius: 14px;
+  box-shadow:
+    0 18px 48px rgba(0, 0, 0, 0.45),
+    0 0 0 1px color-mix(in srgb, var(--c-soft-gold, #f0c674) 24%, transparent),
+    0 0 34px color-mix(in srgb, var(--c-accent-lavender, #b294bb) 30%, transparent);
+  color: var(--c-text-primary, #d8dcef);
+  cursor: pointer;
+  animation: racialProcToastIn 380ms var(--ease-out-soft, cubic-bezier(0.22, 1, 0.36, 1));
+  backdrop-filter: blur(8px);
+}
+
+.racial-proc-toast.racial-proc-toast-closing {
+  animation: racialProcToastOut 320ms var(--ease-out-soft, cubic-bezier(0.22, 1, 0.36, 1)) forwards;
+}
+
+@keyframes racialProcToastIn {
+  from {
+    opacity: 0;
+    transform: translateX(24px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+}
+
+@keyframes racialProcToastOut {
+  from {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(16px) scale(0.97);
+  }
+}
+
+.racial-proc-toast-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.racial-proc-toast-icon {
+  font-size: 22px;
+  filter: drop-shadow(0 0 6px color-mix(in srgb, var(--c-soft-gold, #f0c674) 65%, transparent));
+}
+
+.racial-proc-toast-titles {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.racial-proc-toast-eyebrow {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: color-mix(in srgb, var(--c-soft-gold, #f0c674) 82%, var(--c-text-secondary, #8890b0));
+  font-weight: 600;
+}
+
+.racial-proc-toast-name {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--c-text-primary, #d8dcef);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.racial-proc-toast-text {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--c-text-secondary, #8890b0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .racial-proc-toast,
+  .racial-proc-toast.racial-proc-toast-closing {
+    animation-duration: 80ms;
+  }
+}
+
 /* ── Monster manual / bestiary page ──────────────────────────────────────
    A parchment "field manual" entry for a clicked creature. Tier classes
    (.consider-tier-*) set --consider-accent, reused for the badge + win bar.

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -839,6 +839,19 @@ export interface FleeNotification {
   receivedAt: number;
 }
 
+/**
+ * Top-right toast surfaced when a racial passive cheats death — a lethal-blow
+ * save (Kitsarae reversal, Lithae stoneform, Aetherae phase, Lustriae timeslip).
+ * Built from `Char.Combat.Event` `abilityCast` packets whose `abilityId` is
+ * namespaced `racial:save:`. Low-health racial procs only reach the combat log.
+ */
+export interface RacialProcNotification {
+  id: string;
+  abilityName: string;
+  text: string;
+  receivedAt: number;
+}
+
 export interface QuestRewardItem {
   itemId: string;
   displayName: string;


### PR DESCRIPTION
## Problem

The new racial passive abilities trigger on low health or a would-be-lethal blow, but their proc messages only reached telnet. In the graphical web client they were invisible — the player got saved from death (or erupted in flame) with no on-screen feedback.

## Root cause

`RacialAbilitySystem` announced procs with `OutboundEvent.SendText` only. That raw-text path renders in the telnet stream, but the web client surfaces combat through structured `Char.Combat.Event` GMCP messages. Every other combat line already **dual-emits**: `SendText` for telnet **and** a `CombatEvent` for the web client. Racial procs skipped the second half.

## Fix

**1. Combat-log visibility (all nine abilities)**
- Added an `onCombatEvent` callback to `RacialAbilitySystem`, wired in `GameEngine` to the same `gmcpEmitter.sendCombatEvent` path `CombatSystem`/`StatusEffectSystem` use.
- New `emitProc()` helper dual-emits each proc line: keeps the telnet `SendText` and adds a `CombatEvent.AbilityCast` carrying the server-rendered text (`targetIsPlayer = true`). The web combat log already prefers `event.text`, so both clients show the identical line.

**2. Cheated-death toast (lethal-blow saves)**
- Lethal-blow saves (Kitsarae reversal, Lithae stoneform, Aetherae phase, Lustriae timeslip-success) are tagged with a `racial:save:` ability-id prefix (low-health procs use `racial:` and stay log-only; the timeslip *failure* line is deliberately untagged).
- New `RacialProcToast` component pops a mythic 'cheated death' card keyed off that prefix. It shares the top-right corner slot with the kill/flee toasts via the existing freshest-outcome-wins clearing in `useGameState`, so the three never overlap.

## Tests

- `RacialAbilitySystemTest`: a low-health proc emits an `AbilityCast` carrying its self message (`racial:pyrae_immolate`); a lethal-blow save is tagged `racial:save:kitsarae_reversal`.
- `./gradlew ktlintCheck test --tests "dev.ambon.engine.RacialAbilitySystemTest"` passes; `web-v3` `bun run build` (tsc typecheck + vite) passes.