### PR TITLE
feat(engine): level + stat scaling for absorb shields

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -416,6 +416,7 @@ data class AppConfig(
             b.dodgeStat to "dodgeStat",
             b.spellDamageStat to "spellDamageStat",
             b.healStat to "healStat",
+            b.shieldStat to "shieldStat",
             b.buffStat to "buffStat",
             b.hpScalingStat to "hpScalingStat",
             b.manaScalingStat to "manaScalingStat",
@@ -455,6 +456,10 @@ data class AppConfig(
         }
         require(b.healVarianceMin > 0.0 && b.healVarianceMax >= b.healVarianceMin) {
             "ambonMUD.engine.stats.bindings.healVarianceMin/Max must satisfy 0 < min <= max"
+        }
+        require(b.shieldStatMultiplier >= 0.0) { "ambonMUD.engine.stats.bindings.shieldStatMultiplier must be >= 0" }
+        require(b.shieldLevelScalingRate >= 1.0) {
+            "ambonMUD.engine.stats.bindings.shieldLevelScalingRate must be >= 1.0 (use 1.0 to disable)"
         }
         require(b.buffDurationPerStat >= 0.0) {
             "ambonMUD.engine.stats.bindings.buffDurationPerStat must be >= 0"
@@ -2743,6 +2748,20 @@ data class StatBindingsConfig(
     val healLevelScalingRate: Double = 1.30,
     val healVarianceMin: Double = 0.85,
     val healVarianceMax: Double = 1.15,
+    /**
+     * Bindings for absorb shields (`shield` effect type) — same shape as direct
+     * heals, scaled by [shieldStat] (WIS by default). Replaces the flat authored
+     * `shieldAmount` with a stat + level-scaled pool snapshotted at apply time:
+     *
+     *   statBonus   = (stat - basePoint) × shieldStatMultiplier
+     *   levelScale  = shieldLevelScalingRate ^ (level - 1)
+     *   shield      = (shieldAmount + statBonus) × levelScale
+     *
+     * A shield is a one-time pool, not a per-tick roll, so no variance applies.
+     */
+    val shieldStat: String = "WIS",
+    val shieldStatMultiplier: Double = 0.25,
+    val shieldLevelScalingRate: Double = 1.30,
     /**
      * Bindings for buff-style abilities (`AbilityEffect.ApplyStatus` targeting
      * self/ally/group). [buffStat] (CHA by default) drives duration and magnitude

--- a/src/main/kotlin/dev/ambon/engine/status/StatusEffectSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/status/StatusEffectSystem.kt
@@ -112,7 +112,7 @@ class StatusEffectSystem(
                 expiresAtMs = now + def.durationMs,
                 lastTickAtMs = now,
                 sourceSessionId = sourceSessionId,
-                shieldRemaining = def.shieldAmount,
+                shieldRemaining = computeShieldAmount(def, casterLevel, casterStats),
                 tickAnchor = computeTickAnchor(def, casterLevel, casterStats),
             ),
         )
@@ -152,6 +152,33 @@ class StatusEffectSystem(
         val statBonus = (statTotal - PlayerState.BASE_STAT) * statMul
         val levelScale = rate.pow((casterLevel - 1).coerceAtLeast(0))
         return (anchor + statBonus) * levelScale
+    }
+
+    /**
+     * Scales an absorb shield's pool at apply time using the same shape as
+     * direct heals:
+     *
+     *   statBonus  = (stats[shieldStat] - BASE_STAT) × shieldStatMultiplier
+     *   levelScale = shieldLevelScalingRate ^ (level - 1)
+     *   shield     = (shieldAmount + statBonus) × levelScale
+     *
+     * Unlike DOT/HOT ticks the result is a one-time pool, so no variance is
+     * applied. Falls back to the flat authored [StatusEffectDefinition.shieldAmount]
+     * when no caster context is provided (e.g. environmental or admin-applied
+     * effects) or the effect doesn't absorb damage.
+     */
+    private fun computeShieldAmount(
+        def: StatusEffectDefinition,
+        casterLevel: Int?,
+        casterStats: StatMap?,
+    ): Int {
+        if (def.shieldAmount <= 0) return def.shieldAmount
+        if (casterLevel == null) return def.shieldAmount
+        if (effectTypes.get(def.effectType)?.absorbsDamage != true) return def.shieldAmount
+        val statTotal = casterStats?.get(bindings.shieldStat) ?: PlayerState.BASE_STAT
+        val statBonus = (statTotal - PlayerState.BASE_STAT) * bindings.shieldStatMultiplier
+        val levelScale = bindings.shieldLevelScalingRate.pow((casterLevel - 1).coerceAtLeast(0))
+        return ((def.shieldAmount + statBonus) * levelScale).roundToInt().coerceAtLeast(1)
     }
 
     private fun rollTickValue(

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -153,6 +153,13 @@ ambonmud:
         healLevelScalingRate: 1.30
         healVarianceMin: 0.85
         healVarianceMax: 1.15
+        # Absorb shields scale the authored `shieldAmount` like a heal (WIS by
+        # default), snapshotted at apply time. A shield is a one-time pool, not a
+        # per-tick roll, so no variance applies:
+        #   final = round((shieldAmount + statBonus) * shieldLevelScalingRate^(level-1))
+        shieldStat: WIS
+        shieldStatMultiplier: 0.25
+        shieldLevelScalingRate: 1.30
         # Buff bindings — reserved for utility/support classes (bard, herald).
         # Wiring into status-effect duration/magnitude is a follow-up; the knobs
         # exist now so support abilities have a defined scaling lane.

--- a/src/test/kotlin/dev/ambon/engine/status/StatusEffectScalingTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/status/StatusEffectScalingTest.kt
@@ -48,6 +48,9 @@ class StatusEffectScalingTest {
             healLevelScalingRate = 1.30,
             healVarianceMin = 1.0,
             healVarianceMax = 1.0,
+            shieldStat = "WIS",
+            shieldStatMultiplier = 1.0,
+            shieldLevelScalingRate = 1.30,
         )
 
     private inner class Fixture : TestFixtureBase {
@@ -98,6 +101,18 @@ class StatusEffectScalingTest {
                     tickIntervalMs = 2000,
                     tickMinValue = min,
                     tickMaxValue = max,
+                ),
+            )
+        }
+
+        fun registerShield(amount: Int = 10) {
+            registry.register(
+                StatusEffectDefinition(
+                    id = StatusEffectId("barrier"),
+                    displayName = "Barrier",
+                    effectType = "shield",
+                    durationMs = 6000,
+                    shieldAmount = amount,
                 ),
             )
         }
@@ -253,5 +268,41 @@ class StatusEffectScalingTest {
             skewedSystem.tick(h.clock.millis())
 
             assertEquals(1 + 8, player.hp, "HOT should roll with heal variance window")
+        }
+
+    @Test
+    fun `shield pool scales with caster level and WIS`() =
+        runTest {
+            val h = Fixture()
+            h.login()
+            h.registerShield(amount = 10)
+
+            // Level 5, WIS = BASE + 6 → pool = (10 + 6×1.0) × 1.30^4 ≈ 45.698 → 46
+            val wisBonus = 6
+            val expected = ((10.0 + wisBonus * 1.0) * 1.30.pow(4)).roundToInt()
+            h.system.applyToPlayer(
+                sessionId = sid,
+                effectId = StatusEffectId("barrier"),
+                casterLevel = 5,
+                casterStats = StatMap.of("WIS" to PlayerState.BASE_STAT + wisBonus),
+            )
+
+            // Absorb a huge hit — the remainder tells us how big the pool was.
+            val remaining = h.system.absorbPlayerDamage(sid, 100_000)
+            assertEquals(100_000 - expected, remaining, "Shield pool should scale with level + WIS")
+        }
+
+    @Test
+    fun `omitting caster context falls back to flat shield amount`() =
+        runTest {
+            val h = Fixture()
+            h.login()
+            h.registerShield(amount = 25)
+
+            // No casterLevel → flat authored shieldAmount (backward compatible).
+            h.system.applyToPlayer(sessionId = sid, effectId = StatusEffectId("barrier"))
+
+            val remaining = h.system.absorbPlayerDamage(sid, 100_000)
+            assertEquals(100_000 - 25, remaining, "Without caster context, shield should use authored amount")
         }
 }


### PR DESCRIPTION
## What

`shieldAmount` on status effects was a flat field with no level-scaling, unlike DOT/HOT damage and heals which auto-scale with caster level + stat. This makes shields scale the same way.

## How

Shields now snapshot a scaled pool at apply time using the same shape as direct heals:

```
statBonus  = (stats[shieldStat] - BASE_STAT) × shieldStatMultiplier
levelScale = shieldLevelScalingRate ^ (level - 1)
shield     = round((shieldAmount + statBonus) × levelScale)
```

A shield is a one-time pool (not a per-tick roll), so no variance is applied — the value is snapshotted in `ActiveEffect.shieldRemaining` at apply time, mirroring `computeTickAnchor` for DOTs/HOTs.

New `StatBindingsConfig` knobs (defaults match heals): `shieldStat` = WIS, `shieldStatMultiplier` = 0.25, `shieldLevelScalingRate` = 1.30. Validated in `AppConfig.validated()` and surfaced in `application.yaml`.

## Backward compatibility

Falls back to the flat authored `shieldAmount` when no caster context is provided (admin/environmental effects) or the effect type doesn't absorb damage — so existing behavior is preserved for those paths. Ability casts already pass `casterLevel`/`casterStats`, so player-cast shields scale immediately.

## Tests

Added to `StatusEffectScalingTest`: shield pool scales with level + WIS, and falls back to the flat amount without caster context. `ktlintCheck` + full suite green.