### PR TITLE
fix(web): fit pop-out map to zone on open (large zones showed only a fragment)

### DIFF
--- a/web-v3/src/hooks/useMiniMap.ts
+++ b/web-v3/src/hooks/useMiniMap.ts
@@ -572,7 +572,12 @@ export function useMiniMap() {
     const maxZoom = MAX_ZOOM;
     zoomBoundsRef.current = { min: minZoom, max: maxZoom };
 
-    if (zoomRef.current === 0) zoomRef.current = clamp(DEFAULT_ZOOM, minZoom, maxZoom);
+    // On first open (and after a zone change / recenter, which reset zoom to 0),
+    // open at a zoom that shows the WHOLE zone — but never more zoomed-in than the
+    // comfortable default for zones small enough to already fit at DEFAULT_ZOOM.
+    // Without this, large zones (e.g. 16×28 = 280 rooms) opened at a fixed
+    // DEFAULT_ZOOM showing only a small fragment that scrolled as you travelled.
+    if (zoomRef.current === 0) zoomRef.current = clamp(Math.min(DEFAULT_ZOOM, fitCell), minZoom, maxZoom);
     zoomRef.current = clamp(zoomRef.current, minZoom, maxZoom);
 
     // Pan: follow the current room (or zone centre) until the user takes over.


### PR DESCRIPTION
## Problem

The pop-out **World Map** ("Local Map" tab) opened at a fixed `DEFAULT_ZOOM` (88 px/cell) regardless of zone size. Small zones fit at that zoom and look complete, but a large zone like **crystal_forest** (280 rooms, ~16×28 grid) only showed a **~14×7 fragment** that scrolled to follow the player — reported as "shows only pieces / gets mixed up as you travel on larger zones."

## Root cause

The zone layout itself is correct. Replicating the server's `assignMapCoordinates` BFS (`WorldLoader.kt`) against the real `crystal_forest` data: all 280 rooms form one connected component embedding as a clean grid with **0 cell collisions and 0 non-euclidean exits**. The full `Zone.Map` fog is also delivered to the client fine (its ~70 KB frame is over `maxFrameBytes`, but that cap is inbound-only — verified Ktor 3.5 doesn't enforce `maxFrameSize` on outbound). So the client has complete, correct data; it was just opening too zoomed-in.

## Fix

`web-v3/src/hooks/useMiniMap.ts` — open at `min(DEFAULT_ZOOM, fitCell)` instead of a fixed `DEFAULT_ZOOM`, so large zones open **fit-to-view** while small zones keep the existing comfortable default. Re-applies on first open, zone change, and recenter (all reset zoom to 0).

## Verification

- `tsc -b` and `eslint` pass.
- Deterministic check on crystal_forest's real dimensions: old → 14×7 fragment; new → whole zone visible. Small zones (e.g. 5×5) unchanged at 88 (no regression).