### PR TITLE
Revert gRPC 1.82.0 bump (broken osx-x86_64 protoc plugin)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ repositories {
 val ktorVersion = "3.5.0"
 val hopliteVersion = "2.9.0"
 val micrometerVersion = "1.17.0"
-val grpcVersion = "1.82.0"
+val grpcVersion = "1.81.0"
 val grpcKotlinVersion = "1.5.0"
 val protobufVersion = "4.35.1"
 val exposedVersion = "1.3.0"


### PR DESCRIPTION
## Problem

The dependabot bump to gRPC 1.82.0 (#1357) breaks the build on Intel Macs. `generateProto` fails resolving the `io.grpc:protoc-gen-grpc-java` plugin for `osx-x86_64`.

## Root cause

gRPC **1.82.0 dropped the `osx-x86_64` protoc plugin binary** from Maven Central — only `osx-aarch_64` is published. 1.81.0 still ships `osx-x86_64`. linux-x86_64 CI is unaffected, which is why #1357 merged.

## Fix

Roll `grpcVersion` back to 1.81.0. Verified `./gradlew generateProto` succeeds again locally on osx-x86_64.