### PR TITLE
fix(web): stop dropping the zone map on large zones (only the explored trail rendered)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -305,12 +305,21 @@ class GmcpEmitter(
      * map with cloud-reveal as the player explores. Each room carries its floor
      * (`z`); clients draw one floor at a time. Up/down exits are included so the
      * map can badge stairs, but clients must not treat them as positional edges.
+     *
+     * Room ids and exit targets are sent **without** their `<zone>:` prefix: the
+     * payload already names the [zone] at the top level and exits are filtered to
+     * same-zone targets, so the prefix is pure repetition. Stripping it shrinks a
+     * large zone's payload by ~30% (e.g. a 280-room zone drops from ~67 KB to
+     * ~47 KB), keeping it under [MAX_GMCP_PAYLOAD_BYTES] — above which the whole
+     * map would be silently dropped and the client would render nothing but the
+     * player's own explored trail. Clients re-qualify the ids with the zone.
      */
     suspend fun sendZoneMap(
         sessionId: SessionId,
         zone: String,
         rooms: Collection<Room>,
     ) {
+        val prefix = "$zone:"
         emit(
             sessionId,
             "Zone.Map",
@@ -318,13 +327,13 @@ class GmcpEmitter(
                 zone = zone,
                 rooms = rooms.map { r ->
                     ZoneMapRoom(
-                        id = r.id.value,
+                        id = r.id.value.removePrefix(prefix),
                         x = r.mapX,
                         y = r.mapY,
                         z = r.mapZ,
                         exits = r.exits.entries
                             .filter { (_, target) -> target.zone == zone }
-                            .associate { (dir, target) -> dir.name.lowercase() to target.value },
+                            .associate { (dir, target) -> dir.name.lowercase() to target.value.removePrefix(prefix) },
                     )
                 },
             ),

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -2077,16 +2077,63 @@ class GmcpEmitterTest {
             assertEquals(1, data.size)
             assertEquals("Zone.Map", data[0].gmcpPackage)
             val json = data[0].jsonData
-            // North exit to same zone should be present
-            assertTrue(json.contains("\"north\":\"z:b\""), "Expected north exit. got=$json")
-            // Up exit to same zone should be present (clients badge stairs from it)
-            assertTrue(json.contains("\"up\":\"z:c\""), "Expected up exit. got=$json")
-            // Cross-zone exit should be filtered out
+            // Room ids and exit targets are sent without the redundant `<zone>:`
+            // prefix; clients re-qualify them from the top-level `zone` field.
+            assertTrue(json.contains("\"id\":\"a\""), "Expected unprefixed room id 'a'. got=$json")
+            // North exit to same zone should be present (prefix stripped).
+            assertTrue(json.contains("\"north\":\"b\""), "Expected north exit. got=$json")
+            // Up exit to same zone should be present (clients badge stairs from it).
+            assertTrue(json.contains("\"up\":\"c\""), "Expected up exit. got=$json")
+            // Cross-zone exit should be filtered out entirely.
             assertTrue(!json.contains("other:x"), "Cross-zone exit should be excluded. got=$json")
+            // The full namespaced form must not leak back in.
+            assertTrue(!json.contains("z:a"), "Room ids should be unprefixed. got=$json")
             // Coordinates should be present, including the floor
             assertTrue(json.contains("\"x\":0"), "Expected x coordinate. got=$json")
             assertTrue(json.contains("\"y\":-1"), "Expected y=-1 coordinate. got=$json")
             assertTrue(json.contains("\"z\":1"), "Expected z=1 floor on the attic room. got=$json")
+        }
+
+    @Test
+    fun `sendZoneMap stays under payload cap for a large zone`() =
+        runTest {
+            val e = emitter("Zone.Map")
+            // Mirrors the real crystal_forest profile (300 grid rooms, ~17-char
+            // local ids, 4 exits each). With the redundant `<zone>:` prefix on
+            // every id and exit target the payload serialized to ~73 KB — over
+            // MAX_GMCP_PAYLOAD_BYTES — and emit() silently dropped the whole map,
+            // leaving the client to render only the player's explored trail.
+            // Stripping the prefix brings it to ~51 KB, safely under the cap.
+            val zone = "crystal_forest"
+            val n = 300
+            fun roomId(i: Int) = RoomId("$zone:cf_room_node_%04d".format(i))
+            val rooms = (0 until n).map { i ->
+                zoneRoom(
+                    roomId(i).value,
+                    exits = mapOf(
+                        Direction.NORTH to roomId((i + 1) % n),
+                        Direction.SOUTH to roomId((i + 2) % n),
+                        Direction.EAST to roomId((i + 3) % n),
+                        Direction.WEST to roomId((i + 4) % n),
+                    ),
+                    mapX = i % 16,
+                    mapY = i / 16,
+                )
+            }
+            e.sendZoneMap(sid, zone, rooms)
+            val data = drainGmcp()
+            assertEquals(1, data.size, "Large-zone Zone.Map must not be dropped by the payload cap")
+            assertEquals("Zone.Map", data[0].gmcpPackage)
+            assertTrue(
+                data[0].jsonData.length <= GmcpEmitter.MAX_GMCP_PAYLOAD_BYTES,
+                "Zone.Map payload (${data[0].jsonData.length}B) must stay under the cap",
+            )
+            // Sanity: this is genuinely a large payload (so removing the prefix
+            // strip would push it back over the cap and re-trigger the bug).
+            assertTrue(
+                data[0].jsonData.length > 40_000,
+                "Expected a large payload to guard the regression. got=${data[0].jsonData.length}B",
+            )
         }
 
     @Test

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -481,16 +481,29 @@ export function applyGmcpPackage(
     case "Zone.Map": {
       const packet = data as Partial<Record<string, unknown>>;
       const zone = typeof packet.zone === "string" ? packet.zone : "";
+      // The server strips the redundant `<zone>:` prefix from room ids and exit
+      // targets (the payload already names the zone, and exits are same-zone only)
+      // to keep large zones under the GMCP payload cap. Re-qualify them so the
+      // map keys match the full `zone:room` ids used everywhere else. Guarded on
+      // `:` so a legacy server that still sends full ids keeps working.
+      const qualify = (raw: string): string => (raw === "" || raw.includes(":") ? raw : `${zone}:${raw}`);
       const rooms = Array.isArray(packet.rooms)
         ? packet.rooms
             .filter((r): r is Record<string, unknown> => typeof r === "object" && r !== null)
-            .map((r) => ({
-              id: typeof r.id === "string" ? r.id : "",
-              x: typeof r.x === "number" ? r.x : 0,
-              y: typeof r.y === "number" ? r.y : 0,
-              z: typeof r.z === "number" ? r.z : 0,
-              exits: r.exits && typeof r.exits === "object" ? (r.exits as Record<string, string>) : {},
-            }))
+            .map((r) => {
+              const rawExits = r.exits && typeof r.exits === "object" ? (r.exits as Record<string, string>) : {};
+              const exits: Record<string, string> = {};
+              for (const [dir, target] of Object.entries(rawExits)) {
+                if (typeof target === "string") exits[dir] = qualify(target);
+              }
+              return {
+                id: qualify(typeof r.id === "string" ? r.id : ""),
+                x: typeof r.x === "number" ? r.x : 0,
+                y: typeof r.y === "number" ? r.y : 0,
+                z: typeof r.z === "number" ? r.z : 0,
+                exits,
+              };
+            })
         : [];
       if (zone && rooms.length > 0) {
         ctx.loadZoneMap(zone, rooms);


### PR DESCRIPTION
## Problem

On large zones the pop-out/in-scene map showed only the player's own explored trail — a thin scrolling strip of rooms — instead of the full fog-of-war layout. Reported as "shows only pieces / gets mixed up as you travel on larger zones." (PR #1359 made the pop-out open fit-to-view, but that only reframed the fragment; the underlying data was missing.)

## Root cause

The maps render a fog layout from the `Zone.Map` GMCP package. `GmcpEmitter.emit()` **silently drops** any package whose serialized payload exceeds `MAX_GMCP_PAYLOAD_BYTES` (65,536) — logging `"GMCP payload exceeds 65536B limit for Zone.Map, skipping"`. Measured payload sizes for the real world:

| zone | rooms | payload (before) | after fix |
|------|------:|-----------------:|----------:|
| **crystal_forest** | **280** | **66,962 — DROPPED** | 47,282 |
| clockwork_forest | 180 | 40,104 | 26,606 |
| lake_thalnakh | 122 | 24,393 | 17,421 |
| auringold_academy | 109 | 17,112 | 10,740 |

Only crystal_forest tipped over the cap → only it lost its fog. Smaller zones stayed under, which is why the bug looked size-dependent. When the fog never loads, the client only accumulates rooms it has personally entered (`updateMap` never clears), so you see just your trail.

## Fix

The payload was ~30% redundant: every room `id` and every exit target repeated the `crystal_forest:` zone prefix — even though the payload already carries a top-level `zone` field and `sendZoneMap` filters exits to same-zone targets. So the prefix carries zero information.

- **Server** (`GmcpEmitter.sendZoneMap`): strip the `<zone>:` prefix from ids and exit targets. crystal_forest 67 KB → 47 KB; all current zones now comfortably under the cap.
- **Client** (`applyGmcpPackage.ts` `Zone.Map`): re-qualify ids/targets with the zone so map keys still match the full `zone:room` ids used everywhere else. Guarded on `:` so a legacy server sending full ids keeps working.

## Verification

- `GmcpEmitterTest` passes, including a new `sendZoneMap stays under payload cap for a large zone` regression guard (300-room zone, ~73 KB unstripped → would be dropped → ~51 KB stripped → emitted).
- Updated the existing test to expect unprefixed ids.
- `tsc -b` + `eslint` clean.

This complements [#1359](https://github.com/jnoecker/AmbonMUD/pull/1359): the fog now actually loads **and** opens framed to the whole zone.