### PR TITLE
style: fix ktlint blank-line in GmcpEmitterTest (follow-up to #1362)

### DIFF
--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -2106,6 +2106,7 @@ class GmcpEmitterTest {
             // Stripping the prefix brings it to ~51 KB, safely under the cap.
             val zone = "crystal_forest"
             val n = 300
+
             fun roomId(i: Int) = RoomId("$zone:cf_room_node_%04d".format(i))
             val rooms = (0 until n).map { i ->
                 zoneRoom(


### PR DESCRIPTION
The pre-commit `ktlintFormat` reformatted `GmcpEmitterTest.kt` while committing #1362 but the change wasn't re-staged, so the merged commit kept a `blank-line-before-declaration` violation that CI `ktlintCheck` flags. This adds the missing blank line. `./gradlew ktlintCheck` passes.