### PR TITLE
Flight kiosk: Ambon world map with griffin hotspots

### DIFF
--- a/docs/WORLD_YAML_SPEC.md
+++ b/docs/WORLD_YAML_SPEC.md
@@ -79,6 +79,8 @@ dungeon: <boolean, optional, default false>
 inn: <boolean, optional, default false>
 akathavaeShrine: <boolean, optional, default false>
 flightMaster: <boolean, optional, default false>
+flightMapX: <number, optional - 0..100, % across the Ambon world map; only meaningful with flightMaster>
+flightMapY: <number, optional - 0..100, % down the Ambon world map; only meaningful with flightMaster>
 image: <string, optional - relative path under /images/>
 video: <string, optional - relative path under /videos/, shown as clickable cinematic>
 music: <string, optional - overrides zone audio.music>
@@ -107,6 +109,7 @@ musicBox: <single song object, optional - see `musicBox` notes>
 - The network is **per-player and discovery-gated** — visiting a `flightMaster` room records it; from any flight master you can fly to any point you've personally discovered. Mark every roost in the network with `flightMaster: true`.
 - The fare scales with travel distance (BFS hops between the current room and the destination), clamped to a min/max. Flying is blocked in combat; otherwise gold is the only gate. Configurable via `ambonMUD.engine.flight` in `application.yaml`.
 - Shows a Flight badge + destination panel on the web client canvas.
+- `flightMapX`/`flightMapY` pin this roost on the painted Ambon world map (`flight_map` global asset) in the web kiosk: percentages of the map image (`0` = left/top edge, `100` = right/bottom). They drive a clickable griffin hotspot — the same percentage convention as equipment paper-doll slots, understood by both Arcanum and the engine. Omit them and the roost still works, just listed textually under the map rather than pinned. Loading fails if either value is outside `0..100`.
 
 `jukebox` notes:
 - A non-empty `jukebox` list turns this room into a jukebox: players pay gold to play a song that becomes the room's music for everyone present, locked for the song's `durationSeconds`, then the room reverts to its default `music`.

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -3713,6 +3713,13 @@ data class ImagesConfig(
             "quest_complete_indicator" to "global_assets/quest_complete_indicator.png",
             "minimap_unexplored" to "global_assets/minimap-unexplored.png",
             "map_background" to "global_assets/map_background.png",
+            // Painted Ambon world map behind the flight kiosk. Discovered flight points are
+            // seated onto it as clickable griffin hotspots at their authored flightMapX/Y
+            // percentages. When absent, the kiosk degrades to its plain destination list.
+            "flight_map" to "global_assets/flight_map.png",
+            // Griffin/roost marker painted at each flight hotspot. Optional — a CSS jewel-dot
+            // renders in its place when the art is missing.
+            "flight_roost" to "global_assets/flight_roost.png",
             // Default terrain backgrounds
             "default_bg_inside" to "defaults/bg_inside.png",
             "default_bg_outside" to "defaults/bg_outside.png",

--- a/src/main/kotlin/dev/ambon/domain/world/Room.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/Room.kt
@@ -39,6 +39,14 @@ data class Room(
     val akathavaeShrine: Boolean = false,
     /** True if this room has a flight master (enables `flights`/`fly` fast-travel + kiosk badge). */
     val flightMaster: Boolean = false,
+    /**
+     * Flight-master position on the painted Ambon world map as a percentage (0–100) of the map
+     * image — X across, Y down — driving the clickable griffin hotspot in the web kiosk. Null
+     * means "unplaced": the destination still lists textually but has no map pin. Only meaningful
+     * when [flightMaster] is true. Mirrors the equipment paper-doll percentage convention.
+     */
+    val flightMapX: Double? = null,
+    val flightMapY: Double? = null,
     /** URL to an image representing this room. */
     val image: String? = null,
     /** URL to a video cinematic for this room. */

--- a/src/main/kotlin/dev/ambon/domain/world/data/RoomFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/RoomFile.kt
@@ -33,6 +33,15 @@ data class RoomFile(
     val akathavaeShrine: Boolean = false,
     /** True if this room has a flight master (enables `flights`/`fly` fast-travel + kiosk badge). */
     val flightMaster: Boolean = false,
+    /**
+     * Flight-master position on the painted Ambon world map, as a percentage (0–100) of the map
+     * image — `flightMapX` across, `flightMapY` down. Drives the clickable griffin hotspot in the
+     * web flight kiosk. Same percentage convention as equipment paper-doll slots, understood by
+     * both Arcanum and the engine. Null on a flight master means "unplaced": the destination still
+     * lists textually in the kiosk but gets no map pin. Ignored when [flightMaster] is false.
+     */
+    val flightMapX: Double? = null,
+    val flightMapY: Double? = null,
     /** URL to an image representing this room. */
     val image: String? = null,
     /** URL to a video cinematic for this room. */

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -258,6 +258,8 @@ object WorldLoader {
                         inn = rf.inn,
                         akathavaeShrine = rf.akathavaeShrine,
                         flightMaster = rf.flightMaster,
+                        flightMapX = validateFlightCoord(rf.flightMapX, "flightMapX", id),
+                        flightMapY = validateFlightCoord(rf.flightMapY, "flightMapY", id),
                         image = (rf.image ?: imageDefaults?.room)?.let { "$imagesBase$it" },
                         video = rf.video?.let { "$videosBase$it" },
                         music = (rf.music ?: audioDefaults?.music)?.let { "$audioBase$it" },
@@ -1746,6 +1748,20 @@ object WorldLoader {
                 "$context has invalid terrain '$terrain'; valid values: $VALID_TERRAINS",
             )
         }
+    }
+
+    /**
+     * Validates a flight-master world-map coordinate: a percentage in 0..100, or null when the
+     * room declares no pin. Returned verbatim so it can be assigned inline during room mapping.
+     */
+    private fun validateFlightCoord(value: Double?, field: String, id: RoomId): Double? {
+        if (value == null) return null
+        if (value !in 0.0..100.0) {
+            throw WorldLoadException(
+                "Room '${id.value}' has invalid $field '$value'; must be a percentage in 0..100",
+            )
+        }
+        return value
     }
 
     private fun validateMobCategory(category: String, context: String) {

--- a/src/main/kotlin/dev/ambon/engine/FlightSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/FlightSystem.kt
@@ -38,10 +38,28 @@ class FlightSystem(
         /** BFS hops from the current room, or null when unreachable on this engine. */
         val distance: Int?,
         val cost: Long,
+        /** World-map pin as a percentage (0–100) of the Ambon map, or null when unplaced. */
+        val mapX: Double?,
+        val mapY: Double?,
+    )
+
+    /** The flight master the player is standing at: its name + world-map pin, for the "you are here" marker. */
+    data class Origin(
+        val roomId: RoomId,
+        val name: String,
+        val mapX: Double?,
+        val mapY: Double?,
     )
 
     /** True if [roomId] hosts a flight master right now. */
     fun isFlightMaster(roomId: RoomId): Boolean = world.rooms[roomId]?.flightMaster == true
+
+    /** The origin marker for [roomId] when it hosts a flight master, else null. */
+    fun originAt(roomId: RoomId): Origin? {
+        val room = world.rooms[roomId] ?: return null
+        if (!room.flightMaster) return null
+        return Origin(roomId = roomId, name = room.title, mapX = room.flightMapX, mapY = room.flightMapY)
+    }
 
     /**
      * Records the player's current room as a discovered flight point. Fires on every movement;
@@ -81,6 +99,8 @@ class FlightSystem(
                     zone = roomId.zone,
                     distance = dist,
                     cost = costForDistance(dist),
+                    mapX = room.flightMapX,
+                    mapY = room.flightMapY,
                 )
             }
             .sortedWith(compareBy({ it.zone }, { it.name }))

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -2018,6 +2018,11 @@ class GmcpEmitter(
     data class FlightStatePayload(
         val playerGold: Long,
         val destinations: List<FlightDestinationPayload>,
+        /** Name of the flight master the player is standing at (the "you are here" marker). */
+        val originName: String? = null,
+        /** World-map pin of the origin flight master as a percentage (0–100), or null when unplaced. */
+        val originMapX: Double? = null,
+        val originMapY: Double? = null,
     )
 
     data class FlightDestinationPayload(
@@ -2029,6 +2034,9 @@ class GmcpEmitter(
         val cost: Long,
         /** True when the player can currently afford this fare. */
         val affordable: Boolean,
+        /** World-map pin as a percentage (0–100) of the Ambon map, or null when unplaced (list-only). */
+        val mapX: Double? = null,
+        val mapY: Double? = null,
     )
 
     suspend fun sendFlightClose(sessionId: SessionId) {
@@ -2039,6 +2047,7 @@ class GmcpEmitter(
         sessionId: SessionId,
         playerGold: Long,
         destinations: List<FlightSystem.Destination>,
+        origin: FlightSystem.Origin? = null,
     ) {
         emit(
             sessionId,
@@ -2053,8 +2062,13 @@ class GmcpEmitter(
                         distance = it.distance,
                         cost = it.cost,
                         affordable = playerGold >= it.cost,
+                        mapX = it.mapX,
+                        mapY = it.mapY,
                     )
                 },
+                originName = origin?.name,
+                originMapX = origin?.mapX,
+                originMapY = origin?.mapY,
             ),
         )
     }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/FlightHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/FlightHandler.kt
@@ -166,6 +166,7 @@ class FlightHandler(
             sessionId = sessionId,
             playerGold = me.gold,
             destinations = destinations,
+            origin = flight?.originAt(me.roomId),
         )
     }
 }

--- a/src/main/resources/world/academy.yaml
+++ b/src/main/resources/world/academy.yaml
@@ -52,6 +52,8 @@ rooms:
       Paths lead east to the Scholar's Study, west to the Common Room, and south to the Armory. A winding staircase
       climbs upward to the Catacombs. The Academy Gates are back to the north.
     flightMaster: true
+    flightMapX: 50.0
+    flightMapY: 30.0
     exits:
       n: academy_gates
       e: scholars_study
@@ -273,6 +275,8 @@ rooms:
 
       The Armory is to the north. The Riddle Tower is to the east. The Throne Room lies to the south.
     flightMaster: true
+    flightMapX: 37.0
+    flightMapY: 58.0
     exits:
       n: armory
       e: riddle_tower
@@ -362,6 +366,8 @@ rooms:
 
       The Proving Grounds are back to the north.
     flightMaster: true
+    flightMapX: 55.0
+    flightMapY: 81.0
     exits:
       n: proving_grounds
     features:

--- a/src/test/kotlin/dev/ambon/engine/commands/FlightCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/FlightCommandTest.kt
@@ -97,6 +97,38 @@ class FlightCommandTest {
         }
 
         @Test
+        fun `destinationsFrom carries world-map pins and leaves unpinned roosts null`() {
+            val system = FlightSystem(
+                players = buildTestPlayerRegistry(aerie),
+                world = flightWorld(),
+                outbound = LocalOutboundBus(),
+            )
+            val discovered = setOf(aerie.value, bastion.value, citadel.value)
+            val dests = system.destinationsFrom(aerie, discovered)
+
+            val bastionDest = dests.first { it.name == "Bastion" }
+            val citadelDest = dests.first { it.name == "Citadel" }
+            assertEquals(55.0, bastionDest.mapX)
+            assertEquals(60.0, bastionDest.mapY)
+            assertNull(citadelDest.mapX, "unpinned roost has no map x")
+            assertNull(citadelDest.mapY, "unpinned roost has no map y")
+        }
+
+        @Test
+        fun `originAt returns the current flight master pin and null off a flight master`() {
+            val system = FlightSystem(
+                players = buildTestPlayerRegistry(aerie),
+                world = flightWorld(),
+                outbound = LocalOutboundBus(),
+            )
+            val origin = system.originAt(aerie)
+            assertEquals("Aerie", origin?.name)
+            assertEquals(20.0, origin?.mapX)
+            assertEquals(30.0, origin?.mapY)
+            assertNull(system.originAt(mid1), "non-flight room is not an origin")
+        }
+
+        @Test
         fun `onRoomVisited records the flight point persists and notifies once`() = runTest {
             val players = buildTestPlayerRegistry(aerie)
             val outbound = LocalOutboundBus()
@@ -304,7 +336,15 @@ class FlightCommandTest {
          */
         private fun flightWorld(): World {
             val rooms = mapOf(
-                aerie to Room(aerie, "Aerie", "A high roost.", mapOf(Direction.EAST to mid1), flightMaster = true),
+                aerie to Room(
+                    aerie,
+                    "Aerie",
+                    "A high roost.",
+                    mapOf(Direction.EAST to mid1),
+                    flightMaster = true,
+                    flightMapX = 20.0,
+                    flightMapY = 30.0,
+                ),
                 mid1 to Room(mid1, "Windy Pass", "A pass.", mapOf(Direction.WEST to aerie, Direction.EAST to bastion)),
                 bastion to Room(
                     bastion,
@@ -312,8 +352,11 @@ class FlightCommandTest {
                     "A fortified roost.",
                     mapOf(Direction.WEST to mid1, Direction.EAST to mid2),
                     flightMaster = true,
+                    flightMapX = 55.0,
+                    flightMapY = 60.0,
                 ),
                 mid2 to Room(mid2, "Cloud Bridge", "A bridge.", mapOf(Direction.WEST to bastion, Direction.EAST to citadel)),
+                // Citadel is intentionally left unpinned (no flightMapX/Y) to cover the list-only fallback.
                 citadel to Room(citadel, "Citadel", "A distant roost.", mapOf(Direction.WEST to mid2), flightMaster = true),
             )
             return World(rooms = rooms, startRoom = aerie)

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -1624,7 +1624,7 @@ function App() {
         )}
 
         {drawerPanel === "flight" && (
-          <FlightPanel flightState={state.flightState} onCommand={sendCommand} />
+          <FlightPanel flightState={state.flightState} serverAssets={state.serverAssets} onCommand={sendCommand} />
         )}
 
         {drawerPanel === "auction" && (

--- a/web-v3/src/components/panels/FlightPanel.tsx
+++ b/web-v3/src/components/panels/FlightPanel.tsx
@@ -1,7 +1,10 @@
+import type { CSSProperties } from "react";
 import type { FlightDestination, FlightState } from "../../types";
 
 interface FlightPanelProps {
   flightState: FlightState | null;
+  /** Resolved Server.Assets map — supplies the painted Ambon map (`flight_map`) and griffin marker (`flight_roost`). */
+  serverAssets: Record<string, string>;
   onCommand: (cmd: string) => void;
 }
 
@@ -13,11 +16,55 @@ function distanceLabel(dist: number | null): string {
 }
 
 /**
- * Flight master — pay gold to fast-travel to a flight point you've discovered.
- * Lists every reachable destination with its distance-scaled fare; clicking Fly
- * sends `fly <roomId>` (unambiguous), so the picked roost always matches the row.
+ * One textual destination row — used for the fallback list (no map art) and for the
+ * "other roosts" list of points the worldbuilder hasn't pinned to the map yet.
  */
-export function FlightPanel({ flightState, onCommand }: FlightPanelProps) {
+function DestinationRow({
+  dest,
+  onCommand,
+}: {
+  dest: FlightDestination;
+  onCommand: (cmd: string) => void;
+}) {
+  return (
+    <li className="flight-row">
+      <div className="flight-row-text">
+        <span className="flight-row-name">{dest.name}</span>
+        <span className="flight-row-meta">
+          {dest.zone} · {distanceLabel(dest.distance)}
+        </span>
+      </div>
+      <div className="flight-row-fare">
+        <span className={`flight-cost${dest.affordable ? "" : " flight-cost-short"}`}>
+          {dest.cost.toLocaleString()} gold
+        </span>
+        <button
+          type="button"
+          className="flight-go"
+          disabled={!dest.affordable}
+          title={dest.affordable ? `Fly to ${dest.name}` : "Not enough gold"}
+          aria-label={`Fly to ${dest.name} for ${dest.cost} gold`}
+          onClick={() => onCommand(`fly ${dest.roomId}`)}
+        >
+          Fly
+        </button>
+      </div>
+    </li>
+  );
+}
+
+/**
+ * Flight master — pay gold to fast-travel to a flight point you've discovered.
+ *
+ * When the painted Ambon map (`flight_map`) is available, the kiosk renders it full-bleed and
+ * seats each discovered flight point onto it as a clickable griffin hotspot, positioned by the
+ * room's authored `flightMapX`/`flightMapY` percentages (the same paper-doll convention the
+ * equipment panel uses). The roost you're standing at shows a "you are here" marker; affordable
+ * roosts glow, unaffordable ones dim. Points the worldbuilder hasn't pinned yet, plus the whole
+ * list when no map art is present, fall back to the plain textual list — nothing is unreachable.
+ * Clicking always sends `fly <roomId>` (unambiguous), so the picked roost matches the marker.
+ */
+export function FlightPanel({ flightState, serverAssets, onCommand }: FlightPanelProps) {
   if (!flightState) {
     return (
       <div className="flight-board flight-board-empty">
@@ -28,46 +75,108 @@ export function FlightPanel({ flightState, onCommand }: FlightPanelProps) {
     );
   }
 
-  const { playerGold, destinations } = flightState;
+  const { playerGold, destinations, originName, originMapX, originMapY } = flightState;
+  const mapUrl = serverAssets["flight_map"] ?? null;
+  const roostUrl = serverAssets["flight_roost"] ?? null;
+
+  const placed = destinations.filter((d) => d.mapX != null && d.mapY != null);
+  const unplaced = destinations.filter((d) => d.mapX == null || d.mapY == null);
+  const originPlaced = originMapX != null && originMapY != null;
+
+  // Render the painted map only when we have art and at least one thing to pin onto it;
+  // otherwise the plain list below is the whole kiosk (graceful degradation).
+  const showMap = mapUrl != null && (placed.length > 0 || originPlaced);
+
+  const goldLine = (
+    <div className="flight-gold">
+      Your Gold: <strong>{playerGold.toLocaleString()}</strong>
+    </div>
+  );
+
+  if (!showMap) {
+    return (
+      <div className="flight-board">
+        {goldLine}
+        {destinations.length === 0 ? (
+          <p className="flight-empty">
+            You haven&apos;t discovered any other flight points yet. Explore the world to find more roosts.
+          </p>
+        ) : (
+          <ul className="flight-list">
+            {destinations.map((dest) => (
+              <DestinationRow key={dest.roomId} dest={dest} onCommand={onCommand} />
+            ))}
+          </ul>
+        )}
+      </div>
+    );
+  }
+
+  const skinVars: Record<string, string> = {};
+  if (roostUrl) skinVars["--flight-roost"] = `url("${roostUrl}")`;
 
   return (
-    <div className="flight-board">
-      <div className="flight-gold">
-        Your Gold: <strong>{playerGold.toLocaleString()}</strong>
+    <div className="flight-board flight-board-skinned" style={skinVars as CSSProperties}>
+      {goldLine}
+
+      <div className="flight-map">
+        <img className="flight-map-img" src={mapUrl} alt="Map of Ambon" draggable={false} />
+        {originPlaced && (
+          <div
+            className="flight-marker flight-marker-origin"
+            style={{ left: `${originMapX}%`, top: `${originMapY}%` }}
+          >
+            <span className="flight-marker-dot" />
+            <span className="flight-marker-tip">
+              <span className="flight-tip-name">You are here</span>
+              {originName && <span className="flight-tip-meta">{originName}</span>}
+            </span>
+          </div>
+        )}
+
+        {placed.map((dest) => (
+          <button
+            key={dest.roomId}
+            type="button"
+            className={
+              `flight-marker flight-marker-dest` +
+              `${dest.affordable ? "" : " flight-marker-short"}` +
+              `${roostUrl ? " flight-marker-art" : ""}`
+            }
+            style={{ left: `${dest.mapX}%`, top: `${dest.mapY}%` }}
+            aria-disabled={!dest.affordable}
+            aria-label={
+              dest.affordable
+                ? `Fly to ${dest.name} for ${dest.cost} gold`
+                : `${dest.name} — not enough gold (${dest.cost})`
+            }
+            onClick={() => {
+              if (dest.affordable) onCommand(`fly ${dest.roomId}`);
+            }}
+          >
+            <span className="flight-marker-dot" />
+            <span className="flight-marker-tip">
+              <span className="flight-tip-name">{dest.name}</span>
+              <span className="flight-tip-meta">
+                {dest.zone} · {distanceLabel(dest.distance)}
+              </span>
+              <span className={`flight-tip-fare${dest.affordable ? "" : " flight-cost-short"}`}>
+                {dest.cost.toLocaleString()} gold{dest.affordable ? "" : " — too dear"}
+              </span>
+            </span>
+          </button>
+        ))}
       </div>
 
-      {destinations.length === 0 ? (
-        <p className="flight-empty">
-          You haven&apos;t discovered any other flight points yet. Explore the world to find more roosts.
-        </p>
-      ) : (
-        <ul className="flight-list">
-          {destinations.map((dest: FlightDestination) => (
-            <li key={dest.roomId} className="flight-row">
-              <div className="flight-row-text">
-                <span className="flight-row-name">{dest.name}</span>
-                <span className="flight-row-meta">
-                  {dest.zone} · {distanceLabel(dest.distance)}
-                </span>
-              </div>
-              <div className="flight-row-fare">
-                <span className={`flight-cost${dest.affordable ? "" : " flight-cost-short"}`}>
-                  {dest.cost.toLocaleString()} gold
-                </span>
-                <button
-                  type="button"
-                  className="flight-go"
-                  disabled={!dest.affordable}
-                  title={dest.affordable ? `Fly to ${dest.name}` : "Not enough gold"}
-                  aria-label={`Fly to ${dest.name} for ${dest.cost} gold`}
-                  onClick={() => onCommand(`fly ${dest.roomId}`)}
-                >
-                  Fly
-                </button>
-              </div>
-            </li>
-          ))}
-        </ul>
+      {unplaced.length > 0 && (
+        <div className="flight-unplaced">
+          <p className="flight-unplaced-head">Other roosts</p>
+          <ul className="flight-list">
+            {unplaced.map((dest) => (
+              <DestinationRow key={dest.roomId} dest={dest} onCommand={onCommand} />
+            ))}
+          </ul>
+        </div>
       )}
     </div>
   );

--- a/web-v3/src/components/panels/FlightPanel.tsx
+++ b/web-v3/src/components/panels/FlightPanel.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from "react";
+import { useState, type CSSProperties } from "react";
 import type { FlightDestination, FlightState } from "../../types";
 
 interface FlightPanelProps {
@@ -65,6 +65,14 @@ function DestinationRow({
  * Clicking always sends `fly <roomId>` (unambiguous), so the picked roost matches the marker.
  */
 export function FlightPanel({ flightState, serverAssets, onCommand }: FlightPanelProps) {
+  // The flight_map key is always registered, so its URL is non-null even before the painted
+  // PNG is uploaded. A failed load (404) records the offending URL and we degrade to the
+  // textual list rather than stranding the player on a broken image. Comparing against the
+  // current URL auto-resets the broken state if the art is swapped in later.
+  const mapUrl = serverAssets["flight_map"] ?? null;
+  const [brokenMapUrl, setBrokenMapUrl] = useState<string | null>(null);
+  const mapBroken = brokenMapUrl !== null && brokenMapUrl === mapUrl;
+
   if (!flightState) {
     return (
       <div className="flight-board flight-board-empty">
@@ -76,16 +84,15 @@ export function FlightPanel({ flightState, serverAssets, onCommand }: FlightPane
   }
 
   const { playerGold, destinations, originName, originMapX, originMapY } = flightState;
-  const mapUrl = serverAssets["flight_map"] ?? null;
   const roostUrl = serverAssets["flight_roost"] ?? null;
 
   const placed = destinations.filter((d) => d.mapX != null && d.mapY != null);
   const unplaced = destinations.filter((d) => d.mapX == null || d.mapY == null);
   const originPlaced = originMapX != null && originMapY != null;
 
-  // Render the painted map only when we have art and at least one thing to pin onto it;
-  // otherwise the plain list below is the whole kiosk (graceful degradation).
-  const showMap = mapUrl != null && (placed.length > 0 || originPlaced);
+  // Render the painted map only when we have (working) art and at least one thing to pin onto
+  // it; otherwise the plain list below is the whole kiosk (graceful degradation).
+  const showMap = mapUrl != null && !mapBroken && (placed.length > 0 || originPlaced);
 
   const goldLine = (
     <div className="flight-gold">
@@ -120,7 +127,13 @@ export function FlightPanel({ flightState, serverAssets, onCommand }: FlightPane
       {goldLine}
 
       <div className="flight-map">
-        <img className="flight-map-img" src={mapUrl} alt="Map of Ambon" draggable={false} />
+        <img
+          className="flight-map-img"
+          src={mapUrl ?? undefined}
+          alt="Map of Ambon"
+          draggable={false}
+          onError={() => setBrokenMapUrl(mapUrl)}
+        />
         {originPlaced && (
           <div
             className="flight-marker flight-marker-origin"

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -2016,11 +2016,16 @@ export function applyGmcpPackage(
             distance: typeof d.distance === "number" ? d.distance : null,
             cost: safeNumber(d.cost, 0),
             affordable: d.affordable === true,
+            mapX: typeof d.mapX === "number" ? d.mapX : null,
+            mapY: typeof d.mapY === "number" ? d.mapY : null,
           }))
         : [];
       ctx.setFlightState({
         playerGold: safeNumber(packet.playerGold, 0),
         destinations,
+        originName: typeof packet.originName === "string" ? packet.originName : null,
+        originMapX: typeof packet.originMapX === "number" ? packet.originMapX : null,
+        originMapY: typeof packet.originMapY === "number" ? packet.originMapY : null,
       });
       break;
     }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -28879,3 +28879,164 @@ html:has(.game-shell),
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+/* ---------- Painted Ambon map (skinned flight kiosk) ---------- */
+
+/* The map drives its own height via the <img>; the unplaced list flows beneath it. */
+.flight-map {
+  position: relative;
+  width: 100%;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: 0 2px 14px rgb(0 0 0 / 35%);
+}
+
+.flight-map-img {
+  display: block;
+  width: 100%;
+  height: auto;
+  user-select: none;
+}
+
+/*
+ * A flight hotspot. Positioned by the room's authored flightMapX/flightMapY percentages
+ * (set as inline left/top), centred on that point. Buttons for destinations; a plain div
+ * for the "you are here" origin. The tip floats above on hover/focus.
+ */
+.flight-marker {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  width: 0;
+  height: 0;
+  padding: 0;
+  border: none;
+  background: none;
+}
+
+button.flight-marker {
+  cursor: pointer;
+}
+
+button.flight-marker[aria-disabled="true"] {
+  cursor: not-allowed;
+}
+
+/* The visible pin — a jewel dot by default, replaced by painted griffin art when present. */
+.flight-marker-dot {
+  position: absolute;
+  left: 0;
+  top: 0;
+  transform: translate(-50%, -50%);
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, var(--color-gold-bright), #8a6a1e 70%);
+  border: 2px solid rgb(255 255 255 / 70%);
+  box-shadow: 0 0 8px 2px rgb(212 184 92 / 60%), 0 1px 3px rgb(0 0 0 / 50%);
+  transition: transform 120ms ease, box-shadow 120ms ease, filter 120ms ease;
+}
+
+.flight-marker-art .flight-marker-dot {
+  width: 34px;
+  height: 34px;
+  border: none;
+  border-radius: 0;
+  background: var(--flight-roost) center / contain no-repeat;
+  box-shadow: none;
+  filter: drop-shadow(0 0 6px rgb(212 184 92 / 70%)) drop-shadow(0 1px 2px rgb(0 0 0 / 60%));
+}
+
+.flight-marker:hover .flight-marker-dot,
+.flight-marker:focus-visible .flight-marker-dot {
+  transform: translate(-50%, -50%) scale(1.25);
+  box-shadow: 0 0 12px 4px rgb(212 184 92 / 80%), 0 1px 3px rgb(0 0 0 / 50%);
+}
+
+.flight-marker-art:hover .flight-marker-dot,
+.flight-marker-art:focus-visible .flight-marker-dot {
+  box-shadow: none;
+  filter: drop-shadow(0 0 10px rgb(212 184 92 / 90%)) drop-shadow(0 1px 2px rgb(0 0 0 / 60%));
+}
+
+/* The roost you're standing at — a calm teal beacon, no interaction. */
+.flight-marker-origin .flight-marker-dot {
+  background: radial-gradient(circle at 35% 35%, #7fe3d6, #1f6f66 70%);
+  box-shadow: 0 0 10px 3px rgb(127 227 214 / 55%), 0 1px 3px rgb(0 0 0 / 50%);
+  animation: flight-origin-pulse 2.2s ease-in-out infinite;
+}
+
+@keyframes flight-origin-pulse {
+  0%, 100% { box-shadow: 0 0 8px 2px rgb(127 227 214 / 45%), 0 1px 3px rgb(0 0 0 / 50%); }
+  50% { box-shadow: 0 0 14px 5px rgb(127 227 214 / 75%), 0 1px 3px rgb(0 0 0 / 50%); }
+}
+
+/* Unaffordable destinations dim but stay hoverable so the fare tip still reads. */
+.flight-marker-short .flight-marker-dot {
+  filter: grayscale(0.7) brightness(0.7);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 50%);
+}
+
+.flight-marker-short.flight-marker-art .flight-marker-dot {
+  filter: grayscale(0.7) brightness(0.7) drop-shadow(0 1px 2px rgb(0 0 0 / 60%));
+}
+
+/* Hover/focus tooltip above each marker. */
+.flight-marker-tip {
+  position: absolute;
+  left: 0;
+  bottom: 14px;
+  transform: translate(-50%, 0);
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: max-content;
+  max-width: 22ch;
+  padding: var(--space-2) var(--space-3);
+  background: rgb(18 16 24 / 94%);
+  border: 1px solid rgb(212 184 92 / 35%);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 4px 14px rgb(0 0 0 / 50%);
+  text-align: center;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 120ms ease;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.flight-marker:hover .flight-marker-tip,
+.flight-marker:focus-visible .flight-marker-tip {
+  opacity: 1;
+  visibility: visible;
+}
+
+.flight-tip-name {
+  color: var(--text-heading);
+  font-weight: 600;
+}
+
+.flight-tip-meta {
+  color: var(--text-tertiary);
+  font-size: 0.82em;
+}
+
+.flight-tip-fare {
+  color: var(--color-gold-bright);
+  font-size: 0.85em;
+  white-space: nowrap;
+}
+
+/* "Other roosts" — discovered points the worldbuilder hasn't pinned to the map yet. */
+.flight-unplaced {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.flight-unplaced-head {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.85em;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -1228,12 +1228,19 @@ export interface FlightDestination {
   cost: number;
   /** True when the player can currently afford this fare. */
   affordable: boolean;
+  /** World-map pin as a percentage (0–100) of the Ambon map, or null when unplaced (list-only). */
+  mapX: number | null;
+  mapY: number | null;
 }
 
 /** Flight-master state from the Char.Flight GMCP package. */
 export interface FlightState {
   playerGold: number;
   destinations: FlightDestination[];
+  /** The flight master the player is standing at — drives the "you are here" map marker. */
+  originName: string | null;
+  originMapX: number | null;
+  originMapY: number | null;
 }
 
 export interface DailyQuestEntry {


### PR DESCRIPTION
Reskins the flight-master kiosk as the painted **map of Ambon**. Discovered flight points become clickable **griffin hotspots** positioned by per-room world-map coordinates that both Arcanum and the engine understand — percentage `0–100`, the same convention as equipment paper-doll slots.

## How flight masters indicate their position
In zone YAML, next to `flightMaster: true`:
```yaml
flightMaster: true
flightMapX: 42.0   # % across the Ambon map (0 = left, 100 = right)
flightMapY: 63.0   # % down  the Ambon map (0 = top,  100 = bottom)
```
The web client seats a griffin marker at that point with `left/top` percentages — exactly how `EquipmentPanel` seats paper-doll slots. Roosts left **unpinned** (no coords) still work; they list textually under the map. Loading fails fast if either value is outside `0..100`.

## What's included
- **Backend** — `flightMapX`/`flightMapY` on `RoomFile`/`Room`/`WorldLoader` (+range validation); `FlightSystem.Destination` carries the pins; new `originAt()` for the *you are here* marker; `Char.Flight` GMCP payload gains per-destination + origin coords; `flight_map`/`flight_roost` asset keys registered.
- **Web** — `FlightPanel` reskin: full-bleed map `<img>`, griffin hotspots (glowing if affordable, dimmed if not), hover tooltip (name · zone · distance · fare), pulsing origin beacon, *other roosts* fallback list. Degrades to the plain list when the map art is absent **or 404s**.
- **Content/docs** — Academy roosts pinned (Grand Hall / Proving Grounds / Throne Room); `WORLD_YAML_SPEC` documents the fields.
- **Tests** — `FlightCommandTest` covers coord pass-through + origin + the unpinned fallback. Backend `ktlintCheck`/`test` + web `tsc`/`eslint` all green.

## ⚠️ Needs the painted art
Drop `flight_map.png` (the Ambon map) into `src/main/resources/world/images/global_assets/` — and optionally `flight_roost.png` for the griffin marker (a CSS jewel-dot renders without it). Or ship via Arcanum's hashed `globalAssets` overlay. Until then the kiosk shows the existing destination list (no breakage).