### PR TITLE
fix(web): flight map fits the viewport, drop the blue panel box

### DIFF
--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -28882,10 +28882,14 @@ html:has(.game-shell),
 
 /* ---------- Painted Ambon map (skinned flight kiosk) ---------- */
 
-/* The map drives its own height via the <img>; the unplaced list flows beneath it. */
+/* The image is height-bounded so the whole map fits the viewport (rather than
+   stretching to the panel width, which cropped it on tall screens). The wrapper
+   shrink-wraps that scaled image so the percentage-positioned markers stay aligned. */
 .flight-map {
   position: relative;
-  width: 100%;
+  width: fit-content;
+  max-width: 100%;
+  margin-inline: auto;
   border-radius: var(--radius-md);
   overflow: hidden;
   box-shadow: 0 2px 14px rgb(0 0 0 / 35%);
@@ -28893,7 +28897,9 @@ html:has(.game-shell),
 
 .flight-map-img {
   display: block;
-  width: 100%;
+  width: auto;
+  max-width: 100%;
+  max-height: var(--flight-map-max-h, 62vh);
   height: auto;
   user-select: none;
 }
@@ -29039,4 +29045,30 @@ button.flight-marker[aria-disabled="true"] {
   font-size: 0.85em;
   text-transform: uppercase;
   letter-spacing: 0.06em;
+}
+
+/* On desktop the kiosk drops the blue drawer box entirely and shrink-wraps the
+   painted map — "just the map" floating on the dimmed backdrop, sized so the
+   whole thing is visible at once. The map art carries its own painted border.
+   Only applies when the map is shown; the fallback list keeps normal chrome. */
+@media (min-width: 768px) {
+  .drawer-sheet:has(.flight-board-skinned) {
+    width: auto;
+    max-width: 96vw;
+    height: auto;
+    max-height: 96vh;
+    background: none;
+    border: none;
+    box-shadow: none;
+  }
+
+  .drawer-sheet:has(.flight-board-skinned) .drawer-body {
+    padding: 0;
+  }
+
+  .flight-board-skinned {
+    --flight-map-max-h: 80vh;
+    padding: 0;
+    gap: var(--space-2);
+  }
 }


### PR DESCRIPTION
## What

The Flight Master kiosk stretched the painted Ambon map to the full drawer width, so on tall/large screens the map overflowed its modal and only the top fragment was visible (you had to scroll). It also sat inside the standard blue drawer frame.

This change makes the whole map fit at once and removes the surrounding box so it reads as just the map.

## Changes (CSS only, `web-v3/src/styles.css`)

- **Map fits the viewport.** `.flight-map-img` is now height-bounded (`max-height: var(--flight-map-max-h, 62vh)`, `width: auto`, aspect preserved) instead of `width: 100%`. The `.flight-map` wrapper shrink-wraps the scaled image (`width: fit-content; margin-inline: auto`) so the percentage-positioned griffin/origin markers stay aligned.
- **Drop the blue box on desktop.** When the drawer contains `.flight-board-skinned` (i.e. the painted map is actually showing), the sheet goes `background: none; border: none; box-shadow: none`, shrink-wraps to the map (`width: auto; max-width: 96vw; max-height: 96vh`), and zeroes the body/panel padding. The map art carries its own painted border, so it floats on the dimmed backdrop as "just the map." Desktop bumps the map cap to `80vh`.

The fallback textual list (no map art / unpinned roosts) keeps the normal panel chrome — the `:has(.flight-board-skinned)` guard only strips the box when the map is present.

## Verification

- `bun run build` passes.
- Note: the painted `flight_map.png` is fetched from R2 in production, so a local standalone demo shows the fallback list rather than the map — the layout is best verified on the live demo.