### PR TITLE
feat(xp): bonus XP for killing mobs above your level

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -729,6 +729,12 @@ data class AppConfig(
                 "ambonMUD.progression.xp.diminishing.thresholds[$index].multiplier must be in [0.0, 1.0]"
             }
         }
+        require(progression.xp.underLevelBonus.bonusPerLevel >= 0.0) {
+            "ambonMUD.progression.xp.underLevelBonus.bonusPerLevel must be >= 0"
+        }
+        require(progression.xp.underLevelBonus.maxBonus >= 0.0) {
+            "ambonMUD.progression.xp.underLevelBonus.maxBonus must be >= 0"
+        }
         require(progression.rewards.hpScalingRate >= 1.0) {
             "ambonMUD.progression.rewards.hpScalingRate must be >= 1.0"
         }
@@ -2972,6 +2978,20 @@ data class XpCurveConfig(
     val multiplier: Double = 1.0,
     val defaultKillXp: Long = 50L,
     val diminishing: DiminishingXpConfig = DiminishingXpConfig(),
+    val underLevelBonus: UnderLevelXpBonusConfig = UnderLevelXpBonusConfig(),
+)
+
+/**
+ * Bonus XP for kills against mobs ABOVE the player's level — the reward for
+ * punching up. Grants [bonusPerLevel] extra XP per level the mob out-levels the
+ * killer, capped at [maxBonus]. Kills only; quests/puzzles do not get this.
+ * Complementary to [DiminishingXpConfig], which only ever reduces XP for
+ * over-levelled kills — the two never apply to the same fight.
+ */
+data class UnderLevelXpBonusConfig(
+    val enabled: Boolean = true,
+    val bonusPerLevel: Double = 0.15,
+    val maxBonus: Double = 0.5,
 )
 
 /**

--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -1946,15 +1946,19 @@ class CombatSystem(
             val player = players.get(sid) ?: continue
             val equipStats = items.equipmentBonuses(sid, classRegistry?.get(player.playerClass)).stats
             val totalBonusStat = player.stats[config.bindings.xpBonusStat] + equipStats[config.bindings.xpBonusStat]
-            val diminish = progression.diminishingKillXpMultiplier(player.level, mob.level)
-            val afterDiminish =
-                if (diminish >= 1.0) {
+            // Over-levelled kills are penalised; under-levelled kills are rewarded.
+            // These are mutually exclusive — only one is ever != 1.0 for a given fight.
+            val levelMultiplier =
+                progression.diminishingKillXpMultiplier(player.level, mob.level) *
+                    progression.underLevelKillXpMultiplier(player.level, mob.level)
+            val afterLevel =
+                if (levelMultiplier == 1.0) {
                     perPlayerXp
                 } else {
-                    (perPlayerXp * diminish).toLong().coerceAtLeast(0L)
+                    (perPlayerXp * levelMultiplier).toLong().coerceAtLeast(0L)
                 }
-            if (afterDiminish <= 0L) continue
-            val reward = progression.applyCharismaXpBonus(totalBonusStat, afterDiminish)
+            if (afterLevel <= 0L) continue
+            val reward = progression.applyCharismaXpBonus(totalBonusStat, afterLevel)
 
             val result = players.grantXp(sid, reward, progression) ?: continue
             metrics.onXpAwarded(reward, "kill")

--- a/src/main/kotlin/dev/ambon/engine/PlayerProgression.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerProgression.kt
@@ -207,6 +207,25 @@ class PlayerProgression(
     }
 
     /**
+     * Returns the XP multiplier for a kill against a mob ABOVE the player's
+     * level — the reward for punching up. Grants
+     * [UnderLevelXpBonusConfig.bonusPerLevel] per level the mob out-levels the
+     * killer, capped at [UnderLevelXpBonusConfig.maxBonus]. Returns 1.0 when the
+     * mob is at or below the player's level, or when the bonus is disabled.
+     * Complementary to [diminishingKillXpMultiplier]: that one only ever reduces
+     * XP for over-levelled kills, this one only ever increases it for
+     * under-levelled kills, so the two never both move a single kill.
+     */
+    fun underLevelKillXpMultiplier(playerLevel: Int, mobLevel: Int): Double {
+        val cfg = config.xp.underLevelBonus
+        if (!cfg.enabled || cfg.bonusPerLevel <= 0.0) return 1.0
+        val gap = mobLevel - playerLevel
+        if (gap <= 0) return 1.0
+        val bonus = (cfg.bonusPerLevel * gap).coerceAtMost(cfg.maxBonus)
+        return 1.0 + bonus
+    }
+
+    /**
      * Applies an XP multiplier based on the configured xpBonusStat (+[bindings.xpBonusPerPoint] per
      * point above [PlayerState.BASE_STAT]) to [baseXp]. Returns [baseXp] unchanged if there is no bonus.
      */

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2858,6 +2858,14 @@ ambonmud:
             multiplier: 0.2
           - levelsBelow: 8
             multiplier: 0.0
+      # Bonus XP for punching up: killing a mob above your own level. Grants
+      # `bonusPerLevel` extra per level the mob out-levels you, capped at
+      # `maxBonus`. Kills only (quests/puzzles never get it), and never stacks
+      # with diminishing returns — a fight is either over- or under-levelled.
+      underLevelBonus:
+        enabled: true
+        bonusPerLevel: 0.15
+        maxBonus: 0.5
     rewards:
       hpScalingRate: 1.30
       manaScalingRate: 1.10

--- a/src/test/kotlin/dev/ambon/engine/PlayerProgressionTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/PlayerProgressionTest.kt
@@ -9,6 +9,7 @@ import dev.ambon.config.ProgressionConfig
 import dev.ambon.config.QuestBaselineConfig
 import dev.ambon.config.QuestDifficulty
 import dev.ambon.config.QuestXpConfig
+import dev.ambon.config.UnderLevelXpBonusConfig
 import dev.ambon.config.XpCurveConfig
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
@@ -319,6 +320,50 @@ class PlayerProgressionTest {
             )
 
         assertEquals(1.0, progression.diminishingKillXpMultiplier(playerLevel = 50, mobLevel = 1))
+    }
+
+    @Test
+    fun `under-level bonus rewards punching up and caps`() {
+        val progression =
+            PlayerProgression(
+                ProgressionConfig(
+                    xp = XpCurveConfig(
+                        underLevelBonus = UnderLevelXpBonusConfig(
+                            enabled = true,
+                            bonusPerLevel = 0.15,
+                            maxBonus = 0.5,
+                        ),
+                    ),
+                ),
+            )
+
+        // Mob at or below player level: no bonus.
+        assertEquals(1.0, progression.underLevelKillXpMultiplier(playerLevel = 5, mobLevel = 5))
+        assertEquals(1.0, progression.underLevelKillXpMultiplier(playerLevel = 5, mobLevel = 1))
+        // Mob above player level: +0.15 per level.
+        assertEquals(1.15, progression.underLevelKillXpMultiplier(playerLevel = 1, mobLevel = 2), 1e-9)
+        assertEquals(1.45, progression.underLevelKillXpMultiplier(playerLevel = 1, mobLevel = 4), 1e-9)
+        // Capped at maxBonus (+0.5): 5 levels above would be +0.75 uncapped.
+        assertEquals(1.5, progression.underLevelKillXpMultiplier(playerLevel = 1, mobLevel = 6), 1e-9)
+        assertEquals(1.5, progression.underLevelKillXpMultiplier(playerLevel = 1, mobLevel = 50), 1e-9)
+    }
+
+    @Test
+    fun `under-level bonus disabled yields full xp`() {
+        val progression =
+            PlayerProgression(
+                ProgressionConfig(
+                    xp = XpCurveConfig(
+                        underLevelBonus = UnderLevelXpBonusConfig(
+                            enabled = false,
+                            bonusPerLevel = 0.15,
+                            maxBonus = 0.5,
+                        ),
+                    ),
+                ),
+            )
+
+        assertEquals(1.0, progression.underLevelKillXpMultiplier(playerLevel = 1, mobLevel = 10))
     }
 
     @Test


### PR DESCRIPTION
## Why

XP from a kill is based entirely on the mob's intrinsic worth (tier + level, or an explicit `xpReward`), then only ever *reduced* by the diminishing-returns curve when the player has out-levelled the target. There was **no reward for punching up** — a level 1 beating a level 4 got the mob's flat value (e.g. 81 XP) with zero credit for the difficulty and risk. A hard under-levelled fight paid exactly the same as a fair one.

## What changed

Adds a kill-only **under-level bonus** that mirrors the diminishing curve in the other direction:

- `+bonusPerLevel` (default **+15%**) per level the mob out-levels the killer, capped at `maxBonus` (default **+50%**).
- Applies to **kills only** — quests/puzzles (`grantRewards`) keep the penalty-only curve, so you can't farm bonus XP from over-level content.
- The penalty and bonus multipliers are **mutually exclusive**: a fight is either over- or under-levelled (`gap` has one sign), so they never both move a single kill.

Example: level 1 vs level 4 mob → gap 3 → `1.0 + min(0.5, 0.15×3)` = **×1.45** (81 → 117 XP).

## Config

New block under `ambonMUD.progression.xp`:

\`\`\`yaml
underLevelBonus:
  enabled: true
  bonusPerLevel: 0.15
  maxBonus: 0.5
\`\`\`

Validated in `AppConfig.validated()` (both fields must be ≥ 0).

## Files

- `AppConfig.kt` — `UnderLevelXpBonusConfig` + validation
- `PlayerProgression.kt` — `underLevelKillXpMultiplier()`
- `CombatSystem.kt` — combine penalty × bonus in `grantGroupKillXp()`
- `application.yaml` — default config block
- `PlayerProgressionTest.kt` — unit tests (scaling, cap, at/below-level no-op, disabled)

## Tests

`ktlintCheck` clean; `PlayerProgressionTest` + `*Combat*` suites pass.