### PR TITLE
fix(xp): kill toast shows actual XP awarded, not base reward

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -1857,13 +1857,13 @@ class CombatSystem(
         broadcastToRoom(players, outbound, mob.roomId, "${mob.name} dies.")
         val lootedItems = applyAutolootForKiller(killerSessionId, mob.roomId, mobCarried + rolledDrops)
         val goldGained = grantKillGold(killerSessionId, mob)
-        grantGroupKillXp(killerSessionId, mob)
+        val xpGained = grantGroupKillXp(killerSessionId, mob)
         onCombatEvent(
             killerSessionId,
             CombatEvent.Kill(
                 targetName = mob.name,
                 targetId = mob.id.value,
-                xpGained = mob.xpReward,
+                xpGained = xpGained,
                 goldGained = goldGained,
                 lootedItems = lootedItems,
             ),
@@ -1915,12 +1915,18 @@ class CombatSystem(
         }
     }
 
+    /**
+     * Grants kill XP to the killer (and any eligible group members in the room)
+     * and returns the XP actually awarded to [killerSessionId] — including the
+     * level-difference, group, and stat bonuses — so callers can surface the
+     * real figure in the kill toast. Returns 0 when the killer earns nothing.
+     */
     private suspend fun grantGroupKillXp(
         killerSessionId: SessionId,
         mob: MobState,
-    ) {
+    ): Long {
         val baseReward = progression.killXpReward(mob)
-        if (baseReward <= 0L) return
+        if (baseReward <= 0L) return 0L
 
         val group = groupSystem?.getGroup(killerSessionId)
         val recipients =
@@ -1942,6 +1948,7 @@ class CombatSystem(
             }
         val perPlayerXp = ((baseReward.toDouble() / memberCount) * groupBonus).toLong().coerceAtLeast(1L)
 
+        var killerXp = 0L
         for (sid in recipients) {
             val player = players.get(sid) ?: continue
             val equipStats = items.equipmentBonuses(sid, classRegistry?.get(player.playerClass)).stats
@@ -1961,6 +1968,7 @@ class CombatSystem(
             val reward = progression.applyCharismaXpBonus(totalBonusStat, afterLevel)
 
             val result = players.grantXp(sid, reward, progression) ?: continue
+            if (sid == killerSessionId) killerXp = reward
             metrics.onXpAwarded(reward, "kill")
             outbound.send(OutboundEvent.SendText(sid, "You gain $reward XP."))
             onXpGained(sid, reward, mob.name)
@@ -1978,6 +1986,7 @@ class CombatSystem(
                 callbacks.onLevelUp(sid, result)
             }
         }
+        return killerXp
     }
 
     private fun rollDrops(mob: MobState): List<dev.ambon.domain.items.ItemInstance> {

--- a/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/CombatSystemTest.kt
@@ -3,6 +3,7 @@ package dev.ambon.engine
 import dev.ambon.config.DeathConfig
 import dev.ambon.config.LevelRewardsConfig
 import dev.ambon.config.ProgressionConfig
+import dev.ambon.config.UnderLevelXpBonusConfig
 import dev.ambon.config.XpCurveConfig
 import dev.ambon.domain.DamageRange
 import dev.ambon.domain.StatMap
@@ -430,6 +431,85 @@ class CombatSystemTest {
                     .map { it.text }
             assertTrue(messages.contains("You gain 50 XP."))
             assertTrue(messages.contains("You reached level 2! (+8 max HP, +4 max Mana)"))
+        }
+
+    @Test
+    fun `Kill combat event xpGained reflects the actual award including under-level bonus`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            // Mob out-levels the player by 2 (level 3 vs level 1), so the
+            // under-level bonus (+0.15/level, capped) multiplies the reward.
+            val mob =
+                MobState(
+                    MobId("demo:ogre"),
+                    "an ogre",
+                    fixture.roomId,
+                    hp = 1,
+                    maxHp = 1,
+                    level = 3,
+                    xpReward = 100L,
+                )
+            fixture.mobs.upsert(mob)
+
+            val classRegistry =
+                PlayerClassRegistry().also { reg ->
+                    PlayerClassRegistryLoader.load(dev.ambon.test.testClassEngineConfig(), reg)
+                }
+            val progression =
+                PlayerProgression(
+                    ProgressionConfig(
+                        maxLevel = 20,
+                        xp =
+                            XpCurveConfig(
+                                // Large curve so the boosted reward never levels the player up,
+                                // keeping the assertion focused on the toast value.
+                                baseXp = 100_000L,
+                                exponent = 2.0,
+                                linearXp = 0L,
+                                multiplier = 1.0,
+                                defaultKillXp = 50L,
+                                underLevelBonus = UnderLevelXpBonusConfig(enabled = true),
+                            ),
+                    ),
+                    classRegistry = classRegistry,
+                )
+            val combat =
+                fixture.buildCombat(
+                    rng = Random(5),
+                    minDamage = 1,
+                    maxDamage = 1,
+                    progression = progression,
+                )
+
+            val sid = SessionId(515L)
+            fixture.players.loginOrFail(sid, "Underdog")
+
+            val combatEvents = mutableListOf<CombatEvent>()
+            combat.onCombatEvent = { _, event -> combatEvents += event }
+
+            assertNull(combat.startCombat(sid, "ogre"))
+            fixture.tickCombat(combat)
+
+            // gap = 3 - 1 = 2 → +0.30 → 100 * 1.30 = 130 XP actually awarded.
+            val kill = combatEvents.filterIsInstance<CombatEvent.Kill>().firstOrNull()
+            assertNotNull(kill, "Expected a Kill combat event, got: $combatEvents")
+            assertEquals(
+                130L,
+                kill!!.xpGained,
+                "Kill toast must report the boosted award, not the base ${mob.xpReward} XP",
+            )
+
+            // The toast value must match the "You gain N XP." line the player sees.
+            val messages =
+                fixture.outbound
+                    .drainAll()
+                    .filterIsInstance<OutboundEvent.SendText>()
+                    .filter { it.sessionId == sid }
+                    .map { it.text }
+            assertTrue(
+                messages.contains("You gain 130 XP."),
+                "Expected 'You gain 130 XP.' in: $messages",
+            )
         }
 
     @Test


### PR DESCRIPTION
## Problem

The toast shown after defeating a mob displayed the wrong XP. It reported `mob.xpReward` (the raw base value) while the player was actually granted a different amount that includes:

- the **level-difference bonus** for killing mobs above your level (#1367),
- the group split / group bonus,
- diminishing returns for over-levelled kills,
- the charisma / `xpBonusStat` bonus.

So killing an above-level mob would, e.g., grant 130 XP ("You gain 130 XP.") but the toast still said 100.

## Fix

`CombatSystem.grantGroupKillXp()` now returns the XP actually awarded to the killer, and `handleMobDeath()` passes that value into `CombatEvent.Kill(xpGained = …)` instead of `mob.xpReward`. The toast now always matches the "You gain N XP." line the player sees.

## Tests

Added `CombatSystemTest."Kill combat event xpGained reflects the actual award including under-level bonus"`: a level-1 player kills a level-3 mob (base 100 XP) and asserts the Kill event reports the boosted 130 XP, matching the in-game text.

`./gradlew ktlintCheck test --tests "dev.ambon.engine.CombatSystemTest" -x buildWeb` → BUILD SUCCESSFUL.