### PR TITLE
feat(minimap): show cross-zone boundaries as colour-coded stubs

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -12,6 +12,7 @@ import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.items.ItemSlot
 import dev.ambon.domain.mob.MobState
+import dev.ambon.domain.world.Direction
 import dev.ambon.domain.world.JukeboxSong
 import dev.ambon.domain.world.MusicBox
 import dev.ambon.domain.world.Room
@@ -303,18 +304,39 @@ class GmcpEmitter(
     }
 
     /**
+     * Direction → (dx, dy) grid offset for placing a boundary stub one cell past a
+     * horizontal cross-zone exit. Must match the layout offsets in
+     * `WorldLoader.DIRECTION_OFFSETS` and the client's `MAP_OFFSETS`.
+     */
+    private val zoneMapHorizontalOffsets: Map<Direction, Pair<Int, Int>> = mapOf(
+        Direction.NORTH to (0 to -1),
+        Direction.SOUTH to (0 to 1),
+        Direction.EAST to (1 to 0),
+        Direction.WEST to (-1 to 0),
+    )
+
+    /**
      * Send the full room layout for a zone so the client can render a fog-of-war
      * map with cloud-reveal as the player explores. Each room carries its floor
      * (`z`); clients draw one floor at a time. Up/down exits are included so the
      * map can badge stairs, but clients must not treat them as positional edges.
      *
-     * Room ids and exit targets are sent **without** their `<zone>:` prefix: the
-     * payload already names the [zone] at the top level and exits are filtered to
-     * same-zone targets, so the prefix is pure repetition. Stripping it shrinks a
-     * large zone's payload by ~30% (e.g. a 280-room zone drops from ~67 KB to
-     * ~47 KB), keeping it under [MAX_GMCP_PAYLOAD_BYTES] — above which the whole
-     * map would be silently dropped and the client would render nothing but the
-     * player's own explored trail. Clients re-qualify the ids with the zone.
+     * Cross-zone exits are kept (so the map reflects the true shape of the world
+     * at zone boundaries rather than ending abruptly). Each horizontal exit into a
+     * neighbouring zone also contributes a [BorderStub]: a single ghost room placed
+     * one cell past the boundary, in *this* zone's coordinate frame, tagged with the
+     * neighbour's zone so the client can colour it. Vertical cross-zone exits ride
+     * along as stair badges but seed no stub (they would land on another floor).
+     *
+     * Same-zone room ids and exit targets are sent **without** their `<zone>:`
+     * prefix: the payload already names the [zone] at the top level, so for them the
+     * prefix is pure repetition. Stripping it shrinks a large zone's payload by ~30%
+     * (e.g. a 280-room zone drops from ~67 KB to ~47 KB), keeping it under
+     * [MAX_GMCP_PAYLOAD_BYTES] — above which the whole map would be silently dropped
+     * and the client would render nothing but the player's own explored trail.
+     * Cross-zone targets keep their full `<otherzone>:room` id (the prefix doesn't
+     * match, so nothing is stripped), which both disambiguates them and lets the
+     * client recognise them as foreign. Clients re-qualify the bare ids with [zone].
      */
     suspend fun sendZoneMap(
         sessionId: SessionId,
@@ -322,22 +344,37 @@ class GmcpEmitter(
         rooms: Collection<Room>,
     ) {
         val prefix = "$zone:"
+        val border = LinkedHashMap<String, BorderStub>()
+        val zoneRooms = rooms.map { r ->
+            for ((dir, target) in r.exits) {
+                if (target.zone == zone) continue
+                val offset = zoneMapHorizontalOffsets[dir] ?: continue
+                border.getOrPut(target.value) {
+                    BorderStub(
+                        id = target.value,
+                        zone = target.zone,
+                        x = r.mapX + offset.first,
+                        y = r.mapY + offset.second,
+                        z = r.mapZ,
+                    )
+                }
+            }
+            ZoneMapRoom(
+                id = r.id.value.removePrefix(prefix),
+                x = r.mapX,
+                y = r.mapY,
+                z = r.mapZ,
+                exits = r.exits.entries
+                    .associate { (dir, target) -> dir.name.lowercase() to target.value.removePrefix(prefix) },
+            )
+        }
         emit(
             sessionId,
             "Zone.Map",
             ZoneMapPayload(
                 zone = zone,
-                rooms = rooms.map { r ->
-                    ZoneMapRoom(
-                        id = r.id.value.removePrefix(prefix),
-                        x = r.mapX,
-                        y = r.mapY,
-                        z = r.mapZ,
-                        exits = r.exits.entries
-                            .filter { (_, target) -> target.zone == zone }
-                            .associate { (dir, target) -> dir.name.lowercase() to target.value.removePrefix(prefix) },
-                    )
-                },
+                rooms = zoneRooms,
+                border = border.values.toList(),
             ),
             supportCheck = "Zone.Map",
         )
@@ -3069,6 +3106,7 @@ class GmcpEmitter(
     private data class ZoneMapPayload(
         val zone: String,
         val rooms: List<ZoneMapRoom>,
+        val border: List<BorderStub>,
     )
 
     private data class ZoneMapRoom(
@@ -3077,6 +3115,21 @@ class GmcpEmitter(
         val y: Int,
         val z: Int,
         val exits: Map<String, String>,
+    )
+
+    /**
+     * A ghost room just across a zone boundary: a single cell placed one step past
+     * a horizontal cross-zone exit, in the *current* zone's coordinate frame. Its
+     * [id] is fully qualified (`<zone>:room`) and [zone] names the neighbour so the
+     * client can colour-code it. Stubs carry no exits — the map shows that the world
+     * continues past the edge without pulling the whole neighbour zone into frame.
+     */
+    private data class BorderStub(
+        val id: String,
+        val zone: String,
+        val x: Int,
+        val y: Int,
+        val z: Int,
     )
 
     private data class RoomInfoPayload(

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -1,5 +1,6 @@
 package dev.ambon.engine
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.config.EquipmentConfig
 import dev.ambon.domain.DamageRange
@@ -2077,21 +2078,53 @@ class GmcpEmitterTest {
             assertEquals(1, data.size)
             assertEquals("Zone.Map", data[0].gmcpPackage)
             val json = data[0].jsonData
-            // Room ids and exit targets are sent without the redundant `<zone>:`
-            // prefix; clients re-qualify them from the top-level `zone` field.
+            // Room ids and same-zone exit targets are sent without the redundant
+            // `<zone>:` prefix; clients re-qualify them from the top-level `zone`.
             assertTrue(json.contains("\"id\":\"a\""), "Expected unprefixed room id 'a'. got=$json")
             // North exit to same zone should be present (prefix stripped).
             assertTrue(json.contains("\"north\":\"b\""), "Expected north exit. got=$json")
             // Up exit to same zone should be present (clients badge stairs from it).
             assertTrue(json.contains("\"up\":\"c\""), "Expected up exit. got=$json")
-            // Cross-zone exit should be filtered out entirely.
-            assertTrue(!json.contains("other:x"), "Cross-zone exit should be excluded. got=$json")
-            // The full namespaced form must not leak back in.
-            assertTrue(!json.contains("z:a"), "Room ids should be unprefixed. got=$json")
+            // Cross-zone exit is kept, fully qualified, so the client can draw the
+            // boundary edge and recognise the target as foreign.
+            assertTrue(json.contains("\"east\":\"other:x\""), "Expected cross-zone east exit. got=$json")
+            // The same-zone namespaced form must not leak back in.
+            assertTrue(!json.contains("z:a"), "Same-zone room ids should be unprefixed. got=$json")
             // Coordinates should be present, including the floor
             assertTrue(json.contains("\"x\":0"), "Expected x coordinate. got=$json")
             assertTrue(json.contains("\"y\":-1"), "Expected y=-1 coordinate. got=$json")
             assertTrue(json.contains("\"z\":1"), "Expected z=1 floor on the attic room. got=$json")
+        }
+
+    @Test
+    fun `sendZoneMap places a colour-coded border stub one cell past each horizontal cross-zone exit`() =
+        runTest {
+            val e = emitter("Zone.Map")
+            val rooms = listOf(
+                zoneRoom(
+                    "z:a",
+                    exits = mapOf(
+                        Direction.EAST to RoomId("east_zone:gate"),
+                        // Vertical cross-zone exit: kept as an exit for stair
+                        // badging but must NOT seed a stub (it lands on another
+                        // floor, not an adjacent cell).
+                        Direction.DOWN to RoomId("cellar_zone:hatch"),
+                    ),
+                    mapX = 3,
+                    mapY = 2,
+                    mapZ = 0,
+                ),
+            )
+            e.sendZoneMap(sid, "z", rooms)
+            val border = jacksonObjectMapper().readTree(drainGmcp()[0].jsonData)["border"]
+            assertEquals(1, border.size(), "Only the horizontal cross-zone exit should seed a stub. got=$border")
+            val stub = border[0]
+            assertEquals("east_zone:gate", stub["id"].asText())
+            assertEquals("east_zone", stub["zone"].asText())
+            // One cell east of the source room (3,2) on the same floor.
+            assertEquals(4, stub["x"].asInt())
+            assertEquals(2, stub["y"].asInt())
+            assertEquals(0, stub["z"].asInt())
         }
 
     @Test

--- a/web-v3/src/canvas/GameStateBridge.ts
+++ b/web-v3/src/canvas/GameStateBridge.ts
@@ -25,6 +25,7 @@ import type {
   WorldTime,
   WorldWeather,
   ZoneEnvironment,
+  BorderStub,
 } from "../types";
 
 export interface GameStateSnapshot {
@@ -102,7 +103,7 @@ export const canvasCallbacks: {
   openVideo: ((videoUrl: string) => void) | null;
   dismissDialogue: (() => void) | null;
   openQuestOffers: ((mobKeyword: string) => void) | null;
-  loadZoneMap: ((zone: string, rooms: Array<{ id: string; x: number; y: number; z: number; exits: Record<string, string> }>) => void) | null;
+  loadZoneMap: ((zone: string, rooms: Array<{ id: string; x: number; y: number; z: number; exits: Record<string, string> }>, border: BorderStub[]) => void) | null;
   openMobDetail: ((detail: { name: string; description: string; image: string | null }) => void) | null;
   openImagePreview: ((url: string) => void) | null;
   /** Open the monster-manual / bestiary panel for a clicked creature. */

--- a/web-v3/src/canvas/systems/Minimap.ts
+++ b/web-v3/src/canvas/systems/Minimap.ts
@@ -1,7 +1,8 @@
 import { Container, Graphics, Rectangle, Sprite, Texture } from "pixi.js";
 import { loadTexture } from "../textureLoader";
 import { canvasCallbacks, gameStateRef } from "../GameStateBridge";
-import { MAP_OFFSETS } from "../../constants";
+import { MAP_OFFSETS, zoneColor } from "../../constants";
+import type { BorderStub } from "../../types";
 
 /** Directions that represent the same horizontal plane. Up/down exits are shown
  *  as buttons beside the map but don't place nodes on the parchment. */
@@ -16,6 +17,8 @@ interface MapNode {
   /** Terrain key (forest, mountain, …) once the room has been visited. */
   terrain?: string;
   housing?: boolean;
+  /** Set only for a foreign border stub: the neighbouring zone it belongs to. */
+  zone?: string;
 }
 
 // Server-asset keys (all optional — each falls back to the procedural look).
@@ -145,7 +148,7 @@ export class Minimap {
     this.container.visible = false;
 
     // Register for zone map data from the React layer
-    canvasCallbacks.loadZoneMap = (zone, rooms) => this.loadZoneMap(zone, rooms);
+    canvasCallbacks.loadZoneMap = (zone, rooms, border) => this.loadZoneMap(zone, rooms, border);
   }
 
   /** Width of the parchment — kept as `diameter` for layout-call compatibility. */
@@ -393,20 +396,24 @@ export class Minimap {
       if (terrain) node.terrain = terrain;
     }
 
-    // Pre-place unvisited horizontal neighbors (N/S/E/W only).
+    // Pre-place unvisited horizontal neighbors (N/S/E/W only). A neighbor in a
+    // different zone is a border stub — tag it so redraw() colour-codes it.
     for (const [dir, targetId] of Object.entries(exits)) {
       if (!HORIZONTAL_DIRS.has(dir)) continue;
       if (this.visited.has(targetId)) continue;
       const offset = MAP_OFFSETS[dir];
       if (!offset) continue;
-      this.visited.set(targetId, { x: mapX + offset.dx, y: mapY + offset.dy, exits: {}, title: "", image: null });
+      const targetZone = targetId.split(":")[0];
+      const foreign = targetZone !== zone ? targetZone : undefined;
+      this.visited.set(targetId, { x: mapX + offset.dx, y: mapY + offset.dy, exits: {}, title: "", image: null, zone: foreign });
     }
 
     this.redraw();
   }
 
-  /** Pre-populate all rooms in a zone as fog nodes. */
-  loadZoneMap(zone: string, rooms: Array<{ id: string; x: number; y: number; exits: Record<string, string> }>) {
+  /** Pre-populate all rooms in a zone as fog nodes, plus any cross-zone border
+   *  stubs (foreign rooms one cell past a boundary, tagged with their zone). */
+  loadZoneMap(zone: string, rooms: Array<{ id: string; x: number; y: number; exits: Record<string, string> }>, border: BorderStub[] = []) {
     this.visited.clear();
     this.clearNodeSprites();
     this.currentZone = zone;
@@ -414,6 +421,10 @@ export class Minimap {
     this.lastKey = "";
     for (const r of rooms) {
       this.visited.set(r.id, { x: r.x, y: r.y, exits: r.exits, title: "", image: null });
+    }
+    for (const b of border) {
+      if (this.visited.has(b.id)) continue;
+      this.visited.set(b.id, { x: b.x, y: b.y, exits: {}, title: "", image: null, zone: b.zone });
     }
     this.redraw();
   }
@@ -500,9 +511,11 @@ export class Minimap {
         // Only connect two visible rooms; exits to clipped/off-map rooms are
         // shown by the short direction ticks instead of long stubs into space.
         if (this.inBounds(sp.px, sp.py) && this.inBounds(tp.px, tp.py)) {
+          // An edge into a neighbouring zone takes that zone's colour.
+          const targetZone = this.visited.get(targetId)?.zone ?? node.zone;
           this.mapGraphics.moveTo(sp.px, sp.py);
           this.mapGraphics.lineTo(tp.px, tp.py);
-          this.mapGraphics.stroke({ color: LINE_COLOR, width: 2.5, alpha: 0.9 });
+          this.mapGraphics.stroke({ color: targetZone ? zoneColor(targetZone) : LINE_COLOR, width: 2.5, alpha: 0.9 });
         }
       }
     }
@@ -536,6 +549,13 @@ export class Minimap {
       const nx = p.px;
       const ny = p.py;
       if (!this.inBounds(nx, ny)) continue;
+
+      // Border stub: a foreign room across a zone boundary. A zone-tinted diamond
+      // marks where the map continues, without posing as explored ground here.
+      if (node.zone) {
+        this.drawBorderStub(nx, ny, this._nodeHalf, node.zone);
+        continue;
+      }
 
       const isCurrent = id === this.currentRoomId;
       const half = isCurrent ? this._currentHalf : this._nodeHalf;
@@ -694,6 +714,23 @@ export class Minimap {
     spr.y = ny;
     spr.alpha = alpha;
     spr.visible = true;
+  }
+
+  /** Foreign border stub: a zone-tinted diamond marking where the map continues
+   *  into a neighbouring zone. */
+  private drawBorderStub(nx: number, ny: number, half: number, zone: string) {
+    const color = zoneColor(zone);
+    const diamond = () => {
+      this.mapGraphics.moveTo(nx, ny - half);
+      this.mapGraphics.lineTo(nx + half, ny);
+      this.mapGraphics.lineTo(nx, ny + half);
+      this.mapGraphics.lineTo(nx - half, ny);
+      this.mapGraphics.closePath();
+    };
+    diamond();
+    this.mapGraphics.fill({ color, alpha: 0.5 });
+    diamond();
+    this.mapGraphics.stroke({ color, width: 1.6, alpha: 0.95 });
   }
 
   /** Procedural inked room glyph (fallback when no room asset is present). */

--- a/web-v3/src/constants.ts
+++ b/web-v3/src/constants.ts
@@ -73,6 +73,51 @@ export const MAP_OFFSETS: Record<string, { dx: number; dy: number }> = {
   down: { dx: -1, dy: 1 },
 };
 
+/**
+ * Deterministic hue (0–359°) for a zone name. Used to colour-code rooms that sit
+ * just across a zone boundary on the minimap so each neighbouring zone reads as a
+ * distinct region. Stable across sessions (pure function of the name).
+ */
+export function zoneHue(zone: string): number {
+  let h = 0;
+  for (let i = 0; i < zone.length; i++) h = (Math.imul(h, 31) + zone.charCodeAt(i)) | 0;
+  return ((h % 360) + 360) % 360;
+}
+
+/** Resolve a zone's tint to 8-bit RGB. Mid saturation/lightness so it reads on
+ *  both the light parchment minimap and the dark expanded chart. */
+function zoneRgb(zone: string, saturation: number, lightness: number): { r: number; g: number; b: number } {
+  const h = zoneHue(zone) / 360;
+  const hue2rgb = (p: number, q: number, t: number): number => {
+    let tt = t;
+    if (tt < 0) tt += 1;
+    if (tt > 1) tt -= 1;
+    if (tt < 1 / 6) return p + (q - p) * 6 * tt;
+    if (tt < 1 / 2) return q;
+    if (tt < 2 / 3) return p + (q - p) * (2 / 3 - tt) * 6;
+    return p;
+  };
+  const q = lightness < 0.5 ? lightness * (1 + saturation) : lightness + saturation - lightness * saturation;
+  const p = 2 * lightness - q;
+  return {
+    r: Math.round(hue2rgb(p, q, h + 1 / 3) * 255),
+    g: Math.round(hue2rgb(p, q, h) * 255),
+    b: Math.round(hue2rgb(p, q, h - 1 / 3) * 255),
+  };
+}
+
+/** Zone-boundary tint as a packed 0xRRGGBB integer (for PixiJS `tint`/`color`). */
+export function zoneColor(zone: string, saturation = 0.62, lightness = 0.58): number {
+  const { r, g, b } = zoneRgb(zone, saturation, lightness);
+  return (r << 16) | (g << 8) | b;
+}
+
+/** Zone-boundary tint as a `#rrggbb` CSS string (for Canvas 2D fill/stroke). */
+export function zoneColorCss(zone: string, saturation = 0.62, lightness = 0.58): string {
+  const { r, g, b } = zoneRgb(zone, saturation, lightness);
+  return `#${((1 << 24) | (r << 16) | (g << 8) | b).toString(16).slice(1)}`;
+}
+
 export const EMPTY_VITALS: Vitals = {
   hp: 0,
   maxHp: 0,

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -4,6 +4,7 @@ import type {
   ArcanumJournal,
   ArcanumStatus,
   AuctionListing,
+  BorderStub,
   CharStats,
   FactionStanding,
   StatEntry,
@@ -171,7 +172,7 @@ interface GmcpContext {
   setPuzzleResult: Dispatch<SetStateAction<PuzzleResult | null>>;
   setChatByChannel: Dispatch<SetStateAction<Record<ChatChannel, ChatMessage[]>>>;
   updateMap: (roomId: string, exits: Record<string, string>, title: string, image: string | null, mapX: number, mapY: number, mapZ: number, housing?: boolean, terrain?: string | null) => void;
-  loadZoneMap: (zone: string, rooms: Array<{ id: string; x: number; y: number; z: number; exits: Record<string, string> }>) => void;
+  loadZoneMap: (zone: string, rooms: Array<{ id: string; x: number; y: number; z: number; exits: Record<string, string> }>, border: BorderStub[]) => void;
   pushCombatEvent: (event: CombatEventData) => void;
   setCharStats: Dispatch<SetStateAction<CharStats | null>>;
   setQuests: Dispatch<SetStateAction<QuestEntry[]>>;
@@ -513,8 +514,23 @@ export function applyGmcpPackage(
               };
             })
         : [];
+      // Border stubs: foreign rooms one cell past a horizontal cross-zone exit,
+      // already positioned in this zone's frame and carrying their own zone for
+      // colour-coding. Their ids are sent fully qualified, so no re-qualifying.
+      const border: BorderStub[] = Array.isArray(packet.border)
+        ? packet.border
+            .filter((b): b is Record<string, unknown> => typeof b === "object" && b !== null)
+            .map((b) => ({
+              id: typeof b.id === "string" ? b.id : "",
+              zone: typeof b.zone === "string" ? b.zone : "",
+              x: typeof b.x === "number" ? b.x : 0,
+              y: typeof b.y === "number" ? b.y : 0,
+              z: typeof b.z === "number" ? b.z : 0,
+            }))
+            .filter((b) => b.id !== "" && b.zone !== "")
+        : [];
       if (zone && rooms.length > 0) {
-        ctx.loadZoneMap(zone, rooms);
+        ctx.loadZoneMap(zone, rooms, border);
       }
       break;
     }

--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -111,6 +111,7 @@ import type {
   ZoneEnvironment,
   ZoneInstances,
   CurrencyActivity,
+  BorderStub,
 } from "../types";
 
 function createEmptyChatByChannel(): Record<ChatChannel, ChatMessage[]> {
@@ -196,7 +197,7 @@ export interface MiniMapBridge {
     housing?: boolean,
     terrain?: string | null,
   ) => void;
-  loadZoneMap: (zone: string, rooms: Array<{ id: string; x: number; y: number; z: number; exits: Record<string, string> }>) => void;
+  loadZoneMap: (zone: string, rooms: Array<{ id: string; x: number; y: number; z: number; exits: Record<string, string> }>, border: BorderStub[]) => void;
   resetMap: () => void;
 }
 

--- a/web-v3/src/hooks/useMiniMap.ts
+++ b/web-v3/src/hooks/useMiniMap.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
-import { MAP_OFFSETS } from "../constants";
+import { MAP_OFFSETS, zoneColorCss } from "../constants";
 import { canvasCallbacks, gameStateRef } from "../canvas/GameStateBridge";
-import type { MapRoom } from "../types";
+import type { BorderStub, MapRoom } from "../types";
 
 // Parchment / ink palette — matches the in-scene minimap. The canvas itself is
 // transparent: the parchment scroll (`map_background`) is the map drawer's
@@ -187,6 +187,39 @@ function drawStairBadges(
 }
 
 /** Procedural quest marker (fallback when no minimap_quest asset). */
+/** A room just across a zone boundary: a small zone-tinted diamond with the
+ *  neighbour's name, so the chart shows where the world continues. */
+function drawBorderStub(ctx: CanvasRenderingContext2D, cx: number, cy: number, half: number, zone: string) {
+  const color = zoneColorCss(zone);
+  ctx.save();
+  // Diamond marks it as "a way out" rather than an explored cell.
+  ctx.beginPath();
+  ctx.moveTo(cx, cy - half);
+  ctx.lineTo(cx + half, cy);
+  ctx.lineTo(cx, cy + half);
+  ctx.lineTo(cx - half, cy);
+  ctx.closePath();
+  ctx.globalAlpha = 0.55;
+  ctx.fillStyle = color;
+  ctx.fill();
+  ctx.globalAlpha = 1;
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = color;
+  ctx.stroke();
+  // Zone name beneath the marker.
+  ctx.font = "10px 'JetBrains Mono', 'Cascadia Mono', monospace";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "top";
+  const label = zone.length > 12 ? zone.slice(0, 11) + "…" : zone;
+  const ly = cy + half + 3;
+  ctx.lineWidth = 3;
+  ctx.strokeStyle = LABEL_OUTLINE;
+  ctx.strokeText(label, cx, ly);
+  ctx.fillStyle = color;
+  ctx.fillText(label, cx, ly);
+  ctx.restore();
+}
+
 function drawProceduralQuest(ctx: CanvasRenderingContext2D, cx: number, cy: number, half: number, pulse: number) {
   ctx.save();
   ctx.globalAlpha = pulse;
@@ -291,7 +324,8 @@ function renderMap(
         const tx = nodeX(target);
         const ty = nodeY(target);
         if (sIn && inScrollBounds(tx, ty)) {
-          ctx.strokeStyle = LINE_COLOR;
+          // Edges into a neighbouring zone take that zone's colour so the seam reads.
+          ctx.strokeStyle = target.zone ? zoneColorCss(target.zone) : node.zone ? zoneColorCss(node.zone) : LINE_COLOR;
           ctx.lineWidth = 2.5;
           ctx.beginPath();
           ctx.moveTo(sx, sy);
@@ -364,6 +398,15 @@ function renderMap(
     const x = nodeX(node);
     const y = nodeY(node);
     if (!inScrollBounds(x, y)) continue;
+
+    // Border stub: a room in a neighbouring zone, one cell past the boundary.
+    // Drawn as a small zone-tinted marker with the zone's name, never as a
+    // regular room glyph — it shows the world continues without claiming to be
+    // explored ground in this zone.
+    if (node.zone) {
+      drawBorderStub(ctx, x, y, nodeSize / 2, node.zone);
+      continue;
+    }
 
     const isCurrent = id === currentId;
     const isVisited = node.title !== "";
@@ -740,12 +783,16 @@ export function useMiniMap() {
       }
 
       // Pre-place unvisited horizontal neighbors (N/S/E/W only) on the same floor.
+      // A neighbor in a different zone is a border stub — tag it so it colour-codes.
+      const zone = roomId.split(":")[0];
       for (const [dir, targetId] of Object.entries(exits)) {
         if (dir === "up" || dir === "down") continue;
         if (rooms.has(targetId)) continue;
         const offset = MAP_OFFSETS[dir];
         if (!offset) continue;
-        rooms.set(targetId, { x: mapX + offset.dx, y: mapY + offset.dy, z: mapZ, exits: {}, title: "", image: null });
+        const targetZone = targetId.split(":")[0];
+        const foreign = targetZone !== zone ? targetZone : undefined;
+        rooms.set(targetId, { x: mapX + offset.dx, y: mapY + offset.dy, z: mapZ, exits: {}, title: "", image: null, zone: foreign });
       }
 
       drawMap();
@@ -755,7 +802,11 @@ export function useMiniMap() {
 
   /** Pre-populate the map with all rooms in a zone as fog nodes. */
   const loadZoneMap = useCallback(
-    (zone: string, rooms: Array<{ id: string; x: number; y: number; z: number; exits: Record<string, string> }>) => {
+    (
+      zone: string,
+      rooms: Array<{ id: string; x: number; y: number; z: number; exits: Record<string, string> }>,
+      border: BorderStub[],
+    ) => {
       const map = visitedRef.current;
       map.clear();
       currentRoomIdRef.current = null;
@@ -767,10 +818,17 @@ export function useMiniMap() {
       for (const r of rooms) {
         map.set(r.id, { x: r.x, y: r.y, z: r.z, exits: r.exits, title: "", image: null });
       }
+      // Border stubs: foreign rooms just across a boundary, already positioned in
+      // this zone's frame. Tagged with their zone so drawMap colour-codes them.
+      // A stub never overwrites a real room (defensive — ids shouldn't collide).
+      for (const b of border) {
+        if (map.has(b.id)) continue;
+        map.set(b.id, { x: b.x, y: b.y, z: b.z, exits: {}, title: "", image: null, zone: b.zone });
+      }
       drawMap();
 
       // Also push to the PixiJS compact minimap
-      canvasCallbacks.loadZoneMap?.(zone, rooms);
+      canvasCallbacks.loadZoneMap?.(zone, rooms, border);
     },
     [drawMap],
   );

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -436,6 +436,27 @@ export interface MapRoom {
   /** Terrain key (forest, mountain, …) once the room has been visited. */
   terrain?: string;
   housing?: boolean;
+  /**
+   * Set only for a *foreign* room sitting just across a zone boundary (a border
+   * stub). Names the neighbouring zone, so the renderer colour-codes it. Rooms in
+   * the current zone leave this undefined.
+   */
+  zone?: string;
+}
+
+/**
+ * A ghost room one cell across a zone boundary, positioned in the *current* zone's
+ * coordinate frame. Lets the minimap show that the world continues past an edge
+ * (colour-coded by [zone]) without pulling the whole neighbour zone into view.
+ */
+export interface BorderStub {
+  /** Fully-qualified `<zone>:room` id. */
+  id: string;
+  /** The neighbouring zone this stub belongs to. */
+  zone: string;
+  x: number;
+  y: number;
+  z: number;
 }
 
 export interface TabCycle {


### PR DESCRIPTION
## Problem

The minimap laid out each zone in its own coordinate frame and **dropped every cross-zone exit** (`GmcpEmitter.sendZoneMap` filtered `target.zone == zone`). So the map ended abruptly at zone borders and didn't reflect the true shape of the world — a room directly north of a room in the next zone showed nothing there.

## Approach

**Boundary stubs**, zone-colour-coded (per the chosen scope). We keep each zone's robust independent layout and stitch only the *immediately adjacent* foreign rooms onto the edge — no fragile global coordinate space.

### Server — `GmcpEmitter.sendZoneMap`
- Stop filtering cross-zone exits; they're sent fully qualified (`otherzone:room`), which both lets the client draw the boundary edge and marks them as foreign.
- Emit a new `border` list: one ghost room per **horizontal** cross-zone exit, positioned one cell past the boundary **in the current zone's frame** (source `mapX/mapY` + direction offset) and tagged with the neighbour's zone. Vertical cross-zone exits ride along as stair badges and seed no stub.

### Client
- Parse `border` in the `Zone.Map` handler and thread it through `loadZoneMap` (both renderers).
- Render stubs as **zone-tinted diamonds** with connectors in both the compact PixiJS minimap and the expanded Canvas chart; the big map also labels the neighbour zone's name. Each zone gets a deterministic hue (`zoneHue`/`zoneColor`/`zoneColorCss` in `constants.ts`).
- Clicking a boundary stub on the compact map walks you across the border (falls out of the existing exit click-areas for free).

## Tests
- New `GmcpEmitterTest` case asserting a horizontal cross-zone exit seeds exactly one correctly-positioned, zone-tagged border stub while a vertical one does not; updated the existing test that asserted the old filtering behaviour.
- `ktlintCheck` + `GmcpEmitterTest` green; web `tsc`, `eslint`, and `vite build` green. Full backend suite running.

## Notes / possible follow-ups
- Scope is deliberately one hop across each border. Pulling a deeper fringe of neighbour zones, or a fully unified world layout, would be a larger follow-up.