### PR TITLE
refactor(engine): add SessionScoped helper for per-session lifecycle

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/AutoQuestSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/AutoQuestSystem.kt
@@ -34,11 +34,13 @@ class AutoQuestSystem(
     private val clock: Clock,
     private val random: Random = Random.Default,
 ) : GameSystem {
+    private val scoped = SessionScoped()
+
     /** Active auto-quest per session (at most one). */
-    private val activeQuests = mutableMapOf<SessionId, AutoQuest>()
+    private val activeQuests = scoped.map<AutoQuest>()
 
     /** Epoch-ms timestamp after which a player may request again. */
-    private val cooldowns = mutableMapOf<SessionId, Long>()
+    private val cooldowns = scoped.map<Long>()
 
     /**
      * Generates and assigns a random kill quest based on mobs in the player's
@@ -154,14 +156,11 @@ class AutoQuestSystem(
     }
 
     /** Cleans up when a player disconnects. */
-    override suspend fun onPlayerDisconnected(sessionId: SessionId) {
-        activeQuests.remove(sessionId)
-        cooldowns.remove(sessionId)
-    }
+    override suspend fun onPlayerDisconnected(sessionId: SessionId) = scoped.clear(sessionId)
 
     override fun remapSession(oldSid: SessionId, newSid: SessionId) {
-        activeQuests.remapKey(oldSid, newSid)
-        cooldowns.remapKey(oldSid, newSid)
+        scoped.remap(oldSid, newSid)
+        // The moved AutoQuest still carries the old session id in its body; fix it up.
         activeQuests[newSid]?.let {
             activeQuests[newSid] = it.copy(sessionId = newSid)
         }

--- a/src/main/kotlin/dev/ambon/engine/GameSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameSystem.kt
@@ -28,6 +28,40 @@ internal fun <V> MutableMap<SessionId, V>.remapKey(oldKey: SessionId, newKey: Se
 }
 
 /**
+ * Tracks the session-keyed maps owned by one [GameSystem] so lifecycle fan-out
+ * is automatic: register each map with [map], then delegate
+ * [GameSystem.remapSession] to [remap] and [GameSystem.onPlayerDisconnected] to
+ * [clear]. Adding a new per-session map can no longer silently leak state by
+ * forgetting its cleanup — the map is cleaned up the moment it is registered.
+ *
+ * Each map is captured behind a closure with its concrete value type, so the
+ * star-projection limitation that stops [remapKey] working across a
+ * heterogeneous list of maps does not apply.
+ */
+internal class SessionScoped {
+    private val clearers = mutableListOf<(SessionId) -> Unit>()
+    private val remappers = mutableListOf<(SessionId, SessionId) -> Unit>()
+
+    /** Registers and returns a fresh session-keyed map tracked for lifecycle. */
+    fun <V> map(): MutableMap<SessionId, V> {
+        val backing = mutableMapOf<SessionId, V>()
+        clearers.add { sid -> backing.remove(sid) }
+        remappers.add { old, new -> backing.remapKey(old, new) }
+        return backing
+    }
+
+    /** Moves every tracked entry keyed by [oldSid] to [newSid]. */
+    fun remap(oldSid: SessionId, newSid: SessionId) {
+        for (remapper in remappers) remapper(oldSid, newSid)
+    }
+
+    /** Drops [sessionId] from every tracked map. */
+    fun clear(sessionId: SessionId) {
+        for (clearer in clearers) clearer(sessionId)
+    }
+}
+
+/**
  * Removes [value] from the set at [key], then removes the entry entirely
  * if the set is now empty. This is the canonical room-membership cleanup.
  */

--- a/src/main/kotlin/dev/ambon/engine/GuildHallSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/GuildHallSystem.kt
@@ -30,13 +30,15 @@ class GuildHallSystem(
     private val gmcpEmitter: GmcpEmitter? = null,
     private val guildSystem: GuildSystem,
 ) : GameSystem {
+    private val scoped = SessionScoped()
+
     /**
      * Tracks where each visitor entered from, so we can return them on leave.
      */
-    private val visitorOrigins = mutableMapOf<SessionId, RoomId>()
+    private val visitorOrigins = scoped.map<RoomId>()
 
     /** Tracks which guild hall each session is currently in (by guild id). */
-    private val sessionInHall = mutableMapOf<SessionId, String>()
+    private val sessionInHall = scoped.map<String>()
 
     // -------- lifecycle --------
 
@@ -88,15 +90,9 @@ class GuildHallSystem(
         sessionInHall[sessionId] = guildId
     }
 
-    override suspend fun onPlayerDisconnected(sessionId: SessionId) {
-        visitorOrigins.remove(sessionId)
-        sessionInHall.remove(sessionId)
-    }
+    override suspend fun onPlayerDisconnected(sessionId: SessionId) = scoped.clear(sessionId)
 
-    override fun remapSession(oldSid: SessionId, newSid: SessionId) {
-        visitorOrigins.remapKey(oldSid, newSid)
-        sessionInHall.remapKey(oldSid, newSid)
-    }
+    override fun remapSession(oldSid: SessionId, newSid: SessionId) = scoped.remap(oldSid, newSid)
 
     // -------- commands --------
 

--- a/src/main/kotlin/dev/ambon/engine/HousingSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/HousingSystem.kt
@@ -77,14 +77,16 @@ class HousingSystem(
     /** In-memory cache of loaded houses. Populated on player login, stays until restart. */
     private val housesByOwner = mutableMapOf<PlayerId, HouseRecord>()
 
+    private val scoped = SessionScoped()
+
     /**
      * Tracks where each visitor (including the owner) entered from.
      * Used to resolve the dynamic "exit" when leaving the house.
      */
-    private val visitorOrigins = mutableMapOf<SessionId, RoomId>()
+    private val visitorOrigins = scoped.map<RoomId>()
 
     /** Tracks which house each session is visiting (by owner PlayerId). */
-    private val sessionInHouse = mutableMapOf<SessionId, PlayerId>()
+    private val sessionInHouse = scoped.map<PlayerId>()
 
     // -------- lifecycle --------
 
@@ -130,10 +132,7 @@ class HousingSystem(
         }
     }
 
-    override fun remapSession(oldSid: SessionId, newSid: SessionId) {
-        visitorOrigins.remapKey(oldSid, newSid)
-        sessionInHouse.remapKey(oldSid, newSid)
-    }
+    override fun remapSession(oldSid: SessionId, newSid: SessionId) = scoped.remap(oldSid, newSid)
 
     override suspend fun onPlayerDisconnected(sessionId: SessionId) {
         val ps = players.get(sessionId) ?: return
@@ -146,8 +145,7 @@ class HousingSystem(
         }
 
         // Clean up this session's visitor state (if they were visiting someone else)
-        visitorOrigins.remove(sessionId)
-        sessionInHouse.remove(sessionId)
+        scoped.clear(sessionId)
     }
 
     // -------- house creation --------

--- a/src/main/kotlin/dev/ambon/engine/RegenSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/RegenSystem.kt
@@ -31,21 +31,16 @@ class RegenSystem(
     private val dirtyNotifier: DirtyNotifier = DirtyNotifier.NO_OP,
     private val classRegistry: PlayerClassRegistry? = null,
 ) : GameSystem {
-    private val lastRegenAtMs = mutableMapOf<SessionId, Long>()
-    private val lastManaRegenAtMs = mutableMapOf<SessionId, Long>()
+    private val scoped = SessionScoped()
+    private val lastRegenAtMs = scoped.map<Long>()
+    private val lastManaRegenAtMs = scoped.map<Long>()
 
     override fun remapSession(
         oldSid: SessionId,
         newSid: SessionId,
-    ) {
-        lastRegenAtMs.remapKey(oldSid, newSid)
-        lastManaRegenAtMs.remapKey(oldSid, newSid)
-    }
+    ) = scoped.remap(oldSid, newSid)
 
-    override suspend fun onPlayerDisconnected(sessionId: SessionId) {
-        lastRegenAtMs.remove(sessionId)
-        lastManaRegenAtMs.remove(sessionId)
-    }
+    override suspend fun onPlayerDisconnected(sessionId: SessionId) = scoped.clear(sessionId)
 
     fun tick(capOverride: Int? = null) {
         val now = clock.millis()

--- a/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/abilities/AbilitySystem.kt
@@ -17,13 +17,13 @@ import dev.ambon.engine.PetSystem
 import dev.ambon.engine.PlayerProgression
 import dev.ambon.engine.PlayerRegistry
 import dev.ambon.engine.PlayerState
+import dev.ambon.engine.SessionScoped
 import dev.ambon.engine.applyHeal
 import dev.ambon.engine.broadcastToRoom
 import dev.ambon.engine.ceilSeconds
 import dev.ambon.engine.events.CombatEvent
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
-import dev.ambon.engine.remapKey
 import dev.ambon.engine.resolvePlayerStats
 import dev.ambon.engine.spendMana
 import dev.ambon.engine.status.StatusEffectSystem
@@ -54,10 +54,11 @@ class AbilitySystem(
     private val onCombatEvent: suspend (SessionId, CombatEvent) -> Unit = { _, _ -> },
     val onSummonPet: suspend (SessionId, String, Long) -> Unit = { _, _, _ -> },
 ) : GameSystem {
-    private val manualLearnedAbilities = mutableMapOf<SessionId, MutableSet<AbilityId>>()
-    private val raceGrantedAbilities = mutableMapOf<SessionId, MutableSet<AbilityId>>()
-    private val effectiveAbilities = mutableMapOf<SessionId, MutableSet<AbilityId>>()
-    private val cooldowns = mutableMapOf<SessionId, MutableMap<AbilityId, Long>>()
+    private val scoped = SessionScoped()
+    private val manualLearnedAbilities = scoped.map<MutableSet<AbilityId>>()
+    private val raceGrantedAbilities = scoped.map<MutableSet<AbilityId>>()
+    private val effectiveAbilities = scoped.map<MutableSet<AbilityId>>()
+    private val cooldowns = scoped.map<MutableMap<AbilityId, Long>>()
 
     fun syncAbilities(
         sessionId: SessionId,
@@ -1166,22 +1167,12 @@ class AbilitySystem(
         cooldowns.remove(sessionId)
     }
 
-    override suspend fun onPlayerDisconnected(sessionId: SessionId) {
-        manualLearnedAbilities.remove(sessionId)
-        raceGrantedAbilities.remove(sessionId)
-        effectiveAbilities.remove(sessionId)
-        cooldowns.remove(sessionId)
-    }
+    override suspend fun onPlayerDisconnected(sessionId: SessionId) = scoped.clear(sessionId)
 
     override fun remapSession(
         oldSid: SessionId,
         newSid: SessionId,
-    ) {
-        manualLearnedAbilities.remapKey(oldSid, newSid)
-        raceGrantedAbilities.remapKey(oldSid, newSid)
-        effectiveAbilities.remapKey(oldSid, newSid)
-        cooldowns.remapKey(oldSid, newSid)
-    }
+    ) = scoped.remap(oldSid, newSid)
 
     private fun ensureAbilitiesCurrent(sessionId: SessionId) {
         val player = players.get(sessionId) ?: return


### PR DESCRIPTION
## What

Introduces `SessionScoped` (in `GameSystem.kt`) — a tiny registry that tracks a system's session-keyed maps and fans out `remapSession`/`onPlayerDisconnected` automatically. Each map is captured behind a concrete-typed closure, so registering it wires up both its remap and its cleanup at once.

Applied to the pure multi-map systems:
- `RegenSystem` (2 maps)
- `AbilitySystem` (4 maps)
- `GuildHallSystem` (2 maps)
- `AutoQuestSystem` (2 maps — keeps its `copy(sessionId=)` fixup after the remap)
- `HousingSystem` (2 maps — keeps its owner-boot path; trailing removes become `scoped.clear`)

## Why

Every one of these systems hand-rolled a `remapKey`-per-map / `remove`-per-map pair. Adding a new per-session map without also adding its cleanup line silently leaked state across a session takeover or disconnect — a bug class the compiler can't catch. Now the map is cleaned up the moment it's registered.

## Scope / non-goals

Systems with genuinely custom lifecycle logic (`GroupSystem` leadership transfer, `CombatSystem` PvP cross-refs + threat-table delegation, `DialogueSystem` GMCP side-effect) are intentionally left as-is — forcing them through the helper would obscure more than it saves. `StatusEffectSystem` has a single session map, so it wasn't worth converting.

## Behaviour

Preserving. Early-return guards (e.g. Housing's null-player short-circuit) are kept in place, so cleanup still runs under exactly the same conditions.

## Verification

`compileKotlin` clean · `ktlintFormat` applied · existing AutoQuest / Ability / Housing / StatusEffect / GameEngineLoginFlow / SessionRouter lifecycle tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)