### PR TITLE
refactor(handlers): extract requireRoomFlag and resolveByIndexOrName helpers

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/AkathavaeHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/AkathavaeHandler.kt
@@ -231,17 +231,13 @@ class AkathavaeHandler(
             outbound.send(OutboundEvent.SendError(sessionId, "The Akathavae do not accept pledges in this world."))
             return false
         }
-        val room = world.rooms[me.roomId]
-        if (room == null || !room.akathavaeShrine) {
-            outbound.send(
-                OutboundEvent.SendError(
-                    sessionId,
-                    "Only at an Akathavae shrine can such a vow be spoken or unsaid.",
-                ),
-            )
-            return false
-        }
-        return true
+        return requireRoomFlag(
+            sessionId,
+            me,
+            world,
+            outbound,
+            "Only at an Akathavae shrine can such a vow be spoken or unsaid.",
+        ) { it.akathavaeShrine }
     }
 
     private suspend fun handlePledge(sessionId: SessionId) {

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/BankHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/BankHandler.kt
@@ -28,14 +28,8 @@ class BankHandler(
         router.on<Command.Bank.Balance> { sid, _ -> handleBalance(sid) }
     }
 
-    private suspend fun requireBank(sessionId: SessionId, me: dev.ambon.engine.PlayerState): Boolean {
-        val room = world.rooms[me.roomId]
-        if (room == null || !room.bank) {
-            outbound.send(OutboundEvent.SendError(sessionId, "You need to be at a bank to do that."))
-            return false
-        }
-        return true
-    }
+    private suspend fun requireBank(sessionId: SessionId, me: dev.ambon.engine.PlayerState): Boolean =
+        requireRoomFlag(sessionId, me, world, outbound, "You need to be at a bank to do that.") { it.bank }
 
     private suspend fun handleDepositGold(sessionId: SessionId, cmd: Command.Bank.DepositGold) {
         val me = players.get(sessionId) ?: return

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/BoatHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/BoatHandler.kt
@@ -146,15 +146,8 @@ class BoatHandler(
     private fun resolveDestination(
         arg: String,
         destinations: List<BoatSystem.Destination>,
-    ): BoatSystem.Destination? {
-        if (arg.isEmpty()) return null
-        arg.toIntOrNull()?.let { idx ->
-            return destinations.getOrNull(idx - 1)
-        }
-        destinations.firstOrNull { it.roomId.value.equals(arg, ignoreCase = true) }?.let { return it }
-        destinations.firstOrNull { it.name.equals(arg, ignoreCase = true) }?.let { return it }
-        return destinations.firstOrNull { it.name.contains(arg, ignoreCase = true) }
-    }
+    ): BoatSystem.Destination? =
+        resolveByIndexOrName(arg, destinations, { it.roomId.value }, { it.name })
 
     private suspend fun emitBoatState(
         sessionId: SessionId,

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/FlightHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/FlightHandler.kt
@@ -147,15 +147,8 @@ class FlightHandler(
     private fun resolveDestination(
         arg: String,
         destinations: List<FlightSystem.Destination>,
-    ): FlightSystem.Destination? {
-        if (arg.isEmpty()) return null
-        arg.toIntOrNull()?.let { idx ->
-            return destinations.getOrNull(idx - 1)
-        }
-        destinations.firstOrNull { it.roomId.value.equals(arg, ignoreCase = true) }?.let { return it }
-        destinations.firstOrNull { it.name.equals(arg, ignoreCase = true) }?.let { return it }
-        return destinations.firstOrNull { it.name.contains(arg, ignoreCase = true) }
-    }
+    ): FlightSystem.Destination? =
+        resolveByIndexOrName(arg, destinations, { it.roomId.value }, { it.name })
 
     private suspend fun emitFlightState(
         sessionId: SessionId,

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -1122,3 +1122,45 @@ internal fun resolveGotoArg(
     } else {
         runCatching { RoomId(qualifyId(currentZone, arg)) }.getOrNull()
     }
+
+/**
+ * Gates a command on the player standing in a room whose [flag] is set (bank,
+ * stylist, inn, shrine, …). Sends [errorMessage] and returns `false` when the
+ * room is missing or the flag is unset; returns `true` otherwise. Callers that
+ * early-return use `if (!requireRoomFlag(...)) return`.
+ */
+internal suspend fun requireRoomFlag(
+    sessionId: SessionId,
+    me: PlayerState,
+    world: World,
+    outbound: OutboundBus,
+    errorMessage: String,
+    flag: (Room) -> Boolean,
+): Boolean {
+    val room = world.rooms[me.roomId]
+    if (room == null || !flag(room)) {
+        outbound.send(OutboundEvent.SendError(sessionId, errorMessage))
+        return false
+    }
+    return true
+}
+
+/**
+ * Resolves a user-typed destination argument against [items], trying in order:
+ * a 1-based list index, an exact (case-insensitive) [roomId], an exact
+ * (case-insensitive) [name], then a [name] substring. Shared by the flight and
+ * boat kiosks, which offer the same "pick by number or name" affordance over
+ * different destination types.
+ */
+internal fun <T> resolveByIndexOrName(
+    arg: String,
+    items: List<T>,
+    roomId: (T) -> String,
+    name: (T) -> String,
+): T? {
+    if (arg.isEmpty()) return null
+    arg.toIntOrNull()?.let { idx -> return items.getOrNull(idx - 1) }
+    items.firstOrNull { roomId(it).equals(arg, ignoreCase = true) }?.let { return it }
+    items.firstOrNull { name(it).equals(arg, ignoreCase = true) }?.let { return it }
+    return items.firstOrNull { name(it).contains(arg, ignoreCase = true) }
+}

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/StylistHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/StylistHandler.kt
@@ -34,14 +34,8 @@ class StylistHandler(
         router.on<Command.Stylist.ChangeRace> { sid, cmd -> handleChangeRace(sid, cmd) }
     }
 
-    private suspend fun requireStylist(sessionId: SessionId, me: PlayerState): Boolean {
-        val room = world.rooms[me.roomId]
-        if (room == null || !room.stylist) {
-            outbound.send(OutboundEvent.SendError(sessionId, "You need to be at a stylist to do that."))
-            return false
-        }
-        return true
-    }
+    private suspend fun requireStylist(sessionId: SessionId, me: PlayerState): Boolean =
+        requireRoomFlag(sessionId, me, world, outbound, "You need to be at a stylist to do that.") { it.stylist }
 
     private suspend fun handleList(sessionId: SessionId) {
         val me = players.get(sessionId) ?: return


### PR DESCRIPTION
## What

Extracts two genuinely-identical patterns copy-pasted across service-NPC handlers into `HandlerHelpers`:

- **`resolveByIndexOrName<T>`** — `FlightHandler` and `BoatHandler` each carried a byte-identical 12-line "resolve destination by 1-based index / exact room-id / exact name / name substring" method over their respective `Destination` types.
- **`requireRoomFlag`** — `BankHandler`, `StylistHandler`, and `AkathavaeHandler` each hand-rolled the same "look up the room, send an error + bail if the flag is unset" gate.

## Scope decisions

- `NavigationHandler`'s inn gate stays inline — it needs the `Room` object afterward (`room.title`), so a boolean gate doesn't fit cleanly.
- `HousingHandler.requireBroker` stays as-is — it also emits GMCP UI feedback with a `command` param.
- **The gold-charge pattern was evaluated and deliberately not consolidated.** The 6+ sites diverge on templated (`config.messages.notEnoughGold` with `{cost}`/`{gold}`) vs inline messages, on staff-bypass (Shop/Trainer bypass, Flight/Boat/Stylist don't), and on side-effects interleaved between the deduct and `markVitalsDirty` (Stylist mutates stats mid-sequence). A forced shared helper would risk subtle behaviour changes — better suited to a human-reviewed change than an auto-merge.

## Behaviour

Preserving. `Akathavae`'s earlier `config.enabled` check and multi-line message are kept; only the room-flag portion is routed through the helper.

## Verification

`ktlintCheck` clean · `compileKotlin` clean · existing Flight / Boat / Bank / Stylist / Akathavae / Recall router + system tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)