### PR TITLE
refactor(web): add useTickingClock hook + shared MM:SS formatter

### DIFF
--- a/web-v3/src/components/panels/CombatLogPanel.tsx
+++ b/web-v3/src/components/panels/CombatLogPanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTickingClock } from "../../hooks/useTickingClock";
 import type { CombatLogMessage } from "../../types";
 
 type CombatStyle = CombatLogMessage["style"];
@@ -33,17 +34,12 @@ function formatRelativeTime(receivedAt: number, now: number): string {
 }
 
 export function CombatLogPanel({ messages, onClearLog }: CombatLogPanelProps) {
-  const [now, setNow] = useState(() => Date.now());
+  // Tick once per second to keep relative timestamps fresh.
+  const now = useTickingClock(1000);
   const [hidden, setHidden] = useState<Set<CombatStyle>>(() => new Set());
   const scrollRef = useRef<HTMLDivElement | null>(null);
   // Start sticky so the newest entries are visible when the panel opens.
   const stickyRef = useRef<boolean>(true);
-
-  // Tick the clock once per second to keep relative timestamps fresh.
-  useEffect(() => {
-    const interval = window.setInterval(() => setNow(Date.now()), 1000);
-    return () => window.clearInterval(interval);
-  }, []);
 
   const toggleStyle = useCallback((style: CombatStyle) => {
     setHidden((prev) => {

--- a/web-v3/src/components/panels/CombatPanel.tsx
+++ b/web-v3/src/components/panels/CombatPanel.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import type { CombatTarget, ItemSummary, RoomMob, SkillSummary, Vitals } from "../../types";
 import { selectQuickPotion } from "../../combat/quickPotion";
+import { useTickingClock } from "../../hooks/useTickingClock";
 import { percent } from "../../utils";
 import { CrosshairIcon, FleeIcon, RefreshIcon, SkillCastIcon } from "../Icons";
 
@@ -35,14 +36,9 @@ export function CombatPanel({
   onAttackMob,
   onCommand,
 }: CombatPanelProps) {
-  const [now, setNow] = useState(() => Date.now());
+  const now = useTickingClock(250);
   const [activeTab, setActiveTab] = useState<AbilityTab>("all");
   const [expanded, setExpanded] = useState(false);
-
-  useEffect(() => {
-    const interval = window.setInterval(() => setNow(Date.now()), 250);
-    return () => window.clearInterval(interval);
-  }, []);
 
   const hasTarget = combatTarget !== null && combatTarget.targetId !== null;
   const targetHp = combatTarget?.targetHp ?? 0;

--- a/web-v3/src/components/panels/JukeboxPanel.tsx
+++ b/web-v3/src/components/panels/JukeboxPanel.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useMediaFits } from "../../canvas/loginArtFit";
+import { useTickingClock } from "../../hooks/useTickingClock";
 import type { JukeboxState, UiFeedbackEntry } from "../../types";
+import { formatMinutesSeconds } from "../../utils";
 
 interface JukeboxPanelProps {
   jukebox: JukeboxState | null;
@@ -17,11 +19,6 @@ interface JukeboxPanelProps {
 const LANDSCAPE_PAGE_SIZE = 4;
 const PORTRAIT_PAGE_SIZE = 6;
 
-function formatDuration(seconds: number): string {
-  const s = Math.max(0, Math.floor(seconds));
-  return `${Math.floor(s / 60)}:${(s % 60).toString().padStart(2, "0")}`;
-}
-
 /**
  * Room jukebox. Lists the room's playlist four songs to a page (each seated on a
  * painted scroll when skinned); the player pays a few gold to play a song, which
@@ -30,13 +27,8 @@ function formatDuration(seconds: number): string {
  * next-up slot — the bottom-right plaque shows the queued song's number.
  */
 export function JukeboxPanel({ jukebox, gold, selfName, uiFeedbackFeed, assets, onCommand }: JukeboxPanelProps) {
-  const [now, setNow] = useState(() => Date.now());
+  const now = useTickingClock(1000);
   const [page, setPage] = useState(0);
-
-  useEffect(() => {
-    const timer = window.setInterval(() => setNow(Date.now()), 1000);
-    return () => window.clearInterval(timer);
-  }, []);
 
   const activeFeedback = useMemo(
     () => [...uiFeedbackFeed].reverse().find((e) => e.scope === "jukebox") ?? null,
@@ -72,7 +64,7 @@ export function JukeboxPanel({ jukebox, gold, selfName, uiFeedbackFeed, assets, 
                 {nowPlaying.artist ? <span className="jukebox-np-artist"> — {nowPlaying.artist}</span> : null}
               </div>
               <div className="jukebox-np-sub">
-                Played by {nowPlaying.buyer} · {formatDuration(remaining)} left
+                Played by {nowPlaying.buyer} · {formatMinutesSeconds(remaining)} left
               </div>
               {queued ? (
                 <div className="jukebox-np-next">Up next: “{queued.title}” — queued by {queued.buyer}</div>
@@ -125,7 +117,7 @@ export function JukeboxPanel({ jukebox, gold, selfName, uiFeedbackFeed, assets, 
                   {song.description ? <p className="jukebox-song-desc">{song.description}</p> : null}
                 </div>
                 <div className="jukebox-song-meta">
-                  <span className="jukebox-song-dur">{formatDuration(song.durationSeconds)}</span>
+                  <span className="jukebox-song-dur">{formatMinutesSeconds(song.durationSeconds)}</span>
                   <span className={`jukebox-song-cost${canAfford ? "" : " is-short"}`}>{song.cost} gold</span>
                   <button
                     type="button"

--- a/web-v3/src/components/panels/LotteryPanel.tsx
+++ b/web-v3/src/components/panels/LotteryPanel.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
+import { useTickingClock } from "../../hooks/useTickingClock";
 import type { LotteryInfo, UiFeedbackEntry } from "../../types";
 
 interface LotteryPanelProps {
@@ -22,13 +23,8 @@ function formatHMS(ms: number): string {
  * and Buy Tickets button in the bottom panel.
  */
 export function LotteryPanel({ lotteryInfo, uiFeedbackFeed, onCommand }: LotteryPanelProps) {
-  const [now, setNow] = useState(() => Date.now());
+  const now = useTickingClock(1000);
   const [qty, setQty] = useState(1);
-
-  useEffect(() => {
-    const timer = window.setInterval(() => setNow(Date.now()), 1000);
-    return () => window.clearInterval(timer);
-  }, []);
 
   const activeFeedback = useMemo(
     () => [...uiFeedbackFeed].reverse().find((e) => e.scope === "lottery") ?? null,

--- a/web-v3/src/components/panels/MusicBoxPanel.tsx
+++ b/web-v3/src/components/panels/MusicBoxPanel.tsx
@@ -1,16 +1,13 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
+import { useTickingClock } from "../../hooks/useTickingClock";
 import type { MusicBoxState, UiFeedbackEntry } from "../../types";
+import { formatMinutesSeconds } from "../../utils";
 
 interface MusicBoxPanelProps {
   musicBox: MusicBoxState | null;
   uiFeedbackFeed: UiFeedbackEntry[];
   assets: Record<string, string>;
   onCommand: (command: string) => void;
-}
-
-function formatDuration(seconds: number): string {
-  const s = Math.max(0, Math.floor(seconds));
-  return `${Math.floor(s / 60)}:${(s % 60).toString().padStart(2, "0")}`;
 }
 
 /**
@@ -23,11 +20,7 @@ function formatDuration(seconds: number): string {
 export function MusicBoxPanel({ musicBox, uiFeedbackFeed, assets, onCommand }: MusicBoxPanelProps) {
   // 250ms tick keeps the highlighted lyric line roughly in step with the music
   // without the cost of an animation frame.
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    const timer = window.setInterval(() => setNow(Date.now()), 250);
-    return () => window.clearInterval(timer);
-  }, []);
+  const now = useTickingClock(250);
 
   const activeFeedback = useMemo(
     () => [...uiFeedbackFeed].reverse().find((e) => e.scope === "musicbox") ?? null,
@@ -118,9 +111,9 @@ export function MusicBoxPanel({ musicBox, uiFeedbackFeed, assets, onCommand }: M
           </button>
         )}
         {playing ? (
-          <span className="musicbox-remaining" aria-live="polite">{formatDuration(remaining)} left</span>
+          <span className="musicbox-remaining" aria-live="polite">{formatMinutesSeconds(remaining)} left</span>
         ) : box ? (
-          <span className="musicbox-remaining musicbox-remaining-idle">{formatDuration(duration)}</span>
+          <span className="musicbox-remaining musicbox-remaining-idle">{formatMinutesSeconds(duration)}</span>
         ) : null}
       </div>
 

--- a/web-v3/src/hooks/useTickingClock.ts
+++ b/web-v3/src/hooks/useTickingClock.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Returns `Date.now()`, re-rendering every [intervalMs] so relative timestamps
+ * and countdowns stay fresh. This is the canonical "tick the clock" pattern:
+ * a panel that showed `const [now, setNow] = useState(() => Date.now())` plus a
+ * bare mount interval can collapse to `const now = useTickingClock(ms)`.
+ *
+ * Only for the unconditional case — panels that gate the interval on a
+ * condition (e.g. only while a cooldown is running) keep their own effect.
+ */
+export function useTickingClock(intervalMs: number): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), intervalMs);
+    return () => window.clearInterval(timer);
+  }, [intervalMs]);
+  return now;
+}

--- a/web-v3/src/utils.ts
+++ b/web-v3/src/utils.ts
@@ -38,6 +38,15 @@ export function formatCompact(value: number): string {
   return String(Math.round(value));
 }
 
+/**
+ * Formats a duration in seconds as `M:SS` (e.g. 75 → "1:15"). Clamps negatives
+ * to 0. Shared by the jukebox and music box "time left" readouts.
+ */
+export function formatMinutesSeconds(seconds: number): string {
+  const s = Math.max(0, Math.floor(seconds));
+  return `${Math.floor(s / 60)}:${(s % 60).toString().padStart(2, "0")}`;
+}
+
 export function titleCaseWords(value: string): string {
   return value
     .split(/[\s_-]+/)


### PR DESCRIPTION
## What

- **`useTickingClock(intervalMs)`** — new hook (`web-v3/src/hooks/`) for the canonical "re-render every N ms to keep countdowns/relative timestamps fresh" pattern. Adopted in the five panels that used it unconditionally: `LotteryPanel`, `CombatLogPanel`, `CombatPanel`, `JukeboxPanel`, `MusicBoxPanel`.
- **`formatMinutesSeconds(seconds)`** — moved the byte-identical `formatDuration(seconds) → "M:SS"` helper that `JukeboxPanel` and `MusicBoxPanel` each defined into `utils.ts`.

## Scope

Only the **unconditional** ticking-clock sites were converted. Panels that gate the interval on a condition — `QuestPanel`/`SkillBar`/`ActionBar` (only tick while a cooldown/quest timer is running) and `FriendsBoardPanel` (only while transient banners exist) — keep their own effect, since the hook doesn't model the guard.

The broader panel-scaffolding candidates from the review (a shared `TabBar`, `PanelGuard`, and `ListRow` component) are intentionally **not** included here: they change rendering across many panels and warrant human/visual review rather than an auto-merge. This PR is limited to the provably behaviour-preserving hook/util extractions.

## Behaviour

Preserving. The hook's `[intervalMs]` dependency is equivalent to the original `[]` because every call site passes a constant interval.

## Verification

`tsc -b` clean · `eslint` clean · `bun test` 27/27 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)