### PR TITLE
Map layout pinning, persistent exploration, and full-screen map upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ ecr-trust.json
 
 # Arcanum settings (contains R2 credentials)
 .arcanum/
+.gstack/

--- a/docs/WORLD_YAML_SPEC.md
+++ b/docs/WORLD_YAML_SPEC.md
@@ -119,6 +119,9 @@ ambient: <string, optional - overrides zone audio.ambient>
 jukebox: <list of song objects, optional - see `jukebox` notes>
 musicBox: <single song object, optional - see `musicBox` notes>
 terrain: <string, optional - overrides the zone terrain; same valid values>
+mapX: <integer, optional - explicit minimap grid column; see map pin notes>
+mapY: <integer, optional - explicit minimap grid row; must be given with mapX>
+mapZ: <integer, optional, default 0 - minimap floor; requires mapX/mapY>
 ```
 
 #### Exits
@@ -186,6 +189,11 @@ features:
 
 - Container refills on zone reset / `respawnSeconds` replace whatever is inside, including player-stored items.
 - Sequence puzzles reference features by `keyword` (see Puzzles).
+
+Map pin notes (`mapX`/`mapY`/`mapZ`):
+- By default the loader assigns every room a minimap cell by BFS from the zone's start room (N/S/E/W step one cell; up/down starts a new floor). `mapX`/`mapY` **pin** a room to an exact grid cell instead, and `mapZ` picks its floor (0 = ground, positive = up). `+x` is east, `+y` is south, in the zone's own frame — absolute values don't matter, only relative placement.
+- Pinned rooms are seated first, exactly where the author put them; unpinned rooms are BFS-placed around them (relative to their pinned neighbours where possible). Arcanum's zone editor "Save map layout" writes pins for every room; hand-editing is fine too.
+- Loading fails if `mapX`/`mapY` is given without the other, if `mapZ` appears without both, or if two rooms in the same zone are pinned to the same cell of the same floor.
 
 `bank` notes:
 - When `true`, enables bank commands (`deposit`, `withdraw`, `bank`) in this room.

--- a/src/main/kotlin/dev/ambon/domain/world/data/RoomFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/RoomFile.kt
@@ -72,6 +72,17 @@ data class RoomFile(
     val musicBox: MusicBoxFile? = null,
     /** Terrain type for this room (overrides zone default). Affects weather display and default background. */
     val terrain: String? = null,
+    /**
+     * Explicit minimap grid coordinates, pinning this room's cell on the zone map instead of
+     * letting the loader's BFS place it. Integer grid cells within the zone's own frame: +x is
+     * east, +y is south, [mapZ] is the floor (0 = ground). `mapX`/`mapY` must be given together;
+     * `mapZ` defaults to 0 and requires them. Two rooms pinned to the same cell of the same floor
+     * is a load error. Unpinned rooms are BFS-placed around the pinned ones. Written by Arcanum's
+     * zone editor "Save map layout"; safe to hand-edit.
+     */
+    val mapX: Int? = null,
+    val mapY: Int? = null,
+    val mapZ: Int? = null,
 )
 
 /**

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -66,6 +66,7 @@ import dev.ambon.domain.world.data.MobFile
 import dev.ambon.domain.world.data.MobSpawnFile
 import dev.ambon.domain.world.data.MusicBoxFile
 import dev.ambon.domain.world.data.ReputationRequirementFile
+import dev.ambon.domain.world.data.RoomFile
 import dev.ambon.domain.world.data.WorldFile
 import dev.ambon.domain.world.resolveMobStats
 import dev.ambon.engine.behavior.BehaviorTemplates
@@ -146,6 +147,7 @@ object WorldLoader {
 
         // Normalize + merge all rooms
         val mergedRooms = LinkedHashMap<RoomId, Room>()
+        val roomMapPins = LinkedHashMap<RoomId, MapCell>() // author-pinned minimap cells
         val allExits = LinkedHashMap<RoomId, Map<Direction, RoomId>>() // staged exits per room
         val allGates = LinkedHashMap<RoomId, Map<Direction, AchievementGate>>() // staged per-room achievement gates
         val allRoomFeatures = LinkedHashMap<RoomId, MutableList<RoomFeature>>() // staged features per room
@@ -244,6 +246,7 @@ object WorldLoader {
                 val station = rf.station?.let { raw ->
                     parseCraftingStationType(raw, "Room '${id.value}'")
                 }
+                parseMapPin(rf, id)?.let { roomMapPins[id] = it }
                 mergedRooms[id] =
                     Room(
                         id = id,
@@ -1180,8 +1183,9 @@ object WorldLoader {
             }
         }
 
-        // Assign minimap coordinates via per-zone BFS
-        val coordRooms = assignMapCoordinates(mergedRooms, zoneStartRooms)
+        // Assign minimap coordinates: author pins are honored as fixed anchors,
+        // everything else is placed by per-zone BFS around them.
+        val coordRooms = assignMapCoordinates(mergedRooms, zoneStartRooms, roomMapPins)
 
         return World(
             rooms = coordRooms.toMutableMap(),
@@ -1771,6 +1775,30 @@ object WorldLoader {
     }
 
     /**
+     * Parses a room's explicit minimap pin, or null when the room declares none. `mapX` and
+     * `mapY` must be given together (a half-specified pin is an authoring mistake, not a
+     * preference); `mapZ` is optional, defaults to floor 0, and only makes sense on a pinned room.
+     */
+    private fun parseMapPin(rf: RoomFile, id: RoomId): MapCell? {
+        val x = rf.mapX
+        val y = rf.mapY
+        if (x == null && y == null) {
+            if (rf.mapZ != null) {
+                throw WorldLoadException(
+                    "Room '${id.value}' declares mapZ without mapX/mapY — a floor alone doesn't pin a cell",
+                )
+            }
+            return null
+        }
+        if (x == null || y == null) {
+            throw WorldLoadException(
+                "Room '${id.value}' declares only one of mapX/mapY — a map pin needs both",
+            )
+        }
+        return MapCell(x, y, rf.mapZ ?: 0)
+    }
+
+    /**
      * Parses a dock's authored boat passages: normalizes each destination id relative to [zone]
      * (so `room` is local and `other:room` is cross-zone, exactly like exits) and requires a
      * non-negative fare. Destinations are not checked for existence here — a route to a room not
@@ -2022,10 +2050,18 @@ object WorldLoader {
      * via a spiral search — and a warning names both rooms, since the resulting
      * map draws that exit as a diagonal. Zone authors can keep maps clean by
      * laying out each floor so its horizontal exits are euclidean-consistent.
+     *
+     * [pins] are author-supplied cells (room `mapX`/`mapY`/`mapZ` in zone YAML,
+     * typically written by Arcanum's "Save map layout"). Pinned rooms are placed
+     * first, exactly where the author put them — no spiral displacement — and BFS
+     * lays out only the unpinned remainder around them. Two pins on the same cell
+     * of the same floor of one zone is a load error, since it silently discards
+     * authored intent.
      */
     private fun assignMapCoordinates(
         rooms: Map<RoomId, Room>,
         zoneStartRooms: Map<String, RoomId>,
+        pins: Map<RoomId, MapCell> = emptyMap(),
     ): Map<RoomId, Room> {
         val roomsByZone = rooms.keys.groupBy { it.zone }
         val coords = HashMap<RoomId, MapCell>(rooms.size)
@@ -2047,8 +2083,28 @@ object WorldLoader {
 
             val startId = zoneStartRooms[zone] ?: roomIds.first()
 
+            // Phase 0: seat author pins exactly where they were placed. A duplicate
+            // cell means two rooms were explicitly pinned on top of each other —
+            // fail the load rather than silently displacing authored intent.
+            for (roomId in roomIds) {
+                val pin = pins[roomId] ?: continue
+                val grid = layer(pin.z)
+                val cellKey = pin.x to pin.y
+                grid[cellKey]?.let { other ->
+                    throw WorldLoadException(
+                        "Rooms '${other.value}' and '${roomId.value}' are both pinned to " +
+                            "map cell (${pin.x},${pin.y}) on floor ${pin.z}",
+                    )
+                }
+                coords[roomId] = pin
+                grid[cellKey] = roomId
+            }
+
             // Lays out one floor (horizontal connected component) by BFS from an
             // anchor room at the given cell, warning on any collision-displacement.
+            // Already-placed rooms (pins, earlier passes) keep their cell but still
+            // expand, so BFS flows outward through pinned rooms and seats their
+            // unpinned neighbours relative to the authored layout.
             fun layoutFloor(
                 anchorId: RoomId,
                 anchorX: Int,
@@ -2057,42 +2113,51 @@ object WorldLoader {
             ) {
                 val grid = layer(z)
                 val queue = ArrayDeque<Pending>()
+                val expanded = HashSet<RoomId>()
                 queue.addLast(Pending(anchorId, anchorX, anchorY))
                 while (queue.isNotEmpty()) {
                     val (roomId, desiredX, desiredY) = queue.removeFirst()
-                    if (coords.containsKey(roomId)) continue
-
-                    val pos = findFreePosition(desiredX, desiredY, grid)
-                    if (pos != (desiredX to desiredY)) {
-                        logger.warn(
-                            "Minimap layout: zone '{}' room '{}' displaced from ({},{}) to ({},{}) on floor {} — " +
-                                "cell occupied by '{}'; this exit will draw diagonally on the map",
-                            zone,
-                            roomId.value,
-                            desiredX,
-                            desiredY,
-                            pos.first,
-                            pos.second,
-                            z,
-                            grid[desiredX to desiredY]?.value,
-                        )
+                    var cell = coords[roomId]
+                    if (cell == null) {
+                        val pos = findFreePosition(desiredX, desiredY, grid)
+                        if (pos != (desiredX to desiredY)) {
+                            logger.warn(
+                                "Minimap layout: zone '{}' room '{}' displaced from ({},{}) to ({},{}) on floor {} — " +
+                                    "cell occupied by '{}'; this exit will draw diagonally on the map",
+                                zone,
+                                roomId.value,
+                                desiredX,
+                                desiredY,
+                                pos.first,
+                                pos.second,
+                                z,
+                                grid[desiredX to desiredY]?.value,
+                            )
+                        }
+                        cell = MapCell(pos.first, pos.second, z)
+                        coords[roomId] = cell
+                        grid[pos] = roomId
                     }
-                    coords[roomId] = MapCell(pos.first, pos.second, z)
-                    grid[pos] = roomId
+                    if (!expanded.add(roomId)) continue
+                    // A room pinned on a different floor belongs to that floor's
+                    // layout — don't spread its neighbours onto this one.
+                    if (cell.z != z) continue
 
                     val room = rooms[roomId] ?: continue
                     for ((dir, targetId) in room.exits) {
                         if (dir !in horizontalDirs) continue
-                        if (coords.containsKey(targetId)) continue
+                        if (targetId in expanded) continue
                         if (targetId !in zoneRoomSet) continue
                         val (dx, dy) = DIRECTION_OFFSETS[dir] ?: continue
-                        queue.addLast(Pending(targetId, pos.first + dx, pos.second + dy))
+                        queue.addLast(Pending(targetId, cell.x + dx, cell.y + dy))
                     }
                 }
             }
 
-            // Phase 1: the start room's floor is the zone's ground floor (z=0).
-            layoutFloor(startId, 0, 0, 0)
+            // Phase 1: the start room's floor is the zone's ground floor — unless
+            // the start room itself is pinned, in which case its pin sets the frame.
+            val startPin = coords[startId]
+            layoutFloor(startId, startPin?.x ?: 0, startPin?.y ?: 0, startPin?.z ?: 0)
 
             // Phase 2: repeatedly anchor unplaced floors through their stairs.
             // A placed room with an up/down exit to an unplaced room seeds that

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -1,5 +1,6 @@
 package dev.ambon.engine
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import dev.ambon.bus.OutboundBus
@@ -337,11 +338,19 @@ class GmcpEmitter(
      * Cross-zone targets keep their full `<otherzone>:room` id (the prefix doesn't
      * match, so nothing is stripped), which both disambiguates them and lets the
      * client recognise them as foreign. Clients re-qualify the bare ids with [zone].
+     *
+     * [exploredRooms] is the player's permanent exploration set (full `zone:room`
+     * ids). Explored rooms additionally carry the abbreviated detail fields on
+     * [ZoneMapRoom] (`e`/`t`/`tr`/`poi`) so a returning player's map renders
+     * remembered rooms with names, terrain stamps and service icons; unexplored
+     * rooms omit them entirely, both to avoid leaking detail the player hasn't
+     * earned and to keep a fully-explored large zone under the payload cap.
      */
     suspend fun sendZoneMap(
         sessionId: SessionId,
         zone: String,
         rooms: Collection<Room>,
+        exploredRooms: Set<String> = emptySet(),
     ) {
         val prefix = "$zone:"
         val border = LinkedHashMap<String, BorderStub>()
@@ -359,6 +368,7 @@ class GmcpEmitter(
                     )
                 }
             }
+            val explored = r.id.value in exploredRooms
             ZoneMapRoom(
                 id = r.id.value.removePrefix(prefix),
                 x = r.mapX,
@@ -366,6 +376,12 @@ class GmcpEmitter(
                 z = r.mapZ,
                 exits = r.exits.entries
                     .associate { (dir, target) -> dir.name.lowercase() to target.value.removePrefix(prefix) },
+                e = if (explored) 1 else null,
+                t = if (explored) r.title else null,
+                // The default terrain is implied: an explored room without `tr`
+                // is "outside". Saves ~5 KB on a fully-explored 300-room zone.
+                tr = if (explored && r.terrain != "outside") r.terrain else null,
+                poi = if (explored) roomPoi(r).ifEmpty { null } else null,
             )
         }
         emit(
@@ -3089,13 +3105,43 @@ class GmcpEmitter(
         val border: List<BorderStub>,
     )
 
+    /**
+     * One room of a `Zone.Map` payload. The detail fields are deliberately
+     * abbreviated and null-omitted: they appear on every explored room of what is
+     * already the largest GMCP payload, and full names would push a fully-explored
+     * 300-room zone over [MAX_GMCP_PAYLOAD_BYTES] (see the payload-cap test).
+     * `e` = 1 when the player has explored this room (absent otherwise);
+     * `t` = room title, `tr` = terrain key, `poi` = service tokens matching the
+     * `Room.Info` flag names (bank, tavern, …) — all present only when explored.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private data class ZoneMapRoom(
         val id: String,
         val x: Int,
         val y: Int,
         val z: Int,
         val exits: Map<String, String>,
+        val e: Int? = null,
+        val t: String? = null,
+        val tr: String? = null,
+        val poi: List<String>? = null,
     )
+
+    /** Service tokens for a room's map icon — names match the `Room.Info` flags. */
+    private fun roomPoi(r: Room): List<String> =
+        buildList {
+            if (r.bank) add("bank")
+            if (r.tavern) add("tavern")
+            if (r.stylist) add("stylist")
+            if (r.dungeon) add("dungeon")
+            if (r.auction) add("auction")
+            if (r.housingBroker) add("housingBroker")
+            if (r.inn) add("inn")
+            if (r.akathavaeShrine) add("shrine")
+            if (r.flightMaster) add("flightMaster")
+            if (r.boatDock) add("boatDock")
+            if (r.station != null) add("station")
+        }
 
     /**
      * A ghost room just across a zone boundary: a single cell placed one step past

--- a/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerRegistry.kt
@@ -846,6 +846,20 @@ class PlayerRegistry(
         persistIfClaimed(ps)
     }
 
+    /**
+     * Records that this player has stood in [roomId] — permanent map exploration.
+     * Fires on every room entry; the no-op fast path keeps already-explored moves free
+     * and the write-coalescing repository absorbs bursts while actually exploring.
+     */
+    suspend fun markRoomExplored(
+        sessionId: SessionId,
+        roomId: RoomId,
+    ) {
+        val ps = players[sessionId] ?: return
+        if (!ps.exploredRooms.add(roomId.value)) return
+        persistIfClaimed(ps)
+    }
+
     /** Sets the wimpy auto-flee HP-percent threshold. Caller is responsible for clamping to 0..95. */
     suspend fun setWimpyThresholdPct(
         sessionId: SessionId,

--- a/src/main/kotlin/dev/ambon/engine/PlayerState.kt
+++ b/src/main/kotlin/dev/ambon/engine/PlayerState.kt
@@ -56,6 +56,8 @@ data class PlayerState(
     var dialogueFlags: MutableSet<String> = mutableSetOf(),
     /** Zones whose intro cinematic this player has already watched (auto-plays once per zone). */
     var seenZoneCinematics: MutableSet<String> = mutableSetOf(),
+    /** Room ids (`zone:room`) this player has ever entered — permanent map exploration. */
+    var exploredRooms: MutableSet<String> = mutableSetOf(),
     var unlockedAchievementIds: Set<String> = emptySet(),
     var achievementProgress: Map<String, AchievementState> = emptyMap(),
     var activeTitle: String? = null,
@@ -311,6 +313,7 @@ fun PlayerRecord.toPlayerState(sessionId: SessionId): PlayerState =
         completedQuestIds = completedQuestIds,
         dialogueFlags = dialogueFlags.toMutableSet(),
         seenZoneCinematics = seenZoneCinematics.toMutableSet(),
+        exploredRooms = exploredRooms.toMutableSet(),
         unlockedAchievementIds = unlockedAchievementIds,
         achievementProgress = achievementProgress,
         activeTitle = activeTitle,
@@ -388,6 +391,7 @@ fun PlayerState.toPlayerRecord(lastSeenEpochMs: Long): PlayerRecord {
         completedQuestIds = completedQuestIds,
         dialogueFlags = dialogueFlags.toSet(),
         seenZoneCinematics = seenZoneCinematics.toSet(),
+        exploredRooms = exploredRooms.toSet(),
         unlockedAchievementIds = unlockedAchievementIds,
         achievementProgress = achievementProgress,
         activeTitle = activeTitle,

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -420,6 +420,10 @@ internal suspend fun sendLook(
     val roomId = me.roomId
     val room = world.rooms[roomId] ?: return
 
+    // Standing in a room explores it, permanently. Marked before the zone map is
+    // (possibly) sent below, so a first step into a zone already counts its entry room.
+    players.markRoomExplored(sessionId, roomId)
+
     outbound.send(OutboundEvent.SendText(sessionId, room.title))
     outbound.send(OutboundEvent.SendText(sessionId, room.description))
 

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -600,7 +600,7 @@ internal suspend fun sendLook(
     val zone = room.id.zone
     if (gmcpEmitter != null && gmcpEmitter.trackZoneChange(sessionId, zone)) {
         val zoneRooms = world.rooms.values.filter { it.id.zone == zone }
-        gmcpEmitter.sendZoneMap(sessionId, zone, zoneRooms)
+        gmcpEmitter.sendZoneMap(sessionId, zone, zoneRooms, me.exploredRooms)
         gmcpEmitter.sendZoneEnvironment(sessionId, gmcpEmitter.buildZoneEnvironmentPayload(zone))
         // Zone intro cinematic: auto-plays on the player's first-ever entry,
         // then stays replayable from the expanded map.

--- a/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayerRecord.kt
@@ -116,6 +116,8 @@ data class PlayerRecord(
     val dialogueFlags: Set<String> = emptySet(),
     /** Zones whose intro cinematic this player has already watched (auto-plays once per zone). */
     val seenZoneCinematics: Set<String> = emptySet(),
+    /** Room ids (`zone:room`) this player has ever entered — permanent map exploration. */
+    val exploredRooms: Set<String> = emptySet(),
     /** True while the player is under the Akathavae pledge (combat forbidden, illumination enabled). */
     val isAkathavae: Boolean = false,
     /** Epoch-ms the current Akathavae pledge was taken. 0 = never pledged. */

--- a/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
+++ b/src/main/kotlin/dev/ambon/persistence/PlayersTable.kt
@@ -16,6 +16,7 @@ private val activeQuestsType = object : TypeReference<Map<String, QuestState>>()
 private val completedQuestIdsType = object : TypeReference<Set<String>>() {}
 private val dialogueFlagsType = object : TypeReference<Set<String>>() {}
 private val seenZoneCinematicsType = object : TypeReference<Set<String>>() {}
+private val exploredRoomsType = object : TypeReference<Set<String>>() {}
 private val unlockedAchievementIdsType = object : TypeReference<Set<String>>() {}
 private val achievementProgressType = object : TypeReference<Map<String, AchievementState>>() {}
 private val mailInboxType = object : TypeReference<List<MailMessage>>() {}
@@ -94,6 +95,7 @@ object PlayersTable : Table("players") {
     val racialAbilityCooldownUntilMs = long("racial_ability_cooldown_until_ms").default(0L)
     val dialogueFlags = text("dialogue_flags").default("[]")
     val seenZoneCinematics = text("seen_zone_cinematics").default("[]")
+    val exploredRooms = text("explored_rooms").default("[]")
     val isAkathavae = bool("is_akathavae").default(false)
     val akathavaePledgedAtMs = long("akathavae_pledged_at_ms").default(0L)
     val akathavaeRenouncedAtMs = long("akathavae_renounced_at_ms").default(0L)
@@ -166,6 +168,7 @@ object PlayersTable : Table("players") {
             racialAbilityCooldownUntilMs = row[racialAbilityCooldownUntilMs],
             dialogueFlags = safeReadJson(row[dialogueFlags], dialogueFlagsType, emptySet()),
             seenZoneCinematics = safeReadJson(row[seenZoneCinematics], seenZoneCinematicsType, emptySet()),
+            exploredRooms = safeReadJson(row[exploredRooms], exploredRoomsType, emptySet()),
             isAkathavae = row[isAkathavae],
             akathavaePledgedAtMs = row[akathavaePledgedAtMs],
             akathavaeRenouncedAtMs = row[akathavaeRenouncedAtMs],
@@ -243,6 +246,7 @@ object PlayersTable : Table("players") {
         statement[racialAbilityCooldownUntilMs] = record.racialAbilityCooldownUntilMs
         statement[dialogueFlags] = jsonMapper.writeValueAsString(record.dialogueFlags)
         statement[seenZoneCinematics] = jsonMapper.writeValueAsString(record.seenZoneCinematics)
+        statement[exploredRooms] = jsonMapper.writeValueAsString(record.exploredRooms)
         statement[isAkathavae] = record.isAkathavae
         statement[akathavaePledgedAtMs] = record.akathavaePledgedAtMs
         statement[akathavaeRenouncedAtMs] = record.akathavaeRenouncedAtMs

--- a/src/main/resources/db/migration/V48__add_explored_rooms.sql
+++ b/src/main/resources/db/migration/V48__add_explored_rooms.sql
@@ -1,0 +1,1 @@
+ALTER TABLE players ADD COLUMN explored_rooms TEXT NOT NULL DEFAULT '[]';

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -2128,6 +2128,40 @@ class GmcpEmitterTest {
         }
 
     @Test
+    fun `sendZoneMap marks explored rooms with title terrain and poi and leaves fog rooms bare`() =
+        runTest {
+            val e = emitter("Zone.Map")
+            val rooms = listOf(
+                zoneRoom("z:a", mapX = 0, mapY = 0).copy(title = "Old Gate", terrain = "urban", bank = true, inn = true),
+                zoneRoom("z:b", mapX = 1, mapY = 0).copy(title = "Meadow"), // terrain defaults to "outside"
+                zoneRoom("z:c", mapX = 2, mapY = 0).copy(title = "Secret Grove", terrain = "forest"),
+            )
+            e.sendZoneMap(sid, "z", rooms, exploredRooms = setOf("z:a", "z:b"))
+            val payload = jacksonObjectMapper().readTree(drainGmcp()[0].jsonData)
+            val byId = payload["rooms"].associateBy { it["id"].asText() }
+
+            val a = byId.getValue("a")
+            assertEquals(1, a["e"].asInt(), "explored flag on a")
+            assertEquals("Old Gate", a["t"].asText())
+            assertEquals("urban", a["tr"].asText())
+            assertEquals(listOf("bank", "inn"), a["poi"].map { it.asText() })
+
+            // Default "outside" terrain is implied, not sent.
+            val b = byId.getValue("b")
+            assertEquals(1, b["e"].asInt(), "explored flag on b")
+            assertEquals("Meadow", b["t"].asText())
+            assertTrue(b["tr"] == null, "default terrain must be omitted. got=$b")
+            assertTrue(b["poi"] == null, "no services — poi must be omitted. got=$b")
+
+            // Unexplored: no detail leaks — coordinates and exits only.
+            val c = byId.getValue("c")
+            assertTrue(
+                c["e"] == null && c["t"] == null && c["tr"] == null && c["poi"] == null,
+                "fog room must not carry explored detail. got=$c",
+            )
+        }
+
+    @Test
     fun `sendZoneMap stays under payload cap for a large zone`() =
         runTest {
             val e = emitter("Zone.Map")
@@ -2152,9 +2186,13 @@ class GmcpEmitterTest {
                     ),
                     mapX = i % 16,
                     mapY = i / 16,
-                )
+                    // Realistic-length titles: the fully-explored worst case below
+                    // adds `e`/`t` per room, and long titles are what push the size.
+                ).copy(title = "Crystal Grove Clearing %04d".format(i))
             }
-            e.sendZoneMap(sid, zone, rooms)
+            // Worst case: the player has explored the whole zone, so every room
+            // carries the explored detail fields on top of the base layout.
+            e.sendZoneMap(sid, zone, rooms, exploredRooms = rooms.map { it.id.value }.toSet())
             val data = drainGmcp()
             assertEquals(1, data.size, "Large-zone Zone.Map must not be dropped by the payload cap")
             assertEquals("Zone.Map", data[0].gmcpPackage)

--- a/src/test/kotlin/dev/ambon/engine/commands/ExplorationCommandRouterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/ExplorationCommandRouterTest.kt
@@ -1,0 +1,71 @@
+package dev.ambon.engine.commands
+
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.world.Direction
+import dev.ambon.domain.world.load.WorldLoader
+import dev.ambon.engine.toPlayerRecord
+import dev.ambon.engine.toPlayerState
+import dev.ambon.persistence.PlayerId
+import dev.ambon.test.CommandRouterHarness
+import dev.ambon.test.drainAll
+import dev.ambon.test.loginOrFail
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ExplorationCommandRouterTest {
+    private fun createHarness(): CommandRouterHarness =
+        CommandRouterHarness.create(world = WorldLoader.loadFromResource("world/ok_small.yaml"))
+
+    @Test
+    fun `looking marks the current room explored`() =
+        runTest {
+            val h = createHarness()
+            val sid = SessionId(1)
+            h.players.loginOrFail(sid, "Alice")
+            h.outbound.drainAll()
+
+            h.router.handle(sid, Command.Look)
+            assertTrue("ok_small:a" in h.players.get(sid)!!.exploredRooms)
+            assertFalse("ok_small:b" in h.players.get(sid)!!.exploredRooms)
+        }
+
+    @Test
+    fun `moving marks each visited room explored`() =
+        runTest {
+            val h = createHarness()
+            val sid = SessionId(2)
+            h.players.loginOrFail(sid, "Bob")
+            h.router.handle(sid, Command.Look)
+            h.outbound.drainAll()
+
+            h.router.handle(sid, Command.Move(Direction.NORTH))
+            val explored = h.players.get(sid)!!.exploredRooms
+            assertTrue("ok_small:a" in explored)
+            assertTrue("ok_small:b" in explored)
+        }
+
+    @Test
+    fun `exploredRooms round-trips through PlayerRecord`() =
+        runTest {
+            val h = createHarness()
+            val sid = SessionId(3)
+            h.players.loginOrFail(sid, "Carol")
+            h.router.handle(sid, Command.Look)
+            h.router.handle(sid, Command.Move(Direction.NORTH))
+
+            val state = h.players.get(sid)!!
+            state.playerId = PlayerId(7L)
+            val record = state.toPlayerRecord(lastSeenEpochMs = 123L)
+            assertEquals(setOf("ok_small:a", "ok_small:b"), record.exploredRooms)
+
+            val restored = record.toPlayerState(SessionId(4))
+            assertTrue("ok_small:a" in restored.exploredRooms)
+            assertTrue("ok_small:b" in restored.exploredRooms)
+            assertFalse("ok_small:c" in restored.exploredRooms)
+        }
+}

--- a/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
@@ -121,6 +121,44 @@ class WorldLoaderTest {
     }
 
     @Test
+    fun `honors explicit map pins and BFS-places unpinned rooms around them`() {
+        val world = WorldLoader.loadFromResource("world/ok_pinned_map.yaml")
+
+        fun room(id: String) = world.rooms.getValue(RoomId("ok_pinned_map:$id"))
+        val gate = room("gate")
+        val plaza = room("plaza")
+        val market = room("market")
+        val loft = room("loft")
+        val annex = room("annex")
+
+        // Pinned rooms sit exactly where the author put them.
+        assertEquals(Triple(5, 5, 0), Triple(gate.mapX, gate.mapY, gate.mapZ), "gate pin")
+        assertEquals(Triple(5, 4, 0), Triple(plaza.mapX, plaza.mapY, plaza.mapZ), "plaza pin")
+        assertEquals(Triple(5, 4, 1), Triple(loft.mapX, loft.mapY, loft.mapZ), "loft pin")
+
+        // Unpinned rooms are BFS-placed relative to their pinned neighbours.
+        assertEquals(Triple(6, 4, 0), Triple(market.mapX, market.mapY, market.mapZ), "market east of plaza")
+        assertEquals(Triple(6, 4, 1), Triple(annex.mapX, annex.mapY, annex.mapZ), "annex east of loft")
+    }
+
+    @Test
+    fun `fails when two rooms are pinned to the same cell`() {
+        val ex = assertThrows(WorldLoadException::class.java) {
+            WorldLoader.loadFromResource("world/bad_pin_conflict.yaml")
+        }
+        assertTrue(ex.message!!.contains("pinned to"), "Got: ${ex.message}")
+        assertTrue(ex.message!!.contains("(2,3)"), "Got: ${ex.message}")
+    }
+
+    @Test
+    fun `fails when a room declares only one of mapX and mapY`() {
+        val ex = assertThrows(WorldLoadException::class.java) {
+            WorldLoader.loadFromResource("world/bad_pin_partial.yaml")
+        }
+        assertTrue(ex.message!!.contains("only one of mapX/mapY"), "Got: ${ex.message}")
+    }
+
+    @Test
     fun `loads mobs from a zone file`() {
         val world = dev.ambon.test.TestWorlds.okSmall
 

--- a/src/test/resources/world/bad_pin_conflict.yaml
+++ b/src/test/resources/world/bad_pin_conflict.yaml
@@ -1,0 +1,17 @@
+zone: bad_pin_conflict
+startRoom: a
+rooms:
+  a:
+    title: "Room A"
+    description: "Pinned."
+    mapX: 2
+    mapY: 3
+    exits:
+      n: b
+  b:
+    title: "Room B"
+    description: "Pinned to the same cell as A."
+    mapX: 2
+    mapY: 3
+    exits:
+      s: a

--- a/src/test/resources/world/bad_pin_partial.yaml
+++ b/src/test/resources/world/bad_pin_partial.yaml
@@ -1,0 +1,14 @@
+zone: bad_pin_partial
+startRoom: a
+rooms:
+  a:
+    title: "Room A"
+    description: "Declares mapX without mapY."
+    mapX: 2
+    exits:
+      n: b
+  b:
+    title: "Room B"
+    description: "Plain."
+    exits:
+      s: a

--- a/src/test/resources/world/ok_pinned_map.yaml
+++ b/src/test/resources/world/ok_pinned_map.yaml
@@ -1,0 +1,38 @@
+zone: ok_pinned_map
+startRoom: gate
+rooms:
+  gate:
+    title: "Gate"
+    description: "The pinned start room."
+    mapX: 5
+    mapY: 5
+    exits:
+      n: plaza
+  plaza:
+    title: "Plaza"
+    description: "Pinned one cell north of the gate."
+    mapX: 5
+    mapY: 4
+    exits:
+      s: gate
+      e: market
+      u: loft
+  market:
+    title: "Market"
+    description: "Unpinned — BFS should seat it east of the pinned plaza."
+    exits:
+      w: plaza
+  loft:
+    title: "Loft"
+    description: "Pinned above the plaza on floor 1."
+    mapX: 5
+    mapY: 4
+    mapZ: 1
+    exits:
+      d: plaza
+      e: annex
+  annex:
+    title: "Annex"
+    description: "Unpinned — reachable only through the pinned loft."
+    exits:
+      w: loft

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -66,7 +66,7 @@ import { useMudSocket } from "./hooks/useMudSocket";
 import { useTerminal } from "./hooks/useTerminal";
 import { useAudioEngine } from "./hooks/useAudioEngine";
 import { useCommandHistory } from "./hooks/useCommandHistory";
-import { useMiniMap } from "./hooks/useMiniMap";
+import { POI_META, useMiniMap } from "./hooks/useMiniMap";
 import { useQuickbar } from "./hooks/useQuickbar";
 import { useOnboarding } from "./hooks/useOnboarding";
 import { canvasCallbacks, gameStateRef, pendingCastRef } from "./canvas/GameStateBridge";
@@ -80,7 +80,7 @@ import type {
   PopoutPanel,
   WhoPlayer,
 } from "./types";
-import { sortExits, titleCaseWords } from "./utils";
+import { formatZoneName, sortExits, titleCaseWords } from "./utils";
 import "./styles.css";
 
 // ── Consider (threat assessment) helpers ────────────────────────────────────
@@ -255,10 +255,13 @@ function App() {
     onMapPointerDown,
     onMapPointerMove,
     onMapPointerUp,
+    onMapPointerLeave,
     onMapWheel,
     zoomIn: mapZoomIn,
     zoomOut: mapZoomOut,
     recenter: mapRecenter,
+    zoneStats: mapZoneStats,
+    hoverInfo: mapHoverInfo,
   } = useMiniMap();
 
   const state = useGameState(
@@ -1752,6 +1755,25 @@ function App() {
                 </button>
               )}
             </div>
+            {mapTab === "map" && mapZoneStats && (
+              <div className="map-stats-bar" role="status">
+                <span className="map-stats-explored">
+                  Explored {mapZoneStats.exploredCount}/{mapZoneStats.totalRooms} rooms
+                  {mapZoneStats.totalRooms > 0 && (
+                    <span className="map-stats-pct">
+                      {" "}({Math.round((mapZoneStats.exploredCount / mapZoneStats.totalRooms) * 100)}%)
+                    </span>
+                  )}
+                </span>
+                <span className="map-legend" aria-label="Map legend">
+                  <span className="map-legend-item"><span className="map-legend-swatch map-legend-here" aria-hidden="true" /> you</span>
+                  <span className="map-legend-item"><span className="map-legend-swatch map-legend-explored" aria-hidden="true" /> explored</span>
+                  <span className="map-legend-item"><span className="map-legend-swatch map-legend-fog" aria-hidden="true" /> unexplored</span>
+                  <span className="map-legend-item"><span className="map-legend-swatch map-legend-quest" aria-hidden="true" /> quest</span>
+                  <span className="map-legend-item"><span className="map-legend-swatch map-legend-border" aria-hidden="true" /> next zone</span>
+                </span>
+              </div>
+            )}
             {/* Keep the canvas mounted so the minimap renderer can keep drawing into it
                 even while the Atlas tab is in front — switching back must not lose state. */}
             <div className="drawer-map-canvas-wrap" hidden={mapTab !== "map"}>
@@ -1764,12 +1786,40 @@ function App() {
                 onPointerDown={onMapPointerDown}
                 onPointerMove={onMapPointerMove}
                 onPointerUp={onMapPointerUp}
-                onPointerLeave={onMapPointerUp}
+                onPointerLeave={onMapPointerLeave}
                 onWheel={onMapWheel}
                 aria-label={questMarkerCount > 0
                   ? `Visited room map — ${questMarkerCount} quest objective${questMarkerCount !== 1 ? "s" : ""} marked`
                   : "Visited room map"}
               />
+              {mapHoverInfo && (
+                <div
+                  className="map-hover-tooltip"
+                  role="tooltip"
+                  style={{ left: mapHoverInfo.sx, top: mapHoverInfo.sy }}
+                >
+                  {mapHoverInfo.zone ? (
+                    <span className="map-tooltip-title">→ {formatZoneName(mapHoverInfo.zone)}</span>
+                  ) : mapHoverInfo.explored ? (
+                    <>
+                      <span className="map-tooltip-title">{mapHoverInfo.title}</span>
+                      {mapHoverInfo.terrain && mapHoverInfo.terrain !== "outside" && (
+                        <span className="map-tooltip-terrain">{mapHoverInfo.terrain}</span>
+                      )}
+                      {(mapHoverInfo.poi.length > 0 || mapHoverInfo.hasStairs) && (
+                        <span className="map-tooltip-poi">
+                          {[
+                            ...mapHoverInfo.poi.map((p) => POI_META[p] ? `${POI_META[p].icon} ${POI_META[p].label}` : p),
+                            ...(mapHoverInfo.hasStairs ? ["↕ Stairs"] : []),
+                          ].join(" · ")}
+                        </span>
+                      )}
+                    </>
+                  ) : (
+                    <span className="map-tooltip-title map-tooltip-unknown">Unexplored</span>
+                  )}
+                </div>
+              )}
               <div className="map-zoom-controls" aria-hidden="false">
                 <button type="button" className="map-zoom-btn" onClick={mapZoomIn} title="Zoom in" aria-label="Zoom in">+</button>
                 <button type="button" className="map-zoom-btn" onClick={mapZoomOut} title="Zoom out" aria-label="Zoom out">−</button>

--- a/web-v3/src/canvas/GameStateBridge.ts
+++ b/web-v3/src/canvas/GameStateBridge.ts
@@ -25,6 +25,7 @@ import type {
   WorldTime,
   WorldWeather,
   ZoneEnvironment,
+  ZoneMapRoomData,
   BorderStub,
 } from "../types";
 
@@ -103,7 +104,7 @@ export const canvasCallbacks: {
   openVideo: ((videoUrl: string) => void) | null;
   dismissDialogue: (() => void) | null;
   openQuestOffers: ((mobKeyword: string) => void) | null;
-  loadZoneMap: ((zone: string, rooms: Array<{ id: string; x: number; y: number; z: number; exits: Record<string, string> }>, border: BorderStub[]) => void) | null;
+  loadZoneMap: ((zone: string, rooms: ZoneMapRoomData[], border: BorderStub[]) => void) | null;
   openMobDetail: ((detail: { name: string; description: string; image: string | null }) => void) | null;
   openImagePreview: ((url: string) => void) | null;
   /** Open the monster-manual / bestiary panel for a clicked creature. */

--- a/web-v3/src/canvas/systems/Minimap.ts
+++ b/web-v3/src/canvas/systems/Minimap.ts
@@ -2,7 +2,7 @@ import { Container, Graphics, Rectangle, Sprite, Text, Texture } from "pixi.js";
 import { loadTexture } from "../textureLoader";
 import { canvasCallbacks, gameStateRef } from "../GameStateBridge";
 import { MAP_OFFSETS, zoneColor } from "../../constants";
-import type { BorderStub } from "../../types";
+import type { BorderStub, ZoneMapRoomData } from "../../types";
 
 /** Directions that represent the same horizontal plane. Up/down exits are shown
  *  as buttons beside the map but don't place nodes on the parchment. */
@@ -448,16 +448,24 @@ export class Minimap {
     this.redraw();
   }
 
-  /** Pre-populate all rooms in a zone as fog nodes, plus any cross-zone border
-   *  stubs (foreign rooms one cell past a boundary, tagged with their zone). */
-  loadZoneMap(zone: string, rooms: Array<{ id: string; x: number; y: number; exits: Record<string, string> }>, border: BorderStub[] = []) {
+  /** Pre-populate all rooms in a zone (explored rooms carry remembered detail;
+   *  the rest are hidden fog), plus any cross-zone border stubs (foreign rooms
+   *  one cell past a boundary, tagged with their zone). */
+  loadZoneMap(zone: string, rooms: ZoneMapRoomData[], border: BorderStub[] = []) {
     this.visited.clear();
     this.clearNodeSprites();
     this.currentZone = zone;
     this.currentRoomId = null;
     this.lastKey = "";
     for (const r of rooms) {
-      this.visited.set(r.id, { x: r.x, y: r.y, exits: r.exits, title: "", image: null });
+      this.visited.set(r.id, {
+        x: r.x,
+        y: r.y,
+        exits: r.exits,
+        title: r.explored ? (r.title ?? "") : "",
+        image: null,
+        terrain: r.explored ? r.terrain : undefined,
+      });
     }
     for (const b of border) {
       if (this.visited.has(b.id)) continue;
@@ -535,10 +543,28 @@ export class Minimap {
       return { px: cx + lp.lx * CELL, py: cy + lp.ly * CELL };
     };
 
+    // Fog of war — mirrors the expanded chart: only explored rooms and the
+    // one-hop frontier past them render; deeper fog stays off the parchment.
+    const explored = new Set<string>();
+    for (const [id, node] of this.visited) {
+      if (node.title !== "" && !node.zone) explored.add(id);
+    }
+    const frontier = new Set<string>();
+    for (const id of explored) {
+      const node = this.visited.get(id);
+      if (!node) continue;
+      for (const targetId of Object.values(node.exits)) {
+        if (!explored.has(targetId)) frontier.add(targetId);
+      }
+    }
+    const isRendered = (id: string) => explored.has(id) || frontier.has(id);
+
     const pathEdges = this.computeQuestPath(questTargets);
 
-    // Inked connector lines between rooms.
+    // Inked connector lines — drawn outward from *explored* rooms only, so the
+    // scrap never sketches corridors the player hasn't earned.
     for (const [id] of localPos) {
+      if (!explored.has(id)) continue;
       const node = this.visited.get(id);
       if (!node) continue;
       const sp = posOf(id);
@@ -566,6 +592,9 @@ export class Minimap {
         ? 0.7
         : 0.45 + 0.3 * (0.5 + 0.5 * Math.sin(Date.now() / PATH_SHIMMER_PERIOD * Math.PI * 2));
       for (const [fromId, toId] of pathEdges) {
+        // Only the explored/frontier stretch of the trail draws; the edge
+        // chevrons carry it onward into hidden territory.
+        if (!isRendered(fromId) || !isRendered(toId)) continue;
         const sp = posOf(fromId);
         const tp = posOf(toId);
         if (!sp || !tp) continue;
@@ -581,6 +610,7 @@ export class Minimap {
 
     // Room glyphs — textured stamp when an asset exists, else inked vectors.
     for (const [id] of localPos) {
+      if (!isRendered(id)) continue;
       const node = this.visited.get(id);
       if (!node) continue;
       const p = posOf(id);
@@ -602,16 +632,19 @@ export class Minimap {
       const isHousing = node.housing === true;
       const seed = this.hashSeed(id);
 
-      // Direction ticks for exits that leave the visible map.
-      for (const dir of Object.keys(node.exits)) {
-        if (!HORIZONTAL_DIRS.has(dir)) continue;
-        const tp = posOf(node.exits[dir]);
-        if (tp && this.inBounds(tp.px, tp.py)) continue; // drawn as a connector
-        const off = MAP_OFFSETS[dir];
-        if (!off) continue;
-        this.mapGraphics.moveTo(nx + off.dx * half, ny + off.dy * half);
-        this.mapGraphics.lineTo(nx + off.dx * (half + 6), ny + off.dy * (half + 6));
-        this.mapGraphics.stroke({ color: LINE_COLOR, width: 2, alpha: 0.8 });
+      // Direction ticks for exits that leave the visible map — explored rooms
+      // only, so a frontier room doesn't sketch onward exits the player hasn't seen.
+      if (visited) {
+        for (const dir of Object.keys(node.exits)) {
+          if (!HORIZONTAL_DIRS.has(dir)) continue;
+          const tp = posOf(node.exits[dir]);
+          if (tp && this.inBounds(tp.px, tp.py)) continue; // drawn as a connector
+          const off = MAP_OFFSETS[dir];
+          if (!off) continue;
+          this.mapGraphics.moveTo(nx + off.dx * half, ny + off.dy * half);
+          this.mapGraphics.lineTo(nx + off.dx * (half + 6), ny + off.dy * (half + 6));
+          this.mapGraphics.stroke({ color: LINE_COLOR, width: 2, alpha: 0.8 });
+        }
       }
 
       // Pick the room stamp: current / fog / housing take priority; a plain

--- a/web-v3/src/canvas/systems/Minimap.ts
+++ b/web-v3/src/canvas/systems/Minimap.ts
@@ -545,26 +545,27 @@ export class Minimap {
 
     // Fog of war — mirrors the expanded chart: only explored rooms and the
     // one-hop frontier past them render; deeper fog stays off the parchment.
-    const explored = new Set<string>();
+    // (`fogFrontier`, not `frontier` — the BFS below already uses that name.)
+    const exploredSet = new Set<string>();
     for (const [id, node] of this.visited) {
-      if (node.title !== "" && !node.zone) explored.add(id);
+      if (node.title !== "" && !node.zone) exploredSet.add(id);
     }
-    const frontier = new Set<string>();
-    for (const id of explored) {
+    const fogFrontier = new Set<string>();
+    for (const id of exploredSet) {
       const node = this.visited.get(id);
       if (!node) continue;
       for (const targetId of Object.values(node.exits)) {
-        if (!explored.has(targetId)) frontier.add(targetId);
+        if (!exploredSet.has(targetId)) fogFrontier.add(targetId);
       }
     }
-    const isRendered = (id: string) => explored.has(id) || frontier.has(id);
+    const isRendered = (id: string) => exploredSet.has(id) || fogFrontier.has(id);
 
     const pathEdges = this.computeQuestPath(questTargets);
 
     // Inked connector lines — drawn outward from *explored* rooms only, so the
     // scrap never sketches corridors the player hasn't earned.
     for (const [id] of localPos) {
-      if (!explored.has(id)) continue;
+      if (!exploredSet.has(id)) continue;
       const node = this.visited.get(id);
       if (!node) continue;
       const sp = posOf(id);

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -118,7 +118,7 @@ import type {
 } from "../types";
 import { MAX_CHAT_MESSAGES_PER_CHANNEL } from "../constants";
 import { safeNumber } from "../utils";
-import type { AbilityVisualArchetype, SkillVisual } from "../types";
+import type { AbilityVisualArchetype, SkillVisual, ZoneMapRoomData } from "../types";
 
 const KNOWN_ARCHETYPES: ReadonlySet<AbilityVisualArchetype> = new Set([
   "RANGED_PROJECTILE",
@@ -172,7 +172,7 @@ interface GmcpContext {
   setPuzzleResult: Dispatch<SetStateAction<PuzzleResult | null>>;
   setChatByChannel: Dispatch<SetStateAction<Record<ChatChannel, ChatMessage[]>>>;
   updateMap: (roomId: string, exits: Record<string, string>, title: string, image: string | null, mapX: number, mapY: number, mapZ: number, housing?: boolean, terrain?: string | null) => void;
-  loadZoneMap: (zone: string, rooms: Array<{ id: string; x: number; y: number; z: number; exits: Record<string, string> }>, border: BorderStub[]) => void;
+  loadZoneMap: (zone: string, rooms: ZoneMapRoomData[], border: BorderStub[]) => void;
   pushCombatEvent: (event: CombatEventData) => void;
   setCharStats: Dispatch<SetStateAction<CharStats | null>>;
   setQuests: Dispatch<SetStateAction<QuestEntry[]>>;
@@ -559,12 +559,21 @@ export function applyGmcpPackage(
               for (const [dir, target] of Object.entries(rawExits)) {
                 if (typeof target === "string") exits[dir] = qualify(target);
               }
+              // Explored-room detail rides in abbreviated null-omitted fields
+              // (`e`/`t`/`tr`/`poi`) to keep large zones under the GMCP payload
+              // cap. An explored room without `tr` has the default "outside"
+              // terrain; fog rooms carry no detail at all.
+              const explored = r.e === 1;
               return {
                 id: qualify(typeof r.id === "string" ? r.id : ""),
                 x: typeof r.x === "number" ? r.x : 0,
                 y: typeof r.y === "number" ? r.y : 0,
                 z: typeof r.z === "number" ? r.z : 0,
                 exits,
+                explored,
+                title: typeof r.t === "string" ? r.t : undefined,
+                terrain: typeof r.tr === "string" ? r.tr : explored ? "outside" : undefined,
+                poi: Array.isArray(r.poi) ? r.poi.filter((p): p is string => typeof p === "string") : undefined,
               };
             })
         : [];

--- a/web-v3/src/hooks/useMiniMap.ts
+++ b/web-v3/src/hooks/useMiniMap.ts
@@ -295,7 +295,7 @@ function drawBorderStub(ctx: CanvasRenderingContext2D, cx: number, cy: number, h
 /** Inked compass rose — a quiet cartographic flourish in the corner of the sheet. */
 function drawCompassRose(ctx: CanvasRenderingContext2D, cx: number, cy: number, r: number) {
   ctx.save();
-  ctx.globalAlpha = 0.45;
+  ctx.globalAlpha = 0.6;
   ctx.strokeStyle = INK;
   ctx.fillStyle = INK;
   ctx.lineWidth = 1.2;
@@ -650,8 +650,9 @@ function renderMap(
     ctx.restore();
   }
 
-  // Compass rose — bottom-left corner (the zoom cluster owns the bottom-right).
-  drawCompassRose(ctx, scrollLeft + 42, scrollBottom - 46, 24);
+  // Compass rose — bottom-left, inset past the drawer sheet's painted border art
+  // so the ink reads on open parchment (the zoom cluster owns the bottom-right).
+  drawCompassRose(ctx, scrollLeft + 104, scrollBottom - 100, 24);
 
   // Zone name tag — top-left, derived from the current room id (`<zone>:<room>`).
   const zoneId = currentId.split(":")[0];

--- a/web-v3/src/hooks/useMiniMap.ts
+++ b/web-v3/src/hooks/useMiniMap.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import { MAP_OFFSETS, zoneColorCss } from "../constants";
 import { canvasCallbacks, gameStateRef } from "../canvas/GameStateBridge";
-import type { BorderStub, MapRoom } from "../types";
+import type { BorderStub, MapRoom, ZoneMapRoomData } from "../types";
 
 // Parchment / ink palette — matches the in-scene minimap. The canvas itself is
 // transparent: the parchment scroll (`map_background`) is the map drawer's
@@ -49,6 +49,30 @@ const EDGE_PAD = 0;
 
 function clamp(v: number, lo: number, hi: number): number {
   return Math.max(lo, Math.min(hi, v));
+}
+
+/**
+ * Fog-of-war visibility: only rooms the player has explored, plus the one-hop
+ * *frontier* just past them (targets of an explored room's exits — including
+ * border stubs into neighbouring zones), render at all. Everything further stays
+ * hidden until walked, so the chart physically grows with exploration.
+ * "Explored" is `title !== ""`: titles arrive only with the player's permanent
+ * exploration set (Zone.Map) or by standing in the room (Room.Info).
+ */
+function computeVisibility(visited: Map<string, MapRoom>): { explored: Set<string>; frontier: Set<string> } {
+  const explored = new Set<string>();
+  for (const [id, node] of visited) {
+    if (node.title !== "" && !node.zone) explored.add(id);
+  }
+  const frontier = new Set<string>();
+  for (const id of explored) {
+    const node = visited.get(id);
+    if (!node) continue;
+    for (const target of Object.values(node.exits)) {
+      if (!explored.has(target)) frontier.add(target);
+    }
+  }
+  return { explored, frontier };
 }
 
 /** Zone id → display name, e.g. "demo_ruins" → "Demo Ruins". */
@@ -318,9 +342,16 @@ function renderMap(
   ctx.rect(scrollLeft, scrollTop, scrollRight - scrollLeft, scrollBottom - scrollTop);
   ctx.clip();
 
-  // Connecting lines — only between two visible rooms; off-map exits get a tick.
-  for (const node of visited.values()) {
+  // Fog of war: hidden rooms (neither explored nor on the one-hop frontier)
+  // draw nothing — no node, no edge, no marker.
+  const { explored, frontier } = computeVisibility(visited);
+  const isRendered = (id: string) => explored.has(id) || frontier.has(id);
+
+  // Connecting lines — drawn outward from *explored* rooms only, so the chart
+  // never reveals a corridor between two rooms the player hasn't earned.
+  for (const [nodeId, node] of visited.entries()) {
     if (node.z !== floor) continue;
+    if (!explored.has(nodeId)) continue;
     const sx = nodeX(node);
     const sy = nodeY(node);
     const sIn = inScrollBounds(sx, sy);
@@ -371,6 +402,9 @@ function renderMap(
         if (!fromNode || !toNode) continue;
         if (fromNode.z === floor && toNode.z !== floor) stairHops.add(fromId);
         if (fromNode.z !== floor || toNode.z !== floor) continue;
+        // The trail routes through the full zone graph, but only its explored/
+        // frontier stretch draws — the edge chevron carries it onward from there.
+        if (!isRendered(fromId) || !isRendered(toId)) continue;
         const sx = nodeX(fromNode);
         const sy = nodeY(fromNode);
         const tx = nodeX(toNode);
@@ -404,6 +438,7 @@ function renderMap(
     : 0.45 + 0.4 * (0.5 + 0.5 * Math.sin(Date.now() / PATH_SHIMMER_PERIOD * Math.PI * 2));
   for (const [id, node] of visited.entries()) {
     if (node.z !== floor) continue;
+    if (!isRendered(id)) continue;
     const x = nodeX(node);
     const y = nodeY(node);
     if (!inScrollBounds(x, y)) continue;
@@ -411,7 +446,8 @@ function renderMap(
     // Border stub: a room in a neighbouring zone, one cell past the boundary.
     // Drawn as a small zone-tinted marker with the zone's name, never as a
     // regular room glyph — it shows the world continues without claiming to be
-    // explored ground in this zone.
+    // explored ground in this zone. Renders only once its boundary room is
+    // explored (it sits on the frontier), like any other unearned ground.
     if (node.zone) {
       drawBorderStub(ctx, x, y, nodeSize / 2, node.zone);
       continue;
@@ -433,10 +469,11 @@ function renderMap(
     if (!drew) drawProceduralRoom(ctx, x, y, size / 2, isCurrent, isVisited, isHousing);
 
     // Stair badges — ▲/▼ beside rooms with vertical exits; gold-pulsing when
-    // the quest trail wants the player to take these stairs.
+    // the quest trail wants the player to take these stairs. Explored rooms
+    // only: a frontier room shouldn't advertise stairs the player hasn't seen.
     const hasUp = "up" in node.exits;
     const hasDown = "down" in node.exits;
-    if (hasUp || hasDown) {
+    if (isVisited && (hasUp || hasDown)) {
       drawStairBadges(ctx, x, y, size / 2, hasUp, hasDown, stairHops.has(id) ? stairPulse : 0);
     }
 
@@ -477,7 +514,9 @@ function renderMap(
     if (targetNode.z !== floor) continue; // off-floor targets are routed via the stair badge
     const tx = nodeX(targetNode);
     const ty = nodeY(targetNode);
-    if (inScrollBounds(tx, ty)) continue; // already visible
+    // Skip only when the target actually renders on screen — a quest room in
+    // fog-hidden territory still needs its edge chevron even inside the bounds.
+    if (inScrollBounds(tx, ty) && isRendered(targetId)) continue;
     const ddx = tx - originX;
     const ddy = ty - originY;
     const dist = Math.sqrt(ddx * ddx + ddy * ddy);
@@ -614,13 +653,17 @@ export function useMiniMap() {
 
     // Fit and pan bounds consider only the player's current floor — rooms on
     // other floors aren't drawn, so they shouldn't stretch the zoom either.
+    // Fog-hidden rooms are excluded too: the "whole zone" fit is the *revealed*
+    // chart, so an unexplored zone doesn't open zoomed out onto empty parchment.
     const floor = current?.z ?? 0;
+    const { explored: exploredIds, frontier: frontierIds } = computeVisibility(visited);
     let minX = Infinity;
     let maxX = -Infinity;
     let minY = Infinity;
     let maxY = -Infinity;
-    for (const node of visited.values()) {
+    for (const [nodeId, node] of visited.entries()) {
       if (node.z !== floor) continue;
+      if (!exploredIds.has(nodeId) && !frontierIds.has(nodeId)) continue;
       if (node.x < minX) minX = node.x;
       if (node.x > maxX) maxX = node.x;
       if (node.y < minY) minY = node.y;
@@ -824,11 +867,15 @@ export function useMiniMap() {
     [drawMap],
   );
 
-  /** Pre-populate the map with all rooms in a zone as fog nodes. */
+  /**
+   * Pre-populate the map with all rooms in a zone. Rooms the player has
+   * permanently explored arrive with title/terrain/poi and render remembered;
+   * the rest are fog nodes that stay hidden until their neighbour is explored.
+   */
   const loadZoneMap = useCallback(
     (
       zone: string,
-      rooms: Array<{ id: string; x: number; y: number; z: number; exits: Record<string, string> }>,
+      rooms: ZoneMapRoomData[],
       border: BorderStub[],
     ) => {
       const map = visitedRef.current;
@@ -840,7 +887,16 @@ export function useMiniMap() {
       zoomRef.current = 0;
 
       for (const r of rooms) {
-        map.set(r.id, { x: r.x, y: r.y, z: r.z, exits: r.exits, title: "", image: null });
+        map.set(r.id, {
+          x: r.x,
+          y: r.y,
+          z: r.z,
+          exits: r.exits,
+          title: r.explored ? (r.title ?? "") : "",
+          image: null,
+          terrain: r.explored ? r.terrain : undefined,
+          poi: r.poi,
+        });
       }
       // Border stubs: foreign rooms just across a boundary, already positioned in
       // this zone's frame. Tagged with their zone so drawMap colour-codes them.

--- a/web-v3/src/hooks/useMiniMap.ts
+++ b/web-v3/src/hooks/useMiniMap.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { MAP_OFFSETS, zoneColorCss } from "../constants";
 import { canvasCallbacks, gameStateRef } from "../canvas/GameStateBridge";
 import type { BorderStub, MapRoom, ZoneMapRoomData } from "../types";
@@ -29,6 +29,45 @@ const MAX_ZOOM = 120; // most zoomed-in cell size
 const DEFAULT_ZOOM = 88; // comfortable default centred on the player
 const MAX_NODE = 52; // glyph size caps (px); scaled down to fit the cell
 const MAX_CURRENT = 64;
+
+// POI icon + display name per Zone.Map service token (Room.Info flag names).
+// Icons are drawn straight onto the canvas; names feed the hover tooltip.
+export const POI_META: Record<string, { icon: string; label: string }> = {
+  bank: { icon: "🪙", label: "Bank" },
+  tavern: { icon: "🍺", label: "Tavern" },
+  stylist: { icon: "✂️", label: "Stylist" },
+  dungeon: { icon: "🗝️", label: "Dungeon" },
+  auction: { icon: "🏷️", label: "Auction House" },
+  housingBroker: { icon: "🏠", label: "Housing Broker" },
+  inn: { icon: "🛏️", label: "Inn" },
+  shrine: { icon: "✨", label: "Akathavae Shrine" },
+  flightMaster: { icon: "🪶", label: "Flight Master" },
+  boatDock: { icon: "⚓", label: "Boat Dock" },
+  station: { icon: "🔨", label: "Crafting Station" },
+};
+
+/** Zone completion + floor info for the map header, derived from the loaded chart. */
+export interface MapZoneStats {
+  zone: string;
+  exploredCount: number;
+  totalRooms: number;
+  floor: number;
+  multiFloor: boolean;
+}
+
+/** The room under the cursor, for the hover tooltip (screen coords are canvas-local CSS px). */
+export interface MapHoverInfo {
+  id: string;
+  title: string;
+  explored: boolean;
+  terrain?: string;
+  poi: string[];
+  hasStairs: boolean;
+  /** Border-stub zone, when hovering a neighbouring-zone marker. */
+  zone?: string;
+  sx: number;
+  sy: number;
+}
 
 // Server-asset keys (shared with the in-scene minimap).
 const A_ROOM = "minimap_room";
@@ -250,6 +289,38 @@ function drawBorderStub(ctx: CanvasRenderingContext2D, cx: number, cy: number, h
   ctx.strokeText(label, cx, ly);
   ctx.fillStyle = color;
   ctx.fillText(label, cx, ly);
+  ctx.restore();
+}
+
+/** Inked compass rose — a quiet cartographic flourish in the corner of the sheet. */
+function drawCompassRose(ctx: CanvasRenderingContext2D, cx: number, cy: number, r: number) {
+  ctx.save();
+  ctx.globalAlpha = 0.45;
+  ctx.strokeStyle = INK;
+  ctx.fillStyle = INK;
+  ctx.lineWidth = 1.2;
+  ctx.beginPath();
+  ctx.arc(cx, cy, r * 0.62, 0, Math.PI * 2);
+  ctx.stroke();
+  // Cardinal ticks just past the ring.
+  for (const [dx, dy] of [[0, -1], [1, 0], [0, 1], [-1, 0]] as const) {
+    ctx.beginPath();
+    ctx.moveTo(cx + dx * r * 0.68, cy + dy * r * 0.68);
+    ctx.lineTo(cx + dx * r * 0.88, cy + dy * r * 0.88);
+    ctx.stroke();
+  }
+  // North needle — a slim ink diamond.
+  ctx.beginPath();
+  ctx.moveTo(cx, cy - r * 0.95);
+  ctx.lineTo(cx + r * 0.18, cy);
+  ctx.lineTo(cx, cy + r * 0.34);
+  ctx.lineTo(cx - r * 0.18, cy);
+  ctx.closePath();
+  ctx.fill();
+  ctx.font = "bold 10px 'JetBrains Mono', 'Cascadia Mono', monospace";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "bottom";
+  ctx.fillText("N", cx, cy - r * 0.98);
   ctx.restore();
 }
 
@@ -477,6 +548,28 @@ function renderMap(
       drawStairBadges(ctx, x, y, size / 2, hasUp, hasDown, stairHops.has(id) ? stairPulse : 0);
     }
 
+    // POI icons — small service glyphs across the top edge of explored rooms,
+    // shown once the zoom gives them room to breathe. The hover tooltip names
+    // them all, so hiding them at far zoom loses nothing.
+    if (isVisited && node.poi && node.poi.length > 0 && cell >= 44) {
+      const icons = node.poi
+        .map((p) => POI_META[p]?.icon)
+        .filter((icon): icon is string => !!icon)
+        .slice(0, 3);
+      if (icons.length > 0) {
+        const iconSize = Math.max(10, Math.round(cell * 0.22));
+        ctx.save();
+        ctx.font = `${iconSize}px serif`;
+        ctx.textAlign = "center";
+        ctx.textBaseline = "bottom";
+        const step = iconSize + 2;
+        const startX = x - ((icons.length - 1) * step) / 2;
+        const iy = y - size / 2 - 2;
+        icons.forEach((icon, i) => ctx.fillText(icon, startX + i * step, iy));
+        ctx.restore();
+      }
+    }
+
     // Quest objective marker
     if (!isCurrent && questTargetRoomIds.has(id)) {
       const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
@@ -486,21 +579,28 @@ function renderMap(
       }
     }
 
-    // Labels
+    // Labels — fade in with zoom rather than popping, and allow longer names
+    // at close zoom; the hover tooltip carries the full title regardless.
     if (isVisited && node.title) {
-      ctx.font = isCurrent
-        ? "bold 12px 'JetBrains Mono', 'Cascadia Mono', monospace"
-        : "11px 'JetBrains Mono', 'Cascadia Mono', monospace";
-      ctx.textAlign = "center";
-      ctx.textBaseline = "top";
-      const maxLen = isCurrent ? 18 : 14;
-      const label = node.title.length > maxLen ? node.title.slice(0, maxLen - 1) + "…" : node.title;
-      const ly = y + size / 2 + 4;
-      ctx.lineWidth = 3;
-      ctx.strokeStyle = LABEL_OUTLINE;
-      ctx.strokeText(label, x, ly);
-      ctx.fillStyle = isCurrent ? LABEL_CURRENT : LABEL_VISITED;
-      ctx.fillText(label, x, ly);
+      const labelAlpha = isCurrent ? 1 : clamp((cell - 34) / 26, 0, 1);
+      if (labelAlpha > 0.05) {
+        ctx.save();
+        ctx.globalAlpha = labelAlpha;
+        ctx.font = isCurrent
+          ? "bold 12px 'JetBrains Mono', 'Cascadia Mono', monospace"
+          : "11px 'JetBrains Mono', 'Cascadia Mono', monospace";
+        ctx.textAlign = "center";
+        ctx.textBaseline = "top";
+        const maxLen = isCurrent ? 20 : cell >= 76 ? 22 : 14;
+        const label = node.title.length > maxLen ? node.title.slice(0, maxLen - 1) + "…" : node.title;
+        const ly = y + size / 2 + 4;
+        ctx.lineWidth = 3;
+        ctx.strokeStyle = LABEL_OUTLINE;
+        ctx.strokeText(label, x, ly);
+        ctx.fillStyle = isCurrent ? LABEL_CURRENT : LABEL_VISITED;
+        ctx.fillText(label, x, ly);
+        ctx.restore();
+      }
     }
   }
 
@@ -549,6 +649,9 @@ function renderMap(
     ctx.fill();
     ctx.restore();
   }
+
+  // Compass rose — bottom-left corner (the zoom cluster owns the bottom-right).
+  drawCompassRose(ctx, scrollLeft + 42, scrollBottom - 46, 24);
 
   // Zone name tag — top-left, derived from the current room id (`<zone>:<room>`).
   const zoneId = currentId.split(":")[0];
@@ -638,6 +741,17 @@ export function useMiniMap() {
   const zoomBoundsRef = useRef({ min: 8, max: MAX_ZOOM });
   const dragRef = useRef<{ x: number; y: number; gx: number; gy: number } | null>(null);
 
+  // Last-render view + visibility, kept for pointer hit-testing (hover tooltip).
+  const viewRef = useRef<{ cell: number; panGx: number; panGy: number; originX: number; originY: number; floor: number } | null>(null);
+  const visibilityRef = useRef<{ explored: Set<string>; frontier: Set<string> } | null>(null);
+
+  // Header stats + hover tooltip — React state, updated only on real changes so
+  // the RAF pulse loop doesn't thrash renders.
+  const [zoneStats, setZoneStats] = useState<MapZoneStats | null>(null);
+  const statsKeyRef = useRef("");
+  const [hoverInfo, setHoverInfo] = useState<MapHoverInfo | null>(null);
+  const hoverIdRef = useRef<string | null>(null);
+
   const drawMap = useCallback(() => {
     const canvas = mapCanvasRef.current;
     if (!canvas) return;
@@ -699,6 +813,34 @@ export function useMiniMap() {
     if (hasRooms) {
       panRef.current.gx = clamp(panRef.current.gx, minX - 1, maxX + 1);
       panRef.current.gy = clamp(panRef.current.gy, minY - 1, maxY + 1);
+    }
+
+    // Record the resolved view + visibility for pointer hit-testing, and push
+    // header stats (zone, floor, exploration %) when they actually change.
+    viewRef.current = {
+      cell: zoomRef.current,
+      panGx: panRef.current.gx,
+      panGy: panRef.current.gy,
+      originX: width / 2,
+      originY: height / 2,
+      floor,
+    };
+    visibilityRef.current = { explored: exploredIds, frontier: frontierIds };
+    const zoneId = currentRoomIdRef.current?.split(":")[0] ?? "";
+    if (zoneId) {
+      let totalRooms = 0;
+      let multiFloor = false;
+      for (const node of visited.values()) {
+        if (node.zone) continue; // border stubs aren't this zone's rooms
+        totalRooms++;
+        if (node.z !== floor) multiFloor = true;
+      }
+      const stats: MapZoneStats = { zone: zoneId, exploredCount: exploredIds.size, totalRooms, floor, multiFloor };
+      const key = `${zoneId}|${stats.exploredCount}|${totalRooms}|${floor}|${multiFloor}`;
+      if (key !== statsKeyRef.current) {
+        statsKeyRef.current = key;
+        setZoneStats(stats);
+      }
     }
 
     // Draw a room/quest glyph (auto-trimmed, aspect-fit). Lazily loads the
@@ -766,19 +908,70 @@ export function useMiniMap() {
     y: (rect.height * SCROLL_INSET_TOP + rect.height * (1 - SCROLL_INSET_BOTTOM)) / 2,
   });
 
+  const clearHover = useCallback(() => {
+    if (hoverIdRef.current !== null) {
+      hoverIdRef.current = null;
+      setHoverInfo(null);
+    }
+  }, []);
+
   const onMapPointerDown = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
     e.currentTarget.setPointerCapture?.(e.pointerId);
+    clearHover();
     dragRef.current = {
       x: e.clientX,
       y: e.clientY,
       gx: panRef.current?.gx ?? 0,
       gy: panRef.current?.gy ?? 0,
     };
+  }, [clearHover]);
+
+  /** Hit-test the pointer against the rendered rooms and surface a tooltip. */
+  const updateHover = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
+    const v = viewRef.current;
+    const vis = visibilityRef.current;
+    if (!v || !vis) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const mx = e.clientX - rect.left;
+    const my = e.clientY - rect.top;
+    const gx = Math.round(v.panGx + (mx - v.originX) / v.cell);
+    const gy = Math.round(v.panGy + (my - v.originY) / v.cell);
+    // The cursor must actually be inside the room's box, not just its grid cell.
+    const sx = v.originX + (gx - v.panGx) * v.cell;
+    const sy = v.originY + (gy - v.panGy) * v.cell;
+    const half = Math.min(MAX_NODE, v.cell * 0.62) / 2 + 4;
+    let found: MapHoverInfo | null = null;
+    if (Math.abs(mx - sx) <= half && Math.abs(my - sy) <= half) {
+      for (const [id, node] of visitedRef.current.entries()) {
+        if (node.z !== v.floor || node.x !== gx || node.y !== gy) continue;
+        if (!vis.explored.has(id) && !vis.frontier.has(id)) continue;
+        const explored = node.title !== "" && !node.zone;
+        found = {
+          id,
+          title: explored ? node.title : "",
+          explored,
+          terrain: explored ? node.terrain : undefined,
+          poi: explored ? (node.poi ?? []) : [],
+          hasStairs: explored && ("up" in node.exits || "down" in node.exits),
+          zone: node.zone,
+          sx,
+          sy,
+        };
+        break;
+      }
+    }
+    if ((found?.id ?? null) !== hoverIdRef.current) {
+      hoverIdRef.current = found?.id ?? null;
+      setHoverInfo(found);
+    }
   }, []);
 
   const onMapPointerMove = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
     const d = dragRef.current;
-    if (!d) return;
+    if (!d) {
+      updateHover(e);
+      return;
+    }
     const cell = zoomRef.current || 1;
     panRef.current = {
       gx: d.gx - (e.clientX - d.x) / cell,
@@ -786,12 +979,17 @@ export function useMiniMap() {
     };
     userAdjustedRef.current = true;
     drawMap();
-  }, [drawMap]);
+  }, [drawMap, updateHover]);
 
   const onMapPointerUp = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
     e.currentTarget.releasePointerCapture?.(e.pointerId);
     dragRef.current = null;
   }, []);
+
+  const onMapPointerLeave = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
+    onMapPointerUp(e);
+    clearHover();
+  }, [onMapPointerUp, clearHover]);
 
   const onMapWheel = useCallback((e: React.WheelEvent<HTMLCanvasElement>) => {
     const rect = e.currentTarget.getBoundingClientRect();
@@ -885,6 +1083,7 @@ export function useMiniMap() {
       userAdjustedRef.current = false;
       panRef.current = null;
       zoomRef.current = 0;
+      clearHover();
 
       for (const r of rooms) {
         map.set(r.id, {
@@ -910,7 +1109,7 @@ export function useMiniMap() {
       // Also push to the PixiJS compact minimap
       canvasCallbacks.loadZoneMap?.(zone, rooms, border);
     },
-    [drawMap],
+    [drawMap, clearHover],
   );
 
   const resetMap = useCallback(() => {
@@ -919,8 +1118,11 @@ export function useMiniMap() {
     userAdjustedRef.current = false;
     panRef.current = null;
     zoomRef.current = 0;
+    clearHover();
+    statsKeyRef.current = "";
+    setZoneStats(null);
     drawMap();
-  }, [drawMap]);
+  }, [drawMap, clearHover]);
 
   /** Start a gentle animation loop for quest marker pulse (call when map is visible). */
   const startPulse = useCallback(() => {
@@ -953,9 +1155,12 @@ export function useMiniMap() {
     onMapPointerDown,
     onMapPointerMove,
     onMapPointerUp,
+    onMapPointerLeave,
     onMapWheel,
     zoomIn,
     zoomOut,
     recenter,
+    zoneStats,
+    hoverInfo,
   };
 }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -10104,6 +10104,113 @@ body {
   background: linear-gradient(160deg, rgb(96 66 36 / 94%), rgb(56 38 18 / 96%));
 }
 
+/* Exploration header — ink-on-parchment strip above the chart: zone completion
+   on the left, a glyph legend on the right. */
+.map-stats-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-3);
+  padding: 4px 10px 6px;
+  font-family: var(--font-mono, "JetBrains Mono", "Cascadia Mono", monospace);
+  font-size: 0.72rem;
+  color: #4a3a28;
+  border-bottom: 1px solid rgb(74 58 40 / 30%);
+}
+
+.map-stats-explored {
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.map-stats-pct {
+  font-weight: 400;
+  opacity: 0.75;
+}
+
+.map-legend {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
+  opacity: 0.9;
+}
+
+.map-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  white-space: nowrap;
+}
+
+.map-legend-swatch {
+  width: 10px;
+  height: 10px;
+  display: inline-block;
+  border: 1px solid #4a3a28;
+  border-radius: 2px;
+}
+
+.map-legend-here { background: #9c3b22; }
+.map-legend-explored { background: #cdb487; }
+
+.map-legend-fog {
+  background: transparent;
+  border-color: rgb(138 122 94 / 70%);
+  border-style: dashed;
+}
+
+.map-legend-quest {
+  background: transparent;
+  border-color: #c69a2e;
+  box-shadow: 0 0 4px rgb(198 154 46 / 60%);
+}
+
+.map-legend-border {
+  background: rgb(94 122 168 / 55%);
+  border-color: rgb(94 122 168 / 95%);
+  transform: rotate(45deg);
+  border-radius: 1px;
+}
+
+/* Hover tooltip — a small ink card anchored just above the hovered room. */
+.map-hover-tooltip {
+  position: absolute;
+  transform: translate(-50%, -115%);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-width: 260px;
+  padding: 6px 10px;
+  pointer-events: none;
+  z-index: 3;
+  font-family: var(--font-mono, "JetBrains Mono", "Cascadia Mono", monospace);
+  font-size: 0.72rem;
+  color: #f3e6c8;
+  background: linear-gradient(160deg, rgb(56 42 24 / 96%), rgb(34 24 12 / 97%));
+  border: 1px solid rgb(190 168 115 / 60%);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 4px 14px rgb(20 12 4 / 45%);
+}
+
+.map-tooltip-title {
+  font-weight: 700;
+}
+
+.map-tooltip-unknown {
+  font-style: italic;
+  opacity: 0.8;
+}
+
+.map-tooltip-terrain {
+  text-transform: capitalize;
+  opacity: 0.75;
+}
+
+.map-tooltip-poi {
+  opacity: 0.9;
+}
+
 /* --- Atlas (zone browser) ---------------------------------------------
    Lives on the chart sheet's parchment: ink text, sepia rules, gold accents. */
 

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -10112,10 +10112,13 @@ body {
   justify-content: space-between;
   flex-wrap: wrap;
   gap: var(--space-2) var(--space-3);
-  padding: 4px 10px 6px;
+  /* Wide inline padding clears the chart sheet's painted border art, and the
+     soft cream halo keeps the ink legible where the art runs dark. */
+  padding: 4px 48px 6px;
   font-family: var(--font-mono, "JetBrains Mono", "Cascadia Mono", monospace);
   font-size: 0.72rem;
   color: #4a3a28;
+  text-shadow: 0 1px 2px rgb(243 230 200 / 55%);
   border-bottom: 1px solid rgb(74 58 40 / 30%);
 }
 

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -436,12 +436,31 @@ export interface MapRoom {
   /** Terrain key (forest, mountain, …) once the room has been visited. */
   terrain?: string;
   housing?: boolean;
+  /** Service tokens (bank, tavern, …) from Zone.Map — drives POI icons on explored rooms. */
+  poi?: string[];
   /**
    * Set only for a *foreign* room sitting just across a zone boundary (a border
    * stub). Names the neighbouring zone, so the renderer colour-codes it. Rooms in
    * the current zone leave this undefined.
    */
   zone?: string;
+}
+
+/** One room of a `Zone.Map` payload, after the client re-qualifies ids. */
+export interface ZoneMapRoomData {
+  id: string;
+  x: number;
+  y: number;
+  z: number;
+  exits: Record<string, string>;
+  /** True when the player has permanently explored this room (server-remembered). */
+  explored?: boolean;
+  /** Room title — present only on explored rooms. */
+  title?: string;
+  /** Terrain key — present only on explored rooms ("outside" is implied when absent). */
+  terrain?: string;
+  /** Service tokens (bank, tavern, …) — present only on explored rooms that have any. */
+  poi?: string[];
 }
 
 /**

--- a/web-v3/src/utils.ts
+++ b/web-v3/src/utils.ts
@@ -77,3 +77,12 @@ export function parseGmcp(text: string): { pkg: string; data: unknown } | null {
   }
 }
 
+
+/** Zone id → display name, e.g. "demo_ruins" → "Demo Ruins". */
+export function formatZoneName(zone: string): string {
+  return zone
+    .split("_")
+    .filter((part) => part.length > 0)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}


### PR DESCRIPTION
## Summary
First pass of the coordinated map overhaul (AmbonMUD side; a matching Arcanum PR follows):

- **Zone YAML map pins** — optional per-room `mapX`/`mapY`/`mapZ`; `WorldLoader` honors them as fixed anchors and BFS-places unpinned rooms around them. This is the shared contract Arcanum's zone editor will write via "Save map layout".
- **Persistent exploration** (upcoming) — explored room set on the player record; once you've walked a zone you keep its map forever.
- **ZoneMap GMCP enrichment** (upcoming) — explored rooms carry title/terrain/POI detail.
- **Full-screen map rework** (upcoming) — hidden-until-explored fog of war, header with explored %, legend, hover tooltips, POI icons, parchment art pass.

Out of scope (future): click-to-fast-travel mount system on the map.

## Testing
- `WorldLoaderTest` — new pin fixtures (`ok_pinned_map`, `bad_pin_conflict`, `bad_pin_partial`)
- `./gradlew ktlintCheck test` per checkpoint