### PR TITLE
Map follow-ups: hover-only room labels + staff see the whole map

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/HandlerHelpers.kt
@@ -600,7 +600,11 @@ internal suspend fun sendLook(
     val zone = room.id.zone
     if (gmcpEmitter != null && gmcpEmitter.trackZoneChange(sessionId, zone)) {
         val zoneRooms = world.rooms.values.filter { it.id.zone == zone }
-        gmcpEmitter.sendZoneMap(sessionId, zone, zoneRooms, me.exploredRooms)
+        // Staff see the whole chart: every room ships with its explored detail,
+        // so the client's fog of war never hides anything from them.
+        val exploredForMap =
+            if (me.isStaff) zoneRooms.mapTo(mutableSetOf()) { it.id.value } else me.exploredRooms
+        gmcpEmitter.sendZoneMap(sessionId, zone, zoneRooms, exploredForMap)
         gmcpEmitter.sendZoneEnvironment(sessionId, gmcpEmitter.buildZoneEnvironmentPayload(zone))
         // Zone intro cinematic: auto-plays on the player's first-ever entry,
         // then stays replayable from the expanded map.

--- a/src/test/kotlin/dev/ambon/engine/commands/ExplorationCommandRouterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/ExplorationCommandRouterTest.kt
@@ -1,8 +1,13 @@
 package dev.ambon.engine.commands
 
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.world.Direction
 import dev.ambon.domain.world.load.WorldLoader
+import dev.ambon.engine.GmcpEmitter
+import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.toPlayerRecord
 import dev.ambon.engine.toPlayerState
 import dev.ambon.persistence.PlayerId
@@ -20,6 +25,24 @@ import org.junit.jupiter.api.Test
 class ExplorationCommandRouterTest {
     private fun createHarness(): CommandRouterHarness =
         CommandRouterHarness.create(world = WorldLoader.loadFromResource("world/ok_small.yaml"))
+
+    private fun createGmcpHarness(): CommandRouterHarness {
+        val outbound = LocalOutboundBus()
+        val gmcpEmitter = GmcpEmitter(outbound = outbound, supportsPackage = { _, _ -> true })
+        return CommandRouterHarness.create(
+            world = WorldLoader.loadFromResource("world/ok_small.yaml"),
+            outbound = outbound,
+            gmcpEmitter = gmcpEmitter,
+        )
+    }
+
+    /** Rooms of the pending Zone.Map packet, keyed by room id. */
+    private suspend fun zoneMapRooms(h: CommandRouterHarness): Map<String, JsonNode> {
+        val packet = h.outbound.drainAll()
+            .filterIsInstance<OutboundEvent.GmcpData>()
+            .first { it.gmcpPackage == "Zone.Map" }
+        return jacksonObjectMapper().readTree(packet.jsonData)["rooms"].associateBy { it["id"].asText() }
+    }
 
     @Test
     fun `looking marks the current room explored`() =
@@ -47,6 +70,42 @@ class ExplorationCommandRouterTest {
             val explored = h.players.get(sid)!!.exploredRooms
             assertTrue("ok_small:a" in explored)
             assertTrue("ok_small:b" in explored)
+        }
+
+    @Test
+    fun `regular players get zone map detail only for rooms they explored`() =
+        runTest {
+            val h = createGmcpHarness()
+            val sid = SessionId(10)
+            h.players.loginOrFail(sid, "Norm")
+            h.outbound.drainAll()
+
+            h.router.handle(sid, Command.Look)
+            val rooms = zoneMapRooms(h)
+            assertEquals(1, rooms.getValue("a")["e"]?.asInt(), "entry room must be explored")
+            assertTrue(
+                rooms.getValue("b")["e"] == null && rooms.getValue("b")["t"] == null,
+                "unexplored room must stay bare. got=${rooms.getValue("b")}",
+            )
+        }
+
+    @Test
+    fun `staff get the zone map with every room explored`() =
+        runTest {
+            val h = createGmcpHarness()
+            val sid = SessionId(11)
+            h.players.loginOrFail(sid, "Steph")
+            h.players.get(sid)!!.isStaff = true
+            h.outbound.drainAll()
+
+            h.router.handle(sid, Command.Look)
+            val rooms = zoneMapRooms(h)
+            assertEquals(1, rooms.getValue("a")["e"]?.asInt())
+            assertEquals(1, rooms.getValue("b")["e"]?.asInt(), "staff must see unwalked rooms as explored")
+            assertEquals("Room B", rooms.getValue("b")["t"].asText())
+            // The staff override is view-only: nothing is written to the player's
+            // permanent exploration set beyond the rooms actually stood in.
+            assertFalse("ok_small:b" in h.players.get(sid)!!.exploredRooms)
         }
 
     @Test

--- a/web-v3/src/hooks/useMiniMap.ts
+++ b/web-v3/src/hooks/useMiniMap.ts
@@ -579,29 +579,8 @@ function renderMap(
       }
     }
 
-    // Labels — fade in with zoom rather than popping, and allow longer names
-    // at close zoom; the hover tooltip carries the full title regardless.
-    if (isVisited && node.title) {
-      const labelAlpha = isCurrent ? 1 : clamp((cell - 34) / 26, 0, 1);
-      if (labelAlpha > 0.05) {
-        ctx.save();
-        ctx.globalAlpha = labelAlpha;
-        ctx.font = isCurrent
-          ? "bold 12px 'JetBrains Mono', 'Cascadia Mono', monospace"
-          : "11px 'JetBrains Mono', 'Cascadia Mono', monospace";
-        ctx.textAlign = "center";
-        ctx.textBaseline = "top";
-        const maxLen = isCurrent ? 20 : cell >= 76 ? 22 : 14;
-        const label = node.title.length > maxLen ? node.title.slice(0, maxLen - 1) + "…" : node.title;
-        const ly = y + size / 2 + 4;
-        ctx.lineWidth = 3;
-        ctx.strokeStyle = LABEL_OUTLINE;
-        ctx.strokeText(label, x, ly);
-        ctx.fillStyle = isCurrent ? LABEL_CURRENT : LABEL_VISITED;
-        ctx.fillText(label, x, ly);
-        ctx.restore();
-      }
-    }
+    // Room labels are hover-only: the tooltip names the room under the cursor,
+    // so the chart itself stays clean ink at rest (no per-room text).
   }
 
   // Off-screen quest target edge indicators — gold chevrons at the scroll


### PR DESCRIPTION
## Summary
Two small follow-ups to the map overhaul in #1401:

- **Hover-only room labels (web):** the full-screen map no longer inks every explored room's title onto the chart at close zoom. Room names now appear only in the existing hover tooltip, keeping the parchment clean at rest. (Zone name, floor tag, and border-stub zone names are unchanged — they aren't room labels.)
- **Staff see the whole map (server):** when `Zone.Map` is sent, staff players get every room in the zone marked explored, so the full chart renders with titles, terrain stamps, and POI icons — no fog of war. The override is view-only: the player's permanent `exploredRooms` set still records only rooms actually visited. Payload-wise this is equivalent to a fully-explored zone, which the abbreviated wire format was already sized for.

## Testing
- New `ExplorationCommandRouterTest` cases: staff Zone.Map marks all rooms explored (and doesn't pollute the persisted exploration set); regular players still get detail only for walked rooms.
- `./gradlew ktlintCheck test integrationTest` — all green.
- `bun run lint` + `tsc --noEmit` in `web-v3` — clean.