### PR TITLE
fix(akathavae): stop discovery-XP throttle swallowing illumination drop XP

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/AkathavaeSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/AkathavaeSystem.kt
@@ -207,8 +207,11 @@ class AkathavaeSystem(
 
         // Catalogue what the creature carries as Arcanum pages — this feeds the
         // wardrobe — but take nothing: the subject is unharmed and stays put.
+        // The illumination XP above just armed the discovery-XP throttle, so these
+        // same-action item awards bypass it — otherwise the items get recorded with
+        // their XP silently and permanently swallowed.
         for (drop in mob.drops) {
-            recordItemDiscovery(sessionId, drop.itemId, ArcanumSource.ILLUMINATED)
+            recordItemDiscovery(sessionId, drop.itemId, ArcanumSource.ILLUMINATED, bypassThrottle = true)
         }
 
         // A recorded creature counts as a defeated one for quests and achievements,
@@ -311,9 +314,10 @@ class AkathavaeSystem(
         sessionId: SessionId,
         itemId: dev.ambon.domain.ids.ItemId,
         source: String,
+        bypassThrottle: Boolean = false,
     ) {
         val template = items.getTemplate(itemId) ?: return
-        recordItemDiscovery(sessionId, ItemInstance(id = itemId, item = template), source)
+        recordItemDiscovery(sessionId, ItemInstance(id = itemId, item = template), source, bypassThrottle)
     }
 
     /**
@@ -325,6 +329,7 @@ class AkathavaeSystem(
         sessionId: SessionId,
         item: ItemInstance,
         source: String,
+        bypassThrottle: Boolean = false,
     ) {
         val me = players.get(sessionId) ?: return
         if (!me.isAkathavae) return
@@ -337,7 +342,7 @@ class AkathavaeSystem(
         recordEntry(me.arcanum.items, key, now, source)
         outbound.send(OutboundEvent.SendText(sessionId, "[Arcanum] You record ${item.item.displayName}."))
         announceWorldFirst(sessionId, me, "item:$key", item.item.displayName, now)
-        awardDiscoveryXp(sessionId, me, config.itemDiscoveryXp, "discovery", now)
+        awardDiscoveryXp(sessionId, me, config.itemDiscoveryXp, "discovery", now, bypassThrottle)
         markVitalsDirty?.invoke(sessionId)
         emitStatus(sessionId)
     }
@@ -471,16 +476,24 @@ class AkathavaeSystem(
         }
     }
 
-    /** Grants discovery XP scaled by the XP stat, behind the anti-speedrun throttle. */
+    /**
+     * Grants discovery XP scaled by the XP stat, behind the anti-speedrun throttle.
+     *
+     * [bypassThrottle] is for intra-action awards only (e.g. cataloguing a mob's
+     * drops in the same illumination that just awarded XP): it skips the throttle
+     * check but still updates the next-award window, so a bypassed award never
+     * opens a farming window.
+     */
     private suspend fun awardDiscoveryXp(
         sessionId: SessionId,
         me: PlayerState,
         baseAmount: Long,
         label: String,
         now: Long,
+        bypassThrottle: Boolean = false,
     ) {
         if (baseAmount <= 0L) return
-        if (now < (nextDiscoveryXpAt[sessionId] ?: 0L)) return
+        if (!bypassThrottle && now < (nextDiscoveryXpAt[sessionId] ?: 0L)) return
         nextDiscoveryXpAt[sessionId] = now + config.discoveryXpThrottleMs
 
         val stats = resolvePlayerStats(me, items, statusEffects, classRegistry)

--- a/src/test/kotlin/dev/ambon/engine/AkathavaeIlluminateTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/AkathavaeIlluminateTest.kt
@@ -164,6 +164,66 @@ class AkathavaeIlluminateTest {
     }
 
     @Test
+    fun `first illumination pays item-discovery XP for every drop in the same action`() = runTest {
+        val s = setup(rng = ScriptedRandom(0, 0))
+        val sid = SessionId(1L)
+        val me = loginAkathavae(s, sid, "Thalen")
+        s.fixture.items.loadSpawns(
+            listOf(
+                ItemSpawn(instance = ItemInstance(ItemId("test:dust"), Item(keyword = "dust", displayName = "glittering dust"))),
+                ItemSpawn(instance = ItemInstance(ItemId("test:mote"), Item(keyword = "mote", displayName = "a pale mote"))),
+            ),
+        )
+        val drops = listOf(MobDrop(ItemId("test:dust"), 1.0), MobDrop(ItemId("test:mote"), 0.5))
+        s.fixture.mobs.upsert(wisp(id = "w1", xpReward = 100L, drops = drops))
+
+        s.system.illuminate(sid, "wisp")
+
+        val perItem = AkathavaeConfig().itemDiscoveryXp
+        assertEquals(
+            100L + 2 * perItem,
+            me.xpTotal,
+            "first illumination pays the mob XP plus item XP for each drop, same action",
+        )
+        assertTrue(me.arcanum.items.containsKey("test:dust"))
+        assertTrue(me.arcanum.items.containsKey("test:mote"))
+
+        // Repeat illumination: items already recorded → no further item XP, and the
+        // mob's repeat cooldown suppresses its XP too.
+        s.clock.advance(AkathavaeConfig().discoveryXpThrottleMs + 1)
+        s.fixture.mobs.upsert(wisp(id = "w2", xpReward = 100L, drops = drops))
+        s.system.illuminate(sid, "wisp")
+        assertEquals(100L + 2 * perItem, me.xpTotal, "repeat illumination pays no item XP for known pages")
+    }
+
+    @Test
+    fun `drop-catalogue bypass does not defeat the cross-action discovery throttle`() = runTest {
+        val s = setup(rng = ScriptedRandom(0))
+        val sid = SessionId(1L)
+        val me = loginAkathavae(s, sid, "Thalen")
+        s.fixture.items.loadSpawns(
+            listOf(ItemSpawn(instance = ItemInstance(ItemId("test:dust"), Item(keyword = "dust", displayName = "glittering dust")))),
+        )
+        s.fixture.mobs.upsert(wisp(xpReward = 100L, drops = listOf(MobDrop(ItemId("test:dust"), 1.0))))
+
+        s.system.illuminate(sid, "wisp")
+        val afterIllumination = 100L + AkathavaeConfig().itemDiscoveryXp
+        assertEquals(afterIllumination, me.xpTotal)
+
+        // A separate discovery inside the throttle window: recorded, but no XP.
+        me.roomId = roomB
+        s.system.onRoomVisited(sid)
+        assertEquals(afterIllumination, me.xpTotal, "the intra-action bypass must not open a farming window")
+        assertTrue(me.arcanum.rooms.containsKey(roomB.value), "the room is still recorded")
+
+        // Past the throttle, XP flows again.
+        s.clock.advance(AkathavaeConfig().discoveryXpThrottleMs + 1)
+        me.roomId = roomC
+        s.system.onRoomVisited(sid)
+        assertEquals(afterIllumination + AkathavaeConfig().roomDiscoveryXp, me.xpTotal)
+    }
+
+    @Test
     fun `illumination fires quest kill credit so the pledged complete the same quests`() = runTest {
         val credited = mutableListOf<String>()
         val s = setup(rng = ScriptedRandom(0), onMobKilledByPlayer = { _, templateKey -> credited += templateKey })


### PR DESCRIPTION
## Summary

On a successful first illumination, `resolveSuccess` awards the first-illumination XP (arming the anti-speedrun discovery-XP throttle) and then, in the same action at the same `now`, catalogues the mob's drops via `recordItemDiscovery`. Each of those item awards hit the throttle and returned early — and since the items were now recorded in the Arcanum, the `itemDiscoveryXp` (default 25 per item) was permanently lost, not merely delayed.

## Approach

Per the issue's two options, this takes the **bypass parameter** route (the smaller, behaviour-preserving change that keeps the per-item "You gain X XP (discovery)" lines), not the batched-XP alternative:

- `awardDiscoveryXp` gains a private `bypassThrottle: Boolean = false` parameter. When true it skips the `now < nextDiscoveryXpAt` check but **still updates** `nextDiscoveryXpAt`, so a bypassed award never opens a farming window.
- Both `recordItemDiscovery` overloads gain the same defaulted parameter and pass it down.
- `resolveSuccess` catalogues the drop loop with `bypassThrottle = true`.
- Every other caller (shop purchases, crafting/gathering, room visits) keeps the default throttled behaviour.

## Tests

`AkathavaeIlluminateTest` (using `MutableClock`, no wall-clock):
- First illumination of a mob with 2 drops pays `mobXp + 2 × itemDiscoveryXp` in one action; a repeat illumination pays no item XP for already-recorded pages.
- Regression guard: a room discovery inside the throttle window right after the illumination is recorded but pays 0 XP; after `discoveryXpThrottleMs` elapses, XP flows again.

Closes #1386
Part of #1400