### PR TITLE
fix(akathavae): exclude pledged players from group kill XP

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -185,6 +185,12 @@ class CombatSystem(
 
     private val pvpCombatStates = mutableMapOf<SessionId, PvpCombatState>()
 
+    /**
+     * Sessions already told (this login) that their Akathavae pledge forfeits
+     * group kill XP — the reminder is sent once per login, not on every kill.
+     */
+    private val pledgeKillXpNotified = mutableSetOf<SessionId>()
+
     /** Zone start room lookup, wired by GameEngine after construction. */
     var zoneStartRoomLookup: (String) -> RoomId? = { _ -> null }
 
@@ -457,11 +463,15 @@ class CombatSystem(
                 pvpCombatStates[sid] = state.copy(targetSid = newSid)
             }
         }
+        if (pledgeKillXpNotified.remove(oldSid)) {
+            pledgeKillXpNotified.add(newSid)
+        }
     }
 
     override suspend fun onPlayerDisconnected(sessionId: SessionId) {
         removePlayerFromCombat(sessionId)
         endPvpCombat(sessionId)
+        pledgeKillXpNotified.remove(sessionId)
     }
 
     fun endCombatFor(sessionId: SessionId) {
@@ -1931,13 +1941,29 @@ class CombatSystem(
         val group = groupSystem?.getGroup(killerSessionId)
         val recipients =
             if (group != null) {
-                group.members.filter { sid ->
-                    val p = players.get(sid)
-                    p != null && p.roomId == mob.roomId
+                val membersInRoom =
+                    group.members.mapNotNull { sid ->
+                        players.get(sid)?.takeIf { it.roomId == mob.roomId }?.let { sid to it }
+                    }
+                // Pledged Akathavae forfeit kill XP entirely; they also don't count
+                // toward the split or the group bonus, so the fighters' payout is
+                // identical to a group without the pledged member along.
+                val (pledged, eligible) = membersInRoom.partition { (_, p) -> p.isAkathavae }
+                for ((sid, _) in pledged) {
+                    if (pledgeKillXpNotified.add(sid)) {
+                        outbound.send(
+                            OutboundEvent.SendText(
+                                sid,
+                                "Your pledge holds — the kill earns you nothing. Record the world instead.",
+                            ),
+                        )
+                    }
                 }
+                eligible.map { (sid, _) -> sid }
             } else {
                 listOf(killerSessionId)
             }
+        if (recipients.isEmpty()) return 0L
 
         val memberCount = recipients.size
         val groupBonus =

--- a/src/test/kotlin/dev/ambon/engine/AkathavaeGroupKillXpTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/AkathavaeGroupKillXpTest.kt
@@ -1,0 +1,217 @@
+package dev.ambon.engine
+
+import dev.ambon.config.LevelRewardsConfig
+import dev.ambon.config.ProgressionConfig
+import dev.ambon.config.XpCurveConfig
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.mob.MobState
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.test.CombatTestFixture
+import dev.ambon.test.drainAll
+import dev.ambon.test.loginOrFail
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression tests for the Akathavae pledge loophole (#1387): pledged players
+ * must never receive kill XP from group members' kills, and the fighters'
+ * split must pay out as if the pledged member were not there at all.
+ */
+class AkathavaeGroupKillXpTest {
+    private val pledgeMessage = "Your pledge holds — the kill earns you nothing. Record the world instead."
+
+    /** XP curve big enough that no test kill ever levels anyone up. */
+    private fun flatProgression(): PlayerProgression =
+        PlayerProgression(
+            ProgressionConfig(
+                maxLevel = 20,
+                xp =
+                    XpCurveConfig(
+                        baseXp = 1_000_000L,
+                        exponent = 2.0,
+                        linearXp = 0L,
+                        multiplier = 1.0,
+                        defaultKillXp = 100L,
+                    ),
+                rewards = LevelRewardsConfig(),
+            ),
+        )
+
+    private fun spawnRat(
+        fixture: CombatTestFixture,
+        key: String,
+    ): MobState {
+        val mob =
+            MobState(
+                MobId("demo:$key"),
+                "a rat",
+                fixture.roomId,
+                hp = 1,
+                maxHp = 1,
+                xpReward = 100L,
+            )
+        fixture.mobs.upsert(mob)
+        return mob
+    }
+
+    private suspend fun formGroup(
+        group: GroupSystem,
+        leader: SessionId,
+        members: List<Pair<SessionId, String>>,
+    ) {
+        for ((sid, name) in members) {
+            assertNull(group.invite(leader, name))
+            assertNull(group.accept(sid))
+        }
+    }
+
+    @Test
+    fun `pledged member earns nothing and fighters split as a two-member group`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            val group = GroupSystem(fixture.players, fixture.outbound, fixture.clock)
+            val combat =
+                fixture.buildCombat(
+                    progression = flatProgression(),
+                    groupSystem = group,
+                    groupXpBonusPerMember = 0.10,
+                )
+
+            val fighter1 = SessionId(1L)
+            val fighter2 = SessionId(2L)
+            val pledged = SessionId(3L)
+            fixture.players.loginOrFail(fighter1, "Alice")
+            fixture.players.loginOrFail(fighter2, "Bob")
+            fixture.players.loginOrFail(pledged, "Chronicler")
+            fixture.players.get(pledged)!!.isAkathavae = true
+
+            formGroup(group, fighter1, listOf(fighter2 to "Bob", pledged to "Chronicler"))
+            fixture.outbound.drainAll()
+
+            spawnRat(fixture, "rat1")
+            assertNull(combat.startCombat(fighter1, "rat"))
+            fixture.tickCombat(combat)
+
+            // 100 XP mob split across the 2 eligible fighters with one group-bonus
+            // step: (100 / 2) * 1.10 = 55 each — exactly the 2-member payout.
+            assertEquals(55L, fixture.players.get(fighter1)!!.xpTotal, "killer should get the 2-member split")
+            assertEquals(55L, fixture.players.get(fighter2)!!.xpTotal, "fighter should get the 2-member split")
+            assertEquals(0L, fixture.players.get(pledged)!!.xpTotal, "pledged member must earn no kill XP")
+        }
+
+    @Test
+    fun `fighter payout with a pledged member matches a group without them`() =
+        runTest {
+            // Control: two fighters, no Akathavae.
+            val control = CombatTestFixture()
+            val controlGroup = GroupSystem(control.players, control.outbound, control.clock)
+            val controlCombat =
+                control.buildCombat(
+                    progression = flatProgression(),
+                    groupSystem = controlGroup,
+                    groupXpBonusPerMember = 0.10,
+                )
+            val c1 = SessionId(1L)
+            val c2 = SessionId(2L)
+            control.players.loginOrFail(c1, "Alice")
+            control.players.loginOrFail(c2, "Bob")
+            formGroup(controlGroup, c1, listOf(c2 to "Bob"))
+            spawnRat(control, "rat1")
+            assertNull(controlCombat.startCombat(c1, "rat"))
+            control.tickCombat(controlCombat)
+
+            // Same two fighters plus a pledged Akathavae along for the kill.
+            val fixture = CombatTestFixture()
+            val group = GroupSystem(fixture.players, fixture.outbound, fixture.clock)
+            val combat =
+                fixture.buildCombat(
+                    progression = flatProgression(),
+                    groupSystem = group,
+                    groupXpBonusPerMember = 0.10,
+                )
+            val f1 = SessionId(1L)
+            val f2 = SessionId(2L)
+            val pledged = SessionId(3L)
+            fixture.players.loginOrFail(f1, "Alice")
+            fixture.players.loginOrFail(f2, "Bob")
+            fixture.players.loginOrFail(pledged, "Chronicler")
+            fixture.players.get(pledged)!!.isAkathavae = true
+            formGroup(group, f1, listOf(f2 to "Bob", pledged to "Chronicler"))
+            spawnRat(fixture, "rat1")
+            assertNull(combat.startCombat(f1, "rat"))
+            fixture.tickCombat(combat)
+
+            assertEquals(control.players.get(c1)!!.xpTotal, fixture.players.get(f1)!!.xpTotal)
+            assertEquals(control.players.get(c2)!!.xpTotal, fixture.players.get(f2)!!.xpTotal)
+        }
+
+    @Test
+    fun `non-Akathavae three-member group split is unchanged`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            val group = GroupSystem(fixture.players, fixture.outbound, fixture.clock)
+            val combat =
+                fixture.buildCombat(
+                    progression = flatProgression(),
+                    groupSystem = group,
+                    groupXpBonusPerMember = 0.10,
+                )
+
+            val f1 = SessionId(1L)
+            val f2 = SessionId(2L)
+            val f3 = SessionId(3L)
+            fixture.players.loginOrFail(f1, "Alice")
+            fixture.players.loginOrFail(f2, "Bob")
+            fixture.players.loginOrFail(f3, "Cara")
+            formGroup(group, f1, listOf(f2 to "Bob", f3 to "Cara"))
+
+            spawnRat(fixture, "rat1")
+            assertNull(combat.startCombat(f1, "rat"))
+            fixture.tickCombat(combat)
+
+            // (100 / 3) * 1.20 = 40 each (toLong truncation of 33.33 * 1.2).
+            for (sid in listOf(f1, f2, f3)) {
+                assertEquals(40L, fixture.players.get(sid)!!.xpTotal, "3-member split should be unchanged")
+            }
+        }
+
+    @Test
+    fun `pledge flavor message is sent once per login not on every kill`() =
+        runTest {
+            val fixture = CombatTestFixture()
+            val group = GroupSystem(fixture.players, fixture.outbound, fixture.clock)
+            val combat =
+                fixture.buildCombat(
+                    progression = flatProgression(),
+                    groupSystem = group,
+                    groupXpBonusPerMember = 0.10,
+                )
+
+            val fighter = SessionId(1L)
+            val pledged = SessionId(2L)
+            fixture.players.loginOrFail(fighter, "Alice")
+            fixture.players.loginOrFail(pledged, "Chronicler")
+            fixture.players.get(pledged)!!.isAkathavae = true
+            formGroup(group, fighter, listOf(pledged to "Chronicler"))
+            fixture.outbound.drainAll()
+
+            spawnRat(fixture, "rat1")
+            assertNull(combat.startCombat(fighter, "rat"))
+            fixture.tickCombat(combat)
+
+            spawnRat(fixture, "rat2")
+            assertNull(combat.startCombat(fighter, "rat"))
+            fixture.tickCombat(combat)
+
+            val pledgeMessages =
+                fixture.outbound
+                    .drainAll()
+                    .filterIsInstance<OutboundEvent.SendText>()
+                    .filter { it.sessionId == pledged && it.text == pledgeMessage }
+            assertEquals(1, pledgeMessages.size, "pledge reminder should fire exactly once per login")
+            assertEquals(0L, fixture.players.get(pledged)!!.xpTotal)
+        }
+}


### PR DESCRIPTION
## Summary

Closes the Akathavae pledge loophole where a pledged player could join a group, stand in the room while fighters kill, and collect a full share of kill XP.

`CombatSystem.grantGroupKillXp` now:

- **Excludes pledged Akathavae from the recipients list** — they receive 0 kill XP from group kills.
- **Excludes them from the split semantics** — a pledged member does not count toward `memberCount`, so the per-player divisor and the `groupXpBonusPerMember` bonus pay out exactly as if the group were one member smaller (a group of 3 with one Akathavae pays like a group of 2). Fighters aren't taxed for bringing a Chronicler along.
- **Sends a one-line flavor reminder once per login** ("Your pledge holds — the kill earns you nothing. Record the world instead."), tracked in a per-session set that is remapped on session rebind and cleared on disconnect — no per-kill spam.

Solo kill XP, non-Akathavae group XP, and the illumination XP path are untouched.

## Quest-credit audit (per issue, no change made)

Followed `callbacks.onMobKilledByPlayer` from the kill path: quest/achievement kill credit goes to **threat-table contributors** (`threatTable.playersThreateningMob`), not to group members generally. An idle pledged member gains no threat and thus no quest credit. A pledged member *can* appear in contributors via healing threat (`healingThreatMultiplier`, CombatSystem ~line 786), so an Akathavae healer could receive quest kill-objective credit from a group kill. Left in place as the issue deems acceptable — they could earn identical credit by illuminating the mob themselves (`creditIlluminationKill`).

## Tests

New `AkathavaeGroupKillXpTest`:

- 3-member group with one pledged: pledged XP delta == 0, each fighter gets exactly the 2-member payout (55 from a 100-XP mob at 0.10 bonus).
- Control-group equivalence: fighter payouts with a pledged member present match an identical group without them.
- Non-Akathavae 3-member split unchanged (40 each from a 100-XP mob).
- Flavor message fires exactly once per login across multiple kills.

Closes #1387
Part of #1400