### PR TITLE
fix(akathavae): gate pet combat under the pledge (violence by proxy)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/CombatSystem.kt
@@ -990,6 +990,12 @@ class CombatSystem(
                 if (now < mobCombatState.nextTickAtMs) continue
                 val mob = mobs.get(mobId) ?: continue
                 if (mob.hp <= 0) continue
+                // Pets share their owner's Akathavae pledge: violence by proxy is still
+                // violence. A pledged owner's pets never melee and never auto-cast a
+                // damaging skill (direct roll or DOT), mirroring the owner-swing gate in
+                // the player attack phase above. Purely defensive skills (taunts, buffs)
+                // stay available so a tank pet can still soak hits.
+                val ownerPledged = players.get(sessionId)?.isAkathavae == true
                 // Every pet the owner controls attacks (a single companion is the common case; the
                 // Mycorae spore swarm and other multi-summons all act, and tank pets each build
                 // threat so a wall of mushrooms actually holds aggro).
@@ -1001,7 +1007,7 @@ class CombatSystem(
                         if (petSystem.isManualGraceActive(sessionId, now)) {
                             null
                         } else {
-                            selectPetSkill(pet, now)
+                            selectPetSkill(pet, now, excludeDamaging = ownerPledged)
                         }
 
                     if (autoSkill != null) {
@@ -1009,6 +1015,8 @@ class CombatSystem(
                         onPetSkillCast(sessionId)
                         continue
                     }
+
+                    if (ownerPledged) continue
 
                     val petRoll = rollRange(rng, pet.damage.min, pet.damage.max)
                     val petDamage = (petRoll - mob.armor).coerceAtLeast(1)
@@ -1180,11 +1188,16 @@ class CombatSystem(
      * Unlike [selectMobSpell] this does not exclude a defaultAttack — pets don't model a
      * default-attack spell separate from their melee, and every entry in `pet.spells` is a
      * triggerable signature skill.
+     *
+     * [excludeDamaging] drops skills that would reduce the target's HP (Akathavae owners —
+     * see [petSkillDealsDamage]), leaving only defensive utility like taunts and buffs.
      */
-    private fun selectPetSkill(pet: MobState, now: Long): MobSpell? {
+    private fun selectPetSkill(pet: MobState, now: Long, excludeDamaging: Boolean = false): MobSpell? {
         if (pet.spells.isEmpty()) return null
         val cooldowns = mobSpellCooldowns[pet.id] ?: emptyMap()
-        val eligible = pet.spells.filter { (cooldowns[it.id] ?: 0L) <= now }
+        val eligible = pet.spells.filter { skill ->
+            (cooldowns[skill.id] ?: 0L) <= now && !(excludeDamaging && petSkillDealsDamage(skill))
+        }
         if (eligible.isEmpty()) return null
         val totalWeight = eligible.sumOf { it.weight }
         if (totalWeight <= 0) return eligible.first()
@@ -1571,6 +1584,12 @@ class CombatSystem(
         val skill = pets.findSkill(pet, skillQuery)
             ?: return PetSkillResult.Error("${pet.name} doesn't know '$skillQuery'.", "UNKNOWN_SKILL")
 
+        // The pledge extends to the pet: a pledged owner may still trigger defensive
+        // skills (taunts, buffs) but never one that deals damage, directly or via DOT.
+        if (players.get(ownerSid)?.isAkathavae == true && petSkillDealsDamage(skill)) {
+            return PetSkillResult.Error(ERR_AKATHAVAE_PLEDGE, "AKATHAVAE_PLEDGE")
+        }
+
         val target = getCombatTarget(ownerSid)
             ?: return PetSkillResult.Error("You're not in combat.", "NOT_IN_COMBAT")
         if (target.roomId != pet.roomId) {
@@ -1592,6 +1611,16 @@ class CombatSystem(
         onPetSkillCast(ownerSid)
         return PetSkillResult.Ok
     }
+
+    /**
+     * Returns true if [skill] would reduce a mob's HP: a direct damage roll, or a status
+     * effect whose type ticks damage (DOT). Skills that only taunt, buff, or apply
+     * non-damaging debuffs are not damage-dealing. Used to hold pets to their owner's
+     * Akathavae pledge — violence by proxy is still violence (issue #1398).
+     */
+    private fun petSkillDealsDamage(skill: MobSpell): Boolean =
+        skill.damage != null ||
+            (skill.statusEffectId != null && statusEffects?.effectTicksDamage(skill.statusEffectId) == true)
 
     /**
      * Applies a pet skill against a target mob. Damage portion adds threat to the pet's synthetic

--- a/src/main/kotlin/dev/ambon/engine/status/StatusEffectSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/status/StatusEffectSystem.kt
@@ -352,6 +352,16 @@ class StatusEffectSystem(
         effectType: String,
     ): Boolean = mobEffects[mobId]?.any { registry.get(it.definitionId)?.effectType == effectType } == true
 
+    /**
+     * Returns true if [effectId] resolves to an effect whose type ticks damage on its target
+     * (a DOT). Used by combat to classify pet skills as damage-dealing under the Akathavae
+     * pledge even when the skill has no direct damage roll.
+     */
+    fun effectTicksDamage(effectId: StatusEffectId): Boolean {
+        val def = registry.get(effectId) ?: return false
+        return effectTypes.get(def.effectType)?.ticksDamage == true
+    }
+
     fun getPlayerStatMods(sessionId: SessionId): StatMap = computeStatMods(playerEffects[sessionId])
 
     fun getMobStatMods(mobId: MobId): StatMap = computeStatMods(mobEffects[mobId])

--- a/src/test/kotlin/dev/ambon/engine/PetAkathavaePledgeTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/PetAkathavaePledgeTest.kt
@@ -1,0 +1,258 @@
+package dev.ambon.engine
+
+import dev.ambon.config.PetConfig
+import dev.ambon.config.PetSpellConfig
+import dev.ambon.config.PetTemplateConfig
+import dev.ambon.domain.ids.MobId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.mob.MobState
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.status.StatusEffectDefinition
+import dev.ambon.engine.status.StatusEffectId
+import dev.ambon.engine.status.StatusEffectSystem
+import dev.ambon.test.CombatTestFixture
+import dev.ambon.test.drainAll
+import dev.ambon.test.loginOrFail
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.Random
+
+/**
+ * Regression tests for issue #1398: pets share their owner's Akathavae pledge.
+ *
+ * A pledged owner's pet must never reduce a mob's HP — no melee swings, no
+ * damaging auto-cast skills, no manually triggered damaging skills (direct
+ * damage or DOT). Purely defensive utility (taunts) stays available so a tank
+ * pet can still soak hits, mirroring the owner rule ("dodge, flee, or fall,
+ * and never deal damage").
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PetAkathavaePledgeTest {
+    private val biteSkill = PetSpellConfig(
+        displayName = "Bite",
+        message = "{pet} bites {target}",
+        roomMessage = "{pet} bites {target}",
+        minDamage = 4,
+        maxDamage = 4,
+        statusEffectId = "bleed",
+        cooldownMs = 6_000L,
+        weight = 2,
+    )
+
+    // DOT-only skill: no direct damage roll, but the applied status ticks damage.
+    private val venomSkill = PetSpellConfig(
+        displayName = "Venom",
+        message = "{pet} envenoms {target}",
+        roomMessage = "{pet} envenoms {target}",
+        statusEffectId = "poison",
+        cooldownMs = 6_000L,
+        weight = 1,
+    )
+
+    // Defensive taunt: threat only, deals no damage.
+    private val roarSkill = PetSpellConfig(
+        displayName = "Roar",
+        message = "{pet} roars at {target}",
+        roomMessage = "{pet} roars at {target}",
+        threatBonus = 100.0,
+        cooldownMs = 15_000L,
+        weight = 1,
+    )
+
+    private val petConfig = PetConfig(
+        manualSkillGraceMs = 8_000L,
+        definitions = mapOf(
+            "wolf_companion" to PetTemplateConfig(
+                name = "a wolf companion",
+                baseHp = 25,
+                baseMinDamage = 2,
+                baseMaxDamage = 2,
+                baseArmor = 0,
+                spells = mapOf("bite" to biteSkill, "venom" to venomSkill),
+            ),
+            "bear_guardian" to PetTemplateConfig(
+                name = "a bear guardian",
+                baseHp = 40,
+                baseMinDamage = 5,
+                baseMaxDamage = 5,
+                baseArmor = 2,
+                threatMultiplier = 2.0,
+                spells = mapOf("roar" to roarSkill),
+            ),
+        ),
+    )
+
+    private val ownerStats = PetSystem.OwnerStats(maxHp = 30, damageMin = 1, damageMax = 3, armor = 0)
+
+    private data class Fixture(
+        val base: CombatTestFixture,
+        val combat: CombatSystem,
+        val pets: PetSystem,
+        val statusEffects: StatusEffectSystem,
+    )
+
+    private fun newFixture(): Fixture {
+        val fixture = CombatTestFixture()
+        val pets = PetSystem(petConfig, fixture.mobs, fixture.clock)
+        val bleed = StatusEffectDefinition(
+            id = StatusEffectId("bleed"),
+            displayName = "Bleeding",
+            effectType = "dot",
+            durationMs = 8_000L,
+            tickIntervalMs = 2_000L,
+            tickMinValue = 2,
+            tickMaxValue = 4,
+        )
+        val poison = StatusEffectDefinition(
+            id = StatusEffectId("poison"),
+            displayName = "Poisoned",
+            effectType = "dot",
+            durationMs = 8_000L,
+            tickIntervalMs = 2_000L,
+            tickMinValue = 2,
+            tickMaxValue = 4,
+        )
+        val statusEffects = fixture.buildStatusEffects(bleed, poison)
+        val combat = fixture.buildCombat(
+            rng = Random(1),
+            petSystem = pets,
+            statusEffects = statusEffects,
+        )
+        return Fixture(fixture, combat, pets, statusEffects)
+    }
+
+    /**
+     * Logs in a pledged (or unpledged) owner with a pet, then has the mob force
+     * combat via [CombatSystem.startMobCombat] — the only way a pledged player
+     * enters mob combat, since `kill` is refused under the pledge.
+     */
+    private suspend fun setupMobForcedCombat(
+        fixture: Fixture,
+        petTemplate: String,
+        pledged: Boolean,
+        mobHp: Int = 100,
+    ): Triple<SessionId, MobState, MobState> {
+        val sid = SessionId(7L)
+        fixture.base.players.loginOrFail(sid, "Pilgrim")
+        val player = fixture.base.players.get(sid)!!
+        player.isAkathavae = pledged
+        // Plenty of HP so mob swings across several ticks never kill the owner.
+        player.maxHp = 1_000
+        player.hp = 1_000
+        val pet = fixture.pets.summon(sid, petTemplate, player.roomId, ownerStats)!!
+        val target = MobState(
+            MobId("demo:goblin"),
+            "a goblin",
+            fixture.base.roomId,
+            hp = mobHp,
+            maxHp = mobHp,
+        )
+        fixture.base.mobs.upsert(target)
+        assertTrue(fixture.combat.startMobCombat(target.id, sid), "mob should force combat")
+        fixture.base.outbound.drainAll()
+        return Triple(sid, pet, target)
+    }
+
+    @Test
+    fun `pledged owner's pet never melees or auto-casts damaging skills when a mob attacks`() = runTest {
+        val f = newFixture()
+        val (sid, _, target) = setupMobForcedCombat(f, "wolf_companion", pledged = true)
+        val startHp = target.hp
+
+        repeat(3) { f.base.tickCombat(f.combat) }
+
+        assertEquals(startHp, f.base.mobs.get(target.id)!!.hp, "pledged owner's pet must not damage the mob")
+        assertFalse(f.statusEffects.hasMobEffect(target.id, "dot"), "pledged owner's pet must not apply DOTs")
+        val texts = f.base.outbound.drainAll()
+            .filterIsInstance<OutboundEvent.SendText>()
+            .map { it.text }
+        assertTrue(
+            texts.none { it.contains("a wolf companion hits") || it.contains("bites") || it.contains("envenoms") },
+            "expected no pet attack output for pledged owner, got=$texts",
+        )
+        assertTrue(f.combat.isInCombat(sid), "owner stays in combat — the pledge only stays the pet's teeth")
+    }
+
+    @Test
+    fun `pledged owner cannot manually trigger a direct-damage pet skill`() = runTest {
+        val f = newFixture()
+        val (sid, _, target) = setupMobForcedCombat(f, "wolf_companion", pledged = true)
+        val startHp = target.hp
+
+        val result = f.combat.triggerPetSkill(sid, "bite")
+
+        assertTrue(result is CombatSystem.PetSkillResult.Error, "expected pledge refusal, got $result")
+        result as CombatSystem.PetSkillResult.Error
+        assertEquals("AKATHAVAE_PLEDGE", result.code)
+        assertEquals(ERR_AKATHAVAE_PLEDGE, result.message)
+        assertEquals(startHp, f.base.mobs.get(target.id)!!.hp, "refused skill must not deal damage")
+    }
+
+    @Test
+    fun `pledged owner cannot manually trigger a dot-only pet skill`() = runTest {
+        val f = newFixture()
+        val (sid, _, target) = setupMobForcedCombat(f, "wolf_companion", pledged = true)
+
+        val result = f.combat.triggerPetSkill(sid, "venom")
+
+        assertTrue(result is CombatSystem.PetSkillResult.Error, "expected pledge refusal, got $result")
+        assertEquals("AKATHAVAE_PLEDGE", (result as CombatSystem.PetSkillResult.Error).code)
+        assertFalse(f.statusEffects.hasMobEffect(target.id, "dot"), "refused skill must not apply its DOT")
+    }
+
+    @Test
+    fun `pledged owner may still trigger a defensive taunt skill`() = runTest {
+        val f = newFixture()
+        val (sid, pet, target) = setupMobForcedCombat(f, "bear_guardian", pledged = true)
+        val startHp = target.hp
+
+        val result = f.combat.triggerPetSkill(sid, "roar")
+
+        assertEquals(CombatSystem.PetSkillResult.Ok, result)
+        assertEquals(startHp, f.base.mobs.get(target.id)!!.hp, "taunt deals no damage")
+        val petSid = f.pets.getPetSessionId(pet.id)
+        assertNotNull(petSid)
+        assertTrue(
+            f.combat.threatTable.getThreat(target.id, petSid!!) >= 100.0,
+            "tank pet keeps building threat so it can soak hits under the pledge",
+        )
+    }
+
+    @Test
+    fun `pledged owner's tank pet auto-casts taunt but never melees`() = runTest {
+        val f = newFixture()
+        val (_, pet, target) = setupMobForcedCombat(f, "bear_guardian", pledged = true)
+        val startHp = target.hp
+
+        // First tick auto-casts roar (defensive, allowed); later ticks have no eligible
+        // skill and must skip the melee fallback entirely.
+        repeat(3) { f.base.tickCombat(f.combat) }
+
+        assertEquals(startHp, f.base.mobs.get(target.id)!!.hp, "tank pet must never melee under the pledge")
+        val petSid = f.pets.getPetSessionId(pet.id)
+        assertNotNull(petSid)
+        assertTrue(
+            f.combat.threatTable.getThreat(target.id, petSid!!) >= 100.0,
+            "auto-cast roar should still generate taunt threat",
+        )
+    }
+
+    @Test
+    fun `non-pledged owner's pet still fights back unchanged`() = runTest {
+        val f = newFixture()
+        val (_, _, target) = setupMobForcedCombat(f, "wolf_companion", pledged = false)
+        val startHp = target.hp
+
+        f.base.tickCombat(f.combat)
+
+        assertTrue(
+            f.base.mobs.get(target.id)!!.hp < startHp,
+            "unpledged owner's pet must keep dealing damage",
+        )
+    }
+}


### PR DESCRIPTION
## Audit findings (per issue #1398)

1. **Can a pledged player own a combat-capable pet?** Yes. Pets are summoned via class ability effects (`GameEngine.onSummonPet`) and racial abilities (`summonRacialPet`). The Akathavae gate in `AbilitySystem` (line ~131) only blocks *hostile* casts; summon effects pass through, and the pledge's single-class restriction doesn't exclude pet classes.
2. **Does the pet fight back when a mob aggros a pledged owner?** Yes (before this fix). The pet attack phase in `CombatSystem.tick()` iterated every owner in `playerTarget` with **no** `isAkathavae` check — pets meleed and auto-cast damaging skills. On the killing blow, `handleMobDeath(sessionId, mob)` granted the *owner* full kill credit, XP, and loot through the normal kill path. Violence by proxy was fully open.
3. **Can `pet skill <offensive>` initiate combat?** No — `triggerPetSkill` requires the owner to already have a combat target (`NOT_IN_COMBAT` otherwise). But once a mob forced the owner into combat (aggro, failed illumination), manual offensive skills dealt damage with no pledge check.

## Fix

Policy implemented: **pets follow the same vow as the owner — never deal damage; defensive utility remains.**

- **Pet attack phase** (`CombatSystem.tick`): when the owner `isAkathavae`, the pet never melees and auto-cast skill selection excludes damage-dealing skills (mirrors the owner-swing gate). Non-damaging skills (taunts/buffs) still auto-cast so tank pets keep soaking hits.
- **Manual trigger** (`CombatSystem.triggerPetSkill`): damage-dealing skills are refused with the shared `ERR_AKATHAVAE_PLEDGE` message (code `AKATHAVAE_PLEDGE`, same as duels). Defensive skills still work.
- **"Damage-dealing"** = direct damage roll **or** a DOT status effect — new `StatusEffectSystem.effectTicksDamage()` classifies effect types, so DOT-only skills can't sneak HP reduction past the pledge.
- No reward gate needed: with no damage possible, the pet can never land a killing blow.

Non-pledged behavior is byte-for-byte unchanged (`excludeDamaging` defaults to false; the filter is a no-op for unpledged owners).

## Tests

`PetAkathavaePledgeTest` (new): pledged owner's pet deals zero damage across combat ticks (mob-forced combat via `startMobCombat`); manual direct-damage and DOT-only skills refused with `AKATHAVAE_PLEDGE`; defensive taunt still triggerable and still auto-casts/builds threat; unpledged control still fights.

## Follow-up noted (out of scope)

Pre-existing: in the player attack phase, a pledged (non-stunned) player falls into the `else` branch that sends "You are stunned and cannot act!" every combat tick — misleading flavor for Akathavae under attack. Worth its own small issue under #1400.

Closes #1398
Part of #1400