### PR TITLE
feat(akathavae): make the pledge socially visible (look/who markers)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/CommunicationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/CommunicationHandler.kt
@@ -249,6 +249,7 @@ class CommunicationHandler(
                 if (guildTag != null) append("[$guildTag] ")
                 if (t != null) append("[$t] ")
                 if (grouped) append("[G] ")
+                if (p.isAkathavae) append("[Akathavae] ")
             }
             "$prefix${p.name}"
         }

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/NavigationHandler.kt
@@ -512,6 +512,9 @@ class NavigationHandler(
             if (p.description.isNotEmpty()) {
                 outbound.send(OutboundEvent.SendText(sessionId, p.description))
             }
+            if (p.isAkathavae) {
+                outbound.send(OutboundEvent.SendText(sessionId, AKATHAVAE_PLEDGE_LINE))
+            }
             gmcpEmitter?.sendLookTarget(
                 sessionId,
                 "player",
@@ -570,5 +573,10 @@ class NavigationHandler(
                 }
             }
         }
+    }
+
+    companion object {
+        /** Flavor line appended to `look <player>` when the target is a pledged Akathavae. */
+        const val AKATHAVAE_PLEDGE_LINE = "Ink stains their fingers — a pledged Akathavae, keeper of an Arcanum."
     }
 }

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterBroadcastTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterBroadcastTest.kt
@@ -95,6 +95,45 @@ class CommandRouterBroadcastTest {
         }
 
     @Test
+    fun `who tags pledged Akathavae players and untags them after renounce`() =
+        runTest {
+            val h = CommandRouterHarness.create()
+            val a = SessionId(1)
+            val b = SessionId(2)
+            h.players.loginOrFail(a, "Alice")
+            h.players.loginOrFail(b, "Bob")
+            h.players.get(b)!!.isAkathavae = true
+            h.outbound.drainAll()
+
+            h.router.handle(a, Command.Who)
+            val pledgedMsg = h.outbound.drainAll()
+                .filterIsInstance<OutboundEvent.SendInfo>()
+                .firstOrNull { it.sessionId == a }
+                ?.text
+            assertNotNull(pledgedMsg, "Expected SendInfo for who")
+            assertTrue(
+                pledgedMsg!!.contains("[Akathavae] Bob"),
+                "Expected Bob to carry the Akathavae tag. got=$pledgedMsg",
+            )
+            assertFalse(
+                pledgedMsg.contains("[Akathavae] Alice"),
+                "Alice is not pledged and must not be tagged. got=$pledgedMsg",
+            )
+
+            h.players.get(b)!!.isAkathavae = false
+            h.router.handle(a, Command.Who)
+            val renouncedMsg = h.outbound.drainAll()
+                .filterIsInstance<OutboundEvent.SendInfo>()
+                .firstOrNull { it.sessionId == a }
+                ?.text
+            assertNotNull(renouncedMsg, "Expected SendInfo for who after renounce")
+            assertFalse(
+                renouncedMsg!!.contains("[Akathavae]"),
+                "Tag must disappear once the pledge is renounced. got=$renouncedMsg",
+            )
+        }
+
+    @Test
     fun `who shows G indicator for grouped players`() =
         runTest {
             val world = TestWorlds.testWorld

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandRouterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandRouterTest.kt
@@ -15,6 +15,7 @@ import dev.ambon.engine.LoginResult
 import dev.ambon.engine.PlayerProgression
 import dev.ambon.engine.PrestigePerkPayload
 import dev.ambon.engine.PrestigeSystem
+import dev.ambon.engine.commands.handlers.NavigationHandler
 import dev.ambon.engine.crafting.GatheringRegistry
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.test.CommandRouterHarness
@@ -756,6 +757,53 @@ class CommandRouterTest {
             val textLines = outs.filterIsInstance<OutboundEvent.SendText>()
             assertEquals(1, textLines.size, "Expected only the level line. got=$textLines")
             assertTrue(textLines[0].text.startsWith("You see Bob"), "got=${textLines[0].text}")
+        }
+
+    @Test
+    fun `look at pledged player shows the Akathavae pledge line`() =
+        runTest {
+            val h = CommandRouterHarness.create()
+            val alice = SessionId(1)
+            val bob = SessionId(2)
+            h.loginPlayer(alice, "Alice")
+            h.loginPlayer(bob, "Bob")
+            h.players.get(bob)!!.isAkathavae = true
+            h.drain()
+
+            h.router.handle(alice, Command.LookAt("Bob"))
+            val outs = h.drain()
+
+            assertTrue(
+                outs.any { it is OutboundEvent.SendText && it.text == NavigationHandler.AKATHAVAE_PLEDGE_LINE },
+                "Expected the Akathavae pledge line. got=$outs",
+            )
+        }
+
+    @Test
+    fun `pledge line in look derives from live state and vanishes after renounce`() =
+        runTest {
+            val h = CommandRouterHarness.create()
+            val alice = SessionId(1)
+            val bob = SessionId(2)
+            h.loginPlayer(alice, "Alice")
+            h.loginPlayer(bob, "Bob")
+            h.players.get(bob)!!.isAkathavae = true
+            h.drain()
+
+            h.router.handle(alice, Command.LookAt("Bob"))
+            val pledged = h.drain()
+            assertTrue(
+                pledged.any { it is OutboundEvent.SendText && it.text == NavigationHandler.AKATHAVAE_PLEDGE_LINE },
+                "Expected the pledge line while pledged. got=$pledged",
+            )
+
+            h.players.get(bob)!!.isAkathavae = false
+            h.router.handle(alice, Command.LookAt("Bob"))
+            val renounced = h.drain()
+            assertFalse(
+                renounced.any { it is OutboundEvent.SendText && it.text == NavigationHandler.AKATHAVAE_PLEDGE_LINE },
+                "Pledge line must disappear after renouncing. got=$renounced",
+            )
         }
 
     @Test


### PR DESCRIPTION
## Summary

Makes the Akathavae pledge socially legible to other players, per the issue's three surfaces:

1. **`look <player>`** — when the target `isAkathavae`, appends the flavor line
   `Ink stains their fingers — a pledged Akathavae, keeper of an Arcanum.`
   after the level line and (optional) RP description. Non-pledged targets are unchanged.
2. **`who`** — pledged players get an `[Akathavae]` tag in the roster prefix, alongside the
   existing `[guild] [title] [G]` markers (the telnet `who` line does not show class, so a tag
   was needed). `whois`/`finger` do not exist in the parser, so `who` is the only roster command.
3. **Web client** — covered by class name, no payload changes: the pledge swaps
   `playerClass` to `AKATHAVAE`, which already flows through the `Server.Who` GMCP payload
   (Who board's Class column) and the player look-target payload (`class` field). `Room.Players`
   remains name/level/sprite only, matching the issue's "only add payload fields if nothing
   surfaces it" guidance.

Both markers derive from live `isAkathavae` at render time — renouncing removes them immediately (no cached strings).

## Testing

- New router tests: pledge line in `look <player>` (present when pledged, absent otherwise and after renounce) in `CommandRouterTest`; `[Akathavae]` tag in `who` (tagged while pledged, untagged after renounce, non-pledged players untouched) in `CommandRouterBroadcastTest`.
- `./gradlew ktlintCheck test integrationTest`

Closes #1399
Part of #1400