### PR TITLE
feat(akathavae): surface illumination success odds in consider and the Monster Manual

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/AkathavaeSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/AkathavaeSystem.kt
@@ -141,6 +141,25 @@ class AkathavaeSystem(
     }
 
     /**
+     * Illumination success odds for [me] against [mob], resolving the player's
+     * current effective stats (equipment + status effects included) — the same
+     * inputs [illuminate] rolls against. Surfaced to the player via `consider`
+     * and the `Room.MobInfo` GMCP payload so the pledged never gamble blind.
+     */
+    fun illuminationOddsFor(
+        me: PlayerState,
+        mob: MobState,
+    ): Int {
+        val stats = resolvePlayerStats(me, items, statusEffects, classRegistry)
+        return illuminationSuccessPct(
+            statValue = stats[config.successStat],
+            reliefStatValue = stats[config.gapReliefStat],
+            playerLevel = me.level,
+            mobLevel = mob.level,
+        )
+    }
+
+    /**
      * Success chance: base + per-point bonus above [PlayerState.BASE_STAT] on the
      * success stat, minus a per-level penalty for subjects above the player's level
      * (softened per point of the gap-relief stat), clamped to the configured band.

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -583,7 +583,9 @@ class GameEngine(
     /** Sessions whose stats changed this tick and need a Char.Stats push. */
     private val gmcpDirtyStats = mutableSetOf<SessionId>()
 
-    val gmcpEmitter =
+    // Explicit type: the illuminationOdds lambda references akathavaeSystem, whose
+    // initializer references gmcpEmitter back — inference needs one anchor.
+    val gmcpEmitter: GmcpEmitter =
         GmcpEmitter(
             outbound = outbound,
             supportsPackage = { sid, pkg ->
@@ -647,6 +649,15 @@ class GameEngine(
             raceRegistry = raceRegistry,
             nowMs = { clock.millis() },
             worldAreas = buildWorldAreaPayloads(world),
+            illuminationOdds = { sid, mobId ->
+                val viewer = players.get(sid)
+                val mob = mobs.get(MobId(mobId))
+                if (viewer != null && mob != null && viewer.isAkathavae && mob.role.isCombatant && !mob.isPet) {
+                    akathavaeSystem.illuminationOddsFor(viewer, mob)
+                } else {
+                    null
+                }
+            },
         )
 
     fun markVitalsDirty(sessionId: SessionId) {
@@ -814,7 +825,7 @@ class GameEngine(
             racialAbilitySystem = racialAbilitySystem,
         )
 
-    private val akathavaeSystem =
+    private val akathavaeSystem: AkathavaeSystem =
         AkathavaeSystem(
             players = players,
             items = items,

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -121,6 +121,12 @@ class GmcpEmitter(
     private val raceRegistry: RaceRegistry? = null,
     /** Current engine time in millis, used to compute racial-ability cooldown remaining. */
     private val nowMs: () -> Long = { 0L },
+    /**
+     * Illumination success odds for a viewing session against a mob id, or null
+     * when not applicable (viewer not pledged Akathavae, mob not a combatant).
+     * Feeds the per-viewer `illuminationPct` field of `Room.MobInfo`.
+     */
+    private val illuminationOdds: (SessionId, String) -> Int? = { _, _ -> null },
 ) {
     private val json = jacksonObjectMapper()
     private val imagesBase = if (imagesBaseUrl.endsWith("/")) imagesBaseUrl else "$imagesBaseUrl/"
@@ -2461,13 +2467,19 @@ class GmcpEmitter(
         emit(
             sessionId,
             "Room.MobInfo",
-            mobs.map { toRoomMobInfoPayload(it) },
+            mobs.map { toRoomMobInfoPayload(it, viewer = sessionId) },
         )
     }
 
     suspend fun broadcastRoomMobInfo(roomId: RoomId, mobInfos: List<MobInfoEntry>, players: PlayerRegistry) {
-        val payload = mobInfos.map { toRoomMobInfoPayload(it) }
-        broadcastSerialized(players.playersInRoom(roomId), "Room.MobInfo", payload)
+        // `illuminationPct` is per-viewer (it depends on the pledged player's
+        // effective stats), so pledged recipients get an individually built
+        // payload; everyone else shares a single serialization as before.
+        val (pledged, others) = players.playersInRoom(roomId).partition { it.isAkathavae }
+        broadcastSerialized(others, "Room.MobInfo", mobInfos.map { toRoomMobInfoPayload(it, viewer = null) })
+        for (p in pledged) {
+            sendRoomMobInfo(p.sessionId, mobInfos)
+        }
     }
 
     /**
@@ -3033,19 +3045,22 @@ class GmcpEmitter(
             takeable = item.item.takeable,
         )
 
-    private fun toRoomMobInfoPayload(entry: MobInfoEntry) =
-        RoomMobInfoPayload(
-            id = entry.id,
-            level = entry.level,
-            tier = entry.tier,
-            questGiver = entry.questGiver,
-            questAvailable = entry.questAvailable,
-            questComplete = entry.questComplete,
-            shopKeeper = entry.shopKeeper,
-            dialogue = entry.dialogue,
-            aggressive = entry.aggressive,
-            combatant = entry.combatant,
-        )
+    private fun toRoomMobInfoPayload(
+        entry: MobInfoEntry,
+        viewer: SessionId? = null,
+    ) = RoomMobInfoPayload(
+        id = entry.id,
+        level = entry.level,
+        tier = entry.tier,
+        questGiver = entry.questGiver,
+        questAvailable = entry.questAvailable,
+        questComplete = entry.questComplete,
+        shopKeeper = entry.shopKeeper,
+        dialogue = entry.dialogue,
+        aggressive = entry.aggressive,
+        combatant = entry.combatant,
+        illuminationPct = if (entry.combatant) viewer?.let { illuminationOdds(it, entry.id) } else null,
+    )
 
     // ---------- payload types ----------
 
@@ -3926,6 +3941,7 @@ class GmcpEmitter(
 
     // ---------- room mob info payload ----------
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private data class RoomMobInfoPayload(
         val id: String,
         val level: Int,
@@ -3937,6 +3953,8 @@ class GmcpEmitter(
         val dialogue: Boolean,
         val aggressive: Boolean,
         val combatant: Boolean,
+        /** Per-viewer illumination odds; present only for pledged Akathavae viewers. */
+        val illuminationPct: Int? = null,
     )
 
     // ---------- look target payload ----------

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/CombatHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/CombatHandler.kt
@@ -1,5 +1,6 @@
 package dev.ambon.engine.commands.handlers
 
+import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.world.World
 import dev.ambon.engine.ConsiderOutcome
@@ -25,6 +26,7 @@ class CombatHandler(
     private val players = ctx.players
     private val mobs = ctx.mobs
     private val combat = ctx.combat
+    private val akathavaeSystem = ctx.akathavaeSystem
     private val outbound = ctx.outbound
     private val gmcpEmitter = ctx.gmcpEmitter
     private val metrics = ctx.metrics
@@ -43,7 +45,25 @@ class CombatHandler(
     ) {
         when (val outcome = combat.consider(sessionId, cmd.target)) {
             is ConsiderOutcome.Error -> {
-                outbound.send(OutboundEvent.SendError(sessionId, outcome.message))
+                // Pledged players sizing up a non-combatant NPC get the Akathavae
+                // read (observation always succeeds) instead of the combat error.
+                val me = players.get(sessionId)
+                val mob =
+                    if (me?.isAkathavae == true && akathavaeSystem != null) {
+                        combat.findMobInRoom(me.roomId, cmd.target.trim())
+                    } else {
+                        null
+                    }
+                if (mob != null && !mob.role.isCombatant && !mob.isPet) {
+                    outbound.send(
+                        OutboundEvent.SendInfo(
+                            sessionId,
+                            "${mob.name} poses no threat — observing them for your Arcanum always succeeds.",
+                        ),
+                    )
+                } else {
+                    outbound.send(OutboundEvent.SendError(sessionId, outcome.message))
+                }
             }
             is ConsiderOutcome.Ok -> {
                 val r = outcome.result
@@ -60,6 +80,21 @@ class CombatHandler(
                             "(your ~${r.playerAvgDamage} dmg vs their ~${r.mobAvgDamage} dmg).",
                     ),
                 )
+                // Pledged players don't fight — show their real gamble: the
+                // illumination success roll for their current effective stats.
+                val me = players.get(sessionId)
+                if (me?.isAkathavae == true && akathavaeSystem != null) {
+                    val mob = mobs.get(MobId(r.mobId))
+                    if (mob != null) {
+                        val pct = akathavaeSystem.illuminationOddsFor(me, mob)
+                        outbound.send(
+                            OutboundEvent.SendText(
+                                sessionId,
+                                "  Your steady hand gives you a $pct% chance to illuminate ${r.mobName}.",
+                            ),
+                        )
+                    }
+                }
                 gmcpEmitter?.sendCombatConsider(sessionId, r)
             }
         }

--- a/src/test/kotlin/dev/ambon/engine/AkathavaeIlluminateTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/AkathavaeIlluminateTest.kt
@@ -8,6 +8,7 @@ import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.items.Item
 import dev.ambon.domain.items.ItemInstance
+import dev.ambon.domain.items.ItemSlot
 import dev.ambon.domain.mob.MobRole
 import dev.ambon.domain.mob.MobState
 import dev.ambon.domain.world.Direction
@@ -91,6 +92,7 @@ class AkathavaeIlluminateTest {
         xpReward: Long = 100L,
         drops: List<MobDrop> = emptyList(),
         role: MobRole = MobRole.COMBAT,
+        level: Int = 1,
     ) = MobState(
         id = MobId("test:$id"),
         name = "a wandering wisp",
@@ -101,6 +103,7 @@ class AkathavaeIlluminateTest {
         templateKey = templateKey,
         drops = drops,
         role = role,
+        level = level,
     )
 
     private suspend fun loginAkathavae(s: Setup, sid: SessionId, name: String): PlayerState {
@@ -126,6 +129,53 @@ class AkathavaeIlluminateTest {
         assertEquals(61, s.system.illuminationSuccessPct(10, 20, playerLevel = 5, mobLevel = 8))
         // Clamped to the configured floor.
         assertEquals(5, s.system.illuminationSuccessPct(10, 10, playerLevel = 1, mobLevel = 50))
+    }
+
+    @Test
+    fun `illuminationOddsFor resolves the player's current effective stats`() = runTest {
+        val s = setup()
+        val sid = SessionId(1L)
+        val me = loginAkathavae(s, sid, "Thalen")
+        me.level = 5
+
+        // Base stats, equal level: the configured base chance.
+        assertEquals(70, s.system.illuminationOddsFor(me, wisp(level = 5)))
+
+        // +2% per success-stat (INT) point above base.
+        me.stats = me.stats.with("INT", 20)
+        assertEquals(90, s.system.illuminationOddsFor(me, wisp(level = 5)))
+
+        // Subject above the player: the level-gap penalty applies (70 - 3*8).
+        me.stats = me.stats.with("INT", 10)
+        assertEquals(46, s.system.illuminationOddsFor(me, wisp(level = 8)))
+
+        // The gap-relief stat (STR) softens the penalty (70 - 3*(8 - 10*0.5)).
+        me.stats = me.stats.with("STR", 20)
+        assertEquals(61, s.system.illuminationOddsFor(me, wisp(level = 8)))
+    }
+
+    @Test
+    fun `illuminationOddsFor includes equipment bonuses`() = runTest {
+        val s = setup()
+        val sid = SessionId(1L)
+        val me = loginAkathavae(s, sid, "Thalen")
+        me.level = 5
+        s.fixture.items.setEquippedItem(
+            sid,
+            ItemSlot.HEAD,
+            ItemInstance(
+                id = ItemId("test:circlet"),
+                item = Item(
+                    keyword = "circlet",
+                    displayName = "a scholar's circlet",
+                    slot = ItemSlot.HEAD,
+                    stats = StatMap.of("INT" to 5),
+                ),
+            ),
+        )
+
+        // Effective INT 15 -> 70 + 5*2 = 80.
+        assertEquals(80, s.system.illuminationOddsFor(me, wisp(level = 5)))
     }
 
     // ── Illumination outcomes ────────────────────────────────────────────

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -30,6 +30,7 @@ import dev.ambon.test.drainAll
 import dev.ambon.test.loginOrFail
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -47,7 +48,10 @@ class GmcpEmitterTest {
 
     private val defaultSlotRegistry = EquipmentSlotRegistry(EquipmentConfig())
 
-    private fun emitter(vararg supported: String): GmcpEmitter {
+    private fun emitter(
+        vararg supported: String,
+        illuminationOdds: (SessionId, String) -> Int? = { _, _ -> null },
+    ): GmcpEmitter {
         val packages = supported.toSet()
         return GmcpEmitter(
             outbound = outbound,
@@ -56,6 +60,7 @@ class GmcpEmitterTest {
             },
             progression = progression,
             equipmentSlotRegistry = defaultSlotRegistry,
+            illuminationOdds = illuminationOdds,
         )
     }
 
@@ -1668,6 +1673,19 @@ class GmcpEmitterTest {
 
     // ── Room.MobInfo ──
 
+    private fun mobInfoEntry(combatant: Boolean) = MobInfoEntry(
+        id = "forest:goblin_1",
+        level = 3,
+        tier = "standard",
+        questGiver = true,
+        questAvailable = true,
+        questComplete = false,
+        shopKeeper = false,
+        dialogue = true,
+        aggressive = false,
+        combatant = combatant,
+    )
+
     @Test
     fun `sendRoomMobInfo emits correct JSON`() =
         runTest {
@@ -1697,6 +1715,57 @@ class GmcpEmitterTest {
             assertTrue(events[0].jsonData.contains("\"questGiver\":true"))
             assertTrue(events[0].jsonData.contains("\"shopKeeper\":false"))
             assertTrue(events[0].jsonData.contains("\"dialogue\":true"))
+        }
+
+    @Test
+    fun `sendRoomMobInfo omits illuminationPct without an odds provider`() =
+        runTest {
+            val e = emitter("Room.MobInfo")
+            e.sendRoomMobInfo(sid, listOf(mobInfoEntry(combatant = true)))
+            val events = drainGmcp()
+            assertEquals(1, events.size)
+            assertFalse(events[0].jsonData.contains("illuminationPct"), "got=${events[0].jsonData}")
+        }
+
+    @Test
+    fun `sendRoomMobInfo includes per-viewer illumination odds for combatants`() =
+        runTest {
+            val e = emitter("Room.MobInfo", illuminationOdds = { _, mobId -> if (mobId == "forest:goblin_1") 72 else null })
+            e.sendRoomMobInfo(sid, listOf(mobInfoEntry(combatant = true)))
+            val events = drainGmcp()
+            assertEquals(1, events.size)
+            assertTrue(events[0].jsonData.contains("\"illuminationPct\":72"), "got=${events[0].jsonData}")
+        }
+
+    @Test
+    fun `sendRoomMobInfo never adds illumination odds to non-combatants`() =
+        runTest {
+            val e = emitter("Room.MobInfo", illuminationOdds = { _, _ -> 72 })
+            e.sendRoomMobInfo(sid, listOf(mobInfoEntry(combatant = false)))
+            val events = drainGmcp()
+            assertEquals(1, events.size)
+            assertFalse(events[0].jsonData.contains("illuminationPct"), "got=${events[0].jsonData}")
+        }
+
+    @Test
+    fun `broadcastRoomMobInfo builds per-viewer payloads for pledged players`() =
+        runTest {
+            val e = emitter("Room.MobInfo", illuminationOdds = { viewer, _ -> if (viewer == SessionId(1L)) 72 else null })
+            val roomId = RoomId("test:room1")
+            val players = buildTestPlayerRegistry(roomId)
+            players.loginOrFail(SessionId(1L), "Pledged")
+            players.loginOrFail(SessionId(2L), "Fighter")
+            players.get(SessionId(1L))!!.isAkathavae = true
+            outbound.drainAll() // discard login-side events
+
+            e.broadcastRoomMobInfo(roomId, listOf(mobInfoEntry(combatant = true)), players)
+
+            val events = drainGmcp().filter { it.gmcpPackage == "Room.MobInfo" }
+            assertEquals(2, events.size, "Expected one GMCP event per room occupant")
+            val pledged = events.single { it.sessionId == SessionId(1L) }
+            val fighter = events.single { it.sessionId == SessionId(2L) }
+            assertTrue(pledged.jsonData.contains("\"illuminationPct\":72"), "got=${pledged.jsonData}")
+            assertFalse(fighter.jsonData.contains("illuminationPct"), "got=${fighter.jsonData}")
         }
 
     @Test

--- a/src/test/kotlin/dev/ambon/engine/commands/AkathavaeCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/AkathavaeCommandTest.kt
@@ -9,6 +9,7 @@ import dev.ambon.domain.ids.SessionId
 import dev.ambon.domain.items.Item
 import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.items.ItemSlot
+import dev.ambon.domain.mob.MobRole
 import dev.ambon.domain.mob.MobState
 import dev.ambon.domain.world.Direction
 import dev.ambon.domain.world.Room
@@ -283,6 +284,73 @@ class AkathavaeCommandTest {
             val errors = h.drain().filterIsInstance<OutboundEvent.SendError>().map { it.text }
             assertTrue(errors.any { it.contains("pledge stays your hand") }, "got=$errors")
             assertFalse(h.combat.isInCombat(sid), "Pledged player must not enter combat")
+        }
+
+        @Test
+        fun `consider shows illumination odds while pledged`() = runTest {
+            val h = harness()
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Thalen")
+            h.router.handle(sid, Command.Pledge)
+            h.mobs.upsert(MobState(id = MobId("test:rat"), name = "rat", roomId = shrineRoom))
+            h.drain()
+
+            h.router.handle(sid, Command.Consider("rat"))
+
+            val texts = h.drain().filterIsInstance<OutboundEvent.SendText>().map { it.text }
+            // Base stats, equal level: the configured base chance of 70%.
+            assertTrue(texts.any { it.contains("70% chance to illuminate") }, "got=$texts")
+        }
+
+        @Test
+        fun `consider output is unchanged for the unpledged`() = runTest {
+            val h = harness()
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Thalen")
+            h.mobs.upsert(MobState(id = MobId("test:rat"), name = "rat", roomId = shrineRoom))
+            h.drain()
+
+            h.router.handle(sid, Command.Consider("rat"))
+
+            val events = h.drain()
+            val texts = events.filterIsInstance<OutboundEvent.SendText>().map { it.text }
+            assertTrue(texts.any { it.contains("Estimated win chance") }, "got=$texts")
+            assertFalse(texts.any { it.contains("illuminate") }, "unpledged consider must not mention illumination: got=$texts")
+        }
+
+        @Test
+        fun `consider on a non-combatant tells the pledged that observation always succeeds`() = runTest {
+            val h = harness()
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Thalen")
+            h.router.handle(sid, Command.Pledge)
+            h.mobs.upsert(
+                MobState(id = MobId("test:elder"), name = "the village elder", roomId = shrineRoom, role = MobRole.DIALOG),
+            )
+            h.drain()
+
+            h.router.handle(sid, Command.Consider("elder"))
+
+            val events = h.drain()
+            val infos = events.filterIsInstance<OutboundEvent.SendInfo>().map { it.text }
+            assertTrue(infos.any { it.contains("observing them for your Arcanum always succeeds") }, "got=$infos")
+            assertTrue(events.filterIsInstance<OutboundEvent.SendError>().isEmpty(), "pledged consider on an NPC is not an error")
+        }
+
+        @Test
+        fun `consider on a non-combatant still errors for the unpledged`() = runTest {
+            val h = harness()
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Thalen")
+            h.mobs.upsert(
+                MobState(id = MobId("test:elder"), name = "the village elder", roomId = shrineRoom, role = MobRole.DIALOG),
+            )
+            h.drain()
+
+            h.router.handle(sid, Command.Consider("elder"))
+
+            val errors = h.drain().filterIsInstance<OutboundEvent.SendError>().map { it.text }
+            assertTrue(errors.any { it.contains("isn't a threat") }, "got=$errors")
         }
 
         @Test

--- a/web-v3/src/components/panels/MonsterManualPanel.tsx
+++ b/web-v3/src/components/panels/MonsterManualPanel.tsx
@@ -176,7 +176,11 @@ export function MonsterManualPanel({
   if (info?.shopKeeper) actions.push({ key: "shop", label: "Shop", glyph: "❖", assetKey: "action_shop", variant: "primary", run: onShop });
   // The Akathavae pledge replaces violence with illumination — same slot, same
   // creatures, but the action records the subject into the Arcanum instead.
-  if (monster.canAttack && akathavaePledged) actions.push({ key: "illuminate", label: "Illuminate", glyph: "✒", assetKey: "action_illuminate", variant: "primary", run: () => { onCommand(`illuminate ${name}`); close(); } });
+  // Surface the stat-driven success odds (Room.MobInfo `illuminationPct`) right
+  // on the button — failure turns the creature hostile, so pledged players
+  // shouldn't gamble blind.
+  const illumPct = info?.illuminationPct;
+  if (monster.canAttack && akathavaePledged) actions.push({ key: "illuminate", label: illumPct != null ? `Illuminate · ${illumPct}%` : "Illuminate", glyph: "✒", assetKey: "action_illuminate", variant: "primary", run: () => { onCommand(`illuminate ${name}`); close(); } });
   else if (monster.canAttack) actions.push({ key: "attack", label: "Attack", glyph: "⚔", assetKey: "action_attack", variant: "primary", run: () => { onCommand(`kill ${name}`); close(); } });
   if (monster.video) actions.push({ key: "video", label: "Cinematic", glyph: "▶", assetKey: "action_cinematic", variant: "ghost", run: () => onVideo(monster.video!) });
   if (monster.isStaff) actions.push({ key: "possess", label: "Possess", glyph: "✦", assetKey: "action_possess", variant: "ghost", run: () => { onCommand(`possess ${name}`); close(); } });

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -1458,6 +1458,7 @@ export function applyGmcpPackage(
             dialogue: entry.dialogue === true,
             aggressive: entry.aggressive === true,
             combatant: entry.combatant !== false,
+            illuminationPct: typeof entry.illuminationPct === "number" ? entry.illuminationPct : null,
           })),
       );
       break;

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -981,6 +981,8 @@ export interface MobInfo {
   dialogue: boolean;
   aggressive: boolean;
   combatant: boolean;
+  /** Illumination success odds for the viewer; null unless pledged Akathavae + combatant. */
+  illuminationPct: number | null;
 }
 
 export interface LoginRaceOption {


### PR DESCRIPTION
## Summary

Pledged Akathavae players previously gambled blind: the illumination success percentage was computed server-side but never shown anywhere, despite failure having a real cost (the subject turns hostile and the pledged cannot fight back).

- **Server**: new public `AkathavaeSystem.illuminationOddsFor(me, mob)` resolves the player's current effective stats (equipment + status effects) and delegates to the internal `illuminationSuccessPct` math (kept `internal`).
- **`consider`**: pledged players now see `Your steady hand gives you a NN% chance to illuminate <mob>.` for combatants, and "observing them for your Arcanum always succeeds" for non-combatant NPCs. Non-pledged output is byte-for-byte unchanged — telnet players get full parity.
- **GMCP**: `Room.MobInfo` gains a nullable, null-omitted `illuminationPct` field, populated only when the viewing player is pledged and the mob is a combatant. Broadcast paths build per-viewer payloads for pledged recipients and keep the single shared serialization for everyone else. No transport change needed (`Room.MobInfo 1` already auto-opted-in).
- **Web client**: `MobInfo.illuminationPct` typed + mapped; the Monster Manual's Illuminate button shows the chance (`Illuminate · 72%`).

Closes #1388
Part of #1400

## Testing
- Unit tests for `illuminationOddsFor` (stat/level/equipment combinations) in `AkathavaeIlluminateTest`
- Router tests for pledged vs non-pledged `consider` output
- `GmcpEmitterTest` coverage for the new payload field
- `./gradlew ktlintCheck test integrationTest` + `bun run lint`