### PR TITLE
feat(akathavae): illumination grants items needed by active collect objectives

### DIFF
--- a/docs/WORLD_YAML_SPEC.md
+++ b/docs/WORLD_YAML_SPEC.md
@@ -280,6 +280,7 @@ Map pin notes (`mapX`/`mapY`/`mapZ`):
 - When `true`, enables the `pledge` and `renounce` commands in this room.
 - Pledging is free and converts the player into the AKATHAVAE class (their former class is stashed and restored on renounce): combat and multiclassing are forbidden, vitals rescale to the Akathavae curve, and the player levels by illuminating the world (recording rooms, creatures, and items in their Arcanum journal).
 - Renouncing at a shrine costs gold (`ambonMUD.engine.akathavae.renounceCostGold`, default 2500), restores the former class, and starts a re-pledge cooldown (`repledgeCooldownMs`, default 24h).
+- **Content guideline — quest collect items:** every item targeted by a quest `collect` objective should be obtainable through at least one non-kill channel: a room/ground spawn, a shop, a gathering node, or a mob drop. Mob drops are reachable on the pacifist path because illuminating a creature grants a drop the player still needs for an active collect objective (once per living instance, capped at the remaining count). An item that only exists as loot from a mob no Akathavae can illuminate would make the quest impossible for the pledged.
 
 `station` notes:
 - Designates the room as a crafting station of the given type.

--- a/src/main/kotlin/dev/ambon/engine/AkathavaeSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/AkathavaeSystem.kt
@@ -56,6 +56,14 @@ class AkathavaeSystem(
     private val onLevelUp: (suspend (SessionId, LevelUpResult) -> Unit)? = null,
     private val gmcpEmitter: GmcpEmitter? = null,
 ) {
+    /**
+     * Late-bound quest bridge (wired by GameEngine after both systems exist).
+     * Illumination grants a recorded creature's drops when — and only when — an
+     * active collect objective still needs them, so drop-only quest items stay
+     * reachable on the pacifist path (#1392).
+     */
+    var quests: QuestSystem? = null
+
     /** Per-session, per-subject retry locks after a failed illumination. Runtime-only. */
     private val failCooldowns = mutableMapOf<SessionId, MutableMap<String, Long>>()
 
@@ -216,9 +224,45 @@ class AkathavaeSystem(
         // once per living instance, since illumination no longer consumes it.
         if (creditedIlluminations.getOrPut(sessionId) { mutableSetOf() }.add(mob.id.value)) {
             combat.creditIlluminationKill(sessionId, mob)
+            grantNeededQuestItems(sessionId, mob)
         }
         markVitalsDirty?.invoke(sessionId)
         emitStatus(sessionId)
+    }
+
+    /**
+     * The collect-objective half of the illumination bridge (#1392): kill
+     * credit covers kill objectives, but the pledged never loot, so a collect
+     * item that only drops from mobs would otherwise be unobtainable. For each
+     * of the subject's drops still needed by an active, unfinished collect
+     * objective, one real copy is granted into the inventory — deterministic
+     * (no drop-chance roll: if the quest needs it and the mob can drop it, the
+     * rubbing succeeds) and farm-proof, because this path is reachable only
+     * through the once-per-living-instance credit gate and re-checks the
+     * remaining need per drop entry, so no sellable surplus can accumulate.
+     * Granting through the inventory keeps the downstream flow intact:
+     * [QuestSystem.onItemCollected] advances the objective and turn-in
+     * consumption later finds the item it expects.
+     */
+    private suspend fun grantNeededQuestItems(
+        sessionId: SessionId,
+        mob: MobState,
+    ) {
+        val quests = quests ?: return
+        for (drop in mob.drops) {
+            if (quests.neededForCollectObjectives(sessionId, drop.itemId) <= 0) continue
+            val instance = items.createFromTemplate(drop.itemId) ?: continue
+            items.addToInventory(sessionId, instance)
+            outbound.send(
+                OutboundEvent.SendText(
+                    sessionId,
+                    "Sketching its likeness, you take a careful rubbing of ${instance.item.displayName} for your quest.",
+                ),
+            )
+            gmcpEmitter?.sendCharItemsAdd(sessionId, instance)
+            quests.onItemCollected(sessionId, instance)
+            metrics.onGameEvent("akathavae", "quest_item_rubbing")
+        }
     }
 
     private suspend fun resolveFailure(

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -1256,6 +1256,9 @@ class GameEngine(
             gmcpEmitter.sendCharItemsAdd(sid, item)
             questSystem.onItemCollected(sid, item)
         }
+        // Illumination bridge: a recorded creature's drops can satisfy active
+        // collect objectives for the pledged, who never loot (#1392).
+        akathavaeSystem.quests = questSystem
         guildSystem?.onGuildCreated = { sid ->
             metrics.onGameEvent("guild", "created")
             achievementSystem.onGuildCreated(sid)

--- a/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/QuestSystem.kt
@@ -17,6 +17,7 @@ import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.items.ItemRegistry
 import dev.ambon.engine.quest.CompletionHandlerRegistry
 import dev.ambon.engine.quest.ObjectiveHandlerRegistry
+import dev.ambon.engine.quest.matchesCollectTarget
 import java.time.Clock
 
 class QuestSystem(
@@ -339,10 +340,7 @@ class QuestSystem(
         // Count any inventory items whose id matches the objective target, using the
         // same loose-suffix semantics the collect handler applies at pickup time.
         val currentCount =
-            items.inventory(sessionId).count { inv ->
-                val itemId = inv.id.value
-                itemId == targetIdRaw || itemId.endsWith(":${targetIdRaw.substringAfterLast(':')}")
-            }
+            items.inventory(sessionId).count { inv -> matchesCollectTarget(inv.id.value, targetIdRaw) }
         if (currentCount <= 0) return null
         return handler.advance(objDef, initial, targetIdRaw, currentCount)
     }
@@ -447,6 +445,33 @@ class QuestSystem(
             val currentCount = items.inventory(sessionId).count { inv -> inv.id.value == itemId }
             handler.advance(objDef, prog, itemId, currentCount)
         }
+    }
+
+    /**
+     * Remaining count across every active, unfinished COLLECT objective that
+     * [itemId] would satisfy, matched with the same exact + loose-suffix
+     * semantics as the collect handler ([matchesCollectTarget]). Returns 0
+     * when nothing needs the item. Used by the Akathavae illumination bridge
+     * to decide whether a recorded creature's drop should be granted to a
+     * pledged player, who can never loot it (#1392).
+     */
+    fun neededForCollectObjectives(
+        sessionId: SessionId,
+        itemId: ItemId,
+    ): Int {
+        val ps = players.get(sessionId) ?: return 0
+        var needed = 0
+        for ((questId, state) in ps.activeQuests) {
+            val quest = registry.get(questId) ?: continue
+            for ((index, objDef) in quest.objectives.withIndex()) {
+                if (objectiveHandlers.collectHandler(objDef.type) == null) continue
+                val prog = state.objectives.getOrNull(index) ?: continue
+                if (prog.isComplete) continue
+                if (!matchesCollectTarget(itemId.value, objDef.targetId)) continue
+                needed += prog.required - prog.current
+            }
+        }
+        return needed
     }
 
     /**
@@ -645,12 +670,11 @@ class QuestSystem(
         var removedAny = false
         for (obj in quest.objectives) {
             if (objectiveHandlers.collectHandler(obj.type) == null) continue
-            val localSuffix = ":${obj.targetId.substringAfterLast(':')}"
             var removed = 0
             var removedName: String? = null
             while (removed < obj.count) {
                 val match = items.inventory(sessionId).firstOrNull { inv ->
-                    inv.id.value == obj.targetId || inv.id.value.endsWith(localSuffix)
+                    matchesCollectTarget(inv.id.value, obj.targetId)
                 } ?: break
                 if (items.removeFromInventoryById(sessionId, match.id) == null) break
                 removedName = match.item.displayName

--- a/src/main/kotlin/dev/ambon/engine/quest/BuiltInHandlers.kt
+++ b/src/main/kotlin/dev/ambon/engine/quest/BuiltInHandlers.kt
@@ -17,6 +17,19 @@ class KillObjectiveHandlerImpl : KillObjectiveHandler {
     }
 }
 
+/**
+ * Collect-objective item matching: an item satisfies a collect target when its
+ * id equals the target exactly, or ends with the target's `:<localId>` suffix
+ * (loose-suffix matching, so any zone's copy of the same local item counts).
+ * Shared by the built-in collect handler and every QuestSystem path that must
+ * mirror its semantics (acceptance seeding, turn-in consumption, and the
+ * Akathavae illumination bridge).
+ */
+fun matchesCollectTarget(
+    itemId: String,
+    targetId: String,
+): Boolean = itemId == targetId || itemId.endsWith(":${targetId.substringAfterLast(':')}")
+
 /** Built-in collect objective handler: checks inventory count against the objective target. */
 class CollectObjectiveHandlerImpl : CollectObjectiveHandler {
     override val typeId: String = "collect"
@@ -27,8 +40,7 @@ class CollectObjectiveHandlerImpl : CollectObjectiveHandler {
         itemId: String,
         currentInventoryCount: Int,
     ): ObjectiveProgress? {
-        val targetIdRaw = objDef.targetId
-        if (itemId != targetIdRaw && !itemId.endsWith(":${targetIdRaw.substringAfterLast(':')}")) return null
+        if (!matchesCollectTarget(itemId, objDef.targetId)) return null
         val newCurrent = currentInventoryCount.coerceAtMost(progress.required)
         if (newCurrent <= progress.current) return null
         return progress.copy(current = newCurrent)

--- a/src/test/kotlin/dev/ambon/engine/AkathavaeIlluminateTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/AkathavaeIlluminateTest.kt
@@ -10,6 +10,9 @@ import dev.ambon.domain.items.Item
 import dev.ambon.domain.items.ItemInstance
 import dev.ambon.domain.mob.MobRole
 import dev.ambon.domain.mob.MobState
+import dev.ambon.domain.quest.QuestDef
+import dev.ambon.domain.quest.QuestObjectiveDef
+import dev.ambon.domain.quest.QuestRewards
 import dev.ambon.domain.world.Direction
 import dev.ambon.domain.world.ItemSpawn
 import dev.ambon.domain.world.MobDrop
@@ -25,6 +28,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.util.Random
@@ -283,6 +287,145 @@ class AkathavaeIlluminateTest {
         val errors = s.fixture.outbound.drainAll().filterIsInstance<OutboundEvent.SendError>().map { it.text }
         assertTrue(errors.any { it.contains("pledge") }, "got=$errors")
         assertNotNull(s.fixture.mobs.get(MobId("test:w1")))
+    }
+
+    // ── Quest collect bridge (#1392) ─────────────────────────────────────
+
+    private val dustId = ItemId("test:dust")
+
+    private fun registerDustTemplate(s: Setup) {
+        s.fixture.items.loadSpawns(
+            listOf(ItemSpawn(instance = ItemInstance(dustId, Item(keyword = "dust", displayName = "glittering dust")))),
+        )
+    }
+
+    private fun collectDustQuest(count: Int) = QuestDef(
+        id = "test:gather_dust",
+        name = "Gather Dust",
+        description = "Bring back glittering dust.",
+        giverMobId = "test:quest_giver",
+        objectives = listOf(
+            QuestObjectiveDef(type = "collect", targetId = "test:dust", count = count, description = "Collect $count dust"),
+        ),
+        rewards = QuestRewards(),
+        completionType = "npc_turn_in",
+    )
+
+    /** Builds a QuestSystem over the fixture's components and wires it as the illumination bridge. */
+    private fun attachQuests(s: Setup, quest: QuestDef): QuestSystem {
+        val registry = QuestRegistry()
+        registry.register(quest)
+        val quests = QuestSystem(
+            registry = registry,
+            players = s.fixture.players,
+            items = s.fixture.items,
+            outbound = s.fixture.outbound,
+            clock = s.clock,
+        )
+        s.system.quests = quests
+        return quests
+    }
+
+    @Test
+    fun `illumination grants a needed collect item and turn-in consumes it`() = runTest {
+        val s = setup(rng = ScriptedRandom(0, 0))
+        val sid = SessionId(1L)
+        val me = loginAkathavae(s, sid, "Thalen")
+        registerDustTemplate(s)
+        val quests = attachQuests(s, collectDustQuest(count = 2))
+        assertNull(quests.acceptQuest(sid, "test:gather_dust"))
+        s.fixture.outbound.drainAll()
+
+        // Deterministic grant: the drop's 0.25 chance is never rolled.
+        s.fixture.mobs.upsert(wisp(id = "w1", drops = listOf(MobDrop(dustId, 0.25))))
+        s.system.illuminate(sid, "wisp")
+
+        assertEquals(1, s.fixture.items.inventory(sid).size, "one rubbing per living instance")
+        assertEquals(1, me.activeQuests["test:gather_dust"]!!.objectives[0].current)
+        val texts = s.fixture.outbound.drainAll().filterIsInstance<OutboundEvent.SendText>().map { it.text }
+        assertTrue(texts.any { it.contains("careful rubbing") }, "got=$texts")
+
+        // A second living instance completes the objective.
+        s.fixture.mobs.remove(MobId("test:w1"))
+        s.fixture.mobs.upsert(wisp(id = "w2", drops = listOf(MobDrop(dustId, 0.25))))
+        s.system.illuminate(sid, "wisp")
+        assertEquals(2, s.fixture.items.inventory(sid).size)
+        assertTrue(me.activeQuests["test:gather_dust"]!!.objectives[0].isComplete)
+
+        // Turn-in finds and consumes the granted items, exactly like looted ones.
+        assertNull(quests.turnInQuest(sid, "Gather Dust", listOf("test:quest_giver")))
+        assertTrue(me.completedQuestIds.contains("test:gather_dust"))
+        assertTrue(s.fixture.items.inventory(sid).isEmpty(), "turn-in hands over the rubbings")
+    }
+
+    @Test
+    fun `illumination grants nothing without an active collect objective`() = runTest {
+        val s = setup(rng = ScriptedRandom(0))
+        val sid = SessionId(1L)
+        val me = loginAkathavae(s, sid, "Thalen")
+        registerDustTemplate(s)
+        attachQuests(s, collectDustQuest(count = 2)) // quest exists but is never accepted
+        s.fixture.mobs.upsert(wisp(drops = listOf(MobDrop(dustId, 1.0))))
+
+        s.system.illuminate(sid, "wisp")
+
+        assertTrue(s.fixture.items.inventory(sid).isEmpty(), "no quest, no rubbing")
+        assertTrue(me.arcanum.items.containsKey("test:dust"), "journal cataloguing is unchanged")
+    }
+
+    @Test
+    fun `illumination grants nothing once the objective is complete`() = runTest {
+        val s = setup(rng = ScriptedRandom(0, 0))
+        val sid = SessionId(1L)
+        val me = loginAkathavae(s, sid, "Thalen")
+        registerDustTemplate(s)
+        val quests = attachQuests(s, collectDustQuest(count = 1))
+        assertNull(quests.acceptQuest(sid, "test:gather_dust"))
+
+        s.fixture.mobs.upsert(wisp(id = "w1", drops = listOf(MobDrop(dustId, 1.0))))
+        s.system.illuminate(sid, "wisp")
+        assertTrue(me.activeQuests["test:gather_dust"]!!.objectives[0].isComplete)
+
+        // Objective satisfied — a fresh instance yields no sellable surplus.
+        s.fixture.mobs.remove(MobId("test:w1"))
+        s.fixture.mobs.upsert(wisp(id = "w2", drops = listOf(MobDrop(dustId, 1.0))))
+        s.system.illuminate(sid, "wisp")
+
+        assertEquals(1, s.fixture.items.inventory(sid).size, "grants are capped at the remaining count")
+    }
+
+    @Test
+    fun `re-illuminating the same living instance grants no second item`() = runTest {
+        val s = setup(rng = ScriptedRandom(0, 0))
+        val sid = SessionId(1L)
+        val me = loginAkathavae(s, sid, "Thalen")
+        registerDustTemplate(s)
+        val quests = attachQuests(s, collectDustQuest(count = 2))
+        assertNull(quests.acceptQuest(sid, "test:gather_dust"))
+
+        s.fixture.mobs.upsert(wisp(id = "w1", drops = listOf(MobDrop(dustId, 1.0))))
+        s.system.illuminate(sid, "wisp")
+        s.system.illuminate(sid, "wisp") // same living instance, already credited
+
+        assertEquals(1, s.fixture.items.inventory(sid).size, "a living creature yields quest items at most once")
+        assertEquals(1, me.activeQuests["test:gather_dust"]!!.objectives[0].current)
+    }
+
+    @Test
+    fun `duplicate drop entries cannot overshoot the remaining count`() = runTest {
+        val s = setup(rng = ScriptedRandom(0))
+        val sid = SessionId(1L)
+        val me = loginAkathavae(s, sid, "Thalen")
+        registerDustTemplate(s)
+        val quests = attachQuests(s, collectDustQuest(count = 1))
+        assertNull(quests.acceptQuest(sid, "test:gather_dust"))
+
+        // The mob lists the same drop twice, but the quest only needs one.
+        s.fixture.mobs.upsert(wisp(drops = listOf(MobDrop(dustId, 1.0), MobDrop(dustId, 1.0))))
+        s.system.illuminate(sid, "wisp")
+
+        assertEquals(1, s.fixture.items.inventory(sid).size, "the grant re-checks the remaining need per drop entry")
+        assertTrue(me.activeQuests["test:gather_dust"]!!.objectives[0].isComplete)
     }
 
     // ── Passive discovery ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Pledged (Akathavae) players never kill, so they never loot mob drops — any quest **collect** objective whose target item only drops from mobs was impossible on the pacifist path. The existing illumination bridge only covered **kill** objectives (`creditIlluminationKill`).

This PR extends the bridge to collect objectives:

- **`AkathavaeSystem`**: inside the existing once-per-living-instance credit gate, after kill credit, each of the subject's drops is checked against the player's active, unfinished collect objectives. If still needed, one real copy is granted into the inventory with a flavor line (*"Sketching its likeness, you take a careful rubbing of … for your quest."*), mirrored to the client via `Char.Items.Add`, and fed through `QuestSystem.onItemCollected` so the objective advances and later turn-in consumption (`consumeCollectedItems`) finds the item it expects. Wired late-bound from `GameEngine` (`akathavaeSystem.quests = questSystem`).
- **`QuestSystem.neededForCollectObjectives(sessionId, itemId)`**: new query returning the remaining count across all active, unfinished collect objectives the item would satisfy.
- **Shared matching**: the collect matching semantics (exact template id + loose `:<localId>` suffix) are extracted into `matchesCollectTarget()` in `engine/quest/BuiltInHandlers.kt` and reused by the built-in collect handler, acceptance seeding, turn-in consumption, and the new query — no duplicated logic.
- **Docs**: content guideline added to `docs/WORLD_YAML_SPEC.md` under the `akathavaeShrine` notes: collect items should be obtainable through at least one non-kill channel.

### Design choice (as flagged in the issue)

The grant is **deterministic** — no drop-chance roll. If the quest needs the item and the mob can drop it, the rubbing succeeds. Kinder than RNG, and farm-proof: the grant is only reachable through the once-per-living-instance gate and re-checks the remaining need per drop entry, so no sellable surplus can accumulate.

## Tests

Extended `AkathavaeIlluminateTest`:
- accept collect quest → illuminate dropper twice (two living instances) → objective advances to complete → turn-in consumes the granted items
- no active quest → no item (journal cataloguing unchanged)
- objective already complete → fresh instance grants nothing
- re-illuminating the same living instance → no second item
- duplicate drop entries on one mob cannot overshoot the remaining count

`./gradlew ktlintCheck test integrationTest` green.

Closes #1392
Part of #1400