### PR TITLE
feat(leaderboard): add Master Chronicler leaderboard category

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/LeaderboardSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/LeaderboardSystem.kt
@@ -1,8 +1,10 @@
 package dev.ambon.engine
 
 import dev.ambon.config.LeaderboardConfig
+import dev.ambon.domain.arcanum.ArcanumJournal
 import dev.ambon.persistence.PlayerRecord
 import dev.ambon.persistence.PlayerRepository
+import dev.ambon.persistence.jsonMapper
 import io.github.oshai.kotlinlogging.KotlinLogging
 
 private val log = KotlinLogging.logger {}
@@ -31,6 +33,11 @@ class LeaderboardSystem(
         KILLS("kills", "Monster Slayer", "kills"),
         PRESTIGE("prestige", "Most Prestigious", "prestige"),
         PVP_KILLS("pvp", "PvP Champion", "pvp kills"),
+        CHRONICLER("arcanum", "Master Chronicler", "pages"),
+
+        // TODO(#1391): add WORLD_FIRSTS("firsts", "Pioneer", "firsts") once the persisted
+        //  `worldFirstsCount` field (PlayerRecord/PlayerState, column `world_firsts_count`)
+        //  from the Akathavae achievement-criteria issue lands.
         ;
 
         companion object {
@@ -76,6 +83,20 @@ class LeaderboardSystem(
                 )
             }
 
+            // Chronicler scores are computed in a side map: the Arcanum journal is persisted
+            // as a JSON blob, so parse it per record instead of copying a journal back onto
+            // the record overlay. Online players use their live in-memory journal instead.
+            val chroniclerScores = mutableMapOf<Long, Long>()
+            for (record in allRecords.values) {
+                chroniclerScores[record.id.value] = arcanumPageCount(record.arcanumData)
+            }
+            for (live in playerRegistry.allPlayers()) {
+                val id = live.playerId?.value ?: continue
+                if (id !in allRecords) continue
+                chroniclerScores[id] =
+                    (live.arcanum.mobs.size + live.arcanum.items.size + live.arcanum.rooms.size).toLong()
+            }
+
             val records = allRecords.values.toList()
             val topN = config.topN
 
@@ -87,6 +108,7 @@ class LeaderboardSystem(
             newCache[Category.KILLS.key] = rank(records, topN) { it.mobsKilledTotal }
             newCache[Category.PRESTIGE.key] = rank(records, topN) { it.prestigeLevel.toLong() }
             newCache[Category.PVP_KILLS.key] = rank(records, topN) { it.pvpKills.toLong() }
+            newCache[Category.CHRONICLER.key] = rank(records, topN) { chroniclerScores[it.id.value] ?: 0L }
             cache = newCache
 
             log.debug { "Leaderboard refreshed — ${records.size} records, topN=$topN" }
@@ -108,4 +130,13 @@ class LeaderboardSystem(
 
     private fun maxCraftLevel(record: PlayerRecord): Long =
         record.craftingSkills.values.maxOfOrNull { it.level.toLong() } ?: 0L
+
+    /** Total distinct Arcanum pages in a persisted journal blob. Blank/malformed blobs score 0. */
+    private fun arcanumPageCount(arcanumData: String): Long {
+        if (arcanumData.isBlank()) return 0L
+        val journal = runCatching {
+            jsonMapper.readValue(arcanumData, ArcanumJournal::class.java)
+        }.getOrNull() ?: return 0L
+        return (journal.mobs.size + journal.items.size + journal.rooms.size).toLong()
+    }
 }

--- a/src/test/kotlin/dev/ambon/engine/LeaderboardSystemTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/LeaderboardSystemTest.kt
@@ -1,14 +1,19 @@
 package dev.ambon.engine
 
 import dev.ambon.config.LeaderboardConfig
+import dev.ambon.domain.arcanum.ArcanumEntry
+import dev.ambon.domain.arcanum.ArcanumJournal
 import dev.ambon.domain.crafting.CraftingSkillState
 import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
 import dev.ambon.persistence.InMemoryPlayerRepository
 import dev.ambon.persistence.PlayerId
 import dev.ambon.persistence.PlayerRecord
+import dev.ambon.persistence.jsonMapper
 import dev.ambon.test.MutableClock
 import dev.ambon.test.TEST_ROOM_ID
 import dev.ambon.test.buildTestPlayerRegistry
+import dev.ambon.test.loginOrFail
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -39,6 +44,7 @@ class LeaderboardSystemTest {
         dungeons: Int = 0,
         kills: Long = 0L,
         isStaff: Boolean = false,
+        arcanumData: String = "{}",
     ) {
         val record = PlayerRecord(
             id = PlayerId(id),
@@ -52,8 +58,22 @@ class LeaderboardSystemTest {
             dungeonsCompleted = dungeons,
             mobsKilledTotal = kills,
             isStaff = isStaff,
+            arcanumData = arcanumData,
         )
         repo.save(record)
+    }
+
+    private fun arcanumBlob(
+        mobs: Int,
+        items: Int = 0,
+        rooms: Int = 0,
+    ): String {
+        val journal = ArcanumJournal(
+            mobs = (1..mobs).associate { "zone:mob$it" to ArcanumEntry() }.toMutableMap(),
+            items = (1..items).associate { "item$it" to ArcanumEntry() }.toMutableMap(),
+            rooms = (1..rooms).associate { "zone:room$it" to ArcanumEntry() }.toMutableMap(),
+        )
+        return jsonMapper.writeValueAsString(journal)
     }
 
     @Test
@@ -165,6 +185,54 @@ class LeaderboardSystemTest {
         assertEquals(LeaderboardSystem.Category.LEVEL, LeaderboardSystem.Category.fromKey("level"))
         assertEquals(LeaderboardSystem.Category.KILLS, LeaderboardSystem.Category.fromKey("kills"))
         assertEquals(null, LeaderboardSystem.Category.fromKey("nonexistent"))
+    }
+
+    @Test
+    fun `chronicler leaderboard ranks by total arcanum pages with live overlay`() =
+        runTest {
+            savePlayer(101, "Scribe", arcanumData = arcanumBlob(mobs = 1, items = 1))
+            savePlayer(102, "Sage", arcanumData = arcanumBlob(mobs = 2, items = 2, rooms = 1))
+
+            // Online player: persisted journal is empty, but the live in-memory journal
+            // has unsaved recordings that should be reflected via the overlay.
+            registry.loginOrFail(SessionId(1), "Wanderer")
+            val live = registry.getByName("Wanderer")!!
+            repeat(4) { live.arcanum.mobs["zone:mob$it"] = ArcanumEntry() }
+            repeat(3) { live.arcanum.rooms["zone:room$it"] = ArcanumEntry() }
+
+            system.refresh()
+
+            val entries = system.getEntries(LeaderboardSystem.Category.CHRONICLER)
+            assertEquals(3, entries.size)
+            assertEquals("Wanderer", entries[0].playerName)
+            assertEquals(7L, entries[0].score)
+            assertEquals("Sage", entries[1].playerName)
+            assertEquals(5L, entries[1].score)
+            assertEquals("Scribe", entries[2].playerName)
+            assertEquals(2L, entries[2].score)
+        }
+
+    @Test
+    fun `chronicler scores 0 for blank or malformed arcanum data without errors`() =
+        runTest {
+            savePlayer(101, "Fresh", arcanumData = "")
+            savePlayer(102, "Corrupt", arcanumData = "not-json{{{")
+            savePlayer(103, "Keeper", arcanumData = arcanumBlob(mobs = 0, rooms = 1))
+
+            system.refresh()
+
+            val entries = system.getEntries(LeaderboardSystem.Category.CHRONICLER)
+            assertEquals(3, entries.size)
+            assertEquals("Keeper", entries[0].playerName)
+            assertEquals(1L, entries[0].score)
+            assertEquals(0L, entries[1].score)
+            assertEquals(0L, entries[2].score)
+        }
+
+    @Test
+    fun `Category fromKey resolves arcanum key`() {
+        assertEquals(LeaderboardSystem.Category.CHRONICLER, LeaderboardSystem.Category.fromKey("arcanum"))
+        assertEquals(LeaderboardSystem.Category.CHRONICLER, LeaderboardSystem.Category.fromKey("arc"))
     }
 
     @Test

--- a/web-v3/src/components/panels/LeaderboardPanel.tsx
+++ b/web-v3/src/components/panels/LeaderboardPanel.tsx
@@ -7,6 +7,7 @@ const CATEGORIES = [
   { key: "crafting", label: "Crafting" },
   { key: "dungeons", label: "Dungeons" },
   { key: "kills", label: "Kills" },
+  { key: "arcanum", label: "Chronicler" },
 ];
 
 interface Props {


### PR DESCRIPTION
## Summary

Adds an explorer-facing leaderboard category for the Akathavae Arcanum system:

- **New category** `CHRONICLER("arcanum", "Master Chronicler", "pages")` in `LeaderboardSystem`. Score = total distinct journal pages recorded (`mobs.size + items.size + rooms.size`).
- **Offline players** are scored by parsing the persisted `PlayerRecord.arcanumData` JSON blob with the same `jsonMapper`/`ArcanumJournal` shape used when loading a player. Blank or malformed blobs score 0 without errors. Scores are kept in a side map rather than stuffed back into the record overlay.
- **Online players** are overlaid from their live in-memory `PlayerState.arcanum`, so unsaved recordings are reflected immediately.
- **Web client**: the `Leaderboard.Data` GMCP payload already carries `label`/`scoreLabel` dynamically, but `LeaderboardPanel.tsx` hard-codes its category button list — added a "Chronicler" entry there.

## Skipped (per issue guidance)

The optional `WORLD_FIRSTS("firsts", "Pioneer", "firsts")` category depends on the persisted `worldFirstsCount` field (`world_firsts_count` column) added by PR #1410, which has not merged yet. A TODO comment marks the spot in the `Category` enum; it can follow up once #1410 lands.

## Testing

- New `LeaderboardSystemTest` cases: two offline records with different blob sizes + one live-overlay player (ordering asserted), blank/malformed blob → score 0 with no exception, and `fromKey("arcanum")`/`fromKey("arc")` resolution.
- `./gradlew ktlintCheck test integrationTest`

Closes #1391
Part of #1400