### PR TITLE
feat(akathavae): illumination arts utility ability kit (phase 1)

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/ProgressionHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/ProgressionHandler.kt
@@ -6,6 +6,8 @@ import dev.ambon.engine.AkathavaeSystem
 import dev.ambon.engine.CurrencySystem
 import dev.ambon.engine.GroupSystem
 import dev.ambon.engine.PlayerProgression
+import dev.ambon.engine.PlayerState
+import dev.ambon.engine.abilities.AbilityDefinition
 import dev.ambon.engine.abilities.AbilitySystem
 import dev.ambon.engine.ceilSeconds
 import dev.ambon.engine.commands.Command
@@ -133,12 +135,24 @@ class ProgressionHandler(
     }
 
     private suspend fun handleSpells(sessionId: SessionId) {
-        // For the Akathavae the Arcanum *is* the spellbook: they wield no spells,
-        // so 'spells'/'abilities'/'skills' leafs through their journal instead.
+        // For the Akathavae the Arcanum *is* the spellbook: 'spells'/'abilities'/
+        // 'skills' leafs through their journal instead — and, once the pledge has
+        // taught them the illumination arts, lists those arts alongside it.
         val me = players.get(sessionId)
         if (me != null && me.isAkathavae) {
             akathavaeSystem?.emitJournal(sessionId)
-            outbound.send(OutboundEvent.SendInfo(sessionId, "As an Akathavae you wield no spells — your art is the Arcanum."))
+            val arts = abilitySystem?.knownAbilities(sessionId).orEmpty()
+            if (abilitySystem == null || arts.isEmpty()) {
+                outbound.send(OutboundEvent.SendInfo(sessionId, "As an Akathavae you wield no spells — your art is the Arcanum."))
+            } else {
+                outbound.send(
+                    OutboundEvent.SendInfo(
+                        sessionId,
+                        "Your art is the Arcanum, and these illumination arts serve it (Mana: ${me.mana}/${me.maxMana}):",
+                    ),
+                )
+                sendSpellLines(sessionId, abilitySystem, arts, me)
+            }
             outbound.send(
                 OutboundEvent.SendInfo(
                     sessionId,
@@ -146,6 +160,15 @@ class ProgressionHandler(
                 ),
             )
             outbound.send(OutboundEvent.SendInfo(sessionId, "Type 'arcanum' to leaf through its pages."))
+            if (abilitySystem != null) {
+                gmcpEmitter?.sendCharSkills(
+                    sessionId,
+                    arts,
+                    cooldownRemainingMs = { abilityId -> abilitySystem.cooldownRemainingMs(sessionId, abilityId) },
+                    player = me,
+                    manaCostFor = { ability -> abilitySystem.computeManaCost(me, ability) },
+                )
+            }
             return
         }
         val abilities = requireSystemOrNull(sessionId, abilitySystem, "Abilities", outbound) ?: return
@@ -155,23 +178,7 @@ class ProgressionHandler(
         } else {
             players.withPlayer(sessionId) { me ->
                 outbound.send(OutboundEvent.SendInfo(sessionId, "Known spells (Mana: ${me.mana}/${me.maxMana}):"))
-                for (a in known) {
-                    val remainingMs = abilities.cooldownRemainingMs(sessionId, a.id)
-                    val cdText =
-                        if (remainingMs > 0) {
-                            "${remainingMs.ceilSeconds()}s remaining"
-                        } else if (a.cooldownMs > 0) {
-                            "${a.cooldownMs / 1000}s cooldown"
-                        } else {
-                            "no cooldown"
-                        }
-                    outbound.send(
-                        OutboundEvent.SendInfo(
-                            sessionId,
-                            "  ${a.displayName}  — ${abilities.computeManaCost(me, a)} mana, $cdText — ${a.description}",
-                        ),
-                    )
-                }
+                sendSpellLines(sessionId, abilities, known, me)
             }
         }
         players.withPlayer(sessionId) { me ->
@@ -181,6 +188,31 @@ class ProgressionHandler(
                 cooldownRemainingMs = { abilityId -> abilities.cooldownRemainingMs(sessionId, abilityId) },
                 player = me,
                 manaCostFor = { ability -> abilities.computeManaCost(me, ability) },
+            )
+        }
+    }
+
+    private suspend fun sendSpellLines(
+        sessionId: SessionId,
+        abilities: AbilitySystem,
+        known: List<AbilityDefinition>,
+        me: PlayerState,
+    ) {
+        for (a in known) {
+            val remainingMs = abilities.cooldownRemainingMs(sessionId, a.id)
+            val cdText =
+                if (remainingMs > 0) {
+                    "${remainingMs.ceilSeconds()}s remaining"
+                } else if (a.cooldownMs > 0) {
+                    "${a.cooldownMs / 1000}s cooldown"
+                } else {
+                    "no cooldown"
+                }
+            outbound.send(
+                OutboundEvent.SendInfo(
+                    sessionId,
+                    "  ${a.displayName}  — ${abilities.computeManaCost(me, a)} mana, $cdText — ${a.description}",
+                ),
             )
         }
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -488,6 +488,61 @@ ambonmud:
           description: Calls a massive bear guardian to absorb damage and protect the ranger.
           image: 198deb0c7cb5fae8bf52b14929b10751dc9b50986f334abfc059a95c0432c5a3.png
           requiredClass: RANGER
+        # ── Akathavae illumination arts ──────────────────────────────────
+        # The pledged wield no violence: every art is SELF/ALLY-targeted
+        # (hostile target types are refused under the pledge in AbilitySystem).
+        # skillPointCost 0 means each art is granted automatically when the
+        # pledged reach its level, and set aside again on renounce.
+        # Cooldowns run at least as long as the buffs so these stay rituals
+        # rather than permanent stat lines.
+        chroniclers_focus:
+          displayName: Chronicler's Focus
+          manaCostPct: 20
+          cooldownMs: 75000
+          levelRequired: 3
+          skillPointCost: 0
+          targetType: SELF
+          effect:
+            type: APPLY_STATUS
+            statusEffectId: chroniclers_focus_buff
+          description: A stilling ritual that sharpens the mind's eye, steadying the hand for the illuminations to come.
+          requiredClass: AKATHAVAE
+        soothing_presence:
+          displayName: Soothing Presence
+          manaCostPct: 20
+          cooldownMs: 75000
+          levelRequired: 6
+          skillPointCost: 0
+          targetType: SELF
+          effect:
+            type: APPLY_STATUS
+            statusEffectId: soothing_presence_buff
+          description: Settles the keeper's bearing into a practiced calm, making startled subjects far easier to talk down.
+          requiredClass: AKATHAVAE
+        keepers_ward:
+          displayName: Keeper's Ward
+          manaCostPct: 25
+          cooldownMs: 45000
+          levelRequired: 10
+          skillPointCost: 0
+          targetType: SELF
+          effect:
+            type: APPLY_STATUS
+            statusEffectId: keepers_ward_shield
+          description: Binds the Arcanum's loose pages into a ward of drifting script that absorbs harm while the keeper withdraws.
+          requiredClass: AKATHAVAE
+        muses_insight:
+          displayName: Muse's Insight
+          manaCostPct: 25
+          cooldownMs: 75000
+          levelRequired: 14
+          skillPointCost: 0
+          targetType: ALLY
+          effect:
+            type: APPLY_STATUS
+            statusEffectId: muses_insight_buff
+          description: Shares a whisper of the Arcanum's wisdom with a companion, deepening what they take from every lesson.
+          requiredClass: AKATHAVAE
     statusEffects:
       definitions:
         ignite:
@@ -801,6 +856,34 @@ ambonmud:
           tickMinValue: 5
           tickMaxValue: 8
           stackBehavior: refresh
+        # ── Akathavae illumination-art buffs ─────────────────────────────
+        # Modest magnitudes on purpose: +3 INT is ~+6% illumination success
+        # (successPerStatPoint: 2.0); CHA feeds the talk-out escape roll and
+        # WIS the illumination XP bonus (see ambonMUD.engine.akathavae).
+        chroniclers_focus_buff:
+          displayName: Chronicler's Focus
+          effectType: stat_buff
+          durationMs: 60000
+          stackBehavior: refresh
+          intMod: 3
+        soothing_presence_buff:
+          displayName: Soothing Presence
+          effectType: stat_buff
+          durationMs: 60000
+          stackBehavior: refresh
+          chaMod: 3
+        keepers_ward_shield:
+          displayName: Keeper's Ward
+          effectType: shield
+          durationMs: 20000
+          shieldAmount: 30
+          stackBehavior: refresh
+        muses_insight_buff:
+          displayName: Muse's Insight
+          effectType: stat_buff
+          durationMs: 60000
+          stackBehavior: refresh
+          wisMod: 3
     effectTypes:
       types:
         dot:

--- a/src/test/kotlin/dev/ambon/engine/AkathavaeAbilityKitTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/AkathavaeAbilityKitTest.kt
@@ -1,0 +1,258 @@
+package dev.ambon.engine
+
+import dev.ambon.config.AkathavaeConfig
+import dev.ambon.config.AppConfig
+import dev.ambon.config.AppConfigLoader
+import dev.ambon.domain.DamageRange
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.world.Room
+import dev.ambon.domain.world.World
+import dev.ambon.engine.abilities.AbilityDefinition
+import dev.ambon.engine.abilities.AbilityEffect
+import dev.ambon.engine.abilities.AbilityId
+import dev.ambon.engine.abilities.AbilityRegistry
+import dev.ambon.engine.abilities.AbilityRegistryLoader
+import dev.ambon.engine.abilities.AbilitySystem
+import dev.ambon.engine.status.StatusEffectId
+import dev.ambon.engine.status.StatusEffectRegistry
+import dev.ambon.engine.status.StatusEffectRegistryLoader
+import dev.ambon.engine.status.StatusEffectSystem
+import dev.ambon.test.CombatTestFixture
+import dev.ambon.test.MutableClock
+import dev.ambon.test.drainAll
+import dev.ambon.test.loginOrFail
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.Random
+
+/**
+ * The Akathavae illumination arts (#1394): four SELF/ALLY utility abilities
+ * shipped in the default config with `requiredClass: AKATHAVAE`, granted
+ * automatically on pledge and set aside on renounce. These tests load the
+ * real `application.yaml` so a config regression fails here, not in play.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AkathavaeAbilityKitTest {
+    /** id → levelRequired, as promised by the phased kit design. */
+    private val kitLevels = mapOf(
+        "chroniclers_focus" to 3,
+        "soothing_presence" to 6,
+        "keepers_ward" to 10,
+        "muses_insight" to 14,
+    )
+
+    /** id → the stat its buff must raise (the ward is a shield, not a stat buff). */
+    private val kitBuffStats = mapOf(
+        "chroniclers_focus" to "INT",
+        "soothing_presence" to "CHA",
+        "muses_insight" to "WIS",
+    )
+
+    private val config: AppConfig = AppConfigLoader.load().validated()
+
+    private fun loadedAbilityRegistry(): AbilityRegistry =
+        AbilityRegistry().also { AbilityRegistryLoader.load(config.engine.abilities, it) }
+
+    private fun loadedStatusRegistry(): StatusEffectRegistry =
+        StatusEffectRegistry().also { StatusEffectRegistryLoader.load(config.engine.statusEffects, it) }
+
+    // ── Config shape ─────────────────────────────────────────────────────
+
+    @Test
+    fun `the illumination arts ship in the default config as auto-granted non-hostile arts`() {
+        val registry = loadedAbilityRegistry()
+        for ((id, level) in kitLevels) {
+            val art = registry.get(AbilityId(id))
+            assertNotNull(art, "kit ability '$id' missing from the default config")
+            assertEquals("AKATHAVAE", art!!.requiredClass, "'$id' must be pledge-gated")
+            assertEquals(level, art.levelRequired, "'$id' level")
+            assertEquals(0, art.skillPointCost, "'$id' must auto-grant on pledge (skillPointCost 0)")
+            assertTrue(
+                art.targetType == "self" || art.targetType == "ally",
+                "'$id' must be non-hostile (pledge refuses enemy targets), got '${art.targetType}'",
+            )
+            assertTrue(art.effect is AbilityEffect.ApplyStatus, "'$id' must be an APPLY_STATUS ritual")
+        }
+        val hostileArts = registry.all().filter {
+            it.requiredClass == "AKATHAVAE" && (it.targetType == "enemy" || it.targetType == "all_enemies")
+        }
+        assertTrue(hostileArts.isEmpty(), "no AKATHAVAE ability may target enemies: $hostileArts")
+    }
+
+    @Test
+    fun `the art buffs are modest rituals with cooldowns at least as long as the buffs`() {
+        val abilities = loadedAbilityRegistry()
+        val statuses = loadedStatusRegistry()
+        for (id in kitLevels.keys) {
+            val art = abilities.get(AbilityId(id))!!
+            val statusId = (art.effect as AbilityEffect.ApplyStatus).statusEffectId
+            val status = statuses.get(statusId)
+            assertNotNull(status, "'$id' references unknown status '${statusId.value}'")
+            assertTrue(
+                art.cooldownMs >= status!!.durationMs,
+                "'$id' cooldown (${art.cooldownMs}) must be >= buff duration (${status.durationMs}) — ritual, not stat line",
+            )
+            val buffStat = kitBuffStats[id]
+            if (buffStat != null) {
+                assertEquals("stat_buff", status.effectType, "'$id' status type")
+                val magnitude = status.statMods[buffStat]
+                assertTrue(
+                    magnitude in 2..4,
+                    "'$id' must buff $buffStat modestly (+2..+4), got $magnitude in ${status.statMods}",
+                )
+            } else {
+                assertEquals("shield", status.effectType, "keepers_ward must be an absorb shield")
+                assertTrue(status.shieldAmount > 0, "keepers_ward shield must absorb something")
+            }
+        }
+    }
+
+    // ── Runtime behavior ─────────────────────────────────────────────────
+
+    private val roomA = RoomId("test:room")
+
+    private fun testWorld(): World = World(
+        rooms = mapOf(roomA to Room(roomA, "The Test Room", "A room.", exits = emptyMap())),
+        startRoom = roomA,
+    )
+
+    private class Setup(
+        val fixture: CombatTestFixture,
+        val clock: MutableClock,
+        val statusEffects: StatusEffectSystem,
+        val abilitySystem: AbilitySystem,
+        val akathavae: AkathavaeSystem,
+        val akConfig: AkathavaeConfig,
+    )
+
+    private fun setup(extraAbilities: List<AbilityDefinition> = emptyList()): Setup {
+        val clock = MutableClock(1_000_000L)
+        val fixture = CombatTestFixture(roomId = roomA, clock = clock)
+        val combat = fixture.buildCombat(rng = Random(1))
+        val statusEffects = StatusEffectSystem(
+            registry = loadedStatusRegistry(),
+            players = fixture.players,
+            mobs = fixture.mobs,
+            outbound = fixture.outbound,
+            clock = clock,
+            rng = Random(1),
+        )
+        val abilityRegistry = loadedAbilityRegistry()
+        extraAbilities.forEach { abilityRegistry.register(it) }
+        val abilitySystem = AbilitySystem(
+            players = fixture.players,
+            registry = abilityRegistry,
+            outbound = fixture.outbound,
+            combat = combat,
+            clock = clock,
+            rng = Random(1),
+            statusEffects = statusEffects,
+        )
+        val akConfig = AkathavaeConfig()
+        val akathavae = AkathavaeSystem(
+            players = fixture.players,
+            items = fixture.items,
+            world = testWorld(),
+            outbound = fixture.outbound,
+            combat = combat,
+            statusEffects = statusEffects,
+            clock = clock,
+            rng = Random(1),
+            config = akConfig,
+        )
+        return Setup(fixture, clock, statusEffects, abilitySystem, akathavae, akConfig)
+    }
+
+    private suspend fun loginPledged(s: Setup, sid: SessionId, level: Int): PlayerState {
+        s.fixture.players.loginOrFail(sid, "Thalen")
+        s.fixture.players.setLevel(sid, level)
+        val me = s.fixture.players.get(sid)!!
+        me.isAkathavae = true
+        me.playerClass = "AKATHAVAE"
+        me.unlockedClasses.add("AKATHAVAE")
+        s.abilitySystem.refreshKnownAbilities(sid)
+        me.mana = me.maxMana
+        s.fixture.outbound.drainAll()
+        return me
+    }
+
+    @Test
+    fun `a buffed success stat measurably raises illumination success`() = runTest {
+        val s = setup()
+        val sid = SessionId(1)
+        val me = loginPledged(s, sid, level = 5)
+
+        fun successPct(): Int {
+            val stats = resolvePlayerStats(me, s.fixture.items, s.statusEffects)
+            return s.akathavae.illuminationSuccessPct(
+                statValue = stats[s.akConfig.successStat],
+                reliefStatValue = stats[s.akConfig.gapReliefStat],
+                playerLevel = me.level,
+                mobLevel = me.level,
+            )
+        }
+
+        val baseline = successPct()
+        assertTrue(
+            s.statusEffects.applyToPlayer(sid, StatusEffectId("chroniclers_focus_buff")),
+            "the focus buff should apply",
+        )
+        // +3 INT at successPerStatPoint 2.0 → +6% success.
+        assertEquals(baseline + 6, successPct(), "buffed INT must raise illumination success")
+
+        // The ritual fades: after the buff expires the odds fall back to baseline.
+        s.clock.advance(61_000)
+        s.statusEffects.tick(s.clock.millis())
+        assertEquals(baseline, successPct(), "an expired focus buff must not keep helping")
+    }
+
+    @Test
+    fun `a pledged keeper casts the kit on themselves`() = runTest {
+        val s = setup()
+        val sid = SessionId(1)
+        loginPledged(s, sid, level = 10)
+
+        val knownIds = s.abilitySystem.knownAbilities(sid).map { it.id.value }.toSet()
+        assertEquals(
+            setOf("chroniclers_focus", "soothing_presence", "keepers_ward"),
+            knownIds,
+            "a level-10 pledge should know the first three arts",
+        )
+
+        val err = s.abilitySystem.cast(sid, "chroniclers_focus", null)
+        assertNull(err, "self-cast utility must stay allowed under the pledge, got: $err")
+        val active = s.statusEffects.activePlayerEffects(sid).map { it.name }
+        assertTrue(active.contains("Chronicler's Focus"), "buff should be active, got $active")
+    }
+
+    @Test
+    fun `hostile casts stay refused for the pledged`() = runTest {
+        // A classless enemy-targeted spell is auto-known even while pledged, so
+        // it exercises the pledge gate itself rather than class filtering.
+        val hostile = AbilityDefinition(
+            id = AbilityId("test_bolt"),
+            displayName = "Test Bolt",
+            description = "A test bolt.",
+            manaCostPct = 0.0,
+            cooldownMs = 0,
+            levelRequired = 1,
+            skillPointCost = 0,
+            targetType = "enemy",
+            effect = AbilityEffect.DirectDamage(DamageRange(1, 2)),
+            requiredClass = null,
+        )
+        val s = setup(extraAbilities = listOf(hostile))
+        val sid = SessionId(1)
+        loginPledged(s, sid, level = 5)
+
+        val err = s.abilitySystem.cast(sid, "test_bolt", "rat")
+        assertNotNull(err, "hostile cast must be refused under the pledge")
+        assertTrue(err!!.contains("pledge stays your hand"), "got=$err")
+    }
+}

--- a/src/test/kotlin/dev/ambon/engine/commands/AkathavaeCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/AkathavaeCommandTest.kt
@@ -456,6 +456,141 @@ class AkathavaeCommandTest {
         }
     }
 
+    // ── Illumination arts kit (#1394) ────────────────────────────────────
+
+    @Nested
+    inner class IlluminationArts {
+        private val kit = setOf("chroniclers_focus", "soothing_presence", "keepers_ward", "muses_insight")
+
+        /**
+         * Harness with the shipped ability definitions loaded from the real
+         * `application.yaml`, so pledging grants the actual illumination arts.
+         * A zero-cost Warrior ability is added so the pre-pledge kit visibly
+         * comes and goes around the pledge.
+         */
+        private fun artsHarness(
+            config: AkathavaeConfig = AkathavaeConfig(),
+        ): Pair<CommandRouterHarness, dev.ambon.engine.abilities.AbilitySystem> {
+            val appConfig = dev.ambon.config.AppConfigLoader.load().validated()
+            val classRegistry = dev.ambon.engine.PlayerClassRegistry().also { reg ->
+                dev.ambon.engine.PlayerClassRegistryLoader.load(dev.ambon.test.testClassEngineConfig(), reg)
+            }
+            val progression = dev.ambon.engine.PlayerProgression(classRegistry = classRegistry)
+            val world = shrineWorld()
+            val outbound = dev.ambon.bus.LocalOutboundBus()
+            val items = dev.ambon.engine.items.ItemRegistry()
+            val mobs = dev.ambon.engine.MobRegistry()
+            val players = buildTestPlayerRegistry(
+                world.startRoom,
+                items = items,
+                progression = progression,
+                classRegistry = classRegistry,
+            )
+            val combat = dev.ambon.engine.CombatSystem(players, mobs, items, outbound)
+            val registry = dev.ambon.engine.abilities.AbilityRegistry()
+            dev.ambon.engine.abilities.AbilityRegistryLoader.load(appConfig.engine.abilities, registry)
+            registry.register(
+                dev.ambon.engine.abilities.AbilityDefinition(
+                    id = dev.ambon.engine.abilities.AbilityId("warriors_swing"),
+                    displayName = "Warrior's Swing",
+                    description = "A mighty swing.",
+                    manaCostPct = 10.0,
+                    cooldownMs = 0,
+                    levelRequired = 1,
+                    skillPointCost = 0,
+                    requiredClass = "WARRIOR",
+                    targetType = "enemy",
+                    effect = dev.ambon.engine.abilities.AbilityEffect.DirectDamage(dev.ambon.domain.DamageRange(5, 5)),
+                ),
+            )
+            val abilitySystem = dev.ambon.engine.abilities.AbilitySystem(
+                players = players,
+                registry = registry,
+                outbound = outbound,
+                combat = combat,
+                clock = MutableClock(0L),
+            )
+            val h = CommandRouterHarness.create(
+                world = world,
+                players = players,
+                items = items,
+                mobs = mobs,
+                outbound = outbound,
+                progression = progression,
+                classRegistry = classRegistry,
+                abilitySystem = abilitySystem,
+                akathavaeConfig = config,
+            )
+            return h to abilitySystem
+        }
+
+        @Test
+        fun `pledging grants the illumination arts and renouncing withdraws them`() = runTest {
+            val (h, abilitySystem) = artsHarness(config = AkathavaeConfig(renounceCostGold = 0))
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Thalen")
+            h.players.setLevel(sid, 14)
+            abilitySystem.refreshKnownAbilities(sid)
+            assertTrue(
+                abilitySystem.knownAbilities(sid).any { it.id.value == "warriors_swing" },
+                "warrior kit known before the pledge",
+            )
+            assertTrue(
+                abilitySystem.knownAbilities(sid).none { it.id.value in kit },
+                "no illumination arts before the pledge",
+            )
+            h.drain()
+
+            h.router.handle(sid, Command.Pledge)
+
+            assertEquals(
+                kit,
+                abilitySystem.knownAbilities(sid).map { it.id.value }.toSet(),
+                "a level-14 pledge should know the full kit and nothing else",
+            )
+
+            h.router.handle(sid, Command.Renounce(confirm = true))
+
+            val renouncedIds = abilitySystem.knownAbilities(sid).map { it.id.value }.toSet()
+            assertTrue(renouncedIds.none { it in kit }, "the arts must not outlive the pledge: $renouncedIds")
+            assertTrue("warriors_swing" in renouncedIds, "former-class abilities return on renounce")
+        }
+
+        @Test
+        fun `a low-level pledge only knows the arts they have earned`() = runTest {
+            val (h, abilitySystem) = artsHarness()
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Thalen")
+            h.players.setLevel(sid, 6)
+            h.drain()
+
+            h.router.handle(sid, Command.Pledge)
+
+            assertEquals(
+                setOf("chroniclers_focus", "soothing_presence"),
+                abilitySystem.knownAbilities(sid).map { it.id.value }.toSet(),
+            )
+        }
+
+        @Test
+        fun `spells lists the illumination arts for a pledged keeper`() = runTest {
+            val (h, _) = artsHarness()
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Thalen")
+            h.players.setLevel(sid, 3)
+            h.router.handle(sid, Command.Pledge)
+            h.drain()
+
+            h.router.handle(sid, Command.Spells)
+
+            val infos = h.drain().filterIsInstance<OutboundEvent.SendInfo>().map { it.text }
+            assertTrue(infos.any { it.contains("illumination arts") }, "got=$infos")
+            assertTrue(infos.any { it.contains("Chronicler's Focus") }, "got=$infos")
+            assertTrue(infos.any { it.contains("Arcanum") }, "journal pointer stays, got=$infos")
+            assertFalse(infos.any { it.contains("wield no spells") }, "got=$infos")
+        }
+    }
+
     // ── Multiclass lockout ───────────────────────────────────────────────
 
     @Nested


### PR DESCRIPTION
## Summary

Phase 1 of the Akathavae utility kit — config-only ability definitions plus a small `spells` handler update, per the phased plan in the issue.

### New abilities (all `requiredClass: AKATHAVAE`, non-hostile targets, `skillPointCost: 0` so they auto-grant on pledge and vanish on renounce)

| id | level | target | effect |
|---|---|---|---|
| `chroniclers_focus` | 3 | SELF | +3 INT for 60s (illumination success, ~+6% via `successPerStatPoint: 2.0`) |
| `soothing_presence` | 6 | SELF | +3 CHA for 60s (talk-out escape) |
| `keepers_ward` | 10 | SELF | 30-point absorb shield for 20s (survivability while fleeing) |
| `muses_insight` | 14 | ALLY | +3 WIS for 60s, castable on a group member (illumination XP) |

Cooldowns ≥ buff durations so the arts stay rituals, not permanent stat lines. Four matching status-effect definitions added alongside the existing ones (fortify_shield / blessing_buff pattern). No images yet — `image` is optional and the loader handles its absence.

### `spells` for the pledged

`spells`/`abilities`/`skills` still leafs through the Arcanum, but once the pledged know illumination arts it now lists them (with mana costs and cooldowns) instead of claiming they wield no spells, and emits `Char.Skills` GMCP so the web Skills panel stays in sync. The pre-kit wording is preserved for pledges below level 3.

### Tests

- `AkathavaeAbilityKitTest` (new): loads the real `application.yaml` and asserts the kit's shape (pledge-gated, auto-granted, non-hostile, modest +2..+4 buffs, cooldown ≥ duration); integration checks that the INT buff measurably raises `illuminationSuccessPct` via resolved stats and stops helping after expiry; a pledged keeper can self-cast the arts; hostile casts still refused under the pledge.
- `AkathavaeCommandTest` (extended): pledge at 14 grants exactly the four arts and renounce restores former-class abilities; a level-6 pledge only knows the earned arts; `spells` lists the arts alongside the Arcanum for a pledged keeper.

Closes #1394
Part of #1400

## Verification

- [x] `./gradlew ktlintCheck test integrationTest` — green (252 test classes + 15 integration classes, 0 failures)
- [x] `AppConfig.validated()` passes with the new definitions (kit test loads and validates the shipped yaml)

## Non-goals (per issue)

Phase 2 (`soothing_word` / BREAK_ENGAGEMENT effect type), Page Recall, and group-XP presence bonus are explicitly out of scope and filed separately.