### PR TITLE
feat(akathavae): Arcanum panel search/filter/sort, items in zone completion, telnet paging

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/AkathavaeSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/AkathavaeSystem.kt
@@ -350,6 +350,8 @@ class AkathavaeSystem(
         val roomsTotal: Int,
         val mobsRecorded: Int,
         val mobsTotal: Int,
+        val itemsRecorded: Int,
+        val itemsTotal: Int,
     )
 
     /** Per-zone completion for [me], for every zone with at least one recorded entry plus the current zone. */
@@ -358,8 +360,17 @@ class AkathavaeSystem(
         val roomsRecorded = me.arcanum.rooms.keys.count { RoomId(it).zone == zone }
         val mobsTotal = world.mobTemplates.keys.count { it.value.substringBefore(':') == zone }
         val mobsRecorded = me.arcanum.mobs.keys.count { it.substringBefore(':') == zone }
-        return ZoneCompletion(zone, roomsRecorded, roomsTotal, mobsRecorded, mobsTotal)
+        val itemsTotal = items.templateCountForZone(zone)
+        val itemsRecorded = me.arcanum.items.keys.count { it.contains(':') && it.substringBefore(':') == zone }
+        return ZoneCompletion(zone, roomsRecorded, roomsTotal, mobsRecorded, mobsTotal, itemsRecorded, itemsTotal)
     }
+
+    /** Every zone touched by [me]'s journal — rooms, mobs, and items — in sorted order. */
+    fun recordedZones(me: PlayerState): List<String> = (
+        me.arcanum.rooms.keys.map { it.substringBefore(':') } +
+            me.arcanum.mobs.keys.map { it.substringBefore(':') } +
+            me.arcanum.items.keys.filter { it.contains(':') }.map { it.substringBefore(':') }
+    ).toSortedSet().toList()
 
     /** Returns the permanent world-first credit line for a subject, or null. */
     fun worldFirstCredit(kind: String, subjectKey: String): Pair<String, Long>? =
@@ -381,14 +392,19 @@ class AkathavaeSystem(
     suspend fun emitJournal(sessionId: SessionId) {
         val emitter = gmcpEmitter ?: return
         val me = players.get(sessionId) ?: return
-        val zones = (
-            me.arcanum.rooms.keys.map { it.substringBefore(':') } +
-                me.arcanum.mobs.keys.map { it.substringBefore(':') }
-        ).toSortedSet().map { zoneCompletion(me, it) }
+        val zones = recordedZones(me).map { zoneCompletion(me, it) }
         val payload = GmcpEmitter.ArcanumJournalPayload(
             pledged = me.isAkathavae,
             zones = zones.map {
-                GmcpEmitter.ArcanumZonePayload(it.zone, it.roomsRecorded, it.roomsTotal, it.mobsRecorded, it.mobsTotal)
+                GmcpEmitter.ArcanumZonePayload(
+                    zone = it.zone,
+                    roomsRecorded = it.roomsRecorded,
+                    roomsTotal = it.roomsTotal,
+                    mobsRecorded = it.mobsRecorded,
+                    mobsTotal = it.mobsTotal,
+                    itemsRecorded = it.itemsRecorded,
+                    itemsTotal = it.itemsTotal,
+                )
             },
             mobs = me.arcanum.mobs.entries.sortedBy { it.key }.map { (key, entry) ->
                 val template = world.mobTemplate(dev.ambon.domain.ids.MobId(key))

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -976,6 +976,8 @@ class GmcpEmitter(
         val roomsTotal: Int,
         val mobsRecorded: Int,
         val mobsTotal: Int,
+        val itemsRecorded: Int,
+        val itemsTotal: Int,
     )
 
     data class ArcanumMobPayload(

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -362,9 +362,10 @@ sealed interface Command {
         val target: String,
     ) : Command
 
-    /** View the Arcanum journal. [section] filters to rooms/mobs/items; null = summary. */
+    /** View the Arcanum journal. [section] filters to rooms/mobs/items; null = summary. [page] pages a section; null = page 1. */
     data class Arcanum(
         val section: String?,
+        val page: Int? = null,
     ) : Command
 
     /** Arcanum wardrobe: null keyword lists conjurable items, otherwise conjure-and-wear the match. */
@@ -1532,9 +1533,16 @@ object CommandParser {
         // illuminate — the Akathavae's replacement for attacking
         requiredArg(line, listOf("illuminate", "illum"), "illuminate <creature>", { Command.Illuminate(it) })?.let { return it }
 
-        // arcanum [rooms|mobs|items] — the Akathavae journal
+        // arcanum [rooms|mobs|items] [page] — the Akathavae journal
         matchPrefix(line, listOf("arcanum", "journal")) { rest ->
-            Command.Arcanum(rest.trim().lowercase().takeIf { it.isNotBlank() })
+            val parts = rest.trim().lowercase().split(Regex("\\s+")).filter { it.isNotBlank() }
+            when {
+                parts.isEmpty() -> Command.Arcanum(null)
+                parts.size == 1 -> Command.Arcanum(parts[0])
+                parts.size == 2 && parts[1].toIntOrNull() != null ->
+                    Command.Arcanum(parts[0], parts[1].toInt())
+                else -> Command.Invalid(line, "arcanum [rooms|mobs|items] [page]")
+            }
         }?.let { return it }
 
         // wardrobe [item] — conjure recorded equipment from the Arcanum

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/AkathavaeHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/AkathavaeHandler.kt
@@ -161,20 +161,21 @@ class AkathavaeHandler(
         // Push the full journal to GMCP clients — the Arcanum panel renders from this.
         system.emitJournal(sessionId)
 
+        val page = cmd.page ?: 1
         when (cmd.section) {
             null -> renderArcanumSummary(sessionId, me, system)
-            "rooms", "places" -> renderArcanumSection(sessionId, "Places", me.arcanum.rooms.keys) { key ->
+            "rooms", "places" -> renderArcanumSection(sessionId, "Places", "rooms", page, me.arcanum.rooms.keys) { key ->
                 world.rooms[dev.ambon.domain.ids.RoomId(key)]?.title ?: key
             }
-            "mobs", "creatures", "beasts" -> renderArcanumSection(sessionId, "Creatures", me.arcanum.mobs.keys) { key ->
+            "mobs", "creatures", "beasts" -> renderArcanumSection(sessionId, "Creatures", "mobs", page, me.arcanum.mobs.keys) { key ->
                 val credit = system.worldFirstCredit("mob", key)
                 val name = key.substringAfter(':').replace('_', ' ')
                 if (credit?.first == me.name) "$name ★" else name
             }
-            "items", "things" -> renderArcanumSection(sessionId, "Items", me.arcanum.items.keys) { key ->
+            "items", "things" -> renderArcanumSection(sessionId, "Items", "items", page, me.arcanum.items.keys) { key ->
                 key.substringAfter(':').replace('_', ' ')
             }
-            else -> outbound.send(OutboundEvent.SendError(sessionId, "Usage: arcanum [rooms|mobs|items]"))
+            else -> outbound.send(OutboundEvent.SendError(sessionId, "Usage: arcanum [rooms|mobs|items] [page]"))
         }
     }
 
@@ -189,40 +190,55 @@ class AkathavaeHandler(
                 "  Recorded: ${me.arcanum.rooms.size} places, ${me.arcanum.mobs.size} creatures, ${me.arcanum.items.size} items.",
             ),
         )
-        val zones = (
-            me.arcanum.rooms.keys.map { it.substringBefore(':') } +
-                me.arcanum.mobs.keys.map { it.substringBefore(':') }
-        ).toSortedSet()
-        for (zone in zones) {
+        for (zone in system.recordedZones(me)) {
             val c = system.zoneCompletion(me, zone)
-            if (c.roomsTotal == 0 && c.mobsTotal == 0) continue
+            if (c.roomsTotal == 0 && c.mobsTotal == 0 && c.itemsTotal == 0) continue
             outbound.send(
                 OutboundEvent.SendInfo(
                     sessionId,
-                    "  $zone: ${c.roomsRecorded}/${c.roomsTotal} places, ${c.mobsRecorded}/${c.mobsTotal} creatures.",
+                    "  $zone: ${c.roomsRecorded}/${c.roomsTotal} places, ${c.mobsRecorded}/${c.mobsTotal} creatures, " +
+                        "${c.itemsRecorded}/${c.itemsTotal} items.",
                 ),
             )
         }
-        outbound.send(OutboundEvent.SendInfo(sessionId, "Use 'arcanum rooms|mobs|items' to leaf through the pages."))
+        outbound.send(OutboundEvent.SendInfo(sessionId, "Use 'arcanum rooms|mobs|items [page]' to leaf through the pages."))
     }
 
     private suspend fun renderArcanumSection(
         sessionId: SessionId,
         title: String,
+        sectionWord: String,
+        page: Int,
         keys: Set<String>,
         displayName: (String) -> String,
     ) {
-        outbound.send(OutboundEvent.SendInfo(sessionId, "[ Arcanum — $title (${keys.size}) ]"))
         if (keys.isEmpty()) {
+            outbound.send(OutboundEvent.SendInfo(sessionId, "[ Arcanum — $title (0) ]"))
             outbound.send(OutboundEvent.SendInfo(sessionId, "  These pages are still blank."))
             return
         }
-        keys.sorted().chunked(4).take(MAX_SECTION_ROWS).forEach { row ->
-            outbound.send(OutboundEvent.SendInfo(sessionId, "  " + row.joinToString(", ") { displayName(it) }))
+        val pageSize = MAX_SECTION_ROWS * SECTION_ENTRIES_PER_ROW
+        val totalPages = (keys.size + pageSize - 1) / pageSize
+        if (page < 1 || page > totalPages) {
+            outbound.send(
+                OutboundEvent.SendError(
+                    sessionId,
+                    "The $title pages run 1 to $totalPages — try 'arcanum $sectionWord $totalPages'.",
+                ),
+            )
+            return
         }
-        val shown = minOf(keys.size, MAX_SECTION_ROWS * 4)
-        if (keys.size > shown) {
-            outbound.send(OutboundEvent.SendInfo(sessionId, "  …and ${keys.size - shown} more."))
+        outbound.send(OutboundEvent.SendInfo(sessionId, "[ Arcanum — $title (${keys.size}) ]"))
+        keys.sorted()
+            .drop((page - 1) * pageSize)
+            .take(pageSize)
+            .chunked(SECTION_ENTRIES_PER_ROW)
+            .forEach { row ->
+                outbound.send(OutboundEvent.SendInfo(sessionId, "  " + row.joinToString(", ") { displayName(it) }))
+            }
+        if (totalPages > 1) {
+            val hint = if (page < totalPages) " — 'arcanum $sectionWord ${page + 1}' for more" else ""
+            outbound.send(OutboundEvent.SendInfo(sessionId, "  Page $page/$totalPages$hint."))
         }
     }
 
@@ -426,5 +442,6 @@ class AkathavaeHandler(
         const val AKATHAVAE_CLASS = "AKATHAVAE"
         private const val HOUR_MS = 3_600_000L
         private const val MAX_SECTION_ROWS = 25
+        private const val SECTION_ENTRIES_PER_ROW = 4
     }
 }

--- a/src/main/kotlin/dev/ambon/engine/items/ItemRegistry.kt
+++ b/src/main/kotlin/dev/ambon/engine/items/ItemRegistry.kt
@@ -247,6 +247,13 @@ class ItemRegistry {
 
     fun getTemplate(itemId: ItemId): dev.ambon.domain.items.Item? = itemTemplates[itemId]?.item
 
+    /**
+     * Count of item templates keyed under [zone] (`<zone>:<item>`), for Arcanum
+     * zone-completion totals. Unzoned template ids (no `:`) are excluded.
+     */
+    fun templateCountForZone(zone: String): Int =
+        itemTemplates.keys.count { it.value.contains(':') && idZone(it.value) == zone }
+
     fun createFromTemplate(itemId: ItemId): ItemInstance? {
         val template = itemTemplates[itemId] ?: return null
         return ItemInstance(id = template.id, item = template.item.copy())

--- a/src/test/kotlin/dev/ambon/engine/AkathavaeIlluminateTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/AkathavaeIlluminateTest.kt
@@ -2,6 +2,7 @@ package dev.ambon.engine
 
 import dev.ambon.config.AkathavaeConfig
 import dev.ambon.domain.StatMap
+import dev.ambon.domain.arcanum.ArcanumEntry
 import dev.ambon.domain.ids.ItemId
 import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
@@ -109,6 +110,39 @@ class AkathavaeIlluminateTest {
         me.isAkathavae = true
         s.fixture.outbound.drainAll()
         return me
+    }
+
+    // ── Zone completion ──────────────────────────────────────────────────
+
+    @Test
+    fun `zone completion counts item templates and recorded items for the zone`() = runTest {
+        val s = setup()
+        s.fixture.items.loadSpawns(
+            listOf(
+                ItemSpawn(instance = ItemInstance(ItemId("test:hood"), Item(keyword = "hood", displayName = "a leather hood"))),
+                ItemSpawn(instance = ItemInstance(ItemId("test:ring"), Item(keyword = "ring", displayName = "a copper ring"))),
+                // Another zone's template must not count toward "test".
+                ItemSpawn(instance = ItemInstance(ItemId("other:gem"), Item(keyword = "gem", displayName = "a dull gem"))),
+            ),
+        )
+        val me = loginAkathavae(s, SessionId(1L), "Thalen")
+        me.arcanum.items["test:hood"] = ArcanumEntry(firstRecordedAtMs = 1L)
+        me.arcanum.items["other:gem"] = ArcanumEntry(firstRecordedAtMs = 1L)
+
+        val c = s.system.zoneCompletion(me, "test")
+
+        assertEquals(1, c.itemsRecorded, "only the test-zone recording counts")
+        assertEquals(2, c.itemsTotal, "only test-zone templates count toward the total")
+    }
+
+    @Test
+    fun `recorded zones include zones known only through items`() = runTest {
+        val s = setup()
+        val me = loginAkathavae(s, SessionId(1L), "Thalen")
+        me.arcanum.rooms["test:room"] = ArcanumEntry(firstRecordedAtMs = 1L)
+        me.arcanum.items["bazaar:lamp"] = ArcanumEntry(firstRecordedAtMs = 1L)
+
+        assertEquals(listOf("bazaar", "test"), s.system.recordedZones(me))
     }
 
     // ── Success math ─────────────────────────────────────────────────────

--- a/src/test/kotlin/dev/ambon/engine/commands/AkathavaeCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/AkathavaeCommandTest.kt
@@ -71,6 +71,19 @@ class AkathavaeCommandTest {
         }
 
         @Test
+        fun `arcanum parses an optional page after the section`() {
+            assertEquals(Command.Arcanum("mobs", 2), CommandParser.parse("arcanum mobs 2"))
+            assertEquals(Command.Arcanum("rooms", 10), CommandParser.parse("arcanum rooms 10"))
+            assertEquals(Command.Arcanum("items", 1), CommandParser.parse("journal items 1"))
+        }
+
+        @Test
+        fun `arcanum with a non-numeric page is invalid`() {
+            assertTrue(CommandParser.parse("arcanum mobs two") is Command.Invalid)
+            assertTrue(CommandParser.parse("arcanum mobs 2 extra") is Command.Invalid)
+        }
+
+        @Test
         fun `wardrobe parses with and without keyword`() {
             assertEquals(Command.Wardrobe(null), CommandParser.parse("wardrobe"))
             assertEquals(Command.Wardrobe("hood"), CommandParser.parse("wardrobe hood"))
@@ -526,6 +539,108 @@ class AkathavaeCommandTest {
                 "got=$errors",
             )
             assertFalse(me.unlockedClasses.contains("MAGE"))
+        }
+    }
+
+    // ── Journal (arcanum command) tests ──────────────────────────────────
+
+    @Nested
+    inner class Journal {
+        /** 100 entries per telnet page (MAX_SECTION_ROWS × 4 per row). */
+        private val pageSize = 100
+
+        private suspend fun pledgedWithMobEntries(h: CommandRouterHarness, sid: SessionId, count: Int) {
+            h.loginPlayer(sid, "Thalen")
+            val me = h.players.get(sid)!!
+            me.isAkathavae = true
+            for (i in 1..count) {
+                me.arcanum.mobs["test:mob_${"%03d".format(i)}"] = ArcanumEntry(firstRecordedAtMs = i.toLong())
+            }
+            h.drain()
+        }
+
+        @Test
+        fun `bare arcanum mobs shows page 1 with a paging footer`() = runTest {
+            val h = harness()
+            val sid = SessionId(1)
+            pledgedWithMobEntries(h, sid, count = 150)
+
+            h.router.handle(sid, Command.Arcanum("mobs"))
+
+            val infos = h.drain().filterIsInstance<OutboundEvent.SendInfo>().map { it.text }
+            assertTrue(infos.any { it.contains("Creatures (150)") }, "got=$infos")
+            assertTrue(infos.any { it.contains("mob 001") }, "page 1 should start at the first entry; got=$infos")
+            assertFalse(infos.any { it.contains("mob 150") }, "page 1 must not spill into page 2; got=$infos")
+            assertTrue(infos.any { it.contains("Page 1/2 — 'arcanum mobs 2' for more.") }, "got=$infos")
+        }
+
+        @Test
+        fun `arcanum mobs 2 shows the second page`() = runTest {
+            val h = harness()
+            val sid = SessionId(1)
+            pledgedWithMobEntries(h, sid, count = 150)
+
+            h.router.handle(sid, Command.Arcanum("mobs", 2))
+
+            val infos = h.drain().filterIsInstance<OutboundEvent.SendInfo>().map { it.text }
+            assertTrue(infos.any { it.contains("mob 101") }, "page 2 starts after the first $pageSize; got=$infos")
+            assertTrue(infos.any { it.contains("mob 150") }, "got=$infos")
+            assertFalse(infos.any { it.contains("mob 001") }, "page 2 must not repeat page 1; got=$infos")
+            assertTrue(infos.any { it.contains("Page 2/2.") }, "the last page has no next-page hint; got=$infos")
+        }
+
+        @Test
+        fun `out-of-range page is a friendly error`() = runTest {
+            val h = harness()
+            val sid = SessionId(1)
+            pledgedWithMobEntries(h, sid, count = 150)
+
+            h.router.handle(sid, Command.Arcanum("mobs", 5))
+
+            val errors = h.drain().filterIsInstance<OutboundEvent.SendError>().map { it.text }
+            assertTrue(errors.any { it.contains("run 1 to 2") && it.contains("arcanum mobs 2") }, "got=$errors")
+        }
+
+        @Test
+        fun `a single page renders without a paging footer`() = runTest {
+            val h = harness()
+            val sid = SessionId(1)
+            pledgedWithMobEntries(h, sid, count = 8)
+
+            h.router.handle(sid, Command.Arcanum("mobs"))
+
+            val infos = h.drain().filterIsInstance<OutboundEvent.SendInfo>().map { it.text }
+            assertFalse(infos.any { it.contains("Page 1/") }, "got=$infos")
+        }
+
+        @Test
+        fun `summary zone lines include the items count`() = runTest {
+            val h = harness()
+            val sid = SessionId(1)
+            h.loginPlayer(sid, "Thalen")
+            h.items.loadSpawns(
+                listOf(
+                    dev.ambon.domain.world.ItemSpawn(
+                        instance = ItemInstance(ItemId("test:hood"), Item(keyword = "hood", displayName = "a leather hood")),
+                    ),
+                    dev.ambon.domain.world.ItemSpawn(
+                        instance = ItemInstance(ItemId("test:ring"), Item(keyword = "ring", displayName = "a copper ring")),
+                    ),
+                ),
+            )
+            val me = h.players.get(sid)!!
+            me.isAkathavae = true
+            me.arcanum.rooms[shrineRoom.value] = ArcanumEntry(firstRecordedAtMs = 1L)
+            me.arcanum.items["test:hood"] = ArcanumEntry(firstRecordedAtMs = 1L)
+            h.drain()
+
+            h.router.handle(sid, Command.Arcanum(null))
+
+            val infos = h.drain().filterIsInstance<OutboundEvent.SendInfo>().map { it.text }
+            assertTrue(
+                infos.any { it.contains("test: 1/2 places, 0/0 creatures, 1/2 items.") },
+                "zone line should count all three kinds; got=$infos",
+            )
         }
     }
 

--- a/web-v3/src/components/panels/ArcanumPanel.tsx
+++ b/web-v3/src/components/panels/ArcanumPanel.tsx
@@ -1,7 +1,14 @@
-import { useEffect, useRef, useState } from "react";
-import type { ArcanumJournal, ArcanumStatus } from "../../types";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type {
+  ArcanumItemEntry,
+  ArcanumJournal,
+  ArcanumMobEntry,
+  ArcanumRoomEntry,
+  ArcanumStatus,
+} from "../../types";
 
 type ArcanumTab = "mobs" | "items" | "rooms";
+type ArcanumSort = "name" | "date";
 
 const SOURCE_LABEL: Record<string, string> = {
   illuminated: "Illuminated",
@@ -11,6 +18,12 @@ const SOURCE_LABEL: Record<string, string> = {
   crafted: "Crafted",
   gathered: "Gathered",
 };
+
+/** Sources that can appear on item pages, in chip order. */
+const ITEM_SOURCES = ["illuminated", "observed", "purchased", "crafted", "gathered"];
+
+/** Incremental rendering: cards revealed per "Show more" click. */
+const PAGE_SIZE = 60;
 
 interface Props {
   journal: ArcanumJournal | null;
@@ -26,9 +39,23 @@ interface Props {
  * field-manual sensibility as the monster manual but filtered to what this
  * player has personally recorded: creatures, items, and places, with per-zone
  * completion and permanent world-first credits ("First illuminated by Thalen").
+ *
+ * Built for the completionist: every tab is searchable, creatures and items
+ * sort by name or date recorded, filter chips isolate personal world-firsts
+ * and item sources, places group by zone, and large journals render
+ * incrementally via "Show more".
  */
 export function ArcanumPanel({ journal, status, playerName, connected, onCommand }: Props) {
   const [tab, setTab] = useState<ArcanumTab>("mobs");
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<ArcanumSort>("name");
+  const [firstsOnly, setFirstsOnly] = useState(false);
+  const [sourceFilter, setSourceFilter] = useState<string | null>(null);
+  // Incremental rendering, keyed to the current lens: any change of tab,
+  // search, sort, or filter starts "Show more" over from the first page.
+  const lens = `${tab}|${query}|${sort}|${firstsOnly}|${sourceFilter ?? ""}`;
+  const [shown, setShown] = useState({ lens, count: PAGE_SIZE });
+  const visible = shown.lens === lens ? shown.count : PAGE_SIZE;
   const autoLoaded = useRef(false);
 
   // Fetch the full journal once on open; Arcanum.Journal GMCP fills `journal`.
@@ -38,6 +65,43 @@ export function ArcanumPanel({ journal, status, playerName, connected, onCommand
       onCommand("arcanum");
     }
   }, [connected, onCommand]);
+
+  const trimmedQuery = query.trim().toLowerCase();
+
+  const mobs = useMemo(() => {
+    if (!journal) return [];
+    let list = journal.mobs;
+    if (trimmedQuery) list = list.filter((m) => m.name.toLowerCase().includes(trimmedQuery));
+    if (firstsOnly) list = list.filter((m) => m.firstBy === playerName);
+    return sortEntries(list, sort);
+  }, [journal, trimmedQuery, firstsOnly, sort, playerName]);
+
+  const items = useMemo(() => {
+    if (!journal) return [];
+    let list = journal.items;
+    if (trimmedQuery) list = list.filter((i) => i.name.toLowerCase().includes(trimmedQuery));
+    if (firstsOnly) list = list.filter((i) => i.firstBy === playerName);
+    if (sourceFilter) list = list.filter((i) => i.source === sourceFilter);
+    return sortEntries(list, sort);
+  }, [journal, trimmedQuery, firstsOnly, sourceFilter, sort, playerName]);
+
+  const rooms = useMemo(() => {
+    if (!journal) return [];
+    let list = journal.rooms;
+    if (trimmedQuery) list = list.filter((r) => r.title.toLowerCase().includes(trimmedQuery));
+    if (firstsOnly) list = list.filter((r) => r.firstBy === playerName);
+    // Places group by zone (alphabetical), titles alphabetical within each zone.
+    return [...list].sort(
+      (a, b) => a.zone.localeCompare(b.zone) || a.title.localeCompare(b.title),
+    );
+  }, [journal, trimmedQuery, firstsOnly, playerName]);
+
+  /** Item sources actually present in this journal, so chips never sit dead. */
+  const presentSources = useMemo(() => {
+    if (!journal) return [];
+    const seen = new Set(journal.items.map((i) => i.source));
+    return ITEM_SOURCES.filter((s) => seen.has(s));
+  }, [journal]);
 
   const pledged = journal?.pledged ?? status?.pledged ?? false;
 
@@ -54,6 +118,13 @@ export function ArcanumPanel({ journal, status, playerName, connected, onCommand
     items: journal.items.length,
     rooms: journal.rooms.length,
   };
+  const filtered: Record<ArcanumTab, number> = {
+    mobs: mobs.length,
+    items: items.length,
+    rooms: rooms.length,
+  };
+  const activeCount = filtered[tab];
+  const filtersActive = trimmedQuery.length > 0 || firstsOnly || (tab === "items" && sourceFilter !== null);
 
   const firstLine = (firstBy: string | null) => {
     if (!firstBy) return null;
@@ -63,6 +134,71 @@ export function ArcanumPanel({ journal, status, playerName, connected, onCommand
         ★ First illuminated by {firstBy}
       </span>
     );
+  };
+
+  const showMore = (total: number) =>
+    total > visible && (
+      <button
+        className="arcanum-show-more"
+        onClick={() => setShown({ lens, count: visible + PAGE_SIZE })}
+      >
+        Show more ({total - visible} remaining)
+      </button>
+    );
+
+  /** Empty-state copy: distinguish a blank section from an over-filtered one. */
+  const emptyMessage = (blankText: string) => (
+    <p className="arcanum-empty">
+      {counts[tab] === 0 ? blankText : "No pages match your search or filters."}
+    </p>
+  );
+
+  const mobCard = (m: ArcanumMobEntry) => (
+    <div key={m.key} className="arcanum-card">
+      {m.image && <img className="arcanum-card-art" src={m.image} alt="" loading="lazy" />}
+      <div className="arcanum-card-body">
+        <span className="arcanum-card-name">{m.name}</span>
+        <span className="arcanum-card-meta">
+          {SOURCE_LABEL[m.source] ?? m.source}
+          {m.timesRecorded > 1 ? ` ×${m.timesRecorded}` : ""}
+        </span>
+        {firstLine(m.firstBy)}
+      </div>
+    </div>
+  );
+
+  const itemCard = (i: ArcanumItemEntry) => (
+    <div key={i.key} className="arcanum-card">
+      {i.image && <img className="arcanum-card-art" src={i.image} alt="" loading="lazy" />}
+      <div className="arcanum-card-body">
+        <span className="arcanum-card-name">{i.name}</span>
+        <span className="arcanum-card-meta">
+          {SOURCE_LABEL[i.source] ?? i.source}
+          {i.slot ? ` · ${i.slot}` : ""}
+        </span>
+        {firstLine(i.firstBy)}
+        {pledged && i.wearable && (
+          <button
+            className="arcanum-conjure-btn"
+            disabled={!connected}
+            onClick={() => onCommand(`wardrobe ${i.name}`)}
+          >
+            Conjure &amp; Wear
+          </button>
+        )}
+      </div>
+    </div>
+  );
+
+  /** Visible slice of places, grouped by zone with a labelled sticky header per zone. */
+  const roomGroups = () => {
+    const groups: Array<{ zone: string; rooms: ArcanumRoomEntry[] }> = [];
+    for (const r of rooms.slice(0, visible)) {
+      const last = groups[groups.length - 1];
+      if (last && last.zone === r.zone) last.rooms.push(r);
+      else groups.push({ zone: r.zone, rooms: [r] });
+    }
+    return groups;
   };
 
   return (
@@ -76,8 +212,8 @@ export function ArcanumPanel({ journal, status, playerName, connected, onCommand
       {journal.zones.length > 0 && (
         <div className="arcanum-zones">
           {journal.zones.map((z) => {
-            const total = z.roomsTotal + z.mobsTotal;
-            const recorded = z.roomsRecorded + z.mobsRecorded;
+            const total = z.roomsTotal + z.mobsTotal + z.itemsTotal;
+            const recorded = z.roomsRecorded + z.mobsRecorded + z.itemsRecorded;
             const pct = total > 0 ? Math.round((recorded / total) * 100) : 0;
             return (
               <div key={z.zone} className="arcanum-zone">
@@ -96,13 +232,56 @@ export function ArcanumPanel({ journal, status, playerName, connected, onCommand
                   <div className="arcanum-zone-fill" style={{ width: `${pct}%` }} />
                 </div>
                 <div className="arcanum-zone-detail">
-                  {z.roomsRecorded}/{z.roomsTotal} places · {z.mobsRecorded}/{z.mobsTotal} creatures
+                  {z.roomsRecorded}/{z.roomsTotal} places · {z.mobsRecorded}/{z.mobsTotal} creatures ·{" "}
+                  {z.itemsRecorded}/{z.itemsTotal} items
                 </div>
               </div>
             );
           })}
         </div>
       )}
+
+      <div className="arcanum-controls">
+        <input
+          type="search"
+          className="arcanum-search"
+          placeholder="Search these pages…"
+          aria-label="Search journal entries by name"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        {tab !== "rooms" && (
+          <select
+            className="arcanum-sort"
+            aria-label="Sort entries"
+            value={sort}
+            onChange={(e) => setSort(e.target.value as ArcanumSort)}
+          >
+            <option value="name">By name</option>
+            <option value="date">Newest first</option>
+          </select>
+        )}
+        <div className="arcanum-chips">
+          <button
+            className={`arcanum-chip${firstsOnly ? " arcanum-chip-active" : ""}`}
+            aria-pressed={firstsOnly}
+            onClick={() => setFirstsOnly((v) => !v)}
+          >
+            ★ My firsts
+          </button>
+          {tab === "items" &&
+            presentSources.map((s) => (
+              <button
+                key={s}
+                className={`arcanum-chip${sourceFilter === s ? " arcanum-chip-active" : ""}`}
+                aria-pressed={sourceFilter === s}
+                onClick={() => setSourceFilter((cur) => (cur === s ? null : s))}
+              >
+                {SOURCE_LABEL[s]}
+              </button>
+            ))}
+        </div>
+      </div>
 
       <div className="arcanum-tabs" role="tablist">
         {(["mobs", "items", "rooms"] as const).map((t) => (
@@ -118,65 +297,57 @@ export function ArcanumPanel({ journal, status, playerName, connected, onCommand
         ))}
       </div>
 
+      {filtersActive && (
+        <p className="arcanum-filter-note" aria-live="polite">
+          Showing {activeCount} of {counts[tab]}{" "}
+          {tab === "mobs" ? "creatures" : tab === "items" ? "items" : "places"}.
+        </p>
+      )}
+
       {tab === "mobs" && (
         <div className="arcanum-grid">
-          {journal.mobs.length === 0 && <p className="arcanum-empty">No creatures illuminated yet.</p>}
-          {journal.mobs.map((m) => (
-            <div key={m.key} className="arcanum-card">
-              {m.image && <img className="arcanum-card-art" src={m.image} alt="" loading="lazy" />}
-              <div className="arcanum-card-body">
-                <span className="arcanum-card-name">{m.name}</span>
-                <span className="arcanum-card-meta">
-                  {SOURCE_LABEL[m.source] ?? m.source}
-                  {m.timesRecorded > 1 ? ` ×${m.timesRecorded}` : ""}
-                </span>
-                {firstLine(m.firstBy)}
-              </div>
-            </div>
-          ))}
+          {mobs.length === 0 && emptyMessage("No creatures illuminated yet.")}
+          {mobs.slice(0, visible).map(mobCard)}
         </div>
       )}
+      {tab === "mobs" && showMore(mobs.length)}
 
       {tab === "items" && (
         <div className="arcanum-grid">
-          {journal.items.length === 0 && <p className="arcanum-empty">No items recorded yet.</p>}
-          {journal.items.map((i) => (
-            <div key={i.key} className="arcanum-card">
-              {i.image && <img className="arcanum-card-art" src={i.image} alt="" loading="lazy" />}
-              <div className="arcanum-card-body">
-                <span className="arcanum-card-name">{i.name}</span>
-                <span className="arcanum-card-meta">
-                  {SOURCE_LABEL[i.source] ?? i.source}
-                  {i.slot ? ` · ${i.slot}` : ""}
-                </span>
-                {firstLine(i.firstBy)}
-                {pledged && i.wearable && (
-                  <button
-                    className="arcanum-conjure-btn"
-                    disabled={!connected}
-                    onClick={() => onCommand(`wardrobe ${i.name}`)}
-                  >
-                    Conjure &amp; Wear
-                  </button>
-                )}
-              </div>
-            </div>
-          ))}
+          {items.length === 0 && emptyMessage("No items recorded yet.")}
+          {items.slice(0, visible).map(itemCard)}
         </div>
       )}
+      {tab === "items" && showMore(items.length)}
 
       {tab === "rooms" && (
         <div className="arcanum-rooms">
-          {journal.rooms.length === 0 && <p className="arcanum-empty">No places recorded yet.</p>}
-          {journal.rooms.map((r) => (
-            <div key={r.key} className="arcanum-room-row">
-              <span className="arcanum-room-title">{r.title}</span>
-              <span className="arcanum-room-zone">{r.zone}</span>
-              {firstLine(r.firstBy)}
+          {rooms.length === 0 && emptyMessage("No places recorded yet.")}
+          {roomGroups().map((g) => (
+            <div key={g.zone} className="arcanum-room-group">
+              <div className="arcanum-room-group-head">{g.zone}</div>
+              {g.rooms.map((r) => (
+                <div key={r.key} className="arcanum-room-row">
+                  <span className="arcanum-room-title">{r.title}</span>
+                  {firstLine(r.firstBy)}
+                </div>
+              ))}
             </div>
           ))}
         </div>
       )}
+      {tab === "rooms" && showMore(rooms.length)}
     </div>
   );
+}
+
+/** Name (default) or newest-recorded-first ordering for creature and item cards. */
+function sortEntries<T extends ArcanumMobEntry | ArcanumItemEntry>(list: readonly T[], sort: ArcanumSort): T[] {
+  const sorted = [...list];
+  if (sort === "date") {
+    sorted.sort((a, b) => b.firstRecordedAtMs - a.firstRecordedAtMs || a.name.localeCompare(b.name));
+  } else {
+    sorted.sort((a, b) => a.name.localeCompare(b.name));
+  }
+  return sorted;
 }

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -2270,6 +2270,8 @@ export function applyGmcpPackage(
           roomsTotal: safeNumber(z.roomsTotal, 0),
           mobsRecorded: safeNumber(z.mobsRecorded, 0),
           mobsTotal: safeNumber(z.mobsTotal, 0),
+          itemsRecorded: safeNumber(z.itemsRecorded, 0),
+          itemsTotal: safeNumber(z.itemsTotal, 0),
         })),
         mobs: asRecords(packet.mobs).map((m) => ({
           key: typeof m.key === "string" ? m.key : "",

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -27585,6 +27585,92 @@ html:has(.game-shell),
   color: var(--text-muted);
 }
 
+.arcanum-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.arcanum-search {
+  flex: 1 1 160px;
+  min-width: 120px;
+  padding: 5px 10px;
+  border: 1px solid var(--line-faint);
+  border-radius: var(--radius-sm);
+  background: var(--surface-input);
+  color: var(--text-primary);
+  font-size: 0.8rem;
+}
+
+.arcanum-search::placeholder {
+  color: var(--text-muted);
+}
+
+.arcanum-search:focus-visible {
+  outline: 2px solid var(--primary-dim);
+  outline-offset: 1px;
+}
+
+.arcanum-sort {
+  padding: 5px 8px;
+  border: 1px solid var(--line-faint);
+  border-radius: var(--radius-sm);
+  background: var(--surface-input);
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.arcanum-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+.arcanum-chip {
+  padding: 3px 10px;
+  border: 1px solid var(--line-faint);
+  border-radius: 999px;
+  background: var(--surface-chip);
+  color: var(--text-secondary);
+  font-size: 0.74rem;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.arcanum-chip:hover {
+  background: var(--primary-glass);
+  color: var(--text-primary);
+}
+
+.arcanum-chip-active {
+  background: var(--primary-glass);
+  color: var(--accent-gold);
+  border-color: var(--primary-dim);
+}
+
+.arcanum-filter-note {
+  margin: 0;
+  font-size: 0.74rem;
+  color: var(--text-muted);
+}
+
+.arcanum-show-more {
+  align-self: center;
+  padding: 5px 14px;
+  border: 1px solid var(--primary-dim);
+  border-radius: var(--radius-sm);
+  background: var(--primary-glass);
+  color: var(--text-primary);
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.arcanum-show-more:hover {
+  border-color: var(--accent-gold);
+}
+
 .arcanum-tabs {
   display: flex;
   gap: var(--space-1);
@@ -27681,6 +27767,20 @@ html:has(.game-shell),
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
+}
+
+.arcanum-room-group-head {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding: var(--space-1) var(--space-2);
+  background: var(--surface-subpanel);
+  border-radius: var(--radius-sm);
+  font-size: 0.74rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: capitalize;
+  color: var(--accent-gold);
 }
 
 .arcanum-room-row {

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -1574,6 +1574,8 @@ export interface ArcanumZoneCompletion {
   roomsTotal: number;
   mobsRecorded: number;
   mobsTotal: number;
+  itemsRecorded: number;
+  itemsTotal: number;
 }
 
 export interface ArcanumMobEntry {


### PR DESCRIPTION
## Summary

Arcanum journal UX for the completionist player (issue #1397):

- **Zone completion includes items**: `AkathavaeSystem.zoneCompletion` gains `itemsRecorded`/`itemsTotal` (item templates keyed `<zone>:<item>`; unzoned ids excluded), carried through the `Arcanum.Journal` GMCP zone payload and the telnet `arcanum` summary line.
- **Telnet paging**: `arcanum rooms|mobs|items [page]` — 100 entries per page, `Page X/Y — 'arcanum mobs 3' for more.` footer, friendly out-of-range error; bare section unchanged (page 1).
- **Web panel** (in progress): search box, per-tab sort (name/date), filter chips (My firsts ★, per-source on items), rooms grouped by zone, incremental "Show more" rendering, zone bars across all three kinds.

Closes #1397
Part of #1400

## Testing

- `AkathavaeCommandTest`: parser page tests, paging router tests, summary items line.
- `AkathavaeIlluminateTest`: zone completion item counts, item-only zones.
- `./gradlew ktlintCheck test` + `bun run lint` (web).