### PR TITLE
fix(gmcp): chunk staff world/mob listings to fit the 64KB frame cap

### DIFF
--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -2945,36 +2945,92 @@ class GmcpEmitter(
     // ---------- staff world info ----------
 
     /**
-     * Sends full world zone/room listing to staff players for the teleport browser.
+     * Sends the full world zone/room listing to staff for the teleport browser.
+     *
+     * The production world (20+ zones fetched from R2) serializes to hundreds of
+     * KB — far past [MAX_GMCP_PAYLOAD_BYTES] — so the listing is split into
+     * byte-bounded `{chunk, zones}` frames instead of one array that the frame
+     * cap would silently drop. The client resets its accumulator on `chunk == 0`
+     * and merge-appends later frames by zone key (see [emitStaffZoneChunks]).
      */
     suspend fun sendStaffWorldInfo(sessionId: SessionId, world: World) {
         val zones = world.zones().sorted().map { zone ->
-            val rooms = world.rooms.values
+            zone to world.rooms.values
                 .filter { it.id.zone == zone }
                 .sortedBy { it.id.value }
                 .map { StaffRoomPayload(id = it.id.value, title = it.title) }
-            StaffZonePayload(zone = zone, rooms = rooms)
         }
-        emit(sessionId, "Staff.WorldInfo", zones, supportCheck = "Staff")
+        emitStaffZoneChunks(sessionId, "Staff.WorldInfo", zones) { z, rooms -> StaffZonePayload(zone = z, rooms = rooms) }
     }
 
     /**
-     * Sends mob template listing to staff players for the spawn browser.
+     * Sends the mob template listing to staff for the spawn browser. Chunked the
+     * same way as [sendStaffWorldInfo].
      */
     suspend fun sendStaffMobTemplates(sessionId: SessionId, world: World) {
-        val grouped = world.mobTemplates.values.groupBy { it.id.value.substringBefore(':') }
-        val zones = grouped.entries.sortedBy { it.key }.map { (zone, templates) ->
-            StaffMobZonePayload(
-                zone = zone,
-                mobs = templates.sortedBy { it.id.value }.map { tpl ->
-                    StaffMobTemplatePayload(
-                        id = tpl.id.value,
-                        name = tpl.name,
-                    )
-                },
-            )
+        val zones = world.mobTemplates.values
+            .groupBy { it.id.value.substringBefore(':') }
+            .entries.sortedBy { it.key }
+            .map { (zone, templates) ->
+                zone to templates.sortedBy { it.id.value }
+                    .map { StaffMobTemplatePayload(id = it.id.value, name = it.name) }
+            }
+        emitStaffZoneChunks(sessionId, "Staff.MobTemplates", zones) { z, mobs -> StaffMobZonePayload(zone = z, mobs = mobs) }
+    }
+
+    /**
+     * Packs [zones] (each a `zone -> items` pair, pre-sorted) into byte-bounded
+     * `{chunk, zones}` frames and emits them in order. Each frame stays under
+     * [STAFF_CHUNK_BUDGET] chars; a single zone larger than the budget is split
+     * into multiple same-zone payloads (the client merge-appends by zone key, so
+     * the split is invisible downstream). An empty world still emits one `chunk 0`
+     * frame so the client clears any stale listing.
+     */
+    private suspend fun <I> emitStaffZoneChunks(
+        sessionId: SessionId,
+        packageName: String,
+        zones: List<Pair<String, List<I>>>,
+        zonePayload: (String, List<I>) -> Any,
+    ) {
+        if (!supportsPackage(sessionId, "Staff")) return
+
+        val chunks = mutableListOf<MutableList<Any>>()
+        var current = mutableListOf<Any>()
+        var currentChars = FRAME_ENVELOPE_OVERHEAD
+
+        fun flush() {
+            if (current.isNotEmpty()) {
+                chunks.add(current)
+                current = mutableListOf()
+                currentChars = FRAME_ENVELOPE_OVERHEAD
+            }
         }
-        emit(sessionId, "Staff.MobTemplates", zones, supportCheck = "Staff")
+
+        fun add(zone: String, items: List<I>) {
+            if (items.isEmpty()) return
+            val payload = zonePayload(zone, items)
+            val size = json.writeValueAsString(payload).length + 1 // + array comma
+            if (size > STAFF_CHUNK_BUDGET && items.size > 1) {
+                val mid = items.size / 2
+                add(zone, items.subList(0, mid))
+                add(zone, items.subList(mid, items.size))
+                return
+            }
+            if (currentChars + size > STAFF_CHUNK_BUDGET) flush()
+            current.add(payload)
+            currentChars += size
+        }
+
+        zones.forEach { (zone, items) -> add(zone, items) }
+        flush()
+
+        if (chunks.isEmpty()) {
+            emit(sessionId, packageName, StaffChunkEnvelope(chunk = 0, zones = emptyList()), supportCheck = "Staff")
+            return
+        }
+        chunks.forEachIndexed { index, zonePayloads ->
+            emit(sessionId, packageName, StaffChunkEnvelope(chunk = index, zones = zonePayloads), supportCheck = "Staff")
+        }
     }
 
     @Suppress("unused") // Jackson serializes all fields
@@ -2984,6 +3040,18 @@ class GmcpEmitter(
         val code: String? = null,
         val scope: String? = null,
         val command: String? = null,
+    )
+
+    /**
+     * One chunk of a `Staff.WorldInfo`/`Staff.MobTemplates` listing. [chunk] is a
+     * 0-based frame index; the client resets its accumulator on `chunk == 0` and
+     * merge-appends the [zones] of every frame by zone key. [zones] holds
+     * [StaffZonePayload] or [StaffMobZonePayload] elements — Jackson serializes
+     * each by its runtime type.
+     */
+    private data class StaffChunkEnvelope(
+        val chunk: Int,
+        val zones: List<Any>,
     )
 
     private data class StaffZonePayload(
@@ -4159,6 +4227,16 @@ class GmcpEmitter(
     internal companion object {
         /** Maximum serialized GMCP JSON payload size in bytes (64 KB). */
         const val MAX_GMCP_PAYLOAD_BYTES = 65_536
+
+        /**
+         * Per-chunk size target for the staff world/mob listings — kept well under
+         * [MAX_GMCP_PAYLOAD_BYTES] so a filled chunk plus its envelope never trips
+         * the frame cap. Measured in chars (matching the emit-path length check).
+         */
+        const val STAFF_CHUNK_BUDGET = 48_000
+
+        /** Approx chars a `{"chunk":N,"zones":[]}` envelope adds around the zones array. */
+        const val FRAME_ENVELOPE_OVERHEAD = 32
 
         /** Upper bound for the zone-tracking LRU cache (well above any realistic session count). */
         const val MAX_ZONE_CACHE_ENTRIES = 10_000

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -2661,4 +2661,135 @@ class GmcpEmitterTest {
     fun `MAX_GMCP_PAYLOAD_BYTES is 64KB`() {
         assertEquals(65_536, GmcpEmitter.MAX_GMCP_PAYLOAD_BYTES)
     }
+
+    // ── Staff world/mob listing chunking ──
+
+    /** A world with [zoneCount] zones of [roomsPerZone] rooms each, titles padded to force size. */
+    private fun bigWorld(zoneCount: Int, roomsPerZone: Int): dev.ambon.domain.world.World {
+        val rooms = buildMap {
+            for (z in 0 until zoneCount) {
+                for (r in 0 until roomsPerZone) {
+                    val id = RoomId("zone%02d:room%04d".format(z, r))
+                    put(
+                        id,
+                        Room(
+                            id = id,
+                            title = "Room $r of zone $z — a chamber of some description here",
+                            description = "",
+                            exits = emptyMap(),
+                        ),
+                    )
+                }
+            }
+        }
+        return dev.ambon.domain.world.World(rooms = rooms, startRoom = RoomId("zone00:room0000"))
+    }
+
+    private fun mobWorld(zoneCount: Int, mobsPerZone: Int): dev.ambon.domain.world.World {
+        val templates = buildMap {
+            for (z in 0 until zoneCount) {
+                for (m in 0 until mobsPerZone) {
+                    val id = MobId("zone%02d:mob%04d".format(z, m))
+                    put(id, dev.ambon.domain.world.MobTemplateDef(id = id, name = "Creature $m of zone $z, a fearsome and verbose beast"))
+                }
+            }
+        }
+        return dev.ambon.domain.world.World(
+            rooms = mapOf(
+                RoomId("zone00:spawn") to Room(id = RoomId("zone00:spawn"), title = "Spawn", description = "", exits = emptyMap()),
+            ),
+            startRoom = RoomId("zone00:spawn"),
+            mobTemplates = templates,
+        )
+    }
+
+    @Test
+    fun `sendStaffWorldInfo chunks a large world under the frame cap without losing rooms`() =
+        runTest {
+            val world = bigWorld(zoneCount = 12, roomsPerZone = 220) // well past 64KB serialized
+            val e = emitter("Staff")
+            e.sendStaffWorldInfo(sid, world)
+
+            val frames = drainGmcp().filter { it.gmcpPackage == "Staff.WorldInfo" }
+            assertTrue(frames.size > 1, "expected the listing to split into multiple frames; got ${frames.size}")
+
+            val mapper = jacksonObjectMapper()
+            val seenChunks = mutableListOf<Int>()
+            val roomsByZone = mutableMapOf<String, MutableList<String>>()
+            for (frame in frames) {
+                assertTrue(
+                    frame.jsonData.length <= GmcpEmitter.MAX_GMCP_PAYLOAD_BYTES,
+                    "frame exceeded the cap: ${frame.jsonData.length}",
+                )
+                val node = mapper.readTree(frame.jsonData)
+                seenChunks += node["chunk"].asInt()
+                for (zoneNode in node["zones"]) {
+                    val zone = zoneNode["zone"].asText()
+                    zoneNode["rooms"].forEach { roomsByZone.getOrPut(zone) { mutableListOf() }.add(it["id"].asText()) }
+                }
+            }
+            // Chunk indices are 0..N contiguous.
+            assertEquals((0 until frames.size).toList(), seenChunks)
+            // Every room in the world is present exactly once across all frames.
+            val expected = world.rooms.keys.map { it.value }.sorted()
+            val actual = roomsByZone.values.flatten().sorted()
+            assertEquals(expected, actual, "chunking must not drop or duplicate rooms")
+        }
+
+    @Test
+    fun `sendStaffWorldInfo splits a single oversized zone across frames`() =
+        runTest {
+            val world = bigWorld(zoneCount = 1, roomsPerZone = 1400) // one zone alone over the cap
+            val e = emitter("Staff")
+            e.sendStaffWorldInfo(sid, world)
+
+            val frames = drainGmcp().filter { it.gmcpPackage == "Staff.WorldInfo" }
+            assertTrue(frames.size > 1, "a single huge zone must still split; got ${frames.size}")
+            val mapper = jacksonObjectMapper()
+            frames.forEach { assertTrue(it.jsonData.length <= GmcpEmitter.MAX_GMCP_PAYLOAD_BYTES) }
+            // The same zone key appears in more than one frame (client merges by key).
+            val zoneAppearances = frames.count { mapper.readTree(it.jsonData)["zones"].any { z -> z["zone"].asText() == "zone00" } }
+            assertTrue(zoneAppearances > 1, "the oversized zone should span multiple frames; appeared in $zoneAppearances")
+            val total = frames.sumOf { mapper.readTree(it.jsonData)["zones"].sumOf { z -> z["rooms"].size() } }
+            assertEquals(1400, total, "no rooms lost when splitting one zone")
+        }
+
+    @Test
+    fun `sendStaffMobTemplates chunks large template sets under the frame cap`() =
+        runTest {
+            val world = mobWorld(zoneCount = 10, mobsPerZone = 260)
+            val e = emitter("Staff")
+            e.sendStaffMobTemplates(sid, world)
+
+            val frames = drainGmcp().filter { it.gmcpPackage == "Staff.MobTemplates" }
+            assertTrue(frames.size > 1, "expected multiple frames; got ${frames.size}")
+            val mapper = jacksonObjectMapper()
+            val ids = mutableListOf<String>()
+            frames.forEach { frame ->
+                assertTrue(frame.jsonData.length <= GmcpEmitter.MAX_GMCP_PAYLOAD_BYTES)
+                mapper.readTree(frame.jsonData)["zones"].forEach { z -> z["mobs"].forEach { ids += it["id"].asText() } }
+            }
+            assertEquals(world.mobTemplates.keys.map { it.value }.sorted(), ids.sorted())
+        }
+
+    @Test
+    fun `sendStaffWorldInfo emits a single reset frame for an empty world`() =
+        runTest {
+            // One tiny room → one frame, chunk 0, so the client clears any prior listing.
+            val world = bigWorld(zoneCount = 1, roomsPerZone = 1)
+            val e = emitter("Staff")
+            e.sendStaffWorldInfo(sid, world)
+            val frames = drainGmcp().filter { it.gmcpPackage == "Staff.WorldInfo" }
+            assertEquals(1, frames.size)
+            assertEquals(0, jacksonObjectMapper().readTree(frames[0].jsonData)["chunk"].asInt())
+        }
+
+    @Test
+    fun `staff listings are withheld when the Staff package is unsupported`() =
+        runTest {
+            val e = emitter() // Staff not negotiated
+            e.sendStaffWorldInfo(sid, bigWorld(zoneCount = 2, roomsPerZone = 2))
+            e.sendStaffMobTemplates(sid, mobWorld(zoneCount = 2, mobsPerZone = 2))
+            assertTrue(drainGmcp().isEmpty())
+        }
 }

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -122,6 +122,27 @@ import { MAX_CHAT_MESSAGES_PER_CHANNEL } from "../constants";
 import { safeNumber } from "../utils";
 import type { AbilityVisualArchetype, SkillVisual, ZoneMapRoomData } from "../types";
 
+/**
+ * Merges the chunked staff world/mob listings: [base] is the accumulator so far
+ * (empty on the reset chunk), [incoming] is this frame's zones. Same-key zones
+ * are combined via [combine] (concatenating their room/mob lists), so a zone the
+ * server split across frames reassembles into one entry. Insertion order is
+ * preserved, so zones stay in the server's sorted order.
+ */
+function mergeStaffZones<Z extends { zone: string }>(
+  base: readonly Z[],
+  incoming: readonly Z[],
+  combine: (a: Z, b: Z) => Z,
+): Z[] {
+  const byZone = new Map<string, Z>();
+  for (const z of base) byZone.set(z.zone, z);
+  for (const z of incoming) {
+    const existing = byZone.get(z.zone);
+    byZone.set(z.zone, existing ? combine(existing, z) : z);
+  }
+  return [...byZone.values()];
+}
+
 const KNOWN_ARCHETYPES: ReadonlySet<AbilityVisualArchetype> = new Set([
   "RANGED_PROJECTILE",
   "MELEE_STRIKE",
@@ -2470,21 +2491,27 @@ export function applyGmcpPackage(
     }
 
     case "Staff.WorldInfo": {
-      if (!Array.isArray(data)) break;
-      ctx.setStaffWorldInfo(
-        data
-          .filter((e): e is Record<string, unknown> => typeof e === "object" && e !== null)
-          .map((e) => ({
-            zone: typeof e.zone === "string" ? e.zone : "",
-            rooms: Array.isArray(e.rooms)
-              ? e.rooms
-                  .filter((r): r is Record<string, unknown> => typeof r === "object" && r !== null)
-                  .map((r) => ({
-                    id: typeof r.id === "string" ? r.id : "",
-                    title: typeof r.title === "string" ? r.title : "",
-                  }))
-              : [],
-          })),
+      // Chunked: reset the accumulator on chunk 0, merge-append later chunks by
+      // zone key (a large zone is split across frames server-side). Tolerates the
+      // legacy bare-array shape too, in case an old frame is ever seen.
+      const packet = data as Partial<Record<string, unknown>>;
+      const chunk = Array.isArray(data) ? 0 : safeNumber(packet.chunk, 0);
+      const rawZones = Array.isArray(data) ? data : Array.isArray(packet.zones) ? packet.zones : [];
+      const incoming = rawZones
+        .filter((e): e is Record<string, unknown> => typeof e === "object" && e !== null)
+        .map((e) => ({
+          zone: typeof e.zone === "string" ? e.zone : "",
+          rooms: Array.isArray(e.rooms)
+            ? e.rooms
+                .filter((r): r is Record<string, unknown> => typeof r === "object" && r !== null)
+                .map((r) => ({
+                  id: typeof r.id === "string" ? r.id : "",
+                  title: typeof r.title === "string" ? r.title : "",
+                }))
+            : [],
+        }));
+      ctx.setStaffWorldInfo((prev) =>
+        mergeStaffZones(chunk === 0 ? [] : prev, incoming, (a, b) => ({ zone: a.zone, rooms: [...a.rooms, ...b.rooms] })),
       );
       break;
     }
@@ -2498,21 +2525,25 @@ export function applyGmcpPackage(
     }
 
     case "Staff.MobTemplates": {
-      if (!Array.isArray(data)) break;
-      ctx.setStaffMobTemplates(
-        data
-          .filter((e): e is Record<string, unknown> => typeof e === "object" && e !== null)
-          .map((e) => ({
-            zone: typeof e.zone === "string" ? e.zone : "",
-            mobs: Array.isArray(e.mobs)
-              ? e.mobs
-                  .filter((m): m is Record<string, unknown> => typeof m === "object" && m !== null)
-                  .map((m) => ({
-                    id: typeof m.id === "string" ? m.id : "",
-                    name: typeof m.name === "string" ? m.name : "",
-                  }))
-              : [],
-          })),
+      // Chunked exactly like Staff.WorldInfo above.
+      const packet = data as Partial<Record<string, unknown>>;
+      const chunk = Array.isArray(data) ? 0 : safeNumber(packet.chunk, 0);
+      const rawZones = Array.isArray(data) ? data : Array.isArray(packet.zones) ? packet.zones : [];
+      const incoming = rawZones
+        .filter((e): e is Record<string, unknown> => typeof e === "object" && e !== null)
+        .map((e) => ({
+          zone: typeof e.zone === "string" ? e.zone : "",
+          mobs: Array.isArray(e.mobs)
+            ? e.mobs
+                .filter((m): m is Record<string, unknown> => typeof m === "object" && m !== null)
+                .map((m) => ({
+                  id: typeof m.id === "string" ? m.id : "",
+                  name: typeof m.name === "string" ? m.name : "",
+                }))
+            : [],
+        }));
+      ctx.setStaffMobTemplates((prev) =>
+        mergeStaffZones(chunk === 0 ? [] : prev, incoming, (a, b) => ({ zone: a.zone, mobs: [...a.mobs, ...b.mobs] })),
       );
       break;
     }


### PR DESCRIPTION
## Summary

Production logs (from the metrics-fix investigation) showed:

```
WARN GmcpEmitter - GMCP payload exceeds 65536B limit for Staff.WorldInfo (633129B), skipping
WARN GmcpEmitter - GMCP payload exceeds 65536B limit for Staff.MobTemplates (134160B), skipping
WARN GameEngine - Slow tick: elapsed=2384ms (threshold=200ms)
```

The full production world (20+ zones fetched from R2) serializes both staff listings far past the 64KB GMCP frame cap, so they were built (the 2.4s slow tick at staff login) and then **silently dropped** — staff got an empty teleport browser and empty spawn browser. The bundled Academy world is tiny, so this only bit in production.

## Fix

`Staff.WorldInfo` and `Staff.MobTemplates` now emit as byte-bounded `{chunk, zones}` frames (48KB budget per frame, comfortably under the 64KB cap):
- **Server** (`GmcpEmitter.emitStaffZoneChunks`): greedily packs zones into frames; a single zone larger than the budget is bisected into multiple same-zone frames.
- **Client** (`applyGmcpPackage`): resets its accumulator on `chunk == 0` and merge-appends later frames by zone key (new `mergeStaffZones` helper), so a split zone reassembles transparently. Still tolerates the legacy bare-array shape.

Server and client ship together (the client is bundled into the jar), so there's no version-skew concern with the wire-shape change.

## Testing
`./gradlew ktlintCheck test integrationTest` green, including new `GmcpEmitterTest` coverage:
- large world splits into multiple frames, each under the cap, with every room present exactly once
- a single oversized zone spans multiple frames and loses no rooms
- large mob-template sets chunk the same way
- empty world emits one `chunk 0` reset frame
- the Staff support gate still withholds both listings when unnegotiated

**Not verified live**: exercising the multi-chunk path needs a staff account against the full R2 world; the demo runs the single-zone Academy (one chunk). The unit tests cover the chunking logic; the client merge is a minimal, type-checked change to how the existing accumulated state is built.

Follow-up to the drop-metrics fix in #1420.

🤖 Generated with Claude Code