### PR TITLE
fix(web): Shrine as a room-based kiosk, not a permanent dock item

### DIFF
--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -578,6 +578,7 @@ function App() {
     canvasCallbacks.openJukebox = () => openPanel("jukebox");
     canvasCallbacks.openMusicBox = () => openPanel("musicbox");
     canvasCallbacks.openHousing = () => openPanel("housing");
+    canvasCallbacks.openShrine = () => openPanel("shrine");
     canvasCallbacks.openInn = () => setShowInn(true);
     canvasCallbacks.openAdminPanel = () => setShowAdminPanel(true);
     canvasCallbacks.toggleInvis = () => { sendCommand("invis"); setStaffInvisible((v) => !v); };
@@ -642,6 +643,7 @@ function App() {
       canvasCallbacks.openJukebox = null;
       canvasCallbacks.openMusicBox = null;
       canvasCallbacks.openHousing = null;
+      canvasCallbacks.openShrine = null;
       canvasCallbacks.openInn = null;
       canvasCallbacks.openAdminPanel = null;
       canvasCallbacks.toggleInvis = null;

--- a/web-v3/src/canvas/GameStateBridge.ts
+++ b/web-v3/src/canvas/GameStateBridge.ts
@@ -97,6 +97,7 @@ export const canvasCallbacks: {
   openJukebox: (() => void) | null;
   openMusicBox: (() => void) | null;
   openHousing: (() => void) | null;
+  openShrine: (() => void) | null;
   openInn: (() => void) | null;
   openMail: (() => void) | null;
   openMap: (() => void) | null;
@@ -145,6 +146,7 @@ export const canvasCallbacks: {
   openJukebox: null,
   openMusicBox: null,
   openHousing: null,
+  openShrine: null,
   openInn: null,
   openMail: null,
   openMap: null,

--- a/web-v3/src/canvas/scenes/WorldScene.ts
+++ b/web-v3/src/canvas/scenes/WorldScene.ts
@@ -275,6 +275,13 @@ export class WorldScene {
   private innHitArea = new Graphics();
   private innVisible = false;
 
+  private shrineBadge: Container | null = null;
+  private shrineSprite: Sprite | null = null;
+  private shrineLabel: Text | null = null;
+  private shrineLabelBg = new Graphics();
+  private shrineHitArea = new Graphics();
+  private shrineVisible = false;
+
   private mailBadge: Container | null = null;
   private mailSprite: Sprite | null = null;
   private mailLabel: Text | null = null;
@@ -751,6 +758,36 @@ export class WorldScene {
     this.innBadge.addChild(this.innLabelBg);
     this.innBadge.addChild(this.innLabel);
 
+    // Shrine badge — floating icon when the current room is an Akathavae shrine.
+    // Room-contextual (like Inn), so pledge/renounce lives here, not in the dock.
+    this.shrineBadge = new Container();
+    this.shrineBadge.visible = false;
+    this.shrineBadge.eventMode = "static";
+    this.shrineBadge.cursor = "pointer";
+    this.shrineBadge.on("pointerdown", () => {
+      canvasCallbacks.openShrine?.();
+    });
+    this.shrineBadge.on("pointerover", () => {
+      if (this.shrineSprite) this.shrineSprite.alpha = 1;
+    });
+    this.shrineBadge.on("pointerout", () => {
+      if (this.shrineSprite) this.shrineSprite.alpha = 0.85;
+    });
+    this.shrineHitArea.rect(-hs / 2, -hs / 2, hs, hs + 20);
+    this.shrineHitArea.fill({ color: 0x000000, alpha: 0.001 });
+    this.shrineHitArea.eventMode = "auto";
+    this.shrineBadge.addChild(this.shrineHitArea);
+    this.shrineLabel = new Text({
+      text: "Shrine",
+      style: { fontFamily: "JetBrains Mono, Cascadia Mono, monospace", fontSize: 11, fill: "#e3c98a", dropShadow: { color: 0x000000, alpha: 1, blur: 4, distance: 0 } },
+    });
+    this.shrineLabel.anchor.set(0.5, 0);
+    this.shrineLabel.y = hs / 2 + 2;
+    this.shrineLabel.eventMode = "none";
+    this.shrineLabelBg.eventMode = "none";
+    this.shrineBadge.addChild(this.shrineLabelBg);
+    this.shrineBadge.addChild(this.shrineLabel);
+
     // Mail badge — floating icon at inns / player homes
     this.mailBadge = new Container();
     this.mailBadge.visible = false;
@@ -1036,6 +1073,7 @@ export class WorldScene {
     this.container.addChild(this.dungeonBadge!);
     this.container.addChild(this.housingBadge!);
     this.container.addChild(this.innBadge!);
+    this.container.addChild(this.shrineBadge!);
     this.container.addChild(this.mailBadge!);
     this.container.addChild(this.duelBadge!);
     this.container.addChild(this.puzzleBadge!);
@@ -1087,6 +1125,7 @@ export class WorldScene {
       this.loadDungeonIcon();
       this.loadHousingBrokerIcon();
       this.loadInnIcon();
+      this.loadShrineIcon();
       this.loadMailIcon();
       this.loadDuelIcon();
       this.loadPuzzleIcon();
@@ -1340,6 +1379,12 @@ export class WorldScene {
       if (this.innBadge) this.innBadge.visible = hasInn;
     }
 
+    const hasShrine = !!state.room.shrine;
+    if (hasShrine !== this.shrineVisible) {
+      this.shrineVisible = hasShrine;
+      if (this.shrineBadge) this.shrineBadge.visible = hasShrine;
+    }
+
     // Mail badge removed pending a new home (GH #1189); the badge code is kept
     // dormant. Was: !!state.room.inn || !!state.room.housing.
     const hasMail = false;
@@ -1489,6 +1534,7 @@ export class WorldScene {
     if (this.dungeonBadge) this.dungeonBadge.visible = this.dungeonVisible && !stripMode;
     if (this.housingBadge) this.housingBadge.visible = this.housingVisible && !stripMode;
     if (this.innBadge) this.innBadge.visible = this.innVisible && !stripMode;
+    if (this.shrineBadge) this.shrineBadge.visible = this.shrineVisible && !stripMode;
     if (this.mailBadge) this.mailBadge.visible = this.mailVisible && !stripMode;
     if (this.duelBadge) this.duelBadge.visible = this.duelVisible && !stripMode;
     if (this.puzzleBadge) this.puzzleBadge.visible = this.puzzleVisible && !stripMode;
@@ -1767,6 +1813,7 @@ export class WorldScene {
       this.lotteryBadge?.visible, this.diceBadge?.visible, this.dungeonBadge?.visible,
       this.housingBadge?.visible,
       this.innBadge?.visible,
+      this.shrineBadge?.visible,
       this.mailBadge?.visible,
       this.duelBadge?.visible, this.puzzleBadge?.visible,
       this.doorBadge?.visible, this.containerBadge?.visible,
@@ -1884,6 +1931,13 @@ export class WorldScene {
       this.innBadge.x = badgeX;
       this.innBadge.y = badgeStartY + badgeSlot * badgeSpacing;
       drawLabelPill(this.innLabelBg, this.innLabel!);
+      badgeSlot++;
+    }
+
+    if (this.shrineBadge?.visible) {
+      this.shrineBadge.x = badgeX;
+      this.shrineBadge.y = badgeStartY + badgeSlot * badgeSpacing;
+      drawLabelPill(this.shrineLabelBg, this.shrineLabel!);
       badgeSlot++;
     }
 
@@ -2815,6 +2869,22 @@ export class WorldScene {
       sprite.eventMode = "none";
       this.innSprite = sprite;
       this.innBadge?.addChild(sprite);
+    } catch {
+      // Fallback: text-only label still works
+    }
+  }
+
+  private async loadShrineIcon() {
+    try {
+      const texture = await Assets.load(assetUrl("shrine_widget", "shrine_widget.png"));
+      const sprite = new Sprite(texture);
+      sprite.width = SHOP_BADGE_SIZE;
+      sprite.height = SHOP_BADGE_SIZE;
+      sprite.anchor.set(0.5);
+      sprite.alpha = 0.85;
+      sprite.eventMode = "none";
+      this.shrineSprite = sprite;
+      this.shrineBadge?.addChild(sprite);
     } catch {
       // Fallback: text-only label still works
     }

--- a/web-v3/src/components/Icons.tsx
+++ b/web-v3/src/components/Icons.tsx
@@ -351,19 +351,6 @@ export function MapScrollIcon({ className }: { className?: string }) {
   );
 }
 
-export function ShrineIcon({ className }: { className?: string }) {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">
-      {/* Shrine arch over a vow flame. */}
-      <path d="M5 20h14" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" />
-      <path d="M6.5 20v-8.5a5.5 5.5 0 0 1 11 0V20" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="M12 16.4c-1.5-.9-2.1-2-1.5-3.2.3-.6.8-1.1 1.5-1.7.7.6 1.2 1.1 1.5 1.7.6 1.2 0 2.3-1.5 3.2Z" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" opacity="0.9" />
-      <path d="M12 8.2V7" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" opacity="0.75" />
-      <path d="M9.4 4.6l.9.9M14.6 4.6l-.9.9" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" opacity="0.6" />
-    </svg>
-  );
-}
-
 export function RefreshIcon({ className }: { className?: string }) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">

--- a/web-v3/src/components/KioskBar.tsx
+++ b/web-v3/src/components/KioskBar.tsx
@@ -8,7 +8,6 @@ import {
   QuestsTabIcon,
   AttackIcon,
   MapScrollIcon,
-  ShrineIcon,
 } from "./Icons";
 
 interface KioskDef {
@@ -27,9 +26,9 @@ const KIOSKS: KioskDef[] = [
   { panel: "quests", label: "Quests", assetKey: "quests_widget", fallback: <QuestsTabIcon className="kiosk-icon-svg" /> },
   { panel: "combatlog", label: "Combat Log", assetKey: "combat_log_widget", fallback: <AttackIcon className="kiosk-icon-svg" /> },
   // Anyone keeps a field journal now, so the Arcanum rides for every player.
+  // (The Shrine is a room-based kiosk on the left of the room window — it only
+  // appears when standing in a shrine room, not permanently in this dock.)
   { panel: "arcanum", label: "Arcanum", assetKey: "arcanum_widget", fallback: <MapScrollIcon className="kiosk-icon-svg" /> },
-  // Pledge/renounce home — actions inside gate on standing in a shrine room.
-  { panel: "shrine", label: "Shrine", assetKey: "shrine_widget", fallback: <ShrineIcon className="kiosk-icon-svg" /> },
 ];
 
 interface KioskBarProps {


### PR DESCRIPTION
## Summary

Corrects a UX placement error from #1418: the Shrine was added to the bottom **action dock** (KioskBar) alongside the Arcanum. But pledge/renounce is **room-contextual** — it only works at an Akathavae shrine — so it belongs with the other room-based kiosks (Inn, Music Box, Auction, …) that float on the **left of the room window** and appear only when you're in the relevant room.

## Changes
- **WorldScene**: new shrineBadge in the left-side badge column, visible when Room.Info carries the `shrine` flag, opening the shrine panel through a new canvasCallbacks.openShrine. Mirrors the Inn badge exactly (hover, hit area, shrine_widget asset with a "Shrine" text-label fallback until art is uploaded).
- **KioskBar**: removed the permanent Shrine dock entry. The **Arcanum stays** in the dock — it's a personal panel every player now has. Removed the orphaned ShrineIcon SVG.

The ShrinePanel component and its drawer are unchanged; only the entry point moved from the dock to the room badge.

## Verified live (screenshots)
Ran `./gradlew demo` and walked to the Academy's Alcove of the Akathavae:
- The **Shrine badge appears on the left of the room canvas** (text-label fallback, no art yet), and the bottom dock ends at Arcanum with no Shrine entry.
- Clicking the badge opens the **Akathavae Shrine** panel with the pledge terms + "Take the Pledge" button.
- Stepping into the adjacent Scholar's Study (a Music Box room), the left column shows **Music Box and no Shrine** — confirming the room-contextual gating.

Lint + build clean.

Follow-up to the Akathavae shrine work in #1418. Note: the shrine_widget art still needs uploading (same as tracked for the earlier shrine work) — until then the badge shows a "Shrine" text pill, exactly like other kiosks before their art lands.

🤖 Generated with Claude Code