### PR TITLE
fix(web): close map on mount travel start; don't carry old room's mobs along the ride

### DIFF
--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -398,6 +398,16 @@ function App() {
     };
   });
 
+  // Close the map drawer when a ride actually starts (Travel.Status flips to
+  // riding), so the journey plays out on the main canvas. Keyed on the riding
+  // transition — not the click — so a rejected request leaves the map open,
+  // and re-opening the map mid-ride keeps it open.
+  const isRiding = state.travelStatus?.riding === true;
+  useEffect(() => {
+    if (!isRiding) return;
+    state.setActivePopout((prev) => (prev === "map" ? null : prev));
+  }, [isRiding]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Accept a quest and surface an "accepted" toast (no server signal for accept,
   // so we fire it optimistically from the name we already have on the offer).
   const acceptQuest = (questId: string) => {

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -557,6 +557,16 @@ export function applyGmcpPackage(
           ctx.setDialogue(null);
           ctx.setQuestsAvailable([]);
           ctx.setTrainer(null);
+          // Clear room occupants and interactables too. A normal move re-sends
+          // Room.Players/Mobs/Items/Features right after this packet, but mount
+          // fast travel streams bare Room.Info per hop — without this, the
+          // starting room's mobs appear to ride along for the whole journey.
+          ctx.setPlayers([]);
+          ctx.setMobs([]);
+          ctx.setMobInfo([]);
+          ctx.setRoomItems([]);
+          ctx.setRoomFeatures([]);
+          ctx.setCraftingNodes([]);
         }
         return { id, title, description, exits, image, video, music, ambient, station, trainer, mapX, mapY, mapZ, housing, housingOwner, graphical, terrain, bank, stylist, tavern, dungeon, auction, housingBroker, inn, shrine, flightMaster, boatDock, jukebox, musicBox, canDepart, peek };
       });


### PR DESCRIPTION
Two small mount fast-travel fixes, both in the web client.

## Map closes when travel starts

Clicking a room on the zone map now closes the map drawer once the server confirms the ride (`Travel.Status` flips to `riding`), so the journey plays out on the main canvas. Because it's keyed on the riding transition rather than the click:

- a rejected request (no path, in combat, …) leaves the map open with the error feedback
- re-opening the map mid-ride keeps it open

## Mobs no longer ride along

Mid-ride the server streams a bare `Room.Info` per hop (deliberately — no full-look spam), but the client only cleared dialogue/quests/trainer on a room change. Mobs, players, items, features, and crafting nodes from the starting room stayed rendered, so they visually accompanied the whole journey.

`Room.Info` for a different room now clears all of those. This is safe for every other flow: normal moves, reconnect sync, and hot reload all re-send `Room.Players`/`Room.Mobs`/`Room.Items`/`Room.Features` immediately after `Room.Info`, and mount-travel arrival still does a full look. Pass-through rooms render empty while riding, which matches the "riding past" feel (aggressive mobs already skip the rider).

## Testing

- `bun run lint` and `tsc --noEmit` pass (no client test suite exists)
- No server changes