### PR TITLE
Improve sign readability over custom art

### DIFF
--- a/web-v3/src/components/Drawer.tsx
+++ b/web-v3/src/components/Drawer.tsx
@@ -163,7 +163,7 @@ export function Drawer({ open, title, onClose, children, variant = "default", sk
       />
       <div
         ref={sheetRef}
-        className={`drawer-sheet${variant !== "default" ? ` drawer-sheet-${variant}` : ""}`}
+        className={`drawer-sheet${variant !== "default" ? ` drawer-sheet-${variant}` : ""}${skinBg ? " drawer-sheet-skinned" : ""}`}
         role="dialog"
         aria-modal="true"
         aria-label={title}

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -65,6 +65,11 @@
   --surface-chip: rgb(62 74 108 / 90%);
   --surface-input: rgb(45 56 84 / 96%);
   --surface-terminal: #2f3446;
+  /* Localized protection for light copy laid over authored artwork. The strong
+     core guarantees contrast even on pale art; the soft edge preserves the
+     painting instead of turning the whole panel into a dark overlay. */
+  --surface-reading-veil: rgb(34 41 60 / 84%);
+  --surface-reading-veil-soft: rgb(34 41 60 / 56%);
 
   --bg-primary: #2a3149;
   --bg-secondary: #262f47;
@@ -89,6 +94,10 @@
   --shadow-md: 0 10px 26px rgb(8 10 18 / 36%);
   --shadow-lg: 0 16px 40px rgb(8 10 18 / 44%);
   --shadow-glow: 0 0 22px rgb(103 116 170 / 28%);
+  --shadow-reading-text:
+    0 1px 2px rgb(8 10 18 / 92%),
+    0 0 8px rgb(8 10 18 / 82%),
+    0 0 20px rgb(8 10 18 / 68%);
 
   /* ── Spacing ──────────────────────────────────────────── */
   --space-1: 4px;
@@ -3347,7 +3356,28 @@ body {
 }
 
 .drawer-sheet-feature .drawer-title {
-  text-shadow: 0 1px 2px rgb(0 0 0 / 72%), 0 1px 12px rgb(0 0 0 / 55%);
+  position: relative;
+  z-index: 0;
+  isolation: isolate;
+  text-shadow: var(--shadow-reading-text);
+}
+
+/* Feature titles also sit directly on custom art. Give skinned titles the same
+   feathered reading veil as sign copy without introducing a visible header band. */
+.drawer-sheet-feature.drawer-sheet-skinned .drawer-title::before {
+  content: "";
+  position: absolute;
+  z-index: -1;
+  inset: -14px -32px;
+  border-radius: 50%;
+  background: radial-gradient(
+    ellipse at center,
+    var(--surface-reading-veil) 0 68%,
+    var(--surface-reading-veil-soft) 82%,
+    transparent 100%
+  );
+  filter: blur(4px);
+  pointer-events: none;
 }
 
 /* No divider, no scrim band — the title rides directly on the art (legibility
@@ -3408,6 +3438,8 @@ body {
 
 .feat-sign-text {
   position: relative;
+  z-index: 1;
+  isolation: isolate;
   margin: 0;
   max-width: 56ch;
   text-align: center;
@@ -3417,7 +3449,28 @@ body {
   font-style: italic;
   line-height: 1.62;
   white-space: pre-wrap;
-  text-shadow: 0 1px 2px rgb(0 0 0 / 64%), 0 1px 14px rgb(0 0 0 / 50%);
+  text-shadow: var(--shadow-reading-text);
+}
+
+/* A soft-edged veil follows the copy instead of dimming the whole illustration.
+   Its opaque core extends beyond every glyph, keeping pale text readable over
+   bright, busy, or locally high-contrast sign art. */
+.feat-sign.has-art .feat-sign-text::before {
+  content: "";
+  position: absolute;
+  z-index: -1;
+  inset:
+    calc(-1 * clamp(28px, 5vh, 58px))
+    calc(-1 * clamp(32px, 7vw, 84px));
+  border-radius: 50%;
+  background: radial-gradient(
+    ellipse at center,
+    var(--surface-reading-veil) 0 72%,
+    var(--surface-reading-veil-soft) 86%,
+    transparent 100%
+  );
+  filter: blur(8px);
+  pointer-events: none;
 }
 
 /* ── Container ────────────────────────────────────────────── */

--- a/web-v3/test/signReadability.test.tsx
+++ b/web-v3/test/signReadability.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Drawer } from "../src/components/Drawer";
+import { WorldFeaturesPopout } from "../src/components/WorldFeaturesPopout";
+import type { RoomFeature } from "../src/types";
+
+const sign: RoomFeature = {
+  id: "welcome-card",
+  name: "a tea-stained welcome card",
+  keyword: "card",
+  type: "sign",
+  state: null,
+  direction: null,
+  locked: null,
+  keyRequired: null,
+  text: "Dearest newcomer — a few first words, with love.",
+  backgroundImage: "https://art.example/welcome-card.webp",
+  plateImage: null,
+  handleImage: null,
+  leverPivot: null,
+  upAngle: null,
+  downAngle: null,
+  frameImage: null,
+  leafImage: null,
+  hinge: null,
+  openAngle: null,
+  leafScale: null,
+  leafOffsetY: null,
+  keyImage: null,
+  keyName: null,
+};
+
+describe("sign readability", () => {
+  test("marks art-backed feature content and its drawer as skinned", () => {
+    const panelHtml = renderToStaticMarkup(
+      <WorldFeaturesPopout
+        roomFeatures={[sign]}
+        containerContents={null}
+        preferredType="sign"
+        serverAssets={{}}
+        onCommand={() => {}}
+      />,
+    );
+    const drawerHtml = renderToStaticMarkup(
+      <Drawer
+        open
+        title={sign.name}
+        onClose={() => {}}
+        variant="feature"
+        skinBg={sign.backgroundImage ?? undefined}
+      >
+        {panelHtml}
+      </Drawer>,
+    );
+
+    expect(panelHtml).toContain("feat-panel feat-sign has-art");
+    expect(drawerHtml).toContain("drawer-sheet drawer-sheet-feature drawer-sheet-skinned");
+  });
+
+  test("keeps the CSS-only fallback free of the art veil", () => {
+    const html = renderToStaticMarkup(
+      <WorldFeaturesPopout
+        roomFeatures={[{ ...sign, backgroundImage: null }]}
+        containerContents={null}
+        preferredType="sign"
+        serverAssets={{}}
+        onCommand={() => {}}
+      />,
+    );
+
+    expect(html).toContain("feat-panel feat-sign");
+    expect(html).not.toContain("feat-sign has-art");
+    expect(html).toContain("feat-fallback-sign");
+  });
+
+  test("defines localized reading veils for sign copy and skinned titles", async () => {
+    const styles = await Bun.file(new URL("../src/styles.css", import.meta.url)).text();
+
+    expect(styles).toContain("--surface-reading-veil:");
+    expect(styles).toContain("--shadow-reading-text:");
+    expect(styles).toContain(".feat-sign.has-art .feat-sign-text::before");
+    expect(styles).toContain(".drawer-sheet-feature.drawer-sheet-skinned .drawer-title::before");
+  });
+});


### PR DESCRIPTION
## Summary

- mark drawers with server-provided artwork as skinned
- add warm, feathered reading veils behind sign copy and feature titles
- strengthen text shadows while preserving the surrounding painted artwork
- add regression coverage for both art-backed and CSS-fallback signs

## Why

Custom sign backgrounds can contain bright, detailed, or locally high-contrast regions. The existing light text relied on text shadow alone, so readability varied with each painting.

The new treatment creates localized contrast behind the copy instead of dimming the entire illustration, allowing a wider range of authored backgrounds while keeping the painted frame visible.

## Impact

Players get consistently readable sign text at desktop and phone sizes. Signs without artwork retain the existing CSS fallback treatment.

## Validation

- `bun test` — 36 tests passed
- `bun run lint`
- `bun run build`
- visually stress-tested at 866×508 and 390×844 against a bright, high-frequency background
