### PR TITLE
fix(web): intermittently missing mobs/signs after #1426 — clear room state in packet order

### DIFF
--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -216,6 +216,10 @@ interface GmcpContext {
   setSavedCharacters: Dispatch<SetStateAction<string[]>>;
   resumeTokenRef: { current: string | null };
   pendingAuthCharRef: { current: string | null };
+  /** Last room id seen in Room.Info — synchronous room-change detection. */
+  lastRoomIdRef: { current: string | null };
+  /** Clears occupants/interactables/dialogue when Room.Info reports a new room. */
+  clearRoomScopedState: () => void;
   sendGmcp: (pkg: string, payload: unknown) => boolean;
   setServerAssets: Dispatch<SetStateAction<Record<string, string>>>;
   setServerCommands: Dispatch<SetStateAction<CommandEntry[]>>;
@@ -547,29 +551,22 @@ export function applyGmcpPackage(
         }))
         .filter((p) => p.direction.length > 0 && p.title.length > 0);
 
-      // Detect actual room change (not just a look/refresh of the same room)
-      ctx.setRoom((prev) => {
-        if (prev.id !== id && prev.id !== null) {
-          // Moved to a different room — clear dialogue/quest offers and trainer data.
-          // Trainer state must be cleared or the panel will render stale data from the
-          // previous trainer (e.g. a single-class WARRIOR trainer) when the user opens
-          // it at a new multi-class trainer before `train list` has fetched fresh data.
-          ctx.setDialogue(null);
-          ctx.setQuestsAvailable([]);
-          ctx.setTrainer(null);
-          // Clear room occupants and interactables too. A normal move re-sends
-          // Room.Players/Mobs/Items/Features right after this packet, but mount
-          // fast travel streams bare Room.Info per hop — without this, the
-          // starting room's mobs appear to ride along for the whole journey.
-          ctx.setPlayers([]);
-          ctx.setMobs([]);
-          ctx.setMobInfo([]);
-          ctx.setRoomItems([]);
-          ctx.setRoomFeatures([]);
-          ctx.setCraftingNodes([]);
-        }
-        return { id, title, description, exits, image, video, music, ambient, station, trainer, mapX, mapY, mapZ, housing, housingOwner, graphical, terrain, bank, stylist, tavern, dungeon, auction, housingBroker, inn, shrine, flightMaster, boatDock, jukebox, musicBox, canDepart, peek };
-      });
+      // Detect an actual room change (not just a look/refresh of the same room)
+      // synchronously, while this packet is applied, and clear room-scoped
+      // state (occupants, interactables, dialogue/quest offers, trainer) in
+      // packet order. This must NOT happen inside the setRoom updater: React
+      // runs updaters later, so with Room.Info and Room.Mobs/Features in the
+      // same batch the deferred clear would land after the fresh data and wipe
+      // it (mobs/signs intermittently missing while walking). Every server
+      // flow sends Room.Info before the occupant packets, so clearing here is
+      // safe; a bare Room.Info with no follow-up (mount fast travel mid-ride)
+      // intentionally leaves the rooms ridden through empty.
+      const prevRoomId = ctx.lastRoomIdRef.current;
+      ctx.lastRoomIdRef.current = id;
+      if (prevRoomId !== null && prevRoomId !== id) {
+        ctx.clearRoomScopedState();
+      }
+      ctx.setRoom({ id, title, description, exits, image, video, music, ambient, station, trainer, mapX, mapY, mapZ, housing, housingOwner, graphical, terrain, bank, stylist, tavern, dungeon, auction, housingBroker, inn, shrine, flightMaster, boatDock, jukebox, musicBox, canDepart, peek });
 
       if (id) {
         ctx.updateMap(id, exits, title === "-" ? "" : title, image, mapX, mapY, mapZ, housing, terrain);

--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -226,6 +226,10 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
   const [roomFeatures, setRoomFeatures] = useState<RoomFeature[]>([]);
   const [containerContents, setContainerContents] = useState<ContainerContents | null>(null);
   const [mobInfo, setMobInfo] = useState<MobInfo[]>([]);
+  // Last room id seen in Room.Info, tracked in a ref so the GMCP handler can
+  // detect a room change synchronously — while applying the packet, not later
+  // inside a React updater — and clear room-scoped state in packet order.
+  const lastRoomIdRef = useRef<string | null>(null);
 
   // ── Combat ────────────────────────────────────────
   const [effects, setEffects] = useState<StatusEffect[]>([]);
@@ -629,6 +633,23 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     pushUiFeedback({ type: "info", message: `New mail from ${notification.from}` });
   }, [pushUiFeedback]);
 
+  // Room-scoped state cleared when Room.Info reports a new room id, before the
+  // follow-up Room.Players/Mobs/Items/Features packets repopulate it (a bare
+  // Room.Info with no follow-up — mount fast travel mid-ride — leaves the room
+  // empty). Uses the raw setters, not the ctx-wrapped ones, so this transient
+  // clear doesn't trip side effects like the features panel auto-close.
+  const clearRoomScopedState = useCallback(() => {
+    setDialogue(null);
+    setQuestsAvailable([]);
+    setTrainer(null);
+    setPlayers([]);
+    setMobs([]);
+    setMobInfo([]);
+    setRoomItems([]);
+    setRoomFeatures([]);
+    setCraftingNodes([]);
+  }, []);
+
   // ── GMCP handler ──────────────────────────────────
   const handleGmcp = useCallback(
     (pkg: string, data: unknown) => {
@@ -699,6 +720,8 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
         setSavedCharacters,
         resumeTokenRef,
         pendingAuthCharRef,
+        lastRoomIdRef,
+        clearRoomScopedState,
         setServerAssets,
         setServerCommands,
         setWorldAreas,
@@ -763,7 +786,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
         sendGmcp: (p: string, payload: unknown) => { sendGmcpRef.current(p, payload); return true; },
       });
     },
-    [applyCurrencies, applyFactions, pushFriendNotification, pushCombatEvent, pushGainEvent, pushLevelUp, pushQuestNotification, pushUiFeedback, pushCraftingResult, pushMailNotification, pushArcanumSketch, updateMap, loadZoneMap, resumeTokenRef, pendingAuthCharRef, sendGmcpRef],
+    [applyCurrencies, applyFactions, pushFriendNotification, pushCombatEvent, pushGainEvent, pushLevelUp, pushQuestNotification, pushUiFeedback, pushCraftingResult, pushMailNotification, pushArcanumSketch, updateMap, loadZoneMap, resumeTokenRef, pendingAuthCharRef, sendGmcpRef, clearRoomScopedState],
   );
 
   // ── Reset all HUD state on disconnect ─────────────
@@ -772,6 +795,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     setStatusVarLabels(DEFAULT_STATUS_VAR_LABELS);
     setCharacter(EMPTY_CHAR);
     setRoom(EMPTY_ROOM);
+    lastRoomIdRef.current = null;
     setPlayers([]);
     setMobs([]);
     setRoomItems([]);


### PR DESCRIPTION
Fixes the regression from #1426 where mobs, signs, and other room contents sometimes went missing while walking around.

## Root cause

The room-change clears in #1426 ran **inside the `setRoom` updater**. React executes updater functions lazily (during render), not when `setRoom` is called. So when `Room.Info` and the follow-up `Room.Players`/`Room.Mobs`/`Room.Items`/`Room.Features` packets were applied in the same React batch (one WebSocket frame), the sequence became:

1. `Room.Info` applied → `setRoom(updater)` queued
2. `Room.Mobs` applied → `setMobs(realMobs)` queued
3. React renders → updater runs → `setMobs([])` dispatched **now** — after the real data

Final state: empty. Whether you saw it depended on packet batching, hence "sometimes".

## Fix

Track the last `Room.Info` room id in a ref, detect the room change **synchronously while the packet is applied**, and dispatch the clears in packet order via a `clearRoomScopedState` callback owned by `useGameState`. Every server flow (look, reconnect sync, hot reload) sends `Room.Info` before the occupant packets, so clear-then-repopulate now always resolves in the right order regardless of batching.

Also fixed along the way:

- The clears now use the **raw** setters, so the transient clear no longer trips the features-panel auto-close on every room change (a second subtle regression from #1426 — walking with the World Features panel open would close it even entering a feature-rich room).
- The pre-existing dialogue/quest-offer/trainer clears had the same latent race (e.g. a same-batch `Char.Trainer` could be wiped) and move out of the updater too.

Behavior from #1426 is preserved: bare mid-ride `Room.Info` during mount travel still leaves passed-through rooms empty, and arrival does a full look. The ref resets with the rest of the HUD on disconnect.

## Testing

- `bun run lint` and `tsc --noEmit` pass
- No server changes