### PR TITLE
World Map atlas tab fed by Arcanum map placements

### DIFF
--- a/docs/WORLD_YAML_SPEC.md
+++ b/docs/WORLD_YAML_SPEC.md
@@ -8,7 +8,7 @@ It is written for code generators that need to emit valid zone files.
 - One YAML document describes one zone file.
 - Multiple zone files can be merged into one world.
 - YAML files are deserialized into the DTOs in `src/main/kotlin/dev/ambon/domain/world/data/`:
-  - `WorldFile` (`zone`, `lifespan`, `startRoom`, `graphical`, `pvpEnabled`, `terrain`, `faction`, `scaling`, `image`, `audio`, `video`, `rooms`, `mobs`, `items`, `shops`, `trainers`, `quests`, `gatheringNodes`, `recipes`, `dungeon`, `puzzles`)
+  - `WorldFile` (`zone`, `lifespan`, `startRoom`, `graphical`, `pvpEnabled`, `terrain`, `faction`, `scaling`, `worldMap`, `image`, `audio`, `video`, `rooms`, `mobs`, `items`, `shops`, `trainers`, `quests`, `gatheringNodes`, `recipes`, `dungeon`, `puzzles`)
   - `RoomFile` (with `ExitValue`/`DoorFile` for exits and `FeatureFile` for containers/levers/signs)
   - `MobFile` (with `MobSpawnFile`, `MobDropFile`, `MobSpellFile`, `BehaviorFile`, `DialogueNodeFile`, `SpawnConditionFile`)
   - `ItemFile`
@@ -34,6 +34,11 @@ faction: <string, optional - controlling faction id; inherited by mobs that don'
 scaling:                # optional dynamic level-scaling config
   mode: <string, optional - one of static|bounded|player (case-insensitive); default static>
   levelRange: [<min>, <max>]  # required for bounded mode; min >= 1, max >= min
+worldMap:               # optional footprint on the painted world map (World Map atlas tab)
+  x: <double, 0-100 - left edge, percent of the map width>
+  y: <double, 0-100 - top edge, percent of the map height>
+  w: <double, > 0 - width in percent; x + w must be <= 100>
+  h: <double, > 0 - height in percent; y + h must be <= 100>
 image:                  # zone-wide image defaults
   room: <string, optional>
   mob: <string, optional>
@@ -79,10 +84,16 @@ puzzles: <map<string, Puzzle>, optional, default {}>
 - `player`: mobs and quests scale directly to the reference player's level with no bounds (tutorial zones, social hubs).
 - Declaring conflicting `scaling` blocks for the same zone across files is a load error.
 
+`worldMap` notes:
+- Positions the zone as a region on the painted `world_map` global asset in the web client's World Map atlas tab, labelled with the zone's name and level range. Percent coordinates are measured from the map image's top-left corner, so the same block works at any art resolution.
+- All four fields are required together; a partial block is a load error, as is a rectangle that extends past the map (`x + w > 100` or `y + h > 100`, small float tolerance).
+- Declaring conflicting `worldMap` blocks for the same zone across files is a load error.
+- Normally authored in Arcanum's Map overlay via **Publish to Game** rather than by hand.
+
 ### Required vs optional
 
 - Required top-level fields: `zone`, `startRoom`, `rooms`
-- Optional top-level fields: `lifespan`, `graphical`, `pvpEnabled`, `terrain`, `faction`, `scaling`, `image`, `audio`, `video`, `mobs`, `items`, `shops`, `trainers`, `quests`, `gatheringNodes`, `recipes`, `dungeon`, `puzzles`
+- Optional top-level fields: `lifespan`, `graphical`, `pvpEnabled`, `terrain`, `faction`, `scaling`, `worldMap`, `image`, `audio`, `video`, `mobs`, `items`, `shops`, `trainers`, `quests`, `gatheringNodes`, `recipes`, `dungeon`, `puzzles`
 
 ## Nested Schemas
 

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -3863,6 +3863,12 @@ data class ImagesConfig(
             // flight kiosk), so harbor hotspots sit on the same coastline. Override this key alone
             // to give boats their own map. When absent, the kiosk degrades to its plain route list.
             "boat_map" to "global_assets/flight_map.png",
+            // Painted Ambon world map behind the atlas World Map tab. Zones publish their
+            // footprint rectangles from Arcanum's Map overlay (zone YAML `worldMap`) and are
+            // seated onto this art as glowing regions. Shares the flight kiosk art by default so
+            // the atlas and travel kiosks agree on one coastline; override to give the atlas its
+            // own map. When absent, the tab renders zones on a stylized parchment fallback.
+            "world_map" to "global_assets/flight_map.png",
             // Anchor/ship marker painted at each harbor hotspot — distinguishes boats from griffin
             // flight roosts. Optional — a CSS jewel-dot renders in its place when the art is missing.
             "boat_dock" to "global_assets/boat_dock.png",

--- a/src/main/kotlin/dev/ambon/domain/world/World.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/World.kt
@@ -19,6 +19,7 @@ class World(
     pvpZones: Set<String> = emptySet(),
     zoneStartRooms: Map<String, RoomId> = emptyMap(),
     zoneScaling: Map<String, ZoneScaling> = emptyMap(),
+    zoneWorldMap: Map<String, ZoneWorldMap> = emptyMap(),
     zoneVideos: Map<String, String> = emptyMap(),
     shopDefinitions: List<ShopDefinition> = emptyList(),
     trainerDefinitions: List<TrainerDefinition> = emptyList(),
@@ -66,6 +67,12 @@ class World(
 
     /** Returns the scaling config for a zone. Falls back to STATIC when unset. */
     fun zoneScaling(zoneId: String): ZoneScaling = _zoneScaling[zoneId] ?: ZoneScaling()
+
+    private val _zoneWorldMap = zoneWorldMap.toMutableMap()
+    val zoneWorldMap: Map<String, ZoneWorldMap> get() = _zoneWorldMap
+
+    /** Returns the zone's footprint on the painted world map, or null when unplaced. */
+    fun zoneWorldMap(zoneId: String): ZoneWorldMap? = _zoneWorldMap[zoneId]
 
     private val _zoneVideos = zoneVideos.toMutableMap()
     val zoneVideos: Map<String, String> get() = _zoneVideos
@@ -158,6 +165,9 @@ class World(
         source._zoneScaling[zone]?.let { _zoneScaling[zone] = it }
             ?: _zoneScaling.remove(zone)
 
+        source._zoneWorldMap[zone]?.let { _zoneWorldMap[zone] = it }
+            ?: _zoneWorldMap.remove(zone)
+
         source._zoneVideos[zone]?.let { _zoneVideos[zone] = it }
             ?: _zoneVideos.remove(zone)
 
@@ -195,6 +205,9 @@ class World(
 
         _zoneScaling.clear()
         _zoneScaling.putAll(source._zoneScaling)
+
+        _zoneWorldMap.clear()
+        _zoneWorldMap.putAll(source._zoneWorldMap)
 
         _zoneVideos.clear()
         _zoneVideos.putAll(source._zoneVideos)

--- a/src/main/kotlin/dev/ambon/domain/world/ZoneWorldMap.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/ZoneWorldMap.kt
@@ -1,0 +1,19 @@
+package dev.ambon.domain.world
+
+/**
+ * A zone's authored footprint on the painted world map, in percentages of the
+ * map image (0–100 measured from the top-left corner). Authored in Arcanum's
+ * Map overlay and published into zone YAML as the zone-level `worldMap` block;
+ * surfaced to clients through the `World.Areas` GMCP package so the web atlas
+ * can seat each zone onto the `world_map` art at any resolution.
+ */
+data class ZoneWorldMap(
+    /** Left edge, percent of the map width. */
+    val x: Double,
+    /** Top edge, percent of the map height. */
+    val y: Double,
+    /** Width, percent of the map width. */
+    val w: Double,
+    /** Height, percent of the map height. */
+    val h: Double,
+)

--- a/src/main/kotlin/dev/ambon/domain/world/data/WorldFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/WorldFile.kt
@@ -14,6 +14,12 @@ data class WorldFile(
     val faction: String? = null,
     /** Dynamic level-scaling configuration. Null/missing = STATIC (use authored levels). */
     val scaling: ZoneScalingFile? = null,
+    /**
+     * The zone's rectangle on the painted world map, in percent (0–100) of the
+     * map image from its top-left corner. Published from Arcanum's Map overlay;
+     * drives the web client's World Map atlas tab.
+     */
+    val worldMap: ZoneWorldMapFile? = null,
     val image: ZoneImageDefaults? = null,
     val audio: ZoneAudioDefaults? = null,
     /** Zone cinematic video (relative path under /videos/). Auto-plays on a player's first entry; replayable from the map. */
@@ -34,6 +40,18 @@ data class ZoneScalingFile(
     val mode: String = "static",
     /** Inclusive [min, max] bounds. Required for BOUNDED mode. */
     val levelRange: List<Int>? = null,
+)
+
+/**
+ * Zone-level `worldMap` block: the zone's footprint on the painted world map.
+ * All four fields are required together; percentages of the map image (0–100)
+ * measured from the top-left corner.
+ */
+data class ZoneWorldMapFile(
+    val x: Double? = null,
+    val y: Double? = null,
+    val w: Double? = null,
+    val h: Double? = null,
 )
 
 data class TrainerFile(

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -247,7 +247,10 @@ object WorldLoader {
                 if (x == null || y == null || w == null || h == null) {
                     throw WorldLoadException("Zone '$zone' worldMap requires all of x, y, w and h")
                 }
-                if (x < 0 || y < 0 || w <= 0.0 || h <= 0.0 || x + w > 100 || y + h > 100) {
+                // Small epsilon: authoring tools round to 2 decimals and double
+                // addition can overshoot the far edge by a few ulps.
+                val edge = 100.0 + 1e-6
+                if (x < 0 || y < 0 || w <= 0.0 || h <= 0.0 || x + w > edge || y + h > edge) {
                     throw WorldLoadException(
                         "Zone '$zone' worldMap must be a rectangle inside the map in percent " +
                             "(x >= 0, y >= 0, w > 0, h > 0, x + w <= 100, y + h <= 100; got x=$x y=$y w=$w h=$h)",

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -57,6 +57,7 @@ import dev.ambon.domain.world.ShopDefinition
 import dev.ambon.domain.world.TrainerDefinition
 import dev.ambon.domain.world.World
 import dev.ambon.domain.world.ZoneScaling
+import dev.ambon.domain.world.ZoneWorldMap
 import dev.ambon.domain.world.data.BoatRouteFile
 import dev.ambon.domain.world.data.ExitValue
 import dev.ambon.domain.world.data.ExitValueDeserializer
@@ -165,6 +166,7 @@ object WorldLoader {
         val pvpZones = mutableSetOf<String>()
         val zoneStartRooms = LinkedHashMap<String, RoomId>()
         val zoneScalings = LinkedHashMap<String, ZoneScaling>()
+        val zoneWorldMaps = LinkedHashMap<String, ZoneWorldMap>()
         val zoneVideos = LinkedHashMap<String, String>()
 
         // startRoomOverride wins; otherwise fall back to first file’s declared startRoom.
@@ -235,6 +237,28 @@ object WorldLoader {
                     throw WorldLoadException("Zone '$zone' declares conflicting scaling configs across files")
                 }
                 zoneScalings[zone] = parsed
+            }
+
+            file.worldMap?.let { wm ->
+                val x = wm.x
+                val y = wm.y
+                val w = wm.w
+                val h = wm.h
+                if (x == null || y == null || w == null || h == null) {
+                    throw WorldLoadException("Zone '$zone' worldMap requires all of x, y, w and h")
+                }
+                if (x < 0 || y < 0 || w <= 0.0 || h <= 0.0 || x + w > 100 || y + h > 100) {
+                    throw WorldLoadException(
+                        "Zone '$zone' worldMap must be a rectangle inside the map in percent " +
+                            "(x >= 0, y >= 0, w > 0, h > 0, x + w <= 100, y + h <= 100; got x=$x y=$y w=$w h=$h)",
+                    )
+                }
+                val parsed = ZoneWorldMap(x = x, y = y, w = w, h = h)
+                val existing = zoneWorldMaps[zone]
+                if (existing != null && existing != parsed) {
+                    throw WorldLoadException("Zone '$zone' declares conflicting worldMap placements across files")
+                }
+                zoneWorldMaps[zone] = parsed
             }
 
             // First pass per file: create room shells, detect collisions
@@ -1212,6 +1236,7 @@ object WorldLoader {
             pvpZones = pvpZones.toSet(),
             zoneStartRooms = zoneStartRooms.toMap(),
             zoneScaling = zoneScalings.toMap(),
+            zoneWorldMap = zoneWorldMaps.toMap(),
             zoneVideos = zoneVideos.toMap(),
             shopDefinitions = mergedShops.toList(),
             trainerDefinitions = mergedTrainers.toList(),

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -3368,6 +3368,17 @@ class GameEngine(
 private fun buildWorldAreaPayloads(world: dev.ambon.domain.world.World): List<WorldAreaPayload> {
     val ranges = dev.ambon.engine.commands.handlers.computeWorldZoneLevelRanges(world)
     return ranges
-        .map { (zone, range) -> WorldAreaPayload(zone = zone, minLevel = range?.first, maxLevel = range?.last) }
+        .map { (zone, range) ->
+            val placement = world.zoneWorldMap(zone)
+            WorldAreaPayload(
+                zone = zone,
+                minLevel = range?.first,
+                maxLevel = range?.last,
+                mapX = placement?.x,
+                mapY = placement?.y,
+                mapW = placement?.w,
+                mapH = placement?.h,
+            )
+        }
         .sortedWith(compareBy({ it.minLevel ?: Int.MAX_VALUE }, { it.zone }))
 }

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -73,11 +73,21 @@ data class PrestigePerkPayload(
  * level range. `minLevel`/`maxLevel` are null when the zone has no authored
  * BOUNDED scaling and no leveled mob templates (social/staff zones,
  * scaling-only dungeons), in which case the client renders an em-dash.
+ *
+ * `mapX`/`mapY`/`mapW`/`mapH` are the zone's authored rectangle on the painted
+ * `world_map` art, in percent (0–100) of the image from its top-left corner
+ * (zone YAML `worldMap`, published from Arcanum's Map overlay). All four are
+ * null for zones that have not been placed on the world map; the client's
+ * World Map tab lists those separately as uncharted.
  */
 data class WorldAreaPayload(
     val zone: String,
     val minLevel: Int? = null,
     val maxLevel: Int? = null,
+    val mapX: Double? = null,
+    val mapY: Double? = null,
+    val mapW: Double? = null,
+    val mapH: Double? = null,
 )
 
 /**

--- a/src/main/resources/world/academy.yaml
+++ b/src/main/resources/world/academy.yaml
@@ -1,5 +1,12 @@
 zone: academy
 startRoom: academy_gates
+# Footprint on the painted world map (percent of the image) — the tutorial isle
+# sits mid-map so the World Map atlas tab has something to show in local dev.
+worldMap:
+  x: 40
+  y: 42
+  w: 20
+  h: 16
 rooms:
   academy_gates:
     title: The Academy Gates

--- a/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/GmcpEmitterTest.kt
@@ -2250,7 +2250,15 @@ class GmcpEmitterTest {
                 outbound = outbound,
                 supportsPackage = { _, _ -> true },
                 worldAreas = listOf(
-                    WorldAreaPayload(zone = "academy", minLevel = 1, maxLevel = 5),
+                    WorldAreaPayload(
+                        zone = "academy",
+                        minLevel = 1,
+                        maxLevel = 5,
+                        mapX = 12.5,
+                        mapY = 30.0,
+                        mapW = 22.0,
+                        mapH = 18.0,
+                    ),
                     WorldAreaPayload(zone = "social_hub", minLevel = null, maxLevel = null),
                 ),
             )
@@ -2263,6 +2271,8 @@ class GmcpEmitterTest {
             assertTrue(json.contains("\"social_hub\""), "should contain social_hub zone")
             assertTrue(json.contains("\"minLevel\":1"), "should include numeric bounds")
             assertTrue(json.contains("\"minLevel\":null"), "should serialize unknown bounds as null")
+            assertTrue(json.contains("\"mapX\":12.5"), "should include the world map placement")
+            assertTrue(json.contains("\"mapX\":null"), "should serialize unplaced zones with null placement")
         }
 
     @Test

--- a/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
@@ -1376,6 +1376,41 @@ class WorldLoaderTest {
     }
 
     @Test
+    fun `parses zone worldMap placement`() {
+        val world = WorldLoader.loadFromResource("world/ok_world_map.yaml")
+        val placement = world.zoneWorldMap("mapped_zone")
+        assertNotNull(placement, "Expected mapped_zone to carry a worldMap placement")
+        assertEquals(12.5, placement!!.x)
+        assertEquals(30.0, placement.y)
+        assertEquals(22.0, placement.w)
+        assertEquals(18.25, placement.h)
+    }
+
+    @Test
+    fun `zone without worldMap has no placement`() {
+        val world = dev.ambon.test.TestWorlds.okSmall
+        assertNull(world.zoneWorldMap("ok_small"))
+    }
+
+    @Test
+    fun `fails when worldMap is missing a field`() {
+        val ex =
+            assertThrows(WorldLoadException::class.java) {
+                WorldLoader.loadFromResource("world/bad_world_map_partial.yaml")
+            }
+        assertTrue(ex.message!!.contains("worldMap", ignoreCase = true), "Got: ${ex.message}")
+    }
+
+    @Test
+    fun `fails when worldMap extends past the map edge`() {
+        val ex =
+            assertThrows(WorldLoadException::class.java) {
+                WorldLoader.loadFromResource("world/bad_world_map_bounds.yaml")
+            }
+        assertTrue(ex.message!!.contains("worldMap", ignoreCase = true), "Got: ${ex.message}")
+    }
+
+    @Test
     fun `loads puzzles from a zone file`() {
         val world = dev.ambon.test.TestWorlds.okPuzzles
         val puzzles = world.puzzleDefinitions

--- a/src/test/resources/world/bad_world_map_bounds.yaml
+++ b/src/test/resources/world/bad_world_map_bounds.yaml
@@ -1,0 +1,15 @@
+zone: mapped_zone
+startRoom: start
+worldMap:
+  x: 90
+  y: 30
+  w: 22
+  h: 18
+
+rooms:
+  start:
+    title: "Trailhead"
+    description: "A trail leading into the mapped wilds."
+
+mobs: {}
+items: {}

--- a/src/test/resources/world/bad_world_map_partial.yaml
+++ b/src/test/resources/world/bad_world_map_partial.yaml
@@ -1,0 +1,14 @@
+zone: mapped_zone
+startRoom: start
+worldMap:
+  x: 12.5
+  y: 30
+  w: 22
+
+rooms:
+  start:
+    title: "Trailhead"
+    description: "A trail leading into the mapped wilds."
+
+mobs: {}
+items: {}

--- a/src/test/resources/world/ok_world_map.yaml
+++ b/src/test/resources/world/ok_world_map.yaml
@@ -1,0 +1,15 @@
+zone: mapped_zone
+startRoom: start
+worldMap:
+  x: 12.5
+  y: 30
+  w: 22
+  h: 18.25
+
+rooms:
+  start:
+    title: "Trailhead"
+    description: "A trail leading into the mapped wilds."
+
+mobs: {}
+items: {}

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -51,6 +51,7 @@ const CombatLogPanel = lazy(() => import("./components/panels/CombatLogPanel").t
 import { HelpContent } from "./components/HelpContent";
 import { TerminalOverlay } from "./components/TerminalOverlay";
 import { Atlas } from "./components/Atlas";
+import { WorldMap } from "./components/WorldMap";
 import { DemoBanner } from "./components/DemoBanner";
 import { LevelUpBanner } from "./components/LevelUpBanner";
 import { QuestCompleteToast } from "./components/QuestCompleteToast";
@@ -229,7 +230,7 @@ function App() {
   const [staffInvisible, setStaffInvisible] = useState(false);
   // Bumped by the canvas Claim button (demo characters); opens the claim modal.
   const [claimRequestId, setClaimRequestId] = useState(0);
-  const [mapTab, setMapTab] = useState<"map" | "atlas">("map");
+  const [mapTab, setMapTab] = useState<"map" | "world" | "atlas">("map");
 
   // Lifted command-input state — VitalsBar renders it controlled, palette/canvas can prefill
   const [inputValue, setInputValue] = useState("");
@@ -1747,6 +1748,15 @@ function App() {
                 <button
                   type="button"
                   role="tab"
+                  aria-selected={mapTab === "world"}
+                  className={`drawer-map-tab ${mapTab === "world" ? "drawer-map-tab-active" : ""}`}
+                  onClick={() => setMapTab("world")}
+                >
+                  World Map
+                </button>
+                <button
+                  type="button"
+                  role="tab"
                   aria-selected={mapTab === "atlas"}
                   className={`drawer-map-tab ${mapTab === "atlas" ? "drawer-map-tab-active" : ""}`}
                   onClick={() => setMapTab("atlas")}
@@ -1850,6 +1860,13 @@ function App() {
                 <button type="button" className="map-zoom-btn" onClick={mapRecenter} title="Re-center on you" aria-label="Re-center on you">⌖</button>
               </div>
             </div>
+            {mapTab === "world" && (
+              <WorldMap
+                areas={state.worldAreas}
+                currentZone={currentZone}
+                serverAssets={state.serverAssets}
+              />
+            )}
             {mapTab === "atlas" && (
               <Atlas areas={state.worldAreas} currentZone={currentZone} />
             )}

--- a/web-v3/src/components/WorldMap.tsx
+++ b/web-v3/src/components/WorldMap.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { WorldArea } from "../types";
 import { zoneHue } from "../constants";
 import { formatZoneName } from "../utils";
@@ -45,6 +45,13 @@ export function WorldMap({ areas, currentZone, serverAssets }: WorldMapProps) {
   const uncharted = useMemo(() => areas.filter((a) => !isPlaced(a)), [areas]);
 
   const selectedArea = selected != null ? areas.find((a) => a.zone === selected) ?? null : null;
+
+  // Keep the detail card in view when a zone is selected — on narrow drawers
+  // the map frame can push it below the fold.
+  const detailRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (selected != null) detailRef.current?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }, [selected]);
 
   if (areas.length === 0) {
     return (
@@ -112,7 +119,7 @@ export function WorldMap({ areas, currentZone, serverAssets }: WorldMapProps) {
       </div>
 
       {selectedArea && (
-        <div className="world-map-detail" role="status">
+        <div className="world-map-detail" role="status" ref={detailRef}>
           <div className="world-map-detail-title">
             <span className="world-map-detail-name">{formatZoneName(selectedArea.zone)}</span>
             {selectedArea.zone === currentZone && (

--- a/web-v3/src/components/WorldMap.tsx
+++ b/web-v3/src/components/WorldMap.tsx
@@ -1,0 +1,152 @@
+import { useMemo, useState } from "react";
+import type { WorldArea } from "../types";
+import { zoneHue } from "../constants";
+import { formatZoneName } from "../utils";
+
+interface WorldMapProps {
+  areas: WorldArea[];
+  currentZone: string | null;
+  serverAssets: Record<string, string>;
+}
+
+/** An area whose worldMap placement is fully authored. */
+interface PlacedArea extends WorldArea {
+  mapX: number;
+  mapY: number;
+  mapW: number;
+  mapH: number;
+}
+
+function isPlaced(area: WorldArea): area is PlacedArea {
+  return area.mapX != null && area.mapY != null && area.mapW != null && area.mapH != null;
+}
+
+function formatLevelRange(area: WorldArea): string {
+  if (area.minLevel == null || area.maxLevel == null) return "—";
+  if (area.minLevel === area.maxLevel) return String(area.minLevel);
+  return `${area.minLevel}–${area.maxLevel}`;
+}
+
+/**
+ * The World Map atlas tab: every zone with an authored `worldMap` placement is
+ * seated onto the painted `world_map` art as a soft jewel-tinted region showing
+ * its name and level range. Zones without a placement are listed beneath the
+ * map as uncharted. Selecting a region opens a detail card — the future hook
+ * for viewing that zone's own map.
+ */
+export function WorldMap({ areas, currentZone, serverAssets }: WorldMapProps) {
+  const [selected, setSelected] = useState<string | null>(null);
+  const [artFailed, setArtFailed] = useState(false);
+
+  const mapUrl = serverAssets["world_map"] ?? serverAssets["flight_map"] ?? null;
+  const showArt = mapUrl != null && !artFailed;
+
+  const placed = useMemo(() => areas.filter(isPlaced), [areas]);
+  const uncharted = useMemo(() => areas.filter((a) => !isPlaced(a)), [areas]);
+
+  const selectedArea = selected != null ? areas.find((a) => a.zone === selected) ?? null : null;
+
+  if (areas.length === 0) {
+    return (
+      <div className="atlas-empty">
+        <p>No areas reported by the server yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="world-map-body">
+      <div
+        className={`world-map-frame ${showArt ? "" : "world-map-frame-fallback"}`}
+        role="group"
+        aria-label="World map of known realms"
+      >
+        {showArt && (
+          <img
+            className="world-map-art"
+            src={mapUrl}
+            alt=""
+            draggable={false}
+            onError={() => setArtFailed(true)}
+          />
+        )}
+        <div className="world-map-regions">
+          {placed.map((area) => {
+            const here = area.zone === currentZone;
+            const isSelected = area.zone === selected;
+            const range = formatLevelRange(area);
+            return (
+              <button
+                key={area.zone}
+                type="button"
+                className={[
+                  "world-map-zone",
+                  here ? "world-map-zone-here" : "",
+                  isSelected ? "world-map-zone-selected" : "",
+                ].join(" ")}
+                style={{
+                  left: `${area.mapX}%`,
+                  top: `${area.mapY}%`,
+                  width: `${area.mapW}%`,
+                  height: `${area.mapH}%`,
+                  "--wm-hue": zoneHue(area.zone),
+                } as React.CSSProperties}
+                aria-pressed={isSelected}
+                aria-label={`${formatZoneName(area.zone)}, levels ${range}${here ? ", you are here" : ""}`}
+                onClick={() => setSelected((prev) => (prev === area.zone ? null : area.zone))}
+              >
+                <span className="world-map-zone-label">
+                  <span className="world-map-zone-name">{formatZoneName(area.zone)}</span>
+                  <span className="world-map-zone-level">{range}</span>
+                </span>
+                {here && <span className="world-map-here-dot" aria-hidden="true" />}
+              </button>
+            );
+          })}
+        </div>
+        {placed.length === 0 && (
+          <p className="world-map-unplotted">
+            No realms have been charted onto the world map yet.
+          </p>
+        )}
+      </div>
+
+      {selectedArea && (
+        <div className="world-map-detail" role="status">
+          <div className="world-map-detail-title">
+            <span className="world-map-detail-name">{formatZoneName(selectedArea.zone)}</span>
+            {selectedArea.zone === currentZone && (
+              <span className="atlas-here-pill" aria-label="You are here">
+                you are here
+              </span>
+            )}
+          </div>
+          <div className="world-map-detail-meta">
+            <span>
+              Levels <strong>{formatLevelRange(selectedArea)}</strong>
+            </span>
+            <span className="world-map-detail-id">{selectedArea.zone}</span>
+          </div>
+          <p className="world-map-detail-hint">A closer survey of this realm is still being charted.</p>
+        </div>
+      )}
+
+      {uncharted.length > 0 && (
+        <div className="world-map-uncharted">
+          <span className="world-map-uncharted-label">Uncharted</span>
+          <div className="world-map-uncharted-chips">
+            {uncharted.map((area) => (
+              <span
+                key={area.zone}
+                className={`world-map-chip ${area.zone === currentZone ? "world-map-chip-here" : ""}`}
+              >
+                {formatZoneName(area.zone)}
+                <span className="world-map-chip-level">{formatLevelRange(area)}</span>
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -1661,6 +1661,10 @@ export function applyGmcpPackage(
           zone: String(a.zone ?? ""),
           minLevel: typeof a.minLevel === "number" ? a.minLevel : null,
           maxLevel: typeof a.maxLevel === "number" ? a.maxLevel : null,
+          mapX: typeof a.mapX === "number" ? a.mapX : null,
+          mapY: typeof a.mapY === "number" ? a.mapY : null,
+          mapW: typeof a.mapW === "number" ? a.mapW : null,
+          mapH: typeof a.mapH === "number" ? a.mapH : null,
         }))
         .filter((a) => a.zone.length > 0);
       ctx.setWorldAreas(areas);

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -10479,22 +10479,30 @@ body {
 .world-map-frame {
   position: relative;
   flex: 0 0 auto;
+  width: fit-content;
+  max-width: 100%;
+  margin-inline: auto;
   border: 1px solid rgb(90 60 30 / 45%);
   border-radius: 12px;
   overflow: hidden;
   box-shadow: inset 0 0 24px rgb(60 40 20 / 18%);
 }
 
-/* Painted-art path: the image dictates the frame's aspect. */
+/* Painted-art path: the frame hugs the image so zone-region percentages track
+   the art exactly; height is capped so the detail card stays above the fold. */
 .world-map-art {
   display: block;
-  width: 100%;
+  width: auto;
   height: auto;
+  max-width: 100%;
+  max-height: min(58vh, 640px);
   user-select: none;
 }
 
 /* No art (null/404): an inked-parchment stand-in keeps regions usable. */
 .world-map-frame-fallback {
+  width: 100%;
+  max-width: min(100%, calc(58vh * (16 / 9)));
   aspect-ratio: 16 / 9;
   background:
     radial-gradient(ellipse at 30% 25%, rgb(255 250 236 / 55%), transparent 60%),
@@ -10615,11 +10623,14 @@ body {
   font-style: italic;
 }
 
+/* Solid parchment panel — the drawer sits over dark painted art, so the ink
+   text needs its own light ground to stay legible. */
 .world-map-detail {
   padding: var(--space-2) var(--space-3);
-  background: rgb(60 40 20 / 10%);
-  border: 1px solid rgb(90 60 30 / 40%);
+  background: rgb(240 226 196 / 94%);
+  border: 1px solid rgb(90 60 30 / 50%);
   border-radius: 10px;
+  box-shadow: 0 2px 8px rgb(20 14 8 / 35%);
 }
 
 .world-map-detail-title {
@@ -10660,6 +10671,11 @@ body {
   display: flex;
   flex-direction: column;
   gap: 6px;
+  padding: var(--space-2) var(--space-3);
+  background: rgb(240 226 196 / 94%);
+  border: 1px solid rgb(90 60 30 / 50%);
+  border-radius: 10px;
+  box-shadow: 0 2px 8px rgb(20 14 8 / 35%);
 }
 
 .world-map-uncharted-label {

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -10466,6 +10466,239 @@ body {
   color: #5a4226;
 }
 
+/* --- World Map atlas tab --- */
+
+.world-map-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.world-map-frame {
+  position: relative;
+  flex: 0 0 auto;
+  border: 1px solid rgb(90 60 30 / 45%);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: inset 0 0 24px rgb(60 40 20 / 18%);
+}
+
+/* Painted-art path: the image dictates the frame's aspect. */
+.world-map-art {
+  display: block;
+  width: 100%;
+  height: auto;
+  user-select: none;
+}
+
+/* No art (null/404): an inked-parchment stand-in keeps regions usable. */
+.world-map-frame-fallback {
+  aspect-ratio: 16 / 9;
+  background:
+    radial-gradient(ellipse at 30% 25%, rgb(255 250 236 / 55%), transparent 60%),
+    radial-gradient(ellipse at 75% 70%, rgb(214 186 140 / 45%), transparent 55%),
+    linear-gradient(160deg, #e6d8b8, #d8c49a);
+}
+
+.world-map-regions {
+  position: absolute;
+  inset: 0;
+}
+
+.world-map-zone {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1.5px solid hsl(var(--wm-hue) 45% 32% / 75%);
+  border-radius: 10px;
+  background: hsl(var(--wm-hue) 55% 55% / 14%);
+  box-shadow: inset 0 0 14px hsl(var(--wm-hue) 55% 45% / 12%);
+  cursor: pointer;
+  transition: background 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+}
+
+.world-map-zone:hover,
+.world-map-zone:focus-visible {
+  background: hsl(var(--wm-hue) 60% 55% / 24%);
+  border-color: hsl(var(--wm-hue) 50% 28% / 95%);
+  box-shadow:
+    inset 0 0 18px hsl(var(--wm-hue) 60% 45% / 18%),
+    0 0 12px hsl(var(--wm-hue) 60% 50% / 35%);
+}
+
+.world-map-zone:focus-visible {
+  outline: 2px solid #8a6a2e;
+  outline-offset: 1px;
+}
+
+.world-map-zone-selected {
+  background: hsl(var(--wm-hue) 60% 55% / 28%);
+  border-color: hsl(var(--wm-hue) 50% 26%);
+  box-shadow:
+    inset 0 0 18px hsl(var(--wm-hue) 60% 45% / 22%),
+    0 0 14px hsl(var(--wm-hue) 60% 50% / 45%);
+}
+
+.world-map-zone-label {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  max-width: 100%;
+  padding: 3px 8px;
+  border-radius: 8px;
+  background: rgb(255 250 236 / 82%);
+  border: 1px solid rgb(90 60 30 / 35%);
+  box-shadow: 0 1px 4px rgb(46 34 18 / 25%);
+  pointer-events: none;
+}
+
+.world-map-zone-name {
+  font-family: var(--font-display);
+  font-size: clamp(0.58rem, 1.4vw, 0.78rem);
+  line-height: 1.15;
+  color: #2e2212;
+  text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
+.world-map-zone-level {
+  font-size: clamp(0.52rem, 1.1vw, 0.66rem);
+  font-variant-numeric: tabular-nums;
+  color: #6a4a24;
+}
+
+/* Pulsing "you are here" beacon at the current zone's heart. */
+.world-map-here-dot {
+  position: absolute;
+  left: 50%;
+  top: 12%;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  background: #c9963c;
+  border: 1.5px solid #fff8e8;
+  box-shadow: 0 0 0 0 rgb(201 150 60 / 60%);
+  animation: world-map-here-pulse 2.2s ease-out infinite;
+}
+
+@keyframes world-map-here-pulse {
+  0% { box-shadow: 0 0 0 0 rgb(201 150 60 / 55%); }
+  70% { box-shadow: 0 0 0 9px rgb(201 150 60 / 0%); }
+  100% { box-shadow: 0 0 0 0 rgb(201 150 60 / 0%); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .world-map-here-dot {
+    animation: none;
+  }
+}
+
+.world-map-unplotted {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: var(--space-4);
+  text-align: center;
+  color: #5a4226;
+  font-style: italic;
+}
+
+.world-map-detail {
+  padding: var(--space-2) var(--space-3);
+  background: rgb(60 40 20 / 10%);
+  border: 1px solid rgb(90 60 30 / 40%);
+  border-radius: 10px;
+}
+
+.world-map-detail-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.world-map-detail-name {
+  font-family: var(--font-display);
+  font-size: 1rem;
+  color: #2e2212;
+}
+
+.world-map-detail-meta {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  margin-top: 2px;
+  font-size: 0.82rem;
+  color: #4a3014;
+}
+
+.world-map-detail-id {
+  font-size: 0.72rem;
+  color: #6a4a24;
+  opacity: 0.8;
+}
+
+.world-map-detail-hint {
+  margin: 4px 0 0;
+  font-size: 0.74rem;
+  font-style: italic;
+  color: #6a4a24;
+}
+
+.world-map-uncharted {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.world-map-uncharted-label {
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #6a4a24;
+  font-weight: 600;
+}
+
+.world-map-uncharted-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.world-map-chip {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  background: rgb(255 250 236 / 60%);
+  border: 1px solid rgb(90 60 30 / 40%);
+  font-size: 0.76rem;
+  color: #3a2c1a;
+}
+
+.world-map-chip-here {
+  border-color: #8a6a2e;
+  box-shadow: 0 0 6px rgb(138 106 46 / 40%);
+}
+
+.world-map-chip-level {
+  font-size: 0.68rem;
+  font-variant-numeric: tabular-nums;
+  color: #6a4a24;
+}
+
 /* --- Spellbook panel --- */
 
 .spellbook {

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -1051,6 +1051,15 @@ export interface WorldArea {
   zone: string;
   minLevel: number | null;
   maxLevel: number | null;
+  /**
+   * The zone's authored rectangle on the painted `world_map` art, in percent
+   * (0–100) of the image from its top-left corner. All four are null for zones
+   * not yet placed on the world map (the World Map tab lists them as uncharted).
+   */
+  mapX: number | null;
+  mapY: number | null;
+  mapW: number | null;
+  mapH: number | null;
 }
 
 /**


### PR DESCRIPTION
## Summary
Reworks the global atlas around the painted world map. Zones authored in Arcanum's Map overlay publish their footprint (`worldMap: {x,y,w,h}` percent block in zone YAML); the server validates and forwards them on the existing `World.Areas` GMCP package, and the web client gains a third **World Map** tab that seats each zone onto the painted `world_map` art with its name and level range.

Counterpart Arcanum PR: jnoecker/Arcanum#359 (Publish to Game + `world_map` asset key).

## Server
- `WorldFile.kt`: optional zone-level `worldMap` block (percent of the world map image, top-left origin)
- `WorldLoader.kt`: validation (all four fields required together, rectangle must sit inside the map, cross-file conflict detection)
- `World.kt`: `zoneWorldMap` storage incl. `mergeZone`/`replaceAll`
- `WorldAreaPayload`: nullable `mapX/mapY/mapW/mapH`
- `AppConfig.kt`: new `world_map` global asset key (defaults to the flight kiosk map so all world-map surfaces share one coastline)
- Academy zone gets a sample placement for local dev

## Web client
- (in progress) World Map tab: painted backdrop + zone regions with name/level range, current-zone marker, click-to-select

## Test plan
- [x] `WorldLoaderTest` — ok/bad worldMap fixtures
- [x] `GmcpEmitterTest` — placement serialization incl. nulls
- [x] Full `ktlintCheck test integrationTest` green; web `bun run lint` + `bun run build` green
- [x] Live QA via headless browser: guest login → map drawer → World Map tab; academy region renders with name/level range + you-are-here beacon on the parchment fallback (painted art 404s locally by design); detail card legible and above the fold