### PR TITLE
World Map: full-height map, side-panel ledger, hover labels

### DIFF
--- a/web-v3/src/components/WorldMap.tsx
+++ b/web-v3/src/components/WorldMap.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import type { WorldArea } from "../types";
 import { zoneHue } from "../constants";
 import { formatZoneName } from "../utils";
@@ -28,14 +28,17 @@ function formatLevelRange(area: WorldArea): string {
 }
 
 /**
- * The World Map atlas tab: every zone with an authored `worldMap` placement is
- * seated onto the painted `world_map` art as a soft jewel-tinted region showing
- * its name and level range. Zones without a placement are listed beneath the
- * map as uncharted. Selecting a region opens a detail card — the future hook
- * for viewing that zone's own map.
+ * The World Map atlas tab. The painted `world_map` art is the full-height
+ * centrepiece; every zone with an authored `worldMap` placement is seated onto
+ * it as a soft jewel-tinted region carrying only a tiny level-range tag (hidden
+ * outright on regions too small for it — container queries in styles.css).
+ * Hovering or focusing a region floats a parchment tooltip with the full name;
+ * clicking pins the zone's ledger in the side panel, which also lists uncharted
+ * zones. The side panel is the future hook for viewing that zone's own map.
  */
 export function WorldMap({ areas, currentZone, serverAssets }: WorldMapProps) {
   const [selected, setSelected] = useState<string | null>(null);
+  const [hovered, setHovered] = useState<string | null>(null);
   const [artFailed, setArtFailed] = useState(false);
 
   const mapUrl = serverAssets["world_map"] ?? serverAssets["flight_map"] ?? null;
@@ -45,13 +48,7 @@ export function WorldMap({ areas, currentZone, serverAssets }: WorldMapProps) {
   const uncharted = useMemo(() => areas.filter((a) => !isPlaced(a)), [areas]);
 
   const selectedArea = selected != null ? areas.find((a) => a.zone === selected) ?? null : null;
-
-  // Keep the detail card in view when a zone is selected — on narrow drawers
-  // the map frame can push it below the fold.
-  const detailRef = useRef<HTMLDivElement | null>(null);
-  useEffect(() => {
-    if (selected != null) detailRef.current?.scrollIntoView({ block: "nearest", behavior: "smooth" });
-  }, [selected]);
+  const hoveredArea = hovered != null ? placed.find((a) => a.zone === hovered) ?? null : null;
 
   if (areas.length === 0) {
     return (
@@ -60,6 +57,16 @@ export function WorldMap({ areas, currentZone, serverAssets }: WorldMapProps) {
       </div>
     );
   }
+
+  // Float the hover tooltip above the region, or below it when the region
+  // hugs the map's top edge; clamp horizontally so edge zones stay readable.
+  const tipBelow = hoveredArea != null && hoveredArea.mapY < 9;
+  const tipLeft = hoveredArea != null
+    ? Math.min(88, Math.max(12, hoveredArea.mapX + hoveredArea.mapW / 2))
+    : 0;
+  const tipTop = hoveredArea != null
+    ? (tipBelow ? hoveredArea.mapY + hoveredArea.mapH : hoveredArea.mapY)
+    : 0;
 
   return (
     <div className="world-map-body">
@@ -101,15 +108,26 @@ export function WorldMap({ areas, currentZone, serverAssets }: WorldMapProps) {
                 aria-pressed={isSelected}
                 aria-label={`${formatZoneName(area.zone)}, levels ${range}${here ? ", you are here" : ""}`}
                 onClick={() => setSelected((prev) => (prev === area.zone ? null : area.zone))}
+                onMouseEnter={() => setHovered(area.zone)}
+                onMouseLeave={() => setHovered((prev) => (prev === area.zone ? null : prev))}
+                onFocus={() => setHovered(area.zone)}
+                onBlur={() => setHovered((prev) => (prev === area.zone ? null : prev))}
               >
-                <span className="world-map-zone-label">
-                  <span className="world-map-zone-name">{formatZoneName(area.zone)}</span>
-                  <span className="world-map-zone-level">{range}</span>
-                </span>
+                <span className="world-map-zone-tag">{range}</span>
                 {here && <span className="world-map-here-dot" aria-hidden="true" />}
               </button>
             );
           })}
+          {hoveredArea && (
+            <div
+              className={`world-map-tip ${tipBelow ? "world-map-tip-below" : ""}`}
+              style={{ left: `${tipLeft}%`, top: `${tipTop}%` }}
+              aria-hidden="true"
+            >
+              <span className="world-map-tip-name">{formatZoneName(hoveredArea.zone)}</span>
+              <span className="world-map-tip-level">{formatLevelRange(hoveredArea)}</span>
+            </div>
+          )}
         </div>
         {placed.length === 0 && (
           <p className="world-map-unplotted">
@@ -118,42 +136,54 @@ export function WorldMap({ areas, currentZone, serverAssets }: WorldMapProps) {
         )}
       </div>
 
-      {selectedArea && (
-        <div className="world-map-detail" role="status" ref={detailRef}>
-          <div className="world-map-detail-title">
-            <span className="world-map-detail-name">{formatZoneName(selectedArea.zone)}</span>
-            {selectedArea.zone === currentZone && (
-              <span className="atlas-here-pill" aria-label="You are here">
-                you are here
+      <aside className="world-map-side">
+        {selectedArea ? (
+          <div className="world-map-detail" role="status">
+            <div className="world-map-detail-title">
+              <span className="world-map-detail-name">{formatZoneName(selectedArea.zone)}</span>
+              {selectedArea.zone === currentZone && (
+                <span className="atlas-here-pill" aria-label="You are here">
+                  you are here
+                </span>
+              )}
+            </div>
+            <div className="world-map-detail-meta">
+              <span>
+                Levels <strong>{formatLevelRange(selectedArea)}</strong>
               </span>
-            )}
+              <span className="world-map-detail-id">{selectedArea.zone}</span>
+            </div>
+            <p className="world-map-detail-hint">A closer survey of this realm is still being charted.</p>
           </div>
-          <div className="world-map-detail-meta">
-            <span>
-              Levels <strong>{formatLevelRange(selectedArea)}</strong>
-            </span>
-            <span className="world-map-detail-id">{selectedArea.zone}</span>
+        ) : (
+          <div className="world-map-detail world-map-detail-empty">
+            <p className="world-map-detail-hint">
+              Hover a realm to read its name — click to pin its ledger here.
+            </p>
+            <p className="world-map-detail-hint world-map-legend-line">
+              <span className="world-map-here-dot world-map-legend-dot" aria-hidden="true" /> marks where
+              you stand.
+            </p>
           </div>
-          <p className="world-map-detail-hint">A closer survey of this realm is still being charted.</p>
-        </div>
-      )}
+        )}
 
-      {uncharted.length > 0 && (
-        <div className="world-map-uncharted">
-          <span className="world-map-uncharted-label">Uncharted</span>
-          <div className="world-map-uncharted-chips">
-            {uncharted.map((area) => (
-              <span
-                key={area.zone}
-                className={`world-map-chip ${area.zone === currentZone ? "world-map-chip-here" : ""}`}
-              >
-                {formatZoneName(area.zone)}
-                <span className="world-map-chip-level">{formatLevelRange(area)}</span>
-              </span>
-            ))}
+        {uncharted.length > 0 && (
+          <div className="world-map-uncharted">
+            <span className="world-map-uncharted-label">Uncharted</span>
+            <div className="world-map-uncharted-chips">
+              {uncharted.map((area) => (
+                <span
+                  key={area.zone}
+                  className={`world-map-chip ${area.zone === currentZone ? "world-map-chip-here" : ""}`}
+                >
+                  {formatZoneName(area.zone)}
+                  <span className="world-map-chip-level">{formatLevelRange(area)}</span>
+                </span>
+              ))}
+            </div>
           </div>
-        </div>
-      )}
+        )}
+      </aside>
     </div>
   );
 }

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -10281,6 +10281,9 @@ body {
   flex-direction: column;
   gap: var(--space-3);
   min-height: 0;
+  width: 100%;
+  max-width: 980px;
+  margin-inline: auto;
 }
 
 .atlas-empty {
@@ -10468,20 +10471,24 @@ body {
 
 /* --- World Map atlas tab --- */
 
+/* Map as the full-height centrepiece, ledger + uncharted list in a side
+   panel so the horizontal space beside portrait art earns its keep. */
 .world-map-body {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  justify-content: center;
+  align-items: flex-start;
   gap: var(--space-3);
+  flex: 1 1 auto;
   min-height: 0;
-  overflow-y: auto;
+  overflow: hidden;
 }
 
 .world-map-frame {
   position: relative;
-  flex: 0 0 auto;
+  flex: 0 1 auto;
   width: fit-content;
   max-width: 100%;
-  margin-inline: auto;
   border: 1px solid rgb(90 60 30 / 45%);
   border-radius: 12px;
   overflow: hidden;
@@ -10489,25 +10496,36 @@ body {
 }
 
 /* Painted-art path: the frame hugs the image so zone-region percentages track
-   the art exactly; height is capped so the detail card stays above the fold. */
+   the art exactly. The viewport cap (drawer minus its chrome) lets portrait
+   art fill the drawer's full height. */
 .world-map-art {
   display: block;
   width: auto;
   height: auto;
   max-width: 100%;
-  max-height: min(58vh, 640px);
+  max-height: calc(100vh - 230px);
   user-select: none;
 }
 
 /* No art (null/404): an inked-parchment stand-in keeps regions usable. */
 .world-map-frame-fallback {
-  width: 100%;
-  max-width: min(100%, calc(58vh * (16 / 9)));
-  aspect-ratio: 16 / 9;
+  height: calc(100vh - 230px);
+  max-width: 100%;
+  aspect-ratio: 3 / 4;
   background:
     radial-gradient(ellipse at 30% 25%, rgb(255 250 236 / 55%), transparent 60%),
     radial-gradient(ellipse at 75% 70%, rgb(214 186 140 / 45%), transparent 55%),
     linear-gradient(160deg, #e6d8b8, #d8c49a);
+}
+
+.world-map-side {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  flex: 0 1 300px;
+  min-width: 220px;
+  max-height: calc(100vh - 230px);
+  overflow-y: auto;
 }
 
 .world-map-regions {
@@ -10522,11 +10540,12 @@ body {
   justify-content: center;
   padding: 0;
   border: 1.5px solid hsl(var(--wm-hue) 45% 32% / 75%);
-  border-radius: 10px;
+  border-radius: 8px;
   background: hsl(var(--wm-hue) 55% 55% / 14%);
   box-shadow: inset 0 0 14px hsl(var(--wm-hue) 55% 45% / 12%);
   cursor: pointer;
   transition: background 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+  container-type: size;
 }
 
 .world-map-zone:hover,
@@ -10551,34 +10570,57 @@ body {
     0 0 14px hsl(var(--wm-hue) 60% 50% / 45%);
 }
 
-.world-map-zone-label {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2px;
-  max-width: 100%;
-  padding: 3px 8px;
-  border-radius: 8px;
-  background: rgb(255 250 236 / 82%);
-  border: 1px solid rgb(90 60 30 / 35%);
-  box-shadow: 0 1px 4px rgb(46 34 18 / 25%);
+/* Always-on tag: just the level range, small enough to sit inside dense
+   clusters. Regions too small even for that go bare — hover carries the rest. */
+.world-map-zone-tag {
+  padding: 1px 5px;
+  border-radius: 6px;
+  background: rgb(255 250 236 / 80%);
+  border: 1px solid rgb(90 60 30 / 30%);
+  font-size: 0.58rem;
+  line-height: 1.2;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  color: #4a3014;
   pointer-events: none;
 }
 
-.world-map-zone-name {
-  font-family: var(--font-display);
-  font-size: clamp(0.58rem, 1.4vw, 0.78rem);
-  line-height: 1.15;
-  color: #2e2212;
-  text-align: center;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: 100%;
+@container (width < 44px) or (height < 22px) {
+  .world-map-zone-tag {
+    display: none;
+  }
 }
 
-.world-map-zone-level {
-  font-size: clamp(0.52rem, 1.1vw, 0.66rem);
+/* Shared hover tooltip: full zone name + level range on parchment, floated
+   above (or below, near the top edge) the hovered region. */
+.world-map-tip {
+  position: absolute;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 3px 10px;
+  border-radius: 8px;
+  background: rgb(252 244 222 / 96%);
+  border: 1px solid rgb(90 60 30 / 55%);
+  box-shadow: 0 2px 8px rgb(20 14 8 / 40%);
+  transform: translate(-50%, calc(-100% - 6px));
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 3;
+}
+
+.world-map-tip-below {
+  transform: translate(-50%, 6px);
+}
+
+.world-map-tip-name {
+  font-family: var(--font-display);
+  font-size: 0.78rem;
+  color: #2e2212;
+}
+
+.world-map-tip-level {
+  font-size: 0.66rem;
   font-variant-numeric: tabular-nums;
   color: #6a4a24;
 }
@@ -10608,6 +10650,15 @@ body {
   .world-map-here-dot {
     animation: none;
   }
+}
+
+/* Inline variant of the beacon for the side-panel legend line. */
+.world-map-legend-dot {
+  position: static;
+  display: inline-block;
+  transform: none;
+  vertical-align: -1px;
+  margin-right: 2px;
 }
 
 .world-map-unplotted {
@@ -10713,6 +10764,40 @@ body {
   font-size: 0.68rem;
   font-variant-numeric: tabular-nums;
   color: #6a4a24;
+}
+
+.world-map-detail-empty .world-map-detail-hint {
+  margin-top: 0;
+}
+
+.world-map-legend-line {
+  margin-top: 6px;
+}
+
+/* Narrow windows: stack the side panel under a height-capped map. */
+@media (max-width: 900px) {
+  .world-map-body {
+    flex-direction: column;
+    align-items: center;
+    overflow-y: auto;
+  }
+
+  .world-map-art,
+  .world-map-frame-fallback {
+    max-height: 56vh;
+    height: auto;
+  }
+
+  .world-map-frame-fallback {
+    height: 56vh;
+  }
+
+  .world-map-side {
+    flex: 0 0 auto;
+    width: 100%;
+    max-height: none;
+    overflow-y: visible;
+  }
 }
 
 /* --- Spellbook panel --- */


### PR DESCRIPTION
## Summary
Visual iteration on the World Map tab (follow-up to #1429), driven by live screenshots of the production world:

- **Full-height portrait map.** The painted art now fills the drawer's vertical space as the centrepiece instead of floating small in a sea of parchment; the frame still hugs the image so zone-region percentages stay exact.
- **Side-panel ledger.** The detail card and Uncharted list move into a right-hand panel, using the horizontal space beside portrait art. Empty state carries a hover/click hint and a you-are-here legend.
- **Quieter labels.** Regions now carry only a tiny level-range tag; regions too small even for that go bare (per-region CSS container queries). The full zone name + levels float in a parchment tooltip on hover/focus — no more truncated "Woods…" pills overlapping half the map.
- **Atlas tab** table is width-capped and centered so it stops stretching across the whole drawer.
- Narrow windows (<900px) stack the side panel under a height-capped map.

## Test plan
- [x] `bun run lint` + `bun run build`
- [x] Live QA with 12 synthetic dense zones (production-like density): tags render on medium+ regions, tiny regions go bare, hover tooltip shows "Tiny Grotto 1–5" above the region, click pins the ledger in the side panel, no console errors