### PR TITLE
World Map pan/zoom + click-through zone charts

### DIFF
--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -2359,6 +2359,12 @@ data class CommandsConfig(
                     "with two, shows areas overlapping the range.",
                 category = "navigation",
             ),
+            "map" to CommandMetadata(
+                usage = "map [<zone>] (alias: chart)",
+                description = "Unfurl a zone's charts: a one-line summary, plus the zone map in the " +
+                    "web client with your own exploration fog. Without a zone, re-sends your current zone's map.",
+                category = "navigation",
+            ),
             "say" to CommandMetadata("say <msg> or '<msg>", "Speak to the room", "communication", requiresTarget = true),
             "emote" to CommandMetadata("emote <msg>", "Perform an emote", "communication", requiresTarget = true),
             "pose" to CommandMetadata("pose <msg>", "Strike a pose", "communication", requiresTarget = true),

--- a/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/CommandParser.kt
@@ -75,6 +75,16 @@ sealed interface Command {
         val maxLevel: Int?,
     ) : Command
 
+    /**
+     * Unfurls the charts of [zone] (the player's current zone when null):
+     * prints a one-line summary and re-sends the `Zone.Map` GMCP chart with the
+     * player's own exploration fog, letting the web client preview any realm's
+     * map from the World Map atlas tab.
+     */
+    data class ZoneChart(
+        val zone: String?,
+    ) : Command
+
     data class LookDir(
         val dir: Direction,
     ) : Command
@@ -1301,6 +1311,10 @@ object CommandParser {
 
         matchPrefix(line, listOf("areas", "area")) { rest ->
             parseAreasArgs(rest, line)
+        }?.let { return it }
+
+        matchPrefix(line, listOf("map", "chart")) { rest ->
+            Command.ZoneChart(zone = rest.trim().ifEmpty { null })
         }?.let { return it }
 
         matchPrefix(line, listOf("run")) { rest ->

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldInfoHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldInfoHandler.kt
@@ -22,10 +22,12 @@ class WorldInfoHandler(
     private val world = ctx.world
     private val players = ctx.players
     private val outbound = ctx.outbound
+    private val gmcpEmitter = ctx.gmcpEmitter
 
     override fun register(router: CommandRouter) {
         router.on<Command.Time> { sid, _ -> handleTime(sid) }
         router.on<Command.Areas> { sid, cmd -> handleAreas(sid, cmd) }
+        router.on<Command.ZoneChart> { sid, cmd -> handleZoneChart(sid, cmd) }
     }
 
     private suspend fun handleTime(sessionId: SessionId) {
@@ -93,6 +95,41 @@ class WorldInfoHandler(
             }
             outbound.send(OutboundEvent.SendInfo(sessionId, "  $zone  ($levelStr)"))
         }
+    }
+
+    private suspend fun handleZoneChart(sessionId: SessionId, cmd: Command.ZoneChart) {
+        val me = players.get(sessionId) ?: return
+        // Accept display-style names ("Fae Wood") as well as raw zone ids.
+        val zone = cmd.zone?.trim()?.lowercase()?.replace(Regex("\\s+"), "_") ?: me.roomId.zone
+        val zoneRooms = world.rooms.values.filter { it.id.zone == zone }
+        if (zoneRooms.isEmpty()) {
+            outbound.send(
+                OutboundEvent.SendError(sessionId, "No charts exist for '$zone'. Try 'areas' for the known realms."),
+            )
+            return
+        }
+        // Same fog rules as zone entry: staff see the whole chart, everyone
+        // else sees detail only on rooms they have personally explored.
+        val explored =
+            if (me.isStaff) zoneRooms.mapTo(mutableSetOf()) { it.id.value } else me.exploredRooms
+        val exploredCount = zoneRooms.count { it.id.value in explored }
+        val displayName = zone
+            .split('_')
+            .filter { it.isNotEmpty() }
+            .joinToString(" ") { part -> part.replaceFirstChar { it.uppercaseChar() } }
+        val range = computeWorldZoneLevelRanges(world)[zone]
+        val levelStr = when {
+            range == null -> ""
+            range.first == range.last -> " (level ${range.first})"
+            else -> " (levels ${range.first}-${range.last})"
+        }
+        outbound.send(
+            OutboundEvent.SendInfo(
+                sessionId,
+                "You unfurl the charts of $displayName$levelStr — $exploredCount of ${zoneRooms.size} rooms explored.",
+            ),
+        )
+        gmcpEmitter?.sendZoneMap(sessionId, zone, zoneRooms, explored)
     }
 }
 

--- a/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldInfoHandler.kt
+++ b/src/main/kotlin/dev/ambon/engine/commands/handlers/WorldInfoHandler.kt
@@ -99,15 +99,40 @@ class WorldInfoHandler(
 
     private suspend fun handleZoneChart(sessionId: SessionId, cmd: Command.ZoneChart) {
         val me = players.get(sessionId) ?: return
-        // Accept display-style names ("Fae Wood") as well as raw zone ids.
-        val zone = cmd.zone?.trim()?.lowercase()?.replace(Regex("\\s+"), "_") ?: me.roomId.zone
-        val zoneRooms = world.rooms.values.filter { it.id.zone == zone }
-        if (zoneRooms.isEmpty()) {
-            outbound.send(
-                OutboundEvent.SendError(sessionId, "No charts exist for '$zone'. Try 'areas' for the known realms."),
-            )
-            return
+        val knownZones = world.rooms.values.mapTo(sortedSetOf()) { it.id.zone }
+        // Accept display-style names ("Fae Wood") as well as raw zone ids, and
+        // resolve an unambiguous prefix ("fae" -> "fae_wood") the way `areas`
+        // lists realms, so telnet users can chart from what they see there.
+        val query = cmd.zone?.trim()?.lowercase()?.replace(Regex("\\s+"), "_")
+        val zone = when {
+            query == null -> me.roomId.zone
+            query in knownZones -> query
+            else -> {
+                val matches = knownZones.filter { it.startsWith(query) }
+                when (matches.size) {
+                    1 -> matches.first()
+                    0 -> {
+                        outbound.send(
+                            OutboundEvent.SendError(
+                                sessionId,
+                                "No charts exist for '$query'. Try 'areas' for the known realms.",
+                            ),
+                        )
+                        return
+                    }
+                    else -> {
+                        outbound.send(
+                            OutboundEvent.SendError(
+                                sessionId,
+                                "'$query' could be ${matches.joinToString(", ")} — name the realm more fully.",
+                            ),
+                        )
+                        return
+                    }
+                }
+            }
         }
+        val zoneRooms = world.rooms.values.filter { it.id.zone == zone }
         // Same fog rules as zone entry: staff see the whole chart, everyone
         // else sees detail only on rooms they have personally explored.
         val explored =

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1108,6 +1108,11 @@ ambonmud:
           description: "List known areas. With one level, shows areas covering that level; with two, shows areas overlapping the range."
           category: "navigation"
           staff: false
+        map:
+          usage: "map [<zone>] (alias: chart)"
+          description: "Unfurl a zone's charts: a one-line summary, plus the zone map in the web client with your own exploration fog. Without a zone, re-sends your current zone's map."
+          category: "navigation"
+          staff: false
         say:
           usage: "say <msg> or '<msg>"
           description: "Speak to the room"

--- a/src/test/kotlin/dev/ambon/engine/WebClientParityTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/WebClientParityTest.kt
@@ -34,6 +34,7 @@ class WebClientParityTest {
         "Move" to "move",
         "Run" to "run",
         "Areas" to "areas",
+        "ZoneChart" to "map",
         "Exits" to "exits",
         "Recall" to "recall",
         "Rest" to "rest",

--- a/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/CommandParserTest.kt
@@ -1192,6 +1192,21 @@ class CommandParserTest {
         assertTrue(CommandParser.parse("describe check") is Command.Invalid)
     }
 
+    // ---- Zone chart ----
+
+    @Test
+    fun `map with no args charts the current zone`() {
+        assertEquals(Command.ZoneChart(null), CommandParser.parse("map"))
+        assertEquals(Command.ZoneChart(null), CommandParser.parse("chart"))
+    }
+
+    @Test
+    fun `map with a zone name charts that zone`() {
+        assertEquals(Command.ZoneChart("fae_wood"), CommandParser.parse("map fae_wood"))
+        assertEquals(Command.ZoneChart("Fae Wood"), CommandParser.parse("map Fae Wood"))
+        assertEquals(Command.ZoneChart("sylvawood"), CommandParser.parse("chart sylvawood"))
+    }
+
     // ---- Areas ----
 
     @Test

--- a/src/test/kotlin/dev/ambon/engine/commands/ZoneChartCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/ZoneChartCommandTest.kt
@@ -60,6 +60,19 @@ class ZoneChartCommandTest {
         }
 
     @Test
+    fun `map resolves an unambiguous zone prefix`() =
+        runTest {
+            val h = harness()
+            h.router.handle(h.sid, Command.ZoneChart("ok"))
+            val events = h.outbound.drainAll()
+            val gmcp = events.filterIsInstance<OutboundEvent.GmcpData>()
+            assertTrue(
+                gmcp.any { it.gmcpPackage == "Zone.Map" && it.jsonData.contains("\"ok_small\"") },
+                "Expected 'ok' to resolve to the ok_small chart: $gmcp",
+            )
+        }
+
+    @Test
     fun `map of an unknown zone errors without a chart`() =
         runTest {
             val h = harness()

--- a/src/test/kotlin/dev/ambon/engine/commands/ZoneChartCommandTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/ZoneChartCommandTest.kt
@@ -1,0 +1,115 @@
+package dev.ambon.engine.commands
+
+import dev.ambon.bus.LocalOutboundBus
+import dev.ambon.config.WeatherConfig
+import dev.ambon.config.WorldEventsConfig
+import dev.ambon.config.WorldTimeConfig
+import dev.ambon.domain.ids.RoomId
+import dev.ambon.domain.ids.SessionId
+import dev.ambon.engine.CombatSystem
+import dev.ambon.engine.GmcpEmitter
+import dev.ambon.engine.LoginResult
+import dev.ambon.engine.MobRegistry
+import dev.ambon.engine.WeatherSystem
+import dev.ambon.engine.WorldEventSystem
+import dev.ambon.engine.WorldStateRegistry
+import dev.ambon.engine.WorldTimeSystem
+import dev.ambon.engine.commands.handlers.EngineContext
+import dev.ambon.engine.commands.handlers.WorldInfoHandler
+import dev.ambon.engine.events.OutboundEvent
+import dev.ambon.engine.items.ItemRegistry
+import dev.ambon.persistence.InMemoryPlayerRepository
+import dev.ambon.test.drainAll
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Clock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ZoneChartCommandTest {
+    private val world = dev.ambon.test.TestWorlds.okSmall
+    private val roomA: RoomId = world.startRoom
+
+    @Test
+    fun `map with no zone charts the current zone`() =
+        runTest {
+            val h = harness()
+            h.router.handle(h.sid, Command.ZoneChart(null))
+            val events = h.outbound.drainAll()
+            val texts = events.filterIsInstance<OutboundEvent.SendInfo>().map { it.text }
+            assertTrue(texts.any { it.contains("unfurl the charts of Ok Small") }, "Expected summary line: $texts")
+            val gmcp = events.filterIsInstance<OutboundEvent.GmcpData>()
+            assertTrue(
+                gmcp.any { it.gmcpPackage == "Zone.Map" && it.jsonData.contains("\"ok_small\"") },
+                "Expected a Zone.Map emission for ok_small: $gmcp",
+            )
+        }
+
+    @Test
+    fun `map with a zone name charts that zone`() =
+        runTest {
+            val h = harness()
+            h.router.handle(h.sid, Command.ZoneChart("Ok Small"))
+            val events = h.outbound.drainAll()
+            val gmcp = events.filterIsInstance<OutboundEvent.GmcpData>()
+            assertTrue(
+                gmcp.any { it.gmcpPackage == "Zone.Map" && it.jsonData.contains("\"ok_small\"") },
+                "Expected display-style name to resolve to the ok_small chart: $gmcp",
+            )
+        }
+
+    @Test
+    fun `map of an unknown zone errors without a chart`() =
+        runTest {
+            val h = harness()
+            h.router.handle(h.sid, Command.ZoneChart("atlantis"))
+            val events = h.outbound.drainAll()
+            assertTrue(
+                events.filterIsInstance<OutboundEvent.SendError>().any { it.text.contains("atlantis") },
+                "Expected an error naming the unknown zone: $events",
+            )
+            assertTrue(
+                events.filterIsInstance<OutboundEvent.GmcpData>().none { it.gmcpPackage == "Zone.Map" },
+                "Expected no Zone.Map emission for an unknown zone",
+            )
+        }
+
+    private data class Harness(
+        val sid: SessionId,
+        val router: CommandRouter,
+        val outbound: LocalOutboundBus,
+    )
+
+    private suspend fun harness(): Harness {
+        val items = ItemRegistry()
+        items.loadSpawns(world.itemSpawns)
+        val outbound = LocalOutboundBus()
+        val players = dev.ambon.test.buildTestPlayerRegistry(roomA, InMemoryPlayerRepository(), items)
+        val mobs = MobRegistry()
+        val worldState = WorldStateRegistry(world)
+        val router = CommandRouter(outbound = outbound, players = players)
+        val ctx = EngineContext(
+            players = players,
+            mobs = mobs,
+            world = world,
+            items = items,
+            outbound = outbound,
+            combat = CombatSystem(players, mobs, items, outbound),
+            gmcpEmitter = GmcpEmitter(outbound = outbound, supportsPackage = { _, _ -> true }),
+            worldState = worldState,
+        )
+        val clock = Clock.systemUTC()
+        WorldInfoHandler(
+            ctx = ctx,
+            worldTimeSystem = WorldTimeSystem(WorldTimeConfig(), clock),
+            weatherSystem = WeatherSystem(WeatherConfig(), clock),
+            worldEventSystem = WorldEventSystem(WorldEventsConfig(), clock),
+        ).register(router)
+        val sid = SessionId(1)
+        val res = players.login(sid, "Cartograph", "password")
+        require(res == LoginResult.Ok)
+        outbound.drainAll()
+        return Harness(sid, router, outbound)
+    }
+}

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -1010,6 +1010,16 @@ function App() {
     const colon = id.indexOf(":");
     return colon > 0 ? id.slice(0, colon) : null;
   }, [state.room.id]);
+
+  // World Map ledger → preview another realm's chart on the Local Map tab.
+  // Your own zone needs no round trip; just switch tabs.
+  const handleViewCharts = (zone: string) => {
+    if (zone !== currentZone) {
+      state.beginChartPreview(zone);
+      sendCommand(`map ${zone}`);
+    }
+    setMapTab("map");
+  };
   if (state.activePopout !== prevActivePopout) {
     setPrevActivePopout(state.activePopout);
     if (state.activePopout !== null) {
@@ -1776,6 +1786,20 @@ function App() {
                 </button>
               )}
             </div>
+            {mapTab === "map" && state.mapPreviewZone && (
+              <div className="map-preview-banner" role="status">
+                <span className="map-preview-label">
+                  Viewing the charts of <strong>{formatZoneName(state.mapPreviewZone)}</strong>
+                </span>
+                <button
+                  type="button"
+                  className="map-preview-return"
+                  onClick={() => state.endChartPreview()}
+                >
+                  ⌖ Back to {currentZone ? formatZoneName(currentZone) : "your realm"}
+                </button>
+              </div>
+            )}
             {mapTab === "map" && mapZoneStats && (
               <div className="map-stats-bar" role="status">
                 <span className="map-stats-explored">
@@ -1864,6 +1888,7 @@ function App() {
               <WorldMap
                 areas={state.worldAreas}
                 currentZone={currentZone}
+                onViewCharts={handleViewCharts}
                 serverAssets={state.serverAssets}
               />
             )}

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -264,13 +264,14 @@ function App() {
     zoomIn: mapZoomIn,
     zoomOut: mapZoomOut,
     recenter: mapRecenter,
+    setChartMode,
     zoneStats: mapZoneStats,
     hoverInfo: mapHoverInfo,
   } = useMiniMap((info) => mapRoomClickRef.current(info));
 
   const state = useGameState(
     { resumeTokenRef, pendingAuthCharRef, sendGmcpRef },
-    { updateMap, loadZoneMap, resetMap },
+    { updateMap, loadZoneMap, resetMap, setChartMode },
   );
   const audio = useAudioEngine();
   // Player abilities feed the quickbar and spellbook. Pet skills get their own auto-populated

--- a/web-v3/src/components/WorldMap.tsx
+++ b/web-v3/src/components/WorldMap.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { WorldArea } from "../types";
 import { zoneHue } from "../constants";
 import { formatZoneName } from "../utils";
@@ -7,6 +7,8 @@ interface WorldMapProps {
   areas: WorldArea[];
   currentZone: string | null;
   serverAssets: Record<string, string>;
+  /** Open the named zone's chart (Local Map preview via the `map` command). */
+  onViewCharts: (zone: string) => void;
 }
 
 /** An area whose worldMap placement is fully authored. */
@@ -27,19 +29,43 @@ function formatLevelRange(area: WorldArea): string {
   return `${area.minLevel}–${area.maxLevel}`;
 }
 
+const MIN_ZOOM = 1;
+const MAX_ZOOM = 5;
+const WHEEL_STEP = 1.18;
+/** Pointer travel (px) before a press counts as a pan, not a click. */
+const DRAG_THRESHOLD = 5;
+/** Fallback art aspect (w/h) until the painted map reports its real size. */
+const FALLBACK_ASPECT = 3 / 4;
+
 /**
  * The World Map atlas tab. The painted `world_map` art is the full-height
- * centrepiece; every zone with an authored `worldMap` placement is seated onto
- * it as a soft jewel-tinted region carrying only a tiny level-range tag (hidden
- * outright on regions too small for it — container queries in styles.css).
- * Hovering or focusing a region floats a parchment tooltip with the full name;
- * clicking pins the zone's ledger in the side panel, which also lists uncharted
- * zones. The side panel is the future hook for viewing that zone's own map.
+ * centrepiece inside a pannable, zoomable viewport (wheel or buttons to zoom,
+ * drag to pan). Zoom resizes the layout — not a CSS transform — so each
+ * region's container query re-evaluates and level tags surface as zones grow.
+ * Hover floats a parchment tooltip with the full name; clicking pins the
+ * zone's ledger in the side panel, where "unfurl the charts" opens that
+ * zone's own map via the `map` command.
  */
-export function WorldMap({ areas, currentZone, serverAssets }: WorldMapProps) {
+export function WorldMap({ areas, currentZone, serverAssets, onViewCharts }: WorldMapProps) {
   const [selected, setSelected] = useState<string | null>(null);
   const [hovered, setHovered] = useState<string | null>(null);
   const [artFailed, setArtFailed] = useState(false);
+  const [artAspect, setArtAspect] = useState<number | null>(null);
+  const [zoom, setZoom] = useState(1);
+  const [viewportSize, setViewportSize] = useState<{ w: number; h: number }>({ w: 0, h: 0 });
+
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const zoomRef = useRef(1);
+  const fitRef = useRef<{ w: number; h: number }>({ w: 0, h: 0 });
+  const pendingScrollRef = useRef<{ left: number; top: number } | null>(null);
+  const dragRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    scrollLeft: number;
+    scrollTop: number;
+    dragged: boolean;
+  } | null>(null);
 
   const mapUrl = serverAssets["world_map"] ?? serverAssets["flight_map"] ?? null;
   const showArt = mapUrl != null && !artFailed;
@@ -49,6 +75,137 @@ export function WorldMap({ areas, currentZone, serverAssets }: WorldMapProps) {
 
   const selectedArea = selected != null ? areas.find((a) => a.zone === selected) ?? null : null;
   const hoveredArea = hovered != null ? placed.find((a) => a.zone === hovered) ?? null : null;
+
+  // ── Viewport measurement ──────────────────────────
+  useEffect(() => {
+    const vp = viewportRef.current;
+    if (!vp) return;
+    const measure = () => setViewportSize({ w: vp.clientWidth, h: vp.clientHeight });
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(vp);
+    return () => ro.disconnect();
+  }, []);
+
+  // Contain-fit of the art inside the viewport = the zoom-1 canvas size.
+  const aspect = showArt ? artAspect ?? FALLBACK_ASPECT : FALLBACK_ASPECT;
+  const fit = useMemo(() => {
+    const { w, h } = viewportSize;
+    if (w <= 0 || h <= 0) return { w: 0, h: 0 };
+    const width = Math.min(w, h * aspect);
+    return { w: width, h: width / aspect };
+  }, [viewportSize, aspect]);
+  useEffect(() => {
+    fitRef.current = fit;
+  }, [fit]);
+
+  const canvasW = fit.w * zoom;
+  const canvasH = fit.h * zoom;
+
+  // ── Zoom (wheel at cursor, buttons at centre) ─────
+  const setZoomAt = useCallback((next: number, clientX?: number, clientY?: number) => {
+    const vp = viewportRef.current;
+    if (!vp) return;
+    const prev = zoomRef.current;
+    const nz = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, next));
+    if (nz === prev) return;
+    const rect = vp.getBoundingClientRect();
+    const px = clientX != null ? clientX - rect.left : rect.width / 2;
+    const py = clientY != null ? clientY - rect.top : rect.height / 2;
+    // Content coords of the point under the cursor, accounting for the
+    // margin-auto centering while the canvas is smaller than the viewport.
+    const f = fitRef.current;
+    const offPrevX = Math.max(0, (vp.clientWidth - f.w * prev) / 2);
+    const offPrevY = Math.max(0, (vp.clientHeight - f.h * prev) / 2);
+    const offNextX = Math.max(0, (vp.clientWidth - f.w * nz) / 2);
+    const offNextY = Math.max(0, (vp.clientHeight - f.h * nz) / 2);
+    const contentX = vp.scrollLeft + px - offPrevX;
+    const contentY = vp.scrollTop + py - offPrevY;
+    const ratio = nz / prev;
+    zoomRef.current = nz;
+    setZoom(nz);
+    pendingScrollRef.current = {
+      left: contentX * ratio + offNextX - px,
+      top: contentY * ratio + offNextY - py,
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    const vp = viewportRef.current;
+    const p = pendingScrollRef.current;
+    if (vp && p) {
+      vp.scrollLeft = p.left;
+      vp.scrollTop = p.top;
+      pendingScrollRef.current = null;
+    }
+  }, [zoom]);
+
+  // Native listener: React's synthetic wheel handler is passive, so it can't
+  // preventDefault the page scroll. setZoomAt is stable (reads refs only).
+  useEffect(() => {
+    const vp = viewportRef.current;
+    if (!vp) return;
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const factor = e.deltaY < 0 ? WHEEL_STEP : 1 / WHEEL_STEP;
+      setZoomAt(zoomRef.current * factor, e.clientX, e.clientY);
+    };
+    vp.addEventListener("wheel", onWheel, { passive: false });
+    return () => vp.removeEventListener("wheel", onWheel);
+  }, [setZoomAt]);
+
+  const resetView = useCallback(() => {
+    zoomRef.current = 1;
+    setZoom(1);
+    pendingScrollRef.current = { left: 0, top: 0 };
+  }, []);
+
+  // ── Drag to pan (suppresses the click that ends a drag) ──
+  const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.button !== 0) return;
+    const vp = viewportRef.current;
+    if (!vp) return;
+    dragRef.current = {
+      pointerId: e.pointerId,
+      startX: e.clientX,
+      startY: e.clientY,
+      scrollLeft: vp.scrollLeft,
+      scrollTop: vp.scrollTop,
+      dragged: false,
+    };
+  }, []);
+
+  const onPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    const vp = viewportRef.current;
+    if (!drag || !vp || e.pointerId !== drag.pointerId) return;
+    const dx = e.clientX - drag.startX;
+    const dy = e.clientY - drag.startY;
+    if (!drag.dragged && Math.hypot(dx, dy) < DRAG_THRESHOLD) return;
+    if (!drag.dragged) {
+      drag.dragged = true;
+      vp.setPointerCapture(drag.pointerId);
+    }
+    vp.scrollLeft = drag.scrollLeft - dx;
+    vp.scrollTop = drag.scrollTop - dy;
+  }, []);
+
+  const onPointerEnd = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (drag && e.pointerId === drag.pointerId && !drag.dragged) {
+      dragRef.current = null;
+    }
+    // A completed drag stays in the ref until click-capture consumes it.
+  }, []);
+
+  const onClickCapture = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    dragRef.current = null;
+    if (drag?.dragged) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  }, []);
 
   if (areas.length === 0) {
     return (
@@ -62,7 +219,7 @@ export function WorldMap({ areas, currentZone, serverAssets }: WorldMapProps) {
   // hugs the map's top edge; clamp horizontally so edge zones stay readable.
   const tipBelow = hoveredArea != null && hoveredArea.mapY < 9;
   const tipLeft = hoveredArea != null
-    ? Math.min(88, Math.max(12, hoveredArea.mapX + hoveredArea.mapW / 2))
+    ? Math.min(92, Math.max(8, hoveredArea.mapX + hoveredArea.mapW / 2))
     : 0;
   const tipTop = hoveredArea != null
     ? (tipBelow ? hoveredArea.mapY + hoveredArea.mapH : hoveredArea.mapY)
@@ -70,70 +227,120 @@ export function WorldMap({ areas, currentZone, serverAssets }: WorldMapProps) {
 
   return (
     <div className="world-map-body">
-      <div
-        className={`world-map-frame ${showArt ? "" : "world-map-frame-fallback"}`}
-        role="group"
-        aria-label="World map of known realms"
-      >
-        {showArt && (
-          <img
-            className="world-map-art"
-            src={mapUrl}
-            alt=""
-            draggable={false}
-            onError={() => setArtFailed(true)}
-          />
-        )}
-        <div className="world-map-regions">
-          {placed.map((area) => {
-            const here = area.zone === currentZone;
-            const isSelected = area.zone === selected;
-            const range = formatLevelRange(area);
-            return (
-              <button
-                key={area.zone}
-                type="button"
-                className={[
-                  "world-map-zone",
-                  here ? "world-map-zone-here" : "",
-                  isSelected ? "world-map-zone-selected" : "",
-                ].join(" ")}
-                style={{
-                  left: `${area.mapX}%`,
-                  top: `${area.mapY}%`,
-                  width: `${area.mapW}%`,
-                  height: `${area.mapH}%`,
-                  "--wm-hue": zoneHue(area.zone),
-                } as React.CSSProperties}
-                aria-pressed={isSelected}
-                aria-label={`${formatZoneName(area.zone)}, levels ${range}${here ? ", you are here" : ""}`}
-                onClick={() => setSelected((prev) => (prev === area.zone ? null : area.zone))}
-                onMouseEnter={() => setHovered(area.zone)}
-                onMouseLeave={() => setHovered((prev) => (prev === area.zone ? null : prev))}
-                onFocus={() => setHovered(area.zone)}
-                onBlur={() => setHovered((prev) => (prev === area.zone ? null : prev))}
-              >
-                <span className="world-map-zone-tag">{range}</span>
-                {here && <span className="world-map-here-dot" aria-hidden="true" />}
-              </button>
-            );
-          })}
-          {hoveredArea && (
-            <div
-              className={`world-map-tip ${tipBelow ? "world-map-tip-below" : ""}`}
-              style={{ left: `${tipLeft}%`, top: `${tipTop}%` }}
-              aria-hidden="true"
-            >
-              <span className="world-map-tip-name">{formatZoneName(hoveredArea.zone)}</span>
-              <span className="world-map-tip-level">{formatLevelRange(hoveredArea)}</span>
-            </div>
+      <div className="world-map-stage">
+        <div
+          ref={viewportRef}
+          className="world-map-viewport"
+          role="group"
+          aria-label="World map of known realms — scroll or use the buttons to zoom, drag to pan"
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerEnd}
+          onPointerCancel={onPointerEnd}
+          onClickCapture={onClickCapture}
+          style={{ cursor: zoom > 1 ? "grab" : undefined }}
+        >
+        <div
+          className={`world-map-canvas ${showArt ? "" : "world-map-canvas-fallback"}`}
+          style={{ width: canvasW || undefined, height: canvasH || undefined }}
+        >
+          {showArt && (
+            <img
+              className="world-map-art"
+              src={mapUrl}
+              alt=""
+              draggable={false}
+              onLoad={(e) => {
+                const img = e.currentTarget;
+                if (img.naturalWidth > 0 && img.naturalHeight > 0) {
+                  setArtAspect(img.naturalWidth / img.naturalHeight);
+                }
+              }}
+              onError={() => setArtFailed(true)}
+            />
           )}
+          <div className="world-map-regions">
+            {placed.map((area) => {
+              const here = area.zone === currentZone;
+              const isSelected = area.zone === selected;
+              const range = formatLevelRange(area);
+              return (
+                <button
+                  key={area.zone}
+                  type="button"
+                  className={[
+                    "world-map-zone",
+                    here ? "world-map-zone-here" : "",
+                    isSelected ? "world-map-zone-selected" : "",
+                  ].join(" ")}
+                  style={{
+                    left: `${area.mapX}%`,
+                    top: `${area.mapY}%`,
+                    width: `${area.mapW}%`,
+                    height: `${area.mapH}%`,
+                    "--wm-hue": zoneHue(area.zone),
+                  } as React.CSSProperties}
+                  aria-pressed={isSelected}
+                  aria-label={`${formatZoneName(area.zone)}, levels ${range}${here ? ", you are here" : ""}`}
+                  onClick={() => setSelected((prev) => (prev === area.zone ? null : area.zone))}
+                  onDoubleClick={() => onViewCharts(area.zone)}
+                  onMouseEnter={() => setHovered(area.zone)}
+                  onMouseLeave={() => setHovered((prev) => (prev === area.zone ? null : prev))}
+                  onFocus={() => setHovered(area.zone)}
+                  onBlur={() => setHovered((prev) => (prev === area.zone ? null : prev))}
+                >
+                  <span className="world-map-zone-tag">{range}</span>
+                  {here && <span className="world-map-here-dot" aria-hidden="true" />}
+                </button>
+              );
+            })}
+            {hoveredArea && (
+              <div
+                className={`world-map-tip ${tipBelow ? "world-map-tip-below" : ""}`}
+                style={{ left: `${tipLeft}%`, top: `${tipTop}%` }}
+                aria-hidden="true"
+              >
+                <span className="world-map-tip-name">{formatZoneName(hoveredArea.zone)}</span>
+                <span className="world-map-tip-level">{formatLevelRange(hoveredArea)}</span>
+              </div>
+            )}
+          </div>
+        </div>
         </div>
         {placed.length === 0 && (
           <p className="world-map-unplotted">
             No realms have been charted onto the world map yet.
           </p>
         )}
+        <div className="map-zoom-controls world-map-zoom-controls">
+          <button
+            type="button"
+            className="map-zoom-btn"
+            onClick={() => setZoomAt(zoomRef.current * 1.4)}
+            title="Zoom in"
+            aria-label="Zoom in"
+          >
+            +
+          </button>
+          <button
+            type="button"
+            className="map-zoom-btn"
+            onClick={() => setZoomAt(zoomRef.current / 1.4)}
+            title="Zoom out"
+            aria-label="Zoom out"
+          >
+            −
+          </button>
+          <button
+            type="button"
+            className="map-zoom-btn"
+            onClick={resetView}
+            title="Fit the whole map"
+            aria-label="Fit the whole map"
+          >
+            ⌖
+          </button>
+        </div>
       </div>
 
       <aside className="world-map-side">
@@ -153,12 +360,19 @@ export function WorldMap({ areas, currentZone, serverAssets }: WorldMapProps) {
               </span>
               <span className="world-map-detail-id">{selectedArea.zone}</span>
             </div>
-            <p className="world-map-detail-hint">A closer survey of this realm is still being charted.</p>
+            <button
+              type="button"
+              className="world-map-view-charts"
+              onClick={() => onViewCharts(selectedArea.zone)}
+            >
+              Unfurl this realm&apos;s charts →
+            </button>
           </div>
         ) : (
           <div className="world-map-detail world-map-detail-empty">
             <p className="world-map-detail-hint">
-              Hover a realm to read its name — click to pin its ledger here.
+              Hover a realm to read its name — click to pin its ledger here, double-click to open
+              its charts.
             </p>
             <p className="world-map-detail-hint world-map-legend-line">
               <span className="world-map-here-dot world-map-legend-dot" aria-hidden="true" /> marks where
@@ -172,13 +386,16 @@ export function WorldMap({ areas, currentZone, serverAssets }: WorldMapProps) {
             <span className="world-map-uncharted-label">Uncharted</span>
             <div className="world-map-uncharted-chips">
               {uncharted.map((area) => (
-                <span
+                <button
                   key={area.zone}
+                  type="button"
                   className={`world-map-chip ${area.zone === currentZone ? "world-map-chip-here" : ""}`}
+                  title="Unfurl this realm's charts"
+                  onClick={() => onViewCharts(area.zone)}
                 >
                   {formatZoneName(area.zone)}
                   <span className="world-map-chip-level">{formatLevelRange(area)}</span>
-                </span>
+                </button>
               ))}
             </div>
           </div>

--- a/web-v3/src/components/WorldMap.tsx
+++ b/web-v3/src/components/WorldMap.tsx
@@ -184,7 +184,11 @@ export function WorldMap({ areas, currentZone, serverAssets, onViewCharts }: Wor
     if (!drag.dragged && Math.hypot(dx, dy) < DRAG_THRESHOLD) return;
     if (!drag.dragged) {
       drag.dragged = true;
-      vp.setPointerCapture(drag.pointerId);
+      try {
+        vp.setPointerCapture(drag.pointerId);
+      } catch {
+        // Pointer already gone (or synthetic); the drag still tracks moves.
+      }
     }
     vp.scrollLeft = drag.scrollLeft - dx;
     vp.scrollTop = drag.scrollTop - dy;
@@ -192,10 +196,16 @@ export function WorldMap({ areas, currentZone, serverAssets, onViewCharts }: Wor
 
   const onPointerEnd = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     const drag = dragRef.current;
-    if (drag && e.pointerId === drag.pointerId && !drag.dragged) {
+    if (!drag || e.pointerId !== drag.pointerId) return;
+    if (!drag.dragged) {
       dragRef.current = null;
+      return;
     }
-    // A completed drag stays in the ref until click-capture consumes it.
+    // The click that ends a real drag fires right after pointerup; clear on
+    // the next tick so a drag released without one can't eat a later click.
+    setTimeout(() => {
+      if (dragRef.current === drag) dragRef.current = null;
+    }, 0);
   }, []);
 
   const onClickCapture = useCallback((e: React.MouseEvent<HTMLDivElement>) => {

--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -202,6 +202,8 @@ export interface MiniMapBridge {
   ) => void;
   loadZoneMap: (zone: string, rooms: Array<{ id: string; x: number; y: number; z: number; exits: Record<string, string> }>, border: BorderStub[]) => void;
   resetMap: () => void;
+  /** Toggle chart-preview rendering: sketch the whole loaded zone in fog ink. */
+  setChartMode: (on: boolean) => void;
 }
 
 export interface AuthRefs {
@@ -212,7 +214,7 @@ export interface AuthRefs {
 
 export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
   const { resumeTokenRef, pendingAuthCharRef, sendGmcpRef } = authRefs;
-  const { updateMap, loadZoneMap, resetMap } = miniMap;
+  const { updateMap, loadZoneMap, resetMap, setChartMode } = miniMap;
   // ── Core identity ─────────────────────────────────
   const [vitals, setVitals] = useState<Vitals>(EMPTY_VITALS);
   const [statusVarLabels, setStatusVarLabels] = useState<StatusVarLabels>(DEFAULT_STATUS_VAR_LABELS);
@@ -251,6 +253,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     if (!mapPreviewZoneRef.current) return;
     mapPreviewZoneRef.current = null;
     setMapPreviewZone(null);
+    setChartMode(false);
     const own = ownZoneChartRef.current;
     if (own) {
       loadZoneMap(...own);
@@ -259,7 +262,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
       const last = lastMapUpdateRef.current;
       if (last) updateMap(...last);
     }
-  }, [loadZoneMap, updateMap]);
+  }, [loadZoneMap, updateMap, setChartMode]);
 
   const routedUpdateMap = useCallback<MiniMapBridge["updateMap"]>(
     (...args) => {
@@ -281,6 +284,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
         pendingChartPreviewRef.current = null;
         mapPreviewZoneRef.current = zone;
         setMapPreviewZone(zone);
+        setChartMode(true);
         loadZoneMap(zone, rooms, border);
         return;
       }
@@ -291,9 +295,10 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
         mapPreviewZoneRef.current = null;
         setMapPreviewZone(null);
       }
+      setChartMode(false);
       loadZoneMap(zone, rooms, border);
     },
-    [loadZoneMap],
+    [loadZoneMap, setChartMode],
   );
 
   // ── Combat ────────────────────────────────────────

--- a/web-v3/src/hooks/useGameState.ts
+++ b/web-v3/src/hooks/useGameState.ts
@@ -231,6 +231,71 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
   // inside a React updater — and clear room-scoped state in packet order.
   const lastRoomIdRef = useRef<string | null>(null);
 
+  // ── Zone chart preview (World Map → `map <zone>`) ─
+  // A requested foreign-zone chart temporarily replaces the Local Map graph.
+  // The player's own chart is stashed so backing out is local (no round trip),
+  // and any movement ends the preview so the step lands in the right graph.
+  const [mapPreviewZone, setMapPreviewZone] = useState<string | null>(null);
+  const mapPreviewZoneRef = useRef<string | null>(null);
+  const pendingChartPreviewRef = useRef<string | null>(null);
+  const ownZoneChartRef = useRef<Parameters<MiniMapBridge["loadZoneMap"]> | null>(null);
+  const lastMapUpdateRef = useRef<Parameters<MiniMapBridge["updateMap"]> | null>(null);
+
+  /** Arm the next incoming `Zone.Map` for [zone] to display as a preview. */
+  const beginChartPreview = useCallback((zone: string) => {
+    pendingChartPreviewRef.current = zone;
+  }, []);
+
+  /** Restore the player's own zone chart and clear the preview banner. */
+  const endChartPreview = useCallback(() => {
+    if (!mapPreviewZoneRef.current) return;
+    mapPreviewZoneRef.current = null;
+    setMapPreviewZone(null);
+    const own = ownZoneChartRef.current;
+    if (own) {
+      loadZoneMap(...own);
+      // loadZoneMap clears the current-room marker; replay the last room
+      // update so "you" reappears without waiting for the next Room.Info.
+      const last = lastMapUpdateRef.current;
+      if (last) updateMap(...last);
+    }
+  }, [loadZoneMap, updateMap]);
+
+  const routedUpdateMap = useCallback<MiniMapBridge["updateMap"]>(
+    (...args) => {
+      lastMapUpdateRef.current = args;
+      if (mapPreviewZoneRef.current) {
+        // Any room refresh ends a chart preview; endChartPreview replays the
+        // update just recorded above into the restored own-zone graph.
+        endChartPreview();
+        return;
+      }
+      updateMap(...args);
+    },
+    [updateMap, endChartPreview],
+  );
+
+  const routedLoadZoneMap = useCallback<MiniMapBridge["loadZoneMap"]>(
+    (zone, rooms, border) => {
+      if (pendingChartPreviewRef.current === zone) {
+        pendingChartPreviewRef.current = null;
+        mapPreviewZoneRef.current = zone;
+        setMapPreviewZone(zone);
+        loadZoneMap(zone, rooms, border);
+        return;
+      }
+      // The player's own chart (zone entry, or `map` with no argument): stash
+      // it for local preview back-out, and end any preview in progress.
+      ownZoneChartRef.current = [zone, rooms, border];
+      if (mapPreviewZoneRef.current) {
+        mapPreviewZoneRef.current = null;
+        setMapPreviewZone(null);
+      }
+      loadZoneMap(zone, rooms, border);
+    },
+    [loadZoneMap],
+  );
+
   // ── Combat ────────────────────────────────────────
   const [effects, setEffects] = useState<StatusEffect[]>([]);
   const [combatTarget, setCombatTarget] = useState<CombatTarget | null>(null);
@@ -690,8 +755,8 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
         setFriends,
         pushFriendNotification,
         setChatByChannel,
-        updateMap,
-        loadZoneMap,
+        updateMap: routedUpdateMap,
+        loadZoneMap: routedLoadZoneMap,
         pushCombatEvent,
         setCharStats,
         setQuests,
@@ -786,7 +851,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
         sendGmcp: (p: string, payload: unknown) => { sendGmcpRef.current(p, payload); return true; },
       });
     },
-    [applyCurrencies, applyFactions, pushFriendNotification, pushCombatEvent, pushGainEvent, pushLevelUp, pushQuestNotification, pushUiFeedback, pushCraftingResult, pushMailNotification, pushArcanumSketch, updateMap, loadZoneMap, resumeTokenRef, pendingAuthCharRef, sendGmcpRef, clearRoomScopedState],
+    [applyCurrencies, applyFactions, pushFriendNotification, pushCombatEvent, pushGainEvent, pushLevelUp, pushQuestNotification, pushUiFeedback, pushCraftingResult, pushMailNotification, pushArcanumSketch, routedUpdateMap, routedLoadZoneMap, resumeTokenRef, pendingAuthCharRef, sendGmcpRef, clearRoomScopedState],
   );
 
   // ── Reset all HUD state on disconnect ─────────────
@@ -934,6 +999,7 @@ export function useGameState(authRefs: AuthRefs, miniMap: MiniMapBridge) {
     loginPrompt, loginError, reconnecting, setReconnecting, savedCharacters, setSavedCharacters,
     // Staff / meta
     serverAssets, serverCommands, worldAreas, emotePresets, serverFeatures, staffWorldInfo, staffMobTemplates,
+    mapPreviewZone, beginChartPreview, endChartPreview,
     lookTarget, setLookTarget, considerResult, setConsiderResult, spriteList,
     // UI
     activePopout, setActivePopout, broadcast, setBroadcast, possessing, toast, setToast, uiFeedbackFeed,

--- a/web-v3/src/hooks/useMiniMap.ts
+++ b/web-v3/src/hooks/useMiniMap.ts
@@ -351,6 +351,7 @@ function renderMap(
   serverAssets: Record<string, string>,
   view: View,
   drawGlyph: (ctx: CanvasRenderingContext2D, key: string, cx: number, cy: number, size: number, alpha: number) => boolean,
+  chartMode = false,
 ) {
   const ctx = canvas.getContext("2d");
   if (!ctx) return;
@@ -370,11 +371,13 @@ function renderMap(
   // the scroll reads as one continuous surface behind toolbar and map alike.
   ctx.clearRect(0, 0, width, height);
 
-  if (!currentId) return;
+  // Chart previews have no current room — the player is elsewhere — but the
+  // borrowed chart still draws.
+  if (!currentId && !chartMode) return;
 
   // One floor at a time, following the player. Rooms on other floors stay off
   // the chart; stairs between floors render as ▲/▼ badges instead of edges.
-  const floor = visited.get(currentId)?.z ?? 0;
+  const floor = (currentId ? visited.get(currentId)?.z : 0) ?? 0;
   let multiFloor = false;
   for (const node of visited.values()) {
     if (node.z !== floor) {
@@ -414,8 +417,15 @@ function renderMap(
   ctx.clip();
 
   // Fog of war: hidden rooms (neither explored nor on the one-hop frontier)
-  // draw nothing — no node, no edge, no marker.
+  // draw nothing — no node, no edge, no marker. Chart previews (`map <zone>`)
+  // instead sketch the whole zone in fog ink — that's the point of unfurling a
+  // chart — while explored rooms keep their earned detail.
   const { explored, frontier } = computeVisibility(visited);
+  if (chartMode) {
+    for (const id of visited.keys()) {
+      if (!explored.has(id)) frontier.add(id);
+    }
+  }
   const isRendered = (id: string) => explored.has(id) || frontier.has(id);
 
   // Connecting lines — drawn outward from *explored* rooms only, so the chart
@@ -633,8 +643,10 @@ function renderMap(
   // so the ink reads on open parchment (the zoom cluster owns the bottom-right).
   drawCompassRose(ctx, scrollLeft + 104, scrollBottom - 100, 24);
 
-  // Zone name tag — top-left, derived from the current room id (`<zone>:<room>`).
-  const zoneId = currentId.split(":")[0];
+  // Zone name tag — top-left, derived from the current room id (`<zone>:<room>`),
+  // or — chart previews, where the player is elsewhere — from the first charted
+  // room (zone rooms precede border stubs in insertion order).
+  const zoneId = (currentId ?? visited.keys().next().value ?? "").split(":")[0];
   if (zoneId) {
     const label = formatZoneName(zoneId);
     ctx.font = "bold 13px 'JetBrains Mono', 'Cascadia Mono', monospace";
@@ -715,6 +727,9 @@ export function useMiniMap(onRoomClick?: (info: MapHoverInfo) => void) {
   const currentRoomIdRef = useRef<string | null>(null);
   /** Zone of the last full `Zone.Map` load — what the graph currently shows. */
   const loadedZoneRef = useRef<string | null>(null);
+  /** Chart-preview mode: draw the whole loaded zone in fog ink, not just the
+   *  explored-plus-frontier reveal. Toggled by the zone chart preview flow. */
+  const chartModeRef = useRef(false);
   // Glyph textures keyed by asset key (loaded once; global, not per-zone).
   const glyphCacheRef = useRef<Map<string, GlyphEntry>>(new Map());
   const pulseRafRef = useRef<number | null>(null);
@@ -758,6 +773,11 @@ export function useMiniMap(onRoomClick?: (info: MapHoverInfo) => void) {
     // chart, so an unexplored zone doesn't open zoomed out onto empty parchment.
     const floor = current?.z ?? 0;
     const { explored: exploredIds, frontier: frontierIds } = computeVisibility(visited);
+    if (chartModeRef.current) {
+      for (const id of visited.keys()) {
+        if (!exploredIds.has(id)) frontierIds.add(id);
+      }
+    }
     let minX = Infinity;
     let maxX = -Infinity;
     let minY = Infinity;
@@ -883,6 +903,7 @@ export function useMiniMap(onRoomClick?: (info: MapHoverInfo) => void) {
       assets,
       { cell: zoomRef.current, panGx: panRef.current.gx, panGy: panRef.current.gy },
       drawGlyph,
+      chartModeRef.current,
     );
   }, []);
 
@@ -1111,6 +1132,15 @@ export function useMiniMap(onRoomClick?: (info: MapHoverInfo) => void) {
     [drawMap, clearHover],
   );
 
+  const setChartMode = useCallback(
+    (on: boolean) => {
+      if (chartModeRef.current === on) return;
+      chartModeRef.current = on;
+      drawMap();
+    },
+    [drawMap],
+  );
+
   const resetMap = useCallback(() => {
     visitedRef.current.clear();
     currentRoomIdRef.current = null;
@@ -1148,6 +1178,7 @@ export function useMiniMap(onRoomClick?: (info: MapHoverInfo) => void) {
     drawMap,
     updateMap,
     loadZoneMap,
+    setChartMode,
     resetMap,
     startPulse,
     stopPulse,

--- a/web-v3/src/hooks/useMiniMap.ts
+++ b/web-v3/src/hooks/useMiniMap.ts
@@ -713,6 +713,8 @@ export function useMiniMap(onRoomClick?: (info: MapHoverInfo) => void) {
   }, [onRoomClick]);
   const visitedRef = useRef<Map<string, MapRoom>>(new Map());
   const currentRoomIdRef = useRef<string | null>(null);
+  /** Zone of the last full `Zone.Map` load — what the graph currently shows. */
+  const loadedZoneRef = useRef<string | null>(null);
   // Glyph textures keyed by asset key (loaded once; global, not per-zone).
   const glyphCacheRef = useRef<Map<string, GlyphEntry>>(new Map());
   const pulseRafRef = useRef<number | null>(null);
@@ -811,7 +813,9 @@ export function useMiniMap(onRoomClick?: (info: MapHoverInfo) => void) {
       floor,
     };
     visibilityRef.current = { explored: exploredIds, frontier: frontierIds };
-    const zoneId = currentRoomIdRef.current?.split(":")[0] ?? "";
+    // Chart previews load a foreign zone's graph with no current room; fall
+    // back to the last-loaded zone so the stats bar names what's on screen.
+    const zoneId = currentRoomIdRef.current?.split(":")[0] ?? loadedZoneRef.current ?? "";
     if (zoneId) {
       let totalRooms = 0;
       let multiFloor = false;
@@ -1073,6 +1077,7 @@ export function useMiniMap(onRoomClick?: (info: MapHoverInfo) => void) {
       const map = visitedRef.current;
       map.clear();
       currentRoomIdRef.current = null;
+      loadedZoneRef.current = zone;
       // New zone — reset the view so it re-centres at the default zoom.
       userAdjustedRef.current = false;
       panRef.current = null;

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -10159,6 +10159,50 @@ body {
 
 /* Exploration header — ink-on-parchment strip above the chart: zone completion
    on the left, a glyph legend on the right. */
+/* Chart-preview banner: shown while the Local Map displays another realm's
+   charts (World Map ledger → View charts). Solid parchment so it reads over
+   the painted sheet. */
+.map-preview-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-3);
+  margin: 2px 44px 0;
+  padding: 4px 12px;
+  background: rgb(240 226 196 / 94%);
+  border: 1px solid rgb(90 60 30 / 50%);
+  border-radius: 8px;
+  font-size: 0.78rem;
+  color: #4a3014;
+  box-shadow: 0 2px 8px rgb(20 14 8 / 30%);
+}
+
+.map-preview-label strong {
+  font-family: var(--font-display);
+  color: #2e2212;
+}
+
+.map-preview-return {
+  appearance: none;
+  border: 1px solid rgb(90 60 30 / 55%);
+  background: rgb(255 250 236 / 80%);
+  color: #4a3014;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font: inherit;
+  font-size: 0.74rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 150ms ease, border-color 150ms ease;
+}
+
+.map-preview-return:hover,
+.map-preview-return:focus-visible {
+  background: rgb(255 250 236);
+  border-color: #8a6a2e;
+}
+
 .map-stats-bar {
   display: flex;
   align-items: center;
@@ -10484,38 +10528,62 @@ body {
   overflow: hidden;
 }
 
-.world-map-frame {
+/* Framed stage holding the scrolling viewport plus overlay chrome (zoom
+   cluster, empty-state note) that must not move while the map pans. */
+.world-map-stage {
   position: relative;
-  flex: 0 1 auto;
-  width: fit-content;
-  max-width: 100%;
+  flex: 1 1 auto;
+  min-width: 0;
+  height: calc(100vh - 230px);
+  max-width: 900px;
   border: 1px solid rgb(90 60 30 / 45%);
   border-radius: 12px;
   overflow: hidden;
   box-shadow: inset 0 0 24px rgb(60 40 20 / 18%);
 }
 
-/* Painted-art path: the frame hugs the image so zone-region percentages track
-   the art exactly. The viewport cap (drawer minus its chrome) lets portrait
-   art fill the drawer's full height. */
+/* Pannable, zoomable viewport. Panning is native scroll (drag adjusts
+   scrollLeft/Top); the canvas inside is laid out at fit-size × zoom, so zone
+   regions genuinely grow and their container-query tags re-evaluate. */
+.world-map-viewport {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  overflow: hidden;
+  touch-action: none;
+}
+
+.world-map-viewport:active {
+  cursor: grabbing;
+}
+
+/* margin:auto (not justify-content) centres the canvas while it's smaller
+   than the viewport WITHOUT clipping the leading edge once it overflows. */
+.world-map-canvas {
+  position: relative;
+  flex: 0 0 auto;
+  margin: auto;
+}
+
 .world-map-art {
   display: block;
-  width: auto;
-  height: auto;
-  max-width: 100%;
-  max-height: calc(100vh - 230px);
+  width: 100%;
+  height: 100%;
   user-select: none;
+  -webkit-user-drag: none;
 }
 
 /* No art (null/404): an inked-parchment stand-in keeps regions usable. */
-.world-map-frame-fallback {
-  height: calc(100vh - 230px);
-  max-width: 100%;
-  aspect-ratio: 3 / 4;
+.world-map-canvas-fallback {
   background:
     radial-gradient(ellipse at 30% 25%, rgb(255 250 236 / 55%), transparent 60%),
     radial-gradient(ellipse at 75% 70%, rgb(214 186 140 / 45%), transparent 55%),
     linear-gradient(160deg, #e6d8b8, #d8c49a);
+}
+
+/* Pin the zoom cluster to the viewport (not the scrolling canvas). */
+.world-map-zoom-controls {
+  position: absolute;
 }
 
 .world-map-side {
@@ -10744,6 +10812,7 @@ body {
 }
 
 .world-map-chip {
+  appearance: none;
   display: inline-flex;
   align-items: baseline;
   gap: 6px;
@@ -10751,13 +10820,44 @@ body {
   border-radius: 999px;
   background: rgb(255 250 236 / 60%);
   border: 1px solid rgb(90 60 30 / 40%);
+  font: inherit;
   font-size: 0.76rem;
   color: #3a2c1a;
+  cursor: pointer;
+  transition: background 150ms ease, border-color 150ms ease;
+}
+
+.world-map-chip:hover,
+.world-map-chip:focus-visible {
+  background: rgb(255 250 236 / 90%);
+  border-color: #8a6a2e;
 }
 
 .world-map-chip-here {
   border-color: #8a6a2e;
   box-shadow: 0 0 6px rgb(138 106 46 / 40%);
+}
+
+/* "Unfurl this realm's charts" — the ledger's primary action. */
+.world-map-view-charts {
+  appearance: none;
+  margin-top: 8px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  border: 1px solid rgb(90 60 30 / 55%);
+  background: rgb(255 250 236 / 80%);
+  color: #4a3014;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 150ms ease, border-color 150ms ease;
+}
+
+.world-map-view-charts:hover,
+.world-map-view-charts:focus-visible {
+  background: rgb(255 250 236);
+  border-color: #8a6a2e;
 }
 
 .world-map-chip-level {
@@ -10782,13 +10882,9 @@ body {
     overflow-y: auto;
   }
 
-  .world-map-art,
-  .world-map-frame-fallback {
-    max-height: 56vh;
-    height: auto;
-  }
-
-  .world-map-frame-fallback {
+  .world-map-stage {
+    flex: 0 0 auto;
+    width: 100%;
     height: 56vh;
   }
 


### PR DESCRIPTION
## Summary
Follow-up to #1430, adding the two things it teed up:

### Pan & zoom on the World Map
- Wheel (cursor-anchored), zoom buttons, and a fit-reset; drag to pan.
- Zoom resizes the **layout**, not a CSS transform — each region's container query re-evaluates as it grows, so level tags surface on small zones as you zoom in. Fonts stay crisp at every zoom.
- The framed stage pins the zoom cluster and empty-state note while the map pans beneath.

### Click through to any zone's map
- New `map [<zone>]` command (alias `chart`, accepts display names like `map Fae Wood`): prints a one-line summary (name, level range, your explored count) and re-sends `Zone.Map` for that zone with your own exploration fog — staff see everything, as on zone entry. Works for telnet too via the text summary.
- World Map ledger gains **"Unfurl this realm's charts"** (also zone double-click, and the Uncharted chips are clickable): switches to the Local Map showing the requested zone with a parchment banner — *Viewing the charts of X — ⌖ Back to Y*.
- **Chart mode** sketches the whole zone in fog ink (that's the point of unfurling a chart) while explored rooms keep their earned detail; normal fog-of-war rules are untouched outside previews.
- Backing out is local (the player's own chart is stashed and restored, you-marker replayed); any movement auto-ends the preview so the step lands in the right graph.

## Bugs caught by live QA
- `renderMap` bailed when there was no current room, blanking previews of unvisited zones.
- A drag released without a trailing click left the click-suppression flag armed and ate the next legitimate click.

## Test plan
- [x] `ktlintCheck test integrationTest` green (new `ZoneChartCommandTest`, parser cases, `WebClientParityTest` row + `map` manifest entry)
- [x] `bun run lint` + `bun run build`
- [x] Live headless QA with 12 synthetic zones: cursor-anchored wheel zoom (tag reveal on Tiny Grotto at high zoom), drag pan with edge clamping, select → unfurl → banner + fog-sketched foreign chart + per-zone stats ("Explored 0/2"), Return restores own zone with the you-marker