### PR TITLE
Mount speeds + flying mounts (cross-zone atlas travel)

### DIFF
--- a/docs/WORLD_YAML_SPEC.md
+++ b/docs/WORLD_YAML_SPEC.md
@@ -567,9 +567,13 @@ matchByKey: <boolean, optional, default false>
 basePrice: <integer, optional, default 0, must be >= 0>
 image: <string, optional - relative path under /images/; falls back to zone image.item>
 video: <string, optional - relative path under /videos/, shown in context menu>
-itemType: <string, optional - one of equipment|consumable|quest|treasure|keepsake|misc; inferred when omitted>
+itemType: <string, optional - one of equipment|consumable|quest|treasure|keepsake|mount|misc; inferred when omitted>
 questItem: <boolean, optional, default false>
 takeable: <boolean, optional, default true>
+mountId: <string, required when itemType is mount, forbidden otherwise - the mount this purchase unlocks>
+mountSpeed: <number, optional, default 1.0, must be in (0, 10] - mount items only; ride-speed multiplier>
+flying: <boolean, optional, default false - mount items only; unlocks cross-zone flight>
+
 # Arcanum design-time metadata - accepted for round-trip preservation, ignored by the server:
 level: <integer, optional>
 tier: <string, optional>
@@ -593,6 +597,12 @@ tertiaryStat: <string, optional>
 
 `takeable` notes:
 - When `false`, players cannot `get` the item and auto-loot skips it. Useful for room scenery (statues, fountains, signs) that should appear in the `Items here:` line but stay put.
+
+Mount notes (`itemType: mount`):
+- Buying the item adds `mountId` to the player's permanent owned-mounts set (the item itself never enters the inventory). The id should match a `category: mount` sprite requirement in `sprites.yaml` so the mount shows while riding.
+- `mountSpeed` scales map click-to-ride travel: each hop takes `engine.mountTravel.msPerRoom / mountSpeed` ms.
+- `flying: true` mounts additionally cover explored destinations with **no known ground path** — e.g. a room in another zone picked from a world-map zone chart. The airborne time scales with the distance between the two zones' `worldMap` placements (see `engine.mountTravel.flight*` config).
+- Every item selling the same `mountId` (across all zones) must agree on `mountSpeed` and `flying`; conflicting values are a load error.
 
 `basePrice` notes:
 - Determines the item's value in the shop economy.

--- a/src/main/kotlin/dev/ambon/config/AppConfig.kt
+++ b/src/main/kotlin/dev/ambon/config/AppConfig.kt
@@ -339,6 +339,14 @@ data class AppConfig(
         engine.scheduler.maxActionsPerTick.requirePositive("ambonMUD.engine.scheduler.maxActionsPerTick")
         engine.mountTravel.msPerRoom.requirePositive("ambonMUD.engine.mountTravel.msPerRoom")
         engine.mountTravel.maxPathLength.requirePositive("ambonMUD.engine.mountTravel.maxPathLength")
+        engine.mountTravel.flightMsBase.requirePositive("ambonMUD.engine.mountTravel.flightMsBase")
+        require(engine.mountTravel.flightMsPerMapPercent >= 0) {
+            "ambonMUD.engine.mountTravel.flightMsPerMapPercent must be >= 0"
+        }
+        engine.mountTravel.flightMsMin.requirePositive("ambonMUD.engine.mountTravel.flightMsMin")
+        require(engine.mountTravel.flightMsMax >= engine.mountTravel.flightMsMin) {
+            "ambonMUD.engine.mountTravel.flightMsMax must be >= flightMsMin"
+        }
     }
 
     private fun validateEngineGroup() {
@@ -2159,15 +2167,30 @@ data class FlightMessagesConfig(
  * Tuning for mount fast travel — owning any shop-bought mount lets a player click an explored
  * room on the zone map (or use `travel <room-id>`) to auto-ride the shortest known path there.
  * The ride is free but not instant: the engine walks the path one room per [msPerRoom]
- * milliseconds. Routing is restricted to rooms the player has explored, the path stays inside
- * the current zone (the destination itself may sit one exit-hop into an adjacent zone), and
- * combat cancels the ride.
+ * milliseconds, divided by the mount's authored speed multiplier. Routing is restricted to
+ * rooms the player has explored, the path stays inside the current zone (the destination
+ * itself may sit one exit-hop into an adjacent zone), and combat cancels the ride.
+ *
+ * Flying mounts (items authored with `flying: true`) additionally unlock *flight*: when no
+ * known ground path reaches an explored destination — typically a room in another zone picked
+ * from the world map atlas — the rider takes off and lands there after an airborne delay of
+ * [flightMsBase] plus [flightMsPerMapPercent] per percentage point of distance between the two
+ * zones' world-map placements, clamped to [flightMsMin]..[flightMsMax]. Zones without a
+ * world-map placement fly at the midpoint fallback of that range.
  */
 data class MountTravelConfig(
-    /** Milliseconds spent riding through each room along the path. */
+    /** Milliseconds spent riding through each room along the path (at speed 1.0). */
     val msPerRoom: Long = 300L,
     /** Safety cap on path length (rooms); longer routes are refused. */
     val maxPathLength: Int = 300,
+    /** Base airborne milliseconds for any flight. */
+    val flightMsBase: Long = 2000L,
+    /** Additional airborne ms per percent of world-map distance between zone centres. */
+    val flightMsPerMapPercent: Long = 80L,
+    /** Lower clamp on total airborne time. */
+    val flightMsMin: Long = 2000L,
+    /** Upper clamp on total airborne time. */
+    val flightMsMax: Long = 10000L,
     val messages: MountTravelMessagesConfig = MountTravelMessagesConfig(),
 )
 
@@ -2178,11 +2201,18 @@ data class MountTravelMessagesConfig(
     val alreadyHere: String = "You're already there.",
     val notExplored: String = "You haven't explored that place yet.",
     val noPath: String = "You can't find a route you know to ride there.",
+    val noFlyingMount: String = "Only a flying mount could carry you there.",
     val mountUp: String = "You swing onto {mount} and ride for {dest}...",
     val arrival: String = "You arrive at {dest} and dismount.",
     val combatInterrupted: String = "Your ride is cut short — you're dragged into battle!",
     val mountUpNotice: String = "mounts up and rides off.",
     val arriveNotice: String = "rides in and dismounts.",
+    val takeOff: String = "You swing onto {mount} and take to the skies, bound for {dest}...",
+    val departNotice: String = "soars away into the distance.",
+    val landing: String = "{mount} descends and you alight at {dest}.",
+    val flightInterrupted: String = "Your flight is cut short — you're dragged back to the ground!",
+    val takeOffNotice: String = "mounts up and soars into the sky.",
+    val landNotice: String = "descends from the sky and dismounts.",
 )
 
 /**

--- a/src/main/kotlin/dev/ambon/domain/items/Item.kt
+++ b/src/main/kotlin/dev/ambon/domain/items/Item.kt
@@ -54,6 +54,16 @@ data class Item(
      * stored in the player's owned-mounts set.
      */
     val mountId: String? = null,
+    /**
+     * For [ItemType.MOUNT] items: ride-speed multiplier applied to the base
+     * travel pace (1.0 = base, 2.0 = twice as fast). Meaningless otherwise.
+     */
+    val mountSpeed: Double = 1.0,
+    /**
+     * For [ItemType.MOUNT] items: true when the mount can fly, unlocking
+     * cross-zone travel to any explored room. Meaningless otherwise.
+     */
+    val flying: Boolean = false,
 ) {
     /**
      * Effective item type for categorization. Uses [itemType] when set,

--- a/src/main/kotlin/dev/ambon/domain/world/MountStats.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/MountStats.kt
@@ -1,0 +1,12 @@
+package dev.ambon.domain.world
+
+/**
+ * Ride characteristics of a purchasable mount, authored on the shop item that
+ * sells it (see `ItemFile.mountSpeed`/`flying`) and keyed by mount id.
+ */
+data class MountStats(
+    /** Ride-speed multiplier over the configured base pace (1.0 = base). */
+    val speed: Double,
+    /** True when the mount can fly: cross-zone travel to explored rooms. */
+    val flying: Boolean,
+)

--- a/src/main/kotlin/dev/ambon/domain/world/World.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/World.kt
@@ -47,6 +47,18 @@ class World(
     private val _itemSpawns = itemSpawns.toMutableList()
     val itemSpawns: List<ItemSpawn> get() = _itemSpawns
 
+    /**
+     * Stats of a purchasable mount, resolved from the first item selling
+     * [mountId]. Scans on call so zone hot reloads stay authoritative; the
+     * loader guarantees every item selling the same mountId agrees on these.
+     */
+    fun mountStats(mountId: String): MountStats? =
+        _itemSpawns
+            .firstOrNull { it.instance.item.mountId == mountId }
+            ?.instance
+            ?.item
+            ?.let { MountStats(speed = it.mountSpeed, flying = it.flying) }
+
     private val _zoneLifespansMinutes = zoneLifespansMinutes.toMutableMap()
     val zoneLifespansMinutes: Map<String, Long> get() = _zoneLifespansMinutes
 

--- a/src/main/kotlin/dev/ambon/domain/world/data/ItemFile.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/data/ItemFile.kt
@@ -36,6 +36,16 @@ data class ItemFile(
      */
     val mountId: String? = null,
     /**
+     * Ride-speed multiplier for `itemType: mount` items (1.0 = the configured
+     * base pace, 2.0 = twice as fast). Defaults to 1.0; forbidden on non-mounts.
+     */
+    val mountSpeed: Double? = null,
+    /**
+     * True for `itemType: mount` items whose mount can fly: cross-zone travel
+     * to any explored room via the world map atlas. Forbidden on non-mounts.
+     */
+    val flying: Boolean? = null,
+    /**
      * Optional design-time metadata authored by the Arcanum creator. Accepted
      * for round-trip preservation; the server treats `damage`, `armor`, and
      * `stats` above as authoritative and does not recompute them from

--- a/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
+++ b/src/main/kotlin/dev/ambon/domain/world/load/WorldLoader.kt
@@ -595,6 +595,17 @@ object WorldLoader {
                 if (itemType != ItemType.MOUNT && mountId != null) {
                     throw WorldLoadException("Item '${itemId.value}' sets mountId but itemType is not 'mount'")
                 }
+                if (itemType != ItemType.MOUNT && (itemFile.mountSpeed != null || itemFile.flying != null)) {
+                    throw WorldLoadException(
+                        "Item '${itemId.value}' sets mountSpeed/flying but itemType is not 'mount'",
+                    )
+                }
+                val mountSpeed = itemFile.mountSpeed ?: 1.0
+                if (!mountSpeed.isFinite() || mountSpeed <= 0.0 || mountSpeed > 10.0) {
+                    throw WorldLoadException(
+                        "Item '${itemId.value}' mountSpeed must be in (0, 10] (got ${itemFile.mountSpeed})",
+                    )
+                }
 
                 val roomRaw = itemFile.room?.trim()?.takeUnless { it.isEmpty() }
                 val mobRaw = itemFile.mob?.trim()?.takeUnless { it.isEmpty() }
@@ -648,6 +659,8 @@ object WorldLoader {
                                         questItem = itemFile.questItem,
                                         takeable = itemFile.takeable,
                                         mountId = mountId,
+                                        mountSpeed = mountSpeed,
+                                        flying = itemFile.flying ?: false,
                                     ),
                             ),
                         roomId = roomId,
@@ -1087,6 +1100,21 @@ object WorldLoader {
             if (roomId != null && !mergedRooms.containsKey(roomId)) {
                 throw WorldLoadException(
                     "Item '${itemId.value}' starts in missing room '${roomId.value}'",
+                )
+            }
+        }
+
+        // Mount stats must agree wherever the same mountId is sold: a player owns the
+        // mountId, not the item, so conflicting speed/flying values would be ambiguous.
+        val mountStatsById = HashMap<String, Pair<ItemId, Item>>()
+        for ((itemId, spawn) in mergedItems) {
+            val item = spawn.instance.item
+            val id = item.mountId ?: continue
+            val prior = mountStatsById.putIfAbsent(id, itemId to item)
+            if (prior != null && (prior.second.mountSpeed != item.mountSpeed || prior.second.flying != item.flying)) {
+                throw WorldLoadException(
+                    "Items '${prior.first.value}' and '${itemId.value}' both sell mount '$id' " +
+                        "but disagree on mountSpeed/flying",
                 )
             }
         }

--- a/src/main/kotlin/dev/ambon/engine/GameEngine.kt
+++ b/src/main/kotlin/dev/ambon/engine/GameEngine.kt
@@ -650,6 +650,7 @@ class GameEngine(
             raceRegistry = raceRegistry,
             nowMs = { clock.millis() },
             worldAreas = buildWorldAreaPayloads(world),
+            mountStats = { id -> world.mountStats(id) },
             arcanumFirstBy = { key -> worldState.getArcanumFirst(key)?.first },
             illuminationOdds = { sid, mobId ->
                 val viewer = players.get(sid)

--- a/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
+++ b/src/main/kotlin/dev/ambon/engine/GmcpEmitter.kt
@@ -127,6 +127,8 @@ class GmcpEmitter(
     private val featureFlags: () -> ServerFeaturesPayload = { ServerFeaturesPayload() },
     private val sanctumRoomId: () -> RoomId? = { null },
     private val worldAreas: List<WorldAreaPayload> = emptyList(),
+    /** Mount stats by mount id (speed/flying), for `Travel.Status` capability flags. */
+    private val mountStats: (String) -> dev.ambon.domain.world.MountStats? = { null },
     /** Resolves a player's race so the racial passive can be folded into the spellbook. */
     private val raceRegistry: RaceRegistry? = null,
     /** Current engine time in millis, used to compute racial-ability cooldown remaining. */
@@ -2191,7 +2193,11 @@ class GmcpEmitter(
     private data class TravelStatusPayload(
         /** True when the player owns at least one mount and may click the map to ride. */
         val canTravel: Boolean,
+        /** True when the player owns a flying mount and may fly to explored rooms cross-zone. */
+        val canFly: Boolean,
         val riding: Boolean,
+        /** True while the current ride is a flight (airborne, awaiting landing). */
+        val flying: Boolean = false,
         /** Destination room id while riding, else null. */
         val destination: String? = null,
     )
@@ -2201,13 +2207,16 @@ class GmcpEmitter(
         sessionId: SessionId,
         player: PlayerState,
         destination: String? = null,
+        flying: Boolean = false,
     ) {
         emit(
             sessionId,
             "Travel.Status",
             TravelStatusPayload(
                 canTravel = player.ownedMounts.isNotEmpty(),
+                canFly = player.ownedMounts.any { mountStats(it)?.flying == true },
                 riding = player.ridingMountId != null,
+                flying = flying,
                 destination = destination,
             ),
             supportCheck = "Travel",
@@ -2812,6 +2821,8 @@ class GmcpEmitter(
                         video = item.video,
                         itemType = item.resolvedType().label(),
                         owned = item.mountId != null && item.mountId in ownedMounts,
+                        mountSpeed = if (item.mountId != null) item.mountSpeed else null,
+                        mountFlying = if (item.mountId != null) item.flying else null,
                     )
                 },
             ),
@@ -4202,6 +4213,10 @@ class GmcpEmitter(
         val itemType: String? = null,
         /** True for mount items the player has already purchased. */
         val owned: Boolean = false,
+        /** Mount items only: ride-speed multiplier over the base travel pace. */
+        val mountSpeed: Double? = null,
+        /** Mount items only: true when the mount can fly (cross-zone travel). */
+        val mountFlying: Boolean? = null,
     )
 
     // ---------- puzzle payloads ----------

--- a/src/main/kotlin/dev/ambon/engine/MountTravelSystem.kt
+++ b/src/main/kotlin/dev/ambon/engine/MountTravelSystem.kt
@@ -10,6 +10,8 @@ import dev.ambon.engine.commands.handlers.movePlayerWithNotify
 import dev.ambon.engine.events.OutboundEvent
 import dev.ambon.engine.scheduler.Scheduler
 import dev.ambon.metrics.GameMetrics
+import kotlin.math.roundToLong
+import kotlin.math.sqrt
 
 /**
  * Mount fast travel — map click-to-ride.
@@ -20,14 +22,21 @@ import dev.ambon.metrics.GameMetrics
  * exit-hop into an adjacent zone (the border stubs visible on the zone map).
  *
  * The ride is free but deliberately not instant. Each step is a real room-to-room move
- * scheduled every [MountTravelConfig.msPerRoom] ms on the engine [Scheduler], so bystanders
- * see the rider pass through, the client map animates from the resulting `Room.Info`
- * stream, and per-room side effects (exploration, flight-point discovery, pet follow) fire
- * naturally via [onPlayerMoved]. While riding, [PlayerState.ridingMountId] makes sprite
- * resolution show the mount and aggressive mobs skip the rider.
+ * scheduled every [MountTravelConfig.msPerRoom] ms (divided by the mount's authored speed
+ * multiplier) on the engine [Scheduler], so bystanders see the rider pass through, the
+ * client map animates from the resulting `Room.Info` stream, and per-room side effects
+ * (exploration, flight-point discovery, pet follow) fire naturally via [onPlayerMoved].
+ * While riding, [PlayerState.ridingMountId] makes sprite resolution show the mount and
+ * aggressive mobs skip the rider.
  *
- * A ride cancels when combat starts, when the player moves by any other means (the step
- * finds them off-path and dismounts quietly), or when a new travel request supersedes it.
+ * *Flying* mounts (items authored `flying: true`) additionally cover destinations no known
+ * ground path reaches — an explored room in any zone, picked from the world map atlas's
+ * zone charts. A flight keeps the rider in place for an airborne delay scaled from the two
+ * zones' world-map placements, then lands them at the destination in one hop.
+ *
+ * A ride or flight cancels when combat starts, when the player moves by any other means
+ * (the next step/landing finds them off-path and dismounts quietly), or when a new travel
+ * request supersedes it.
  */
 class MountTravelSystem(
     private val players: PlayerRegistry,
@@ -49,11 +58,22 @@ class MountTravelSystem(
         val path: List<RoomId>,
         var index: Int,
         val destName: String,
+        /** Milliseconds per hop for this ride — base pace over the mount's speed. */
+        val stepMs: Long,
+    )
+
+    private class Flight(
+        /** Where the flight took off; the rider stays here until landing. */
+        val origin: RoomId,
+        val dest: RoomId,
+        val destName: String,
+        val mountName: String,
     )
 
     private val rides = mutableMapOf<SessionId, Ride>()
+    private val flights = mutableMapOf<SessionId, Flight>()
 
-    fun isRiding(sessionId: SessionId): Boolean = sessionId in rides
+    fun isRiding(sessionId: SessionId): Boolean = sessionId in rides || sessionId in flights
 
     /** Validates a travel request and, if valid, mounts up and schedules the first step. */
     suspend fun requestTravel(
@@ -85,13 +105,32 @@ class MountTravelSystem(
             return
         }
         val path = findKnownPath(me.roomId, dest, me.exploredRooms)
-        if (path == null || path.size > config.maxPathLength) {
-            sendError(sessionId, msgs.noPath, code = "NO_PATH")
+        if (path != null && path.size <= config.maxPathLength) {
+            beginRide(sessionId, me, path, destRoom.title, dest)
             return
         }
+        // No known ground route — a flying mount crosses anyway, in one airborne hop.
+        val flyingMountId = flightMountId(me)
+        if (flyingMountId == null) {
+            // Distinguish "buy a flying mount" from plain unreachability only in the code;
+            // the message already hints at the upgrade path.
+            sendError(sessionId, msgs.noFlyingMount, code = "NO_FLYING_MOUNT")
+            return
+        }
+        beginFlight(sessionId, me, flyingMountId, dest, destRoom.title)
+    }
 
+    private suspend fun beginRide(
+        sessionId: SessionId,
+        me: PlayerState,
+        path: List<RoomId>,
+        destName: String,
+        dest: RoomId,
+    ) {
+        val msgs = config.messages
         // A new request re-targets any ride already underway (map clicks are the primary UI).
         rides.remove(sessionId)
+        flights.remove(sessionId)
 
         val mountId = rideMountId(me)
         val mountName = spriteRegistry?.mountSprite(mountId)?.displayName ?: "your mount"
@@ -101,7 +140,7 @@ class MountTravelSystem(
         outbound.send(
             OutboundEvent.SendText(
                 sessionId,
-                msgs.mountUp.replace("{mount}", mountName).replace("{dest}", destRoom.title),
+                msgs.mountUp.replace("{mount}", mountName).replace("{dest}", destName),
             ),
         )
         if (!me.invisible) {
@@ -113,9 +152,43 @@ class MountTravelSystem(
         }
         gmcpEmitter?.sendTravelStatus(sessionId, me, destination = dest.value)
 
-        val ride = Ride(path = path, index = 0, destName = destRoom.title)
+        val ride = Ride(path = path, index = 0, destName = destName, stepMs = stepMs(mountId))
         rides[sessionId] = ride
-        scheduler.scheduleIn(config.msPerRoom) { step(sessionId, ride) }
+        scheduler.scheduleIn(ride.stepMs) { step(sessionId, ride) }
+    }
+
+    private suspend fun beginFlight(
+        sessionId: SessionId,
+        me: PlayerState,
+        mountId: String,
+        dest: RoomId,
+        destName: String,
+    ) {
+        val msgs = config.messages
+        rides.remove(sessionId)
+        flights.remove(sessionId)
+
+        val mountName = spriteRegistry?.mountSprite(mountId)?.displayName ?: "your mount"
+        me.ridingMountId = mountId
+        metrics.onGameEvent("mountTravel", "takeOff")
+
+        outbound.send(
+            OutboundEvent.SendText(
+                sessionId,
+                msgs.takeOff.replace("{mount}", mountName).replace("{dest}", destName),
+            ),
+        )
+        if (!me.invisible) {
+            for (other in players.playersInRoom(me.roomId).filter { it.sessionId != sessionId }) {
+                outbound.send(OutboundEvent.SendText(other.sessionId, "${me.name} ${msgs.takeOffNotice}"))
+                gmcpEmitter?.sendRoomAddPlayer(other.sessionId, me)
+            }
+        }
+        gmcpEmitter?.sendTravelStatus(sessionId, me, destination = dest.value, flying = true)
+
+        val flight = Flight(origin = me.roomId, dest = dest, destName = destName, mountName = mountName)
+        flights[sessionId] = flight
+        scheduler.scheduleIn(flightMs(me.roomId.zone, dest.zone)) { land(sessionId, flight) }
     }
 
     /** Dismounts in place (e.g. combat interruption), optionally telling the player why. */
@@ -123,12 +196,75 @@ class MountTravelSystem(
         sessionId: SessionId,
         notice: String? = null,
     ) {
-        if (rides.remove(sessionId) == null) return
+        val hadRide = rides.remove(sessionId) != null
+        val hadFlight = flights.remove(sessionId) != null
+        if (!hadRide && !hadFlight) return
         val me = players.get(sessionId) ?: return
         me.ridingMountId = null
         if (notice != null) outbound.send(OutboundEvent.SendText(sessionId, notice))
         gmcpEmitter?.sendTravelStatus(sessionId, me)
         metrics.onGameEvent("mountTravel", "cancel")
+    }
+
+    /** The scheduled landing of a flight: one teleport hop to the destination. */
+    private suspend fun land(
+        sessionId: SessionId,
+        flight: Flight,
+    ) {
+        if (flights[sessionId] !== flight) return // superseded or cancelled
+        val me = players.get(sessionId)
+        if (me == null) {
+            flights.remove(sessionId)
+            return
+        }
+        if (combat.isInCombat(sessionId)) {
+            cancelRide(sessionId, config.messages.flightInterrupted)
+            return
+        }
+        if (me.roomId != flight.origin) {
+            // Moved by other means (recall, teleport, manual walk) — dismount quietly.
+            cancelRide(sessionId)
+            return
+        }
+        val destRoom = world.rooms[flight.dest]
+        if (destRoom == null) {
+            // World changed under the flight (hot reload) — dismount quietly.
+            cancelRide(sessionId)
+            return
+        }
+        flights.remove(sessionId)
+        movePlayerWithNotify(
+            sessionId,
+            from = flight.origin,
+            to = flight.dest,
+            departMsg = config.messages.departNotice,
+            arriveMsg = config.messages.landNotice,
+            players = players,
+            outbound = outbound,
+            gmcpEmitter = gmcpEmitter,
+            dialogueSystem = dialogueSystem,
+            world = world,
+        )
+        onPlayerMoved?.invoke(sessionId, flight.dest)
+        me.ridingMountId = null
+        metrics.onGameEvent("mountTravel", "land")
+        outbound.send(
+            OutboundEvent.SendText(
+                sessionId,
+                config.messages.landing
+                    .replace("{mount}", flight.mountName)
+                    .replace("{dest}", flight.destName),
+            ),
+        )
+        if (!me.invisible) {
+            // movePlayerWithNotify already announced the landing; just refresh
+            // the rider's sprite for bystanders now that the mount is gone.
+            for (other in players.playersInRoom(flight.dest).filter { it.sessionId != sessionId }) {
+                gmcpEmitter?.sendRoomAddPlayer(other.sessionId, me)
+            }
+        }
+        sendLook?.invoke(sessionId)
+        gmcpEmitter?.sendTravelStatus(sessionId, me)
     }
 
     /** One scheduled hop along the path; re-schedules itself until arrival or cancellation. */
@@ -199,27 +335,66 @@ class MountTravelSystem(
         } else {
             // Mid-ride: keep the map animating without spamming full room text.
             gmcpEmitter?.sendRoomInfo(sessionId, nextRoom)
-            scheduler.scheduleIn(config.msPerRoom) { step(sessionId, ride) }
+            scheduler.scheduleIn(ride.stepMs) { step(sessionId, ride) }
         }
     }
 
     /**
-     * The mount to display for this ride: the mount matching the player's active sprite when
-     * that sprite is one of their mounts, otherwise their first-purchased mount.
+     * The mount to ride: the mount matching the player's active sprite when that
+     * sprite is one of their mounts, otherwise their fastest-owned mount.
      */
     private fun rideMountId(me: PlayerState): String {
-        val active = me.activeSprite
-        if (active != null && spriteRegistry != null) {
-            val def = spriteRegistry.findVariant(active)?.first
-            if (def != null && def.category == SpriteCategory.MOUNT) {
-                val mountId = def.requirements
-                    .filterIsInstance<dev.ambon.domain.sprite.SpriteRequirement.Mount>()
-                    .firstOrNull()
-                    ?.mountId
-                if (mountId != null && mountId in me.ownedMounts) return mountId
-            }
-        }
-        return me.ownedMounts.first()
+        activeSpriteMountId(me)?.let { return it }
+        return me.ownedMounts.maxByOrNull { mountSpeed(it) } ?: me.ownedMounts.first()
+    }
+
+    /**
+     * The mount to fly: the active-sprite mount when it flies, otherwise the
+     * fastest flying mount owned. Null when the player owns no flying mount.
+     */
+    private fun flightMountId(me: PlayerState): String? {
+        activeSpriteMountId(me)?.takeIf { world.mountStats(it)?.flying == true }?.let { return it }
+        return me.ownedMounts
+            .filter { world.mountStats(it)?.flying == true }
+            .maxByOrNull { mountSpeed(it) }
+    }
+
+    /** The owned mount backing the player's active sprite, if any. */
+    private fun activeSpriteMountId(me: PlayerState): String? {
+        val active = me.activeSprite ?: return null
+        val def = spriteRegistry?.findVariant(active)?.first ?: return null
+        if (def.category != SpriteCategory.MOUNT) return null
+        val mountId = def.requirements
+            .filterIsInstance<dev.ambon.domain.sprite.SpriteRequirement.Mount>()
+            .firstOrNull()
+            ?.mountId
+        return mountId?.takeIf { it in me.ownedMounts }
+    }
+
+    /** Speed multiplier for [mountId]; mounts no longer sold anywhere ride at base pace. */
+    private fun mountSpeed(mountId: String): Double = world.mountStats(mountId)?.speed ?: 1.0
+
+    /** Milliseconds per ride hop for [mountId] — the base pace over the mount's speed. */
+    private fun stepMs(mountId: String): Long =
+        (config.msPerRoom / mountSpeed(mountId)).roundToLong().coerceAtLeast(1L)
+
+    /**
+     * Airborne milliseconds for a flight from [fromZone] to [toZone]: base plus a
+     * per-percent rate over the straight-line distance between the zones' world-map
+     * centres, clamped. Zones unplaced on the world map fly at the clamp midpoint.
+     */
+    private fun flightMs(
+        fromZone: String,
+        toZone: String,
+    ): Long {
+        val a = world.zoneWorldMap(fromZone)
+        val b = world.zoneWorldMap(toZone)
+        if (a == null || b == null) return (config.flightMsMin + config.flightMsMax) / 2
+        val dx = (a.x + a.w / 2) - (b.x + b.w / 2)
+        val dy = (a.y + a.h / 2) - (b.y + b.h / 2)
+        val distancePercent = sqrt(dx * dx + dy * dy)
+        return (config.flightMsBase + (config.flightMsPerMapPercent * distancePercent).roundToLong())
+            .coerceIn(config.flightMsMin, config.flightMsMax)
     }
 
     /**

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1021,6 +1021,10 @@ ambonmud:
     mountTravel:
       msPerRoom: 300
       maxPathLength: 300
+      flightMsBase: 2000
+      flightMsPerMapPercent: 80
+      flightMsMin: 2000
+      flightMsMax: 10000
     navigation:
       recall:
         cooldownMs: 60000

--- a/src/main/resources/world/academy.yaml
+++ b/src/main/resources/world/academy.yaml
@@ -1761,7 +1761,19 @@ items:
       by clicking the zone map.
     itemType: mount
     mountId: academy_pony
+    mountSpeed: 1.0
     basePrice: 250
+  academy_gryphon:
+    displayName: a stormfeather gryphon
+    keyword: gryphon
+    description: A proud gryphon fledged in the Academy's high aviary, storm-grey feathers still crackling faintly. She
+      rides twice as fast as any pony — and she flies. Open the world map, unfurl the charts of any realm you've
+      visited, and click an explored room to soar there.
+    itemType: mount
+    mountId: academy_gryphon
+    mountSpeed: 2.0
+    flying: true
+    basePrice: 2500
 shops:
   academy_supply:
     name: Academy Armory Supplies
@@ -1775,6 +1787,7 @@ shops:
       - hearty_ration
       - elixir_of_clarity
       - academy_pony
+      - academy_gryphon
     image: a4ef3072c160a20d53e319f67d8d03498e889e391dd51d563525b82ec2383008.jpg
 trainers:
   valence_trainer:

--- a/src/main/resources/world/sprites.yaml
+++ b/src/main/resources/world/sprites.yaml
@@ -15,3 +15,12 @@ sprites:
       - type: mount
         mountId: academy_pony
     image: player_sprites/mount_academy_pony.png
+  academy_gryphon:
+    displayName: Stormfeather Gryphon
+    description: A storm-grey gryphon from the Academy aviary. Rides at twice the pace — and flies you to explored
+      rooms in any realm from the world map.
+    category: mount
+    requirements:
+      - type: mount
+        mountId: academy_gryphon
+    image: player_sprites/mount_academy_gryphon.png

--- a/src/test/kotlin/dev/ambon/engine/commands/MountTravelTest.kt
+++ b/src/test/kotlin/dev/ambon/engine/commands/MountTravelTest.kt
@@ -2,17 +2,23 @@ package dev.ambon.engine.commands
 
 import dev.ambon.bus.LocalOutboundBus
 import dev.ambon.config.MountTravelConfig
+import dev.ambon.domain.ids.ItemId
 import dev.ambon.domain.ids.MobId
 import dev.ambon.domain.ids.RoomId
 import dev.ambon.domain.ids.SessionId
+import dev.ambon.domain.items.Item
+import dev.ambon.domain.items.ItemInstance
+import dev.ambon.domain.items.ItemType
 import dev.ambon.domain.mob.MobState
 import dev.ambon.domain.sprite.SpriteCategory
 import dev.ambon.domain.sprite.SpriteDefinition
 import dev.ambon.domain.sprite.SpriteRequirement
 import dev.ambon.domain.sprite.SpriteVariant
 import dev.ambon.domain.world.Direction
+import dev.ambon.domain.world.ItemSpawn
 import dev.ambon.domain.world.Room
 import dev.ambon.domain.world.World
+import dev.ambon.domain.world.ZoneWorldMap
 import dev.ambon.engine.CombatSystem
 import dev.ambon.engine.MobRegistry
 import dev.ambon.engine.MountTravelSystem
@@ -81,10 +87,11 @@ class MountTravelTest {
         fun `refuses when the only route crosses unexplored rooms`() = runTest {
             val env = env()
             env.ownMount()
-            // Destination explored, but the middle of the only route is not.
+            // Destination explored, but the middle of the only route is not — only
+            // wings could reach it, and the pony has none.
             env.explored(listOf(stable, road1, gate))
             env.system.requestTravel(env.sid, gate.value)
-            env.assertError("route")
+            env.assertError("flying")
         }
 
         @Test
@@ -136,13 +143,13 @@ class MountTravelTest {
         }
 
         @Test
-        fun `rooms deeper in an adjacent zone are unreachable`() = runTest {
+        fun `rooms deeper in an adjacent zone need a flying mount`() = runTest {
             val env = env()
             env.ownMount()
             env.explored(listOf(stable, road1, road2, gate, border, deep))
 
             env.system.requestTravel(env.sid, deep.value)
-            env.assertError("route")
+            env.assertError("flying")
         }
 
         @Test
@@ -181,6 +188,173 @@ class MountTravelTest {
             env.tick()
             assertNull(env.me().ridingMountId)
             assertTrue(!env.system.isRiding(env.sid))
+        }
+    }
+
+    @Nested
+    inner class Speeds {
+        @Test
+        fun `a faster mount covers each room in msPerRoom over its speed`() = runTest {
+            val env = env()
+            env.ownFlyingMount() // storm_gryphon, speed 2.0 -> 150ms per hop
+            env.explored(listOf(stable, road1, road2, gate))
+
+            env.system.requestTravel(env.sid, gate.value)
+            env.advance(149)
+            assertEquals(stable, env.me().roomId, "not yet due at 149ms")
+            env.advance(1)
+            assertEquals(road1, env.me().roomId, "gryphon hops every 150ms")
+        }
+
+        @Test
+        fun `the fastest owned mount is picked by default`() = runTest {
+            val env = env()
+            env.ownMount()
+            env.ownFlyingMount()
+            env.explored(listOf(stable, road1, road2, gate))
+
+            env.system.requestTravel(env.sid, gate.value)
+            assertEquals("storm_gryphon", env.me().ridingMountId)
+        }
+
+        @Test
+        fun `an active mount sprite overrides the fastest pick`() = runTest {
+            val env = env(spriteRegistry = ponyRegistry())
+            env.ownMount()
+            env.ownFlyingMount()
+            env.explored(listOf(stable, road1, road2, gate))
+            env.me().activeSprite = "mount_dappled_pony"
+
+            env.system.requestTravel(env.sid, gate.value)
+            assertEquals("dappled_pony", env.me().ridingMountId, "rides the sprite's mount")
+            env.advance(150)
+            assertEquals(stable, env.me().roomId, "pony pace, not gryphon pace")
+            env.advance(150)
+            assertEquals(road1, env.me().roomId)
+        }
+    }
+
+    @Nested
+    inner class Flights {
+        @Test
+        fun `flies to an explored room deep in another zone`() = runTest {
+            val env = env()
+            env.ownFlyingMount()
+            env.explored(listOf(stable, deep))
+
+            env.system.requestTravel(env.sid, deep.value)
+            assertEquals("storm_gryphon", env.me().ridingMountId, "airborne on the gryphon")
+            assertEquals(stable, env.me().roomId, "takeoff is not arrival")
+            assertTrue(env.system.isRiding(env.sid))
+
+            env.advance(FALLBACK_FLIGHT_MS - 1)
+            assertEquals(stable, env.me().roomId, "still airborne")
+
+            env.advance(1)
+            assertEquals(deep, env.me().roomId, "landed at the destination")
+            assertNull(env.me().ridingMountId, "dismounted on landing")
+            assertTrue(!env.system.isRiding(env.sid))
+            val texts = env.texts()
+            assertTrue(texts.any { it.contains("alight", ignoreCase = true) }, "got=$texts")
+        }
+
+        @Test
+        fun `flight time scales with the zones' world-map distance`() = runTest {
+            // Centres: plains (10,10), hills (20,10) -> distance 10% -> 2000 + 80*10 = 2800ms.
+            val env = env(
+                zoneWorldMap = mapOf(
+                    "plains" to ZoneWorldMap(x = 0.0, y = 0.0, w = 20.0, h = 20.0),
+                    "hills" to ZoneWorldMap(x = 10.0, y = 0.0, w = 20.0, h = 20.0),
+                ),
+            )
+            env.ownFlyingMount()
+            env.explored(listOf(stable, deep))
+
+            env.system.requestTravel(env.sid, deep.value)
+            env.advance(2799)
+            assertEquals(stable, env.me().roomId, "still airborne at 2799ms")
+            env.advance(1)
+            assertEquals(deep, env.me().roomId, "landed at 2800ms")
+        }
+
+        @Test
+        fun `a ground route is preferred over flying when one is known`() = runTest {
+            val env = env()
+            env.ownFlyingMount()
+            env.explored(listOf(stable, road1, road2, gate))
+
+            env.system.requestTravel(env.sid, gate.value)
+            env.advance(150)
+            assertEquals(road1, env.me().roomId, "rode the first hop instead of taking off")
+        }
+
+        @Test
+        fun `a non-flying active sprite still flies on the owned flying mount`() = runTest {
+            val env = env(spriteRegistry = ponyRegistry())
+            env.ownMount()
+            env.ownFlyingMount()
+            env.explored(listOf(stable, deep))
+            env.me().activeSprite = "mount_dappled_pony"
+
+            env.system.requestTravel(env.sid, deep.value)
+            assertEquals("storm_gryphon", env.me().ridingMountId, "ponies cannot fly")
+        }
+
+        @Test
+        fun `an unexplored destination cannot be flown to`() = runTest {
+            val env = env()
+            env.ownFlyingMount()
+            env.explored(listOf(stable))
+
+            env.system.requestTravel(env.sid, deep.value)
+            env.assertError("explored")
+        }
+
+        @Test
+        fun `combat at landing time cancels the flight in place`() = runTest {
+            val env = env()
+            env.ownFlyingMount()
+            env.explored(listOf(stable, deep))
+
+            env.system.requestTravel(env.sid, deep.value)
+            env.mobs.upsert(MobState(MobId("plains:bandit"), "a bandit", stable, hp = 10, maxHp = 10))
+            assertNull(env.combat.startCombat(env.sid, "bandit"))
+            env.outbound.drainAll()
+
+            env.advance(FALLBACK_FLIGHT_MS)
+            assertEquals(stable, env.me().roomId, "never left the ground")
+            assertNull(env.me().ridingMountId)
+            val texts = env.texts()
+            assertTrue(texts.any { it.contains("cut short", ignoreCase = true) }, "got=$texts")
+        }
+
+        @Test
+        fun `moving by other means cancels the flight quietly`() = runTest {
+            val env = env()
+            env.ownFlyingMount()
+            env.explored(listOf(stable, road1, deep))
+
+            env.system.requestTravel(env.sid, deep.value)
+            env.players.moveTo(env.sid, road1)
+            env.outbound.drainAll()
+
+            env.advance(FALLBACK_FLIGHT_MS)
+            assertEquals(road1, env.me().roomId, "stays where they walked")
+            assertNull(env.me().ridingMountId)
+            assertTrue(!env.system.isRiding(env.sid))
+        }
+
+        @Test
+        fun `a new travel request supersedes the flight`() = runTest {
+            val env = env()
+            env.ownFlyingMount()
+            env.explored(listOf(stable, road1, road2, gate, deep))
+
+            env.system.requestTravel(env.sid, deep.value)
+            // Re-target to a ground destination before the landing fires.
+            env.system.requestTravel(env.sid, gate.value)
+            env.advance(FALLBACK_FLIGHT_MS)
+            assertTrue(env.me().roomId.zone == "plains", "old landing never fired; got=${env.me().roomId}")
         }
     }
 
@@ -268,6 +442,10 @@ class MountTravelTest {
             me().ownedMounts.add("dappled_pony")
         }
 
+        fun ownFlyingMount() {
+            me().ownedMounts.add("storm_gryphon")
+        }
+
         fun explored(rooms: List<RoomId>) {
             me().exploredRooms = rooms.map { it.value }.toMutableSet()
         }
@@ -278,14 +456,46 @@ class MountTravelTest {
             scheduler.runDue()
         }
 
+        /** Advances an arbitrary interval and runs due scheduler actions. */
+        suspend fun advance(ms: Long) {
+            clock.advance(ms)
+            scheduler.runDue()
+        }
+
         fun assertError(fragment: String) {
             val errors = outbound.drainAll().filterIsInstance<OutboundEvent.SendError>().map { it.text }
             assertTrue(errors.any { it.contains(fragment, ignoreCase = true) }, "expected error containing '$fragment', got=$errors")
         }
+
+        fun texts(): List<String> = outbound.drainAll().filterIsInstance<OutboundEvent.SendText>().map { it.text }
     }
 
-    private suspend fun env(): Env {
-        val world = travelWorld()
+    /** A registry holding just the (non-flying) pony's mount sprite. */
+    private fun ponyRegistry(): SpriteRegistry {
+        val reg = SpriteRegistry()
+        reg.register(
+            SpriteDefinition(
+                id = "dappled_pony",
+                displayName = "Dappled Pony",
+                category = SpriteCategory.MOUNT,
+                requirements = listOf(SpriteRequirement.Mount("dappled_pony")),
+                variants = listOf(
+                    SpriteVariant(
+                        imageId = "mount_dappled_pony",
+                        displayName = "Dappled Pony",
+                        imagePath = "player_sprites/mount_dappled_pony.png",
+                    ),
+                ),
+            ),
+        )
+        return reg
+    }
+
+    private suspend fun env(
+        zoneWorldMap: Map<String, ZoneWorldMap> = emptyMap(),
+        spriteRegistry: SpriteRegistry? = null,
+    ): Env {
+        val world = travelWorld(zoneWorldMap)
         val players = buildTestPlayerRegistry(world.startRoom)
         val mobs = MobRegistry()
         val items = ItemRegistry()
@@ -293,13 +503,20 @@ class MountTravelTest {
         val combat = CombatSystem(players, mobs, items, outbound)
         val clock = MutableClock(0L)
         val scheduler = Scheduler(clock)
-        val config = MountTravelConfig(msPerRoom = 300L)
+        val config = MountTravelConfig(
+            msPerRoom = 300L,
+            flightMsBase = 2000L,
+            flightMsPerMapPercent = 80L,
+            flightMsMin = 2000L,
+            flightMsMax = 10000L,
+        )
         val system = MountTravelSystem(
             players = players,
             world = world,
             outbound = outbound,
             combat = combat,
             scheduler = scheduler,
+            spriteRegistry = spriteRegistry,
             config = config,
         )
         val sid = SessionId(1)
@@ -316,12 +533,37 @@ class MountTravelTest {
         private val border = RoomId("hills:border")
         private val deep = RoomId("hills:deep")
 
+        /** With flightMsBase=2000 and no placements, flights fall back to (min+max)/2. */
+        private const val FALLBACK_FLIGHT_MS = 6000L
+
+        private fun mountItem(
+            id: String,
+            mountId: String,
+            speed: Double,
+            flying: Boolean,
+        ): ItemSpawn =
+            ItemSpawn(
+                instance = ItemInstance(
+                    id = ItemId(id),
+                    item = Item(
+                        keyword = mountId,
+                        displayName = mountId,
+                        itemType = ItemType.MOUNT,
+                        mountId = mountId,
+                        mountSpeed = speed,
+                        flying = flying,
+                        basePrice = 100,
+                    ),
+                ),
+            )
+
         /**
          * Linear chain stable =e= road1 =e= road2 =e= gate =e= hills:border =e= hills:deep.
-         * The border room is one hop into the adjacent zone (a valid destination); deep is
-         * two hops in (never routable from plains).
+         * The border room is one hop into the adjacent zone (a valid ground destination);
+         * deep is two hops in (only reachable on wings). The shop items define two mounts:
+         * a 1.0x ground pony and a 2.0x flying gryphon.
          */
-        private fun travelWorld(): World {
+        private fun travelWorld(zoneWorldMap: Map<String, ZoneWorldMap> = emptyMap()): World {
             val rooms = mapOf(
                 stable to Room(stable, "Stable", "A stable.", mapOf(Direction.EAST to road1)),
                 road1 to Room(road1, "Road West", "A road.", mapOf(Direction.WEST to stable, Direction.EAST to road2)),
@@ -330,7 +572,15 @@ class MountTravelTest {
                 border to Room(border, "Hills Border", "A border.", mapOf(Direction.WEST to gate, Direction.EAST to deep)),
                 deep to Room(deep, "Deep Hills", "Deep hills.", mapOf(Direction.WEST to border)),
             )
-            return World(rooms = rooms, startRoom = stable)
+            return World(
+                rooms = rooms,
+                startRoom = stable,
+                itemSpawns = listOf(
+                    mountItem("plains:pony_item", "dappled_pony", speed = 1.0, flying = false),
+                    mountItem("plains:gryphon_item", "storm_gryphon", speed = 2.0, flying = true),
+                ),
+                zoneWorldMap = zoneWorldMap,
+            )
         }
     }
 }

--- a/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
+++ b/src/test/kotlin/dev/ambon/world/load/WorldLoaderTest.kt
@@ -1111,6 +1111,48 @@ class WorldLoaderTest {
                 }
             assertTrue(ex.message!!.contains("mountId", ignoreCase = true), "Got: ${ex.message}")
         }
+
+        @Test
+        fun `loads mount stats and resolves them by mount id`() {
+            val world = WorldLoader.loadFromResource("world/ok_mount_stats.yaml")
+
+            val pony = world.mountStats("dappled_pony")!!
+            assertEquals(1.0, pony.speed)
+            assertEquals(false, pony.flying)
+
+            val gryphon = world.mountStats("storm_gryphon")!!
+            assertEquals(2.0, gryphon.speed)
+            assertEquals(true, gryphon.flying)
+
+            assertEquals(null, world.mountStats("unknown_mount"))
+        }
+
+        @Test
+        fun `fails when a non-mount item sets mountSpeed`() {
+            val ex =
+                assertThrows(WorldLoadException::class.java) {
+                    WorldLoader.loadFromResource("world/bad_mount_speed_on_non_mount.yaml")
+                }
+            assertTrue(ex.message!!.contains("mountSpeed", ignoreCase = true), "Got: ${ex.message}")
+        }
+
+        @Test
+        fun `fails when mountSpeed is out of range`() {
+            val ex =
+                assertThrows(WorldLoadException::class.java) {
+                    WorldLoader.loadFromResource("world/bad_mount_speed_out_of_range.yaml")
+                }
+            assertTrue(ex.message!!.contains("mountSpeed", ignoreCase = true), "Got: ${ex.message}")
+        }
+
+        @Test
+        fun `fails when items selling the same mount disagree on stats`() {
+            val ex =
+                assertThrows(WorldLoadException::class.java) {
+                    WorldLoader.loadFromResource("world/bad_mount_conflicting_stats.yaml")
+                }
+            assertTrue(ex.message!!.contains("disagree", ignoreCase = true), "Got: ${ex.message}")
+        }
     }
 
     @Test

--- a/src/test/resources/world/bad_mount_conflicting_stats.yaml
+++ b/src/test/resources/world/bad_mount_conflicting_stats.yaml
@@ -1,0 +1,21 @@
+zone: bad_mount_conflicting_stats
+startRoom: stable
+items:
+  pony_a:
+    displayName: "a dappled pony"
+    keyword: "pony"
+    itemType: mount
+    mountId: dappled_pony
+    mountSpeed: 1.0
+    basePrice: 100
+  pony_b:
+    displayName: "the same pony, faster somehow"
+    keyword: "pony"
+    itemType: mount
+    mountId: dappled_pony
+    mountSpeed: 2.0
+    basePrice: 100
+rooms:
+  stable:
+    title: "Stable"
+    description: "A stable."

--- a/src/test/resources/world/bad_mount_speed_on_non_mount.yaml
+++ b/src/test/resources/world/bad_mount_speed_on_non_mount.yaml
@@ -1,0 +1,12 @@
+zone: bad_mount_speed_on_non_mount
+startRoom: stable
+items:
+  sword:
+    displayName: "a swift sword"
+    keyword: "sword"
+    mountSpeed: 2.0
+    basePrice: 100
+rooms:
+  stable:
+    title: "Stable"
+    description: "A stable."

--- a/src/test/resources/world/bad_mount_speed_out_of_range.yaml
+++ b/src/test/resources/world/bad_mount_speed_out_of_range.yaml
@@ -1,0 +1,14 @@
+zone: bad_mount_speed_out_of_range
+startRoom: stable
+items:
+  pony:
+    displayName: "a dappled pony"
+    keyword: "pony"
+    itemType: mount
+    mountId: dappled_pony
+    mountSpeed: 0.0
+    basePrice: 100
+rooms:
+  stable:
+    title: "Stable"
+    description: "A stable."

--- a/src/test/resources/world/ok_mount_stats.yaml
+++ b/src/test/resources/world/ok_mount_stats.yaml
@@ -1,0 +1,21 @@
+zone: ok_mount_stats
+startRoom: stable
+items:
+  pony:
+    displayName: "a dappled pony"
+    keyword: "pony"
+    itemType: mount
+    mountId: dappled_pony
+    basePrice: 100
+  gryphon:
+    displayName: "a storm gryphon"
+    keyword: "gryphon"
+    itemType: mount
+    mountId: storm_gryphon
+    mountSpeed: 2.0
+    flying: true
+    basePrice: 1000
+rooms:
+  stable:
+    title: "Stable"
+    description: "A stable."

--- a/web-v3/src/App.tsx
+++ b/web-v3/src/App.tsx
@@ -389,18 +389,6 @@ function App() {
     resetComposerTraversal();
   };
 
-  // Map click-to-ride: owning a mount lets any explored, non-current room on the
-  // zone chart (including border stubs into adjacent zones) be a travel target.
-  // The server re-validates everything; this just gates the obvious no-ops.
-  useEffect(() => {
-    mapRoomClickRef.current = (info: MapHoverInfo) => {
-      if (!state.travelStatus?.canTravel) return;
-      if (info.id === state.room.id) return;
-      if (!info.explored && !info.zone) return; // fog-of-war frontier: nothing to ride to
-      sendCommand(`travel ${info.id}`);
-    };
-  });
-
   // Close the map drawer when a ride actually starts (Travel.Status flips to
   // riding), so the journey plays out on the main canvas. Keyed on the riding
   // transition — not the click — so a rejected request leaves the map open,
@@ -1011,6 +999,32 @@ function App() {
     const colon = id.indexOf(":");
     return colon > 0 ? id.slice(0, colon) : null;
   }, [state.room.id]);
+
+  // Map click-to-ride/fly: owning a mount lets any explored, non-current room on
+  // the zone chart (including border stubs into adjacent zones) be a travel
+  // target; a flying mount extends that to explored rooms on a previewed
+  // foreign-zone chart (World Map → unfurl charts). The server re-validates
+  // everything; this just gates the obvious no-ops and picks the hint verb.
+  const travelModeFor = (info: MapHoverInfo): "ride" | "fly" | null => {
+    const travel = state.travelStatus;
+    if (!travel?.canTravel) return null;
+    if (info.id === state.room.id) return null;
+    if (state.mapPreviewZone != null && state.mapPreviewZone !== currentZone) {
+      // Foreign charts have no rideable border stubs — explored rooms only,
+      // and reaching them takes wings.
+      return travel.canFly && info.explored ? "fly" : null;
+    }
+    if (!info.explored && !info.zone) return null; // fog-of-war frontier: nothing to ride to
+    return "ride";
+  };
+  const mapHoverTravelMode = mapHoverInfo ? travelModeFor(mapHoverInfo) : null;
+
+  useEffect(() => {
+    mapRoomClickRef.current = (info: MapHoverInfo) => {
+      if (travelModeFor(info) == null) return;
+      sendCommand(`travel ${info.id}`);
+    };
+  });
 
   // World Map ledger → preview another realm's chart on the Local Map tab.
   // Your own zone needs no round trip; just switch tabs.
@@ -1791,6 +1805,9 @@ function App() {
               <div className="map-preview-banner" role="status">
                 <span className="map-preview-label">
                   Viewing the charts of <strong>{formatZoneName(state.mapPreviewZone)}</strong>
+                  {state.travelStatus?.canFly && state.mapPreviewZone !== currentZone && (
+                    <span className="map-preview-fly-hint"> — click an explored room to fly there</span>
+                  )}
                 </span>
                 <button
                   type="button"
@@ -1830,12 +1847,7 @@ function App() {
                 height={760}
                 role="img"
                 style={{
-                  cursor: state.travelStatus?.canTravel &&
-                    mapHoverInfo &&
-                    mapHoverInfo.id !== state.room.id &&
-                    (mapHoverInfo.explored || mapHoverInfo.zone)
-                    ? "pointer"
-                    : undefined,
+                  cursor: mapHoverTravelMode != null ? "pointer" : undefined,
                 }}
                 onPointerDown={onMapPointerDown}
                 onPointerMove={onMapPointerMove}
@@ -1872,10 +1884,11 @@ function App() {
                   ) : (
                     <span className="map-tooltip-title map-tooltip-unknown">Unexplored</span>
                   )}
-                  {state.travelStatus?.canTravel &&
-                    mapHoverInfo.id !== state.room.id &&
-                    (mapHoverInfo.explored || mapHoverInfo.zone) && (
+                  {mapHoverTravelMode === "ride" && (
                     <span className="map-tooltip-ride">🐎 Click to ride here</span>
+                  )}
+                  {mapHoverTravelMode === "fly" && (
+                    <span className="map-tooltip-ride">🦅 Click to fly here</span>
                   )}
                 </div>
               )}
@@ -1891,6 +1904,7 @@ function App() {
                 currentZone={currentZone}
                 onViewCharts={handleViewCharts}
                 serverAssets={state.serverAssets}
+                canFly={state.travelStatus?.canFly === true}
               />
             )}
             {mapTab === "atlas" && (

--- a/web-v3/src/components/ShopPopout.tsx
+++ b/web-v3/src/components/ShopPopout.tsx
@@ -147,6 +147,20 @@ export function ShopPopout({ shop, inventory, equipment, gold, onBuyItem, onSell
                           {item.consumable && item.slot && (
                             <span className="shop-stat-slot">consumable</span>
                           )}
+                          {item.mountSpeed != null && (
+                            <span className="shop-stat-slot" title="Ride speed over the base travel pace">
+                              🐎 {item.mountSpeed}× speed
+                            </span>
+                          )}
+                          {item.mountFlying === true && (
+                            <span
+                              className="shop-stat-slot"
+                              title="Can fly — travel to explored rooms in any realm from the world map"
+                            >
+                              🦅 flying
+                            </span>
+                          )}
+                          {item.owned && <span className="shop-stat-slot">owned</span>}
                         </div>
                       </div>
                     </div>
@@ -157,10 +171,10 @@ export function ShopPopout({ shop, inventory, equipment, gold, onBuyItem, onSell
                       <button
                         type="button"
                         className="soft-button shop-popout-buy-btn"
-                        disabled={!canAfford}
+                        disabled={!canAfford || item.owned}
                         onClick={(e) => { e.stopPropagation(); onBuyItem(item.keyword); }}
                       >
-                        Buy
+                        {item.owned ? "Owned" : "Buy"}
                       </button>
                     </div>
                   </div>

--- a/web-v3/src/components/WorldMap.tsx
+++ b/web-v3/src/components/WorldMap.tsx
@@ -9,6 +9,8 @@ interface WorldMapProps {
   serverAssets: Record<string, string>;
   /** Open the named zone's chart (Local Map preview via the `map` command). */
   onViewCharts: (zone: string) => void;
+  /** True when the player owns a flying mount — zone charts become fly-to pickers. */
+  canFly: boolean;
 }
 
 /** An area whose worldMap placement is fully authored. */
@@ -46,7 +48,7 @@ const FALLBACK_ASPECT = 3 / 4;
  * zone's ledger in the side panel, where "unfurl the charts" opens that
  * zone's own map via the `map` command.
  */
-export function WorldMap({ areas, currentZone, serverAssets, onViewCharts }: WorldMapProps) {
+export function WorldMap({ areas, currentZone, serverAssets, onViewCharts, canFly }: WorldMapProps) {
   const [selected, setSelected] = useState<string | null>(null);
   const [hovered, setHovered] = useState<string | null>(null);
   const [artFailed, setArtFailed] = useState(false);
@@ -377,6 +379,12 @@ export function WorldMap({ areas, currentZone, serverAssets, onViewCharts }: Wor
             >
               Unfurl this realm&apos;s charts →
             </button>
+            {canFly && selectedArea.zone !== currentZone && (
+              <p className="world-map-detail-hint">
+                Your flying mount can carry you there — unfurl the charts and click any room
+                you&apos;ve explored.
+              </p>
+            )}
           </div>
         ) : (
           <div className="world-map-detail world-map-detail-empty">

--- a/web-v3/src/gmcp/applyGmcpPackage.ts
+++ b/web-v3/src/gmcp/applyGmcpPackage.ts
@@ -1582,6 +1582,9 @@ export function applyGmcpPackage(
               consumable: e.consumable === true,
               image: typeof e.image === "string" ? e.image : null,
               video: typeof e.video === "string" ? e.video : null,
+              owned: e.owned === true,
+              mountSpeed: typeof e.mountSpeed === "number" ? e.mountSpeed : null,
+              mountFlying: typeof e.mountFlying === "boolean" ? e.mountFlying : null,
             }))
         : [];
       ctx.setShop({ name, sellMultiplier, items });
@@ -2088,7 +2091,9 @@ export function applyGmcpPackage(
       const packet = data as Partial<Record<string, unknown>>;
       ctx.setTravelStatus({
         canTravel: packet.canTravel === true,
+        canFly: packet.canFly === true,
         riding: packet.riding === true,
+        flying: packet.flying === true,
         destination: typeof packet.destination === "string" ? packet.destination : null,
       });
       break;

--- a/web-v3/src/styles.css
+++ b/web-v3/src/styles.css
@@ -10183,6 +10183,11 @@ body {
   color: #2e2212;
 }
 
+.map-preview-fly-hint {
+  opacity: 0.78;
+  font-style: italic;
+}
+
 .map-preview-return {
   appearance: none;
   border: 1px solid rgb(90 60 30 / 55%);

--- a/web-v3/src/types.ts
+++ b/web-v3/src/types.ts
@@ -340,6 +340,12 @@ export interface ShopItem {
   consumable: boolean;
   image: string | null;
   video: string | null;
+  /** Mount items only: true when the player already owns this mount. */
+  owned: boolean;
+  /** Mount items only: ride-speed multiplier over the base travel pace. */
+  mountSpeed: number | null;
+  /** Mount items only: true when the mount can fly (cross-zone travel). */
+  mountFlying: boolean | null;
 }
 
 export interface ShopState {
@@ -1310,7 +1316,11 @@ export interface FlightState {
 export interface TravelStatus {
   /** True when the player owns at least one mount and may click the map to ride. */
   canTravel: boolean;
+  /** True when the player owns a flying mount — explored rooms in other zones become travel targets. */
+  canFly: boolean;
   riding: boolean;
+  /** True while the current ride is a flight (airborne, awaiting landing). */
+  flying: boolean;
   /** Destination room id while riding, else null. */
   destination: string | null;
 }


### PR DESCRIPTION
## Summary
Builds on mount fast travel with two authored mount stats:

- **`mountSpeed`** — per-mount ride-speed multiplier over `mountTravel.msPerRoom` (ride pace = base / speed). Mount pick upgrades from *first purchased* to *active-sprite-else-fastest*.
- **`flying`** — flying mounts unlock **flight**: when an explored destination has no known ground path (typically a room in another zone, picked by unfurling that zone's charts from the World Map atlas), the rider takes off and lands there after an airborne delay scaled from the two zones' `worldMap` placements (clamped, configurable). Free; combat or moving by other means cancels; hot-reload safe.

Ground travel semantics are unchanged for non-flying mounts (in-zone + one-hop border stubs). Requests that used to fail with `NO_PATH` for explored-but-unrouted destinations now fail with a `NO_FLYING_MOUNT` hint ("Only a flying mount could carry you there.") when the player owns no flying mount.

## Contract changes
- **Item YAML** (mount items only): optional `mountSpeed` ((0, 10], default 1.0) and `flying` (default false); loader rejects them on non-mounts and rejects conflicting stats across items sharing a `mountId`. Documented in WORLD_YAML_SPEC (which now also lists `mount`/`mountId` itself).
- **GMCP** `Travel.Status`: new `canFly` (owns a flying mount) + `flying` (currently airborne). `Shop.List` mount items: new `mountSpeed`/`mountFlying` (+ the client now reads `owned`).
- **Config**: `engine.mountTravel.flightMsBase/flightMsPerMapPercent/flightMsMin/flightMsMax` + flight messages.

## Web client
- The map click gate is unified in `travelModeFor`: own-zone behavior unchanged; a previewed foreign-zone chart (World Map → "unfurl charts") accepts explored-room clicks when `canFly`, with a 🦅 "click to fly here" tooltip and a preview-banner hint.
- World Map ledger points flying-mount owners at the charts; shop cards show speed/flying chips and an *Owned* buy-state for purchased mounts.

## Demo content
Academy armory now sells **a stormfeather gryphon** (2.0×, flying, 2500g) beside the pony (1.0×, 250g), with a matching mount sprite. Note: the bundled world is single-zone, so cross-zone flight really shines on the full Auringold world; in the demo, flight covers explored rooms with no known ground route.

## Follow-up (other repo)
Arcanum authoring support for `mountSpeed`/`flying` on mount items (cross-repo mount contract).

## Testing
`ktlintCheck`, `test`, `integrationTest`, web `lint` + `tsc --noEmit` all green. New coverage: per-mount hop pacing, mount selection (fastest default, active-sprite override, non-flying sprite falls back to flying mount for flights), flight lifecycle (fallback + map-distance timing, ground-route preference, combat/movement/supersede cancellation), loader validation (stats on non-mounts, range, cross-item conflicts).